### PR TITLE
[RHDM-1837] fix concurrency tests for mvel dialect

### DIFF
--- a/drools-mvel/src/main/java/org/drools/mvel/expr/MvelEvaluator.java
+++ b/drools-mvel/src/main/java/org/drools/mvel/expr/MvelEvaluator.java
@@ -35,7 +35,7 @@ public class MvelEvaluator<T> {
 
     private static final EvaluatorType DEFAULT_EVALUATOR_TYPE = EvaluatorType.THREAD_UNSAFE;
 
-    private static final EvaluatorType EVALUATOR_TYPE = EvaluatorType.decode( System.getProperty(THREAD_SAFETY_PROPERTY, DEFAULT_EVALUATOR_TYPE.id) );
+    private static EvaluatorType EVALUATOR_TYPE = EvaluatorType.decode( System.getProperty(THREAD_SAFETY_PROPERTY, DEFAULT_EVALUATOR_TYPE.id) );
 
     private static final Logger logger = LoggerFactory.getLogger(MvelEvaluator.class);
 
@@ -81,6 +81,14 @@ public class MvelEvaluator<T> {
             }
             throw new UnsupportedOperationException("Unknown evaluator type: " + id);
         }
+    }
+
+    // only for testing purposes
+    public static void setEvaluatorType(EvaluatorType evaluatorType) {
+        EVALUATOR_TYPE = evaluatorType;
+    }
+    public static void resetEvaluatorType() {
+        EVALUATOR_TYPE = DEFAULT_EVALUATOR_TYPE;
     }
 
     private MvelEvaluator(Serializable expr) {


### PR DESCRIPTION
**Thank you for submitting this pull request**

**NOTE!:** Double check the target branch for this PR.
The default is `main` so it will target Drools 8 / Kogito / Optaplanner 8.
If this PR is not strictly related to drools and kogito project in `drools.git`, it should probably target `7.x`as a branch

**Ports** If a forward-port or a backport is needed, paste the forward port PR here

[link](https://www.example.com)

**JIRA**: https://issues.redhat.com/browse/RHDM-1837
