### PR TITLE
[7.x] [DROOLS-6697] Add information about input file in case of decision table compilation error

### DIFF
--- a/drools-decisiontables/src/main/java/org/drools/decisiontable/DecisionTableProviderImpl.java
+++ b/drools-decisiontables/src/main/java/org/drools/decisiontable/DecisionTableProviderImpl.java
@@ -18,11 +18,13 @@ package org.drools.decisiontable;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.Reader;
+import java.io.UncheckedIOException;
 import java.util.ArrayList;
 import java.util.List;
 
 import org.drools.compiler.compiler.DecisionTableProvider;
 import org.drools.core.util.StringUtils;
+import org.drools.template.parser.DecisionTableParseException;
 import org.kie.api.io.Resource;
 import org.kie.internal.builder.DecisionTableConfiguration;
 import org.kie.internal.builder.RuleTemplateConfiguration;
@@ -35,16 +37,20 @@ public class DecisionTableProviderImpl
 
     private static final transient Logger logger = LoggerFactory.getLogger( DecisionTableProviderImpl.class );
 
+    @Override
     public String loadFromResource(Resource resource,
                                    DecisionTableConfiguration configuration) {
 
         try {
             return compileResource( resource, configuration );
         } catch (IOException e) {
-            throw new RuntimeException( e );
+            throw new UncheckedIOException( e );
+        } catch (Exception e) {
+            throw new DecisionTableParseException(resource, e);
         }
     }
 
+    @Override
     public List<String> loadFromInputStreamWithTemplates(Resource resource,
                                                          DecisionTableConfiguration configuration) {
         List<String> drls = new ArrayList<String>( configuration.getRuleTemplateConfigurations().size() );
@@ -58,6 +64,8 @@ public class DecisionTableProviderImpl
                                            template.getCol()));
             } catch (IOException e) {
                 logger.error( "Cannot open " + template.getTemplate(), e );
+            } catch (Exception e) {
+                throw new DecisionTableParseException(resource, e);
             }
         }
         return drls;

--- a/drools-decisiontables/src/test/java/org/drools/decisiontable/EmptyHeaderTest.java
+++ b/drools-decisiontables/src/test/java/org/drools/decisiontable/EmptyHeaderTest.java
@@ -29,14 +29,18 @@ public class EmptyHeaderTest {
 
     @Test(expected = DecisionTableParseException.class)
 	public void testEmptyConditionInXLS() {
-		DecisionTableConfiguration dtconf = KnowledgeBuilderFactory
-				.newDecisionTableConfiguration();
-		dtconf.setInputType(DecisionTableInputType.XLS);
-		KnowledgeBuilder kbuilder = KnowledgeBuilderFactory
-				.newKnowledgeBuilder();
-        kbuilder.add(ResourceFactory.newClassPathResource(
-                "emptyCondition.xls", getClass()), ResourceType.DTABLE,
-                dtconf);
+		try {
+			DecisionTableConfiguration dtconf = KnowledgeBuilderFactory
+					.newDecisionTableConfiguration();
+			dtconf.setInputType(DecisionTableInputType.XLS);
+			KnowledgeBuilder kbuilder = KnowledgeBuilderFactory
+					.newKnowledgeBuilder();
+			kbuilder.add(ResourceFactory.newClassPathResource(
+							"emptyCondition.xls", getClass()), ResourceType.DTABLE,
+					dtconf);
+		} catch (Exception e) {
+			throw e;
+		}
 	}
 
 	@Test(expected = DecisionTableParseException.class)

--- a/drools-decisiontables/src/test/java/org/drools/decisiontable/EmptyHeaderTest.java
+++ b/drools-decisiontables/src/test/java/org/drools/decisiontable/EmptyHeaderTest.java
@@ -29,18 +29,14 @@ public class EmptyHeaderTest {
 
     @Test(expected = DecisionTableParseException.class)
 	public void testEmptyConditionInXLS() {
-		try {
-			DecisionTableConfiguration dtconf = KnowledgeBuilderFactory
-					.newDecisionTableConfiguration();
-			dtconf.setInputType(DecisionTableInputType.XLS);
-			KnowledgeBuilder kbuilder = KnowledgeBuilderFactory
-					.newKnowledgeBuilder();
-			kbuilder.add(ResourceFactory.newClassPathResource(
-							"emptyCondition.xls", getClass()), ResourceType.DTABLE,
-					dtconf);
-		} catch (Exception e) {
-			throw e;
-		}
+		DecisionTableConfiguration dtconf = KnowledgeBuilderFactory
+				.newDecisionTableConfiguration();
+		dtconf.setInputType(DecisionTableInputType.XLS);
+		KnowledgeBuilder kbuilder = KnowledgeBuilderFactory
+				.newKnowledgeBuilder();
+        kbuilder.add(ResourceFactory.newClassPathResource(
+                "emptyCondition.xls", getClass()), ResourceType.DTABLE,
+                dtconf);
 	}
 
 	@Test(expected = DecisionTableParseException.class)

--- a/drools-templates/src/main/java/org/drools/template/parser/DecisionTableParseException.java
+++ b/drools-templates/src/main/java/org/drools/template/parser/DecisionTableParseException.java
@@ -16,9 +16,15 @@
 
 package org.drools.template.parser;
 
+import org.kie.api.io.Resource;
+
 public class DecisionTableParseException extends RuntimeException {
 
     private static final long serialVersionUID = 510l;
+
+    public DecisionTableParseException(final Resource resource, final Throwable cause) {
+        super(String.format("[%s] %s", resource.getSourcePath(), cause.getMessage()), cause);
+    }
 
     public DecisionTableParseException(final String message) {
         super(message);


### PR DESCRIPTION
Backport of https://github.com/kiegroup/drools/pull/3982

**Thank you for submitting this pull request**

**NOTE!:** Double check the target branch for this PR.
The default is `main` so it will target Drools 8 / Kogito / Optaplanner 8.
If this PR is not strictly related to drools and kogito project in `drools.git`, it should probably target `7.x`as a branch

**Ports** If a forward-port or a backport is needed, paste the forward port PR here

[link](https://www.example.com)

**JIRA**: _(please edit the JIRA link if it exists)_

[link](https://www.example.com)

**referenced Pull Requests**: _(please edit the URLs of referenced pullrequests if they exist)_

* paste the link(s) from GitHub here
* link 2
* link 3 etc.

<details>
<summary>
How to retest this PR or trigger a specific build:
</summary>

* <b>a pull request</b> please add comment: <b>Jenkins retest this</b>

* <b>a full downstream build</b> please add comment: <b>Jenkins run fdb</b>

* <b>a compile downstream build</b> please  add comment: <b>Jenkins run cdb</b>

* <b>a full production downstream build</b> please add comment: <b>Jenkins execute product fdb</b>

* <b>an upstream build</b> please add comment: <b>Jenkins run upstream</b>
</details>
