### PR TITLE
Fix jdk8 compilation (#3926)

### DIFF
--- a/kie-pmml-trusty/kie-pmml-compiler/kie-pmml-compiler-commons/src/main/java/org/kie/pmml/compiler/commons/implementations/KiePMMLModelRetriever.java
+++ b/kie-pmml-trusty/kie-pmml-compiler/kie-pmml-compiler-commons/src/main/java/org/kie/pmml/compiler/commons/implementations/KiePMMLModelRetriever.java
@@ -58,7 +58,8 @@ public class KiePMMLModelRetriever {
                 .map(kiePMMLModel -> getPopulatedWithPMMLModelFields(kiePMMLModel, compilationDTO.getFields(),
                                                                      compilationDTO.getMiningSchema(),
                                                                      compilationDTO.getOutput()))
-                .map(kiePMMLModel -> getPopulatedWithKiePMMLTargets(kiePMMLModel, compilationDTO.getTargets()))
+                // Additional cast necessary to make it compile with JDK8
+                .map(kiePMMLModel -> getPopulatedWithKiePMMLTargets((KiePMMLModel) kiePMMLModel, compilationDTO.getTargets()))
                 .findFirst();
     }
 


### PR DESCRIPTION
**Thank you for submitting this pull request**

**NOTE!:** Double check the target branch for this PR.
The default is `main` so it will target Drools 8 / Kogito / Optaplanner 8.
If this PR is not strictly related to drools and kogito project in `drools.git`, it should probably target `7.x`as a branch

**Ports** If a forward-port or a backport is needed, paste the forward port PR here

[link](https://www.example.com)

**JIRA**: _(please edit the JIRA link if it exists)_

[link](https://www.example.com)

**referenced Pull Requests**: _(please edit the URLs of referenced pullrequests if they exist)_

* paste the link(s) from GitHub here
* link 2
* link 3 etc.

<details>
<summary>
How to retest this PR or trigger a specific build:
</summary>

* <b>a pull request</b> please add comment: <b>Jenkins retest this</b>

* <b>a full downstream build</b> please add comment: <b>Jenkins run fdb</b>

* <b>a compile downstream build</b> please  add comment: <b>Jenkins run cdb</b>

* <b>a full production downstream build</b> please add comment: <b>Jenkins execute product fdb</b>

* <b>an upstream build</b> please add comment: <b>Jenkins run upstream</b>
</details>
