### PR TITLE
BXMSPROD-1577 Improved result message for nightlies

### DIFF
--- a/.ci/jenkins/Jenkinsfile.deploy
+++ b/.ci/jenkins/Jenkinsfile.deploy
@@ -98,12 +98,15 @@ pipeline {
         stage('Build & Test') {
             steps {
                 script {
-                    getMavenCommand().skipTests(params.SKIP_TESTS).run('clean install')
+                    getMavenCommand().withProperty('maven.test.failure.ignore', true).skipTests(params.SKIP_TESTS).run('clean install')
                 }
             }
             post {
                 always {
-                    saveReports(params.SKIP_TESTS)
+                    script {
+                        saveReports()
+                        util.archiveConsoleLog()
+                    }
                 }
             }
         }
@@ -184,8 +187,8 @@ pipeline {
     }
 }
 
-void saveReports(boolean allowEmpty=false) {
-    junit testResults: '**/target/surefire-reports/**/*.xml, **/target/failsafe-reports/**/*.xml', allowEmptyResults: allowEmpty
+void saveReports() {
+    junit testResults: '**/target/surefire-reports/**/*.xml, **/target/failsafe-reports/**/*.xml', allowEmptyResults: true
 }
 
 void checkoutRepo() {
@@ -210,9 +213,7 @@ void commitAndCreatePR() {
 
 void sendNotification() {
     if (params.SEND_NOTIFICATION) {
-        emailext body: "**Deploy job** #${BUILD_NUMBER} was: ${currentBuild.currentResult}\nPlease look here: ${BUILD_URL}",
-             subject: "[${getBuildBranch()}] Drools",
-             to: env.KOGITO_CI_EMAIL_TO
+        mailer.sendZulipTestSummaryNotification('Deploy', "[${getBuildBranch()}] Drools", [env.KOGITO_CI_EMAIL_TO])
     } else {
         echo 'No notification sent per configuration'
     }

--- a/.ci/jenkins/Jenkinsfile.promote
+++ b/.ci/jenkins/Jenkinsfile.promote
@@ -108,9 +108,7 @@ pipeline {
 
 void sendNotification() {
     if (params.SEND_NOTIFICATION) {
-        emailext body: "**Promote job** #${BUILD_NUMBER} was: ${currentBuild.currentResult}\nPlease look here: ${BUILD_URL}",
-             subject: "[${getBuildBranch()}] Drools",
-             to: env.KOGITO_CI_EMAIL_TO
+        mailer.sendMarkdownTestSummaryNotification('Promote', "[${getBuildBranch()}] Drools", [env.KOGITO_CI_EMAIL_TO])
     } else {
         echo 'No notification sent per configuration'
     }


### PR DESCRIPTION
https://issues.redhat.com/browse/BXMSPROD-1577

This will improve the error message on Zulip
Examples: https://kie.zulipchat.com/#narrow/stream/236603-kogito-ci/topic/.5Btest.5D.20Test.20display.20failed.20tests

Depends on 
- https://github.com/kiegroup/jenkins-pipeline-shared-libraries/pull/173
- https://github.com/kiegroup/jenkins-pipeline-shared-libraries/pull/174

Related PRs:
- https://github.com/kiegroup/drools/pull/4064
- https://github.com/kiegroup/kogito-runtimes/pull/1773
- https://github.com/kiegroup/optaplanner/pull/1715
- https://github.com/kiegroup/kogito-apps/pull/1149
- https://github.com/kiegroup/kogito-examples/pull/1023

<details>
<summary>
How to replicate CI configuration locally?
</summary>

Build Chain tool does "simple" maven build(s), the builds are just Maven commands, but because the repositories relates and depends on each other and any change in API or class method could affect several of those repositories there is a need to use [build-chain tool](https://github.com/kiegroup/github-action-build-chain) to handle cross repository builds and be sure that we always use latest version of the code for each repository.
 
[build-chain tool](https://github.com/kiegroup/github-action-build-chain) is a build tool which can be used on command line locally or in Github Actions workflow(s), in case you need to change multiple repositories and send multiple dependent pull requests related with a change you can easily reproduce the same build by executing it on Github hosted environment or locally in your development environment. See [local execution](https://github.com/kiegroup/github-action-build-chain#local-execution) details to get more information about it.
</details>

<details>
<summary>
How to retest this PR or trigger a specific build:
</summary>

* <b>a pull request</b> please add comment: <b>Jenkins retest this</b>

* <b>a full downstream build</b> please add comment: <b>Jenkins run fdb</b>

* <b>a compile downstream build</b> please  add comment: <b>Jenkins run cdb</b>

* <b>a full production downstream build</b> please add comment: <b>Jenkins execute product fdb</b>

* <b>an upstream build</b> please add comment: <b>Jenkins run upstream</b>
</details>
