### PR TITLE
[DROOLS-6780] Add toString for BeforeEvaluateAllEventImpl and AfterEvaluateAllEventImpl

### DIFF
--- a/kie-dmn/kie-dmn-core/src/main/java/org/kie/dmn/core/impl/AfterEvaluateAllEventImpl.java
+++ b/kie-dmn/kie-dmn-core/src/main/java/org/kie/dmn/core/impl/AfterEvaluateAllEventImpl.java
@@ -21,7 +21,7 @@ import org.kie.dmn.api.core.event.AfterEvaluateAllEvent;
 
 public class AfterEvaluateAllEventImpl implements AfterEvaluateAllEvent {
 
-    private String modelNamespace;
+	private String modelNamespace;
     private String modelName;
     private DMNResult result;
 
@@ -45,5 +45,10 @@ public class AfterEvaluateAllEventImpl implements AfterEvaluateAllEvent {
     public DMNResult getResult() {
         return result;
     }
+    
+    @Override
+	public String toString() {
+		return "AfterEvaluateAllEventImpl{ modelNamespace=" + modelNamespace + ", modelName=" + modelName + "}";
+	}
 
 }

--- a/kie-dmn/kie-dmn-core/src/main/java/org/kie/dmn/core/impl/AfterEvaluateAllEventImpl.java
+++ b/kie-dmn/kie-dmn-core/src/main/java/org/kie/dmn/core/impl/AfterEvaluateAllEventImpl.java
@@ -21,7 +21,7 @@ import org.kie.dmn.api.core.event.AfterEvaluateAllEvent;
 
 public class AfterEvaluateAllEventImpl implements AfterEvaluateAllEvent {
 
-	private String modelNamespace;
+    private String modelNamespace;
     private String modelName;
     private DMNResult result;
 
@@ -45,10 +45,10 @@ public class AfterEvaluateAllEventImpl implements AfterEvaluateAllEvent {
     public DMNResult getResult() {
         return result;
     }
-    
+
     @Override
-	public String toString() {
-		return "AfterEvaluateAllEventImpl{ modelNamespace=" + modelNamespace + ", modelName=" + modelName + "}";
-	}
+    public String toString() {
+        return "AfterEvaluateAllEventImpl{ modelNamespace=" + modelNamespace + ", modelName=" + modelName + "}";
+    }
 
 }

--- a/kie-dmn/kie-dmn-core/src/main/java/org/kie/dmn/core/impl/BeforeEvaluateAllEventImpl.java
+++ b/kie-dmn/kie-dmn-core/src/main/java/org/kie/dmn/core/impl/BeforeEvaluateAllEventImpl.java
@@ -45,5 +45,10 @@ public class BeforeEvaluateAllEventImpl implements BeforeEvaluateAllEvent {
     public DMNResult getResult() {
         return result;
     }
+    
+    @Override
+	public String toString() {
+		return "BeforeEvaluateAllEventImpl{ modelNamespace=" + modelNamespace + ", modelName=" + modelName + "}";
+    }
 
 }

--- a/kie-dmn/kie-dmn-core/src/main/java/org/kie/dmn/core/impl/BeforeEvaluateAllEventImpl.java
+++ b/kie-dmn/kie-dmn-core/src/main/java/org/kie/dmn/core/impl/BeforeEvaluateAllEventImpl.java
@@ -48,7 +48,7 @@ public class BeforeEvaluateAllEventImpl implements BeforeEvaluateAllEvent {
     
     @Override
     public String toString() {
-		return "BeforeEvaluateAllEventImpl{ modelNamespace=" + modelNamespace + ", modelName=" + modelName + "}";
+        return "BeforeEvaluateAllEventImpl{ modelNamespace=" + modelNamespace + ", modelName=" + modelName + "}";
     }
 
 }

--- a/kie-dmn/kie-dmn-core/src/main/java/org/kie/dmn/core/impl/BeforeEvaluateAllEventImpl.java
+++ b/kie-dmn/kie-dmn-core/src/main/java/org/kie/dmn/core/impl/BeforeEvaluateAllEventImpl.java
@@ -47,7 +47,7 @@ public class BeforeEvaluateAllEventImpl implements BeforeEvaluateAllEvent {
     }
     
     @Override
-	public String toString() {
+    public String toString() {
 		return "BeforeEvaluateAllEventImpl{ modelNamespace=" + modelNamespace + ", modelName=" + modelName + "}";
     }
 


### PR DESCRIPTION
[**DROOLS-6780**](https://issues.redhat.com/browse/DROOLS-6780)

the idea of this PR is to provide toString method to those two Events.

Here is the template of the implementation :

"....{ modelNamespace=" + modelNamespace + ", modelName=" + modelName + "}"

this simple template avoid to get this kind of log "org.kie.dmn.core.impl.AfterEvaluateAllEventImpl@33c9c80e"
