### PR TITLE
DROOLS-6725 DMN DMNLiteralExpressionEvaluator to internalize FEEL

### DIFF
--- a/kie-dmn/kie-dmn-core/src/main/java/org/kie/dmn/core/ast/DMNLiteralExpressionEvaluator.java
+++ b/kie-dmn/kie-dmn-core/src/main/java/org/kie/dmn/core/ast/DMNLiteralExpressionEvaluator.java
@@ -29,9 +29,7 @@ import org.kie.dmn.api.feel.runtime.events.FEELEventListener;
 import org.kie.dmn.core.api.DMNExpressionEvaluator;
 import org.kie.dmn.core.api.EvaluatorResult;
 import org.kie.dmn.core.api.EvaluatorResult.ResultType;
-import org.kie.dmn.core.compiler.DMNProfile;
 import org.kie.dmn.core.impl.DMNResultImpl;
-import org.kie.dmn.core.impl.DMNRuntimeImpl;
 import org.kie.dmn.core.util.Msg;
 import org.kie.dmn.core.util.MsgUtil;
 import org.kie.dmn.feel.FEEL;
@@ -55,8 +53,9 @@ public class DMNLiteralExpressionEvaluator
     private LiteralExpression expressionNode;
     private CompiledExpression expression;
     private boolean isFunctionDef;
+    final FEELImpl feelInstance;
 
-    public DMNLiteralExpressionEvaluator(CompiledExpression expression, LiteralExpression expressionNode) {
+    public DMNLiteralExpressionEvaluator(CompiledExpression expression, LiteralExpression expressionNode, FEEL feel) {
         this.expressionNode = expressionNode;
         this.expression = expression;
         if (expression instanceof CompiledExpressionImpl) {
@@ -67,6 +66,7 @@ public class DMNLiteralExpressionEvaluator
             throw new IllegalArgumentException(
                     "Cannot create DMNLiteralExpressionEvaluator: unsupported type " + expression.getClass());
         }
+        this.feelInstance = (FEELImpl) feel;
     }
 
     public boolean isFunctionDefinition() {
@@ -80,14 +80,10 @@ public class DMNLiteralExpressionEvaluator
     @Override
     public EvaluatorResult evaluate(DMNRuntimeEventManager dmrem, DMNResult dmnr) {
         DMNResultImpl result = (DMNResultImpl) dmnr;
-        // in case an exception is thrown, the parent node will report it
-        List<DMNProfile> profiles = ((DMNRuntimeImpl) dmrem.getRuntime()).getProfiles();
-        @SuppressWarnings({"unchecked", "rawtypes"})
-        FEELImpl feelInstance = (FEELImpl) FEEL.newInstance(dmrem.getRuntime().getRootClassLoader(), (List) profiles);
         LiteralInvocationListener liListener = new LiteralInvocationListener();
-        @SuppressWarnings({"unchecked", "rawtypes"})
         EvaluationContextImpl ectx = feelInstance.newEvaluationContext(Arrays.asList(liListener), result.getContext().getAll());
         ectx.setDMNRuntime(dmrem.getRuntime());
+        // in case an exception is thrown, the parent node will report it
         Object val = feelInstance.evaluate(expression, ectx);
         ResultType resultType = ResultType.SUCCESS;
         for (FEELEvent captured : liListener.events) {

--- a/kie-dmn/kie-dmn-core/src/main/java/org/kie/dmn/core/compiler/DMNEvaluatorCompiler.java
+++ b/kie-dmn/kie-dmn-core/src/main/java/org/kie/dmn/core/compiler/DMNEvaluatorCompiler.java
@@ -906,7 +906,7 @@ public class DMNEvaluatorCompiler implements DMNDecisionLogicCompiler {
                                                                                         exprText,
                                                                                         exprName,
                                                                                         node.getIdentifierString() );
-                    evaluator = new DMNLiteralExpressionEvaluator(compiledExpression, expression);
+                    evaluator = new DMNLiteralExpressionEvaluator(compiledExpression, expression, ctx.getFeelHelper().newFEELInstance());
                 } catch ( Throwable e ) {
                     MsgUtil.reportMessage( logger,
                                            DMNMessage.Severity.ERROR,


### PR DESCRIPTION
like:
 - DMNInvocationEvaluator
 - DMNDTExpressionEvaluator

**JIRA**: https://issues.redhat.com/browse/DROOLS-6725

**referenced Pull Requests**: 

superseeds
- https://github.com/kiegroup/drools/pull/3838#issuecomment-979980488

related PRs:
- https://github.com/kiegroup/kie-benchmarks/pull/151

Benchmarks demonstrating a ~100% improvement on a realistic use-case scenario of a 10x usual numbers of decision (usually a handful, measuring more)
```
BEFORE
Benchmark                                              (numberOfDecisionsWithContext)  Mode    Cnt  Score   Error  Units
DMNEvaluateTriangularNumHardBenchmark.evaluateContext                              20    ss  50000  0.103 ± 0.001  ms/op
DMNEvaluateTriangularNumHardBenchmark.evaluateContext                              50    ss  50000  0.245 ± 0.001  ms/op
AFTER
Benchmark                                              (numberOfDecisionsWithContext)  Mode    Cnt  Score   Error  Units
DMNEvaluateTriangularNumHardBenchmark.evaluateContext                              20    ss  50000  0.038 ± 0.001  ms/op
DMNEvaluateTriangularNumHardBenchmark.evaluateContext                              50    ss  50000  0.141 ± 0.001  ms/op

BEFORE
Benchmark                                                (numberOfDecisions)  Mode    Cnt  Score   Error  Units
DMNEvaluateFewLiteralDecisionBenchmark.evaluateDecision                   20    ss  10000  0.123 ± 0.005  ms/op
DMNEvaluateFewLiteralDecisionBenchmark.evaluateDecision                   50    ss  10000  0.297 ± 0.006  ms/op
DMNEvaluateFewLiteralDecisionBenchmark.evaluateDecision                  100    ss  10000  0.712 ± 0.006  ms/op
AFTER
Benchmark                                                (numberOfDecisions)  Mode    Cnt  Score   Error  Units
DMNEvaluateFewLiteralDecisionBenchmark.evaluateDecision                   20    ss  10000  0.061 ± 0.001  ms/op
DMNEvaluateFewLiteralDecisionBenchmark.evaluateDecision                   50    ss  10000  0.150 ± 0.004  ms/op
DMNEvaluateFewLiteralDecisionBenchmark.evaluateDecision                  100    ss  10000  0.503 ± 0.005  ms/op
```

<details>
<summary>
How to replicate CI configuration locally?
</summary>

Build Chain tool does "simple" maven build(s), the builds are just Maven commands, but because the repositories relates and depends on each other and any change in API or class method could affect several of those repositories there is a need to use [build-chain tool](https://github.com/kiegroup/github-action-build-chain) to handle cross repository builds and be sure that we always use latest version of the code for each repository.
 
[build-chain tool](https://github.com/kiegroup/github-action-build-chain) is a build tool which can be used on command line locally or in Github Actions workflow(s), in case you need to change multiple repositories and send multiple dependent pull requests related with a change you can easily reproduce the same build by executing it on Github hosted environment or locally in your development environment. See [local execution](https://github.com/kiegroup/github-action-build-chain#local-execution) details to get more information about it.
</details>

<details>
<summary>
How to retest this PR or trigger a specific build:
</summary>

* <b>a pull request</b> please add comment: <b>Jenkins retest this</b>

* <b>a full downstream build</b> please add comment: <b>Jenkins run fdb</b>

* <b>a compile downstream build</b> please  add comment: <b>Jenkins run cdb</b>

* <b>a full production downstream build</b> please add comment: <b>Jenkins execute product fdb</b>

* <b>an upstream build</b> please add comment: <b>Jenkins run upstream</b>
</details>
