### PR TITLE
[DROOLS-6830] Declaring PMMLRuntime as SPI-managed 

### DIFF
--- a/drools-core/src/main/java/org/drools/core/impl/KnowledgeBaseImpl.java
+++ b/drools-core/src/main/java/org/drools/core/impl/KnowledgeBaseImpl.java
@@ -98,6 +98,7 @@ import org.kie.api.definition.type.FactType;
 import org.kie.api.definition.type.Role;
 import org.kie.api.event.kiebase.KieBaseEventListener;
 import org.kie.api.internal.io.ResourceTypePackage;
+import org.kie.api.internal.utils.KieService;
 import org.kie.api.internal.utils.ServiceRegistry;
 import org.kie.api.internal.weaver.KieWeavers;
 import org.kie.api.io.Resource;
@@ -1305,6 +1306,9 @@ public class KnowledgeBaseImpl
 
         if ( ! newPkg.getResourceTypePackages().isEmpty() ) {
             KieWeavers weavers = ServiceRegistry.getService(KieWeavers.class);
+            if (weavers == null) {
+                throw new IllegalStateException("Unable to find KieWeavers implementation");
+            }
             for ( ResourceTypePackage rtkKpg : newPkg.getResourceTypePackages().values() ) {
                 weavers.merge( this, pkg, rtkKpg );
             }

--- a/kie-pmml-trusty/kie-pmml-evaluator/kie-pmml-evaluator-core/src/main/resources/META-INF/services/org.kie.pmml.api.runtime.PMMLRuntime
+++ b/kie-pmml-trusty/kie-pmml-evaluator/kie-pmml-evaluator-core/src/main/resources/META-INF/services/org.kie.pmml.api.runtime.PMMLRuntime
@@ -1,0 +1,1 @@
+org.kie.pmml.evaluator.core.service.PMMLRuntimeInternalImpl


### PR DESCRIPTION
@danielezonca backport


**Thank you for submitting this pull request**

**NOTE!:** Double check the target branch for this PR.
The default is `main` so it will target Drools 8 / Kogito / Optaplanner 8.
If this PR is not strictly related to drools and kogito project in `drools.git`, it should probably target `7.x`as a branch

Backport of

[link](https://github.com/kiegroup/drools/pull/4209)

**JIRA**: 

[link](https://issues.redhat.com/browse/DROOLS-6830)

**referenced Pull Requests**: _(please edit the URLs of referenced pullrequests if they exist)_

* paste the link(s) from GitHub here
* link 2
* link 3 etc.

<details>
<summary>
How to replicate CI configuration locally?
</summary>

Build Chain tool does "simple" maven build(s), the builds are just Maven commands, but because the repositories relates and depends on each other and any change in API or class method could affect several of those repositories there is a need to use [build-chain tool](https://github.com/kiegroup/github-action-build-chain) to handle cross repository builds and be sure that we always use latest version of the code for each repository.
 
[build-chain tool](https://github.com/kiegroup/github-action-build-chain) is a build tool which can be used on command line locally or in Github Actions workflow(s), in case you need to change multiple repositories and send multiple dependent pull requests related with a change you can easily reproduce the same build by executing it on Github hosted environment or locally in your development environment. See [local execution](https://github.com/kiegroup/github-action-build-chain#local-execution) details to get more information about it.
</details>

<details>
<summary>
How to retest this PR or trigger a specific build:
</summary>

* <b>a pull request</b> please add comment: <b>Jenkins retest this</b>

* for a <b>full downstream build</b> 
  * for <b>jenkins</b> job: please add comment: <b>Jenkins run fdb</b>
  * for <b>github actions</b> job: add the label `run_fdb`

* <b>a compile downstream build</b> please  add comment: <b>Jenkins run cdb</b>

* <b>a full production downstream build</b> please add comment: <b>Jenkins execute product fdb</b>

* <b>an upstream build</b> please add comment: <b>Jenkins run upstream</b>
</details>
