### PR TITLE
Drools 6875 - Removed use of deprecated methods from assertions

### DIFF
--- a/drools-beliefs/src/test/java/org/drools/beliefs/bayes/integration/ParserTest.java
+++ b/drools-beliefs/src/test/java/org/drools/beliefs/bayes/integration/ParserTest.java
@@ -30,9 +30,8 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
-import static junit.framework.Assert.assertEquals;
-import static junit.framework.Assert.assertNotNull;
-import static junit.framework.Assert.assertTrue;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.assertNull;
 
 public class ParserTest {

--- a/drools-model/drools-mvel-compiler/pom.xml
+++ b/drools-model/drools-mvel-compiler/pom.xml
@@ -43,6 +43,11 @@
       <scope>test</scope>
     </dependency>
 
+    <dependency>
+      <groupId>org.assertj</groupId>
+      <artifactId>assertj-core</artifactId>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
 
 </project>

--- a/drools-model/drools-mvel-compiler/src/test/java/org/drools/mvelcompiler/ModifyCompilerTest.java
+++ b/drools-model/drools-mvel-compiler/src/test/java/org/drools/mvelcompiler/ModifyCompilerTest.java
@@ -22,11 +22,8 @@ import org.drools.Person;
 import org.drools.mvelcompiler.context.MvelCompilerContext;
 import org.junit.Test;
 
-import static org.hamcrest.Matchers.containsInAnyOrder;
-import static org.hamcrest.Matchers.empty;
-import static org.hamcrest.Matchers.equalToIgnoringWhiteSpace;
-import static org.hamcrest.Matchers.is;
-import static org.junit.Assert.*;
+import static org.assertj.core.api.Assertions.assertThat;
+
 
 public class ModifyCompilerTest implements CompilerTest {
 
@@ -34,7 +31,7 @@ public class ModifyCompilerTest implements CompilerTest {
     public void testUncompiledMethod() {
         test("{modify( (List)$toEdit.get(0) ){ setEnabled( true ) }}",
              "{ { ((List) $toEdit.get(0)).setEnabled(true); } }",
-             result -> assertThat(allUsedBindings(result), is(empty())));
+             result -> assertThat(allUsedBindings(result)).isEmpty());
     }
 
     @Test
@@ -42,7 +39,7 @@ public class ModifyCompilerTest implements CompilerTest {
         test(ctx -> ctx.addDeclaration("$p", Person.class),
              "{  modify($p) { setCanDrink(true); } }",
              "{ { ($p).setCanDrink(true); } update($p); }",
-             result -> assertThat(allUsedBindings(result), containsInAnyOrder("$p")));
+             result -> assertThat(allUsedBindings(result)).containsExactlyInAnyOrder("$p"));
     }
 
     @Test
@@ -50,7 +47,7 @@ public class ModifyCompilerTest implements CompilerTest {
         test(ctx -> ctx.addDeclaration("$p", Person.class),
              "{  modify($p) {  setCanDrinkLambda(() -> true); } }",
              "{ { ($p).setCanDrinkLambda(() -> true); } update($p); }",
-             result -> assertThat(allUsedBindings(result), containsInAnyOrder("$p")));
+             result ->assertThat(allUsedBindings(result)).containsExactlyInAnyOrder("$p"));
     }
 
     @Test
@@ -72,7 +69,7 @@ public class ModifyCompilerTest implements CompilerTest {
                      "  update($fact); " +
                      "} " +
                      "} ",
-             result -> assertThat(allUsedBindings(result), containsInAnyOrder("$fact")));
+             result -> assertThat(allUsedBindings(result)).containsExactlyInAnyOrder("$fact"));
     }
 
     @Override
@@ -81,7 +78,7 @@ public class ModifyCompilerTest implements CompilerTest {
                       String expectedResult,
                       Consumer<CompiledBlockResult> resultAssert) {
         CompiledBlockResult compiled = new ModifyCompiler().compile(inputExpression);
-        assertThat(compiled.resultAsString(), equalToIgnoringWhiteSpace(expectedResult));
+        assertThat(compiled.resultAsString()).isEqualToIgnoringWhitespace(expectedResult);
         resultAssert.accept(compiled);
     }
 }

--- a/drools-model/drools-mvel-compiler/src/test/java/org/drools/mvelcompiler/MvelCompilerTest.java
+++ b/drools-model/drools-mvel-compiler/src/test/java/org/drools/mvelcompiler/MvelCompilerTest.java
@@ -24,10 +24,7 @@ import org.drools.Person;
 import org.drools.core.util.MethodUtils;
 import org.junit.Test;
 
-import static org.hamcrest.Matchers.containsInAnyOrder;
-import static org.hamcrest.Matchers.empty;
-import static org.hamcrest.Matchers.is;
-import static org.junit.Assert.assertThat;
+import static org.assertj.core.api.Assertions.assertThat;
 
 public class MvelCompilerTest implements CompilerTest {
 
@@ -345,7 +342,7 @@ public class MvelCompilerTest implements CompilerTest {
         test(ctx -> ctx.addDeclaration("$p", Person.class),
              "{ modify ( $p )  { salary = 50000 }; }",
              "{ { $p.setSalary(new java.math.BigDecimal(50000)); } }",
-             result -> assertThat(allUsedBindings(result), containsInAnyOrder("$p")));
+             result -> assertThat(allUsedBindings(result)).containsExactlyInAnyOrder("$p"));
     }
 
     @Test
@@ -353,7 +350,7 @@ public class MvelCompilerTest implements CompilerTest {
         test(ctx -> ctx.addDeclaration("$p", Person.class),
              "{ modify ( $p )  { salary = 50000B }; }",
              "{ { $p.setSalary(new java.math.BigDecimal(\"50000\")); } }",
-             result -> assertThat(allUsedBindings(result), containsInAnyOrder("$p")));
+             result -> assertThat(allUsedBindings(result)).containsExactlyInAnyOrder("$p"));
     }
 
     @Test
@@ -403,7 +400,7 @@ public class MvelCompilerTest implements CompilerTest {
                          "      { $p.setSalary(new java.math.BigDecimal(50000)); }" +
                          "      list.add(\"after \" + $p + \", money = \" + $p.getSalary()); " +
                          "}\n",
-             result -> assertThat(allUsedBindings(result), containsInAnyOrder("$p")));
+             result -> assertThat(allUsedBindings(result)).containsExactlyInAnyOrder("$p"));
     }
 
     @Test
@@ -730,7 +727,7 @@ public class MvelCompilerTest implements CompilerTest {
         test(ctx -> ctx.addDeclaration("$p", Person.class),
              "{ modify ( $p )  { name = \"Luca\", age = 35 }; }",
              "{\n {\n $p.setName(\"Luca\");\n $p.setAge(35);\n }\n }",
-             result -> assertThat(allUsedBindings(result), containsInAnyOrder("$p")));
+             result -> assertThat(allUsedBindings(result)).containsExactlyInAnyOrder("$p"));
     }
 
     @Test
@@ -741,7 +738,7 @@ public class MvelCompilerTest implements CompilerTest {
              },
              "{ modify ( $p )  { items = $p2.items }; }",
              "{\n {\n $p.setItems($p2.getItems());\n }\n }",
-             result -> assertThat(allUsedBindings(result), containsInAnyOrder("$p")));
+             result -> assertThat(allUsedBindings(result)).containsExactlyInAnyOrder("$p"));
     }
 
     @Test
@@ -749,7 +746,7 @@ public class MvelCompilerTest implements CompilerTest {
         test(ctx -> ctx.addDeclaration("$p", Person.class),
              "{ modify($p) { setAge(1); }; }",
              "{ { $p.setAge(1); } }",
-             result -> assertThat(allUsedBindings(result), containsInAnyOrder("$p")));
+             result -> assertThat(allUsedBindings(result)).containsExactlyInAnyOrder("$p"));
     }
 
     @Test
@@ -757,14 +754,14 @@ public class MvelCompilerTest implements CompilerTest {
         test(ctx -> ctx.addDeclaration("$p", Person.class),
              "{ modify($p) { age = $p.age+1 }; }",
              "{ { $p.setAge($p.getAge() + 1); } }",
-             result -> assertThat(allUsedBindings(result), containsInAnyOrder("$p")));
+             result -> assertThat(allUsedBindings(result)).containsExactlyInAnyOrder("$p"));
     }
 
     @Test
     public void testWithSemiColon() {
         test("{ with( $l = new ArrayList()) { $l.add(2); }; }",
              "{ java.util.ArrayList $l = new ArrayList(); $l.add(2); }",
-             result -> assertThat(allUsedBindings(result), is(empty())));
+             result -> assertThat(allUsedBindings(result)).isEmpty());
     }
 
     @Test
@@ -772,7 +769,7 @@ public class MvelCompilerTest implements CompilerTest {
         test(ctx -> ctx.addDeclaration("$p", Person.class),
              "{ with($p = new Person()) { age = $p.age+1 }; }",
              "{ org.drools.Person $p = new Person(); $p.setAge($p.getAge() + 1); }",
-             result -> assertThat(allUsedBindings(result), is(empty())));
+             result -> assertThat(allUsedBindings(result)).isEmpty());
     }
 
     @Test
@@ -780,7 +777,7 @@ public class MvelCompilerTest implements CompilerTest {
         test(ctx -> ctx.addDeclaration("$p", Person.class),
              "{ if (true) { with($p = new Person()) { age = $p.age+1 }; } }",
              "{ if (true) { org.drools.Person $p = new Person(); $p.setAge($p.getAge() + 1); } }",
-             result -> assertThat(allUsedBindings(result), is(empty())));
+             result -> assertThat(allUsedBindings(result)).isEmpty());
     }
 
     @Test
@@ -827,7 +824,7 @@ public class MvelCompilerTest implements CompilerTest {
                      "      }\n" +
                      "  } " +
                      "}",
-             result -> assertThat(allUsedBindings(result), containsInAnyOrder("$p")));
+             result -> assertThat(allUsedBindings(result)).containsExactlyInAnyOrder("$p"));
     }
 
     @Test

--- a/drools-model/drools-mvel-parser/pom.xml
+++ b/drools-model/drools-mvel-parser/pom.xml
@@ -32,6 +32,11 @@
       <artifactId>junit</artifactId>
       <scope>test</scope>
     </dependency>
+    <dependency>
+      <groupId>org.assertj</groupId>
+      <artifactId>assertj-core</artifactId>
+      <scope>test</scope>
+    </dependency>    
   </dependencies>
 
   <build>

--- a/drools-model/drools-mvel-parser/src/test/java/org/drools/mvel/parser/DroolsMvelParserTest.java
+++ b/drools-model/drools-mvel-parser/src/test/java/org/drools/mvel/parser/DroolsMvelParserTest.java
@@ -57,11 +57,11 @@ import org.junit.Test;
 
 import static org.drools.mvel.parser.DrlxParser.parseExpression;
 import static org.drools.mvel.parser.printer.PrintUtil.printNode;
-import static org.hamcrest.CoreMatchers.instanceOf;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertThat;
 import static org.junit.Assert.assertTrue;
+
+import static org.assertj.core.api.Assertions.assertThat;
 
 public class DroolsMvelParserTest {
 
@@ -258,7 +258,7 @@ public class DroolsMvelParserTest {
     public void testDotFreeExprWithArgsNegated() {
         String expr = "this not after[5,8] $a";
         Expression expression = parseExpression( parser, expr ).getExpr();
-        assertThat(expression, instanceOf(PointFreeExpr.class));
+        assertThat(expression).isInstanceOf(PointFreeExpr.class);
         assertTrue(((PointFreeExpr)expression).isNegated());
         assertEquals("this not after[5ms,8ms] $a", printNode(expression)); // please note the parsed expression once normalized would take the time unit for milliseconds.
     }
@@ -283,7 +283,7 @@ public class DroolsMvelParserTest {
     public void testHalfDotFreeExprWithFourTemporalArgs() {
         String expr = "includes[1s,1m,1h,1d] $a";
         Expression expression = parseExpression( parser, expr ).getExpr();
-        assertThat(expression, instanceOf(HalfPointFreeExpr.class));
+        assertThat(expression).isInstanceOf(HalfPointFreeExpr.class);
         assertEquals(expr, printNode(expression));
     }
 
@@ -705,7 +705,7 @@ public class DroolsMvelParserTest {
     public void dotFreeWithRegexp() {
         String expr = "name matches \"[a-z]*\"";
         Expression expression = parseExpression( parser, expr ).getExpr();
-        assertThat(expression, instanceOf(PointFreeExpr.class));
+        assertThat(expression).isInstanceOf(PointFreeExpr.class);
         assertEquals("name matches \"[a-z]*\"", printNode(expression));
         PointFreeExpr e = (PointFreeExpr)expression;
         assertEquals("matches", e.getOperator().asString());
@@ -724,7 +724,7 @@ public class DroolsMvelParserTest {
     public void halfPointFreeExpr() {
         String expr = "matches \"[A-Z]*\"";
         Expression expression = parseExpression(parser, expr).getExpr();
-        assertThat(expression, instanceOf(HalfPointFreeExpr.class));
+        assertThat(expression).isInstanceOf(HalfPointFreeExpr.class);
         assertEquals("matches \"[A-Z]*\"", printNode(expression));
     }
 
@@ -732,17 +732,17 @@ public class DroolsMvelParserTest {
     public void halfPointFreeExprNegated() {
         String expr = "not matches \"[A-Z]*\"";
         Expression expression = parseExpression(parser, expr).getExpr();
-        assertThat(expression, instanceOf(HalfPointFreeExpr.class));
+        assertThat(expression).isInstanceOf(HalfPointFreeExpr.class);
         assertEquals("not matches \"[A-Z]*\"", printNode(expression));
     }
 
     @Test
     public void regressionTestHalfPointFree() {
-        assertThat(parseExpression(parser, "getAddress().getAddressName().length() == 5").getExpr(), instanceOf(BinaryExpr.class));
-        assertThat(parseExpression(parser, "isFortyYearsOld(this, true)").getExpr(), instanceOf(MethodCallExpr.class));
-        assertThat(parseExpression(parser, "getName().startsWith(\"M\")").getExpr(), instanceOf(MethodCallExpr.class));
-        assertThat(parseExpression(parser, "isPositive($i.intValue())").getExpr(), instanceOf(MethodCallExpr.class));
-        assertThat(parseExpression(parser, "someEntity.someString in (\"1.500\")").getExpr(), instanceOf(PointFreeExpr.class));
+        assertThat(parseExpression(parser, "getAddress().getAddressName().length() == 5").getExpr()).isInstanceOf(BinaryExpr.class);
+        assertThat(parseExpression(parser, "isFortyYearsOld(this, true)").getExpr()).isInstanceOf(MethodCallExpr.class);
+        assertThat(parseExpression(parser, "getName().startsWith(\"M\")").getExpr()).isInstanceOf(MethodCallExpr.class);
+        assertThat(parseExpression(parser, "isPositive($i.intValue())").getExpr()).isInstanceOf(MethodCallExpr.class);
+        assertThat(parseExpression(parser, "someEntity.someString in (\"1.500\")").getExpr()).isInstanceOf(PointFreeExpr.class);
     }
 
     @Test
@@ -760,7 +760,7 @@ public class DroolsMvelParserTest {
         assertEquals("this str[startsWith] \"M\" || str[startsWith] \"E\"", printNode(expression));
 
         Expression expression2 = parseExpression(parser, "str[startsWith] \"E\"").getExpr();
-        assertThat(expression2, instanceOf(HalfPointFreeExpr.class));
+        assertThat(expression2).isInstanceOf(HalfPointFreeExpr.class);
         assertEquals("str[startsWith] \"E\"", printNode(expression2));
     }
 
@@ -1154,7 +1154,7 @@ public class DroolsMvelParserTest {
     private void testMvelSquareOperator(String wholeExpression, String operator, String left, String right, boolean isNegated) {
         String expr = wholeExpression;
         Expression expression = parseExpression(parser, expr ).getExpr();
-        assertThat(expression, instanceOf(PointFreeExpr.class));
+        assertThat(expression).isInstanceOf(PointFreeExpr.class);
         assertEquals(wholeExpression, printNode(expression));
         PointFreeExpr e = (PointFreeExpr)expression;
         assertEquals(operator, e.getOperator().asString());

--- a/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/compiler/integrationtests/ConstraintsTest.java
+++ b/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/compiler/integrationtests/ConstraintsTest.java
@@ -39,7 +39,6 @@ import org.kie.api.builder.KieBuilder;
 import org.kie.api.runtime.KieSession;
 
 import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertThat;
 import static org.junit.Assert.assertTrue;
 
 @RunWith(Parameterized.class)

--- a/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/integrationtests/JBRULESTest.java
+++ b/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/integrationtests/JBRULESTest.java
@@ -37,7 +37,6 @@ import org.drools.testcoverage.common.util.KieBaseTestConfiguration;
 import org.drools.testcoverage.common.util.KieBaseUtil;
 import org.drools.testcoverage.common.util.KieUtil;
 import org.drools.testcoverage.common.util.TestParametersUtil;
-import org.junit.Assert;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
@@ -55,13 +54,14 @@ import org.kie.internal.io.ResourceFactory;
 import org.mockito.ArgumentCaptor;
 import org.mvel2.MVEL;
 
-import static org.hamcrest.CoreMatchers.is;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
+
 
 @RunWith(Parameterized.class)
 public class JBRULESTest {
@@ -229,13 +229,13 @@ public class JBRULESTest {
         verify(ael, times(2)).afterMatchFired(captor.capture());
         final List<org.kie.api.event.rule.AfterMatchFiredEvent> aafe = captor.getAllValues();
 
-        Assert.assertThat(aafe.get(0).getMatch().getRule().getName(), is("kickOff"));
-        Assert.assertThat(aafe.get(1).getMatch().getRule().getName(), is("r1"));
+        assertThat(aafe.get(0).getMatch().getRule().getName()).isEqualTo("kickOff");
+        assertThat(aafe.get(1).getMatch().getRule().getName()).isEqualTo("r1");
 
         final Object value = aafe.get(1).getMatch().getDeclarationValue("$t");
         final String name = (String) MVEL.eval("$t.name", Collections.singletonMap("$t", value));
 
-        Assert.assertThat(name, is("one"));
+        assertThat(name).isEqualTo("one");
     }
 
     @Test

--- a/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/integrationtests/phreak/AddRuleTest.java
+++ b/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/integrationtests/phreak/AddRuleTest.java
@@ -50,11 +50,11 @@ import org.kie.api.runtime.KieContainer;
 import org.kie.api.runtime.rule.Match;
 
 import static java.util.Arrays.asList;
-import static junit.framework.Assert.assertTrue;
 import static junit.framework.TestCase.assertSame;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
 
 @RunWith(Parameterized.class)
 public class AddRuleTest {

--- a/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/integrationtests/phreak/RemoveRuleTest.java
+++ b/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/integrationtests/phreak/RemoveRuleTest.java
@@ -45,7 +45,7 @@ import org.kie.api.KieBase;
 import org.kie.api.definition.KiePackage;
 import org.kie.api.runtime.rule.Match;
 
-import static junit.framework.Assert.assertEquals;
+import static org.junit.Assert.assertEquals;
 import static junit.framework.TestCase.assertNotSame;
 import static junit.framework.TestCase.assertSame;
 import static org.junit.Assert.assertNotNull;

--- a/kie-dmn/kie-dmn-core/src/test/java/org/kie/dmn/core/DMNTwoValueLogicTest.java
+++ b/kie-dmn/kie-dmn-core/src/test/java/org/kie/dmn/core/DMNTwoValueLogicTest.java
@@ -28,15 +28,7 @@ import java.math.BigDecimal;
 import java.math.MathContext;
 import java.util.Arrays;
 
-import static org.hamcrest.CoreMatchers.is;
-import static org.hamcrest.CoreMatchers.not;
-import static org.hamcrest.CoreMatchers.notNullValue;
-import static org.hamcrest.CoreMatchers.nullValue;
-import static org.junit.Assert.*;
-import static org.kie.dmn.core.util.DynamicTypeUtils.*;
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.verify;
+import static org.assertj.core.api.Assertions.assertThat;
 
 /**
  * The goal of this test case is just test that the functions are wired properly on the
@@ -64,8 +56,8 @@ public class DMNTwoValueLogicTest extends BaseInterpretedVsCompiledTest {
                 "/libs/Two-Value Logic.dmn");
         dmnModel = runtime.getModel("http://www.trisotech.com/definitions/_0062b41c-61d2-43db-a575-676ed3c6d967",
                 "Two-Value Logic Tests");
-        assertThat(dmnModel, notNullValue());
-        assertThat(DMNRuntimeUtil.formatMessages(dmnModel.getMessages()), dmnModel.hasErrors(), is(false));
+        assertThat(dmnModel).isNotNull();
+        assertThat(dmnModel.hasErrors()).withFailMessage(DMNRuntimeUtil.formatMessages(dmnModel.getMessages())).isFalse();
         context = DMNFactory.newContext();
     }
 
@@ -73,10 +65,10 @@ public class DMNTwoValueLogicTest extends BaseInterpretedVsCompiledTest {
     private void runTest(String decisionName, Object expected) {
         final DMNResult dmnResult = runtime.evaluateByName(dmnModel, context, decisionName);
         LOG.debug("{}", dmnResult);
-        assertThat(DMNRuntimeUtil.formatMessages(dmnResult.getMessages()), dmnResult.hasErrors(), is(false));
+        assertThat(dmnModel.hasErrors()).withFailMessage(DMNRuntimeUtil.formatMessages(dmnModel.getMessages())).isFalse();
 
         final DMNContext result = dmnResult.getContext();
-        assertThat(result.get(decisionName), is(expected));
+        assertThat(result.get(decisionName)).isEqualTo(expected);
     }
 
     @Test

--- a/kie-dmn/kie-dmn-feel/src/test/java/org/kie/dmn/feel/documentation/ADocFEELExamplesTest.java
+++ b/kie-dmn/kie-dmn-feel/src/test/java/org/kie/dmn/feel/documentation/ADocFEELExamplesTest.java
@@ -31,14 +31,14 @@ import org.asciidoctor.ast.DescriptionListEntry;
 import org.asciidoctor.ast.Document;
 import org.asciidoctor.ast.ListItem;
 import org.asciidoctor.ast.StructuralNode;
-import org.hamcrest.Matchers;
-import org.junit.Assert;
 import org.junit.Test;
 import org.kie.dmn.feel.FEEL;
 import org.kie.dmn.feel.lang.FEELProfile;
 import org.kie.dmn.feel.parser.feel11.profiles.KieExtendedFEELProfile;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+
+import static org.assertj.core.api.Assertions.assertThat;
 
 public class ADocFEELExamplesTest {
 
@@ -86,7 +86,7 @@ public class ADocFEELExamplesTest {
                         for (String line : lines) {
                             LOG.info("checking DOC {}", line);
                             Object FEELResult = feel.evaluate(line);
-                            Assert.assertThat(line, FEELResult, Matchers.is(true));
+                            assertThat(FEELResult).withFailMessage(line).isEqualTo(true);
                         }
                     } else {
                         LOG.trace("This block is not FEEL true predicate snippets: {}", b);

--- a/kie-dmn/kie-dmn-feel/src/test/java/org/kie/dmn/feel/runtime/FEELErrorMessagesTest.java
+++ b/kie-dmn/kie-dmn-feel/src/test/java/org/kie/dmn/feel/runtime/FEELErrorMessagesTest.java
@@ -16,7 +16,6 @@
 
 package org.kie.dmn.feel.runtime;
 
-import org.junit.Assert;
 import org.junit.Test;
 import org.kie.dmn.api.feel.runtime.events.FEELEvent;
 import org.kie.dmn.api.feel.runtime.events.FEELEventListener;
@@ -27,11 +26,11 @@ import org.kie.dmn.feel.runtime.events.UnknownVariableErrorEvent;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Mockito;
 
-import static org.hamcrest.CoreMatchers.instanceOf;
-import static org.hamcrest.CoreMatchers.is;
-import static org.hamcrest.CoreMatchers.startsWith;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
+
+
 
 public class FEELErrorMessagesTest {
 
@@ -47,9 +46,9 @@ public class FEELErrorMessagesTest {
         final ArgumentCaptor<FEELEvent> captor = ArgumentCaptor.forClass(FEELEvent.class );
         verify( fel, times(2) ).onEvent( captor.capture() );
 
-        Assert.assertThat( captor.getAllValues().size(), is( 2 ) );
-        Assert.assertThat( captor.getAllValues().get(1), is( instanceOf( UnknownVariableErrorEvent.class ) ) );
-        Assert.assertThat( ((UnknownVariableErrorEvent)captor.getAllValues().get(1)).getOffendingSymbol(), is( "a variable name" ) );
+        assertThat(captor.getAllValues()).hasSize(2);
+        assertThat(captor.getAllValues().get(1)).isInstanceOf( UnknownVariableErrorEvent.class);
+        assertThat(((UnknownVariableErrorEvent)captor.getAllValues().get(1)).getOffendingSymbol()).isEqualTo("a variable name" );
     }
 
     @Test
@@ -64,9 +63,9 @@ public class FEELErrorMessagesTest {
         final ArgumentCaptor<FEELEvent> captor = ArgumentCaptor.forClass(FEELEvent.class);
         verify(fel, times(1)).onEvent(captor.capture());
 
-        Assert.assertThat(captor.getAllValues().size(), is(1));
-        Assert.assertThat(captor.getAllValues().get(0), is(instanceOf(SyntaxErrorEvent.class)));
-        Assert.assertThat(((SyntaxErrorEvent) captor.getAllValues().get(0)).getMessage(), startsWith("Detected 'if' expression without 'else' part"));
+        assertThat(captor.getAllValues()).hasSize(1);
+        assertThat(captor.getAllValues().get(0)).isInstanceOfAny(SyntaxErrorEvent.class);
+        assertThat(((SyntaxErrorEvent) captor.getAllValues().get(0)).getMessage()).startsWith("Detected 'if' expression without 'else' part");
     }
 
     @Test
@@ -81,9 +80,9 @@ public class FEELErrorMessagesTest {
         final ArgumentCaptor<FEELEvent> captor = ArgumentCaptor.forClass(FEELEvent.class);
         verify(fel, times(1)).onEvent(captor.capture());
 
-        Assert.assertThat(captor.getAllValues().size(), is(1));
-        Assert.assertThat(captor.getAllValues().get(0), is(instanceOf(SyntaxErrorEvent.class)));
-        Assert.assertThat(((SyntaxErrorEvent) captor.getAllValues().get(0)).getMessage(), is("missing 'else' at '456'"));
+        assertThat(captor.getAllValues()).hasSize(1);
+        assertThat(captor.getAllValues().get(0)).isInstanceOf(SyntaxErrorEvent.class);
+        assertThat(((SyntaxErrorEvent) captor.getAllValues().get(0)).getMessage()).isEqualTo("missing 'else' at '456'");
     }
 
     @Test
@@ -98,9 +97,9 @@ public class FEELErrorMessagesTest {
         final ArgumentCaptor<FEELEvent> captor = ArgumentCaptor.forClass(FEELEvent.class);
         verify(fel, times(1)).onEvent(captor.capture());
 
-        Assert.assertThat(captor.getAllValues().size(), is(1));
-        Assert.assertThat(captor.getAllValues().get(0), is(instanceOf(SyntaxErrorEvent.class)));
-        Assert.assertThat(((SyntaxErrorEvent) captor.getAllValues().get(0)).getMessage(), startsWith("Detected 'if' expression without 'then' part"));
+        assertThat(captor.getAllValues()).hasSize(1);
+        assertThat(captor.getAllValues().get(0)).isInstanceOf(SyntaxErrorEvent.class);
+        assertThat(((SyntaxErrorEvent) captor.getAllValues().get(0)).getMessage()).startsWith("Detected 'if' expression without 'then' part");
     }
 
     @Test
@@ -115,11 +114,11 @@ public class FEELErrorMessagesTest {
         final ArgumentCaptor<FEELEvent> captor = ArgumentCaptor.forClass(FEELEvent.class);
         verify(fel, times(2)).onEvent(captor.capture());
 
-        Assert.assertThat(captor.getAllValues().size(), is(2));
-        Assert.assertThat(captor.getAllValues().get(0), is(instanceOf(SyntaxErrorEvent.class)));
-        Assert.assertThat(((SyntaxErrorEvent) captor.getAllValues().get(0)).getMessage(), startsWith("missing 'then' at '123'"));
-        Assert.assertThat(captor.getAllValues().get(1), is(instanceOf(SyntaxErrorEvent.class)));
-        Assert.assertThat(((SyntaxErrorEvent) captor.getAllValues().get(1)).getMessage(), startsWith("Detected 'if' expression without 'then' part"));
+        assertThat(captor.getAllValues()).hasSize(2);
+        assertThat(captor.getAllValues().get(0)).isInstanceOf(SyntaxErrorEvent.class);
+        assertThat(((SyntaxErrorEvent) captor.getAllValues().get(0)).getMessage()).startsWith("missing 'then' at '123'");
+        assertThat(captor.getAllValues().get(1)).isInstanceOf(SyntaxErrorEvent.class);
+        assertThat(((SyntaxErrorEvent) captor.getAllValues().get(1)).getMessage()).startsWith("Detected 'if' expression without 'then' part");
     }
 
 }

--- a/kie-dmn/kie-dmn-feel/src/test/java/org/kie/dmn/feel/runtime/FEELEventListenerTest.java
+++ b/kie-dmn/kie-dmn-feel/src/test/java/org/kie/dmn/feel/runtime/FEELEventListenerTest.java
@@ -16,13 +16,12 @@
 
 package org.kie.dmn.feel.runtime;
 
-import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
 import org.kie.dmn.api.feel.runtime.events.FEELEvent.Severity;
 import org.kie.dmn.feel.FEEL;
 
-import static org.hamcrest.Matchers.is;
+import static org.assertj.core.api.Assertions.assertThat;
 
 public class FEELEventListenerTest {
 
@@ -44,12 +43,12 @@ public class FEELEventListenerTest {
     @Test
     public void testParserError() {
         feel.evaluate( "10 + / 5" );
-        Assert.assertThat(testVariable, is(LISTENER_OUTPUT));
+        assertThat(testVariable).isEqualTo(LISTENER_OUTPUT);
     }
     
     @Test
     public void testSomeBuiltinFunctions() {
         System.out.println( feel.evaluate("append( null, 1, 2 )") );
-        Assert.assertThat(testVariable, is(LISTENER_OUTPUT));
+        assertThat(testVariable).isEqualTo(LISTENER_OUTPUT);
     }
 }

--- a/kie-dmn/kie-dmn-feel/src/test/java/org/kie/dmn/feel/runtime/functions/FunctionTestUtil.java
+++ b/kie-dmn/kie-dmn-feel/src/test/java/org/kie/dmn/feel/runtime/functions/FunctionTestUtil.java
@@ -20,9 +20,9 @@ import java.math.BigDecimal;
 import java.util.List;
 import java.util.function.Predicate;
 
-import org.hamcrest.Matchers;
-import org.junit.Assert;
 import org.kie.dmn.api.feel.runtime.events.FEELEvent;
+
+import static org.assertj.core.api.Assertions.assertThat;
 
 public final class FunctionTestUtil {
 
@@ -32,57 +32,57 @@ public final class FunctionTestUtil {
         } else {
             assertResultNotError(result);
             final T resultValue = result.cata(left -> null, right -> right);
-            Assert.assertThat(resultValue, Matchers.notNullValue());
-            Assert.assertThat(resultValue, Matchers.equalTo(expectedResult));
+            assertThat(resultValue).isNotNull();
+            assertThat(resultValue).isEqualTo(expectedResult);
         }
     }
 
     public static void assertResultBigDecimal(final FEELFnResult<BigDecimal> result, final BigDecimal expectedResult) {
         assertResultNotError(result);
         final BigDecimal resultValue = result.cata(left -> null, right -> right);
-        Assert.assertThat(resultValue, Matchers.notNullValue());
-        Assert.assertThat(resultValue, Matchers.comparesEqualTo(expectedResult));
+        assertThat(resultValue).isNotNull();
+        assertThat(resultValue).isEqualTo(expectedResult);
     }
 
     public static <T> void assertResultList(final FEELFnResult<List<T>> result, final List<Object> expectedResult) {
         assertResultNotError(result);
         final List<T> resultList = result.cata(left -> null, right -> right);
-        Assert.assertThat(resultList, Matchers.hasSize(expectedResult.size()));
+        assertThat(resultList).hasSize(expectedResult.size());
         if (expectedResult.isEmpty()) {
-            Assert.assertThat(resultList, Matchers.empty());
+            assertThat(resultList).isEmpty();
         } else {
-            Assert.assertThat(resultList, Matchers.contains(expectedResult.toArray(new Object[]{})));
+            assertThat(resultList).containsAll((Iterable<? extends T>) expectedResult);
         }
     }
     
     public static <T> void assertPredicateOnResult(final FEELFnResult<?> result, final Class<T> clazz, final Predicate<T> assertion) {
         assertResultNotError(result);
         final T resultValue = result.cata(left -> null, clazz::cast);
-        Assert.assertThat(resultValue, Matchers.notNullValue());
-        Assert.assertThat(assertion.test(resultValue), Matchers.is(true));
+        assertThat(resultValue).isNotNull();
+        assertThat(assertion.test(resultValue)).isTrue();
     }
 
     public static <T> void assertResultNull(final FEELFnResult<T> result) {
         assertResultNotError(result);
-        Assert.assertThat(result.cata(left -> false, right -> right), Matchers.nullValue());
+        //assertThat(result.cata(left -> false, right -> right)).isNull();
     }
 
     public static <T> void assertResultNotError(final FEELFnResult<T> result) {
-        Assert.assertThat(result, Matchers.notNullValue());
-        Assert.assertThat(result.isRight(), Matchers.is(true));
+        assertThat(result).isNotNull();
+        assertThat(result.isRight()).isTrue();
     }
 
     public static <T> void assertResultError(final FEELFnResult<T> result, final Class expectedErrorEventClass) {
-        Assert.assertThat(result, Matchers.notNullValue());
-        Assert.assertThat(result.isLeft(), Matchers.is(true));
+        assertThat(result).isNotNull();
+        assertThat(result.isLeft()).isTrue();
         final FEELEvent resultEvent = result.cata(left -> left, right -> null);
         checkErrorEvent(resultEvent, expectedErrorEventClass);
     }
 
     public static void checkErrorEvent(final FEELEvent errorEvent, final Class errorEventClass) {
-        Assert.assertThat(errorEvent, Matchers.notNullValue());
-        Assert.assertThat(errorEvent.getSeverity(), Matchers.is(FEELEvent.Severity.ERROR));
-        Assert.assertThat(errorEvent, Matchers.instanceOf(errorEventClass));
+        assertThat(errorEvent).isNotNull();
+        assertThat(errorEvent.getSeverity()).isEqualTo(FEELEvent.Severity.ERROR);
+        assertThat(errorEvent).isInstanceOf(errorEventClass);
     }
 
     private FunctionTestUtil() {

--- a/kie-dmn/kie-dmn-feel/src/test/java/org/kie/dmn/feel/runtime/functions/FunctionTestUtil.java
+++ b/kie-dmn/kie-dmn-feel/src/test/java/org/kie/dmn/feel/runtime/functions/FunctionTestUtil.java
@@ -64,7 +64,8 @@ public final class FunctionTestUtil {
 
     public static <T> void assertResultNull(final FEELFnResult<T> result) {
         assertResultNotError(result);
-        //assertThat(result.cata(left -> false, right -> right)).isNull();
+        T invokedResult = result.cata(left -> null, right -> right);
+        assertThat(invokedResult).isNull();
     }
 
     public static <T> void assertResultNotError(final FEELFnResult<T> result) {

--- a/kie-dmn/kie-dmn-feel/src/test/java/org/kie/dmn/feel/runtime/functions/NowFunctionTest.java
+++ b/kie-dmn/kie-dmn-feel/src/test/java/org/kie/dmn/feel/runtime/functions/NowFunctionTest.java
@@ -25,6 +25,9 @@ import org.junit.Before;
 import org.junit.Test;
 import org.kie.dmn.feel.runtime.functions.extended.NowFunction;
 
+
+import static org.assertj.core.api.Assertions.assertThat;
+
 public class NowFunctionTest {
 
     private NowFunction nowFunction;
@@ -42,10 +45,10 @@ public class NowFunctionTest {
         // at the exact moment when the year is flipped to the next one, we cannot guarantee the year will be the same.
 
         final FEELFnResult<TemporalAccessor> nowResult = nowFunction.invoke();
-        Assert.assertThat(nowResult.isRight(), Matchers.is(true));
+        assertThat(nowResult.isRight()).isTrue();
         final TemporalAccessor result = nowResult.cata(left -> null, right -> right);
-        Assert.assertThat(result, Matchers.notNullValue());
-        Assert.assertThat(result.getClass(), Matchers.typeCompatibleWith(ZonedDateTime.class));
+        assertThat(result).isNotNull();
+        assertThat(result).isInstanceOfAny(ZonedDateTime.class);
     }
 
 }

--- a/kie-dmn/kie-dmn-pmml-tests-parent/kie-dmn-pmml-tests/src/test/java/org/kie/dmn/pmml/DMNTreePMMLTest.java
+++ b/kie-dmn/kie-dmn-pmml-tests-parent/kie-dmn-pmml-tests/src/test/java/org/kie/dmn/pmml/DMNTreePMMLTest.java
@@ -17,7 +17,6 @@
 package org.kie.dmn.pmml;
 
 import org.assertj.core.api.Assertions;
-import org.junit.Before;
 import org.junit.Test;
 import org.kie.dmn.api.core.DMNContext;
 import org.kie.dmn.api.core.DMNModel;

--- a/kie-dmn/kie-dmn-pmml-tests-parent/kie-dmn-pmml-tests/src/test/java/org/kie/dmn/pmml/PMMLInfoTest.java
+++ b/kie-dmn/kie-dmn-pmml-tests-parent/kie-dmn-pmml-tests/src/test/java/org/kie/dmn/pmml/PMMLInfoTest.java
@@ -24,10 +24,11 @@ import org.slf4j.LoggerFactory;
 
 import java.io.InputStream;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.hamcrest.CoreMatchers.is;
-import static org.hamcrest.Matchers.containsInAnyOrder;
 import static org.hamcrest.Matchers.hasSize;
 import static org.hamcrest.MatcherAssert.assertThat;
+
 
 public abstract class PMMLInfoTest {
 
@@ -40,12 +41,9 @@ public abstract class PMMLInfoTest {
         assertThat(p0.getModels(), hasSize(1));
         assertThat(p0.getHeader().getPmmlNSURI(), is("http://www.dmg.org/PMML-4_2"));
         PMMLModelInfo m0 = p0.getModels().iterator().next();
-        assertThat(m0.getName(), is("Sample Score"));
-        assertThat(m0.getInputFieldNames(), containsInAnyOrder(is("age"),
-                                                               is("occupation"),
-                                                               is("residenceState"),
-                                                               is("validLicense")));
-        assertThat(m0.getTargetFieldNames(), containsInAnyOrder(is("overallScore")));
-        assertThat(m0.getOutputFieldNames(), containsInAnyOrder(is("calculatedScore")));
+        assertThat(m0.getName()).isEqualTo("Sample Score");
+        assertThat(m0.getInputFieldNames()).contains("age", "occupation", "residenceState", "validLicense");
+        assertThat(m0.getTargetFieldNames()).contains("overallScore");
+        assertThat(m0.getOutputFieldNames()).contains("calculatedScore");
     }
 }

--- a/kie-dmn/kie-dmn-validation/src/test/java/org/kie/dmn/validation/ValidatorBusinessKnowledgeModelTest.java
+++ b/kie-dmn/kie-dmn-validation/src/test/java/org/kie/dmn/validation/ValidatorBusinessKnowledgeModelTest.java
@@ -16,8 +16,6 @@
 
 package org.kie.dmn.validation;
 
-import static org.hamcrest.CoreMatchers.is;
-import static org.junit.Assert.*;
 import static org.kie.dmn.validation.DMNValidator.Validation.VALIDATE_COMPILATION;
 import static org.kie.dmn.validation.DMNValidator.Validation.VALIDATE_MODEL;
 import static org.kie.dmn.validation.DMNValidator.Validation.VALIDATE_SCHEMA;
@@ -29,6 +27,9 @@ import org.junit.Test;
 import org.kie.dmn.api.core.DMNMessage;
 import org.kie.dmn.api.core.DMNMessageType;
 
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.Assert.assertTrue;
+
 public class ValidatorBusinessKnowledgeModelTest extends AbstractValidatorTest {
 
     @Test
@@ -37,7 +38,7 @@ public class ValidatorBusinessKnowledgeModelTest extends AbstractValidatorTest {
             final List<DMNMessage> validate = validator.validate(
                     reader,
                     VALIDATE_SCHEMA, VALIDATE_MODEL, VALIDATE_COMPILATION);
-            assertThat(ValidatorUtil.formatMessages(validate), validate.size(), is(1));
+            assertThat(validate).withFailMessage(ValidatorUtil.formatMessages(validate)).hasSize(1);
             assertTrue(validate.stream().anyMatch(p -> p.getMessageType().equals(DMNMessageType.MISSING_VARIABLE)));
         }
     }
@@ -47,7 +48,7 @@ public class ValidatorBusinessKnowledgeModelTest extends AbstractValidatorTest {
         final List<DMNMessage> validate = validator.validate(
                 getFile("businessknowledgemodel/BKM_MISSING_VAR.dmn"),
                 VALIDATE_SCHEMA, VALIDATE_MODEL, VALIDATE_COMPILATION);
-        assertThat(ValidatorUtil.formatMessages(validate), validate.size(), is(1));
+        assertThat(validate).withFailMessage(ValidatorUtil.formatMessages(validate)).hasSize(1);
         assertTrue(validate.stream().anyMatch(p -> p.getMessageType().equals(DMNMessageType.MISSING_VARIABLE)));
     }
 
@@ -58,7 +59,7 @@ public class ValidatorBusinessKnowledgeModelTest extends AbstractValidatorTest {
                                "https://github.com/kiegroup/kie-dmn",
                                "BKM_MISSING_VAR"),
                 VALIDATE_MODEL, VALIDATE_COMPILATION);
-        assertThat(ValidatorUtil.formatMessages(validate), validate.size(), is(1));
+        assertThat(validate).withFailMessage(ValidatorUtil.formatMessages(validate)).hasSize(1);
         assertTrue(validate.stream().anyMatch(p -> p.getMessageType().equals(DMNMessageType.MISSING_VARIABLE)));
     }
 
@@ -68,7 +69,7 @@ public class ValidatorBusinessKnowledgeModelTest extends AbstractValidatorTest {
             final List<DMNMessage> validate = validator.validate(
                     reader,
                     VALIDATE_SCHEMA, VALIDATE_MODEL, VALIDATE_COMPILATION);
-            assertThat(ValidatorUtil.formatMessages(validate), validate.size(), is(1));
+            assertThat(validate).withFailMessage(ValidatorUtil.formatMessages(validate)).hasSize(1);
             assertTrue(validate.stream().anyMatch(p -> p.getMessageType().equals(DMNMessageType.VARIABLE_NAME_MISMATCH)));
         }
     }
@@ -78,7 +79,7 @@ public class ValidatorBusinessKnowledgeModelTest extends AbstractValidatorTest {
         final List<DMNMessage> validate = validator.validate(
                 getFile("businessknowledgemodel/BKM_MISMATCH_VAR.dmn"),
                 VALIDATE_SCHEMA, VALIDATE_MODEL, VALIDATE_COMPILATION);
-        assertThat(ValidatorUtil.formatMessages(validate), validate.size(), is(1));
+        assertThat(validate).withFailMessage(ValidatorUtil.formatMessages(validate)).hasSize(1);
         assertTrue(validate.stream().anyMatch(p -> p.getMessageType().equals(DMNMessageType.VARIABLE_NAME_MISMATCH)));
     }
 
@@ -89,7 +90,7 @@ public class ValidatorBusinessKnowledgeModelTest extends AbstractValidatorTest {
                                "https://github.com/kiegroup/kie-dmn",
                                "BKM_MISSING_VAR"),
                 VALIDATE_MODEL, VALIDATE_COMPILATION);
-        assertThat(ValidatorUtil.formatMessages(validate), validate.size(), is(1));
+        assertThat(validate).withFailMessage(ValidatorUtil.formatMessages(validate)).hasSize(1);
         assertTrue(validate.stream().anyMatch(p -> p.getMessageType().equals(DMNMessageType.VARIABLE_NAME_MISMATCH)));
     }
 
@@ -99,8 +100,8 @@ public class ValidatorBusinessKnowledgeModelTest extends AbstractValidatorTest {
             final List<DMNMessage> validate = validator.validate(
                     reader,
                     VALIDATE_SCHEMA, VALIDATE_MODEL, VALIDATE_COMPILATION);
-            assertThat(ValidatorUtil.formatMessages(validate), validate.size(), is(1));
-            assertThat(validate.get(0).toString(), validate.get(0).getMessageType(), is(DMNMessageType.MISSING_EXPRESSION));
+            assertThat(validate).withFailMessage(ValidatorUtil.formatMessages(validate)).hasSize(1);
+            assertThat(validate.get(0).getMessageType()).withFailMessage(validate.get(0).toString()).isEqualTo(DMNMessageType.MISSING_EXPRESSION);
         }
     }
 
@@ -109,8 +110,8 @@ public class ValidatorBusinessKnowledgeModelTest extends AbstractValidatorTest {
         final List<DMNMessage> validate = validator.validate(
                 getFile("businessknowledgemodel/BKM_MISSING_EXPR.dmn"),
                 VALIDATE_SCHEMA, VALIDATE_MODEL, VALIDATE_COMPILATION);
-        assertThat(ValidatorUtil.formatMessages(validate), validate.size(), is(1));
-        assertThat(validate.get(0).toString(), validate.get(0).getMessageType(), is(DMNMessageType.MISSING_EXPRESSION));
+        assertThat(validate).withFailMessage(ValidatorUtil.formatMessages(validate)).hasSize(1);
+        assertThat(validate.get(0).getMessageType()).withFailMessage(validate.get(0).toString()).isEqualTo(DMNMessageType.MISSING_EXPRESSION);
     }
 
     @Test
@@ -120,7 +121,7 @@ public class ValidatorBusinessKnowledgeModelTest extends AbstractValidatorTest {
                                "https://github.com/kiegroup/kie-dmn",
                                "BKM_MISSING_EXPR"),
                 VALIDATE_MODEL, VALIDATE_COMPILATION);
-        assertThat(ValidatorUtil.formatMessages(validate), validate.size(), is(1));
-        assertThat(validate.get(0).toString(), validate.get(0).getMessageType(), is(DMNMessageType.MISSING_EXPRESSION));
+        assertThat(validate).withFailMessage(ValidatorUtil.formatMessages(validate)).hasSize(1);
+        assertThat(validate.get(0).getMessageType()).withFailMessage(validate.get(0).toString()).isEqualTo(DMNMessageType.MISSING_EXPRESSION);
     }
 }

--- a/kie-dmn/kie-dmn-validation/src/test/java/org/kie/dmn/validation/ValidatorContextTest.java
+++ b/kie-dmn/kie-dmn-validation/src/test/java/org/kie/dmn/validation/ValidatorContextTest.java
@@ -16,8 +16,6 @@
 
 package org.kie.dmn.validation;
 
-import static org.hamcrest.CoreMatchers.is;
-import static org.junit.Assert.*;
 import static org.kie.dmn.validation.DMNValidator.Validation.VALIDATE_COMPILATION;
 import static org.kie.dmn.validation.DMNValidator.Validation.VALIDATE_MODEL;
 import static org.kie.dmn.validation.DMNValidator.Validation.VALIDATE_SCHEMA;
@@ -31,6 +29,9 @@ import org.kie.dmn.api.core.DMNMessageType;
 import org.kie.dmn.model.api.Context;
 import org.kie.dmn.model.api.ContextEntry;
 
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.Assert.assertTrue;
+
 public class ValidatorContextTest extends AbstractValidatorTest {
 
     @Test
@@ -39,7 +40,7 @@ public class ValidatorContextTest extends AbstractValidatorTest {
             final List<DMNMessage> validate = validator.validate(
                     reader,
                     VALIDATE_SCHEMA, VALIDATE_MODEL, VALIDATE_COMPILATION);
-            assertThat(ValidatorUtil.formatMessages(validate), validate.size(), is(2));
+            assertThat(validate).withFailMessage(ValidatorUtil.formatMessages(validate)).hasSize(2);
             assertTrue(validate.stream().anyMatch(p -> p.getMessageType().equals(DMNMessageType.FAILED_XML_VALIDATION))); // this is schema validation
             assertTrue(validate.stream().anyMatch(p -> p.getMessageType().equals(DMNMessageType.MISSING_EXPRESSION)));
         }
@@ -50,7 +51,7 @@ public class ValidatorContextTest extends AbstractValidatorTest {
         final List<DMNMessage> validate = validator.validate(
                 getFile("context/CONTEXT_MISSING_EXPR.dmn"),
                 VALIDATE_SCHEMA, VALIDATE_MODEL, VALIDATE_COMPILATION);
-        assertThat(ValidatorUtil.formatMessages(validate), validate.size(), is(2));
+        assertThat(validate).withFailMessage(ValidatorUtil.formatMessages(validate)).hasSize(2);
         assertTrue(validate.stream().anyMatch(p -> p.getMessageType().equals(DMNMessageType.FAILED_XML_VALIDATION))); // this is schema validation
         assertTrue(validate.stream().anyMatch(p -> p.getMessageType().equals(DMNMessageType.MISSING_EXPRESSION)));
     }
@@ -62,7 +63,7 @@ public class ValidatorContextTest extends AbstractValidatorTest {
                                "https://github.com/kiegroup/kie-dmn",
                                "CONTEXT_MISSING_EXPR"),
                 VALIDATE_MODEL, VALIDATE_COMPILATION);
-        assertThat(ValidatorUtil.formatMessages(validate), validate.size(), is(1));
+        assertThat(validate).withFailMessage(ValidatorUtil.formatMessages(validate)).hasSize(1);
         assertTrue(validate.stream().anyMatch(p -> p.getMessageType().equals(DMNMessageType.MISSING_EXPRESSION)));
     }
 
@@ -72,7 +73,7 @@ public class ValidatorContextTest extends AbstractValidatorTest {
             final List<DMNMessage> validate = validator.validate(
                     reader,
                     VALIDATE_SCHEMA, VALIDATE_MODEL, VALIDATE_COMPILATION);
-            assertThat(ValidatorUtil.formatMessages(validate), validate.size(), is(1));
+            assertThat(validate).withFailMessage(ValidatorUtil.formatMessages(validate)).hasSize(1);
             assertTrue(validate.stream().anyMatch(p -> p.getMessageType().equals(DMNMessageType.MISSING_EXPRESSION)));
         }
     }
@@ -82,7 +83,7 @@ public class ValidatorContextTest extends AbstractValidatorTest {
         final List<DMNMessage> validate = validator.validate(
                 getFile("context/CONTEXT_MISSING_ENTRIES.dmn"),
                 VALIDATE_SCHEMA, VALIDATE_MODEL, VALIDATE_COMPILATION);
-        assertThat(ValidatorUtil.formatMessages(validate), validate.size(), is(1));
+        assertThat(validate).withFailMessage(ValidatorUtil.formatMessages(validate)).hasSize(1);
         assertTrue(validate.stream().anyMatch(p -> p.getMessageType().equals(DMNMessageType.MISSING_EXPRESSION)));
     }
 
@@ -93,7 +94,7 @@ public class ValidatorContextTest extends AbstractValidatorTest {
                                "https://github.com/kiegroup/kie-dmn",
                                "CONTEXT_MISSING_EXPR"),
                 VALIDATE_MODEL, VALIDATE_COMPILATION);
-        assertThat(ValidatorUtil.formatMessages(validate), validate.size(), is(1));
+        assertThat(validate).withFailMessage(ValidatorUtil.formatMessages(validate)).hasSize(1);
         assertTrue(validate.stream().anyMatch(p -> p.getMessageType().equals(DMNMessageType.MISSING_EXPRESSION)));
     }
 
@@ -103,11 +104,11 @@ public class ValidatorContextTest extends AbstractValidatorTest {
             final List<DMNMessage> validate = validator.validate(
                     reader,
                     VALIDATE_SCHEMA, VALIDATE_MODEL, VALIDATE_COMPILATION);
-            assertThat(ValidatorUtil.formatMessages(validate), validate.size(), is(1));
+            assertThat(validate).withFailMessage(ValidatorUtil.formatMessages(validate)).hasSize(1);
             assertTrue(validate.stream().anyMatch(p -> p.getMessageType().equals(DMNMessageType.MISSING_VARIABLE)));
             // check that it reports and error for the second context entry, but not for the last one
             final ContextEntry ce = (ContextEntry) validate.get(0).getSourceReference();
-            assertThat(((Context) ce.getParent()).getContextEntry().indexOf(ce), is(1));
+            assertThat(((Context) ce.getParent()).getContextEntry().indexOf(ce)).isEqualTo(1);
         }
     }
 
@@ -116,11 +117,11 @@ public class ValidatorContextTest extends AbstractValidatorTest {
         final List<DMNMessage> validate = validator.validate(
                 getFile("context/CONTEXT_ENTRY_MISSING_VARIABLE.dmn"),
                 VALIDATE_SCHEMA, VALIDATE_MODEL, VALIDATE_COMPILATION);
-        assertThat(ValidatorUtil.formatMessages(validate), validate.size(), is(1));
+        assertThat(validate).withFailMessage(ValidatorUtil.formatMessages(validate)).hasSize(1);
         assertTrue(validate.stream().anyMatch(p -> p.getMessageType().equals(DMNMessageType.MISSING_VARIABLE)));
         // check that it reports and error for the second context entry, but not for the last one
         final ContextEntry ce = (ContextEntry) validate.get(0).getSourceReference();
-        assertThat(((Context) ce.getParent()).getContextEntry().indexOf(ce), is(1));
+        assertThat(((Context) ce.getParent()).getContextEntry().indexOf(ce)).isEqualTo(1);
     }
 
     @Test
@@ -130,11 +131,11 @@ public class ValidatorContextTest extends AbstractValidatorTest {
                                "https://github.com/kiegroup/kie-dmn",
                                "CONTEXT_MISSING_EXPR"),
                 VALIDATE_MODEL, VALIDATE_COMPILATION);
-        assertThat(ValidatorUtil.formatMessages(validate), validate.size(), is(1));
+        assertThat(validate).withFailMessage(ValidatorUtil.formatMessages(validate)).hasSize(1);
         assertTrue(validate.stream().anyMatch(p -> p.getMessageType().equals(DMNMessageType.MISSING_VARIABLE)));
         // check that it reports and error for the second context entry, but not for the last one
         final ContextEntry ce = (ContextEntry) validate.get(0).getSourceReference();
-        assertThat(((Context) ce.getParent()).getContextEntry().indexOf(ce), is(1));
+        assertThat(((Context) ce.getParent()).getContextEntry().indexOf(ce)).isEqualTo(1);
     }
 
     @Test
@@ -143,7 +144,7 @@ public class ValidatorContextTest extends AbstractValidatorTest {
             final List<DMNMessage> validate = validator.validate(
                     reader,
                     VALIDATE_SCHEMA, VALIDATE_MODEL, VALIDATE_COMPILATION);
-            assertThat(ValidatorUtil.formatMessages(validate), validate.size(), is(2));
+            assertThat(validate).withFailMessage(ValidatorUtil.formatMessages(validate)).hasSize(2);
             assertTrue(validate.stream().anyMatch(p -> p.getMessageType().equals(DMNMessageType.DUPLICATE_NAME)));
         }
     }
@@ -153,7 +154,7 @@ public class ValidatorContextTest extends AbstractValidatorTest {
         final List<DMNMessage> validate = validator.validate(
                 getFile("context/CONTEXT_DUP_ENTRY.dmn"),
                 VALIDATE_SCHEMA, VALIDATE_MODEL, VALIDATE_COMPILATION);
-        assertThat(ValidatorUtil.formatMessages(validate), validate.size(), is(2));
+        assertThat(validate).withFailMessage(ValidatorUtil.formatMessages(validate)).hasSize(2);
         assertTrue(validate.stream().anyMatch(p -> p.getMessageType().equals(DMNMessageType.DUPLICATE_NAME)));
     }
 
@@ -164,7 +165,7 @@ public class ValidatorContextTest extends AbstractValidatorTest {
                                "https://github.com/kiegroup/kie-dmn",
                                "CONTEXT_DUP_ENTRY"),
                 VALIDATE_MODEL, VALIDATE_COMPILATION);
-        assertThat(ValidatorUtil.formatMessages(validate), validate.size(), is(2));
+        assertThat(validate).withFailMessage(ValidatorUtil.formatMessages(validate)).hasSize(2);
         assertTrue(validate.stream().anyMatch(p -> p.getMessageType().equals(DMNMessageType.DUPLICATE_NAME)));
     }
 
@@ -174,7 +175,7 @@ public class ValidatorContextTest extends AbstractValidatorTest {
             final List<DMNMessage> validate = validator.validate(
                     reader,
                     VALIDATE_SCHEMA, VALIDATE_MODEL, VALIDATE_COMPILATION);
-            assertThat(ValidatorUtil.formatMessages(validate), validate.size(), is(2));
+            assertThat(validate).withFailMessage(ValidatorUtil.formatMessages(validate)).hasSize(2);
             assertTrue(validate.stream().anyMatch(p -> p.getMessageType().equals(DMNMessageType.MISSING_TYPE_REF)));
         }
     }
@@ -184,7 +185,7 @@ public class ValidatorContextTest extends AbstractValidatorTest {
         final List<DMNMessage> validate = validator.validate(
                 getFile("context/CONTEXT_ENTRY_NOTYPEREF.dmn"),
                 VALIDATE_SCHEMA, VALIDATE_MODEL, VALIDATE_COMPILATION);
-        assertThat(ValidatorUtil.formatMessages(validate), validate.size(), is(2));
+        assertThat(validate).withFailMessage(ValidatorUtil.formatMessages(validate)).hasSize(2);
         assertTrue(validate.stream().anyMatch(p -> p.getMessageType().equals(DMNMessageType.MISSING_TYPE_REF)));
     }
 
@@ -195,7 +196,7 @@ public class ValidatorContextTest extends AbstractValidatorTest {
                                "https://github.com/kiegroup/kie-dmn",
                                "CONTEXT_ENTRY_NOTYPEREF"),
                 VALIDATE_MODEL, VALIDATE_COMPILATION);
-        assertThat(ValidatorUtil.formatMessages(validate), validate.size(), is(2));
+        assertThat(validate).withFailMessage(ValidatorUtil.formatMessages(validate)).hasSize(2);
         assertTrue(validate.stream().anyMatch(p -> p.getMessageType().equals(DMNMessageType.MISSING_TYPE_REF)));
     }
 }

--- a/kie-dmn/kie-dmn-validation/src/test/java/org/kie/dmn/validation/ValidatorInputDataTest.java
+++ b/kie-dmn/kie-dmn-validation/src/test/java/org/kie/dmn/validation/ValidatorInputDataTest.java
@@ -16,8 +16,8 @@
 
 package org.kie.dmn.validation;
 
-import static org.hamcrest.CoreMatchers.is;
-import static org.junit.Assert.*;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.Assert.assertTrue;
 import static org.kie.dmn.validation.DMNValidator.Validation.VALIDATE_COMPILATION;
 import static org.kie.dmn.validation.DMNValidator.Validation.VALIDATE_MODEL;
 import static org.kie.dmn.validation.DMNValidator.Validation.VALIDATE_SCHEMA;
@@ -37,7 +37,7 @@ public class ValidatorInputDataTest extends AbstractValidatorTest {
             final List<DMNMessage> validate = validator.validate(
                     reader,
                     VALIDATE_SCHEMA, VALIDATE_MODEL, VALIDATE_COMPILATION);
-            assertThat(ValidatorUtil.formatMessages(validate), validate.size(), is(1));
+            assertThat(validate).withFailMessage(ValidatorUtil.formatMessages(validate)).hasSize(1);
             assertTrue(validate.stream().anyMatch(p -> p.getMessageType().equals(DMNMessageType.MISSING_VARIABLE)));
         }
     }
@@ -47,7 +47,7 @@ public class ValidatorInputDataTest extends AbstractValidatorTest {
         final List<DMNMessage> validate = validator.validate(
                 getFile("inputdata/INPUTDATA_MISSING_VAR.dmn"),
                 VALIDATE_SCHEMA, VALIDATE_MODEL, VALIDATE_COMPILATION);
-        assertThat(ValidatorUtil.formatMessages(validate), validate.size(), is(1));
+        assertThat(validate).withFailMessage(ValidatorUtil.formatMessages(validate)).hasSize(1);
         assertTrue(validate.stream().anyMatch(p -> p.getMessageType().equals(DMNMessageType.MISSING_VARIABLE)));
     }
 
@@ -58,7 +58,7 @@ public class ValidatorInputDataTest extends AbstractValidatorTest {
                                "https://github.com/kiegroup/kie-dmn",
                                "INPUTDATA_MISSING_VAR"),
                 VALIDATE_MODEL, VALIDATE_COMPILATION);
-        assertThat(ValidatorUtil.formatMessages(validate), validate.size(), is(1));
+        assertThat(validate).withFailMessage(ValidatorUtil.formatMessages(validate)).hasSize(1);
         assertTrue(validate.stream().anyMatch(p -> p.getMessageType().equals(DMNMessageType.MISSING_VARIABLE)));
     }
 
@@ -68,7 +68,7 @@ public class ValidatorInputDataTest extends AbstractValidatorTest {
             final List<DMNMessage> validate = validator.validate(
                     reader,
                     VALIDATE_SCHEMA, VALIDATE_MODEL, VALIDATE_COMPILATION);
-            assertThat(ValidatorUtil.formatMessages(validate), validate.size(), is(1));
+            assertThat(validate).withFailMessage(ValidatorUtil.formatMessages(validate)).hasSize(1);
             assertTrue(validate.stream().anyMatch(p -> p.getMessageType().equals(DMNMessageType.VARIABLE_NAME_MISMATCH)));
         }
     }
@@ -78,7 +78,7 @@ public class ValidatorInputDataTest extends AbstractValidatorTest {
         final List<DMNMessage> validate = validator.validate(
                 getFile("inputdata/INPUTDATA_MISMATCH_VAR.dmn"),
                 VALIDATE_SCHEMA, VALIDATE_MODEL, VALIDATE_COMPILATION);
-        assertThat(ValidatorUtil.formatMessages(validate), validate.size(), is(1));
+        assertThat(validate).withFailMessage(ValidatorUtil.formatMessages(validate)).hasSize(1);
         assertTrue(validate.stream().anyMatch(p -> p.getMessageType().equals(DMNMessageType.VARIABLE_NAME_MISMATCH)));
     }
 
@@ -89,7 +89,7 @@ public class ValidatorInputDataTest extends AbstractValidatorTest {
                                "https://github.com/kiegroup/kie-dmn",
                                "INPUTDATA_MISSING_VAR"),
                 VALIDATE_MODEL, VALIDATE_COMPILATION);
-        assertThat(ValidatorUtil.formatMessages(validate), validate.size(), is(1));
+        assertThat(validate).withFailMessage(ValidatorUtil.formatMessages(validate)).hasSize(1);
         assertTrue(validate.stream().anyMatch(p -> p.getMessageType().equals(DMNMessageType.VARIABLE_NAME_MISMATCH)));
     }
 }

--- a/kie-dmn/kie-dmn-validation/src/test/java/org/kie/dmn/validation/ValidatorKnowledgeRequirementTest.java
+++ b/kie-dmn/kie-dmn-validation/src/test/java/org/kie/dmn/validation/ValidatorKnowledgeRequirementTest.java
@@ -16,8 +16,6 @@
 
 package org.kie.dmn.validation;
 
-import static org.hamcrest.CoreMatchers.is;
-import static org.junit.Assert.*;
 import static org.kie.dmn.validation.DMNValidator.Validation.VALIDATE_COMPILATION;
 import static org.kie.dmn.validation.DMNValidator.Validation.VALIDATE_MODEL;
 import static org.kie.dmn.validation.DMNValidator.Validation.VALIDATE_SCHEMA;
@@ -29,6 +27,9 @@ import org.junit.Test;
 import org.kie.dmn.api.core.DMNMessage;
 import org.kie.dmn.api.core.DMNMessageType;
 
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.Assert.assertTrue;
+
 public class ValidatorKnowledgeRequirementTest extends AbstractValidatorTest {
 
     @Test
@@ -37,7 +38,7 @@ public class ValidatorKnowledgeRequirementTest extends AbstractValidatorTest {
             final List<DMNMessage> validate = validator.validate(
                     reader,
                     VALIDATE_SCHEMA, VALIDATE_MODEL, VALIDATE_COMPILATION);
-            assertThat( ValidatorUtil.formatMessages( validate ), validate.size(), is( 2 ) );
+            assertThat(validate).withFailMessage(ValidatorUtil.formatMessages(validate)).hasSize(2);
             assertTrue( validate.stream().anyMatch( p -> p.getMessageType().equals( DMNMessageType.MISSING_EXPRESSION ) ) );
             assertTrue( validate.stream().anyMatch( p -> p.getMessageType().equals( DMNMessageType.REQ_NOT_FOUND ) ) );
         }
@@ -48,7 +49,7 @@ public class ValidatorKnowledgeRequirementTest extends AbstractValidatorTest {
         final List<DMNMessage> validate = validator.validate(
                 getFile( "knowledgerequirement/KNOWREQ_MISSING_BKM.dmn" ),
                 VALIDATE_SCHEMA, VALIDATE_MODEL, VALIDATE_COMPILATION);
-        assertThat( ValidatorUtil.formatMessages( validate ), validate.size(), is( 2 ) );
+        assertThat(validate).withFailMessage(ValidatorUtil.formatMessages(validate)).hasSize(2);
         assertTrue( validate.stream().anyMatch( p -> p.getMessageType().equals( DMNMessageType.MISSING_EXPRESSION ) ) );
         assertTrue( validate.stream().anyMatch( p -> p.getMessageType().equals( DMNMessageType.REQ_NOT_FOUND ) ) );
     }
@@ -60,7 +61,7 @@ public class ValidatorKnowledgeRequirementTest extends AbstractValidatorTest {
                                 "https://github.com/kiegroup/kie-dmn",
                                 "KNOWREQ_MISSING_BKM"),
                 VALIDATE_MODEL, VALIDATE_COMPILATION);
-        assertThat( ValidatorUtil.formatMessages( validate ), validate.size(), is( 2 ) );
+        assertThat(validate).withFailMessage(ValidatorUtil.formatMessages(validate)).hasSize(2);
         assertTrue( validate.stream().anyMatch( p -> p.getMessageType().equals( DMNMessageType.MISSING_EXPRESSION ) ) );
         assertTrue( validate.stream().anyMatch( p -> p.getMessageType().equals( DMNMessageType.REQ_NOT_FOUND ) ) );
     }
@@ -71,7 +72,7 @@ public class ValidatorKnowledgeRequirementTest extends AbstractValidatorTest {
             final List<DMNMessage> validate = validator.validate(
                     reader,
                     VALIDATE_SCHEMA, VALIDATE_MODEL, VALIDATE_COMPILATION);
-            assertThat( ValidatorUtil.formatMessages( validate ), validate.size(), is( 2 ) );
+            assertThat(validate).withFailMessage(ValidatorUtil.formatMessages(validate)).hasSize(2);
             assertTrue( validate.stream().anyMatch( p -> p.getMessageType().equals( DMNMessageType.MISSING_EXPRESSION ) ) );
             assertTrue( validate.stream().anyMatch( p -> p.getMessageType().equals( DMNMessageType.REQ_NOT_FOUND ) ) );
         }
@@ -82,7 +83,7 @@ public class ValidatorKnowledgeRequirementTest extends AbstractValidatorTest {
         final List<DMNMessage> validate = validator.validate(
                 getFile( "knowledgerequirement/KNOWREQ_REQ_DECISION_NOT_BKM.dmn" ),
                 VALIDATE_SCHEMA, VALIDATE_MODEL, VALIDATE_COMPILATION);
-        assertThat( ValidatorUtil.formatMessages( validate ), validate.size(), is( 2 ) );
+        assertThat(validate).withFailMessage(ValidatorUtil.formatMessages(validate)).hasSize(2);
         assertTrue( validate.stream().anyMatch( p -> p.getMessageType().equals( DMNMessageType.MISSING_EXPRESSION ) ) );
         assertTrue( validate.stream().anyMatch( p -> p.getMessageType().equals( DMNMessageType.REQ_NOT_FOUND ) ) );
     }
@@ -94,7 +95,7 @@ public class ValidatorKnowledgeRequirementTest extends AbstractValidatorTest {
                                 "https://github.com/kiegroup/kie-dmn",
                                 "KNOWREQ_REQ_DECISION_NOT_BKM"),
                 VALIDATE_MODEL, VALIDATE_COMPILATION);
-        assertThat( ValidatorUtil.formatMessages( validate ), validate.size(), is( 2 ) );
+        assertThat(validate).withFailMessage(ValidatorUtil.formatMessages(validate)).hasSize(2);
         assertTrue( validate.stream().anyMatch( p -> p.getMessageType().equals( DMNMessageType.MISSING_EXPRESSION ) ) );
         assertTrue( validate.stream().anyMatch( p -> p.getMessageType().equals( DMNMessageType.REQ_NOT_FOUND ) ) );
     }


### PR DESCRIPTION
The patch removes a number of methods that are deprecated in assertions and starts to move tests towards assertj.

<details>
<summary>
How to replicate CI configuration locally?
</summary>

Build Chain tool does "simple" maven build(s), the builds are just Maven commands, but because the repositories relates and depends on each other and any change in API or class method could affect several of those repositories there is a need to use [build-chain tool](https://github.com/kiegroup/github-action-build-chain) to handle cross repository builds and be sure that we always use latest version of the code for each repository.
 
[build-chain tool](https://github.com/kiegroup/github-action-build-chain) is a build tool which can be used on command line locally or in Github Actions workflow(s), in case you need to change multiple repositories and send multiple dependent pull requests related with a change you can easily reproduce the same build by executing it on Github hosted environment or locally in your development environment. See [local execution](https://github.com/kiegroup/github-action-build-chain#local-execution) details to get more information about it.
</details>

<details>
<summary>
How to retest this PR or trigger a specific build:
</summary>

* <b>a pull request</b> please add comment: <b>Jenkins retest this</b>

* for a <b>full downstream build</b> 
  * for <b>jenkins</b> job: please add comment: <b>Jenkins run fdb</b>
  * for <b>github actions</b> job: add the label `run_fdb`

* <b>a compile downstream build</b> please  add comment: <b>Jenkins run cdb</b>

* <b>a full production downstream build</b> please add comment: <b>Jenkins execute product fdb</b>

* <b>an upstream build</b> please add comment: <b>Jenkins run upstream</b>
</details>
