### PR TITLE
DROOLS-6803 DMN validation test compatibility JDK17

### DIFF
--- a/kie-dmn/kie-dmn-validation/pom.xml
+++ b/kie-dmn/kie-dmn-validation/pom.xml
@@ -144,6 +144,54 @@
     </dependency>
 
   </dependencies>
+  
+  <profiles>
+    <profile>
+      <!-- prepare for JDK17 -->
+      <id>add-jdk17plus-dependencies</id>
+      <activation>
+        <jdk>[17,)</jdk>
+      </activation>
+      <dependencyManagement>
+        <dependencies>
+          <!-- the expected ones from default (non profile-specific from this pom.xml) -->
+          <dependency>
+            <groupId>org.drools</groupId>
+            <artifactId>drools-bom</artifactId>
+            <version>${project.version}</version>
+            <type>pom</type>
+            <scope>import</scope>
+          </dependency>
+          <dependency>
+            <groupId>org.kie</groupId>
+            <artifactId>kie-pmml-bom</artifactId>
+            <version>${project.version}</version>
+            <type>pom</type>
+            <scope>import</scope>
+          </dependency>
+          <dependency>
+            <groupId>org.kie</groupId>
+            <artifactId>kie-dmn-core</artifactId>
+            <classifier>tests</classifier>
+            <version>${project.version}</version>
+          </dependency>
+          <dependency>
+            <groupId>org.kie</groupId>
+            <artifactId>kie-dmn-validation-bootstrap</artifactId>
+            <optional>true</optional>
+            <version>${project.version}</version>
+          </dependency>
+          <!-- /end the expected ones from default -->
+          <!-- JDK17 compatibility: -->
+          <dependency>
+            <groupId>com.sun.xml.bind</groupId>
+            <artifactId>jaxb-impl</artifactId>
+            <version>2.3.1</version>
+          </dependency>
+        </dependencies>
+      </dependencyManagement>
+    </profile>
+  </profiles>
 
   <build>
     <plugins>


### PR DESCRIPTION
**JIRA**:  https://issues.redhat.com/browse/DROOLS-6803

**referenced Pull Requests**: none

@mariofusco @mareknovotny please let me know if there are any concerns with this modification; to be noted this is a `provided` scope dependency, and this modification is required only to avoid the test crashing when running with JDK17 (the code uses pure JAXB so no compilation-time direct dependency, but when the underlying JAXB runtime is not managed correctly at run-time it crashes). More details are also documented in the linked JIRA.

<details>
<summary>
How to replicate CI configuration locally?
</summary>

Build Chain tool does "simple" maven build(s), the builds are just Maven commands, but because the repositories relates and depends on each other and any change in API or class method could affect several of those repositories there is a need to use [build-chain tool](https://github.com/kiegroup/github-action-build-chain) to handle cross repository builds and be sure that we always use latest version of the code for each repository.
 
[build-chain tool](https://github.com/kiegroup/github-action-build-chain) is a build tool which can be used on command line locally or in Github Actions workflow(s), in case you need to change multiple repositories and send multiple dependent pull requests related with a change you can easily reproduce the same build by executing it on Github hosted environment or locally in your development environment. See [local execution](https://github.com/kiegroup/github-action-build-chain#local-execution) details to get more information about it.
</details>

<details>
<summary>
How to retest this PR or trigger a specific build:
</summary>

* <b>a pull request</b> please add comment: <b>Jenkins retest this</b>

* for a <b>full downstream build</b> 
  * for <b>jenkins</b> job: please add comment: <b>Jenkins run fdb</b>
  * for <b>github actions</b> job: add the label `run_fdb`

* <b>a compile downstream build</b> please  add comment: <b>Jenkins run cdb</b>

* <b>a full production downstream build</b> please add comment: <b>Jenkins execute product fdb</b>

* <b>an upstream build</b> please add comment: <b>Jenkins run upstream</b>
</details>
