### PR TITLE
[DROOLS-6797] UnsupportedOperationException when different package rules from DRL and RF

### DIFF
--- a/drools-model/drools-model-compiler/src/main/java/org/drools/modelcompiler/builder/ModelBuilderImpl.java
+++ b/drools-model/drools-model-compiler/src/main/java/org/drools/modelcompiler/builder/ModelBuilderImpl.java
@@ -18,6 +18,7 @@ package org.drools.modelcompiler.builder;
 
 import java.util.Collection;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -130,6 +131,7 @@ public class ModelBuilderImpl<T extends PackageSources> extends KnowledgeBuilder
     private Collection<CompositePackageDescr> findPackages( Collection<CompositePackageDescr> compositePackages ) {
         if (compositePackages != null && !compositePackages.isEmpty()) {
             if (compositePackagesMap != null) {
+                compositePackages = new HashSet<>(compositePackages);
                 for (Map.Entry<String, CompositePackageDescr> entry : compositePackagesMap.entrySet()) {
                     Optional<CompositePackageDescr> optPkg = compositePackages.stream().filter(pkg -> pkg.getNamespace().equals(entry.getKey()) ).findFirst();
                     if (optPkg.isPresent()) {

--- a/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/integrationtests/FakeDRFAssemblerService.java
+++ b/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/integrationtests/FakeDRFAssemblerService.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright 2022 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.drools.mvel.integrationtests;
+
+import java.io.StringReader;
+
+import org.drools.compiler.builder.impl.KnowledgeBuilderImpl;
+import org.kie.api.internal.assembler.KieAssemblerService;
+import org.kie.api.io.Resource;
+import org.kie.api.io.ResourceConfiguration;
+import org.kie.api.io.ResourceType;
+
+public class FakeDRFAssemblerService implements KieAssemblerService {
+
+    private static final String GATEWAY_RULE = "package com.example.rules\n" +
+                                               "import com.example.*;\n" +
+                                               "rule \"RuleFlow-Split-example-xxx-DROOLS_DEFAULT\"  @Propagation(EAGER)\n" +
+                                               "      ruleflow-group \"DROOLS_SYSTEM\"\n" +
+                                               "    when\n" +
+                                               "      exists String(this == \"Left\")\n" +
+                                               "    then\n" +
+                                               "end";
+
+    @Override
+    public ResourceType getResourceType() {
+        return ResourceType.DRF;
+    }
+
+    @Override
+    public void addResourceAfterRules(Object kbuilder, Resource resource, ResourceType type, ResourceConfiguration configuration) throws Exception {
+        // Just add one fake gateway drl rule. Not for process capability testing
+        ((KnowledgeBuilderImpl) kbuilder).addPackageFromDrl(new StringReader(GATEWAY_RULE), resource);
+    }
+}

--- a/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/integrationtests/PackageInMultipleResourcesTest.java
+++ b/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/integrationtests/PackageInMultipleResourcesTest.java
@@ -17,6 +17,7 @@ package org.drools.mvel.integrationtests;
 
 import java.util.Collection;
 import java.util.List;
+import java.util.Map;
 import java.util.stream.Collectors;
 
 import org.drools.testcoverage.common.util.KieBaseTestConfiguration;
@@ -27,8 +28,10 @@ import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
 import org.kie.api.KieBase;
 import org.kie.api.definition.KiePackage;
+import org.kie.api.internal.assembler.KieAssemblerService;
 import org.kie.api.internal.assembler.KieAssemblers;
 import org.kie.api.internal.utils.ServiceRegistry;
+import org.kie.api.io.ResourceType;
 import org.kie.internal.services.KieAssemblersImpl;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -52,35 +55,55 @@ public class PackageInMultipleResourcesTest {
     public void testSamePackageRulesInDRLAndRF() {
         // DROOLS-6785
         KieAssemblersImpl assemblers = (KieAssemblersImpl) ServiceRegistry.getService(KieAssemblers.class);
-        assemblers.accept(new FakeDRFAssemblerService());
+        Map<ResourceType, KieAssemblerService> internalAssemblers = assemblers.getAssemblers();
+        KieAssemblerService originalDRFAssemblerService = internalAssemblers.get(ResourceType.DRF);
+        try {
+            assemblers.accept(new FakeDRFAssemblerService());
 
-        KieBase kbase = KieBaseUtil.getKieBaseFromClasspathResources(this.getClass(), kieBaseTestConfiguration, "rf_test_rules.drl", "rf_test_rueflow.rf");
+            KieBase kbase = KieBaseUtil.getKieBaseFromClasspathResources(this.getClass(), kieBaseTestConfiguration, "rf_test_rules.drl", "rf_test_rueflow.rf");
 
-        KiePackage kiePackage = kbase.getKiePackage("com.example.rules");
-        List<String> ruleNames = kiePackage.getRules().stream().map(rule -> rule.getName()).collect(Collectors.toList());
+            KiePackage kiePackage = kbase.getKiePackage("com.example.rules");
+            List<String> ruleNames = kiePackage.getRules().stream().map(rule -> rule.getName()).collect(Collectors.toList());
 
-        assertEquals(3, ruleNames.size());
-        assertThat(ruleNames).contains("RuleFlow-Split-example-xxx-DROOLS_DEFAULT", "Left Rule", "Right Rule");
+            assertEquals(3, ruleNames.size());
+            assertThat(ruleNames).contains("RuleFlow-Split-example-xxx-DROOLS_DEFAULT", "Left Rule", "Right Rule");
+        } finally {
+            if (originalDRFAssemblerService == null) {
+                internalAssemblers.remove(ResourceType.DRF);
+            } else {
+                assemblers.accept(originalDRFAssemblerService);
+            }
+        }
     }
 
     @Test
     public void testDifferentPackagesRulesInDRLAndRF() {
         // DROOLS-6797
         KieAssemblersImpl assemblers = (KieAssemblersImpl) ServiceRegistry.getService(KieAssemblers.class);
-        assemblers.accept(new FakeDRFAssemblerService());
+        Map<ResourceType, KieAssemblerService> internalAssemblers = assemblers.getAssemblers();
+        KieAssemblerService originalDRFAssemblerService = internalAssemblers.get(ResourceType.DRF);
+        try {
+            assemblers.accept(new FakeDRFAssemblerService());
 
-        KieBase kbase = KieBaseUtil.getKieBaseFromClasspathResources(this.getClass(), kieBaseTestConfiguration, "rf_test_rules_different_pkg.drl", "rf_test_rueflow.rf");
+            KieBase kbase = KieBaseUtil.getKieBaseFromClasspathResources(this.getClass(), kieBaseTestConfiguration, "rf_test_rules_different_pkg.drl", "rf_test_rueflow.rf");
 
-        KiePackage kiePackage = kbase.getKiePackage("com.example.rules");
-        List<String> ruleNames = kiePackage.getRules().stream().map(rule -> rule.getName()).collect(Collectors.toList());
+            KiePackage kiePackage = kbase.getKiePackage("com.example.rules");
+            List<String> ruleNames = kiePackage.getRules().stream().map(rule -> rule.getName()).collect(Collectors.toList());
 
-        assertEquals(1, ruleNames.size());
-        assertThat(ruleNames).contains("RuleFlow-Split-example-xxx-DROOLS_DEFAULT");
+            assertEquals(1, ruleNames.size());
+            assertThat(ruleNames).contains("RuleFlow-Split-example-xxx-DROOLS_DEFAULT");
 
-        KiePackage kiePackageDiffPkg = kbase.getKiePackage("com.example.rules.different.pkg");
-        List<String> ruleNamesDiffPkg = kiePackageDiffPkg.getRules().stream().map(rule -> rule.getName()).collect(Collectors.toList());
+            KiePackage kiePackageDiffPkg = kbase.getKiePackage("com.example.rules.different.pkg");
+            List<String> ruleNamesDiffPkg = kiePackageDiffPkg.getRules().stream().map(rule -> rule.getName()).collect(Collectors.toList());
 
-        assertEquals(2, ruleNamesDiffPkg.size());
-        assertThat(ruleNamesDiffPkg).contains("Left Rule", "Right Rule");
+            assertEquals(2, ruleNamesDiffPkg.size());
+            assertThat(ruleNamesDiffPkg).contains("Left Rule", "Right Rule");
+        } finally {
+            if (originalDRFAssemblerService == null) {
+                internalAssemblers.remove(ResourceType.DRF);
+            } else {
+                assemblers.accept(originalDRFAssemblerService);
+            }
+        }
     }
 }

--- a/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/integrationtests/PackageInMultipleResourcesTest.java
+++ b/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/integrationtests/PackageInMultipleResourcesTest.java
@@ -1,0 +1,86 @@
+/*
+ * Copyright 2022 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+*/
+
+package org.drools.mvel.integrationtests;
+
+import java.util.Collection;
+import java.util.List;
+import java.util.stream.Collectors;
+
+import org.drools.testcoverage.common.util.KieBaseTestConfiguration;
+import org.drools.testcoverage.common.util.KieBaseUtil;
+import org.drools.testcoverage.common.util.TestParametersUtil;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+import org.kie.api.KieBase;
+import org.kie.api.definition.KiePackage;
+import org.kie.api.internal.assembler.KieAssemblers;
+import org.kie.api.internal.utils.ServiceRegistry;
+import org.kie.internal.services.KieAssemblersImpl;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.Assert.assertEquals;
+
+@RunWith(Parameterized.class)
+public class PackageInMultipleResourcesTest {
+
+    private final KieBaseTestConfiguration kieBaseTestConfiguration;
+
+    public PackageInMultipleResourcesTest(final KieBaseTestConfiguration kieBaseTestConfiguration) {
+        this.kieBaseTestConfiguration = kieBaseTestConfiguration;
+    }
+
+    @Parameterized.Parameters(name = "KieBase type={0}")
+    public static Collection<Object[]> getParameters() {
+        return TestParametersUtil.getKieBaseCloudConfigurations(true);
+    }
+
+    @Test
+    public void testSamePackageRulesInDRLAndRF() {
+        // DROOLS-6785
+        KieAssemblersImpl assemblers = (KieAssemblersImpl) ServiceRegistry.getService(KieAssemblers.class);
+        assemblers.accept(new FakeDRFAssemblerService());
+
+        KieBase kbase = KieBaseUtil.getKieBaseFromClasspathResources(this.getClass(), kieBaseTestConfiguration, "rf_test_rules.drl", "rf_test_rueflow.rf");
+
+        KiePackage kiePackage = kbase.getKiePackage("com.example.rules");
+        List<String> ruleNames = kiePackage.getRules().stream().map(rule -> rule.getName()).collect(Collectors.toList());
+
+        assertEquals(3, ruleNames.size());
+        assertThat(ruleNames).contains("RuleFlow-Split-example-xxx-DROOLS_DEFAULT", "Left Rule", "Right Rule");
+    }
+
+    @Test
+    public void testDifferentPackagesRulesInDRLAndRF() {
+        // DROOLS-6797
+        KieAssemblersImpl assemblers = (KieAssemblersImpl) ServiceRegistry.getService(KieAssemblers.class);
+        assemblers.accept(new FakeDRFAssemblerService());
+
+        KieBase kbase = KieBaseUtil.getKieBaseFromClasspathResources(this.getClass(), kieBaseTestConfiguration, "rf_test_rules_different_pkg.drl", "rf_test_rueflow.rf");
+
+        KiePackage kiePackage = kbase.getKiePackage("com.example.rules");
+        List<String> ruleNames = kiePackage.getRules().stream().map(rule -> rule.getName()).collect(Collectors.toList());
+
+        assertEquals(1, ruleNames.size());
+        assertThat(ruleNames).contains("RuleFlow-Split-example-xxx-DROOLS_DEFAULT");
+
+        KiePackage kiePackageDiffPkg = kbase.getKiePackage("com.example.rules.different.pkg");
+        List<String> ruleNamesDiffPkg = kiePackageDiffPkg.getRules().stream().map(rule -> rule.getName()).collect(Collectors.toList());
+
+        assertEquals(2, ruleNamesDiffPkg.size());
+        assertThat(ruleNamesDiffPkg).contains("Left Rule", "Right Rule");
+    }
+}

--- a/drools-test-coverage/test-compiler-integration/src/test/resources/org/drools/mvel/integrationtests/rf_test_ruleflow.rf
+++ b/drools-test-coverage/test-compiler-integration/src/test/resources/org/drools/mvel/integrationtests/rf_test_ruleflow.rf
@@ -1,0 +1,43 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<process xmlns="http://drools.org/drools-5.0/process"
+         xmlns:xs="http://www.w3.org/2001/XMLSchema-instance"
+         xs:schemaLocation="http://drools.org/drools-5.0/process drools-processes-5.0.xsd"
+         type="RuleFlow" name="example" id="example" package-name="com.example.rules" version="" routerLayout="2" >
+
+  <header>
+    <imports>
+      <import name="com.example.*" />
+    </imports>
+  </header>
+
+  <nodes>
+    <end id="115" name="End" x="156" y="444" width="123" height="44" />
+    <start id="53" name="Start" x="156" y="24" width="123" height="44" />
+    <ruleSet id="245" name="RFG-1" x="120" y="108" width="121" height="48" ruleFlowGroup="RFG-1" />
+    <split id="246" name="Gateway" x="156" y="192" width="49" height="49" type="2" >
+      <metaData name="UniqueId">
+        <value>_jbpm-unique-3</value>
+      </metaData>
+      <constraints>
+        <constraint toNodeId="248" toType="DROOLS_DEFAULT" name="constraint" priority="1" type="rule" dialect="mvel" >exists Values(this == Values.LEFT)</constraint>
+        <constraint toNodeId="249" toType="DROOLS_DEFAULT" name="constraint" priority="1" type="rule" dialect="mvel" >exists Values(this == Values.RIGHT)</constraint>
+        <constraint toNodeId="250" toType="DROOLS_DEFAULT" name="constraint" type="rule" dialect="mvel" >eval(true)</constraint>
+      </constraints>
+    </split>
+    <ruleSet id="248" name="RFG-2" x="72" y="276" width="85" height="48" ruleFlowGroup="RFG-2" />
+    <ruleSet id="249" name="RFG-3" x="204" y="276" width="85" height="48" ruleFlowGroup="RFG-3" />
+    <join id="250" name="Join" x="156" y="360" width="49" height="49" type="2" />
+  </nodes>
+
+  <connections>
+    <connection from="250" to="115" />
+    <connection from="53" to="245" />
+    <connection from="245" to="246" />
+    <connection from="246" to="248" />
+    <connection from="246" to="249" />
+    <connection from="248" to="250" />
+    <connection from="249" to="250" />
+    <connection from="246" to="250" />
+  </connections>
+
+</process>

--- a/drools-test-coverage/test-compiler-integration/src/test/resources/org/drools/mvel/integrationtests/rf_test_rules.drl
+++ b/drools-test-coverage/test-compiler-integration/src/test/resources/org/drools/mvel/integrationtests/rf_test_rules.drl
@@ -1,0 +1,33 @@
+/*
+ * Copyright 2022 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+*/
+
+package com.example.rules
+
+rule "Left Rule"
+ruleflow-group "RFG-1"
+    when
+        String( this == "Left" )
+    then
+        System.out.println("Left Rule Fired");
+end
+
+
+rule "Right Rule"
+ruleflow-group "RFG-2"
+    when
+        String( this == "Right" )
+    then
+        System.out.println("Right Rule Fired");
+end

--- a/drools-test-coverage/test-compiler-integration/src/test/resources/org/drools/mvel/integrationtests/rf_test_rules_different_pkg.drl
+++ b/drools-test-coverage/test-compiler-integration/src/test/resources/org/drools/mvel/integrationtests/rf_test_rules_different_pkg.drl
@@ -1,0 +1,33 @@
+/*
+ * Copyright 2022 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+*/
+
+package com.example.rules.different.pkg
+
+rule "Left Rule"
+ruleflow-group "RFG-1"
+    when
+        String( this == "Left" )
+    then
+        System.out.println("Left Rule Fired");
+end
+
+
+rule "Right Rule"
+ruleflow-group "RFG-2"
+    when
+        String( this == "Right" )
+    then
+        System.out.println("Right Rule Fired");
+end


### PR DESCRIPTION
**Ports** 
This PR is a combined forward-port of
https://github.com/kiegroup/drools/pull/4151
https://github.com/kiegroup/drools/pull/4154


**JIRA**: 
https://issues.redhat.com/browse/DROOLS-6797
https://issues.redhat.com/browse/DROOLS-6800

<details>
<summary>
How to replicate CI configuration locally?
</summary>

Build Chain tool does "simple" maven build(s), the builds are just Maven commands, but because the repositories relates and depends on each other and any change in API or class method could affect several of those repositories there is a need to use [build-chain tool](https://github.com/kiegroup/github-action-build-chain) to handle cross repository builds and be sure that we always use latest version of the code for each repository.
 
[build-chain tool](https://github.com/kiegroup/github-action-build-chain) is a build tool which can be used on command line locally or in Github Actions workflow(s), in case you need to change multiple repositories and send multiple dependent pull requests related with a change you can easily reproduce the same build by executing it on Github hosted environment or locally in your development environment. See [local execution](https://github.com/kiegroup/github-action-build-chain#local-execution) details to get more information about it.
</details>

<details>
<summary>
How to retest this PR or trigger a specific build:
</summary>

* <b>a pull request</b> please add comment: <b>Jenkins retest this</b>

* for a <b>full downstream build</b> 
  * for <b>jenkins</b> job: please add comment: <b>Jenkins run fdb</b>
  * for <b>github actions</b> job: add the label `run_fdb`

* <b>a compile downstream build</b> please  add comment: <b>Jenkins run cdb</b>

* <b>a full production downstream build</b> please add comment: <b>Jenkins execute product fdb</b>

* <b>an upstream build</b> please add comment: <b>Jenkins run upstream</b>
</details>
