### PR TITLE
[RHDM-1837] Drools concurrency tests fail intermittently

### DIFF
--- a/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/compiler/integrationtests/concurrency/AccumulateFunctionConcurrencyTest.java
+++ b/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/compiler/integrationtests/concurrency/AccumulateFunctionConcurrencyTest.java
@@ -19,11 +19,13 @@ import java.util.Collection;
 
 import org.drools.testcoverage.common.util.KieBaseTestConfiguration;
 import org.drools.testcoverage.common.util.TestParametersUtil;
+import org.junit.Ignore;
 import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
 import org.kie.test.testcategory.TurtleTestCategory;
 
+@Ignore("RHDM-1837 : The test can run independently")
 @RunWith(Parameterized.class)
 @Category(TurtleTestCategory.class)
 public class AccumulateFunctionConcurrencyTest extends BaseConcurrencyTest {

--- a/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/compiler/integrationtests/concurrency/ConsequenceConcurrencyTest.java
+++ b/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/compiler/integrationtests/concurrency/ConsequenceConcurrencyTest.java
@@ -21,12 +21,14 @@ import java.util.List;
 
 import org.drools.testcoverage.common.util.KieBaseTestConfiguration;
 import org.drools.testcoverage.common.util.TestParametersUtil;
+import org.junit.Ignore;
 import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
 import org.kie.api.runtime.KieSession;
 import org.kie.test.testcategory.TurtleTestCategory;
 
+@Ignore("RHDM-1837 : The test can run independently")
 @RunWith(Parameterized.class)
 @Category(TurtleTestCategory.class)
 public class ConsequenceConcurrencyTest extends BaseConcurrencyTest {

--- a/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/compiler/integrationtests/concurrency/ConsequenceWithAndOrConcurrencyTest.java
+++ b/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/compiler/integrationtests/concurrency/ConsequenceWithAndOrConcurrencyTest.java
@@ -21,6 +21,7 @@ import java.util.List;
 
 import org.drools.testcoverage.common.util.KieBaseTestConfiguration;
 import org.drools.testcoverage.common.util.TestParametersUtil;
+import org.junit.Ignore;
 import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
@@ -28,6 +29,7 @@ import org.kie.api.KieBase;
 import org.kie.api.runtime.KieSession;
 import org.kie.test.testcategory.TurtleTestCategory;
 
+@Ignore("RHDM-1837 : The test can run independently")
 @RunWith(Parameterized.class)
 @Category(TurtleTestCategory.class)
 public class ConsequenceWithAndOrConcurrencyTest extends BaseConcurrencyTest {

--- a/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/compiler/integrationtests/concurrency/ConstraintConcurrencyTest.java
+++ b/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/compiler/integrationtests/concurrency/ConstraintConcurrencyTest.java
@@ -19,11 +19,13 @@ import java.util.Collection;
 
 import org.drools.testcoverage.common.util.KieBaseTestConfiguration;
 import org.drools.testcoverage.common.util.TestParametersUtil;
+import org.junit.Ignore;
 import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
 import org.kie.test.testcategory.TurtleTestCategory;
 
+@Ignore("RHDM-1837 : The test can run independently")
 @RunWith(Parameterized.class)
 @Category(TurtleTestCategory.class)
 public class ConstraintConcurrencyTest extends BaseConcurrencyTest {

--- a/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/compiler/integrationtests/concurrency/ConstraintWithAndOrConcurrencyTest.java
+++ b/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/compiler/integrationtests/concurrency/ConstraintWithAndOrConcurrencyTest.java
@@ -19,6 +19,7 @@ import java.util.Collection;
 
 import org.drools.testcoverage.common.util.KieBaseTestConfiguration;
 import org.drools.testcoverage.common.util.TestParametersUtil;
+import org.junit.Ignore;
 import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
@@ -26,6 +27,7 @@ import org.kie.api.KieBase;
 import org.kie.api.runtime.KieSession;
 import org.kie.test.testcategory.TurtleTestCategory;
 
+@Ignore("RHDM-1837 : The test can run independently")
 @RunWith(Parameterized.class)
 @Category(TurtleTestCategory.class)
 public class ConstraintWithAndOrConcurrencyTest extends BaseConcurrencyTest {

--- a/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/compiler/integrationtests/concurrency/ConstraintWithAndOrJittingConcurrencyTest.java
+++ b/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/compiler/integrationtests/concurrency/ConstraintWithAndOrJittingConcurrencyTest.java
@@ -19,6 +19,7 @@ import java.util.Collection;
 
 import org.drools.testcoverage.common.util.KieBaseTestConfiguration;
 import org.drools.testcoverage.common.util.TestParametersUtil;
+import org.junit.Ignore;
 import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
@@ -26,6 +27,7 @@ import org.kie.api.KieBase;
 import org.kie.api.runtime.KieSession;
 import org.kie.test.testcategory.TurtleTestCategory;
 
+@Ignore("RHDM-1837 : The test can run independently")
 @RunWith(Parameterized.class)
 @Category(TurtleTestCategory.class)
 public class ConstraintWithAndOrJittingConcurrencyTest extends BaseConcurrencyTest {

--- a/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/compiler/integrationtests/concurrency/EvalConcurrencyTest.java
+++ b/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/compiler/integrationtests/concurrency/EvalConcurrencyTest.java
@@ -19,11 +19,13 @@ import java.util.Collection;
 
 import org.drools.testcoverage.common.util.KieBaseTestConfiguration;
 import org.drools.testcoverage.common.util.TestParametersUtil;
+import org.junit.Ignore;
 import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
 import org.kie.test.testcategory.TurtleTestCategory;
 
+@Ignore("RHDM-1837 : The test can run independently")
 @RunWith(Parameterized.class)
 @Category(TurtleTestCategory.class)
 public class EvalConcurrencyTest extends BaseConcurrencyTest {

--- a/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/compiler/integrationtests/concurrency/FromAccumulateConcurrencyTest.java
+++ b/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/compiler/integrationtests/concurrency/FromAccumulateConcurrencyTest.java
@@ -19,11 +19,13 @@ import java.util.Collection;
 
 import org.drools.testcoverage.common.util.KieBaseTestConfiguration;
 import org.drools.testcoverage.common.util.TestParametersUtil;
+import org.junit.Ignore;
 import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
 import org.kie.test.testcategory.TurtleTestCategory;
 
+@Ignore("RHDM-1837 : The test can run independently")
 @RunWith(Parameterized.class)
 @Category(TurtleTestCategory.class)
 public class FromAccumulateConcurrencyTest extends BaseConcurrencyTest {

--- a/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/compiler/integrationtests/concurrency/MVELDateClassFieldReaderConcurrencyTest.java
+++ b/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/compiler/integrationtests/concurrency/MVELDateClassFieldReaderConcurrencyTest.java
@@ -20,12 +20,14 @@ import java.util.Date;
 
 import org.drools.testcoverage.common.util.KieBaseTestConfiguration;
 import org.drools.testcoverage.common.util.TestParametersUtil;
+import org.junit.Ignore;
 import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
 import org.kie.api.runtime.KieSession;
 import org.kie.test.testcategory.TurtleTestCategory;
 
+@Ignore("RHDM-1837 : The test can run independently")
 @RunWith(Parameterized.class)
 @Category(TurtleTestCategory.class)
 public class MVELDateClassFieldReaderConcurrencyTest extends BaseConcurrencyTest {

--- a/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/compiler/integrationtests/concurrency/MVELNumberClassFieldReaderConcurrencyTest.java
+++ b/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/compiler/integrationtests/concurrency/MVELNumberClassFieldReaderConcurrencyTest.java
@@ -19,12 +19,14 @@ import java.util.Collection;
 
 import org.drools.testcoverage.common.util.KieBaseTestConfiguration;
 import org.drools.testcoverage.common.util.TestParametersUtil;
+import org.junit.Ignore;
 import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
 import org.kie.api.runtime.KieSession;
 import org.kie.test.testcategory.TurtleTestCategory;
 
+@Ignore("RHDM-1837 : The test can run independently")
 @RunWith(Parameterized.class)
 @Category(TurtleTestCategory.class)
 public class MVELNumberClassFieldReaderConcurrencyTest extends BaseConcurrencyTest {

--- a/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/compiler/integrationtests/concurrency/MVELObjectClassFieldReaderConcurrencyTest.java
+++ b/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/compiler/integrationtests/concurrency/MVELObjectClassFieldReaderConcurrencyTest.java
@@ -19,12 +19,14 @@ import java.util.Collection;
 
 import org.drools.testcoverage.common.util.KieBaseTestConfiguration;
 import org.drools.testcoverage.common.util.TestParametersUtil;
+import org.junit.Ignore;
 import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
 import org.kie.api.runtime.KieSession;
 import org.kie.test.testcategory.TurtleTestCategory;
 
+@Ignore("RHDM-1837 : The test can run independently")
 @RunWith(Parameterized.class)
 @Category(TurtleTestCategory.class)
 public class MVELObjectClassFieldReaderConcurrencyTest extends BaseConcurrencyTest {


### PR DESCRIPTION
- Added `@Ignore` but those tests can run independently

Filed this PR to avoid jenkins failure. But RHDM-1837 is not a blocker so @mariofusco , please close this PR if we don't need to rush. We will rework on those tests to make them better.

**JIRA**: 
https://issues.redhat.com/browse/RHDM-1837

<details>
<summary>
How to retest this PR or trigger a specific build:
</summary>

* <b>a pull request</b> please add comment: <b>Jenkins retest this</b>

* <b>a full downstream build</b> please add comment: <b>Jenkins run fdb</b>

* <b>a compile downstream build</b> please  add comment: <b>Jenkins run cdb</b>

* <b>a full production downstream build</b> please add comment: <b>Jenkins execute product fdb</b>

* <b>an upstream build</b> please add comment: <b>Jenkins run upstream</b>
</details>
