### PR TITLE
[DROOLS-6800] Fix PackageInMultipleResourcesTest to cleanup FakeDRFAs…

### DIFF
--- a/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/integrationtests/PackageInMultipleResourcesTest.java
+++ b/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/integrationtests/PackageInMultipleResourcesTest.java
@@ -17,6 +17,7 @@ package org.drools.mvel.integrationtests;
 
 import java.util.Collection;
 import java.util.List;
+import java.util.Map;
 import java.util.stream.Collectors;
 
 import org.drools.testcoverage.common.util.KieBaseTestConfiguration;
@@ -27,8 +28,10 @@ import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
 import org.kie.api.KieBase;
 import org.kie.api.definition.KiePackage;
+import org.kie.api.internal.assembler.KieAssemblerService;
 import org.kie.api.internal.assembler.KieAssemblers;
 import org.kie.api.internal.utils.ServiceRegistry;
+import org.kie.api.io.ResourceType;
 import org.kie.internal.services.KieAssemblersImpl;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -52,35 +55,55 @@ public class PackageInMultipleResourcesTest {
     public void testSamePackageRulesInDRLAndRF() {
         // DROOLS-6785
         KieAssemblersImpl assemblers = (KieAssemblersImpl) ServiceRegistry.getService(KieAssemblers.class);
-        assemblers.accept(new FakeDRFAssemblerService());
+        Map<ResourceType, KieAssemblerService> internalAssemblers = assemblers.getAssemblers();
+        KieAssemblerService originalDRFAssemblerService = internalAssemblers.get(ResourceType.DRF);
+        try {
+            assemblers.accept(new FakeDRFAssemblerService());
 
-        KieBase kbase = KieBaseUtil.getKieBaseFromClasspathResources(this.getClass(), kieBaseTestConfiguration, "rf_test_rules.drl", "rf_test_rueflow.rf");
+            KieBase kbase = KieBaseUtil.getKieBaseFromClasspathResources(this.getClass(), kieBaseTestConfiguration, "rf_test_rules.drl", "rf_test_rueflow.rf");
 
-        KiePackage kiePackage = kbase.getKiePackage("com.example.rules");
-        List<String> ruleNames = kiePackage.getRules().stream().map(rule -> rule.getName()).collect(Collectors.toList());
+            KiePackage kiePackage = kbase.getKiePackage("com.example.rules");
+            List<String> ruleNames = kiePackage.getRules().stream().map(rule -> rule.getName()).collect(Collectors.toList());
 
-        assertEquals(3, ruleNames.size());
-        assertThat(ruleNames).contains("RuleFlow-Split-example-xxx-DROOLS_DEFAULT", "Left Rule", "Right Rule");
+            assertEquals(3, ruleNames.size());
+            assertThat(ruleNames).contains("RuleFlow-Split-example-xxx-DROOLS_DEFAULT", "Left Rule", "Right Rule");
+        } finally {
+            if (originalDRFAssemblerService == null) {
+                internalAssemblers.remove(ResourceType.DRF);
+            } else {
+                assemblers.accept(originalDRFAssemblerService);
+            }
+        }
     }
 
     @Test
     public void testDifferentPackagesRulesInDRLAndRF() {
         // DROOLS-6797
         KieAssemblersImpl assemblers = (KieAssemblersImpl) ServiceRegistry.getService(KieAssemblers.class);
-        assemblers.accept(new FakeDRFAssemblerService());
+        Map<ResourceType, KieAssemblerService> internalAssemblers = assemblers.getAssemblers();
+        KieAssemblerService originalDRFAssemblerService = internalAssemblers.get(ResourceType.DRF);
+        try {
+            assemblers.accept(new FakeDRFAssemblerService());
 
-        KieBase kbase = KieBaseUtil.getKieBaseFromClasspathResources(this.getClass(), kieBaseTestConfiguration, "rf_test_rules_different_pkg.drl", "rf_test_rueflow.rf");
+            KieBase kbase = KieBaseUtil.getKieBaseFromClasspathResources(this.getClass(), kieBaseTestConfiguration, "rf_test_rules_different_pkg.drl", "rf_test_rueflow.rf");
 
-        KiePackage kiePackage = kbase.getKiePackage("com.example.rules");
-        List<String> ruleNames = kiePackage.getRules().stream().map(rule -> rule.getName()).collect(Collectors.toList());
+            KiePackage kiePackage = kbase.getKiePackage("com.example.rules");
+            List<String> ruleNames = kiePackage.getRules().stream().map(rule -> rule.getName()).collect(Collectors.toList());
 
-        assertEquals(1, ruleNames.size());
-        assertThat(ruleNames).contains("RuleFlow-Split-example-xxx-DROOLS_DEFAULT");
+            assertEquals(1, ruleNames.size());
+            assertThat(ruleNames).contains("RuleFlow-Split-example-xxx-DROOLS_DEFAULT");
 
-        KiePackage kiePackageDiffPkg = kbase.getKiePackage("com.example.rules.different.pkg");
-        List<String> ruleNamesDiffPkg = kiePackageDiffPkg.getRules().stream().map(rule -> rule.getName()).collect(Collectors.toList());
+            KiePackage kiePackageDiffPkg = kbase.getKiePackage("com.example.rules.different.pkg");
+            List<String> ruleNamesDiffPkg = kiePackageDiffPkg.getRules().stream().map(rule -> rule.getName()).collect(Collectors.toList());
 
-        assertEquals(2, ruleNamesDiffPkg.size());
-        assertThat(ruleNamesDiffPkg).contains("Left Rule", "Right Rule");
+            assertEquals(2, ruleNamesDiffPkg.size());
+            assertThat(ruleNamesDiffPkg).contains("Left Rule", "Right Rule");
+        } finally {
+            if (originalDRFAssemblerService == null) {
+                internalAssemblers.remove(ResourceType.DRF);
+            } else {
+                assemblers.accept(originalDRFAssemblerService);
+            }
+        }
     }
 }


### PR DESCRIPTION
…semblerService

**Ports** 
This PR is for 7.x. 

for main -> https://github.com/kiegroup/drools/pull/4155

**JIRA**: 
https://issues.redhat.com/browse/DROOLS-6800

<details>
<summary>
How to replicate CI configuration locally?
</summary>

Build Chain tool does "simple" maven build(s), the builds are just Maven commands, but because the repositories relates and depends on each other and any change in API or class method could affect several of those repositories there is a need to use [build-chain tool](https://github.com/kiegroup/github-action-build-chain) to handle cross repository builds and be sure that we always use latest version of the code for each repository.
 
[build-chain tool](https://github.com/kiegroup/github-action-build-chain) is a build tool which can be used on command line locally or in Github Actions workflow(s), in case you need to change multiple repositories and send multiple dependent pull requests related with a change you can easily reproduce the same build by executing it on Github hosted environment or locally in your development environment. See [local execution](https://github.com/kiegroup/github-action-build-chain#local-execution) details to get more information about it.
</details>

<details>
<summary>
How to retest this PR or trigger a specific build:
</summary>

* <b>a pull request</b> please add comment: <b>Jenkins retest this</b>

* for a <b>full downstream build</b> 
  * for <b>jenkins</b> job: please add comment: <b>Jenkins run fdb</b>
  * for <b>github actions</b> job: add the label `run_fdb`

* <b>a compile downstream build</b> please  add comment: <b>Jenkins run cdb</b>

* <b>a full production downstream build</b> please add comment: <b>Jenkins execute product fdb</b>

* <b>an upstream build</b> please add comment: <b>Jenkins run upstream</b>
</details>
