### PR TITLE
KOGITO-6682 Force maven version to 3.8.1+

### DIFF
--- a/.ci/jenkins/Jenkinsfile.deploy
+++ b/.ci/jenkins/Jenkinsfile.deploy
@@ -12,7 +12,7 @@ pipeline {
     }
 
     tools {
-        maven 'kie-maven-3.6.3'
+        maven 'kie-maven-3.8.1'
         jdk 'kie-jdk11'
     }
 

--- a/.ci/jenkins/Jenkinsfile.promote
+++ b/.ci/jenkins/Jenkinsfile.promote
@@ -12,7 +12,7 @@ pipeline {
     }
 
     tools {
-        maven 'kie-maven-3.6.3'
+        maven 'kie-maven-3.8.1'
         jdk 'kie-jdk11'
     }
 

--- a/build-parent/pom.xml
+++ b/build-parent/pom.xml
@@ -204,7 +204,7 @@
         <version.com.github.spotbugs-maven-plugin>3.1.8</version.com.github.spotbugs-maven-plugin>
         <version.org.jboss.maven.plugins.maven-jdocbook-plugin>2.3.9</version.org.jboss.maven.plugins.maven-jdocbook-plugin>
 
-        <maven.min.version>3.6.3</maven.min.version>
+        <maven.min.version>3.8.1</maven.min.version>
         <!-- Important: this is one and only place where the supported user agents (browsers) are configured.
              All webapps/showcases must use this property in their *.gwt.xml files.
              We only need to support IE11+, but there is no ie11 permutation. IE11 will use the Firefox one (gecko1_8) -->


### PR DESCRIPTION
https://issues.redhat.com/browse/KOGITO-6682

Related PRs:
- https://github.com/kiegroup/drools/pull/4174
- https://github.com/kiegroup/kogito-runtimes/pull/1962
- https://github.com/kiegroup/optaplanner/pull/1820
- https://github.com/kiegroup/optaweb-vehicle-routing/pull/647
- https://github.com/kiegroup/optaplanner-quickstarts/pull/277
- https://github.com/kiegroup/kogito-apps/pull/1227
- https://github.com/kiegroup/kogito-examples/pull/1109