### PR TITLE
[DROOLS-5193] Overall PMML listener design implementation

### DIFF
--- a/kie-pmml-trusty/kie-pmml-api/pom.xml
+++ b/kie-pmml-trusty/kie-pmml-api/pom.xml
@@ -41,6 +41,11 @@
       <artifactId>junit</artifactId>
       <scope>test</scope>
     </dependency>
+    <dependency>
+      <groupId>org.mockito</groupId>
+      <artifactId>mockito-core</artifactId>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
 
 

--- a/kie-pmml-trusty/kie-pmml-api/src/main/java/org/kie/pmml/api/enums/PMML_STEP.java
+++ b/kie-pmml-trusty/kie-pmml-api/src/main/java/org/kie/pmml/api/enums/PMML_STEP.java
@@ -22,9 +22,7 @@ package org.kie.pmml.api.enums;
 public enum PMML_STEP {
 
     START,
-    AFTER_PREPROCESS,
-    BEFORE_POSTPROCESS,
+    PRE_EVALUATION_TRANSFORMATIONS,
+    POST_EVALUATION_TRANSFORMATIONS,
     END;
-
-
 }

--- a/kie-pmml-trusty/kie-pmml-api/src/main/java/org/kie/pmml/api/enums/PMML_STEP.java
+++ b/kie-pmml-trusty/kie-pmml-api/src/main/java/org/kie/pmml/api/enums/PMML_STEP.java
@@ -22,7 +22,7 @@ package org.kie.pmml.api.enums;
 public enum PMML_STEP {
 
     START,
-    PRE_EVALUATION_TRANSFORMATIONS,
-    POST_EVALUATION_TRANSFORMATIONS,
-    END;
+    PRE_EVALUATION,
+    POST_EVALUATION,
+    END
 }

--- a/kie-pmml-trusty/kie-pmml-api/src/main/java/org/kie/pmml/api/enums/PMML_STEP.java
+++ b/kie-pmml-trusty/kie-pmml-api/src/main/java/org/kie/pmml/api/enums/PMML_STEP.java
@@ -1,0 +1,30 @@
+/*
+ * Copyright 2022 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.kie.pmml.api.enums;
+
+/**
+ * Values common to all models, i.e. to overall execution
+ * This should not contain any reference to a specific implementation, to keep modules decoupling
+ */
+public enum PMML_STEP {
+
+    START,
+    AFTER_PREPROCESS,
+    BEFORE_POSTPROCESS,
+    END;
+
+
+}

--- a/kie-pmml-trusty/kie-pmml-api/src/main/java/org/kie/pmml/api/models/PMMLStep.java
+++ b/kie-pmml-trusty/kie-pmml-api/src/main/java/org/kie/pmml/api/models/PMMLStep.java
@@ -1,0 +1,30 @@
+/*
+ * Copyright 2022 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.kie.pmml.api.models;
+
+import java.io.Serializable;
+import java.util.Map;
+
+/**
+ * Interface representing a meaningful <b>step</b> of PMML execution.
+ * The actual meaning will be implemented on a per-model basis
+ */
+public interface PMMLStep extends Serializable {
+
+    void addInfo(String infoName, Object infoValue);
+
+    Map<String, Object> getInfo();
+}

--- a/kie-pmml-trusty/kie-pmml-api/src/main/java/org/kie/pmml/api/runtime/PMMLContext.java
+++ b/kie-pmml-trusty/kie-pmml-api/src/main/java/org/kie/pmml/api/runtime/PMMLContext.java
@@ -16,7 +16,9 @@
 package org.kie.pmml.api.runtime;
 
 import java.util.LinkedHashMap;
+import java.util.List;
 import java.util.Map;
+import java.util.Set;
 
 import org.kie.api.pmml.PMMLRequestData;
 import org.kie.api.runtime.Context;
@@ -60,4 +62,14 @@ public interface PMMLContext extends Context {
     void setProbabilityResultMap(LinkedHashMap<String, Double> probabilityResultMap);
 
     Map<String, Object> getOutputFieldsMap();
+
+    /**
+     * Add the given <code>PMMLListener</code> to the current <code>PMMLContext</code>
+     * That listener, in turn, will be available only for evaluation of that specific <code>PMMLContext</code>
+     * @param toAdd
+     */
+    void addPMMLListener(final PMMLListener toAdd);
+
+    Set<PMMLListener> getPMMLListeners();
+
 }

--- a/kie-pmml-trusty/kie-pmml-api/src/main/java/org/kie/pmml/api/runtime/PMMLListener.java
+++ b/kie-pmml-trusty/kie-pmml-api/src/main/java/org/kie/pmml/api/runtime/PMMLListener.java
@@ -1,0 +1,28 @@
+/*
+ * Copyright 2022 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.kie.pmml.api.runtime;
+
+import org.kie.pmml.api.models.PMMLStep;
+
+public interface PMMLListener {
+
+    /**
+     * Method invoked when a <code>PMMLStep</code> is executed
+     * @param step
+     */
+    void stepExecuted(PMMLStep step);
+
+}

--- a/kie-pmml-trusty/kie-pmml-api/src/main/java/org/kie/pmml/api/runtime/PMMLRuntime.java
+++ b/kie-pmml-trusty/kie-pmml-api/src/main/java/org/kie/pmml/api/runtime/PMMLRuntime.java
@@ -17,10 +17,10 @@ package org.kie.pmml.api.runtime;
 
 import java.util.List;
 import java.util.Optional;
+import java.util.Set;
 
 import org.kie.api.pmml.PMML4Result;
 import org.kie.pmml.api.models.PMMLModel;
-import org.kie.pmml.api.models.PMMLModelImpl;
 
 public interface PMMLRuntime {
 
@@ -64,4 +64,9 @@ public interface PMMLRuntime {
      */
     void removePMMLListener(final PMMLListener toRemove);
 
+    /**
+     * Returns an <b>unmodifiable set</b> of the <code>PMMLListener</code>s registered with the
+     * current instance
+     */
+    Set<PMMLListener> getPMMLListeners();
 }

--- a/kie-pmml-trusty/kie-pmml-api/src/main/java/org/kie/pmml/api/runtime/PMMLRuntime.java
+++ b/kie-pmml-trusty/kie-pmml-api/src/main/java/org/kie/pmml/api/runtime/PMMLRuntime.java
@@ -48,4 +48,20 @@ public interface PMMLRuntime {
      */
     Optional<PMMLModel> getPMMLModel(final String modelName);
 
+    /**
+     * Add the given <code>PMMLListener</code> to the current <code>PMMLRuntime</code>
+     * That listener, in turn, will be added to any <code>PMMLContext</code> passed
+     * to the <code>evaluate</code> method
+     * @param toAdd
+     */
+    void addPMMLListener(final PMMLListener toAdd);
+
+    /**
+     * Remove the given <code>PMMLListener</code> from the current <code>PMMLRuntime</code>.
+     * That listener, in turn, will not be added anymore to <code>PMMLContext</code>s passed
+     * to the <code>evaluate</code> method
+     * @param toRemove
+     */
+    void removePMMLListener(final PMMLListener toRemove);
+
 }

--- a/kie-pmml-trusty/kie-pmml-commons/src/test/java/org/kie/pmml/commons/testingutility/PMMLContextTest.java
+++ b/kie-pmml-trusty/kie-pmml-commons/src/test/java/org/kie/pmml/commons/testingutility/PMMLContextTest.java
@@ -18,9 +18,11 @@ package org.kie.pmml.commons.testingutility;
 import java.util.HashMap;
 import java.util.LinkedHashMap;
 import java.util.Map;
+import java.util.Set;
 
 import org.kie.api.pmml.PMMLRequestData;
 import org.kie.pmml.api.runtime.PMMLContext;
+import org.kie.pmml.api.runtime.PMMLListener;
 
 public class PMMLContextTest implements PMMLContext {
 
@@ -135,5 +137,15 @@ public class PMMLContextTest implements PMMLContext {
     @Override
     public Map<String, Object> getOutputFieldsMap() {
         return outputFieldsMap;
+    }
+
+    @Override
+    public void addPMMLListener(PMMLListener toAdd) {
+
+    }
+
+    @Override
+    public Set<PMMLListener> getPMMLListeners() {
+        return null;
     }
 }

--- a/kie-pmml-trusty/kie-pmml-evaluator/kie-pmml-evaluator-core/src/main/java/org/kie/pmml/evaluator/core/PMMLContextImpl.java
+++ b/kie-pmml-trusty/kie-pmml-evaluator/kie-pmml-evaluator-core/src/main/java/org/kie/pmml/evaluator/core/PMMLContextImpl.java
@@ -17,13 +17,16 @@ package org.kie.pmml.evaluator.core;
 
 import java.util.Collections;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.LinkedHashMap;
 import java.util.Map;
+import java.util.Set;
 import java.util.concurrent.atomic.AtomicReference;
 
 import org.drools.core.command.impl.ContextImpl;
 import org.kie.api.pmml.PMMLRequestData;
 import org.kie.pmml.api.runtime.PMMLContext;
+import org.kie.pmml.api.runtime.PMMLListener;
 
 public class PMMLContextImpl extends ContextImpl implements PMMLContext {
 
@@ -32,6 +35,7 @@ public class PMMLContextImpl extends ContextImpl implements PMMLContext {
     private final Map<String, Object> commonTransformationMap = new HashMap<>();
     private final Map<String, Object> localTransformationMap = new HashMap<>();
     private final Map<String, Object> outputFieldsMap = new HashMap<>();
+    private final Set<PMMLListener> pmmlListeners = new HashSet<>();
 
     private Object predictedDisplayValue;
     private Object entityId;
@@ -41,6 +45,11 @@ public class PMMLContextImpl extends ContextImpl implements PMMLContext {
     public PMMLContextImpl(final PMMLRequestData pmmlRequestData) {
         super();
         set(PMML_REQUEST_DATA, pmmlRequestData);
+    }
+
+    public PMMLContextImpl(final PMMLRequestData pmmlRequestData, final Set<PMMLListener> pmmlListeners) {
+        this(pmmlRequestData);
+        this.pmmlListeners.addAll(pmmlListeners);
     }
 
     @Override
@@ -63,16 +72,28 @@ public class PMMLContextImpl extends ContextImpl implements PMMLContext {
         commonTransformationMap.put(fieldName, commonTranformation);
     }
 
+    /**
+     * Returns an <b>unmodifiable map</b> of <code>missingValueReplacedMap</code>
+     * @return
+     */
     @Override
     public Map<String, Object> getMissingValueReplacedMap() {
         return Collections.unmodifiableMap(missingValueReplacedMap);
     }
 
+    /**
+     * Returns an <b>unmodifiable map</b> of <code>commonTransformationMap</code>
+     * @return
+     */
     @Override
     public Map<String, Object> getCommonTransformationMap() {
         return Collections.unmodifiableMap(commonTransformationMap);
     }
 
+    /**
+     * Returns an <b>unmodifiable map</b> of <code>localTransformationMap</code>
+     * @return
+     */
     @Override
     public Map<String, Object> getLocalTransformationMap() {
         return Collections.unmodifiableMap(localTransformationMap);
@@ -126,6 +147,10 @@ public class PMMLContextImpl extends ContextImpl implements PMMLContext {
         this.affinity = affinity;
     }
 
+    /**
+     * Returns an <b>unmodifiable map</b> of probabilities, or an empty one
+     * @return
+     */
     @Override
     public Map<String, Double> getProbabilityMap() {
         final LinkedHashMap<String, Double> probabilityResultMap = getProbabilityResultMap();
@@ -146,5 +171,19 @@ public class PMMLContextImpl extends ContextImpl implements PMMLContext {
     @Override
     public Map<String, Object> getOutputFieldsMap() {
         return outputFieldsMap;
+    }
+
+    @Override
+    public void addPMMLListener(final PMMLListener toAdd) {
+        pmmlListeners.add(toAdd);
+    }
+
+    /**
+     * Returns an <b>unmodifiable set</b> of <code>pmmlListeners</code>
+     * @return
+     */
+    @Override
+    public Set<PMMLListener> getPMMLListeners() {
+        return Collections.unmodifiableSet(pmmlListeners);
     }
 }

--- a/kie-pmml-trusty/kie-pmml-evaluator/kie-pmml-evaluator-core/src/main/java/org/kie/pmml/evaluator/core/implementations/AbstractPMMLStep.java
+++ b/kie-pmml-trusty/kie-pmml-evaluator/kie-pmml-evaluator-core/src/main/java/org/kie/pmml/evaluator/core/implementations/AbstractPMMLStep.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright 2022 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.kie.pmml.evaluator.core.implementations;
+
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+
+import org.kie.pmml.api.models.PMMLStep;
+
+/**
+ * Common abstract implementation of <code>PMMLStep</code>
+ */
+public class AbstractPMMLStep implements PMMLStep {
+
+    private static final long serialVersionUID = -7633308400272166095L;
+
+    private final Map<String, Object> info = new HashMap<>();
+
+    @Override
+    public void addInfo(String infoName, Object infoValue) {
+        info.put(infoName, infoValue);
+    }
+
+    /**
+     * Returns an <b>unmodifiable map</b> of <code>info</code>
+     * @return
+     */
+    @Override
+    public Map<String, Object> getInfo() {
+        return Collections.unmodifiableMap(info);
+    }
+}

--- a/kie-pmml-trusty/kie-pmml-evaluator/kie-pmml-evaluator-core/src/main/java/org/kie/pmml/evaluator/core/implementations/PMMLRuntimeStep.java
+++ b/kie-pmml-trusty/kie-pmml-evaluator/kie-pmml-evaluator-core/src/main/java/org/kie/pmml/evaluator/core/implementations/PMMLRuntimeStep.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright 2022 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.kie.pmml.evaluator.core.implementations;
+
+import org.kie.pmml.api.enums.PMML_STEP;
+
+/**
+ * <code>PMMLStep</code>> common to all models, i.e. to overall execution.
+ */
+public class PMMLRuntimeStep extends AbstractPMMLStep {
+
+    private static final long serialVersionUID = -881985972308818180L;
+    private final PMML_STEP pmmlStep;
+
+    public PMMLRuntimeStep(PMML_STEP pmmlStep) {
+        this.pmmlStep = pmmlStep;
+    }
+
+    public PMML_STEP getPmmlStep() {
+        return pmmlStep;
+    }
+}

--- a/kie-pmml-trusty/kie-pmml-evaluator/kie-pmml-evaluator-core/src/main/java/org/kie/pmml/evaluator/core/service/PMMLRuntimeInternalImpl.java
+++ b/kie-pmml-trusty/kie-pmml-evaluator/kie-pmml-evaluator-core/src/main/java/org/kie/pmml/evaluator/core/service/PMMLRuntimeInternalImpl.java
@@ -16,24 +16,37 @@
 package org.kie.pmml.evaluator.core.service;
 
 import java.util.ArrayList;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Optional;
+import java.util.Set;
+import java.util.function.Supplier;
 
 import org.kie.api.KieBase;
 import org.kie.api.pmml.PMML4Result;
+import org.kie.api.pmml.PMMLRequestData;
 import org.kie.pmml.api.enums.PMML_MODEL;
+import org.kie.pmml.api.enums.PMML_STEP;
 import org.kie.pmml.api.exceptions.KiePMMLException;
 import org.kie.pmml.api.models.PMMLModel;
+import org.kie.pmml.api.models.PMMLStep;
 import org.kie.pmml.api.runtime.PMMLContext;
+import org.kie.pmml.api.runtime.PMMLListener;
 import org.kie.pmml.commons.model.KiePMMLModel;
 import org.kie.pmml.commons.model.ProcessingDTO;
 import org.kie.pmml.evaluator.api.executor.PMMLRuntimeInternal;
 import org.kie.pmml.evaluator.core.executor.PMMLModelEvaluator;
 import org.kie.pmml.evaluator.core.executor.PMMLModelEvaluatorFinderImpl;
+import org.kie.pmml.evaluator.core.implementations.PMMLRuntimeStep;
 import org.kie.pmml.evaluator.core.utils.KnowledgeBaseUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import static org.kie.pmml.api.enums.PMML_STEP.AFTER_PREPROCESS;
+import static org.kie.pmml.api.enums.PMML_STEP.BEFORE_POSTPROCESS;
+import static org.kie.pmml.api.enums.PMML_STEP.END;
+import static org.kie.pmml.api.enums.PMML_STEP.START;
+import static org.kie.pmml.evaluator.core.utils.PMMLListenerUtils.stepExecuted;
 import static org.kie.pmml.evaluator.core.utils.PostProcess.postProcess;
 import static org.kie.pmml.evaluator.core.utils.PreProcess.preProcess;
 
@@ -43,6 +56,7 @@ public class PMMLRuntimeInternalImpl implements PMMLRuntimeInternal {
 
     private final KieBase knowledgeBase;
     private final PMMLModelEvaluatorFinderImpl pmmlModelExecutorFinder;
+    private final Set<PMMLListener> pmmlListeners = new HashSet<>();
 
     public PMMLRuntimeInternalImpl(final KieBase knowledgeBase, final PMMLModelEvaluatorFinderImpl pmmlModelExecutorFinder) {
         this.knowledgeBase = knowledgeBase;
@@ -84,17 +98,52 @@ public class PMMLRuntimeInternalImpl implements PMMLRuntimeInternal {
         return evaluate(toEvaluate, context);
     }
 
+    @Override
+    public void addPMMLListener(PMMLListener toAdd) {
+        pmmlListeners.add(toAdd);
+    }
+
+    @Override
+    public void removePMMLListener(PMMLListener toRemove) {
+        pmmlListeners.remove(toRemove);
+    }
+
     @SuppressWarnings({"unchecked", "rawtypes"})
     protected PMML4Result evaluate(final KiePMMLModel model, final PMMLContext context) {
         if (logger.isDebugEnabled()) {
             logger.debug("evaluate {} {}", model, context);
         }
+        pmmlListeners.forEach(context::addPMMLListener);
+        addStep(() -> getStep(START, model, context.getRequestData()), context);
         final ProcessingDTO processingDTO = preProcess(model, context);
+        addStep(() -> getStep(AFTER_PREPROCESS, model, context.getRequestData()), context);
         PMMLModelEvaluator executor = getFromPMMLModelType(model.getPmmlMODEL())
                 .orElseThrow(() -> new KiePMMLException(String.format("PMMLModelEvaluator not found for model %s",
                                                                       model.getPmmlMODEL())));
         PMML4Result toReturn = executor.evaluate(knowledgeBase, model, context);
+        addStep(() -> getStep(BEFORE_POSTPROCESS, model, context.getRequestData()), context);
         postProcess(toReturn, model, context, processingDTO);
+        addStep(() -> getStep(END, model, context.getRequestData()), context);
+        return toReturn;
+    }
+
+    /**
+     * Send the given <code>PMMLStep</code>
+     * to the <code>PMMLContext</code>
+     * @param stepSupplier
+     * @param pmmlContext
+     */
+    void addStep(final Supplier<PMMLStep> stepSupplier, final PMMLContext pmmlContext) {
+        stepExecuted(stepSupplier, pmmlContext);
+    }
+
+    PMMLStep getStep(final PMML_STEP pmmlStep, final KiePMMLModel model, final PMMLRequestData requestData) {
+        final PMMLStep toReturn = new PMMLRuntimeStep(pmmlStep);
+        toReturn.addInfo("MODEL", model.getName());
+        toReturn.addInfo("CORRELATION ID", requestData.getCorrelationId());
+        toReturn.addInfo("REQUEST MODEL", requestData.getModelName());
+        requestData.getRequestParams()
+                .forEach(requestParam -> toReturn.addInfo(requestParam.getName(), requestParam.getValue()));
         return toReturn;
     }
 

--- a/kie-pmml-trusty/kie-pmml-evaluator/kie-pmml-evaluator-core/src/main/java/org/kie/pmml/evaluator/core/service/PMMLRuntimeInternalImpl.java
+++ b/kie-pmml-trusty/kie-pmml-evaluator/kie-pmml-evaluator-core/src/main/java/org/kie/pmml/evaluator/core/service/PMMLRuntimeInternalImpl.java
@@ -44,8 +44,8 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import static org.kie.pmml.api.enums.PMML_STEP.END;
-import static org.kie.pmml.api.enums.PMML_STEP.POST_EVALUATION_TRANSFORMATIONS;
-import static org.kie.pmml.api.enums.PMML_STEP.PRE_EVALUATION_TRANSFORMATIONS;
+import static org.kie.pmml.api.enums.PMML_STEP.POST_EVALUATION;
+import static org.kie.pmml.api.enums.PMML_STEP.PRE_EVALUATION;
 import static org.kie.pmml.api.enums.PMML_STEP.START;
 import static org.kie.pmml.evaluator.core.utils.PMMLListenerUtils.stepExecuted;
 import static org.kie.pmml.evaluator.core.utils.PostProcess.postProcess;
@@ -122,12 +122,12 @@ public class PMMLRuntimeInternalImpl implements PMMLRuntimeInternal {
         pmmlListeners.forEach(context::addPMMLListener);
         addStep(() -> getStep(START, model, context.getRequestData()), context);
         final ProcessingDTO processingDTO = preProcess(model, context);
-        addStep(() -> getStep(PRE_EVALUATION_TRANSFORMATIONS, model, context.getRequestData()), context);
+        addStep(() -> getStep(PRE_EVALUATION, model, context.getRequestData()), context);
         PMMLModelEvaluator executor = getFromPMMLModelType(model.getPmmlMODEL())
                 .orElseThrow(() -> new KiePMMLException(String.format("PMMLModelEvaluator not found for model %s",
                                                                       model.getPmmlMODEL())));
         PMML4Result toReturn = executor.evaluate(knowledgeBase, model, context);
-        addStep(() -> getStep(POST_EVALUATION_TRANSFORMATIONS, model, context.getRequestData()), context);
+        addStep(() -> getStep(POST_EVALUATION, model, context.getRequestData()), context);
         postProcess(toReturn, model, context, processingDTO);
         addStep(() -> getStep(END, model, context.getRequestData()), context);
         return toReturn;

--- a/kie-pmml-trusty/kie-pmml-evaluator/kie-pmml-evaluator-core/src/main/java/org/kie/pmml/evaluator/core/utils/PMMLListenerUtils.java
+++ b/kie-pmml-trusty/kie-pmml-evaluator/kie-pmml-evaluator-core/src/main/java/org/kie/pmml/evaluator/core/utils/PMMLListenerUtils.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright 2022 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.kie.pmml.evaluator.core.utils;
+
+import java.util.function.Supplier;
+
+import org.kie.pmml.api.models.PMMLStep;
+import org.kie.pmml.api.runtime.PMMLContext;
+
+/**
+ * Common utility methods related to <code>PMMLListener</code>
+ */
+public class PMMLListenerUtils {
+
+    /**
+     * Send the <code>PMMLStep</code> to all registered <code>PMMLListener</code>s
+     * @param stepSupplier
+     * @param context
+     */
+    public static void stepExecuted(final Supplier<PMMLStep> stepSupplier, final PMMLContext context) {
+        if (!context.getPMMLListeners().isEmpty()) {
+            final PMMLStep step = stepSupplier.get();
+            context.getPMMLListeners().forEach(listener -> listener.stepExecuted(step));
+        }
+    }
+
+    private PMMLListenerUtils() {
+    }
+}

--- a/kie-pmml-trusty/kie-pmml-evaluator/kie-pmml-evaluator-core/src/test/java/org/kie/pmml/evaluator/core/service/PMMLRuntimeInternalImplTest.java
+++ b/kie-pmml-trusty/kie-pmml-evaluator/kie-pmml-evaluator-core/src/test/java/org/kie/pmml/evaluator/core/service/PMMLRuntimeInternalImplTest.java
@@ -1,0 +1,205 @@
+/*
+ * Copyright 2022 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.kie.pmml.evaluator.core.service;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.stream.IntStream;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.kie.api.KieBase;
+import org.kie.api.pmml.PMML4Result;
+import org.kie.api.pmml.PMMLRequestData;
+import org.kie.pmml.api.enums.DATA_TYPE;
+import org.kie.pmml.api.enums.PMML_MODEL;
+import org.kie.pmml.api.enums.PMML_STEP;
+import org.kie.pmml.api.exceptions.KiePMMLException;
+import org.kie.pmml.api.models.MiningField;
+import org.kie.pmml.api.models.PMMLStep;
+import org.kie.pmml.api.runtime.PMMLContext;
+import org.kie.pmml.api.runtime.PMMLListener;
+import org.kie.pmml.commons.model.KiePMMLModel;
+import org.kie.pmml.evaluator.core.PMMLContextImpl;
+import org.kie.pmml.evaluator.core.executor.PMMLModelEvaluator;
+import org.kie.pmml.evaluator.core.executor.PMMLModelEvaluatorFinderImpl;
+import org.kie.pmml.evaluator.core.implementations.PMMLRuntimeStep;
+
+import static junit.framework.TestCase.assertEquals;
+import static junit.framework.TestCase.assertNotNull;
+import static org.junit.Assert.assertTrue;
+import static org.kie.pmml.api.enums.ResultCode.OK;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.reset;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+public class PMMLRuntimeInternalImplTest {
+
+    private PMMLContext pmmlContextMock;
+    private KieBase kieBaseMock = mock(KieBase.class);
+    private PMML4Result resultMock = mock(PMML4Result.class);
+    private PMMLModelEvaluator evaluatorMock = mock(PMMLModelEvaluator.class);
+    private PMMLModelEvaluatorFinderImpl pmmlModelExecutorFinderMock = mock(PMMLModelEvaluatorFinderImpl.class);
+    private KiePMMLModel modelMock;
+    private PMMLRuntimeInternalImpl pmmlRuntime;
+    private static final String MODEL_NAME = "MODEL_NAME";
+
+    @Before
+    public void setup() {
+        modelMock = getKiePMMLModelMock();
+        when(resultMock.getResultCode()).thenReturn(OK.getName());
+        when(resultMock.getResultVariables()).thenReturn(Collections.emptyMap());
+
+        when(evaluatorMock.getPMMLModelType()).thenReturn(PMML_MODEL.TEST_MODEL);
+        when(evaluatorMock.evaluate(any(), any(), any())).thenReturn(resultMock);
+        List<PMMLModelEvaluator> modelEvaluators = Collections.singletonList(evaluatorMock);
+        when(pmmlModelExecutorFinderMock.getImplementations(false)).thenReturn(modelEvaluators);
+
+        pmmlRuntime = new PMMLRuntimeInternalImpl(kieBaseMock, pmmlModelExecutorFinderMock);
+        pmmlContextMock = mock(PMMLContextImpl.class);
+    }
+
+    @Test
+    public void addPMMLListener() {
+        try {
+            pmmlRuntime.evaluate(MODEL_NAME, pmmlContextMock);
+            verify(pmmlContextMock, never()).addPMMLListener(any());
+        } catch (KiePMMLException e) {
+            commonManageException(e);
+        }
+        try {
+            reset(pmmlContextMock);
+            PMMLListener listener = getPMMLListener(new ArrayList<>());
+            pmmlRuntime.addPMMLListener(listener);
+            pmmlRuntime.evaluate(MODEL_NAME, pmmlContextMock);
+            verify(pmmlContextMock).addPMMLListener(listener);
+        } catch (KiePMMLException e) {
+            commonManageException(e);
+        }
+    }
+
+    @Test
+    public void removePMMLListener() {
+        try {
+            PMMLListener listener = getPMMLListener(new ArrayList<>());
+            pmmlRuntime.addPMMLListener(listener);
+            pmmlRuntime.removePMMLListener(listener);
+            pmmlRuntime.evaluate("MODEL_NAME", pmmlContextMock);
+            verify(pmmlContextMock, never()).addPMMLListener(listener);
+        } catch (KiePMMLException e) {
+            commonManageException(e);
+        }
+    }
+
+    @Test
+    public void evaluateWithPmmlRuntimeListeners() {
+        final PMMLRequestData requestData = getPMMLRequestData();
+        final List<PMMLStep> pmmlSteps = new ArrayList<>();
+        final PMMLContext pmmlContext = new PMMLContextImpl(requestData);
+        pmmlRuntime.addPMMLListener(getPMMLListener(pmmlSteps));
+        pmmlRuntime.evaluate(modelMock, pmmlContext);
+        Arrays.stream(PMML_STEP.values()).forEach(pmml_step -> {
+            Optional<PMMLStep> retrieved =
+                    pmmlSteps.stream().filter(pmmlStep -> pmml_step.equals(((PMMLRuntimeStep) pmmlStep).getPmmlStep()))
+                    .findFirst();
+            assertTrue(retrieved.isPresent());
+            commonValuateStep(retrieved.get(), pmml_step, modelMock, requestData);
+        });
+    }
+
+    @Test
+    public void evaluateWithPMMLContextListeners() {
+        final PMMLRequestData requestData = getPMMLRequestData();
+        final List<PMMLStep> pmmlSteps = new ArrayList<>();
+        final PMMLContext pmmlContext = new PMMLContextImpl(requestData,
+                                                            Collections.singleton(getPMMLListener(pmmlSteps)));
+        pmmlRuntime.evaluate(modelMock, pmmlContext);
+        Arrays.stream(PMML_STEP.values()).forEach(pmml_step -> {
+            Optional<PMMLStep> retrieved =
+                    pmmlSteps.stream().filter(pmmlStep -> pmml_step.equals(((PMMLRuntimeStep) pmmlStep).getPmmlStep()))
+                    .findFirst();
+            assertTrue(retrieved.isPresent());
+            commonValuateStep(retrieved.get(), pmml_step, modelMock, requestData);
+        });
+    }
+
+    @Test
+    public void evaluateWithoutListeners() {
+        final PMMLRequestData requestData = getPMMLRequestData();
+        final PMMLContext pmmlContext = new PMMLContextImpl(requestData);
+        pmmlRuntime.evaluate(modelMock, pmmlContext);
+    }
+
+    @Test
+    public void getStep() {
+        final PMMLRequestData requestData = getPMMLRequestData();
+        Arrays.stream(PMML_STEP.values()).forEach(pmml_step -> {
+            PMMLStep retrieved = pmmlRuntime.getStep(pmml_step, modelMock, requestData);
+            commonValuateStep(retrieved, pmml_step, modelMock, requestData);
+        });
+    }
+
+    private void commonValuateStep(final PMMLStep toVerify, final PMML_STEP pmmlStep, final KiePMMLModel kiePMMLModel,
+                                   final PMMLRequestData requestData) {
+        assertNotNull(toVerify);
+        assertTrue(toVerify instanceof PMMLRuntimeStep);
+        assertEquals(pmmlStep, ((PMMLRuntimeStep) toVerify).getPmmlStep());
+        Map<String, Object> info = toVerify.getInfo();
+        assertEquals(info.get("MODEL"), kiePMMLModel.getName());
+        assertEquals(info.get("CORRELATION ID"), requestData.getCorrelationId());
+        assertEquals(info.get("REQUEST MODEL"), requestData.getModelName());
+        requestData.getRequestParams()
+                .forEach(requestParam ->
+                                 assertEquals(requestParam.getValue(), info.get(requestParam.getName())));
+    }
+
+    private void commonManageException(KiePMMLException toManage) {
+        String expectedMessage = String.format("Failed to retrieve model with name %s", MODEL_NAME);
+        assertEquals(expectedMessage, toManage.getMessage());
+    }
+
+    private KiePMMLModel getKiePMMLModelMock() {
+        KiePMMLModel toReturn = mock(KiePMMLModel.class);
+        String targetFieldName = "targetFieldName";
+        MiningField miningFieldMock = mock(MiningField.class);
+        when(miningFieldMock.getName()).thenReturn(targetFieldName);
+        when(miningFieldMock.getDataType()).thenReturn(DATA_TYPE.FLOAT);
+        when(toReturn.getName()).thenReturn(MODEL_NAME);
+        when(toReturn.getMiningFields()).thenReturn(Collections.singletonList(miningFieldMock));
+        when(toReturn.getTargetField()).thenReturn(targetFieldName);
+        when(toReturn.getPmmlMODEL()).thenReturn(PMML_MODEL.TEST_MODEL);
+        return toReturn;
+    }
+
+    private PMMLRequestData getPMMLRequestData() {
+        final PMMLRequestData toReturn = new PMMLRequestData();
+        toReturn.setModelName(MODEL_NAME);
+        toReturn.setCorrelationId("CORRELATION_ID");
+        IntStream.range(0, 3).forEach(i -> toReturn.addRequestParam("PARAM_" + i, i));
+        return toReturn;
+    }
+
+    private PMMLListener getPMMLListener(final List<PMMLStep> pmmlSteps) {
+        return pmmlSteps::add;
+    }
+}

--- a/kie-pmml-trusty/kie-pmml-evaluator/kie-pmml-evaluator-core/src/test/java/org/kie/pmml/evaluator/core/service/PMMLRuntimeInternalImplTest.java
+++ b/kie-pmml-trusty/kie-pmml-evaluator/kie-pmml-evaluator-core/src/test/java/org/kie/pmml/evaluator/core/service/PMMLRuntimeInternalImplTest.java
@@ -144,13 +144,6 @@ public class PMMLRuntimeInternalImplTest {
     }
 
     @Test
-    public void evaluateWithoutListeners() {
-        final PMMLRequestData requestData = getPMMLRequestData();
-        final PMMLContext pmmlContext = new PMMLContextImpl(requestData);
-        pmmlRuntime.evaluate(modelMock, pmmlContext);
-    }
-
-    @Test
     public void getStep() {
         final PMMLRequestData requestData = getPMMLRequestData();
         Arrays.stream(PMML_STEP.values()).forEach(pmml_step -> {

--- a/kie-pmml-trusty/kie-pmml-evaluator/kie-pmml-evaluator-core/src/test/java/org/kie/pmml/evaluator/core/utils/PMMLListenerUtilsTest.java
+++ b/kie-pmml-trusty/kie-pmml-evaluator/kie-pmml-evaluator-core/src/test/java/org/kie/pmml/evaluator/core/utils/PMMLListenerUtilsTest.java
@@ -1,0 +1,86 @@
+package org.kie.pmml.evaluator.core.utils;/*
+ * Copyright 2022 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.stream.IntStream;
+
+import org.junit.Test;
+import org.kie.api.pmml.PMMLRequestData;
+import org.kie.pmml.api.models.PMMLStep;
+import org.kie.pmml.api.runtime.PMMLContext;
+import org.kie.pmml.api.runtime.PMMLListener;
+import org.kie.pmml.evaluator.core.PMMLContextImpl;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+public class PMMLListenerUtilsTest {
+
+    @Test
+    public void stepExecuted() {
+        final Map<Integer, PMMLStep> listenerFeedback = new HashMap<>();
+        int size = 3;
+        PMMLContext pmmlContext = getPMMLContext(size, listenerFeedback);
+        AtomicBoolean invoked = new AtomicBoolean(false);
+        PMMLListenerUtils.stepExecuted(() -> new PMMLStepTest(invoked), pmmlContext);
+        assertTrue(invoked.get());
+        assertEquals(size, listenerFeedback.size());
+        final PMMLStep retrieved = listenerFeedback.get(0);
+        IntStream.range(1, size).forEach(i -> assertEquals(retrieved, listenerFeedback.get(i)));
+    }
+
+    @Test
+    public void stepNotExecuted() {
+        PMMLContext pmmlContext = new PMMLContextImpl(new PMMLRequestData());
+        AtomicBoolean invoked = new AtomicBoolean(false);
+        PMMLListenerUtils.stepExecuted(() -> new PMMLStepTest(invoked), pmmlContext);
+        assertFalse(invoked.get());
+    }
+
+    private PMMLContext getPMMLContext(int size, Map<Integer, PMMLStep> listenerFeedback) {
+        PMMLContext toReturn = new PMMLContextImpl(new PMMLRequestData());
+        IntStream.range(0, size).forEach(i -> toReturn.addPMMLListener(getPMMLListener(i, listenerFeedback)));
+        return toReturn;
+    }
+
+    private PMMLListener getPMMLListener(int id, Map<Integer, PMMLStep> listenerFeedback) {
+        return step -> listenerFeedback.put(id, step);
+    }
+
+    private static class PMMLStepTest implements PMMLStep {
+
+        private static final long serialVersionUID = -2348602567874639224L;
+        private AtomicBoolean invoked;
+
+        public PMMLStepTest(AtomicBoolean invoked) {
+            this.invoked = invoked;
+            this.invoked.set(true);
+        }
+
+        @Override
+        public void addInfo(String infoName, Object infoValue) {
+
+        }
+
+        @Override
+        public Map<String, Object> getInfo() {
+            return null;
+        }
+    }
+}

--- a/kie-pmml-trusty/kie-pmml-models/kie-pmml-models-mining/kie-pmml-models-mining-evaluator/src/main/java/org/kie/pmml/models/mining/evaluator/PMMLMiningModelStep.java
+++ b/kie-pmml-trusty/kie-pmml-models/kie-pmml-models-mining/kie-pmml-models-mining-evaluator/src/main/java/org/kie/pmml/models/mining/evaluator/PMMLMiningModelStep.java
@@ -1,0 +1,23 @@
+/*
+ * Copyright 2022 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.kie.pmml.models.mining.evaluator;
+
+import org.kie.pmml.evaluator.core.implementations.AbstractPMMLStep;
+
+public class PMMLMiningModelStep extends AbstractPMMLStep {
+
+    private static final long serialVersionUID = -4825166115437877749L;
+}

--- a/kie-pmml-trusty/kie-pmml-models/kie-pmml-models-mining/kie-pmml-models-mining-tests/src/test/java/org/kie/pmml/mining/tests/MiningListenerTest.java
+++ b/kie-pmml-trusty/kie-pmml-models/kie-pmml-models-mining/kie-pmml-models-mining-tests/src/test/java/org/kie/pmml/mining/tests/MiningListenerTest.java
@@ -1,0 +1,115 @@
+/*
+ * Copyright 2020 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.kie.pmml.mining.tests;
+
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
+
+import org.junit.BeforeClass;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+import org.kie.pmml.api.models.PMMLStep;
+import org.kie.pmml.api.runtime.PMMLListener;
+import org.kie.pmml.api.runtime.PMMLRuntime;
+import org.kie.pmml.evaluator.core.implementations.PMMLRuntimeStep;
+import org.kie.pmml.models.tests.AbstractPMMLTest;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+@RunWith(Parameterized.class)
+public class MiningListenerTest extends AbstractPMMLTest {
+
+    private static final String FILE_NAME = "MultipleMining.pmml";
+    private static final String MODEL_NAME = "MixedMining";
+    private static PMMLRuntime pmmlRuntime;
+
+    private String categoricalX;
+    private String categoricalY;
+    private double age;
+    private String occupation;
+    private String residenceState;
+    private boolean validLicense;
+
+    public MiningListenerTest(String categoricalX,
+                              String categoricalY,
+                              double age,
+                              String occupation,
+                              String residenceState,
+                              boolean validLicense) {
+        this.categoricalX = categoricalX;
+        this.categoricalY = categoricalY;
+        this.age = age;
+        this.occupation = occupation;
+        this.residenceState = residenceState;
+        this.validLicense = validLicense;
+    }
+
+    @BeforeClass
+    public static void setupClass() {
+        pmmlRuntime = getPMMLRuntime(FILE_NAME);
+    }
+
+    @Parameterized.Parameters
+    public static Collection<Object[]> data() {
+        return Arrays.asList(new Object[][]{
+                {"red", "classA", 25.0, "ASTRONAUT", "AP", true},
+                {"blue", "classA", 2.3, "PROGRAMMER", "KN", true},
+                {"yellow", "classC", 333.56, "INSTRUCTOR", "TN", false},
+                {"orange", "classB", 0.12, "ASTRONAUT", "KN", true},
+                {"green", "classC", 122.12, "TEACHER", "TN", false},
+                {"green", "classB", 11.33, "INSTRUCTOR", "AP", false},
+                {"orange", "classB", 423.2, "SKYDIVER", "KN", true},
+        });
+    }
+
+    @Test
+    public void testMixedMining() {
+        final Map<String, Object> inputData = new HashMap<>();
+        inputData.put("categoricalX", categoricalX);
+        inputData.put("categoricalY", categoricalY);
+        inputData.put("age", age);
+        inputData.put("occupation", occupation);
+        inputData.put("residenceState", residenceState);
+        inputData.put("validLicense", validLicense);
+        Set<PMMLListener> pmmlListeners = IntStream.range(0, 3)
+                .mapToObj(i -> getPMMLListener()).collect(Collectors.toSet());
+        evaluate(pmmlRuntime, inputData, MODEL_NAME, pmmlListeners);
+        final List<PMMLStep> retrieved = ((PMMLListenerTest)pmmlListeners.iterator().next()).getSteps();
+        retrieved
+                .stream()
+                .filter(pmmlStep -> !(pmmlStep instanceof PMMLRuntimeStep))
+                .collect(Collectors.toList())
+                .forEach(this::commonValidateStep);
+        commonValidateListeners(pmmlListeners, retrieved);
+    }
+
+    private void commonValidateStep(final PMMLStep toValidate) {
+        Map<String, Object> retrieved = toValidate.getInfo();
+        assertTrue(retrieved.containsKey("SEGMENT"));
+        assertTrue(retrieved.containsKey("RESULT CODE"));
+        assertTrue(retrieved.containsKey("MODEL"));
+        assertTrue(retrieved.containsKey("RESULT"));
+    }
+}

--- a/kie-pmml-trusty/kie-pmml-models/kie-pmml-models-tests/pom.xml
+++ b/kie-pmml-trusty/kie-pmml-models/kie-pmml-models-tests/pom.xml
@@ -27,6 +27,14 @@
       <groupId>org.kie</groupId>
       <artifactId>kie-test-util</artifactId>
     </dependency>
+    <dependency>
+      <groupId>junit</groupId>
+      <artifactId>junit</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.assertj</groupId>
+      <artifactId>assertj-core</artifactId>
+    </dependency>
   </dependencies>
 
 


### PR DESCRIPTION
@danielezonca @jiripetrlik 

Important notes:
1) Listeners are used only at evaluation time - i.e. involve only PMMLRuntime and model execution
2) every model implementation may - or may not - implement is own listening system
3) it is possible to add listeners on pmmlruntime - in which case they will be available for all pmmlcontext/evaluations, or only inside specific pmmlcontext, in which case they will be available only for that specific context/evaluation
4) I used the term "PMMLStep" because I'm pretty sure I'll have to use PMMLEvent somewhere else, to avoid confusion
5) for the moment being the step information is a simple map - it is not very semantically defined, but at the same time it easily allows model to populate it with model-specific information
6) for the moment being I implemented only the overall execution listening and the miningmodel one; I plan to do other in future PRs
7) it would be interesting to find some feedback/opinion from actual users about what information could be interesting for each model


**Thank you for submitting this pull request**

**NOTE!:** Double check the target branch for this PR.
The default is `main` so it will target Drools 8 / Kogito / Optaplanner 8.
If this PR is not strictly related to drools and kogito project in `drools.git`, it should probably target `7.x`as a branch

**Ports** If a forward-port or a backport is needed, paste the forward port PR here

[link](https://www.example.com)

**JIRA**: 
[link](https://issues.redhat.com/browse/DROOLS-5193)

**referenced Pull Requests**: _(please edit the URLs of referenced pullrequests if they exist)_

* paste the link(s) from GitHub here
* link 2
* link 3 etc.

<details>
<summary>
How to replicate CI configuration locally?
</summary>

Build Chain tool does "simple" maven build(s), the builds are just Maven commands, but because the repositories relates and depends on each other and any change in API or class method could affect several of those repositories there is a need to use [build-chain tool](https://github.com/kiegroup/github-action-build-chain) to handle cross repository builds and be sure that we always use latest version of the code for each repository.
 
[build-chain tool](https://github.com/kiegroup/github-action-build-chain) is a build tool which can be used on command line locally or in Github Actions workflow(s), in case you need to change multiple repositories and send multiple dependent pull requests related with a change you can easily reproduce the same build by executing it on Github hosted environment or locally in your development environment. See [local execution](https://github.com/kiegroup/github-action-build-chain#local-execution) details to get more information about it.
</details>

<details>
<summary>
How to retest this PR or trigger a specific build:
</summary>

* <b>a pull request</b> please add comment: <b>Jenkins retest this</b>

* for a <b>full downstream build</b> 
  * for <b>jenkins</b> job: please add comment: <b>Jenkins run fdb</b>
  * for <b>github actions</b> job: add the label `run_fdb`

* <b>a compile downstream build</b> please  add comment: <b>Jenkins run cdb</b>

* <b>a full production downstream build</b> please add comment: <b>Jenkins execute product fdb</b>

* <b>an upstream build</b> please add comment: <b>Jenkins run upstream</b>
</details>
