### PR TITLE
[DROOLS-6112] executable-model test failure in test-compiler-integrat…

### DIFF
--- a/drools-model/drools-model-compiler/src/main/java/org/drools/modelcompiler/builder/ModelBuilderImpl.java
+++ b/drools-model/drools-model-compiler/src/main/java/org/drools/modelcompiler/builder/ModelBuilderImpl.java
@@ -42,6 +42,7 @@ import org.drools.drl.ast.descr.GlobalDescr;
 import org.drools.drl.ast.descr.ImportDescr;
 import org.drools.drl.ast.descr.PackageDescr;
 import org.drools.drl.ast.descr.TypeDeclarationDescr;
+import org.drools.modelcompiler.builder.errors.UnsupportedFeatureError;
 import org.drools.modelcompiler.builder.generator.DRLIdGenerator;
 import org.drools.modelcompiler.builder.generator.DrlxParseUtil;
 import org.drools.modelcompiler.builder.generator.declaredtype.POJOGenerator;
@@ -192,6 +193,9 @@ public class ModelBuilderImpl<T extends PackageSources> extends KnowledgeBuilder
                 type.setTypeClassDef( createClassDefinition( typeClass, typeDescr.getResource() ) );
             }
             TypeDeclarationFactory.processAnnotations(typeDescr, type);
+            if (!type.isTypesafe()) {
+                addBuilderResult(new UnsupportedFeatureError("@typesafe(false) is not supported in executable model : " + type));
+            }
             getOrCreatePackageRegistry(new PackageDescr(typePkg)).getPackage().addTypeDeclaration(type );
         } catch (ClassNotFoundException e) {
             TypeDeclaration type = new TypeDeclaration( typeDescr.getTypeName() );

--- a/drools-model/drools-model-compiler/src/main/java/org/drools/modelcompiler/builder/errors/UnsupportedFeatureError.java
+++ b/drools-model/drools-model-compiler/src/main/java/org/drools/modelcompiler/builder/errors/UnsupportedFeatureError.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright 2022 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.drools.modelcompiler.builder.errors;
+
+import org.drools.compiler.compiler.DroolsError;
+import org.kie.internal.builder.ResultSeverity;
+
+public class UnsupportedFeatureError extends DroolsError {
+
+    private String message;
+
+    public UnsupportedFeatureError(String message) {
+        super();
+        this.message = message;
+    }
+
+    @Override
+    public ResultSeverity getSeverity() {
+        return ResultSeverity.ERROR;
+    }
+
+    @Override
+    public String getMessage() {
+        return message;
+    }
+
+    @Override
+    public int[] getLines() {
+        return new int[0];
+    }
+}

--- a/drools-model/drools-model-compiler/src/test/java/org/drools/modelcompiler/CompilationFailuresTest.java
+++ b/drools-model/drools-model-compiler/src/test/java/org/drools/modelcompiler/CompilationFailuresTest.java
@@ -27,6 +27,7 @@ import org.kie.api.builder.Results;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
 
 public class CompilationFailuresTest extends BaseModelTest {
 
@@ -214,5 +215,29 @@ public class CompilationFailuresTest extends BaseModelTest {
         public BigDecimal getFortyTwo() {
             return BigDecimal.valueOf(42);
         }
+    }
+
+    @Test
+    public void testTypeSafe() {
+        String str =
+                "import " + Parent.class.getCanonicalName() + ";" +
+                     "declare\n" +
+                     "   Parent @typesafe(false)\n" +
+                     "end\n" +
+                     "rule R1\n" +
+                     "when\n" +
+                     "   $a : Parent( x == 1 )\n" +
+                     "then\n" +
+                     "end\n";
+
+        Results results = createKieBuilder(str).getResults();
+        if (testRunType.isExecutableModel()) {
+            assertThat(results.getMessages(Message.Level.ERROR).get(0).getText().contains("@typesafe(false) is not supported in executable model"));
+        } else {
+            assertTrue(results.getMessages(Message.Level.ERROR).isEmpty());
+        }
+    }
+
+    public static class Parent {
     }
 }

--- a/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/compiler/integrationtests/drl/DrlSpecificFeaturesTest.java
+++ b/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/compiler/integrationtests/drl/DrlSpecificFeaturesTest.java
@@ -49,6 +49,7 @@ public class DrlSpecificFeaturesTest {
 
     @Parameterized.Parameters(name = "KieBase type={0}")
     public static Collection<Object[]> getParameters() {
+        // This class is meant to test features only supported by non-exec-model.
         return TestParametersUtil.getKieBaseCloudConfigurations(false);
     }
 
@@ -97,6 +98,7 @@ public class DrlSpecificFeaturesTest {
             assertEquals(4, ksession.fireAllRules());
 
             // give time to async jitting to complete
+            // actually, the constraint is not jitted because MVELConstraint.isDynamic == true
             Thread.sleep(100);
 
             ksession.insert(new ChildA(1));


### PR DESCRIPTION
…ion DrlSpecificFeaturesTest (#4183)

- Leave DrlSpecificFeaturesTest because it is for non-exec-model test
- Raise a build error when @typesafe(false) is used with exec-model

**Ports** 
This is a forward-port PR of https://github.com/kiegroup/drools/pull/4183 for main

**JIRA**:
https://issues.redhat.com/browse/DROOLS-6112

<details>
<summary>
How to replicate CI configuration locally?
</summary>

Build Chain tool does "simple" maven build(s), the builds are just Maven commands, but because the repositories relates and depends on each other and any change in API or class method could affect several of those repositories there is a need to use [build-chain tool](https://github.com/kiegroup/github-action-build-chain) to handle cross repository builds and be sure that we always use latest version of the code for each repository.
 
[build-chain tool](https://github.com/kiegroup/github-action-build-chain) is a build tool which can be used on command line locally or in Github Actions workflow(s), in case you need to change multiple repositories and send multiple dependent pull requests related with a change you can easily reproduce the same build by executing it on Github hosted environment or locally in your development environment. See [local execution](https://github.com/kiegroup/github-action-build-chain#local-execution) details to get more information about it.
</details>

<details>
<summary>
How to retest this PR or trigger a specific build:
</summary>

* <b>a pull request</b> please add comment: <b>Jenkins retest this</b>

* for a <b>full downstream build</b> 
  * for <b>jenkins</b> job: please add comment: <b>Jenkins run fdb</b>
  * for <b>github actions</b> job: add the label `run_fdb`

* <b>a compile downstream build</b> please  add comment: <b>Jenkins run cdb</b>

* <b>a full production downstream build</b> please add comment: <b>Jenkins execute product fdb</b>

* <b>an upstream build</b> please add comment: <b>Jenkins run upstream</b>
</details>
