### PR TITLE
[RHDM-1833] fix no-loop for rules with or (#3922)

### DIFF
--- a/drools-core/src/main/java/org/drools/core/reteoo/RuleTerminalNode.java
+++ b/drools-core/src/main/java/org/drools/core/reteoo/RuleTerminalNode.java
@@ -280,11 +280,7 @@ public class RuleTerminalNode extends AbstractTerminalNode {
     }
 
     private int calculateHashCode() {
-        int result = 31 * rule.hashCode();
-        result = 31 * result + subruleIndex;
-        result = 31 * result + (consequenceName != null ? consequenceName.hashCode() : 0);
-
-        return result;
+        return 31 * this.rule.hashCode() + (consequenceName == null ? 0 : 37 * consequenceName.hashCode());
     }
 
     @Override
@@ -297,7 +293,7 @@ public class RuleTerminalNode extends AbstractTerminalNode {
             return false;
         }
         final RuleTerminalNode other = (RuleTerminalNode) object;
-        return subruleIndex == other.subruleIndex && rule.equals(other.rule) && (consequenceName == null ? other.consequenceName == null : consequenceName.equals(other.consequenceName));
+        return rule.equals(other.rule) && (consequenceName == null ? other.consequenceName == null : consequenceName.equals(other.consequenceName));
     }
 
     public short getType() {

--- a/drools-test-coverage/test-suite/src/test/java/org/drools/testcoverage/functional/ActivationGroupTest.java
+++ b/drools-test-coverage/test-suite/src/test/java/org/drools/testcoverage/functional/ActivationGroupTest.java
@@ -1,0 +1,109 @@
+/*
+ * Copyright 2021 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.drools.testcoverage.functional;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
+
+import org.assertj.core.api.Assertions;
+import org.drools.testcoverage.common.listener.TrackingAgendaEventListener;
+import org.drools.testcoverage.common.util.KieBaseTestConfiguration;
+import org.drools.testcoverage.common.util.KieBaseUtil;
+import org.drools.testcoverage.common.util.TestConstants;
+import org.drools.testcoverage.common.util.TestParametersUtil;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+import org.kie.api.KieBase;
+import org.kie.api.KieServices;
+import org.kie.api.command.Command;
+import org.kie.api.io.Resource;
+import org.kie.api.runtime.KieSession;
+
+@RunWith(Parameterized.class)
+public class ActivationGroupTest {
+    private final KieBaseTestConfiguration kieBaseTestConfiguration;
+
+    public ActivationGroupTest(final KieBaseTestConfiguration kieBaseTestConfiguration) {
+        this.kieBaseTestConfiguration = kieBaseTestConfiguration;
+    }
+
+    @Parameterized.Parameters
+    public static Collection<Object[]> getParameters() {
+        return TestParametersUtil.getKieBaseConfigurations();
+    }
+
+    /**
+     * Only one rule from activation group fires. 
+     */
+    @Test
+    public void basicTestActivationGroup() {
+        TrackingAgendaEventListener listener = prepareKSession("basicActivationGroup");
+
+        Assertions.assertThat(listener.isRuleFired("basic1")).isFalse();
+        Assertions.assertThat(listener.isRuleFired("basic2")).isTrue(); 
+        Assertions.assertThat(listener.isRuleFired("basic3")).isFalse();
+    }
+    
+    @Test
+    public void recursiveTestActivationGroup() {
+        TrackingAgendaEventListener listener = prepareKSession("recursiveActivationGroup");
+        
+        Assertions.assertThat(listener.isRuleFired("simplyRecursive1")).isFalse();
+        Assertions.assertThat(listener.isRuleFired("simplyRecursive2")).isTrue();
+        Assertions.assertThat(listener.isRuleFired("simplyRecursive3")).isTrue();
+    }
+    
+    @Test
+    public void testActivationGroupWithDefaultSalience() {
+        TrackingAgendaEventListener listener = prepareKSession("defaultSalienceActivationGroup");
+        
+        Assertions.assertThat(listener.rulesCount()).isEqualTo(1);
+    }
+    
+    @Test
+    public void testActivationGroupRecursivelyWithDefaultSalience() {
+        TrackingAgendaEventListener listener = prepareKSession("defaultSalienceWithRecursion");
+        
+        Assertions.assertThat(listener.rulesCount()).isEqualTo(2);
+    }
+    
+    private TrackingAgendaEventListener prepareKSession(String startingRule) {
+        List<Command<?>> commands = new ArrayList<Command<?>>();
+        TrackingAgendaEventListener listener = new TrackingAgendaEventListener();
+
+        final KieSession ksession = getKieBaseForTest().newKieSession();
+        try {
+            ksession.addEventListener(listener);
+
+            ksession.insert(startingRule);
+            ksession.fireAllRules();
+        } finally {
+            ksession.dispose();
+        }
+        return listener;
+    }
+
+    private KieBase getKieBaseForTest() {
+        final Resource drlResource =
+                KieServices.Factory.get().getResources().newClassPathResource("activation-group.drl", getClass());
+        return KieBaseUtil.getKieBaseFromKieModuleFromResources(TestConstants.PACKAGE_FUNCTIONAL,
+                                                                kieBaseTestConfiguration, drlResource);
+    }
+
+}

--- a/drools-test-coverage/test-suite/src/test/resources/org/drools/testcoverage/functional/activation-group.drl
+++ b/drools-test-coverage/test-suite/src/test/resources/org/drools/testcoverage/functional/activation-group.drl
@@ -1,0 +1,126 @@
+/*
+ * Copyright 2021 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.drools.testcoverage.functional
+
+// activation group test
+
+rule "basic1"
+    activation-group "basic"
+    salience 0
+    when
+        String(this == "basicActivationGroup")
+    then
+end
+
+rule "basic2"
+    activation-group "basic"
+    salience 10
+    when
+	 String(this == "basicActivationGroup")
+    then
+end
+
+rule "basic3"
+    activation-group "basic"
+    salience 5
+    when
+        String(this == "basicActivationGroup")
+    then
+end
+
+//----------------------------------------------------------------------
+
+rule "simplyRecursive1"
+    activation-group "simplyRecursive"
+    salience 0
+    when
+        String(this == "recursiveActivationGroup") or String(this == "simplyRecursiveCall")
+    then
+end
+
+rule "simplyRecursive2"
+    activation-group "simplyRecursive"
+    salience 5
+    when
+        String(this == "recursiveActivationGroup") or String(this == "simplyRecursiveCall")
+    then
+end
+
+rule "simplyRecursive3"
+    no-loop true
+    activation-group "simplyRecursive"
+    salience 10
+    when
+        String(this == "recursiveActivationGroup") or String(this == "simplyRecursiveCall")
+    then
+        insert("simplyRecursiveCall");
+end
+
+//----------------------------------------------------------------------
+
+rule "defaultSalience1"
+    activation-group "defaultSalience"
+    when
+        String(this == "defaultSalienceActivationGroup")
+    then
+end
+
+rule "defaultSalience2"
+    activation-group "defaultSalience"
+    when
+        String(this == "defaultSalienceActivationGroup")
+    then
+end
+
+rule "defaultSalience3"
+    activation-group "defaultSalience"
+    when
+        String(this == "defaultSalienceActivationGroup")
+    then
+end
+
+//----------------------------------------------------------------------
+
+rule "defaultSalienceWithRecursion1"
+    no-loop
+    activation-group "defaultSalienceRecursion"
+    when
+	String(this == "defaultSalienceWithRecursion") or String(this == "defaultSalienceWithRecursionCall")
+    then
+	insert("defaultSalienceWithRecursionCall");	
+end
+
+rule "defaultSalienceWithRecursion2"
+    activation-group "defaultSalienceRecursion"
+    when
+	String(this == "defaultSalienceWithRecursion") or String(this == "defaultSalienceWithRecursionCall")
+    then
+end
+
+rule "defaultSalienceWithRecursion3"
+    no-loop
+    activation-group "defaultSalienceRecursion"
+    when
+	String(this == "defaultSalienceWithRecursion") or String(this == "defaultSalienceWithRecursionCall")
+    then
+        insert("defaultSalienceWithRecursionCall");
+end
+
+//--------------------------------------------------------------------
+
+
+


### PR DESCRIPTION
(cherry picked from commit ae3c72ca554d547aa96aacada82841bbe5e7d0b8)

**Thank you for submitting this pull request**

**NOTE!:** Double check the target branch for this PR.
The default is `main` so it will target Drools 8 / Kogito / Optaplanner 8.
If this PR is not strictly related to drools and kogito project in `drools.git`, it should probably target `7.x`as a branch

Backport to 7.59.x branch of fix for https://issues.redhat.com/browse/RHDM-1833