### PR TITLE
[7.x] KOGITO-6781: XML Prolog support for .scesim files 

### DIFF
--- a/drools-scenario-simulation/drools-scenario-simulation-backend/src/main/java/org/drools/scenariosimulation/backend/util/ScenarioSimulationXMLPersistence.java
+++ b/drools-scenario-simulation/drools-scenario-simulation-backend/src/main/java/org/drools/scenariosimulation/backend/util/ScenarioSimulationXMLPersistence.java
@@ -41,6 +41,7 @@ import org.kie.soup.xstream.XStreamUtils;
 import org.w3c.dom.Document;
 
 import static org.drools.scenariosimulation.api.utils.ConstantsHolder.BACKGROUND_NODE;
+import static org.drools.scenariosimulation.api.utils.ConstantsHolder.SCENARIO_SIMULATION_MODEL_NODE;
 import static org.drools.scenariosimulation.api.utils.ConstantsHolder.SCESIM_MODEL_DESCRIPTOR_NODE;
 import static org.drools.scenariosimulation.api.utils.ConstantsHolder.SETTINGS;
 import static org.drools.scenariosimulation.api.utils.ConstantsHolder.SIMULATION_DESCRIPTOR_NODE;
@@ -50,7 +51,7 @@ public class ScenarioSimulationXMLPersistence {
 
     private static final ScenarioSimulationXMLPersistence INSTANCE = new ScenarioSimulationXMLPersistence();
     private static final String CURRENT_VERSION = new ScenarioSimulationModel().getVersion();
-    private static final Pattern p = Pattern.compile("version=\"([0-9]+\\.[0-9]+)");
+    private static final Pattern p = Pattern.compile(SCENARIO_SIMULATION_MODEL_NODE + " version=\"([0-9]+\\.[0-9]+)");
 
     private XStream xt;
     private MigrationStrategy migrationStrategy = new InMemoryMigrationStrategy();

--- a/drools-scenario-simulation/drools-scenario-simulation-backend/src/test/java/org/drools/scenariosimulation/backend/util/ScenarioSimulationXMLPersistenceTest.java
+++ b/drools-scenario-simulation/drools-scenario-simulation-backend/src/test/java/org/drools/scenariosimulation/backend/util/ScenarioSimulationXMLPersistenceTest.java
@@ -305,6 +305,22 @@ public class ScenarioSimulationXMLPersistenceTest {
         assertEquals("1.0", version);
     }
 
+    @Test
+    public void extractVersionWhenXmlPrologIsPresent() {
+        String version = instance.extractVersion("<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n" +
+                                                         "<ScenarioSimulationModel version=\"1.1\">");
+        assertEquals("1.1", version);
+    }
+
+    @Test
+    public void extractVersionWhenMoreVersionAttributesArePresent() {
+        String version = instance.extractVersion("<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n" +
+                                                         "<ScenarioSimulationModel version=\"1.2\">\n" +
+                                                         "<someUnknownTag version=\"1.1\"/>\n" +
+                                                         "</ScenarioSimulationModel>");
+        assertEquals("1.2", version);
+    }
+
     @Test(expected = IllegalArgumentException.class)
     public void unmarshalEmptyContent() throws Exception {
         ScenarioSimulationXMLPersistence.getInstance().unmarshal("");
@@ -334,6 +350,7 @@ public class ScenarioSimulationXMLPersistenceTest {
     /**
      * Verify the given <code>Map</code> has one single entry, whose <code>List</code> value also has a single children.
      * If <b>expectedTextContent</b> is given, it also check the children text content match
+     *
      * @param toCheck
      * @param expectedTextContent
      */

--- a/drools-scenario-simulation/drools-scenario-simulation-backend/src/test/resources/folderToTest/scesim-1-1.scesim
+++ b/drools-scenario-simulation/drools-scenario-simulation-backend/src/test/resources/folderToTest/scesim-1-1.scesim
@@ -1,4 +1,4 @@
-<?xml version="1.1" encoding="UTF-8"?>
+<?xml version="1.0" encoding="UTF-8"?>
 <ScenarioSimulationModel version="1.1">
   <simulation>
     <simulationDescriptor>

--- a/drools-scenario-simulation/drools-scenario-simulation-backend/src/test/resources/folderToTest/scesim-1-2.scesim
+++ b/drools-scenario-simulation/drools-scenario-simulation-backend/src/test/resources/folderToTest/scesim-1-2.scesim
@@ -1,3 +1,4 @@
+<?xml version="1.0" encoding="UTF-8"?>
 <ScenarioSimulationModel version="1.2">
   <simulation>
     <simulationDescriptor>

--- a/drools-scenario-simulation/drools-scenario-simulation-backend/src/test/resources/folderToTest/scesim-1-3-dmn_1.scesim
+++ b/drools-scenario-simulation/drools-scenario-simulation-backend/src/test/resources/folderToTest/scesim-1-3-dmn_1.scesim
@@ -1,3 +1,4 @@
+<?xml version="1.0" encoding="UTF-8"?>
 <ScenarioSimulationModel version="1.3">
   <simulation>
     <simulationDescriptor>

--- a/drools-scenario-simulation/drools-scenario-simulation-backend/src/test/resources/folderToTest/scesim-1-3-dmn_2.scesim
+++ b/drools-scenario-simulation/drools-scenario-simulation-backend/src/test/resources/folderToTest/scesim-1-3-dmn_2.scesim
@@ -1,3 +1,4 @@
+<?xml version="1.0" encoding="UTF-8"?>
 <ScenarioSimulationModel version="1.3">
   <simulation>
     <simulationDescriptor>

--- a/drools-scenario-simulation/drools-scenario-simulation-backend/src/test/resources/folderToTest/scesim-1-3-rule.scesim
+++ b/drools-scenario-simulation/drools-scenario-simulation-backend/src/test/resources/folderToTest/scesim-1-3-rule.scesim
@@ -1,3 +1,4 @@
+<?xml version="1.0" encoding="UTF-8"?>
 <ScenarioSimulationModel version="1.3">
   <simulation>
     <simulationDescriptor>

--- a/drools-scenario-simulation/drools-scenario-simulation-backend/src/test/resources/folderToTest/scesim-1-4-rule.scesim
+++ b/drools-scenario-simulation/drools-scenario-simulation-backend/src/test/resources/folderToTest/scesim-1-4-rule.scesim
@@ -1,3 +1,4 @@
+<?xml version="1.0" encoding="UTF-8"?>
 <ScenarioSimulationModel version="1.4">
   <simulation>
     <simulationDescriptor>

--- a/drools-scenario-simulation/drools-scenario-simulation-backend/src/test/resources/folderToTest/scesim-1-5-dmn.scesim
+++ b/drools-scenario-simulation/drools-scenario-simulation-backend/src/test/resources/folderToTest/scesim-1-5-dmn.scesim
@@ -1,3 +1,4 @@
+<?xml version="1.0" encoding="UTF-8"?>
 <ScenarioSimulationModel version="1.5">
   <simulation>
     <simulationDescriptor>

--- a/drools-scenario-simulation/drools-scenario-simulation-backend/src/test/resources/folderToTest/scesim-1-6-dmn.scesim
+++ b/drools-scenario-simulation/drools-scenario-simulation-backend/src/test/resources/folderToTest/scesim-1-6-dmn.scesim
@@ -1,3 +1,4 @@
+<?xml version="1.0" encoding="UTF-8"?>
 <ScenarioSimulationModel version="1.6">
   <simulation>
     <simulationDescriptor>

--- a/drools-scenario-simulation/drools-scenario-simulation-backend/src/test/resources/folderToTest/scesim-1-6-rule.scesim
+++ b/drools-scenario-simulation/drools-scenario-simulation-backend/src/test/resources/folderToTest/scesim-1-6-rule.scesim
@@ -1,3 +1,4 @@
+<?xml version="1.0" encoding="UTF-8"?>
 <ScenarioSimulationModel version="1.6">
   <simulation>
     <simulationDescriptor>

--- a/drools-scenario-simulation/drools-scenario-simulation-backend/src/test/resources/folderToTest/scesim-1-7-dmn.scesim
+++ b/drools-scenario-simulation/drools-scenario-simulation-backend/src/test/resources/folderToTest/scesim-1-7-dmn.scesim
@@ -1,3 +1,4 @@
+<?xml version="1.0" encoding="UTF-8"?>
 <ScenarioSimulationModel version="1.7">
   <simulation>
     <simulationDescriptor>

--- a/drools-scenario-simulation/drools-scenario-simulation-backend/src/test/resources/folderToTest/scesim-1-7-rule.scesim
+++ b/drools-scenario-simulation/drools-scenario-simulation-backend/src/test/resources/folderToTest/scesim-1-7-rule.scesim
@@ -1,3 +1,4 @@
+<?xml version="1.0" encoding="UTF-8"?>
 <ScenarioSimulationModel version="1.7">
   <simulation>
     <simulationDescriptor>

--- a/drools-scenario-simulation/drools-scenario-simulation-backend/src/test/resources/folderToTest/scesim-dmn.scesim
+++ b/drools-scenario-simulation/drools-scenario-simulation-backend/src/test/resources/folderToTest/scesim-dmn.scesim
@@ -1,3 +1,4 @@
+<?xml version="1.0" encoding="UTF-8"?>
 <ScenarioSimulationModel version="1.8">
   <simulation>
     <simulationDescriptor>

--- a/drools-scenario-simulation/drools-scenario-simulation-backend/src/test/resources/folderToTest/scesim-rule.scesim
+++ b/drools-scenario-simulation/drools-scenario-simulation-backend/src/test/resources/folderToTest/scesim-rule.scesim
@@ -1,3 +1,4 @@
+<?xml version="1.0" encoding="UTF-8"?>
 <ScenarioSimulationModel version="1.8">
   <simulation>
     <simulationDescriptor>


### PR DESCRIPTION
Scesim unmarshaller extracts the scesim version from the XML prolog instead of ScenarioSimulationNode

JIRA: https://issues.redhat.com/browse/KOGITO-6781

Backport of https://github.com/kiegroup/drools/pull/4205

Required to support scesims files generated with lastest versions of Kogito
