### PR TITLE
[DROOLS-6137] executable-model test failure in test-compiler-integration UnlinkingTest

### DIFF
--- a/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/integrationtests/UnlinkingTest.java
+++ b/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/integrationtests/UnlinkingTest.java
@@ -44,8 +44,7 @@ public class UnlinkingTest {
 
     @Parameterized.Parameters(name = "KieBase type={0}")
     public static Collection<Object[]> getParameters() {
-     // TODO: EM failed with some tests. File JIRAs
-        return TestParametersUtil.getKieBaseCloudConfigurations(false);
+        return TestParametersUtil.getKieBaseCloudConfigurations(true);
     }
 
     @Test

--- a/drools-test-coverage/test-compiler-integration/src/test/resources/org/drools/mvel/integrationtests/test_LRUnlinking.drl
+++ b/drools-test-coverage/test-compiler-integration/src/test/resources/org/drools/mvel/integrationtests/test_LRUnlinking.drl
@@ -21,9 +21,9 @@ rule "Test LR unlinking with multiple joins on the same object type"
 	when
 	 $p1 : Person ($name : name != null)
 	 $p2 : Person ($likes : likes != null)
-	 $p3 : Person ($age : age != null)
+	 $p3 : Person ($age : age != 0)
 	 $p4 : Person ($hair : hair != null)
-	 $p5 : Person ($happy : happy != null)
+	 $p5 : Person ($happy : happy != false)
 	 $p6 : Person (name != $name,
 	               likes == $likes, 
 	               age == $age, 


### PR DESCRIPTION
Exec-model failing test is `UnlinkingTest.multipleJoinsUsingSameOTN()`.

**Ports** 
This is a PR for 7.x

[link](https://www.example.com) <- will do for main

**JIRA**: 
https://issues.redhat.com/browse/DROOLS-6137

<details>
<summary>
How to replicate CI configuration locally?
</summary>

Build Chain tool does "simple" maven build(s), the builds are just Maven commands, but because the repositories relates and depends on each other and any change in API or class method could affect several of those repositories there is a need to use [build-chain tool](https://github.com/kiegroup/github-action-build-chain) to handle cross repository builds and be sure that we always use latest version of the code for each repository.
 
[build-chain tool](https://github.com/kiegroup/github-action-build-chain) is a build tool which can be used on command line locally or in Github Actions workflow(s), in case you need to change multiple repositories and send multiple dependent pull requests related with a change you can easily reproduce the same build by executing it on Github hosted environment or locally in your development environment. See [local execution](https://github.com/kiegroup/github-action-build-chain#local-execution) details to get more information about it.
</details>

<details>
<summary>
How to retest this PR or trigger a specific build:
</summary>

* <b>a pull request</b> please add comment: <b>Jenkins retest this</b>

* <b>a full downstream build</b> please add comment: <b>Jenkins run fdb</b>

* <b>a compile downstream build</b> please  add comment: <b>Jenkins run cdb</b>

* <b>a full production downstream build</b> please add comment: <b>Jenkins execute product fdb</b>

* <b>an upstream build</b> please add comment: <b>Jenkins run upstream</b>
</details>
