### PR TITLE
[DROOLS-6680] Already expired event entering session remain forever i…

### DIFF
--- a/drools-core/src/main/java/org/drools/core/common/NamedEntryPoint.java
+++ b/drools-core/src/main/java/org/drools/core/common/NamedEntryPoint.java
@@ -351,6 +351,11 @@ public class NamedEntryPoint
                     throw new IllegalArgumentException("Invalid Entry Point. You updated the FactHandle on entry point '" + handle.getEntryPointId() + "' instead of '" + getEntryPointId() + "'");
                 }
 
+                if(handle.isExpired() && handle instanceof EventFactHandle){
+                    //let an expired fact potentially (re)enters the objectStore, but make sure that it will be clear at the end of the inference cycle
+                    ((EventFactHandle)handle).setPendingRemoveFromStore(true);
+                }
+
                 final ObjectTypeConf typeConf = changedObject ?
                         getObjectTypeConfigurationRegistry().getOrCreateObjectTypeConf(this.entryPoint, object) :
                         getObjectTypeConfigurationRegistry().getObjectTypeConf(object);

--- a/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/integrationtests/ExpirationTest.java
+++ b/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/integrationtests/ExpirationTest.java
@@ -1019,4 +1019,53 @@ public class ExpirationTest {
         Assertions.assertThat(kieSession.fireAllRules()).isEqualTo(2);
         Assertions.assertThat(kieSession.fireAllRules()).isEqualTo(0);
     }
+
+    @Test
+    public void testAvoidAlreadyExpiredFactsToForeverRemainInWM() {
+
+        String drl =
+                " import " + DummyEvent.class.getCanonicalName() + ";\n" +
+                " import " + OtherEvent.class.getCanonicalName() + ";\n" +
+                "\n" +
+                "declare DummyEvent\n" +
+                "    @role(event)\n" +
+                "    @timestamp(eventTimestamp)\n" +
+                "    @expires (3d)\n" +
+                "end\n" +
+                "rule \"R1\"\n" +
+                "no-loop \n" +
+                "when\n" +
+                "    $evt: DummyEvent()\n" +
+                "then\n" +
+                "    modify($evt){\n" +
+                "        setState(\"value\")\n" +
+                "    }\n" +
+                "end\n" +
+                "rule \"R2\"\n" +
+                "when\n" +
+                "    $b: OtherEvent()\n" +
+                "    $a: DummyEvent()\n" +
+                "then\n" +
+                "end";
+
+        KieBaseTestConfiguration equalityConfig = TestParametersUtil.getEqualityInstanceOf(kieBaseTestConfiguration);
+        KieBase kieBase = KieBaseUtil.getKieBaseFromKieModuleFromDrl("test", equalityConfig, drl);
+
+        final KieSessionConfiguration sessionConfig = KnowledgeBaseFactory.newKnowledgeSessionConfiguration();
+        sessionConfig.setOption( ClockTypeOption.get( ClockType.PSEUDO_CLOCK.getId() ) );
+        final KieSession kieSession = kieBase.newKieSession( sessionConfig, null );
+
+        final long now = System.currentTimeMillis();
+        final PseudoClockScheduler clock = kieSession.getSessionClock();
+
+        clock.advanceTime(now, TimeUnit.MILLISECONDS);
+
+        final long fiveDaysAgo = now - Duration.ofDays(5).toMillis();
+        final DummyEvent dummyEvent = new DummyEvent(1, fiveDaysAgo);
+
+        kieSession.insert(dummyEvent);
+
+        Assertions.assertThat(kieSession.fireAllRules()).isEqualTo(1);
+        Assertions.assertThat(kieSession.getFactCount()).isEqualTo(0);
+    }
 }


### PR DESCRIPTION
…n working memory

**JIRA**: 

[link](https://issues.redhat.com/browse/DROOLS-6680)

* <b>a pull request</b> please add comment: <b>Jenkins retest this</b>

* <b>a full downstream build</b> please add comment: <b>Jenkins run fdb</b>

* <b>a compile downstream build</b> please  add comment: <b>Jenkins run cdb</b>

* <b>a full production downstream build</b> please add comment: <b>Jenkins execute product fdb</b>

* <b>an upstream build</b> please add comment: <b>Jenkins run upstream</b>
</details>
