### PR TITLE
[DROOLS-6680] flag for removal from the working memory a modified eve…

### DIFF
--- a/drools-core/src/main/java/org/drools/core/common/NamedEntryPoint.java
+++ b/drools-core/src/main/java/org/drools/core/common/NamedEntryPoint.java
@@ -351,6 +351,11 @@ public class NamedEntryPoint
                     throw new IllegalArgumentException("Invalid Entry Point. You updated the FactHandle on entry point '" + handle.getEntryPointId() + "' instead of '" + getEntryPointId() + "'");
                 }
 
+                if (handle.isExpired()) {
+                    // let an expired event potentially (re)enters the objectStore, but make sure that it will be clear at the end of the inference cycle
+                    ((EventFactHandle)handle).setPendingRemoveFromStore(true);
+                }
+
                 final ObjectTypeConf typeConf = changedObject ?
                         getObjectTypeConfigurationRegistry().getOrCreateObjectTypeConf(this.entryPoint, object) :
                         getObjectTypeConfigurationRegistry().getObjectTypeConf(object);


### PR DESCRIPTION
…nt that is already expired (#3942)

(cherry picked from commit ce5a8702180c2ce93d2151bbc9fa68d5fe99cafb)

**Thank you for submitting this pull request**

**NOTE!:** Double check the target branch for this PR.
The default is `main` so it will target Drools 8 / Kogito / Optaplanner 8.
If this PR is not strictly related to drools and kogito project in `drools.git`, it should probably target `7.x`as a branch

**Ports** If a forward-port or a backport is needed, paste the forward port PR here

[link](https://www.example.com)

**JIRA**: _(please edit the JIRA link if it exists)_

[link](https://www.example.com)

**referenced Pull Requests**: _(please edit the URLs of referenced pullrequests if they exist)_

* paste the link(s) from GitHub here
* link 2
* link 3 etc.

<details>
<summary>
How to retest this PR or trigger a specific build:
</summary>

* <b>a pull request</b> please add comment: <b>Jenkins retest this</b>

* <b>a full downstream build</b> please add comment: <b>Jenkins run fdb</b>

* <b>a compile downstream build</b> please  add comment: <b>Jenkins run cdb</b>

* <b>a full production downstream build</b> please add comment: <b>Jenkins execute product fdb</b>

* <b>an upstream build</b> please add comment: <b>Jenkins run upstream</b>
</details>
