### PR TITLE
[DROOLS-6852] ForceEagerActivationFilter doesn't work correctly for e…

### DIFF
--- a/drools-core/src/main/java/org/drools/core/reteoo/builder/GroupElementBuilder.java
+++ b/drools-core/src/main/java/org/drools/core/reteoo/builder/GroupElementBuilder.java
@@ -129,7 +129,7 @@ public class GroupElementBuilder
             boolean hasTimer = context.getRule().getTimer() != null;
             RuleBaseConfiguration conf = context.getRuleBase().getConfiguration();
             boolean lockOnActive = context.getRule().isLockOnActive();
-            boolean eager = context.getRule().getMetaData( Propagation.class.getName() ) != null;
+            boolean eager = context.getRule().getMetaData(Propagation.class.getName()) != null || context.getRule().getMetaData(Propagation.class.getSimpleName()) != null;
             return !isInitialFact && !hasTimer && !lockOnActive && !eager &&
                     !conf.isMultithreadEvaluation() && !conf.isSequential() && !conf.isDeclarativeAgenda();
         }

--- a/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/compiler/common/ActivationIteratorTest.java
+++ b/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/compiler/common/ActivationIteratorTest.java
@@ -54,8 +54,7 @@ public class ActivationIteratorTest {
 
     @Parameterized.Parameters(name = "KieBase type={0}")
     public static Collection<Object[]> getParameters() {
-     // TODO: EM failed with testFilteredEagerEvaluation, testLianPlusEvalnWithSharingWithMixedDormantAndActive, testSingleJoinNodePlusEvalnWithSharingWithMixedDormantAndActive. File JIRAs
-        return TestParametersUtil.getKieBaseCloudConfigurations(false);
+        return TestParametersUtil.getKieBaseCloudConfigurations(true);
     }
 
     @Test


### PR DESCRIPTION
…xec-model (#4238)

**Ports** 
This is a forward-port PR of https://github.com/kiegroup/drools/pull/4238 for main

**JIRA**: 
https://issues.redhat.com/browse/DROOLS-6852

<details>
<summary>
How to replicate CI configuration locally?
</summary>

Build Chain tool does "simple" maven build(s), the builds are just Maven commands, but because the repositories relates and depends on each other and any change in API or class method could affect several of those repositories there is a need to use [build-chain tool](https://github.com/kiegroup/github-action-build-chain) to handle cross repository builds and be sure that we always use latest version of the code for each repository.
 
[build-chain tool](https://github.com/kiegroup/github-action-build-chain) is a build tool which can be used on command line locally or in Github Actions workflow(s), in case you need to change multiple repositories and send multiple dependent pull requests related with a change you can easily reproduce the same build by executing it on Github hosted environment or locally in your development environment. See [local execution](https://github.com/kiegroup/github-action-build-chain#local-execution) details to get more information about it.
</details>

<details>
<summary>
How to retest this PR or trigger a specific build:
</summary>

* <b>a pull request</b> please add comment: <b>Jenkins retest this</b>

* for a <b>full downstream build</b> 
  * for <b>jenkins</b> job: please add comment: <b>Jenkins run fdb</b>
  * for <b>github actions</b> job: add the label `run_fdb`

* <b>a compile downstream build</b> please  add comment: <b>Jenkins run cdb</b>

* <b>a full production downstream build</b> please add comment: <b>Jenkins execute product fdb</b>

* <b>an upstream build</b> please add comment: <b>Jenkins run upstream</b>
</details>
