### PR TITLE
Revert "[main] Update version to 8.15.0-SNAPSHOT"

### DIFF
--- a/bom/drools-bom/pom.xml
+++ b/bom/drools-bom/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.kie</groupId>
     <artifactId>kie-core-bom</artifactId>
-    <version>8.15.0-SNAPSHOT</version>
+    <version>8.14.0-SNAPSHOT</version>
     <relativePath>../kie-core-bom/pom.xml</relativePath>
   </parent>
 

--- a/bom/kie-core-bom/pom.xml
+++ b/bom/kie-core-bom/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.kie</groupId>
     <artifactId>drools-parent</artifactId>
-    <version>8.15.0-SNAPSHOT</version>
+    <version>8.14.0-SNAPSHOT</version>
     <relativePath>../../pom.xml</relativePath>
   </parent>
 

--- a/bom/kie-dmn-bom/pom.xml
+++ b/bom/kie-dmn-bom/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.kie</groupId>
     <artifactId>kie-core-bom</artifactId>
-    <version>8.15.0-SNAPSHOT</version>
+    <version>8.14.0-SNAPSHOT</version>
     <relativePath>../kie-core-bom/pom.xml</relativePath>
   </parent>
 

--- a/bom/kie-pmml-bom/pom.xml
+++ b/bom/kie-pmml-bom/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.kie</groupId>
     <artifactId>kie-core-bom</artifactId>
-    <version>8.15.0-SNAPSHOT</version>
+    <version>8.14.0-SNAPSHOT</version>
     <relativePath>../kie-core-bom/pom.xml</relativePath>
   </parent>
 

--- a/bom/pom.xml
+++ b/bom/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>drools-parent</artifactId>
         <groupId>org.kie</groupId>
-        <version>8.15.0-SNAPSHOT</version>
+        <version>8.14.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/build-parent/pom.xml
+++ b/build-parent/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>drools-parent</artifactId>
         <groupId>org.kie</groupId>
-        <version>8.15.0-SNAPSHOT</version>
+        <version>8.14.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/drools-alphanetwork-compiler/pom.xml
+++ b/drools-alphanetwork-compiler/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.kie</groupId>
     <artifactId>drools-build-parent</artifactId>
-    <version>8.15.0-SNAPSHOT</version>
+    <version>8.14.0-SNAPSHOT</version>
     <relativePath>../build-parent/pom.xml</relativePath>
   </parent>
 

--- a/drools-beliefs/pom.xml
+++ b/drools-beliefs/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.kie</groupId>
     <artifactId>drools-build-parent</artifactId>
-    <version>8.15.0-SNAPSHOT</version>
+    <version>8.14.0-SNAPSHOT</version>
     <relativePath>../build-parent/pom.xml</relativePath>
   </parent>
 

--- a/drools-cdi/pom.xml
+++ b/drools-cdi/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.kie</groupId>
     <artifactId>drools-build-parent</artifactId>
-    <version>8.15.0-SNAPSHOT</version>
+    <version>8.14.0-SNAPSHOT</version>
     <relativePath>../build-parent/pom.xml</relativePath>
   </parent>
 

--- a/drools-compiler/pom.xml
+++ b/drools-compiler/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.kie</groupId>
     <artifactId>drools-build-parent</artifactId>
-    <version>8.15.0-SNAPSHOT</version>
+    <version>8.14.0-SNAPSHOT</version>
     <relativePath>../build-parent/pom.xml</relativePath>
   </parent>
 

--- a/drools-core-dynamic/pom.xml
+++ b/drools-core-dynamic/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.kie</groupId>
     <artifactId>drools-build-parent</artifactId>
-    <version>8.15.0-SNAPSHOT</version>
+    <version>8.14.0-SNAPSHOT</version>
     <relativePath>../build-parent/pom.xml</relativePath>
   </parent>
 

--- a/drools-core-reflective/pom.xml
+++ b/drools-core-reflective/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>org.kie</groupId>
         <artifactId>drools-build-parent</artifactId>
-        <version>8.15.0-SNAPSHOT</version>
+        <version>8.14.0-SNAPSHOT</version>
         <relativePath>../build-parent/pom.xml</relativePath>
     </parent>
 

--- a/drools-core/pom.xml
+++ b/drools-core/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.kie</groupId>
     <artifactId>drools-build-parent</artifactId>
-    <version>8.15.0-SNAPSHOT</version>
+    <version>8.14.0-SNAPSHOT</version>
     <relativePath>../build-parent/pom.xml</relativePath>
   </parent>
 

--- a/drools-decisiontables/pom.xml
+++ b/drools-decisiontables/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.kie</groupId>
     <artifactId>drools-build-parent</artifactId>
-    <version>8.15.0-SNAPSHOT</version>
+    <version>8.14.0-SNAPSHOT</version>
     <relativePath>../build-parent/pom.xml</relativePath>
   </parent>
 

--- a/drools-distribution/pom.xml
+++ b/drools-distribution/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.kie</groupId>
     <artifactId>drools-build-parent</artifactId>
-    <version>8.15.0-SNAPSHOT</version>
+    <version>8.14.0-SNAPSHOT</version>
     <relativePath>../build-parent/pom.xml</relativePath>
   </parent>
 

--- a/drools-ecj/pom.xml
+++ b/drools-ecj/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>org.kie</groupId>
         <artifactId>drools-build-parent</artifactId>
-        <version>8.15.0-SNAPSHOT</version>
+        <version>8.14.0-SNAPSHOT</version>
         <relativePath>../build-parent/pom.xml</relativePath>
     </parent>
 

--- a/drools-engine-classic/pom.xml
+++ b/drools-engine-classic/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.kie</groupId>
     <artifactId>drools-build-parent</artifactId>
-    <version>8.15.0-SNAPSHOT</version>
+    <version>8.14.0-SNAPSHOT</version>
     <relativePath>../build-parent/pom.xml</relativePath>
   </parent>
 

--- a/drools-engine/pom.xml
+++ b/drools-engine/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.kie</groupId>
     <artifactId>drools-build-parent</artifactId>
-    <version>8.15.0-SNAPSHOT</version>
+    <version>8.14.0-SNAPSHOT</version>
     <relativePath>../build-parent/pom.xml</relativePath>
   </parent>
 

--- a/drools-examples-api/default-kiesession-from-file/pom.xml
+++ b/drools-examples-api/default-kiesession-from-file/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.drools</groupId>
     <artifactId>drools-examples-api</artifactId>
-    <version>8.15.0-SNAPSHOT</version>
+    <version>8.14.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>default-kiesession-from-file</artifactId>

--- a/drools-examples-api/default-kiesession/pom.xml
+++ b/drools-examples-api/default-kiesession/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.drools</groupId>
     <artifactId>drools-examples-api</artifactId>
-    <version>8.15.0-SNAPSHOT</version>
+    <version>8.14.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>default-kiesession</artifactId>

--- a/drools-examples-api/kie-module-from-multiple-files/pom.xml
+++ b/drools-examples-api/kie-module-from-multiple-files/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.drools</groupId>
     <artifactId>drools-examples-api</artifactId>
-    <version>8.15.0-SNAPSHOT</version>
+    <version>8.14.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>kie-module-from-multiple-files</artifactId>

--- a/drools-examples-api/kiebase-inclusion/pom.xml
+++ b/drools-examples-api/kiebase-inclusion/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.drools</groupId>
     <artifactId>drools-examples-api</artifactId>
-    <version>8.15.0-SNAPSHOT</version>
+    <version>8.14.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>kiebase-inclusion</artifactId>

--- a/drools-examples-api/kiecontainer-from-kierepo/pom.xml
+++ b/drools-examples-api/kiecontainer-from-kierepo/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.drools</groupId>
     <artifactId>drools-examples-api</artifactId>
-    <version>8.15.0-SNAPSHOT</version>
+    <version>8.14.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>kiecontainer-from-kierepo</artifactId>

--- a/drools-examples-api/kiefilesystem-example/pom.xml
+++ b/drools-examples-api/kiefilesystem-example/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.drools</groupId>
     <artifactId>drools-examples-api</artifactId>
-    <version>8.15.0-SNAPSHOT</version>
+    <version>8.14.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>kiefilesystem-example</artifactId>

--- a/drools-examples-api/kiemodulemodel-example/pom.xml
+++ b/drools-examples-api/kiemodulemodel-example/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.drools</groupId>
     <artifactId>drools-examples-api</artifactId>
-    <version>8.15.0-SNAPSHOT</version>
+    <version>8.14.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>kiemodulemodel-example</artifactId>

--- a/drools-examples-api/multiple-kbases/pom.xml
+++ b/drools-examples-api/multiple-kbases/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.drools</groupId>
     <artifactId>drools-examples-api</artifactId>
-    <version>8.15.0-SNAPSHOT</version>
+    <version>8.14.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>multiple-kbases</artifactId>

--- a/drools-examples-api/named-kiesession-from-file/pom.xml
+++ b/drools-examples-api/named-kiesession-from-file/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.drools</groupId>
     <artifactId>drools-examples-api</artifactId>
-    <version>8.15.0-SNAPSHOT</version>
+    <version>8.14.0-SNAPSHOT</version>
   </parent>
 
   <name>Drools :: API examples :: Named KieSession from File</name>

--- a/drools-examples-api/named-kiesession/pom.xml
+++ b/drools-examples-api/named-kiesession/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.drools</groupId>
     <artifactId>drools-examples-api</artifactId>
-    <version>8.15.0-SNAPSHOT</version>
+    <version>8.14.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>named-kiesession</artifactId>

--- a/drools-examples-api/pom.xml
+++ b/drools-examples-api/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.kie</groupId>
     <artifactId>drools-build-parent</artifactId>
-    <version>8.15.0-SNAPSHOT</version>
+    <version>8.14.0-SNAPSHOT</version>
     <relativePath>../build-parent/pom.xml</relativePath>
   </parent>
 

--- a/drools-examples-api/reactive-kiesession/pom.xml
+++ b/drools-examples-api/reactive-kiesession/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.drools</groupId>
     <artifactId>drools-examples-api</artifactId>
-    <version>8.15.0-SNAPSHOT</version>
+    <version>8.14.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>reactive-kiesession</artifactId>

--- a/drools-examples-cdi/cdi-example-scopes/pom.xml
+++ b/drools-examples-cdi/cdi-example-scopes/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.drools</groupId>
     <artifactId>drools-examples-cdi</artifactId>
-    <version>8.15.0-SNAPSHOT</version>
+    <version>8.14.0-SNAPSHOT</version>
   </parent>
   <artifactId>cdi-example-scopes</artifactId>
 

--- a/drools-examples-cdi/cdi-example-with-inclusion/pom.xml
+++ b/drools-examples-cdi/cdi-example-with-inclusion/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.drools</groupId>
     <artifactId>drools-examples-cdi</artifactId>
-    <version>8.15.0-SNAPSHOT</version>
+    <version>8.14.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>cdi-example-with-inclusion</artifactId>

--- a/drools-examples-cdi/cdi-example/pom.xml
+++ b/drools-examples-cdi/cdi-example/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.drools</groupId>
     <artifactId>drools-examples-cdi</artifactId>
-    <version>8.15.0-SNAPSHOT</version>
+    <version>8.14.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>cdi-example</artifactId>

--- a/drools-examples-cdi/pom.xml
+++ b/drools-examples-cdi/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.kie</groupId>
     <artifactId>drools-build-parent</artifactId>
-    <version>8.15.0-SNAPSHOT</version>
+    <version>8.14.0-SNAPSHOT</version>
     <relativePath>../build-parent/pom.xml</relativePath>
   </parent>
 

--- a/drools-examples/pom.xml
+++ b/drools-examples/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.kie</groupId>
     <artifactId>drools-build-parent</artifactId>
-    <version>8.15.0-SNAPSHOT</version>
+    <version>8.14.0-SNAPSHOT</version>
     <relativePath>../build-parent/pom.xml</relativePath>
   </parent>
 

--- a/drools-impact-analysis/drools-impact-analysis-graph/drools-impact-analysis-graph-common/pom.xml
+++ b/drools-impact-analysis/drools-impact-analysis-graph/drools-impact-analysis-graph-common/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <artifactId>drools-impact-analysis-graph</artifactId>
     <groupId>org.drools</groupId>
-    <version>8.15.0-SNAPSHOT</version>
+    <version>8.14.0-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/drools-impact-analysis/drools-impact-analysis-graph/drools-impact-analysis-graph-graphviz/pom.xml
+++ b/drools-impact-analysis/drools-impact-analysis-graph/drools-impact-analysis-graph-graphviz/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <artifactId>drools-impact-analysis-graph</artifactId>
     <groupId>org.drools</groupId>
-    <version>8.15.0-SNAPSHOT</version>
+    <version>8.14.0-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/drools-impact-analysis/drools-impact-analysis-graph/pom.xml
+++ b/drools-impact-analysis/drools-impact-analysis-graph/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <artifactId>drools-impact-analysis</artifactId>
     <groupId>org.drools</groupId>
-    <version>8.15.0-SNAPSHOT</version>
+    <version>8.14.0-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/drools-impact-analysis/drools-impact-analysis-itests/pom.xml
+++ b/drools-impact-analysis/drools-impact-analysis-itests/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <artifactId>drools-impact-analysis</artifactId>
     <groupId>org.drools</groupId>
-    <version>8.15.0-SNAPSHOT</version>
+    <version>8.14.0-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/drools-impact-analysis/drools-impact-analysis-model/pom.xml
+++ b/drools-impact-analysis/drools-impact-analysis-model/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <artifactId>drools-impact-analysis</artifactId>
     <groupId>org.drools</groupId>
-    <version>8.15.0-SNAPSHOT</version>
+    <version>8.14.0-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/drools-impact-analysis/drools-impact-analysis-parser/pom.xml
+++ b/drools-impact-analysis/drools-impact-analysis-parser/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <artifactId>drools-impact-analysis</artifactId>
     <groupId>org.drools</groupId>
-    <version>8.15.0-SNAPSHOT</version>
+    <version>8.14.0-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/drools-impact-analysis/pom.xml
+++ b/drools-impact-analysis/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.kie</groupId>
     <artifactId>drools-build-parent</artifactId>
-    <version>8.15.0-SNAPSHOT</version>
+    <version>8.14.0-SNAPSHOT</version>
     <relativePath>../build-parent/pom.xml</relativePath>
   </parent>
 

--- a/drools-legacy-test-util/pom.xml
+++ b/drools-legacy-test-util/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>org.kie</groupId>
         <artifactId>drools-build-parent</artifactId>
-        <version>8.15.0-SNAPSHOT</version>
+        <version>8.14.0-SNAPSHOT</version>
         <relativePath>../build-parent/pom.xml</relativePath>
     </parent>
 

--- a/drools-metric/pom.xml
+++ b/drools-metric/pom.xml
@@ -7,7 +7,7 @@
   <parent>
     <groupId>org.kie</groupId>
     <artifactId>drools-build-parent</artifactId>
-    <version>8.15.0-SNAPSHOT</version>
+    <version>8.14.0-SNAPSHOT</version>
     <relativePath>../build-parent/pom.xml</relativePath>
   </parent>
 

--- a/drools-model/drools-canonical-model/pom.xml
+++ b/drools-model/drools-canonical-model/pom.xml
@@ -7,7 +7,7 @@
   <parent>
     <groupId>org.drools</groupId>
     <artifactId>drools-model</artifactId>
-    <version>8.15.0-SNAPSHOT</version>
+    <version>8.14.0-SNAPSHOT</version>
   </parent>
 
   <name>Drools :: Canonical Model</name>

--- a/drools-model/drools-model-compiler/pom.xml
+++ b/drools-model/drools-model-compiler/pom.xml
@@ -7,7 +7,7 @@
   <parent>
     <groupId>org.drools</groupId>
     <artifactId>drools-model</artifactId>
-    <version>8.15.0-SNAPSHOT</version>
+    <version>8.14.0-SNAPSHOT</version>
   </parent>
 
   <name>Drools :: Model :: Compiler</name>

--- a/drools-model/drools-mvel-compiler/pom.xml
+++ b/drools-model/drools-mvel-compiler/pom.xml
@@ -7,7 +7,7 @@
   <parent>
     <groupId>org.drools</groupId>
     <artifactId>drools-model</artifactId>
-    <version>8.15.0-SNAPSHOT</version>
+    <version>8.14.0-SNAPSHOT</version>
   </parent>
 
   <name>Drools :: MVEL Compiler</name>

--- a/drools-model/drools-mvel-parser/pom.xml
+++ b/drools-model/drools-mvel-parser/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.drools</groupId>
     <artifactId>drools-model</artifactId>
-    <version>8.15.0-SNAPSHOT</version>
+    <version>8.14.0-SNAPSHOT</version>
   </parent>
 
   <name>Drools :: MVEL Parser</name>

--- a/drools-model/pom.xml
+++ b/drools-model/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.kie</groupId>
     <artifactId>drools-build-parent</artifactId>
-    <version>8.15.0-SNAPSHOT</version>
+    <version>8.14.0-SNAPSHOT</version>
     <relativePath>../build-parent/pom.xml</relativePath>
   </parent>
 

--- a/drools-mvel/pom.xml
+++ b/drools-mvel/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>org.kie</groupId>
         <artifactId>drools-build-parent</artifactId>
-        <version>8.15.0-SNAPSHOT</version>
+        <version>8.14.0-SNAPSHOT</version>
         <relativePath>../build-parent/pom.xml</relativePath>
     </parent>
 

--- a/drools-persistence/drools-persistence-api/pom.xml
+++ b/drools-persistence/drools-persistence-api/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.drools</groupId>
     <artifactId>drools-persistence</artifactId>
-    <version>8.15.0-SNAPSHOT</version>
+    <version>8.14.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>drools-persistence-api</artifactId>

--- a/drools-persistence/drools-persistence-jpa/pom.xml
+++ b/drools-persistence/drools-persistence-jpa/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.drools</groupId>
     <artifactId>drools-persistence</artifactId>
-    <version>8.15.0-SNAPSHOT</version>
+    <version>8.14.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>drools-persistence-jpa</artifactId>

--- a/drools-persistence/pom.xml
+++ b/drools-persistence/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.kie</groupId>
     <artifactId>drools-build-parent</artifactId>
-    <version>8.15.0-SNAPSHOT</version>
+    <version>8.14.0-SNAPSHOT</version>
     <relativePath>../build-parent/pom.xml</relativePath>
   </parent>
 

--- a/drools-retediagram/pom.xml
+++ b/drools-retediagram/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.kie</groupId>
     <artifactId>drools-build-parent</artifactId>
-    <version>8.15.0-SNAPSHOT</version>
+    <version>8.14.0-SNAPSHOT</version>
     <relativePath>../build-parent/pom.xml</relativePath>
   </parent>
 

--- a/drools-scenario-simulation/drools-scenario-simulation-api/pom.xml
+++ b/drools-scenario-simulation/drools-scenario-simulation-api/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <artifactId>drools-scenario-simulation</artifactId>
     <groupId>org.drools</groupId>
-    <version>8.15.0-SNAPSHOT</version>
+    <version>8.14.0-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/drools-scenario-simulation/drools-scenario-simulation-backend/pom.xml
+++ b/drools-scenario-simulation/drools-scenario-simulation-backend/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <artifactId>drools-scenario-simulation</artifactId>
     <groupId>org.drools</groupId>
-    <version>8.15.0-SNAPSHOT</version>
+    <version>8.14.0-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/drools-scenario-simulation/pom.xml
+++ b/drools-scenario-simulation/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.kie</groupId>
     <artifactId>drools-build-parent</artifactId>
-    <version>8.15.0-SNAPSHOT</version>
+    <version>8.14.0-SNAPSHOT</version>
     <relativePath>../build-parent/pom.xml</relativePath>
   </parent>
 

--- a/drools-serialization-protobuf/pom.xml
+++ b/drools-serialization-protobuf/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>org.kie</groupId>
         <artifactId>drools-build-parent</artifactId>
-        <version>8.15.0-SNAPSHOT</version>
+        <version>8.14.0-SNAPSHOT</version>
         <relativePath>../build-parent/pom.xml</relativePath>
     </parent>
 

--- a/drools-templates/pom.xml
+++ b/drools-templates/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.kie</groupId>
     <artifactId>drools-build-parent</artifactId>
-    <version>8.15.0-SNAPSHOT</version>
+    <version>8.14.0-SNAPSHOT</version>
     <relativePath>../build-parent/pom.xml</relativePath>
   </parent>
 

--- a/drools-test-coverage/pom.xml
+++ b/drools-test-coverage/pom.xml
@@ -7,7 +7,7 @@
   <parent>
     <groupId>org.kie</groupId>
     <artifactId>drools-build-parent</artifactId>
-    <version>8.15.0-SNAPSHOT</version>
+    <version>8.14.0-SNAPSHOT</version>
     <relativePath>../build-parent/pom.xml</relativePath>
   </parent>
 

--- a/drools-test-coverage/standalone/kie-ci-with-domain/pom.xml
+++ b/drools-test-coverage/standalone/kie-ci-with-domain/pom.xml
@@ -8,7 +8,7 @@
   <parent>
     <groupId>org.drools.testcoverage</groupId>
     <artifactId>drools-standalone-parent</artifactId>
-    <version>8.15.0-SNAPSHOT</version>
+    <version>8.14.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>drools-kie-ci-with-domain-parent</artifactId>

--- a/drools-test-coverage/standalone/kie-ci-with-domain/test-domain/pom.xml
+++ b/drools-test-coverage/standalone/kie-ci-with-domain/test-domain/pom.xml
@@ -8,7 +8,7 @@
   <parent>
     <groupId>org.drools.testcoverage</groupId>
     <artifactId>drools-kie-ci-with-domain-parent</artifactId>
-    <version>8.15.0-SNAPSHOT</version>
+    <version>8.14.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>drools-kie-ci-with-domain-test-domain</artifactId>

--- a/drools-test-coverage/standalone/kie-ci-with-domain/test-kjar/pom.xml
+++ b/drools-test-coverage/standalone/kie-ci-with-domain/test-kjar/pom.xml
@@ -8,7 +8,7 @@
   <parent>
     <groupId>org.drools.testcoverage</groupId>
     <artifactId>drools-kie-ci-with-domain-parent</artifactId>
-    <version>8.15.0-SNAPSHOT</version>
+    <version>8.14.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>drools-kie-ci-with-domain-test-kjar</artifactId>

--- a/drools-test-coverage/standalone/kie-ci-with-domain/tests/pom.xml
+++ b/drools-test-coverage/standalone/kie-ci-with-domain/tests/pom.xml
@@ -8,7 +8,7 @@
   <parent>
     <groupId>org.drools.testcoverage</groupId>
     <artifactId>drools-kie-ci-with-domain-parent</artifactId>
-    <version>8.15.0-SNAPSHOT</version>
+    <version>8.14.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>drools-kie-ci-with-domain-tests</artifactId>

--- a/drools-test-coverage/standalone/kie-ci-without-domain/pom.xml
+++ b/drools-test-coverage/standalone/kie-ci-without-domain/pom.xml
@@ -8,7 +8,7 @@
   <parent>
     <groupId>org.drools.testcoverage</groupId>
     <artifactId>drools-standalone-parent</artifactId>
-    <version>8.15.0-SNAPSHOT</version>
+    <version>8.14.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>drools-kie-ci-without-domain-parent</artifactId>

--- a/drools-test-coverage/standalone/kie-ci-without-domain/test-domain/pom.xml
+++ b/drools-test-coverage/standalone/kie-ci-without-domain/test-domain/pom.xml
@@ -8,7 +8,7 @@
   <parent>
     <groupId>org.drools.testcoverage</groupId>
     <artifactId>drools-kie-ci-without-domain-parent</artifactId>
-    <version>8.15.0-SNAPSHOT</version>
+    <version>8.14.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>drools-kie-ci-without-domain-test-domain</artifactId>

--- a/drools-test-coverage/standalone/kie-ci-without-domain/test-kjar/pom.xml
+++ b/drools-test-coverage/standalone/kie-ci-without-domain/test-kjar/pom.xml
@@ -8,7 +8,7 @@
   <parent>
     <groupId>org.drools.testcoverage</groupId>
     <artifactId>drools-kie-ci-without-domain-parent</artifactId>
-    <version>8.15.0-SNAPSHOT</version>
+    <version>8.14.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>drools-kie-ci-without-domain-test-kjar</artifactId>

--- a/drools-test-coverage/standalone/kie-ci-without-domain/tests/pom.xml
+++ b/drools-test-coverage/standalone/kie-ci-without-domain/tests/pom.xml
@@ -8,7 +8,7 @@
   <parent>
     <groupId>org.drools.testcoverage</groupId>
     <artifactId>drools-kie-ci-without-domain-parent</artifactId>
-    <version>8.15.0-SNAPSHOT</version>
+    <version>8.14.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>drools-kie-ci-without-domain-tests</artifactId>

--- a/drools-test-coverage/standalone/pom.xml
+++ b/drools-test-coverage/standalone/pom.xml
@@ -8,7 +8,7 @@
   <parent>
     <groupId>org.drools.testcoverage</groupId>
     <artifactId>drools-test-coverage-parent</artifactId>
-    <version>8.15.0-SNAPSHOT</version>
+    <version>8.14.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>drools-standalone-parent</artifactId>

--- a/drools-test-coverage/test-compiler-integration/pom.xml
+++ b/drools-test-coverage/test-compiler-integration/pom.xml
@@ -21,7 +21,7 @@
   <parent>
     <artifactId>drools-test-coverage-parent</artifactId>
     <groupId>org.drools.testcoverage</groupId>
-    <version>8.15.0-SNAPSHOT</version>
+    <version>8.14.0-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/drools-test-coverage/test-integration-nomvel/pom.xml
+++ b/drools-test-coverage/test-integration-nomvel/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <artifactId>drools-test-coverage-parent</artifactId>
         <groupId>org.drools.testcoverage</groupId>
-        <version>8.15.0-SNAPSHOT</version>
+        <version>8.14.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/drools-test-coverage/test-integration-noxml/pom.xml
+++ b/drools-test-coverage/test-integration-noxml/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <artifactId>drools-test-coverage-parent</artifactId>
         <groupId>org.drools.testcoverage</groupId>
-        <version>8.15.0-SNAPSHOT</version>
+        <version>8.14.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/drools-test-coverage/test-suite/pom.xml
+++ b/drools-test-coverage/test-suite/pom.xml
@@ -8,7 +8,7 @@
   <parent>
     <groupId>org.drools.testcoverage</groupId>
     <artifactId>drools-test-coverage-parent</artifactId>
-    <version>8.15.0-SNAPSHOT</version>
+    <version>8.14.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>drools-test-suite</artifactId>

--- a/drools-traits/pom.xml
+++ b/drools-traits/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.kie</groupId>
     <artifactId>drools-build-parent</artifactId>
-    <version>8.15.0-SNAPSHOT</version>
+    <version>8.14.0-SNAPSHOT</version>
     <relativePath>../build-parent/pom.xml</relativePath>
   </parent>
 

--- a/drools-verifier/drools-verifier-api/pom.xml
+++ b/drools-verifier/drools-verifier-api/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>org.drools</groupId>
         <artifactId>drools-verifier</artifactId>
-        <version>8.15.0-SNAPSHOT</version>
+        <version>8.14.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/drools-verifier/drools-verifier-core/pom.xml
+++ b/drools-verifier/drools-verifier-core/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>drools-verifier</artifactId>
         <groupId>org.drools</groupId>
-        <version>8.15.0-SNAPSHOT</version>
+        <version>8.14.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/drools-verifier/drools-verifier-drl/pom.xml
+++ b/drools-verifier/drools-verifier-drl/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.drools</groupId>
     <artifactId>drools-verifier</artifactId>
-    <version>8.15.0-SNAPSHOT</version>
+    <version>8.14.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>drools-verifier-drl</artifactId>

--- a/drools-verifier/pom.xml
+++ b/drools-verifier/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.kie</groupId>
     <artifactId>drools-build-parent</artifactId>
-    <version>8.15.0-SNAPSHOT</version>
+    <version>8.14.0-SNAPSHOT</version>
     <relativePath>../build-parent/pom.xml</relativePath>
   </parent>
 

--- a/drools-xml-support/pom.xml
+++ b/drools-xml-support/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.kie</groupId>
     <artifactId>drools-build-parent</artifactId>
-    <version>8.15.0-SNAPSHOT</version>
+    <version>8.14.0-SNAPSHOT</version>
     <relativePath>../build-parent/pom.xml</relativePath>
   </parent>
 

--- a/kie-api/pom.xml
+++ b/kie-api/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.kie</groupId>
     <artifactId>drools-build-parent</artifactId>
-    <version>8.15.0-SNAPSHOT</version>
+    <version>8.14.0-SNAPSHOT</version>
     <relativePath>../build-parent/pom.xml</relativePath>
   </parent>
 

--- a/kie-archetypes/kie-drools-archetype/pom.xml
+++ b/kie-archetypes/kie-drools-archetype/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.kie</groupId>
     <artifactId>kie-archetypes</artifactId>
-    <version>8.15.0-SNAPSHOT</version>
+    <version>8.14.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>kie-drools-archetype</artifactId>

--- a/kie-archetypes/kie-kjar-archetype/pom.xml
+++ b/kie-archetypes/kie-kjar-archetype/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.kie</groupId>
     <artifactId>kie-archetypes</artifactId>
-    <version>8.15.0-SNAPSHOT</version>
+    <version>8.14.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>kie-kjar-archetype</artifactId>

--- a/kie-archetypes/kie-model-archetype/pom.xml
+++ b/kie-archetypes/kie-model-archetype/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.kie</groupId>
     <artifactId>kie-archetypes</artifactId>
-    <version>8.15.0-SNAPSHOT</version>
+    <version>8.14.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>kie-model-archetype</artifactId>

--- a/kie-archetypes/kie-service-spring-boot-archetype/pom.xml
+++ b/kie-archetypes/kie-service-spring-boot-archetype/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.kie</groupId>
     <artifactId>kie-archetypes</artifactId>
-    <version>8.15.0-SNAPSHOT</version>
+    <version>8.14.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>kie-service-spring-boot-archetype</artifactId>

--- a/kie-archetypes/pom.xml
+++ b/kie-archetypes/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.kie</groupId>
     <artifactId>drools-build-parent</artifactId>
-    <version>8.15.0-SNAPSHOT</version>
+    <version>8.14.0-SNAPSHOT</version>
     <relativePath>../build-parent/pom.xml</relativePath>
   </parent>
 

--- a/kie-ci/pom.xml
+++ b/kie-ci/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.kie</groupId>
     <artifactId>drools-build-parent</artifactId>
-    <version>8.15.0-SNAPSHOT</version>
+    <version>8.14.0-SNAPSHOT</version>
     <relativePath>../build-parent/pom.xml</relativePath>
   </parent>
 

--- a/kie-dmn/kie-dmn-api/pom.xml
+++ b/kie-dmn/kie-dmn-api/pom.xml
@@ -7,7 +7,7 @@
   <parent>
     <groupId>org.kie</groupId>
     <artifactId>kie-dmn</artifactId>
-    <version>8.15.0-SNAPSHOT</version>
+    <version>8.14.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>kie-dmn-api</artifactId>

--- a/kie-dmn/kie-dmn-backend/pom.xml
+++ b/kie-dmn/kie-dmn-backend/pom.xml
@@ -7,7 +7,7 @@
   <parent>
     <groupId>org.kie</groupId>
     <artifactId>kie-dmn</artifactId>
-    <version>8.15.0-SNAPSHOT</version>
+    <version>8.14.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>kie-dmn-backend</artifactId>

--- a/kie-dmn/kie-dmn-core/pom.xml
+++ b/kie-dmn/kie-dmn-core/pom.xml
@@ -7,7 +7,7 @@
   <parent>
     <artifactId>kie-dmn</artifactId>
     <groupId>org.kie</groupId>
-    <version>8.15.0-SNAPSHOT</version>
+    <version>8.14.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>kie-dmn-core</artifactId>

--- a/kie-dmn/kie-dmn-feel-gwt-functions/pom.xml
+++ b/kie-dmn/kie-dmn-feel-gwt-functions/pom.xml
@@ -7,7 +7,7 @@
   <parent>
     <groupId>org.kie</groupId>
     <artifactId>kie-dmn</artifactId>
-    <version>8.15.0-SNAPSHOT</version>
+    <version>8.14.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>kie-dmn-feel-gwt-functions</artifactId>

--- a/kie-dmn/kie-dmn-feel-gwt-showcase/pom.xml
+++ b/kie-dmn/kie-dmn-feel-gwt-showcase/pom.xml
@@ -7,7 +7,7 @@
   <parent>
     <groupId>org.kie</groupId>
     <artifactId>kie-dmn</artifactId>
-    <version>8.15.0-SNAPSHOT</version>
+    <version>8.14.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>kie-dmn-feel-gwt-showcase</artifactId>

--- a/kie-dmn/kie-dmn-feel-gwt/pom.xml
+++ b/kie-dmn/kie-dmn-feel-gwt/pom.xml
@@ -7,7 +7,7 @@
   <parent>
     <groupId>org.kie</groupId>
     <artifactId>kie-dmn</artifactId>
-    <version>8.15.0-SNAPSHOT</version>
+    <version>8.14.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>kie-dmn-feel-gwt</artifactId>

--- a/kie-dmn/kie-dmn-feel/pom.xml
+++ b/kie-dmn/kie-dmn-feel/pom.xml
@@ -7,7 +7,7 @@
   <parent>
     <groupId>org.kie</groupId>
     <artifactId>kie-dmn</artifactId>
-    <version>8.15.0-SNAPSHOT</version>
+    <version>8.14.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>kie-dmn-feel</artifactId>

--- a/kie-dmn/kie-dmn-model/pom.xml
+++ b/kie-dmn/kie-dmn-model/pom.xml
@@ -7,7 +7,7 @@
   <parent>
     <artifactId>kie-dmn</artifactId>
     <groupId>org.kie</groupId>
-    <version>8.15.0-SNAPSHOT</version>
+    <version>8.14.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>kie-dmn-model</artifactId>

--- a/kie-dmn/kie-dmn-openapi/pom.xml
+++ b/kie-dmn/kie-dmn-openapi/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.kie</groupId>
     <artifactId>kie-dmn</artifactId>
-    <version>8.15.0-SNAPSHOT</version>
+    <version>8.14.0-SNAPSHOT</version>
   </parent>
   <artifactId>kie-dmn-openapi</artifactId>
   

--- a/kie-dmn/kie-dmn-pmml-tests-parent/kie-dmn-pmml-tests-trusty/pom.xml
+++ b/kie-dmn/kie-dmn-pmml-tests-parent/kie-dmn-pmml-tests-trusty/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <artifactId>kie-dmn-pmml-tests-parent</artifactId>
     <groupId>org.kie</groupId>
-    <version>8.15.0-SNAPSHOT</version>
+    <version>8.14.0-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/kie-dmn/kie-dmn-pmml-tests-parent/kie-dmn-pmml-tests/pom.xml
+++ b/kie-dmn/kie-dmn-pmml-tests-parent/kie-dmn-pmml-tests/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <artifactId>kie-dmn-pmml-tests-parent</artifactId>
     <groupId>org.kie</groupId>
-    <version>8.15.0-SNAPSHOT</version>
+    <version>8.14.0-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/kie-dmn/kie-dmn-pmml-tests-parent/pom.xml
+++ b/kie-dmn/kie-dmn-pmml-tests-parent/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <artifactId>kie-dmn</artifactId>
     <groupId>org.kie</groupId>
-    <version>8.15.0-SNAPSHOT</version>
+    <version>8.14.0-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
   <packaging>pom</packaging>

--- a/kie-dmn/kie-dmn-signavio/pom.xml
+++ b/kie-dmn/kie-dmn-signavio/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.kie</groupId>
     <artifactId>kie-dmn</artifactId>
-    <version>8.15.0-SNAPSHOT</version>
+    <version>8.14.0-SNAPSHOT</version>
   </parent>
   <artifactId>kie-dmn-signavio</artifactId>
   

--- a/kie-dmn/kie-dmn-tck/pom.xml
+++ b/kie-dmn/kie-dmn-tck/pom.xml
@@ -21,7 +21,7 @@
   <parent>
     <artifactId>kie-dmn</artifactId>
     <groupId>org.kie</groupId>
-    <version>8.15.0-SNAPSHOT</version>
+    <version>8.14.0-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
   <packaging>pom</packaging>

--- a/kie-dmn/kie-dmn-trisotech/pom.xml
+++ b/kie-dmn/kie-dmn-trisotech/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.kie</groupId>
     <artifactId>kie-dmn</artifactId>
-    <version>8.15.0-SNAPSHOT</version>
+    <version>8.14.0-SNAPSHOT</version>
   </parent>
   <artifactId>kie-dmn-trisotech</artifactId>
 

--- a/kie-dmn/kie-dmn-validation-bootstrap/pom.xml
+++ b/kie-dmn/kie-dmn-validation-bootstrap/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.kie</groupId>
     <artifactId>kie-dmn</artifactId>
-    <version>8.15.0-SNAPSHOT</version>
+    <version>8.14.0-SNAPSHOT</version>
   </parent>
   <artifactId>kie-dmn-validation-bootstrap</artifactId>
 

--- a/kie-dmn/kie-dmn-validation/pom.xml
+++ b/kie-dmn/kie-dmn-validation/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.kie</groupId>
     <artifactId>kie-dmn</artifactId>
-    <version>8.15.0-SNAPSHOT</version>
+    <version>8.14.0-SNAPSHOT</version>
   </parent>
   <artifactId>kie-dmn-validation</artifactId>
     <packaging>jar</packaging>

--- a/kie-dmn/kie-dmn-xls2dmn-cli/pom.xml
+++ b/kie-dmn/kie-dmn-xls2dmn-cli/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.kie</groupId>
     <artifactId>kie-dmn</artifactId>
-    <version>8.15.0-SNAPSHOT</version>
+    <version>8.14.0-SNAPSHOT</version>
   </parent>
   <artifactId>kie-dmn-xls2dmn-cli</artifactId>
   <packaging>jar</packaging>

--- a/kie-dmn/pom.xml
+++ b/kie-dmn/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.kie</groupId>
     <artifactId>drools-build-parent</artifactId>
-    <version>8.15.0-SNAPSHOT</version>
+    <version>8.14.0-SNAPSHOT</version>
     <relativePath>../build-parent/pom.xml</relativePath>
   </parent>
 

--- a/kie-internal/pom.xml
+++ b/kie-internal/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.kie</groupId>
     <artifactId>drools-build-parent</artifactId>
-    <version>8.15.0-SNAPSHOT</version>
+    <version>8.14.0-SNAPSHOT</version>
     <relativePath>../build-parent/pom.xml</relativePath>
   </parent>
 

--- a/kie-memory-compiler/pom.xml
+++ b/kie-memory-compiler/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.kie</groupId>
     <artifactId>drools-build-parent</artifactId>
-    <version>8.15.0-SNAPSHOT</version>
+    <version>8.14.0-SNAPSHOT</version>
     <relativePath>../build-parent/pom.xml</relativePath>
   </parent>
 

--- a/kie-pmml-trusty/kie-pmml-api/pom.xml
+++ b/kie-pmml-trusty/kie-pmml-api/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <artifactId>kie-pmml-trusty</artifactId>
     <groupId>org.kie</groupId>
-    <version>8.15.0-SNAPSHOT</version>
+    <version>8.14.0-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/kie-pmml-trusty/kie-pmml-benchmarks/kie-pmml-benchmarks-regression/pom.xml
+++ b/kie-pmml-trusty/kie-pmml-benchmarks/kie-pmml-benchmarks-regression/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <artifactId>kie-pmml-benchmarks</artifactId>
     <groupId>org.kie</groupId>
-    <version>8.15.0-SNAPSHOT</version>
+    <version>8.14.0-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/kie-pmml-trusty/kie-pmml-benchmarks/pom.xml
+++ b/kie-pmml-trusty/kie-pmml-benchmarks/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <artifactId>kie-pmml-trusty</artifactId>
     <groupId>org.kie</groupId>
-    <version>8.15.0-SNAPSHOT</version>
+    <version>8.14.0-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/kie-pmml-trusty/kie-pmml-commons/pom.xml
+++ b/kie-pmml-trusty/kie-pmml-commons/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.kie</groupId>
     <artifactId>kie-pmml-trusty</artifactId>
-    <version>8.15.0-SNAPSHOT</version>
+    <version>8.14.0-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/kie-pmml-trusty/kie-pmml-compiler/kie-pmml-compiler-api/pom.xml
+++ b/kie-pmml-trusty/kie-pmml-compiler/kie-pmml-compiler-api/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.kie</groupId>
     <artifactId>kie-pmml-compiler</artifactId>
-    <version>8.15.0-SNAPSHOT</version>
+    <version>8.14.0-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/kie-pmml-trusty/kie-pmml-compiler/kie-pmml-compiler-commons/pom.xml
+++ b/kie-pmml-trusty/kie-pmml-compiler/kie-pmml-compiler-commons/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.kie</groupId>
     <artifactId>kie-pmml-compiler</artifactId>
-    <version>8.15.0-SNAPSHOT</version>
+    <version>8.14.0-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/kie-pmml-trusty/kie-pmml-compiler/kie-pmml-compiler-core/pom.xml
+++ b/kie-pmml-trusty/kie-pmml-compiler/kie-pmml-compiler-core/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.kie</groupId>
     <artifactId>kie-pmml-compiler</artifactId>
-    <version>8.15.0-SNAPSHOT</version>
+    <version>8.14.0-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/kie-pmml-trusty/kie-pmml-compiler/pom.xml
+++ b/kie-pmml-trusty/kie-pmml-compiler/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.kie</groupId>
     <artifactId>kie-pmml-trusty</artifactId>
-    <version>8.15.0-SNAPSHOT</version>
+    <version>8.14.0-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/kie-pmml-trusty/kie-pmml-dependencies/pom.xml
+++ b/kie-pmml-trusty/kie-pmml-dependencies/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.kie</groupId>
     <artifactId>kie-pmml-trusty</artifactId>
-    <version>8.15.0-SNAPSHOT</version>
+    <version>8.14.0-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/kie-pmml-trusty/kie-pmml-evaluator/kie-pmml-evaluator-api/pom.xml
+++ b/kie-pmml-trusty/kie-pmml-evaluator/kie-pmml-evaluator-api/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.kie</groupId>
     <artifactId>kie-pmml-evaluator</artifactId>
-    <version>8.15.0-SNAPSHOT</version>
+    <version>8.14.0-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/kie-pmml-trusty/kie-pmml-evaluator/kie-pmml-evaluator-assembler/pom.xml
+++ b/kie-pmml-trusty/kie-pmml-evaluator/kie-pmml-evaluator-assembler/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.kie</groupId>
     <artifactId>kie-pmml-evaluator</artifactId>
-    <version>8.15.0-SNAPSHOT</version>
+    <version>8.14.0-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/kie-pmml-trusty/kie-pmml-evaluator/kie-pmml-evaluator-core/pom.xml
+++ b/kie-pmml-trusty/kie-pmml-evaluator/kie-pmml-evaluator-core/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.kie</groupId>
     <artifactId>kie-pmml-evaluator</artifactId>
-    <version>8.15.0-SNAPSHOT</version>
+    <version>8.14.0-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/kie-pmml-trusty/kie-pmml-evaluator/pom.xml
+++ b/kie-pmml-trusty/kie-pmml-evaluator/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.kie</groupId>
     <artifactId>kie-pmml-trusty</artifactId>
-    <version>8.15.0-SNAPSHOT</version>
+    <version>8.14.0-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
   <packaging>pom</packaging>

--- a/kie-pmml-trusty/kie-pmml-kie-internal/pom.xml
+++ b/kie-pmml-trusty/kie-pmml-kie-internal/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <artifactId>kie-pmml-trusty</artifactId>
     <groupId>org.kie</groupId>
-    <version>8.15.0-SNAPSHOT</version>
+    <version>8.14.0-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/kie-pmml-trusty/kie-pmml-models-archetype/pom.xml
+++ b/kie-pmml-trusty/kie-pmml-models-archetype/pom.xml
@@ -7,7 +7,7 @@
   <parent>
     <groupId>org.kie</groupId>
     <artifactId>kie-pmml-trusty</artifactId>
-    <version>8.15.0-SNAPSHOT</version>
+    <version>8.14.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>kie-pmml-models-archetype</artifactId>

--- a/kie-pmml-trusty/kie-pmml-models-drools-archetype/pom.xml
+++ b/kie-pmml-trusty/kie-pmml-models-drools-archetype/pom.xml
@@ -7,7 +7,7 @@
   <parent>
     <groupId>org.kie</groupId>
     <artifactId>kie-pmml-trusty</artifactId>
-    <version>8.15.0-SNAPSHOT</version>
+    <version>8.14.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>kie-pmml-models-drools-archetype</artifactId>

--- a/kie-pmml-trusty/kie-pmml-models/kie-pmml-models-clustering/kie-pmml-models-clustering-compiler/pom.xml
+++ b/kie-pmml-trusty/kie-pmml-models/kie-pmml-models-clustering/kie-pmml-models-clustering-compiler/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.kie</groupId>
     <artifactId>kie-pmml-models-clustering</artifactId>
-    <version>8.15.0-SNAPSHOT</version>
+    <version>8.14.0-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/kie-pmml-trusty/kie-pmml-models/kie-pmml-models-clustering/kie-pmml-models-clustering-evaluator/pom.xml
+++ b/kie-pmml-trusty/kie-pmml-models/kie-pmml-models-clustering/kie-pmml-models-clustering-evaluator/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.kie</groupId>
     <artifactId>kie-pmml-models-clustering</artifactId>
-    <version>8.15.0-SNAPSHOT</version>
+    <version>8.14.0-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/kie-pmml-trusty/kie-pmml-models/kie-pmml-models-clustering/kie-pmml-models-clustering-model/pom.xml
+++ b/kie-pmml-trusty/kie-pmml-models/kie-pmml-models-clustering/kie-pmml-models-clustering-model/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.kie</groupId>
     <artifactId>kie-pmml-models-clustering</artifactId>
-    <version>8.15.0-SNAPSHOT</version>
+    <version>8.14.0-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/kie-pmml-trusty/kie-pmml-models/kie-pmml-models-clustering/kie-pmml-models-clustering-tests/pom.xml
+++ b/kie-pmml-trusty/kie-pmml-models/kie-pmml-models-clustering/kie-pmml-models-clustering-tests/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.kie</groupId>
     <artifactId>kie-pmml-models-clustering</artifactId>
-    <version>8.15.0-SNAPSHOT</version>
+    <version>8.14.0-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/kie-pmml-trusty/kie-pmml-models/kie-pmml-models-clustering/pom.xml
+++ b/kie-pmml-trusty/kie-pmml-models/kie-pmml-models-clustering/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.kie</groupId>
     <artifactId>kie-pmml-models</artifactId>
-    <version>8.15.0-SNAPSHOT</version>
+    <version>8.14.0-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
   <packaging>pom</packaging>

--- a/kie-pmml-trusty/kie-pmml-models/kie-pmml-models-drools/kie-pmml-models-drools-common/pom.xml
+++ b/kie-pmml-trusty/kie-pmml-models/kie-pmml-models-drools/kie-pmml-models-drools-common/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.kie</groupId>
     <artifactId>kie-pmml-models-drools</artifactId>
-    <version>8.15.0-SNAPSHOT</version>
+    <version>8.14.0-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/kie-pmml-trusty/kie-pmml-models/kie-pmml-models-drools/kie-pmml-models-drools-scorecard/kie-pmml-models-drools-scorecard-compiler/pom.xml
+++ b/kie-pmml-trusty/kie-pmml-models/kie-pmml-models-drools/kie-pmml-models-drools-scorecard/kie-pmml-models-drools-scorecard-compiler/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.kie</groupId>
     <artifactId>kie-pmml-models-drools-scorecard</artifactId>
-    <version>8.15.0-SNAPSHOT</version>
+    <version>8.14.0-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/kie-pmml-trusty/kie-pmml-models/kie-pmml-models-drools/kie-pmml-models-drools-scorecard/kie-pmml-models-drools-scorecard-evaluator/pom.xml
+++ b/kie-pmml-trusty/kie-pmml-models/kie-pmml-models-drools/kie-pmml-models-drools-scorecard/kie-pmml-models-drools-scorecard-evaluator/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.kie</groupId>
     <artifactId>kie-pmml-models-drools-scorecard</artifactId>
-    <version>8.15.0-SNAPSHOT</version>
+    <version>8.14.0-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/kie-pmml-trusty/kie-pmml-models/kie-pmml-models-drools/kie-pmml-models-drools-scorecard/kie-pmml-models-drools-scorecard-model/pom.xml
+++ b/kie-pmml-trusty/kie-pmml-models/kie-pmml-models-drools/kie-pmml-models-drools-scorecard/kie-pmml-models-drools-scorecard-model/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.kie</groupId>
     <artifactId>kie-pmml-models-drools-scorecard</artifactId>
-    <version>8.15.0-SNAPSHOT</version>
+    <version>8.14.0-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/kie-pmml-trusty/kie-pmml-models/kie-pmml-models-drools/kie-pmml-models-drools-scorecard/kie-pmml-models-drools-scorecard-tests/pom.xml
+++ b/kie-pmml-trusty/kie-pmml-models/kie-pmml-models-drools/kie-pmml-models-drools-scorecard/kie-pmml-models-drools-scorecard-tests/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.kie</groupId>
     <artifactId>kie-pmml-models-drools-scorecard</artifactId>
-    <version>8.15.0-SNAPSHOT</version>
+    <version>8.14.0-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/kie-pmml-trusty/kie-pmml-models/kie-pmml-models-drools/kie-pmml-models-drools-scorecard/pom.xml
+++ b/kie-pmml-trusty/kie-pmml-models/kie-pmml-models-drools/kie-pmml-models-drools-scorecard/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.kie</groupId>
     <artifactId>kie-pmml-models-drools</artifactId>
-    <version>8.15.0-SNAPSHOT</version>
+    <version>8.14.0-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
   <packaging>pom</packaging>

--- a/kie-pmml-trusty/kie-pmml-models/kie-pmml-models-drools/kie-pmml-models-drools-tree/kie-pmml-models-drools-tree-compiler/pom.xml
+++ b/kie-pmml-trusty/kie-pmml-models/kie-pmml-models-drools/kie-pmml-models-drools-tree/kie-pmml-models-drools-tree-compiler/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.kie</groupId>
     <artifactId>kie-pmml-models-drools-tree</artifactId>
-    <version>8.15.0-SNAPSHOT</version>
+    <version>8.14.0-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/kie-pmml-trusty/kie-pmml-models/kie-pmml-models-drools/kie-pmml-models-drools-tree/kie-pmml-models-drools-tree-evaluator/pom.xml
+++ b/kie-pmml-trusty/kie-pmml-models/kie-pmml-models-drools/kie-pmml-models-drools-tree/kie-pmml-models-drools-tree-evaluator/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.kie</groupId>
     <artifactId>kie-pmml-models-drools-tree</artifactId>
-    <version>8.15.0-SNAPSHOT</version>
+    <version>8.14.0-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/kie-pmml-trusty/kie-pmml-models/kie-pmml-models-drools/kie-pmml-models-drools-tree/kie-pmml-models-drools-tree-model/pom.xml
+++ b/kie-pmml-trusty/kie-pmml-models/kie-pmml-models-drools/kie-pmml-models-drools-tree/kie-pmml-models-drools-tree-model/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.kie</groupId>
     <artifactId>kie-pmml-models-drools-tree</artifactId>
-    <version>8.15.0-SNAPSHOT</version>
+    <version>8.14.0-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/kie-pmml-trusty/kie-pmml-models/kie-pmml-models-drools/kie-pmml-models-drools-tree/kie-pmml-models-drools-tree-tests/pom.xml
+++ b/kie-pmml-trusty/kie-pmml-models/kie-pmml-models-drools/kie-pmml-models-drools-tree/kie-pmml-models-drools-tree-tests/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.kie</groupId>
     <artifactId>kie-pmml-models-drools-tree</artifactId>
-    <version>8.15.0-SNAPSHOT</version>
+    <version>8.14.0-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/kie-pmml-trusty/kie-pmml-models/kie-pmml-models-drools/kie-pmml-models-drools-tree/pom.xml
+++ b/kie-pmml-trusty/kie-pmml-models/kie-pmml-models-drools/kie-pmml-models-drools-tree/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.kie</groupId>
     <artifactId>kie-pmml-models-drools</artifactId>
-    <version>8.15.0-SNAPSHOT</version>
+    <version>8.14.0-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
   <packaging>pom</packaging>

--- a/kie-pmml-trusty/kie-pmml-models/kie-pmml-models-drools/pom.xml
+++ b/kie-pmml-trusty/kie-pmml-models/kie-pmml-models-drools/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.kie</groupId>
     <artifactId>kie-pmml-models</artifactId>
-    <version>8.15.0-SNAPSHOT</version>
+    <version>8.14.0-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/kie-pmml-trusty/kie-pmml-models/kie-pmml-models-mining/kie-pmml-models-mining-compiler/pom.xml
+++ b/kie-pmml-trusty/kie-pmml-models/kie-pmml-models-mining/kie-pmml-models-mining-compiler/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.kie</groupId>
     <artifactId>kie-pmml-models-mining</artifactId>
-    <version>8.15.0-SNAPSHOT</version>
+    <version>8.14.0-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/kie-pmml-trusty/kie-pmml-models/kie-pmml-models-mining/kie-pmml-models-mining-evaluator/pom.xml
+++ b/kie-pmml-trusty/kie-pmml-models/kie-pmml-models-mining/kie-pmml-models-mining-evaluator/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.kie</groupId>
     <artifactId>kie-pmml-models-mining</artifactId>
-    <version>8.15.0-SNAPSHOT</version>
+    <version>8.14.0-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/kie-pmml-trusty/kie-pmml-models/kie-pmml-models-mining/kie-pmml-models-mining-model/pom.xml
+++ b/kie-pmml-trusty/kie-pmml-models/kie-pmml-models-mining/kie-pmml-models-mining-model/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.kie</groupId>
     <artifactId>kie-pmml-models-mining</artifactId>
-    <version>8.15.0-SNAPSHOT</version>
+    <version>8.14.0-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/kie-pmml-trusty/kie-pmml-models/kie-pmml-models-mining/kie-pmml-models-mining-tests/pom.xml
+++ b/kie-pmml-trusty/kie-pmml-models/kie-pmml-models-mining/kie-pmml-models-mining-tests/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.kie</groupId>
     <artifactId>kie-pmml-models-mining</artifactId>
-    <version>8.15.0-SNAPSHOT</version>
+    <version>8.14.0-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/kie-pmml-trusty/kie-pmml-models/kie-pmml-models-mining/pom.xml
+++ b/kie-pmml-trusty/kie-pmml-models/kie-pmml-models-mining/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.kie</groupId>
     <artifactId>kie-pmml-models</artifactId>
-    <version>8.15.0-SNAPSHOT</version>
+    <version>8.14.0-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
   <packaging>pom</packaging>

--- a/kie-pmml-trusty/kie-pmml-models/kie-pmml-models-regression/kie-pmml-models-regression-compiler/pom.xml
+++ b/kie-pmml-trusty/kie-pmml-models/kie-pmml-models-regression/kie-pmml-models-regression-compiler/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.kie</groupId>
     <artifactId>kie-pmml-models-regression</artifactId>
-    <version>8.15.0-SNAPSHOT</version>
+    <version>8.14.0-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/kie-pmml-trusty/kie-pmml-models/kie-pmml-models-regression/kie-pmml-models-regression-evaluator/pom.xml
+++ b/kie-pmml-trusty/kie-pmml-models/kie-pmml-models-regression/kie-pmml-models-regression-evaluator/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.kie</groupId>
     <artifactId>kie-pmml-models-regression</artifactId>
-    <version>8.15.0-SNAPSHOT</version>
+    <version>8.14.0-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/kie-pmml-trusty/kie-pmml-models/kie-pmml-models-regression/kie-pmml-models-regression-model/pom.xml
+++ b/kie-pmml-trusty/kie-pmml-models/kie-pmml-models-regression/kie-pmml-models-regression-model/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.kie</groupId>
     <artifactId>kie-pmml-models-regression</artifactId>
-    <version>8.15.0-SNAPSHOT</version>
+    <version>8.14.0-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/kie-pmml-trusty/kie-pmml-models/kie-pmml-models-regression/kie-pmml-models-regression-tests/pom.xml
+++ b/kie-pmml-trusty/kie-pmml-models/kie-pmml-models-regression/kie-pmml-models-regression-tests/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.kie</groupId>
     <artifactId>kie-pmml-models-regression</artifactId>
-    <version>8.15.0-SNAPSHOT</version>
+    <version>8.14.0-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/kie-pmml-trusty/kie-pmml-models/kie-pmml-models-regression/pom.xml
+++ b/kie-pmml-trusty/kie-pmml-models/kie-pmml-models-regression/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.kie</groupId>
     <artifactId>kie-pmml-models</artifactId>
-    <version>8.15.0-SNAPSHOT</version>
+    <version>8.14.0-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
   <packaging>pom</packaging>

--- a/kie-pmml-trusty/kie-pmml-models/kie-pmml-models-scorecard/kie-pmml-models-scorecard-compiler/pom.xml
+++ b/kie-pmml-trusty/kie-pmml-models/kie-pmml-models-scorecard/kie-pmml-models-scorecard-compiler/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.kie</groupId>
     <artifactId>kie-pmml-models-scorecard</artifactId>
-    <version>8.15.0-SNAPSHOT</version>
+    <version>8.14.0-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/kie-pmml-trusty/kie-pmml-models/kie-pmml-models-scorecard/kie-pmml-models-scorecard-evaluator/pom.xml
+++ b/kie-pmml-trusty/kie-pmml-models/kie-pmml-models-scorecard/kie-pmml-models-scorecard-evaluator/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.kie</groupId>
     <artifactId>kie-pmml-models-scorecard</artifactId>
-    <version>8.15.0-SNAPSHOT</version>
+    <version>8.14.0-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/kie-pmml-trusty/kie-pmml-models/kie-pmml-models-scorecard/kie-pmml-models-scorecard-model/pom.xml
+++ b/kie-pmml-trusty/kie-pmml-models/kie-pmml-models-scorecard/kie-pmml-models-scorecard-model/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.kie</groupId>
     <artifactId>kie-pmml-models-scorecard</artifactId>
-    <version>8.15.0-SNAPSHOT</version>
+    <version>8.14.0-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/kie-pmml-trusty/kie-pmml-models/kie-pmml-models-scorecard/kie-pmml-models-scorecard-tests/pom.xml
+++ b/kie-pmml-trusty/kie-pmml-models/kie-pmml-models-scorecard/kie-pmml-models-scorecard-tests/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.kie</groupId>
     <artifactId>kie-pmml-models-scorecard</artifactId>
-    <version>8.15.0-SNAPSHOT</version>
+    <version>8.14.0-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/kie-pmml-trusty/kie-pmml-models/kie-pmml-models-scorecard/pom.xml
+++ b/kie-pmml-trusty/kie-pmml-models/kie-pmml-models-scorecard/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.kie</groupId>
     <artifactId>kie-pmml-models</artifactId>
-    <version>8.15.0-SNAPSHOT</version>
+    <version>8.14.0-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
   <packaging>pom</packaging>

--- a/kie-pmml-trusty/kie-pmml-models/kie-pmml-models-tests/pom.xml
+++ b/kie-pmml-trusty/kie-pmml-models/kie-pmml-models-tests/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <artifactId>kie-pmml-models</artifactId>
     <groupId>org.kie</groupId>
-    <version>8.15.0-SNAPSHOT</version>
+    <version>8.14.0-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/kie-pmml-trusty/kie-pmml-models/kie-pmml-models-tree/kie-pmml-models-tree-compiler/pom.xml
+++ b/kie-pmml-trusty/kie-pmml-models/kie-pmml-models-tree/kie-pmml-models-tree-compiler/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.kie</groupId>
     <artifactId>kie-pmml-models-tree</artifactId>
-    <version>8.15.0-SNAPSHOT</version>
+    <version>8.14.0-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/kie-pmml-trusty/kie-pmml-models/kie-pmml-models-tree/kie-pmml-models-tree-evaluator/pom.xml
+++ b/kie-pmml-trusty/kie-pmml-models/kie-pmml-models-tree/kie-pmml-models-tree-evaluator/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.kie</groupId>
     <artifactId>kie-pmml-models-tree</artifactId>
-    <version>8.15.0-SNAPSHOT</version>
+    <version>8.14.0-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/kie-pmml-trusty/kie-pmml-models/kie-pmml-models-tree/kie-pmml-models-tree-model/pom.xml
+++ b/kie-pmml-trusty/kie-pmml-models/kie-pmml-models-tree/kie-pmml-models-tree-model/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.kie</groupId>
     <artifactId>kie-pmml-models-tree</artifactId>
-    <version>8.15.0-SNAPSHOT</version>
+    <version>8.14.0-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/kie-pmml-trusty/kie-pmml-models/kie-pmml-models-tree/kie-pmml-models-tree-tests/pom.xml
+++ b/kie-pmml-trusty/kie-pmml-models/kie-pmml-models-tree/kie-pmml-models-tree-tests/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.kie</groupId>
     <artifactId>kie-pmml-models-tree</artifactId>
-    <version>8.15.0-SNAPSHOT</version>
+    <version>8.14.0-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/kie-pmml-trusty/kie-pmml-models/kie-pmml-models-tree/pom.xml
+++ b/kie-pmml-trusty/kie-pmml-models/kie-pmml-models-tree/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.kie</groupId>
     <artifactId>kie-pmml-models</artifactId>
-    <version>8.15.0-SNAPSHOT</version>
+    <version>8.14.0-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
   <packaging>pom</packaging>

--- a/kie-pmml-trusty/kie-pmml-models/pom.xml
+++ b/kie-pmml-trusty/kie-pmml-models/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.kie</groupId>
     <artifactId>kie-pmml-trusty</artifactId>
-    <version>8.15.0-SNAPSHOT</version>
+    <version>8.14.0-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/kie-pmml-trusty/pom.xml
+++ b/kie-pmml-trusty/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.kie</groupId>
     <artifactId>drools-build-parent</artifactId>
-    <version>8.15.0-SNAPSHOT</version>
+    <version>8.14.0-SNAPSHOT</version>
     <relativePath>../build-parent/pom.xml</relativePath>
   </parent>
 

--- a/kie-test-util/pom.xml
+++ b/kie-test-util/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.kie</groupId>
     <artifactId>drools-build-parent</artifactId>
-    <version>8.15.0-SNAPSHOT</version>
+    <version>8.14.0-SNAPSHOT</version>
     <relativePath>../build-parent/pom.xml</relativePath>
   </parent>
 

--- a/kie-util/kie-util-maven-integration/pom.xml
+++ b/kie-util/kie-util-maven-integration/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.kie</groupId>
     <artifactId>kie-util</artifactId>
-    <version>8.15.0-SNAPSHOT</version>
+    <version>8.14.0-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/kie-util/kie-util-maven-support/pom.xml
+++ b/kie-util/kie-util-maven-support/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.kie</groupId>
     <artifactId>kie-util</artifactId>
-    <version>8.15.0-SNAPSHOT</version>
+    <version>8.14.0-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/kie-util/kie-util-xml/pom.xml
+++ b/kie-util/kie-util-xml/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.kie</groupId>
     <artifactId>kie-util</artifactId>
-    <version>8.15.0-SNAPSHOT</version>
+    <version>8.14.0-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/kie-util/pom.xml
+++ b/kie-util/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.kie</groupId>
     <artifactId>drools-build-parent</artifactId>
-    <version>8.15.0-SNAPSHOT</version>
+    <version>8.14.0-SNAPSHOT</version>
     <relativePath>../build-parent/pom.xml</relativePath>
   </parent>
 

--- a/pom.xml
+++ b/pom.xml
@@ -13,7 +13,7 @@
   <groupId>org.kie</groupId>
   <artifactId>drools-parent</artifactId>
   <packaging>pom</packaging>
-  <version>8.15.0-SNAPSHOT</version>
+  <version>8.14.0-SNAPSHOT</version>
 
   <name>Drools :: Parent</name>
   <description>


### PR DESCRIPTION
Reverts kiegroup/drools#4018 due to Nexus issues which create problems to go further ... it will be set back once Nexus issues are solved