### PR TITLE
BXMSPROD-1511 - remove Sonarcloud analysis skip from retediagram module

### DIFF
--- a/drools-retediagram/pom.xml
+++ b/drools-retediagram/pom.xml
@@ -18,8 +18,6 @@
 
   <properties>
     <java.module.name>org.drools.retediagram</java.module.name>
-    <sonar.exclusions>**/*</sonar.exclusions>
-    <sonar.skip>true</sonar.skip>
   </properties>
 
   <dependencies>


### PR DESCRIPTION
Signed-off-by: Alberto Morales Perez <almorale@redhat.com>

**JIRA**:

[BXMSPROD-1511](https://issues.redhat.com/browse/BXMSPROD-1511)

Skipping the last module Sonarcloud analysis in a Maven multimodule project results on, after deferring the analysis to the last module, ignoring the whole project analysis. We need to remove the `sonar.skip` on the `retediagram` module to enable the analysis again.