### PR TITLE
[DROOLS-6804] use a MathContext in BigDecimal expressions generated b…

### DIFF
--- a/drools-model/drools-mvel-compiler/src/main/java/org/drools/mvelcompiler/ast/BigDecimalArithmeticExprT.java
+++ b/drools-model/drools-mvel-compiler/src/main/java/org/drools/mvelcompiler/ast/BigDecimalArithmeticExprT.java
@@ -97,16 +97,14 @@ public class BigDecimalArithmeticExprT implements TypedExpression {
 
     @Override
     public Node toJavaExpression() {
-
-        Expression methodCallExpr = new MethodCallExpr((Expression) scope.toJavaExpression(),
-                                                           name,
-                                                           nodeList((Expression) argument.toJavaExpression()));
-        if(isNegated) {
-            methodCallExpr = new UnaryExpr(new EnclosedExpr(methodCallExpr), UnaryExpr.Operator.LOGICAL_COMPLEMENT);
+        MethodCallExpr methodCallExpr = new MethodCallExpr((Expression) scope.toJavaExpression(), name,
+                nodeList((Expression) argument.toJavaExpression()));
+        if (!"valueOf".equals(name) && !"equals".equals(name)) {
+            methodCallExpr.addArgument("java.math.MathContext.DECIMAL128");
         }
-        return methodCallExpr;
+        return isNegated ? new UnaryExpr(new EnclosedExpr(methodCallExpr), UnaryExpr.Operator.LOGICAL_COMPLEMENT) : methodCallExpr;
     }
-
+    
     @Override
     public String toString() {
         return "BigDecimalExprT{" +

--- a/drools-model/drools-mvel-compiler/src/test/java/org/drools/mvelcompiler/ConstraintCompilerTest.java
+++ b/drools-model/drools-mvel-compiler/src/test/java/org/drools/mvelcompiler/ConstraintCompilerTest.java
@@ -32,7 +32,7 @@ public class ConstraintCompilerTest implements CompilerTest {
     @Test
     public void testBigDecimalPromotion() {
         testExpression(c -> c.setRootPatternPrefix(Person.class, "_this"), "salary + salary",
-                       "_this.getSalary().add(_this.getSalary())");
+                       "_this.getSalary().add(_this.getSalary(), java.math.MathContext.DECIMAL128)");
     }
 
     @Test

--- a/drools-model/drools-mvel-compiler/src/test/java/org/drools/mvelcompiler/MvelCompilerTest.java
+++ b/drools-model/drools-mvel-compiler/src/test/java/org/drools/mvelcompiler/MvelCompilerTest.java
@@ -272,7 +272,7 @@ public class MvelCompilerTest implements CompilerTest {
     public void testSetterBigDecimal() {
         test(ctx -> ctx.addDeclaration("$p", Person.class),
              "{ $p.salary = $p.salary + 50000; }",
-             "{ $p.setSalary($p.getSalary().add(new java.math.BigDecimal(50000))); }");
+             "{ $p.setSalary($p.getSalary().add(new java.math.BigDecimal(50000), java.math.MathContext.DECIMAL128)); }");
     }
 
     @Test
@@ -360,7 +360,7 @@ public class MvelCompilerTest implements CompilerTest {
     public void testBigDecimalModulo() {
         test(ctx -> ctx.addDeclaration("$b1", BigDecimal.class),
              "{ java.math.BigDecimal result = $b1 % 2; }",
-             "{ java.math.BigDecimal result = $b1.remainder(new java.math.BigDecimal(2)); }");
+             "{ java.math.BigDecimal result = $b1.remainder(new java.math.BigDecimal(2), java.math.MathContext.DECIMAL128); }");
     }
 
     @Test
@@ -376,7 +376,7 @@ public class MvelCompilerTest implements CompilerTest {
                  ctx.addDeclaration("$b2", BigDecimal.class);
              },
              "{ java.math.BigDecimal result = $b1 % $b2; }",
-             "{ java.math.BigDecimal result = $b1.remainder($b2); }");
+             "{ java.math.BigDecimal result = $b1.remainder($b2, java.math.MathContext.DECIMAL128); }");
     }
 
     @Test
@@ -387,7 +387,7 @@ public class MvelCompilerTest implements CompilerTest {
                  ctx.addDeclaration("$p", Person.class);
              },
              "{ $p.salary = $p.salary + (bd1.multiply(bd2)); }",
-             "{ $p.setSalary($p.getSalary().add(bd1.multiply(bd2)));\n }");
+             "{ $p.setSalary($p.getSalary().add(bd1.multiply(bd2), java.math.MathContext.DECIMAL128));\n }");
     }
 
     @Test
@@ -607,8 +607,8 @@ public class MvelCompilerTest implements CompilerTest {
              "{ " +
                      "    java.math.BigDecimal sum = new java.math.BigDecimal(0);\n" +
                      "    java.math.BigDecimal money = new java.math.BigDecimal(10);\n" +
-                     "    sum = sum.add(money);\n" +
-                     "    sum = sum.subtract(money);\n" +
+                     "    sum = sum.add(money, java.math.MathContext.DECIMAL128);\n" +
+                     "    sum = sum.subtract(money, java.math.MathContext.DECIMAL128);\n" +
                      "}");
     }
 
@@ -619,7 +619,7 @@ public class MvelCompilerTest implements CompilerTest {
                      "    $p.salary += 50000B;\n" +
                      "}",
              "{ " +
-                     "    $p.setSalary($p.getSalary().add(new java.math.BigDecimal(\"50000\")));\n" +
+                     "    $p.setSalary($p.getSalary().add(new java.math.BigDecimal(\"50000\"), java.math.MathContext.DECIMAL128));\n" +
                      "}");
     }
 
@@ -630,7 +630,7 @@ public class MvelCompilerTest implements CompilerTest {
                      "    $p.salary += $p.salary;\n" +
                      "}",
              "{ " +
-                     "    $p.setSalary($p.getSalary().add($p.getSalary()));\n" +
+                     "    $p.setSalary($p.getSalary().add($p.getSalary(), java.math.MathContext.DECIMAL128));\n" +
                      "}");
     }
 
@@ -641,7 +641,7 @@ public class MvelCompilerTest implements CompilerTest {
                      "    java.math.BigDecimal operation = $p.salary + $p.salary;\n" +
                      "}",
              "{ " +
-                     "    java.math.BigDecimal operation = $p.getSalary().add($p.getSalary());\n" +
+                     "    java.math.BigDecimal operation = $p.getSalary().add($p.getSalary(), java.math.MathContext.DECIMAL128);\n" +
                      "}");
     }
 
@@ -652,7 +652,7 @@ public class MvelCompilerTest implements CompilerTest {
                      "    java.math.BigDecimal operation = $p.salary + 10B;\n" +
                      "}",
              "{ " +
-                     "    java.math.BigDecimal operation = $p.getSalary().add(new java.math.BigDecimal(\"10\"));\n" +
+                     "    java.math.BigDecimal operation = $p.getSalary().add(new java.math.BigDecimal(\"10\"), java.math.MathContext.DECIMAL128);\n" +
                      "}");
     }
 
@@ -663,7 +663,7 @@ public class MvelCompilerTest implements CompilerTest {
                      "    java.math.BigDecimal operation = $p.salary + 10;\n" +
                      "}",
              "{ " +
-                     "    java.math.BigDecimal operation = $p.getSalary().add(new java.math.BigDecimal(10));\n" +
+                     "    java.math.BigDecimal operation = $p.getSalary().add(new java.math.BigDecimal(10), java.math.MathContext.DECIMAL128);\n" +
                      "}");
     }
 
@@ -681,11 +681,11 @@ public class MvelCompilerTest implements CompilerTest {
                      "}",
              "{ " +
                      "        java.math.BigDecimal result = new java.math.BigDecimal(\"0\");\n" +
-                     "        result = result.add(new java.math.BigDecimal(50000));\n" +
-                     "        result = result.subtract(new java.math.BigDecimal(10000));\n" +
-                     "        result = result.divide(new java.math.BigDecimal(10));\n" +
-                     "        result = result.multiply(new java.math.BigDecimal(10));\n" +
-                     "        result = result.multiply($p.getSalary());\n" +
+                     "        result = result.add(new java.math.BigDecimal(50000), java.math.MathContext.DECIMAL128);\n" +
+                     "        result = result.subtract(new java.math.BigDecimal(10000), java.math.MathContext.DECIMAL128);\n" +
+                     "        result = result.divide(new java.math.BigDecimal(10), java.math.MathContext.DECIMAL128);\n" +
+                     "        result = result.multiply(new java.math.BigDecimal(10), java.math.MathContext.DECIMAL128);\n" +
+                     "        result = result.multiply($p.getSalary(), java.math.MathContext.DECIMAL128);\n" +
                      "        $p.setSalary(result);\n" +
                      "}");
     }
@@ -700,7 +700,7 @@ public class MvelCompilerTest implements CompilerTest {
              "{ " +
                      "        java.math.BigDecimal result = new java.math.BigDecimal(\"0\");\n" +
                      "        int anotherVariable = 20;\n" +
-                     "        result = result.add(new java.math.BigDecimal(anotherVariable));\n" +
+                     "        result = result.add(new java.math.BigDecimal(anotherVariable), java.math.MathContext.DECIMAL128);\n" +
                      "}");
     }
 
@@ -712,7 +712,7 @@ public class MvelCompilerTest implements CompilerTest {
                      "}",
              "{ " +
                      "        int anotherVariable = 20;\n" +
-                     "        $p.setSalary($p.getSalary().add(new java.math.BigDecimal(anotherVariable)));\n" +
+                     "        $p.setSalary($p.getSalary().add(new java.math.BigDecimal(anotherVariable), java.math.MathContext.DECIMAL128));\n" +
                      "}");
     }
 


### PR DESCRIPTION
…… (#4160)

* [DROOLS-6804] use a MathContext in BigDecimal expressions generated by the executable model

* fix tests

(cherry picked from commit 33fcdf9661e6ac754d55f563c1b674b5321553e9)