### PR TITLE
[DROOLS-6746] make drools-core to depend on the static wiring instead…

### DIFF
--- a/drools-compiler/pom.xml
+++ b/drools-compiler/pom.xml
@@ -108,6 +108,12 @@
     </dependency>
 
     <dependency>
+      <groupId>org.drools</groupId>
+      <artifactId>drools-wiring-dynamic</artifactId>
+      <scope>test</scope>
+    </dependency>
+
+    <dependency>
       <groupId>org.kie</groupId>
       <artifactId>kie-test-util</artifactId>
       <scope>test</scope>

--- a/drools-compiler/src/main/java/org/drools/compiler/builder/impl/KnowledgeBuilderConfigurationImpl.java
+++ b/drools-compiler/src/main/java/org/drools/compiler/builder/impl/KnowledgeBuilderConfigurationImpl.java
@@ -154,41 +154,31 @@ public class KnowledgeBuilderConfigurationImpl
 
      /**
      * Constructor that sets the parent class loader for the package being built/compiled
-     * @param classLoaders
      */
-    public KnowledgeBuilderConfigurationImpl(ClassLoader... classLoaders) {
-        init(null,
-                classLoaders);
+    public KnowledgeBuilderConfigurationImpl(ClassLoader classLoader) {
+        init(null, classLoader);
     }
 
     /**
      * Programmatic properties file, added with lease precedence
      */
     public KnowledgeBuilderConfigurationImpl(Properties properties) {
-        init(properties,
-                (ClassLoader[]) null);
+        init(properties, null);
     }
 
     /**
      * Programmatic properties file, added with lease precedence
      */
-    public KnowledgeBuilderConfigurationImpl(Properties properties,
-            ClassLoader... classLoaders) {
-        init(properties,
-                classLoaders);
+    public KnowledgeBuilderConfigurationImpl(Properties properties, ClassLoader classLoader) {
+        init(properties, classLoader);
     }
 
     public KnowledgeBuilderConfigurationImpl() {
-        init(null,
-                (ClassLoader[]) null);
+        init(null, null);
     }
 
-    private void init(Properties properties,
-            ClassLoader... classLoaders) {
-        if (classLoaders != null && classLoaders.length > 1) {
-            throw new RuntimeException("Multiple classloaders are no longer supported");
-        }
-        setClassLoader(classLoaders == null || classLoaders.length == 0 ? null : classLoaders[0]);
+    private void init(Properties properties, ClassLoader classLoader) {
+        this.classLoader = ProjectClassLoader.getClassLoader(classLoader, getClass(), isClassLoaderCacheEnabled());
         init(properties);
     }
 
@@ -438,13 +428,6 @@ public class KnowledgeBuilderConfigurationImpl
 
     public ClassLoader getClassLoader() {
         return this.classLoader;
-    }
-
-    /** Use this to override the classLoader that will be used for the rules. */
-    private void setClassLoader(ClassLoader classLoader) {
-        this.classLoader = ProjectClassLoader.getClassLoader(classLoader,
-                getClass(),
-                isClassLoaderCacheEnabled());
     }
 
     public void addSemanticModule(SemanticModule module) {

--- a/drools-compiler/src/main/java/org/drools/compiler/builder/impl/KnowledgeBuilderFactoryServiceImpl.java
+++ b/drools-compiler/src/main/java/org/drools/compiler/builder/impl/KnowledgeBuilderFactoryServiceImpl.java
@@ -35,8 +35,8 @@ public class KnowledgeBuilderFactoryServiceImpl implements KnowledgeBuilderFacto
     }
 
     @Override
-    public KnowledgeBuilderConfiguration newKnowledgeBuilderConfiguration(Properties properties, ClassLoader... classLoaders) {
-        return new KnowledgeBuilderConfigurationImpl(properties, classLoaders);
+    public KnowledgeBuilderConfiguration newKnowledgeBuilderConfiguration(Properties properties, ClassLoader classLoader) {
+        return new KnowledgeBuilderConfigurationImpl(properties, classLoader);
     }
 
     @Override

--- a/drools-core/pom.xml
+++ b/drools-core/pom.xml
@@ -43,8 +43,7 @@
     </dependency>
     <dependency>
       <groupId>org.drools</groupId>
-      <artifactId>drools-wiring-dynamic</artifactId>
-      <scope>runtime</scope>
+      <artifactId>drools-wiring-static</artifactId>
     </dependency>
 
     <dependency>

--- a/drools-core/src/main/java/org/drools/core/impl/EnvironmentFactory.java
+++ b/drools-core/src/main/java/org/drools/core/impl/EnvironmentFactory.java
@@ -17,7 +17,7 @@
 package org.drools.core.impl;
 
 import org.drools.core.marshalling.impl.ClassObjectMarshallingStrategyAcceptor;
-import org.drools.core.marshalling.impl.SerializablePlaceholderResolverStrategy;
+import org.drools.core.reteoo.RuntimeComponentFactory;
 import org.kie.api.marshalling.ObjectMarshallingStrategy;
 import org.kie.api.runtime.Environment;
 import org.kie.api.runtime.EnvironmentName;
@@ -28,7 +28,7 @@ public class EnvironmentFactory {
             Environment env = new EnvironmentImpl();
             env.set(EnvironmentName.OBJECT_MARSHALLING_STRATEGIES, 
                     new ObjectMarshallingStrategy [] {
-                        new SerializablePlaceholderResolverStrategy(ClassObjectMarshallingStrategyAcceptor.DEFAULT)
+                        RuntimeComponentFactory.get().createDefaultObjectMarshallingStrategy(ClassObjectMarshallingStrategyAcceptor.DEFAULT)
                     });
         return env;
     }

--- a/drools-core/src/main/java/org/drools/core/reteoo/RuntimeComponentFactory.java
+++ b/drools-core/src/main/java/org/drools/core/reteoo/RuntimeComponentFactory.java
@@ -30,9 +30,12 @@ import org.drools.core.factmodel.traits.TraitRegistry;
 import org.drools.core.impl.RuleBase;
 import org.drools.core.management.DroolsManagementAgent;
 import org.drools.core.management.GenericKieSessionMonitoringImpl;
+import org.drools.core.marshalling.impl.SerializablePlaceholderResolverStrategy;
 import org.drools.core.spi.FactHandleFactory;
 import org.drools.core.spi.KnowledgeHelper;
 import org.kie.api.internal.utils.ServiceRegistry;
+import org.kie.api.marshalling.ObjectMarshallingStrategy;
+import org.kie.api.marshalling.ObjectMarshallingStrategyAcceptor;
 import org.kie.api.runtime.Environment;
 import org.kie.api.runtime.KieSessionConfiguration;
 import org.kie.api.runtime.KieSessionsPool;
@@ -84,5 +87,9 @@ public interface RuntimeComponentFactory {
 
     static <T> T throwExceptionForMissingRuntime() {
         throw new RuntimeException(NO_RUNTIME);
+    }
+
+    default ObjectMarshallingStrategy createDefaultObjectMarshallingStrategy(ObjectMarshallingStrategyAcceptor acceptor) {
+        return new SerializablePlaceholderResolverStrategy(acceptor);
     }
 }

--- a/drools-decisiontables/pom.xml
+++ b/drools-decisiontables/pom.xml
@@ -64,6 +64,11 @@
       <artifactId>poi</artifactId>
     </dependency>
 
+    <dependency>
+      <groupId>org.drools</groupId>
+      <artifactId>drools-mvel</artifactId>
+      <scope>test</scope>
+    </dependency>
 
     <dependency>
       <groupId>commons-io</groupId>

--- a/drools-engine-classic/pom.xml
+++ b/drools-engine-classic/pom.xml
@@ -38,6 +38,10 @@
     </dependency>
     <dependency>
       <groupId>org.drools</groupId>
+      <artifactId>drools-wiring-dynamic</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.drools</groupId>
       <artifactId>drools-kiesession</artifactId>
     </dependency>
     <dependency>

--- a/drools-engine/pom.xml
+++ b/drools-engine/pom.xml
@@ -38,6 +38,10 @@
     </dependency>
     <dependency>
       <groupId>org.drools</groupId>
+      <artifactId>drools-wiring-dynamic</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.drools</groupId>
       <artifactId>drools-kiesession</artifactId>
     </dependency>
     <dependency>

--- a/drools-kiesession/pom.xml
+++ b/drools-kiesession/pom.xml
@@ -63,6 +63,12 @@
     </dependency>
 
     <dependency>
+      <groupId>org.drools</groupId>
+      <artifactId>drools-wiring-dynamic</artifactId>
+      <scope>test</scope>
+    </dependency>
+
+    <dependency>
       <groupId>junit</groupId>
       <artifactId>junit</artifactId>
       <scope>test</scope>

--- a/drools-mvel/pom.xml
+++ b/drools-mvel/pom.xml
@@ -54,6 +54,10 @@
             <type>test-jar</type>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>org.drools</groupId>
+            <artifactId>drools-wiring-dynamic</artifactId>
+        </dependency>
 
         <dependency>
             <groupId>com.sun.xml.bind</groupId>

--- a/drools-templates/pom.xml
+++ b/drools-templates/pom.xml
@@ -40,10 +40,6 @@
       <artifactId>drools-compiler</artifactId>
     </dependency>
     <dependency>
-      <groupId>org.drools</groupId>
-      <artifactId>drools-mvel</artifactId>
-    </dependency>
-    <dependency>
       <groupId>org.kie</groupId>
       <artifactId>kie-api</artifactId>
     </dependency>
@@ -54,6 +50,12 @@
     <dependency>
       <groupId>org.mvel</groupId>
       <artifactId>mvel2</artifactId>
+    </dependency>
+
+    <dependency>
+      <groupId>org.drools</groupId>
+      <artifactId>drools-mvel</artifactId>
+      <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>org.hsqldb</groupId>

--- a/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/integrationtests/FailureOnRemovalTest.java
+++ b/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/integrationtests/FailureOnRemovalTest.java
@@ -103,8 +103,7 @@ public class FailureOnRemovalTest {
     }
 
     private KnowledgeBuilderConfiguration createKnowledgeBuilderConfiguration() {
-        KnowledgeBuilderConfiguration kconf = KnowledgeBuilderFactory.newKnowledgeBuilderConfiguration( null,
-                                                                                                        getClass().getClassLoader() );
+        KnowledgeBuilderConfiguration kconf = KnowledgeBuilderFactory.newKnowledgeBuilderConfiguration( null, getClass().getClassLoader() );
         kconf.setOption( DefaultDialectOption.get( "java" ) );
         return kconf;
     }

--- a/drools-wiring/drools-wiring-static/src/main/java/org/drools/wiring/statics/SimpleInstanceCreator.java
+++ b/drools-wiring/drools-wiring-static/src/main/java/org/drools/wiring/statics/SimpleInstanceCreator.java
@@ -28,9 +28,18 @@ public class SimpleInstanceCreator {
 
     static Object instance(String className) {
         try {
-            return Class.forName(className).newInstance();
+            return Class.forName(className).getConstructor().newInstance();
         } catch (Exception e) {
             throw new RuntimeException(e);
         }
+    }
+
+    static Object tryInstance(String className) {
+        try {
+            return Class.forName(className).getConstructor().newInstance();
+        } catch (Exception e) {
+            // ignore
+        }
+        return null;
     }
 }

--- a/drools-wiring/drools-wiring-static/src/main/java/org/drools/wiring/statics/SimpleInstanceCreator.java
+++ b/drools-wiring/drools-wiring-static/src/main/java/org/drools/wiring/statics/SimpleInstanceCreator.java
@@ -16,6 +16,7 @@
 package org.drools.wiring.statics;
 
 import java.lang.reflect.Constructor;
+import java.util.Optional;
 
 public class SimpleInstanceCreator {
     static Constructor<?> constructor(String className) {
@@ -34,12 +35,11 @@ public class SimpleInstanceCreator {
         }
     }
 
-    static Object tryInstance(String className) {
+    static Optional<Object> tryInstance(String className) {
         try {
-            return Class.forName(className).getConstructor().newInstance();
+            return Optional.of( Class.forName(className).getConstructor().newInstance() );
         } catch (Exception e) {
-            // ignore
+            return Optional.empty();
         }
-        return null;
     }
 }

--- a/drools-wiring/drools-wiring-static/src/main/java/org/drools/wiring/statics/StaticKieAssemblers.java
+++ b/drools-wiring/drools-wiring-static/src/main/java/org/drools/wiring/statics/StaticKieAssemblers.java
@@ -28,6 +28,8 @@ import org.kie.api.io.ResourceWithConfiguration;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import static org.drools.wiring.statics.SimpleInstanceCreator.tryInstance;
+
 public class StaticKieAssemblers implements KieAssemblers {
 
     private static final Logger log = LoggerFactory.getLogger(StaticKieAssemblers.class);
@@ -35,10 +37,8 @@ public class StaticKieAssemblers implements KieAssemblers {
     private Map<ResourceType, KieAssemblerService> assemblers = new HashMap<>();
 
     public StaticKieAssemblers() {
-        // insert here reflective instantiation to assembler services
-        // this is an ad-interim solution
-        // e.g. assemblers.put(ResourceType.DMN, (KieAssemblerService)
-        //         instance("org.kie.dmn.core.assembler.DMNAssemblerService"));
+        assemblers.put(ResourceType.DMN, (KieAssemblerService) tryInstance("org.kie.dmn.core.assembler.DMNAssemblerService"));
+        assemblers.put(ResourceType.PMML, (KieAssemblerService) tryInstance("org.kie.pmml.evaluator.assembler.service.PMMLAssemblerService"));
     }
 
     @Override

--- a/drools-wiring/drools-wiring-static/src/main/java/org/drools/wiring/statics/StaticKieAssemblers.java
+++ b/drools-wiring/drools-wiring-static/src/main/java/org/drools/wiring/statics/StaticKieAssemblers.java
@@ -34,11 +34,13 @@ public class StaticKieAssemblers implements KieAssemblers {
 
     private static final Logger log = LoggerFactory.getLogger(StaticKieAssemblers.class);
 
-    private Map<ResourceType, KieAssemblerService> assemblers = new HashMap<>();
+    private final Map<ResourceType, KieAssemblerService> assemblers = new HashMap<>();
 
     public StaticKieAssemblers() {
-        assemblers.put(ResourceType.DMN, (KieAssemblerService) tryInstance("org.kie.dmn.core.assembler.DMNAssemblerService"));
-        assemblers.put(ResourceType.PMML, (KieAssemblerService) tryInstance("org.kie.pmml.evaluator.assembler.service.PMMLAssemblerService"));
+        tryInstance("org.kie.dmn.core.assembler.DMNAssemblerService")
+                .ifPresent(i -> assemblers.put(ResourceType.DMN, (KieAssemblerService) i));
+        tryInstance("org.kie.pmml.evaluator.assembler.service.PMMLAssemblerService")
+                .ifPresent(i -> assemblers.put(ResourceType.PMML, (KieAssemblerService) i));
     }
 
     @Override

--- a/drools-wiring/drools-wiring-static/src/main/java/org/drools/wiring/statics/StaticProjectClassLoader.java
+++ b/drools-wiring/drools-wiring-static/src/main/java/org/drools/wiring/statics/StaticProjectClassLoader.java
@@ -80,7 +80,7 @@ public class StaticProjectClassLoader extends ProjectClassLoader {
         }
 
         public Class<?> defineClass(String name, byte[] bytecode) {
-            throw new UnsupportedOperationException();
+            throw new UnsupportedOperationException("You're trying to dynamically define a class, please add the module org.drools:drools-wiring-dynamic to your classpath.");
         }
 
         protected Class<?> loadClass(String name, boolean resolve) throws ClassNotFoundException {

--- a/drools-wiring/drools-wiring-static/src/main/java/org/drools/wiring/statics/StaticServiceRegistry.java
+++ b/drools-wiring/drools-wiring-static/src/main/java/org/drools/wiring/statics/StaticServiceRegistry.java
@@ -51,13 +51,14 @@ public class StaticServiceRegistry implements ServiceRegistry {
         registerService("org.kie.api.io.KieResources", "org.drools.core.io.impl.ResourceFactoryServiceImpl", true);
         registerService("org.kie.api.concurrent.KieExecutors", "org.drools.core.concurrent.ExecutorProviderImpl", true);
         registerService("org.kie.api.KieServices", "org.drools.compiler.kie.builder.impl.KieServicesImpl", false);
-        registerService("org.kie.internal.builder.KnowledgeBuilderFactoryService", "org.drools.compiler.builder.impl.KnowledgeBuilderFactoryServiceImpl", true);
+        registerService("org.kie.internal.builder.KnowledgeBuilderFactoryService", "org.drools.compiler.builder.impl.KnowledgeBuilderFactoryServiceImpl", false);
         registerService("org.kie.api.internal.assembler.KieAssemblers", "org.drools.wiring.statics.StaticKieAssemblers", true);
         registerService("org.kie.api.internal.runtime.KieRuntimes", "org.kie.internal.services.KieRuntimesImpl", true);
         registerService("org.kie.api.internal.weaver.KieWeavers", "org.kie.internal.services.KieWeaversImpl", true);
 
-        registerService("org.drools.compiler.kie.builder.impl.InternalKieModuleProvider", "org.drools.modelcompiler.CanonicalKieModuleProvider", true);
+        registerService("org.drools.compiler.kie.builder.impl.InternalKieModuleProvider", "org.drools.modelcompiler.CanonicalKieModuleProvider", false);
         registerService("org.drools.compiler.compiler.DecisionTableProvider", "org.drools.decisiontable.DecisionTableProviderImpl", false);
+        registerService("org.drools.compiler.kie.builder.impl.KieBaseUpdaters", "org.drools.compiler.kie.builder.impl.KieBaseUpdatersImpl", false);
         registerService("org.drools.core.reteoo.RuntimeComponentFactory", "org.drools.kiesession.factory.RuntimeComponentFactoryImpl", false);
 
         registerService("org.drools.core.marshalling.impl.ProcessMarshallerFactoryService", "org.jbpm.marshalling.impl.ProcessMarshallerFactoryServiceImpl", false);
@@ -70,6 +71,10 @@ public class StaticServiceRegistry implements ServiceRegistry {
         // pmml
         registerKieRuntimeService("org.kie.pmml.api.runtime.PMMLRuntime", "org.kie.pmml.evaluator.core.service.PMMLRuntimeService", false);
         registerKieWeaverService("org.kie.pmml.evaluator.assembler.PMMLWeaverService", false);
+
+        // dmn
+        registerKieRuntimeService("org.kie.dmn.api.core.DMNRuntime", "org.kie.dmn.core.runtime.DMNRuntimeService", false);
+        registerKieWeaverService("org.kie.dmn.core.weaver.DMNWeaverService", false);
 
         // marshalling
         registerService(org.kie.api.marshalling.KieMarshallers.class.getCanonicalName(), "org.drools.serialization.protobuf.MarshallerProviderImpl", false);

--- a/kie-dmn/kie-dmn-validation-bootstrap/pom.xml
+++ b/kie-dmn/kie-dmn-validation-bootstrap/pom.xml
@@ -42,6 +42,11 @@ This is not an user dependency, hence is not added to the boms</description>
       <groupId>org.slf4j</groupId>
       <artifactId>slf4j-api</artifactId>
     </dependency>
+
+    <dependency>
+      <groupId>org.drools</groupId>
+      <artifactId>drools-wiring-dynamic</artifactId>
+    </dependency>
   </dependencies>
   
   <profiles>

--- a/kie-dmn/kie-dmn-validation/pom.xml
+++ b/kie-dmn/kie-dmn-validation/pom.xml
@@ -114,12 +114,6 @@
     </dependency>
 
     <dependency>
-      <groupId>org.drools</groupId>
-      <artifactId>drools-wiring-dynamic</artifactId>
-      <scope>runtime</scope>
-    </dependency>
-
-    <dependency>
       <groupId>junit</groupId>
       <artifactId>junit</artifactId>
       <scope>test</scope>

--- a/kie-dmn/kie-dmn-validation/pom.xml
+++ b/kie-dmn/kie-dmn-validation/pom.xml
@@ -114,6 +114,12 @@
     </dependency>
 
     <dependency>
+      <groupId>org.drools</groupId>
+      <artifactId>drools-wiring-dynamic</artifactId>
+      <scope>runtime</scope>
+    </dependency>
+
+    <dependency>
       <groupId>junit</groupId>
       <artifactId>junit</artifactId>
       <scope>test</scope>

--- a/kie-internal/src/main/java/org/kie/internal/builder/KnowledgeBuilderFactory.java
+++ b/kie-internal/src/main/java/org/kie/internal/builder/KnowledgeBuilderFactory.java
@@ -85,9 +85,8 @@ public class KnowledgeBuilderFactory {
      * @return
      *     The KnowledgeBuilderConfiguration.
      */
-    public static KnowledgeBuilderConfiguration newKnowledgeBuilderConfiguration(Properties properties,
-                                                                                 ClassLoader... classLoaders) {
-        return FactoryServiceHolder.factoryService.newKnowledgeBuilderConfiguration( properties, classLoaders );
+    public static KnowledgeBuilderConfiguration newKnowledgeBuilderConfiguration(Properties properties, ClassLoader classLoader) {
+        return FactoryServiceHolder.factoryService.newKnowledgeBuilderConfiguration( properties, classLoader );
     }
 
     /**

--- a/kie-internal/src/main/java/org/kie/internal/builder/KnowledgeBuilderFactoryService.java
+++ b/kie-internal/src/main/java/org/kie/internal/builder/KnowledgeBuilderFactoryService.java
@@ -44,7 +44,7 @@ public interface KnowledgeBuilderFactoryService  extends Service {
      *     Provided ClassLoader, can be null and then ClassLoader defaults to Thread.currentThread().getContextClassLoader()
      * @return
      */
-    KnowledgeBuilderConfiguration newKnowledgeBuilderConfiguration(Properties properties, ClassLoader... classLoader);
+    KnowledgeBuilderConfiguration newKnowledgeBuilderConfiguration(Properties properties, ClassLoader classLoader);
 
     /**
      * DecisionTables need to take a configuration of the InputType and XLS based

--- a/kie-pmml-trusty/kie-pmml-evaluator/kie-pmml-evaluator-assembler/pom.xml
+++ b/kie-pmml-trusty/kie-pmml-evaluator/kie-pmml-evaluator-assembler/pom.xml
@@ -64,6 +64,11 @@
     </dependency>
     <!-- TEST -->
     <dependency>
+      <groupId>org.drools</groupId>
+      <artifactId>drools-wiring-dynamic</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
       <groupId>org.kie</groupId>
       <artifactId>kie-pmml-commons</artifactId>
       <scope>test</scope>

--- a/kie-pmml-trusty/kie-pmml-models/kie-pmml-models-clustering/kie-pmml-models-clustering-tests/pom.xml
+++ b/kie-pmml-trusty/kie-pmml-models/kie-pmml-models-clustering/kie-pmml-models-clustering-tests/pom.xml
@@ -16,6 +16,11 @@
     <!-- TEST -->
     <!-- PMML -->
     <dependency>
+      <groupId>org.drools</groupId>
+      <artifactId>drools-wiring-dynamic</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
       <groupId>org.kie</groupId>
       <artifactId>kie-pmml-models-clustering-model</artifactId>
       <scope>test</scope>

--- a/kie-pmml-trusty/kie-pmml-models/kie-pmml-models-mining/kie-pmml-models-mining-tests/pom.xml
+++ b/kie-pmml-trusty/kie-pmml-models/kie-pmml-models-mining/kie-pmml-models-mining-tests/pom.xml
@@ -15,6 +15,11 @@
     <!-- TEST -->
     <!-- PMML -->
     <dependency>
+      <groupId>org.drools</groupId>
+      <artifactId>drools-wiring-dynamic</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
       <groupId>org.kie</groupId>
       <artifactId>kie-pmml-models-mining-model</artifactId>
       <scope>test</scope>

--- a/kie-pmml-trusty/kie-pmml-models/kie-pmml-models-regression/kie-pmml-models-regression-tests/pom.xml
+++ b/kie-pmml-trusty/kie-pmml-models/kie-pmml-models-regression/kie-pmml-models-regression-tests/pom.xml
@@ -17,6 +17,11 @@
     <!-- TEST -->
     <!-- PMML -->
     <dependency>
+      <groupId>org.drools</groupId>
+      <artifactId>drools-wiring-dynamic</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
       <groupId>org.kie</groupId>
       <artifactId>kie-pmml-models-regression-model</artifactId>
       <scope>test</scope>

--- a/kie-pmml-trusty/kie-pmml-models/kie-pmml-models-scorecard/kie-pmml-models-scorecard-tests/pom.xml
+++ b/kie-pmml-trusty/kie-pmml-models/kie-pmml-models-scorecard/kie-pmml-models-scorecard-tests/pom.xml
@@ -16,6 +16,11 @@
     <!-- TEST -->
     <!-- PMML -->
     <dependency>
+      <groupId>org.drools</groupId>
+      <artifactId>drools-wiring-dynamic</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
       <groupId>org.kie</groupId>
       <artifactId>kie-pmml-models-scorecard-model</artifactId>
       <scope>test</scope>

--- a/kie-pmml-trusty/kie-pmml-models/kie-pmml-models-tree/kie-pmml-models-tree-tests/pom.xml
+++ b/kie-pmml-trusty/kie-pmml-models/kie-pmml-models-tree/kie-pmml-models-tree-tests/pom.xml
@@ -16,6 +16,11 @@
     <!-- TEST -->
     <!-- PMML -->
     <dependency>
+      <groupId>org.drools</groupId>
+      <artifactId>drools-wiring-dynamic</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
       <groupId>org.kie</groupId>
       <artifactId>kie-pmml-models-tree-model</artifactId>
       <scope>test</scope>


### PR DESCRIPTION
… of the dynamic one

**JIRA**: https://issues.redhat.com/browse/DROOLS-6746

Related PRs
https://github.com/kiegroup/drools/pull/4066
https://github.com/kiegroup/kogito-runtimes/pull/1782
https://github.com/kiegroup/kogito-examples/pull/1033

I made `drools-core` to depend on `drools-wiring-static` and fixed the static registry, especially for the missing entries in the dmn area. This should allow a better integration on kogito side and give the possibility to get rid of at least some of the shading modules we created there. 

When necessary (mostly for tests) I brought in the `drools-wiring-dynamic` module. Note that in these cases it is not required to exclude the static one. In fact, when present, the dynamic module simply takes a [higher precedence](https://github.com/kiegroup/drools/blob/main/kie-api/src/main/java/org/kie/api/internal/utils/ServiceRegistry.java#L89) over the static one. Similarly the dependency to `drools-wiring-dynamic` has been added to modules when the dynamic context is evident and unavoidable like `drools-mvel`.

This change will probably require to create user friendly aggregating poms for both pmml and dmn, including the dynamic module in pure drools 8 (no kogito) usage scenarios. I already did the same for both `drools-engine` and `drools-engine-classic`.