### PR TITLE
[DROOLS-6666] java.lang.ClassCastException: class com.github.javapars…

### DIFF
--- a/drools-model/drools-model-compiler/src/test/java/org/drools/modelcompiler/MvelDialectTest.java
+++ b/drools-model/drools-model-compiler/src/test/java/org/drools/modelcompiler/MvelDialectTest.java
@@ -17,6 +17,7 @@
 package org.drools.modelcompiler;
 
 import java.math.BigDecimal;
+import java.math.BigInteger;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
@@ -1447,5 +1448,68 @@ public class MvelDialectTest extends BaseModelTest {
         ksession.insert(person);
         ksession.fireAllRules();
         assertThat(result).containsExactly(1);
+    }
+
+    @Test
+    public void testMVELBigIntegerLiteralRHS() {
+        String str = "package com.example.reproducer\n" +
+                "import " + Person.class.getCanonicalName() + ";\n" +
+                "rule R\n" +
+                "dialect \"mvel\"\n" +
+                "when\n" +
+                "  $p : Person()\n" +
+                "then\n" +
+                "  $p.setAgeInSeconds(10000I);\n" +
+                "end";
+
+        KieSession ksession = getKieSession(str);
+
+        Person p = new Person();
+        ksession.insert(p);
+        ksession.fireAllRules();
+
+        assertTrue(p.getAgeInSeconds().equals(new BigInteger("10000")));
+    }
+
+    @Test
+    public void testMVELBigDecimalLiteralRHS() {
+        String str = "package com.example.reproducer\n" +
+                "import " + Person.class.getCanonicalName() + ";\n" +
+                "rule R\n" +
+                "dialect \"mvel\"\n" +
+                "when\n" +
+                "  $p : Person()\n" +
+                "then\n" +
+                "  $p.setMoney(10000B);\n" +
+                "end";
+
+        KieSession ksession = getKieSession(str);
+
+        Person p = new Person();
+        ksession.insert(p);
+        ksession.fireAllRules();
+
+        assertTrue(p.getMoney().equals(new BigDecimal("10000")));
+    }
+
+    @Test
+    public void testMVELBigIntegerLiteralLHS() {
+        String str = "package com.example.reproducer\n" +
+                "import " + Person.class.getCanonicalName() + ";\n" +
+                "rule R\n" +
+                "dialect \"mvel\"\n" +
+                "when\n" +
+                "  $p : Person(ageInSeconds == 10000I)\n" +
+                "then\n" +
+                "end";
+
+        KieSession ksession = getKieSession(str);
+
+        Person p = new Person();
+        p.setAgeInSeconds(new BigInteger("10000"));
+        ksession.insert(p);
+        int fired = ksession.fireAllRules();
+
+        assertEquals(1, fired);
     }
 }

--- a/drools-model/drools-mvel-compiler/src/main/java/org/drools/mvelcompiler/RHSPhase.java
+++ b/drools-model/drools-mvel-compiler/src/main/java/org/drools/mvelcompiler/RHSPhase.java
@@ -46,10 +46,12 @@ import com.github.javaparser.ast.stmt.ExpressionStmt;
 import org.drools.core.util.ClassUtils;
 import org.drools.core.util.MethodUtils.NullType;
 import org.drools.mvel.parser.ast.expr.BigDecimalLiteralExpr;
+import org.drools.mvel.parser.ast.expr.BigIntegerLiteralExpr;
 import org.drools.mvel.parser.ast.expr.DrlNameExpr;
 import org.drools.mvel.parser.ast.visitor.DrlGenericVisitor;
 import org.drools.mvelcompiler.ast.BigDecimalArithmeticExprT;
 import org.drools.mvelcompiler.ast.BigDecimalConvertedExprT;
+import org.drools.mvelcompiler.ast.BigIntegerConvertedExprT;
 import org.drools.mvelcompiler.ast.BinaryExprT;
 import org.drools.mvelcompiler.ast.CastExprT;
 import org.drools.mvelcompiler.ast.CharacterLiteralExpressionT;
@@ -339,6 +341,11 @@ public class RHSPhase implements DrlGenericVisitor<TypedExpression, RHSPhase.Con
     @Override
     public TypedExpression visit(BigDecimalLiteralExpr n, Context arg) {
         return new BigDecimalConvertedExprT(new StringLiteralExpressionT(new StringLiteralExpr(n.getValue())));
+    }
+
+    @Override
+    public TypedExpression visit(BigIntegerLiteralExpr n, Context arg) {
+        return new BigIntegerConvertedExprT(new StringLiteralExpressionT(new StringLiteralExpr(n.getValue())));
     }
 
     private Class<?> resolveType(com.github.javaparser.ast.type.Type type) {

--- a/drools-model/drools-mvel-compiler/src/main/java/org/drools/mvelcompiler/ast/BigIntegerConvertedExprT.java
+++ b/drools-model/drools-mvel-compiler/src/main/java/org/drools/mvelcompiler/ast/BigIntegerConvertedExprT.java
@@ -1,0 +1,58 @@
+/*
+ * Copyright 2021 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.drools.mvelcompiler.ast;
+
+import java.lang.reflect.Type;
+import java.math.BigInteger;
+import java.util.Optional;
+
+import com.github.javaparser.StaticJavaParser;
+import com.github.javaparser.ast.Node;
+import com.github.javaparser.ast.expr.Expression;
+import com.github.javaparser.ast.expr.ObjectCreationExpr;
+
+import static com.github.javaparser.ast.NodeList.nodeList;
+
+public class BigIntegerConvertedExprT implements TypedExpression {
+
+    private final TypedExpression value;
+    private final Type type = BigInteger.class;
+
+    public BigIntegerConvertedExprT(TypedExpression value) {
+        this.value = value;
+    }
+
+    @Override
+    public Optional<Type> getType() {
+        return Optional.of(type);
+    }
+
+    @Override
+    public Node toJavaExpression() {
+
+        return new ObjectCreationExpr(null,
+                                      StaticJavaParser.parseClassOrInterfaceType(type.getTypeName()),
+                                      nodeList((Expression) value.toJavaExpression()));
+    }
+
+    @Override
+    public String toString() {
+        return "BigIntegerConvertedExprT{" +
+                "value=" + value +
+                '}';
+    }
+}

--- a/drools-model/drools-mvel-compiler/src/test/java/org/drools/mvelcompiler/MvelCompilerTest.java
+++ b/drools-model/drools-mvel-compiler/src/test/java/org/drools/mvelcompiler/MvelCompilerTest.java
@@ -407,6 +407,15 @@ public class MvelCompilerTest implements CompilerTest {
     }
 
     @Test
+    public void testSetterBigIntegerLiteral() {
+        test(ctx -> {
+                 ctx.addDeclaration("$p", Person.class);
+             },
+             "{ $p.ageAsInteger = 10000I; }",
+             "{ $p.setAgeAsInteger(new java.math.BigInteger(\"10000\")); }");
+    }
+
+    @Test
     public void testSetterPublicField() {
         test(ctx -> ctx.addDeclaration("$p", Person.class),
              "{ $p.nickName = \"Luca\"; } ",

--- a/drools-model/drools-mvel-parser/src/main/java/org/drools/mvel/parser/ast/expr/BigIntegerLiteralExpr.java
+++ b/drools-model/drools-mvel-parser/src/main/java/org/drools/mvel/parser/ast/expr/BigIntegerLiteralExpr.java
@@ -62,18 +62,19 @@ public final class BigIntegerLiteralExpr extends LiteralStringValueExpr {
 
     @Override
     public <R, A> R accept(GenericVisitor<R, A> v, A arg) {
-        return ((DrlGenericVisitor<R, A>)v).visit(this, arg);
+        return ((DrlGenericVisitor<R, A>) v).visit(this, arg);
     }
 
     @Override
     public <A> void accept(VoidVisitor<A> v, A arg) {
-        ((DrlVoidVisitor<A>)v).visit(this, arg);
+        ((DrlVoidVisitor<A>) v).visit(this, arg);
     }
 
     @Override
     public boolean remove(Node node) {
-        if (node == null)
+        if (node == null) {
             return false;
+        }
         return super.remove(node);
     }
 
@@ -81,12 +82,17 @@ public final class BigIntegerLiteralExpr extends LiteralStringValueExpr {
      * @return the literal value as an long while respecting different number representations
      */
     public BigInteger asBigInteger() {
+        return new BigInteger(getValue());
+    }
+
+    @Override
+    public String getValue() {
         String result = value.replaceAll("_", "");
         char lastChar = result.charAt(result.length() - 1);
         if (lastChar == 'I') {
             result = result.substring(0, result.length() - 1);
         }
-        return new BigInteger(result);
+        return result;
     }
 
     public BigIntegerLiteralExpr setLong(long value) {


### PR DESCRIPTION
…er.ast.visitor.CloneVisitor cannot be cast to class org.drools.mvel.parser.ast.visitor.DrlGenericVisitor in exec-model with BigInteger literal RHS (#3919)

**Ports** 
This is a forward-port PR of https://github.com/kiegroup/drools/pull/3919

**JIRA**: 

https://issues.redhat.com/browse/DROOLS-6666

<details>
<summary>
How to retest this PR or trigger a specific build:
</summary>

* <b>a pull request</b> please add comment: <b>Jenkins retest this</b>

* <b>a full downstream build</b> please add comment: <b>Jenkins run fdb</b>

* <b>a compile downstream build</b> please  add comment: <b>Jenkins run cdb</b>

* <b>a full production downstream build</b> please add comment: <b>Jenkins execute product fdb</b>

* <b>an upstream build</b> please add comment: <b>Jenkins run upstream</b>
</details>
