### PR TITLE
Revert "[7.x] Fixed potential XXE vulnerabilities"

### DIFF
--- a/drools-scenario-simulation/drools-scenario-simulation-backend/src/main/java/org/drools/scenariosimulation/backend/util/DOMParserUtil.java
+++ b/drools-scenario-simulation/drools-scenario-simulation-backend/src/main/java/org/drools/scenariosimulation/backend/util/DOMParserUtil.java
@@ -352,8 +352,6 @@ public class DOMParserUtil {
     public static String getString(Document toRead) throws TransformerException {
         DOMSource domSource = new DOMSource(toRead);
         TransformerFactory factory = TransformerFactory.newInstance();
-        factory.setAttribute(XMLConstants.ACCESS_EXTERNAL_DTD, "");
-        factory.setAttribute(XMLConstants.ACCESS_EXTERNAL_STYLESHEET, "");
         factory.setFeature(XMLConstants.FEATURE_SECURE_PROCESSING, true);
         Transformer transformer = factory.newTransformer();
         transformer.setOutputProperty(OutputKeys.INDENT, "yes");

--- a/kie-dmn/kie-dmn-backend/src/main/java/org/kie/dmn/backend/marshalling/v1_1/xstream/XStreamMarshaller.java
+++ b/kie-dmn/kie-dmn-backend/src/main/java/org/kie/dmn/backend/marshalling/v1_1/xstream/XStreamMarshaller.java
@@ -16,6 +16,8 @@
 
 package org.kie.dmn.backend.marshalling.v1_1.xstream;
 
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
 import java.io.OutputStream;
 import java.io.OutputStreamWriter;
 import java.io.Reader;
@@ -26,10 +28,18 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 
+import javax.xml.XMLConstants;
 import javax.xml.namespace.QName;
 import javax.xml.stream.XMLStreamException;
 import javax.xml.stream.XMLStreamReader;
 import javax.xml.stream.XMLStreamWriter;
+import javax.xml.transform.OutputKeys;
+import javax.xml.transform.Source;
+import javax.xml.transform.Transformer;
+import javax.xml.transform.TransformerFactory;
+import javax.xml.transform.sax.SAXSource;
+import javax.xml.transform.sax.SAXTransformerFactory;
+import javax.xml.transform.stream.StreamResult;
 
 import com.thoughtworks.xstream.XStream;
 import com.thoughtworks.xstream.io.xml.AbstractPullReader;
@@ -84,6 +94,7 @@ import org.kie.dmn.model.v1_1.TUnaryTests;
 import org.kie.soup.xstream.XStreamUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.xml.sax.InputSource;
 
 public class XStreamMarshaller
         implements DMNMarshaller {
@@ -198,7 +209,25 @@ public class XStreamMarshaller
         }
     }
     
-
+    /** 
+     * Unnecessary as the stax driver custom anon as static definition is embedding the indentation.
+     */
+    @Deprecated
+    public static String formatXml(String xml){
+        try{
+           TransformerFactory transformerFactory = SAXTransformerFactory.newInstance();
+           transformerFactory.setFeature(XMLConstants.FEATURE_SECURE_PROCESSING, true);
+           Transformer serializer = transformerFactory.newTransformer();
+           serializer.setOutputProperty(OutputKeys.INDENT, "yes");         
+           serializer.setOutputProperty("{http://xml.apache.org/xslt}indent-amount", "2");
+           Source xmlSource=new SAXSource(new InputSource(new ByteArrayInputStream(xml.getBytes())));
+           StreamResult res =  new StreamResult(new ByteArrayOutputStream());            
+           serializer.transform(xmlSource, res);
+           return new String(((ByteArrayOutputStream)res.getOutputStream()).toByteArray());
+        }catch(Exception e){   
+           return xml;
+        }
+     }
     
     private XStream newXStream() {
         XStream xStream = XStreamUtils.createNonTrustingXStream(staxDriver, Definitions.class.getClassLoader(), DMNXStream::from);


### PR DESCRIPTION
Reverts kiegroup/drools#4283

The PR introduced 6 tests failures in https://github.com/kiegroup/droolsjbpm-integration tests: 

eg. 
org.kie.server.integrationtests.scenariosimulation.ScenarioSimulationIntegrationTest.executeScenarioTest[JAXB KieServicesConfiguration{transport=REST, serverUrl='http://localhost:40477/kie-server-services/services/rest/server'}]

`org.kie.server.api.exception.KieServicesHttpException: 
Unexpected HTTP response code when requesting URI 'http://localhost:40477/kie-server-services/services/rest/server/containers/input-data-string/scesim'! Error code: 400, message: <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
<response type="FAILURE" msg="Test scenario parsing error: Not supported: [http://javax.xml.XMLConstants/property/accessExternalDTD"/](http://javax.xml.xmlconstants/property/accessExternalDTD)>`


As the same patch has been applied in 8.x stream, I suggest to double check if Test Scenario works correctly in main too.