### PR TITLE
[DROOLS-5828] executable-model test failure in test-compiler-integrat…

### DIFF
--- a/drools-model/drools-model-compiler/src/main/java/org/drools/modelcompiler/builder/generator/RuleContext.java
+++ b/drools-model/drools-model-compiler/src/main/java/org/drools/modelcompiler/builder/generator/RuleContext.java
@@ -73,6 +73,8 @@ import static org.drools.modelcompiler.builder.generator.QueryGenerator.toQueryA
 
 public class RuleContext {
 
+    private static final String SCOPE_SUFFIX = "_sCoPe";
+
     private final KnowledgeBuilderImpl kbuilder;
     private final PackageModel packageModel;
     private final TypeResolver typeResolver;
@@ -365,7 +367,17 @@ public class RuleContext {
         }
         this.scopedDeclarations.put(d.getBindingId(), d);
         this.allDeclarations.put(d.getBindingId(), d);
-        definedVars.put(bindingId, bindingId);
+        String var = stripIfScoped(bindingId);
+        definedVars.put(var, bindingId);
+    }
+
+    private String stripIfScoped(String bindingId) {
+        if (bindingId.endsWith(SCOPE_SUFFIX)) {
+            String stripSuffix = bindingId.substring(0, bindingId.lastIndexOf(SCOPE_SUFFIX));
+            return stripSuffix.substring(0, stripSuffix.lastIndexOf("_")); // strip counter
+        } else {
+            return bindingId;
+        }
     }
 
     public void addOOPathDeclaration(DeclarationSpec d) {
@@ -615,7 +627,7 @@ public class RuleContext {
         if ( idGenerator.isGenerated( x ) || ruleUnitVars.containsKey( x ) ) {
             return DrlxParseUtil.toVar( x );
         }
-        String var = x.endsWith( "sCoPe" ) ? x : definedVars.get(x);
+        String var = x.endsWith( SCOPE_SUFFIX ) ? x : definedVars.get(x);
         return DrlxParseUtil.toVar(var != null ? var : x + currentScope.id);
     }
 
@@ -643,7 +655,7 @@ public class RuleContext {
         }
 
         private Scope( ConditionalElementDescr scopeElement ) {
-            this( "_" + scopeCounter++ + "_sCoPe", scopeElement );
+            this( "_" + scopeCounter++ + SCOPE_SUFFIX, scopeElement );
         }
 
         private Scope( String id, ConditionalElementDescr scopeElement ) {

--- a/drools-model/drools-model-compiler/src/main/java/org/drools/modelcompiler/builder/generator/visitor/accumulate/AccumulateVisitor.java
+++ b/drools-model/drools-model-compiler/src/main/java/org/drools/modelcompiler/builder/generator/visitor/accumulate/AccumulateVisitor.java
@@ -239,7 +239,7 @@ public class AccumulateVisitor {
             if ( declaration.isPresent() ) {
                 nameExpr = declaration.get().getBindingId();
             } else {
-                throw new RuntimeException("Unknown parameter in accumulate: " + accumulateFunctionParameter);
+                throw new RuntimeException("Unknown parameter in accumulate: " + name);
             }
         }
 

--- a/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/integrationtests/MatchTest.java
+++ b/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/integrationtests/MatchTest.java
@@ -30,8 +30,6 @@ import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
 import org.kie.api.KieBase;
 import org.kie.api.runtime.KieSession;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
@@ -48,12 +46,8 @@ public class MatchTest {
 
     @Parameterized.Parameters(name = "KieBase type={0}")
     public static Collection<Object[]> getParameters() {
-        // TODO: EM failed with testGetObjectsAccumulateWithNestedExists, testGetObjectsAccumulate, 
-        // testObjectsDeepOnAccumulateNotSupportingReverse, testObjectsDeepOnNestedAccumulate. File JIRAs
-        return TestParametersUtil.getKieBaseCloudConfigurations(false);
+        return TestParametersUtil.getKieBaseCloudConfigurations(true);
     }
-
-    private static Logger logger = LoggerFactory.getLogger(MatchTest.class);
 
     @Test
     public void testGetObjectsOnePattern() {


### PR DESCRIPTION
…… (#4051)

* [DROOLS-5828] executable-model test failure in test-compiler-integration MatchTest
- Strip sCoPe for definedVars
- Use LambdaAccumulator.BindingAcc even if sourcePattern is null

* make "_sCoPe" a constant

**Ports** 
This PR is a forward-port of https://github.com/kiegroup/drools/pull/4051 to main

**JIRA**: 
https://issues.redhat.com/browse/DROOLS-5828

<details>
<summary>
How to replicate CI configuration locally?
</summary>

Build Chain tool does "simple" maven build(s), the builds are just Maven commands, but because the repositories relates and depends on each other and any change in API or class method could affect several of those repositories there is a need to use [build-chain tool](https://github.com/kiegroup/github-action-build-chain) to handle cross repository builds and be sure that we always use latest version of the code for each repository.
 
[build-chain tool](https://github.com/kiegroup/github-action-build-chain) is a build tool which can be used on command line locally or in Github Actions workflow(s), in case you need to change multiple repositories and send multiple dependent pull requests related with a change you can easily reproduce the same build by executing it on Github hosted environment or locally in your development environment. See [local execution](https://github.com/kiegroup/github-action-build-chain#local-execution) details to get more information about it.
</details>

<details>
<summary>
How to retest this PR or trigger a specific build:
</summary>

* <b>a pull request</b> please add comment: <b>Jenkins retest this</b>

* <b>a full downstream build</b> please add comment: <b>Jenkins run fdb</b>

* <b>a compile downstream build</b> please  add comment: <b>Jenkins run cdb</b>

* <b>a full production downstream build</b> please add comment: <b>Jenkins execute product fdb</b>

* <b>an upstream build</b> please add comment: <b>Jenkins run upstream</b>
</details>
