### PR TITLE
in-memory database tests fail due to upgrade of H2 driver version to 1.4.197

### DIFF
--- a/kie-test-util/src/main/java/org/kie/test/util/db/PersistenceUtil.java
+++ b/kie-test-util/src/main/java/org/kie/test/util/db/PersistenceUtil.java
@@ -147,7 +147,7 @@ public class PersistenceUtil {
         if (driverClass.startsWith("org.h2")) {
             String jdbcUrl = dsProps.getProperty("url");
             // fix an incomplete JDBC URL used by some tests
-            if (jdbcUrl.startsWith("jdbc:h2:") && !jdbcUrl.contains("tcp://")) {
+            if (jdbcUrl.startsWith("jdbc:h2:") && !jdbcUrl.contains("tcp://") && !jdbcUrl.contains("mem:")) {
                 dsProps.put("url", jdbcUrl + "tcp://localhost/target/./persistence-test");
             }
             h2Server.start();


### PR DESCRIPTION
**JIRA**: https://issues.redhat.com/browse/RHDM-1849

**referenced Pull Requests**: none

This PR adds a condition to check if the URL connection contains in-memory database instruction (mem:). It should not affect any out-of-the-box test and will not add unnecessary values to the URL connection used by QE automation. It fixes a failure in one specific test which already contains the URL connection (with mem: instruction) and stopped to work with the invalid value "jdbc:h2:mem:testtcp://localhost..." due to the syntax validation introduced by the H2 driver upgrade.

<summary>
How to retest this PR or trigger a specific build:
</summary>

* <b>a pull request</b> please add comment: <b>Jenkins retest this</b>

* <b>a full downstream build</b> please add comment: <b>Jenkins run fdb</b>

* <b>a compile downstream build</b> please  add comment: <b>Jenkins run cdb</b>

* <b>a full production downstream build</b> please add comment: <b>Jenkins execute product fdb</b>

* <b>an upstream build</b> please add comment: <b>Jenkins run upstream</b>
</details>
