### PR TITLE
[DROOLS-6719] MVELDialect.java::loadImportedClass optimization

### DIFF
--- a/drools-mvel/src/main/java/org/drools/mvel/builder/MVELDialect.java
+++ b/drools-mvel/src/main/java/org/drools/mvel/builder/MVELDialect.java
@@ -452,10 +452,10 @@ public class MVELDialect
 
     private Class<?> loadImportedClass(String className) {
         try {
-            return pkg.getTypeResolver().resolveType(className);
+            return this.packageRegistry.getPackageClassLoader().loadClass(className);
         } catch (ClassNotFoundException e) { }
         try {
-            return this.packageRegistry.getPackageClassLoader().loadClass(className);
+            return pkg.getTypeResolver().resolveType(className);
         } catch (ClassNotFoundException e) { }
         return null;
     }


### PR DESCRIPTION
When doing a _KieBuilder::buildAll_, mvel dialect tries to import all functions looking for the class in the classpath first, which takes too long, and then in drools, which is pretty faster. I propose to exchange the order in which they are looked for a better performance.

In my tests it's about 33%-50% faster. (in a DRL with 1000 rules and 50 function, _::buildAll_ goes from 10s to 6s)

Can it be applied to _7.62.0.Final_ too, please?

First time pulling, sorry in advance for any inconvenience.