### PR TITLE
Removed deprecated annotation

### DIFF
--- a/drools-core/src/test/java/org/drools/core/util/BinaryHeapQueueTest.java
+++ b/drools-core/src/test/java/org/drools/core/util/BinaryHeapQueueTest.java
@@ -236,7 +236,7 @@ public class BinaryHeapQueueTest {
          * Is the value equal to another value, as tested by the
          * {@link java.lang.Object#equals} invokedMethod?
          */
-        @Factory
+        
         public static Matcher<List<InternalFactHandle>> isTuple(List<InternalFactHandle> operand) {
             return new IsTuple( operand );
         }

--- a/drools-core/src/test/java/org/drools/core/util/BinaryHeapQueueTest.java
+++ b/drools-core/src/test/java/org/drools/core/util/BinaryHeapQueueTest.java
@@ -32,7 +32,6 @@ import org.drools.core.spi.Consequence;
 import org.drools.core.spi.PropagationContext;
 import org.hamcrest.BaseMatcher;
 import org.hamcrest.Description;
-import org.hamcrest.Factory;
 import org.hamcrest.Matcher;
 import org.junit.Before;
 import org.junit.Test;


### PR DESCRIPTION
This is a fix to remove a compilation problem that appears when we upgrade the hamcrest version.

The hamcrest upgrade is required to remove a potential conflict that is generated by upgrading awaitility version.

The awaitility upgrade is required to properly backport a fix to unstable time sensitive tests.


<details>
<summary>
How to replicate CI configuration locally?
</summary>

Build Chain tool does "simple" maven build(s), the builds are just Maven commands, but because the repositories relates and depends on each other and any change in API or class method could affect several of those repositories there is a need to use [build-chain tool](https://github.com/kiegroup/github-action-build-chain) to handle cross repository builds and be sure that we always use latest version of the code for each repository.
 
[build-chain tool](https://github.com/kiegroup/github-action-build-chain) is a build tool which can be used on command line locally or in Github Actions workflow(s), in case you need to change multiple repositories and send multiple dependent pull requests related with a change you can easily reproduce the same build by executing it on Github hosted environment or locally in your development environment. See [local execution](https://github.com/kiegroup/github-action-build-chain#local-execution) details to get more information about it.
</details>

<details>
<summary>
How to retest this PR or trigger a specific build:
</summary>

* <b>a pull request</b> please add comment: <b>Jenkins retest this</b>

* for a <b>full downstream build</b> 
  * for <b>jenkins</b> job: please add comment: <b>Jenkins run fdb</b>
  * for <b>github actions</b> job: add the label `run_fdb`

* <b>a compile downstream build</b> please  add comment: <b>Jenkins run cdb</b>

* <b>a full production downstream build</b> please add comment: <b>Jenkins execute product fdb</b>

* <b>an upstream build</b> please add comment: <b>Jenkins run upstream</b>
</details>
