### PR TITLE
[7.x] Fixed potential XXE vulnerabilities

### DIFF
--- a/drools-scenario-simulation/drools-scenario-simulation-backend/src/main/java/org/drools/scenariosimulation/backend/util/DOMParserUtil.java
+++ b/drools-scenario-simulation/drools-scenario-simulation-backend/src/main/java/org/drools/scenariosimulation/backend/util/DOMParserUtil.java
@@ -352,6 +352,8 @@ public class DOMParserUtil {
     public static String getString(Document toRead) throws TransformerException {
         DOMSource domSource = new DOMSource(toRead);
         TransformerFactory factory = TransformerFactory.newInstance();
+        factory.setAttribute(XMLConstants.ACCESS_EXTERNAL_DTD, "");
+        factory.setAttribute(XMLConstants.ACCESS_EXTERNAL_STYLESHEET, "");
         factory.setFeature(XMLConstants.FEATURE_SECURE_PROCESSING, true);
         Transformer transformer = factory.newTransformer();
         transformer.setOutputProperty(OutputKeys.INDENT, "yes");

--- a/kie-dmn/kie-dmn-backend/src/main/java/org/kie/dmn/backend/marshalling/v1_1/xstream/XStreamMarshaller.java
+++ b/kie-dmn/kie-dmn-backend/src/main/java/org/kie/dmn/backend/marshalling/v1_1/xstream/XStreamMarshaller.java
@@ -16,8 +16,6 @@
 
 package org.kie.dmn.backend.marshalling.v1_1.xstream;
 
-import java.io.ByteArrayInputStream;
-import java.io.ByteArrayOutputStream;
 import java.io.OutputStream;
 import java.io.OutputStreamWriter;
 import java.io.Reader;
@@ -28,18 +26,10 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 
-import javax.xml.XMLConstants;
 import javax.xml.namespace.QName;
 import javax.xml.stream.XMLStreamException;
 import javax.xml.stream.XMLStreamReader;
 import javax.xml.stream.XMLStreamWriter;
-import javax.xml.transform.OutputKeys;
-import javax.xml.transform.Source;
-import javax.xml.transform.Transformer;
-import javax.xml.transform.TransformerFactory;
-import javax.xml.transform.sax.SAXSource;
-import javax.xml.transform.sax.SAXTransformerFactory;
-import javax.xml.transform.stream.StreamResult;
 
 import com.thoughtworks.xstream.XStream;
 import com.thoughtworks.xstream.io.xml.AbstractPullReader;
@@ -94,7 +84,6 @@ import org.kie.dmn.model.v1_1.TUnaryTests;
 import org.kie.soup.xstream.XStreamUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import org.xml.sax.InputSource;
 
 public class XStreamMarshaller
         implements DMNMarshaller {
@@ -209,25 +198,7 @@ public class XStreamMarshaller
         }
     }
     
-    /** 
-     * Unnecessary as the stax driver custom anon as static definition is embedding the indentation.
-     */
-    @Deprecated
-    public static String formatXml(String xml){
-        try{
-           TransformerFactory transformerFactory = SAXTransformerFactory.newInstance();
-           transformerFactory.setFeature(XMLConstants.FEATURE_SECURE_PROCESSING, true);
-           Transformer serializer = transformerFactory.newTransformer();
-           serializer.setOutputProperty(OutputKeys.INDENT, "yes");         
-           serializer.setOutputProperty("{http://xml.apache.org/xslt}indent-amount", "2");
-           Source xmlSource=new SAXSource(new InputSource(new ByteArrayInputStream(xml.getBytes())));
-           StreamResult res =  new StreamResult(new ByteArrayOutputStream());            
-           serializer.transform(xmlSource, res);
-           return new String(((ByteArrayOutputStream)res.getOutputStream()).toByteArray());
-        }catch(Exception e){   
-           return xml;
-        }
-     }
+
     
     private XStream newXStream() {
         XStream xStream = XStreamUtils.createNonTrustingXStream(staxDriver, Definitions.class.getClassLoader(), DMNXStream::from);


### PR DESCRIPTION
This is a backport to 7.x of https://github.com/kiegroup/drools/pull/4176

<details>
<summary>
How to replicate CI configuration locally?
</summary>

Build Chain tool does "simple" maven build(s), the builds are just Maven commands, but because the repositories relates and depends on each other and any change in API or class method could affect several of those repositories there is a need to use [build-chain tool](https://github.com/kiegroup/github-action-build-chain) to handle cross repository builds and be sure that we always use latest version of the code for each repository.
 
[build-chain tool](https://github.com/kiegroup/github-action-build-chain) is a build tool which can be used on command line locally or in Github Actions workflow(s), in case you need to change multiple repositories and send multiple dependent pull requests related with a change you can easily reproduce the same build by executing it on Github hosted environment or locally in your development environment. See [local execution](https://github.com/kiegroup/github-action-build-chain#local-execution) details to get more information about it.
</details>

<details>
<summary>
How to retest this PR or trigger a specific build:
</summary>

* <b>a pull request</b> please add comment: <b>Jenkins retest this</b>

* for a <b>full downstream build</b> 
  * for <b>jenkins</b> job: please add comment: <b>Jenkins run fdb</b>
  * for <b>github actions</b> job: add the label `run_fdb`

* <b>a compile downstream build</b> please  add comment: <b>Jenkins run cdb</b>

* <b>a full production downstream build</b> please add comment: <b>Jenkins execute product fdb</b>

* <b>an upstream build</b> please add comment: <b>Jenkins run upstream</b>
</details>
