### PR TITLE
fix backward incompatibility wrt old executable model bytecode

### DIFF
--- a/drools-model/drools-canonical-model/src/main/java/org/drools/model/functions/PredicateInformation.java
+++ b/drools-model/drools-canonical-model/src/main/java/org/drools/model/functions/PredicateInformation.java
@@ -40,6 +40,10 @@ public class PredicateInformation {
         addRuleNames(ruleNames);
     }
 
+    public PredicateInformation(String stringConstraint, String ruleName, String ruleFileName) {
+        this(stringConstraint, new String[]{ruleName, ruleFileName});
+    }
+
     public String getStringConstraint() {
         return stringConstraint;
     }


### PR DESCRIPTION
**Ports** 
[7.x backport](https://github.com/kiegroup/drools/pull/3946)

**referenced Pull Requests**:

* https://github.com/kiegroup/drools/pull/3880

<details>
<summary>
In PR #3880, the `PredicateInformation` constructor was generalized from 3 String parameters to 1+2n variadic parameters. Although this maintains source-compatibility with old executable models, it breaks bytecode compatibility, because now the constructor with 3 String parameters cannot be found anymore when loading a kjar compiled with an older Drools version.

To fix this problem, we simply add back the old constructor overload with 3 String parameters.

How to retest this PR or trigger a specific build:
</summary>

* <b>a pull request</b> please add comment: <b>Jenkins retest this</b>

* <b>a full downstream build</b> please add comment: <b>Jenkins run fdb</b>

* <b>a compile downstream build</b> please  add comment: <b>Jenkins run cdb</b>

* <b>a full production downstream build</b> please add comment: <b>Jenkins execute product fdb</b>

* <b>an upstream build</b> please add comment: <b>Jenkins run upstream</b>
</details>
