### PR TITLE
[DROOLS-6506] Executable model does not accept comparisons between so…

### DIFF
--- a/drools-model/drools-model-compiler/src/main/java/org/drools/modelcompiler/builder/generator/TypedExpression.java
+++ b/drools-model/drools-model-compiler/src/main/java/org/drools/modelcompiler/builder/generator/TypedExpression.java
@@ -26,6 +26,7 @@ import java.util.Optional;
 import com.github.javaparser.ast.expr.Expression;
 import org.drools.mvel.parser.printer.PrintUtil;
 
+import static org.drools.modelcompiler.builder.generator.DrlxParseUtil.THIS_PLACEHOLDER;
 import static org.drools.modelcompiler.builder.generator.DrlxParseUtil.toClassOrInterfaceType;
 import static org.drools.modelcompiler.util.ClassUtil.toNonPrimitiveType;
 import static org.drools.modelcompiler.util.ClassUtil.toRawClass;
@@ -35,6 +36,7 @@ public class TypedExpression {
     private Class<?> originalPatternType;
     private final Expression expression;
     private Type type;
+    private Type typeBeforeCoercion;
     private final String fieldName;
 
     protected Boolean staticExpr;
@@ -46,12 +48,21 @@ public class TypedExpression {
     }
 
     public TypedExpression( Expression expression, Type type ) {
-        this(expression, type, null);
+        this(expression, type, null, null);
+    }
+
+    public TypedExpression( Expression expression, Type type, Type typeBeforeCoercion) {
+        this(expression, type, typeBeforeCoercion, null);
     }
 
     public TypedExpression( Expression expression, Type type, String fieldName ) {
+        this(expression, type, null, fieldName);
+    }
+
+    public TypedExpression( Expression expression, Type type, Type typeBeforeCoercion, String fieldName ) {
         this.expression = expression;
         this.type = type;
+        this.typeBeforeCoercion = typeBeforeCoercion;
         this.fieldName = fieldName;
     }
 
@@ -78,6 +89,10 @@ public class TypedExpression {
 
     public Class<?> getRawClass() {
         return toRawClass( type );
+    }
+
+    public Class<?> getTypeBeforeCoercion() {
+        return toRawClass( typeBeforeCoercion );
     }
 
     public Optional<Class<?>> getBoxedType() {
@@ -162,6 +177,10 @@ public class TypedExpression {
 
     public void setOriginalPatternType(Class<?> originalPatternType) {
         this.originalPatternType = originalPatternType;
+    }
+
+    public boolean containThis() {
+        return getExpression().toString().contains(THIS_PLACEHOLDER);
     }
 
     @Override

--- a/drools-model/drools-model-compiler/src/main/java/org/drools/modelcompiler/builder/generator/drlxparse/CoercedExpression.java
+++ b/drools-model/drools-model-compiler/src/main/java/org/drools/modelcompiler/builder/generator/drlxparse/CoercedExpression.java
@@ -101,7 +101,11 @@ public class CoercedExpression {
         }
 
         if ((nonPrimitiveLeftClass == Integer.class || nonPrimitiveLeftClass == Long.class) && nonPrimitiveRightClass == Double.class) {
-            return new CoercedExpressionResult(new TypedExpression( new CastExpr( PrimitiveType.doubleType(), left.getExpression()), double.class ), right, false);
+            CastExpr castExpression = new CastExpr(PrimitiveType.doubleType(), this.left.getExpression());
+            return new CoercedExpressionResult(
+                    new TypedExpression(castExpression, double.class, left.getType()),
+                    right,
+                    false);
         }
 
         final boolean leftIsPrimitive = leftClass.isPrimitive() || Number.class.isAssignableFrom( leftClass );

--- a/drools-model/drools-model-compiler/src/main/java/org/drools/modelcompiler/builder/generator/drlxparse/ConstraintParser.java
+++ b/drools-model/drools-model-compiler/src/main/java/org/drools/modelcompiler/builder/generator/drlxparse/ConstraintParser.java
@@ -163,7 +163,7 @@ public class ConstraintParser {
     }
 
     private void addDeclaration(DrlxExpression drlx, SingleDrlxParseSuccess singleResult, String bindId) {
-        DeclarationSpec decl = context.addDeclaration( bindId, singleResult.getLeftExprRawClass() );
+        DeclarationSpec decl = context.addDeclaration( bindId, singleResult.getLeftExprTypeBeforeCoercion() );
         if (drlx.getExpr() instanceof NameExpr) {
             decl.setBoundVariable( drlx.getExpr().toString() );
         }
@@ -541,11 +541,11 @@ public class ConstraintParser {
         TypedExpression left = optLeft.get();
         List<String> usedDeclarationsOnLeft = hasBind ? new ArrayList<>( expressionTyperContext.getUsedDeclarations() ) : null;
 
-        List<Expression> leftPrefixExpresssions = new ArrayList<>();
+        List<Expression> leftPrefixExpressions = new ArrayList<>();
         if (isOrBinary) {
-            leftPrefixExpresssions.addAll(expressionTyperContext.getNullSafeExpressions());
+            leftPrefixExpressions.addAll(expressionTyperContext.getNullSafeExpressions());
             expressionTyperContext.getNullSafeExpressions().clear();
-            leftPrefixExpresssions.addAll(expressionTyperContext.getPrefixExpresssions());
+            leftPrefixExpressions.addAll(expressionTyperContext.getPrefixExpresssions());
             expressionTyperContext.getPrefixExpresssions().clear();
         }
 
@@ -607,7 +607,7 @@ public class ConstraintParser {
         }
 
         if (isOrBinary) {
-            combo = combineExpressions( leftPrefixExpresssions, rightPrefixExpresssions, combo ); // NullSafeExpressions are combined here because the order is complex
+            combo = combineExpressions( leftPrefixExpressions, rightPrefixExpresssions, combo ); // NullSafeExpressions are combined here because the order is complex
         } else {
             combo = combineExpressions( leftTypedExpressionResult, combo ); // NullSafeExpressions will be added later by PatternDSL.addNullSafeExpr() which will be separated AlphaNodes
         }

--- a/drools-model/drools-model-compiler/src/main/java/org/drools/modelcompiler/builder/generator/drlxparse/SingleDrlxParseSuccess.java
+++ b/drools-model/drools-model-compiler/src/main/java/org/drools/modelcompiler/builder/generator/drlxparse/SingleDrlxParseSuccess.java
@@ -281,6 +281,16 @@ public class SingleDrlxParseSuccess extends AbstractDrlxParseSuccess {
         return left != null ? left.getRawClass() : getExprRawClass();
     }
 
+    public Class<?> getLeftExprTypeBeforeCoercion() {
+        if (left != null) {
+            Class<?> typeBeforeCoercion = left.getTypeBeforeCoercion();
+            if(typeBeforeCoercion != null) {
+                return typeBeforeCoercion;
+            }
+        }
+        return getLeftExprRawClass();
+    }
+
     public Class<?> getPatternType() {
         return patternType;
     }

--- a/drools-model/drools-model-compiler/src/main/java/org/drools/modelcompiler/builder/generator/expression/AbstractExpressionBuilder.java
+++ b/drools-model/drools-model-compiler/src/main/java/org/drools/modelcompiler/builder/generator/expression/AbstractExpressionBuilder.java
@@ -28,6 +28,7 @@ import com.github.javaparser.ast.body.Parameter;
 import com.github.javaparser.ast.expr.BinaryExpr;
 import com.github.javaparser.ast.expr.CastExpr;
 import com.github.javaparser.ast.expr.ClassExpr;
+import com.github.javaparser.ast.expr.DoubleLiteralExpr;
 import com.github.javaparser.ast.expr.EnclosedExpr;
 import com.github.javaparser.ast.expr.Expression;
 import com.github.javaparser.ast.expr.FieldAccessExpr;
@@ -254,6 +255,10 @@ public abstract class AbstractExpressionBuilder {
                 String expressionString = stringValue(expression);
                 final BigInteger bigInteger = new BigDecimal(expressionString).toBigInteger();
                 return toNewExpr(BigInteger.class, toStringLiteral(bigInteger.toString()));
+            }
+
+            if (leftType.equals(float.class)) {
+                return new DoubleLiteralExpr(expression + "f");
             }
 
         }

--- a/drools-model/drools-model-compiler/src/test/java/org/drools/modelcompiler/PrimitiveConversionErrorsTest.java
+++ b/drools-model/drools-model-compiler/src/test/java/org/drools/modelcompiler/PrimitiveConversionErrorsTest.java
@@ -1,0 +1,325 @@
+/*
+ * Copyright (c) 2020. Red Hat, Inc. and/or its affiliates.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.drools.modelcompiler;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.List;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+import org.kie.api.KieBase;
+import org.kie.api.KieServices;
+import org.kie.api.builder.KieBuilder;
+import org.kie.api.builder.KieFileSystem;
+import org.kie.api.builder.Message;
+import org.kie.api.builder.Message.Level;
+import org.kie.api.io.Resource;
+import org.kie.api.runtime.KieContainer;
+import org.kie.api.runtime.KieSession;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+// DROOLS-6506
+@RunWith(Parameterized.class)
+public class PrimitiveConversionErrorsTest {
+
+    private static final String RULE_TEMPLATE = "" +
+            "package com.example.rules\n" +
+            "\n" +
+            "import java.util.*\n" +
+            "\n" +
+            "import com.example.*\n" +
+            "import " + ClassWithValue.class.getCanonicalName() + ";\n" +
+            "\n" +
+            "rule \"Rule that breaks ExecutableModel\"\n" +
+            "    when\n" +
+            "     $values:  List()\n" +
+            "  codef:   ClassWithValue(\n" +
+            "       $value: value<value_type> != <test_value>\n" +
+            "      )\n" +
+            "      \n" +
+            "  exists   ClassWithValue(\n" +
+            "       value<value_type> != $value\n" +
+            "      )\n" +
+            "    then\n" +
+            "     $values.add($value);\n" +
+            "end";
+
+    @Parameterized.Parameters(name = "value{0} != {2}: Method Returns {0}, test against {1}")
+    public static Collection<Object[]> data() {
+        Object[][] data = new Object[][]{
+                {Float.class, Float.class, 4f, 5f, 6f},
+                {Float.class, Double.class, 4d, 5f, 6f},
+                {Float.class, Integer.class, 4, 5f, 6f},
+                {Float.class, Short.class, (short) 4, 5f, 6f},
+                {Float.class, Byte.class, (byte) 4, 5f, 6f},
+
+                {Double.class, Float.class, 4f, 5d, 6d},
+                {Double.class, Double.class, 4d, 5d, 6d},
+                {Double.class, Integer.class, 4, 5d, 6d},
+                {Double.class, Short.class, (short) 4, 5d, 6d},
+                {Double.class, Byte.class, (byte) 4, 5d, 6d},
+
+                {Integer.class, Float.class, 4f, 5, 6},
+                {Integer.class, Double.class, 4d, 5, 6},
+                {Integer.class, Integer.class, 4, 5, 6},
+                {Integer.class, Short.class, (short) 4, 5, 6},
+                {Integer.class, Byte.class, (byte) 4, 5, 6},
+
+                {Short.class, Float.class, 4f, (short) 5, (short) 6},
+                {Short.class, Double.class, 4d, (short) 5, (short) 6},
+                {Short.class, Integer.class, 4, (short) 5, (short) 6},
+                {Short.class, Short.class, (short) 4, (short) 5, (short) 6},
+                {Short.class, Byte.class, (byte) 4, (short) 5, (short) 6},
+
+                {Byte.class, Float.class, 4f, (byte) 5, (byte) 6},
+                {Byte.class, Double.class, 4d, (byte) 5, (byte) 6},
+                {Byte.class, Integer.class, 4, (byte) 5, (byte) 6},
+                {Byte.class, Short.class, (short) 4, (byte) 5, (byte) 6},
+                {Byte.class, Byte.class, (byte) 4, (byte) 5, (byte) 6},
+        };
+        return Arrays.asList(data);
+    }
+
+    private final Object valueCheck;
+    private final Class<?> valueType;
+    private final Object valueA;
+    private final Object valueB;
+
+    public PrimitiveConversionErrorsTest(Class<?> valueType, Class<?> valueCheckType, Object valueCheck, Object valueA, Object valueB) {
+        this.valueCheck = valueCheck;
+        this.valueType = valueType;
+        this.valueA = valueA;
+        this.valueB = valueB;
+    }
+
+    @Test
+    public void withExecutableModel() throws IOException {
+
+        KieBase kbase = loadRules(this.valueType, this.valueCheck, true);
+
+        KieSession session = kbase.newKieSession();
+        List<Object> values = new ArrayList<>();
+        ClassWithValue ca = makeClassWithValue(this.valueA);
+        ClassWithValue cb = makeClassWithValue(this.valueB);
+
+        session.insert(values);
+        session.insert(ca);
+        session.insert(cb);
+
+        session.fireAllRules();
+
+        assertEquals(2, values.size());
+        assertTrue(values.contains(this.valueA));
+        assertTrue(values.contains(this.valueB));
+    }
+
+    @Test
+    public void withoutExecutableModel() throws IOException {
+
+        KieBase kbase = loadRules(this.valueType, this.valueCheck, false);
+
+        KieSession session = kbase.newKieSession();
+        List<Object> values = new ArrayList<>();
+        ClassWithValue ca = makeClassWithValue(this.valueA);
+        ClassWithValue cb = makeClassWithValue(this.valueB);
+
+        session.insert(values);
+        session.insert(ca);
+        session.insert(cb);
+
+        session.fireAllRules();
+
+        assertEquals(2, values.size());
+        assertTrue(values.contains(this.valueA));
+        assertTrue(values.contains(this.valueB));
+    }
+
+    private static KieBase loadRules(Class<?> valueType, Object value, boolean useExecutable) throws IOException {
+
+
+        KieServices services = KieServices.Factory.get();
+        KieFileSystem kfs = services.newKieFileSystem();
+
+        String drlString =
+                RULE_TEMPLATE
+                        .replace("<value_type>", valueType.getSimpleName())
+                        .replace("<test_value>", getValueString(value));
+
+        Resource drl = services.getResources().newByteArrayResource(drlString.getBytes());
+
+        kfs.write("src/main/resources/rules.drl", drl);
+
+        KieBuilder builder = services.newKieBuilder(kfs);
+
+        builder = useExecutable ?
+                builder.buildAll(ExecutableModelProject.class) :
+                builder.buildAll();
+
+        if (builder.getResults().hasMessages(Level.ERROR)) {
+            List<Message> errors = builder.getResults().getMessages(Level.ERROR);
+            StringBuilder sb = new StringBuilder("Errors:");
+            for (Message msg : errors) {
+                sb.append("\n  " + prettyBuildMessage(msg));
+            }
+
+            throw new RuntimeException(sb.toString());
+        }
+
+        KieContainer container = services.newKieContainer(
+                services.getRepository().getDefaultReleaseId());
+
+        return container.getKieBase();
+    }
+
+    private static String getValueString(Object value) {
+
+        if (value instanceof Float) {
+            return String.format("%.2ff", value);
+        } else if (value instanceof Double) {
+            return String.format("%.2f", value);
+        } else {
+            return value.toString();
+        }
+    }
+
+    private static String prettyBuildMessage(Message msg) {
+        return "Message: {"
+                + "id=" + msg.getId()
+                + ", level=" + msg.getLevel()
+                + ", path=" + msg.getPath()
+                + ", line=" + msg.getLine()
+                + ", column=" + msg.getColumn()
+                + ", text=\"" + msg.getText() + "\""
+                + "}";
+    }
+
+    private static ClassWithValue makeClassWithValue(Object value) {
+
+        ClassWithValue cwv = new ClassWithValue();
+
+        if (value instanceof Float) {
+            cwv.setValueFloat((float) value);
+        } else if (value instanceof Double) {
+            cwv.setValueDouble((double) value);
+        } else if (value instanceof Integer) {
+            cwv.setValueInteger((int) value);
+        } else if (value instanceof Short) {
+            cwv.setValueShort((short) value);
+        } else if (value instanceof Byte) {
+            cwv.setValueByte((byte) value);
+        }
+
+        return cwv;
+    }
+
+    public static class ClassWithValue {
+
+        private int valueInteger;
+        private double valueDouble;
+        private float valueFloat;
+        private short valueShort;
+        private byte valueByte;
+
+        public int getValueInteger() {
+            return valueInteger;
+        }
+
+        public void setValueInteger(int valueInt) {
+            this.valueInteger = valueInt;
+        }
+
+        public double getValueDouble() {
+            return valueDouble;
+        }
+
+        public void setValueDouble(double valueDouble) {
+            this.valueDouble = valueDouble;
+        }
+
+        public float getValueFloat() {
+            return valueFloat;
+        }
+
+        public void setValueFloat(float valueFloat) {
+            this.valueFloat = valueFloat;
+        }
+
+        public short getValueShort() {
+            return valueShort;
+        }
+
+        public void setValueShort(short valueShort) {
+            this.valueShort = valueShort;
+        }
+
+        public byte getValueByte() {
+            return valueByte;
+        }
+
+        public void setValueByte(byte valueByte) {
+            this.valueByte = valueByte;
+        }
+
+        @Override
+        public int hashCode() {
+            final int prime = 31;
+            int result = 1;
+            result = prime * result + valueByte;
+            long temp;
+            temp = Double.doubleToLongBits(valueDouble);
+            result = prime * result + (int) (temp ^ (temp >>> 32));
+            result = prime * result + Float.floatToIntBits(valueFloat);
+            result = prime * result + valueInteger;
+            result = prime * result + valueShort;
+            return result;
+        }
+
+        @Override
+        public boolean equals(Object obj) {
+			if (this == obj) {
+				return true;
+			}
+			if (obj == null) {
+				return false;
+			}
+			if (getClass() != obj.getClass()) {
+				return false;
+			}
+            ClassWithValue other = (ClassWithValue) obj;
+			if (valueByte != other.valueByte) {
+				return false;
+			}
+			if (Double.doubleToLongBits(valueDouble) != Double.doubleToLongBits(other.valueDouble)) {
+				return false;
+			}
+			if (Float.floatToIntBits(valueFloat) != Float.floatToIntBits(other.valueFloat)) {
+				return false;
+			}
+			if (valueInteger != other.valueInteger) {
+				return false;
+			}
+			if (valueShort != other.valueShort) {
+				return false;
+			}
+            return true;
+        }
+    }
+}


### PR DESCRIPTION
…me primitive types (#3923)

* Refactor to avoid duplicating indexedByLambda
* Use original type for binding after a coercion

Backport of https://github.com/kiegroup/drools/pull/3923/files on 7.x branch

**Thank you for submitting this pull request**

**NOTE!:** Double check the target branch for this PR.
The default is `main` so it will target Drools 8 / Kogito / Optaplanner 8.
If this PR is not strictly related to drools and kogito project in `drools.git`, it should probably target `7.x`as a branch

**Ports** If a forward-port or a backport is needed, paste the forward port PR here

[link](https://www.example.com)

**JIRA**: _(please edit the JIRA link if it exists)_

[link](https://www.example.com)

**referenced Pull Requests**: _(please edit the URLs of referenced pullrequests if they exist)_

* paste the link(s) from GitHub here
* link 2
* link 3 etc.

<details>
<summary>
How to retest this PR or trigger a specific build:
</summary>

* <b>a pull request</b> please add comment: <b>Jenkins retest this</b>

* <b>a full downstream build</b> please add comment: <b>Jenkins run fdb</b>

* <b>a compile downstream build</b> please  add comment: <b>Jenkins run cdb</b>

* <b>a full production downstream build</b> please add comment: <b>Jenkins execute product fdb</b>

* <b>an upstream build</b> please add comment: <b>Jenkins run upstream</b>
</details>
