### PR TITLE
[KOGITO-6075] allow to use windows with oopath constraints

### DIFF
--- a/drools-compiler/src/main/java/org/drools/compiler/lang/DRL6Parser.java
+++ b/drools-compiler/src/main/java/org/drools/compiler/lang/DRL6Parser.java
@@ -3306,7 +3306,7 @@ public class DRL6Parser extends AbstractDRLParser implements DRLParser {
     }
 
     /**
-     * lhsPattern := xpathPrimary |
+     * lhsPattern := xpathPrimary (OVER patternFilter)? |
      *               ( QUESTION? qualifiedIdentifier
      *                 LEFT_PAREN positionalConstraints? constraints? RIGHT_PAREN
      *                 (OVER patternFilter)? (FROM patternSource)? )
@@ -3329,6 +3329,9 @@ public class DRL6Parser extends AbstractDRLParser implements DRLParser {
             pattern.constraint(expr);
             if ( label != null ) {
                 pattern.id(label, isUnification);
+            }
+            if (helper.validateIdentifierKey(DroolsSoftKeywords.OVER)) {
+                patternFilter(pattern);
             }
             return;
         }
@@ -3389,7 +3392,6 @@ public class DRL6Parser extends AbstractDRLParser implements DRLParser {
         }
 
         if (helper.validateIdentifierKey(DroolsSoftKeywords.OVER)) {
-            //           || input.LA( 1 ) == DRL6Lexer.PIPE ) {
             patternFilter(pattern);
         }
 


### PR DESCRIPTION
**Thank you for submitting this pull request**

**NOTE!:** Double check the target branch for this PR.
The default is `main` so it will target Drools 8 / Kogito / Optaplanner 8.
If this PR is not strictly related to drools and kogito project in `drools.git`, it should probably target `7.x`as a branch

**Ports** If a forward-port or a backport is needed, paste the forward port PR here

[link](https://www.example.com)

**JIRA**: https://issues.redhat.com/browse/KOGITO-6075

