### PR TITLE
DROOLS-6847 Refactor ResourceToPkgDescrMapper

### DIFF
--- a/drools-compiler/src/main/java/org/drools/compiler/builder/impl/CompositeKnowledgeBuilderImpl.java
+++ b/drools-compiler/src/main/java/org/drools/compiler/builder/impl/CompositeKnowledgeBuilderImpl.java
@@ -22,7 +22,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
 
-import org.drools.compiler.builder.impl.resources.DrlResourceHandler;
 import org.drools.compiler.lang.descr.CompositePackageDescr;
 import org.drools.drl.ast.descr.PackageDescr;
 import org.kie.api.internal.assembler.KieAssemblers;
@@ -328,15 +327,35 @@ public class CompositeKnowledgeBuilderImpl implements CompositeKnowledgeBuilder 
     private interface ResourceToPkgDescrMapper {
         PackageDescr map(KnowledgeBuilderImpl kBuilder, ResourceDescr resourceDescr) throws Exception;
 
-        ResourceToPkgDescrMapper DRL_TO_PKG_DESCR = ( kBuilder, resourceDescr ) -> {
-            DrlResourceHandler handler = new DrlResourceHandler(kBuilder.getBuilderConfiguration());
-            PackageDescr result = handler.process(resourceDescr.resource);
-            handler.getResults().forEach(kBuilder::addBuilderResult);
-            return result;
+        ResourceToPkgDescrMapper DRL_TO_PKG_DESCR = (kBuilder, resourceDescr) -> {
+            ProcessorDrl processor = new ProcessorDrl(kBuilder.getBuilderConfiguration());
+            PackageDescr pkg = processor.process(resourceDescr.resource);
+            processor.getResults().forEach(kBuilder::addBuilderResult);
+            return pkg;
         };
-        ResourceToPkgDescrMapper TEMPLATE_TO_PKG_DESCR = ( kBuilder, resourceDescr ) -> kBuilder.templateToPackageDescr( resourceDescr.resource);
-        ResourceToPkgDescrMapper DSLR_TO_PKG_DESCR = ( kBuilder, resourceDescr ) -> kBuilder.dslrToPackageDescr(resourceDescr.resource);
-        ResourceToPkgDescrMapper XML_TO_PKG_DESCR = ( kBuilder, resourceDescr ) -> kBuilder.xmlToPackageDescr(resourceDescr.resource);
-        ResourceToPkgDescrMapper DTABLE_TO_PKG_DESCR = ( kBuilder, resourceDescr ) -> kBuilder.decisionTableToPackageDescr(resourceDescr.resource, resourceDescr.configuration);
+        ResourceToPkgDescrMapper TEMPLATE_TO_PKG_DESCR = (kBuilder, resourceDescr) -> {
+            ProcessorTemplate processor = new ProcessorTemplate(kBuilder.getBuilderConfiguration(), kBuilder.getReleaseId());
+            PackageDescr pkg = processor.process(resourceDescr.resource, kBuilder.getDslExpander());
+            processor.getResults().forEach(kBuilder::addBuilderResult);
+            return pkg;
+        };
+        ResourceToPkgDescrMapper DSLR_TO_PKG_DESCR = (kBuilder, resourceDescr) -> {
+            ProcessorDslr processor = new ProcessorDslr(kBuilder.getBuilderConfiguration());
+            PackageDescr pkg = processor.process(resourceDescr.resource, kBuilder.getDslExpander());
+            processor.getResults().forEach(kBuilder::addBuilderResult);
+            return pkg;
+        };
+        ResourceToPkgDescrMapper XML_TO_PKG_DESCR = (kBuilder, resourceDescr) -> {
+            ProcessorXml processor = new ProcessorXml(kBuilder.getBuilderConfiguration());
+            PackageDescr pkg = processor.process(resourceDescr.resource);
+            processor.getResults().forEach(kBuilder::addBuilderResult);
+            return pkg;
+        };
+        ResourceToPkgDescrMapper DTABLE_TO_PKG_DESCR = (kBuilder, resourceDescr) -> {
+            ProcessorDecisionTable processor = new ProcessorDecisionTable(kBuilder.getBuilderConfiguration(), kBuilder.getReleaseId());
+            PackageDescr pkg = processor.process(resourceDescr.resource, resourceDescr.configuration);
+            processor.getResults().forEach(kBuilder::addBuilderResult);
+            return pkg;
+        };
     }
 }

--- a/drools-compiler/src/main/java/org/drools/compiler/builder/impl/Processor.java
+++ b/drools-compiler/src/main/java/org/drools/compiler/builder/impl/Processor.java
@@ -84,7 +84,7 @@ public abstract class Processor {
             IoUtils.write(dumpFile, generatedDrl.getBytes(IoUtils.UTF8_CHARSET));
         } catch (IOException ex) {
             // nothing serious, just failure when writing the generated DRL to file, just log the exception and continue
-            logger.warn("Can't write the DRL generated from decision table to file " + dumpFile.getAbsolutePath() + "!\n" +
+            logger.warn("Can't write the DRL generated from decision table to file {}!\n{}", dumpFile.getAbsolutePath(),
                     Arrays.toString(ex.getStackTrace()));
         }
     }

--- a/drools-compiler/src/main/java/org/drools/compiler/builder/impl/Processor.java
+++ b/drools-compiler/src/main/java/org/drools/compiler/builder/impl/Processor.java
@@ -1,0 +1,129 @@
+/*
+ * Copyright 2015 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.drools.compiler.builder.impl;
+
+import org.drools.drl.parser.DrlParser;
+import org.drools.drl.parser.DroolsParserException;
+import org.drools.drl.parser.ParserError;
+import org.drools.drl.parser.lang.ExpanderException;
+import org.drools.drl.parser.lang.dsl.DefaultExpander;
+import org.drools.util.IoUtils;
+import org.drools.drl.ast.descr.PackageDescr;
+import org.kie.api.builder.ReleaseId;
+import org.kie.api.io.Resource;
+import org.kie.internal.builder.KnowledgeBuilderResult;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.File;
+import java.io.IOException;
+import java.io.Reader;
+import java.io.StringReader;
+import java.io.UncheckedIOException;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.UUID;
+
+public abstract class Processor {
+    protected KnowledgeBuilderConfigurationImpl configuration;
+    protected Collection<KnowledgeBuilderResult> results = new ArrayList<>();
+    protected ReleaseId releaseId;
+    protected static final Logger logger = LoggerFactory.getLogger(Processor.class);
+
+    public Processor(KnowledgeBuilderConfigurationImpl configuration, ReleaseId releaseId) {
+        this.configuration = configuration;
+        this.releaseId = releaseId;
+    }
+
+    public Processor(KnowledgeBuilderConfigurationImpl configuration) {
+        this.configuration = configuration;
+    }
+
+    public Collection<KnowledgeBuilderResult> getResults(){
+        return this.results;
+    }
+
+    protected PackageDescr generatedDrlToPackageDescr(Resource resource, String generatedDrl) throws DroolsParserException {
+        // dump the generated DRL if the dump dir was configured
+        if (this.configuration.getDumpDir() != null) {
+            dumpDrlGeneratedFromDTable(this.configuration.getDumpDir(), generatedDrl, resource.getSourcePath());
+        }
+
+        DrlParser parser = new DrlParser(configuration.getLanguageLevel());
+        PackageDescr pkg = parser.parse(resource, new StringReader(generatedDrl));
+        this.results.addAll(parser.getErrors());
+        if (pkg == null) {
+            this.results.add(new ParserError(resource, "Parser returned a null Package", 0, 0));
+        } else {
+            pkg.setResource(resource);
+        }
+        return parser.hasErrors() ? null : pkg;
+    }
+
+    protected void dumpDrlGeneratedFromDTable(File dumpDir, String generatedDrl, String srcPath) {
+        String fileName = srcPath != null ? srcPath : "decision-table-" + UUID.randomUUID();
+        if (releaseId != null) {
+            fileName = releaseId.getGroupId() + "_" + releaseId.getArtifactId() + "_" + fileName;
+        }
+        File dumpFile = createDumpDrlFile(dumpDir, fileName, ".drl");
+        try {
+            IoUtils.write(dumpFile, generatedDrl.getBytes(IoUtils.UTF8_CHARSET));
+        } catch (IOException ex) {
+            // nothing serious, just failure when writing the generated DRL to file, just log the exception and continue
+            logger.warn("Can't write the DRL generated from decision table to file " + dumpFile.getAbsolutePath() + "!\n" +
+                    Arrays.toString(ex.getStackTrace()));
+        }
+    }
+
+    protected File createDumpDrlFile(File dumpDir, String fileName, String extension) {
+        return new File(dumpDir, fileName.replaceAll("[^a-zA-Z0-9\\.\\-_]+", "_") + extension);
+    }
+
+    protected PackageDescr dslrReaderToPackageDescr(Resource resource, Reader dslrReader, DefaultExpander expander) throws DroolsParserException {
+        boolean hasErrors;
+        PackageDescr pkg;
+
+        DrlParser parser = new DrlParser(configuration.getLanguageLevel());
+
+        try {
+            try {
+                if (expander == null) {
+                    expander = new DefaultExpander();
+                }
+                String str = expander.expand(dslrReader);
+                if (expander.hasErrors()) {
+                    for (ExpanderException error : expander.getErrors()) {
+                        error.setResource(resource);
+                        this.results.add(error);
+                    }
+                }
+
+                pkg = parser.parse(resource, str);
+                this.results.addAll(parser.getErrors());
+                hasErrors = parser.hasErrors();
+            } finally {
+                if (dslrReader != null) {
+                    dslrReader.close();
+                }
+            }
+        } catch (IOException ex) {
+            throw new UncheckedIOException(ex);
+        }
+        return hasErrors ? null : pkg;
+    }
+
+}

--- a/drools-compiler/src/main/java/org/drools/compiler/builder/impl/ProcessorDecisionTable.java
+++ b/drools-compiler/src/main/java/org/drools/compiler/builder/impl/ProcessorDecisionTable.java
@@ -1,0 +1,65 @@
+/*
+ * Copyright 2015 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.drools.compiler.builder.impl;
+
+import org.drools.compiler.builder.conf.DecisionTableConfigurationImpl;
+import org.drools.drl.extensions.DecisionTableFactory;
+import org.drools.drl.parser.DroolsParserException;
+import org.drools.compiler.lang.descr.CompositePackageDescr;
+import org.drools.drl.ast.descr.PackageDescr;
+import org.kie.api.builder.ReleaseId;
+import org.kie.api.io.Resource;
+import org.kie.api.io.ResourceConfiguration;
+import org.kie.internal.builder.DecisionTableConfiguration;
+import java.util.List;
+
+public class ProcessorDecisionTable extends Processor{
+
+    public ProcessorDecisionTable(KnowledgeBuilderConfigurationImpl configuration, ReleaseId releaseId)
+    {
+        super(configuration, releaseId);
+    }
+
+    public PackageDescr process(Resource resource, ResourceConfiguration rConfiguration) throws DroolsParserException {
+        DecisionTableConfiguration dtableConfiguration = rConfiguration instanceof DecisionTableConfiguration ?
+                (DecisionTableConfiguration) rConfiguration :
+                new DecisionTableConfigurationImpl();
+
+        if (!dtableConfiguration.getRuleTemplateConfigurations().isEmpty()) {
+            List<String> generatedDrls = DecisionTableFactory.loadFromInputStreamWithTemplates(resource, dtableConfiguration);
+            if (generatedDrls.size() == 1) {
+                return generatedDrlToPackageDescr(resource, generatedDrls.get(0));
+            }
+            CompositePackageDescr compositePackageDescr = null;
+            for (String generatedDrl : generatedDrls) {
+                PackageDescr packageDescr = generatedDrlToPackageDescr(resource, generatedDrl);
+                if (packageDescr != null) {
+                    if (compositePackageDescr == null) {
+                        compositePackageDescr = new CompositePackageDescr(resource, packageDescr);
+                    } else {
+                        compositePackageDescr.addPackageDescr(resource, packageDescr);
+                    }
+                }
+            }
+            return compositePackageDescr;
+        }
+
+        dtableConfiguration.setTrimCell( this.configuration.isTrimCellsInDTable() );
+
+        String generatedDrl = DecisionTableFactory.loadFromResource(resource, dtableConfiguration);
+        return generatedDrlToPackageDescr(resource, generatedDrl);
+    }
+}

--- a/drools-compiler/src/main/java/org/drools/compiler/builder/impl/ProcessorDrl.java
+++ b/drools-compiler/src/main/java/org/drools/compiler/builder/impl/ProcessorDrl.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright 2015 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.drools.compiler.builder.impl;
+
+import org.drools.drl.parser.DrlParser;
+import org.drools.drl.parser.DroolsParserException;
+import org.drools.drl.parser.ParserError;
+import org.drools.util.io.DescrResource;
+import org.drools.drl.ast.descr.PackageDescr;
+import org.kie.api.io.Resource;
+
+import java.io.IOException;
+
+public class ProcessorDrl extends Processor{
+    public ProcessorDrl(KnowledgeBuilderConfigurationImpl configuration){
+        super(configuration);
+    }
+    public PackageDescr process(Resource resource) throws DroolsParserException, IOException{
+        PackageDescr pkg;
+        boolean hasErrors = false;
+        if (resource instanceof DescrResource){
+            pkg = (PackageDescr) ((DescrResource) resource).getDescr();
+        }else{
+            final DrlParser parser = new DrlParser(this.configuration.getLanguageLevel());
+            pkg = parser.parse(resource);
+            this.results.addAll(parser.getErrors());
+            if (pkg == null) {
+                this.results.add(new ParserError(resource, "Parser returned a null Package", 0, 0));
+            }
+            hasErrors = parser.hasErrors();
+        }
+        if (pkg != null) {
+            pkg.setResource(resource);
+        }
+        return hasErrors ? null : pkg;
+    }
+}

--- a/drools-compiler/src/main/java/org/drools/compiler/builder/impl/ProcessorDslr.java
+++ b/drools-compiler/src/main/java/org/drools/compiler/builder/impl/ProcessorDslr.java
@@ -1,0 +1,32 @@
+/*
+ * Copyright 2015 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.drools.compiler.builder.impl;
+
+import org.drools.drl.parser.DroolsParserException;
+import org.drools.drl.ast.descr.PackageDescr;
+import org.drools.drl.parser.lang.dsl.DefaultExpander;
+import org.kie.api.io.Resource;
+import java.io.IOException;
+
+public class ProcessorDslr extends Processor{
+    public ProcessorDslr(KnowledgeBuilderConfigurationImpl configuration){
+        super(configuration);
+    }
+
+    public PackageDescr process(Resource resource, DefaultExpander expander) throws DroolsParserException, IOException {
+        return dslrReaderToPackageDescr(resource, resource.getReader(), expander);
+    }
+}

--- a/drools-compiler/src/main/java/org/drools/compiler/builder/impl/ProcessorTemplate.java
+++ b/drools-compiler/src/main/java/org/drools/compiler/builder/impl/ProcessorTemplate.java
@@ -52,7 +52,7 @@ public class ProcessorTemplate extends Processor{
         } else if (ResourceType.DRL.equals(resourceType)) {
             return generatedDrlToPackageDescr(resource, resourceConversionResult.getContent());
         } else {
-            throw new RuntimeException("Converting generated " + resourceType + " into PackageDescr is not supported!");
+            throw new DroolsParserException("Converting generated " + resourceType + " into PackageDescr is not supported!");
         }
     }
 

--- a/drools-compiler/src/main/java/org/drools/compiler/builder/impl/ProcessorTemplate.java
+++ b/drools-compiler/src/main/java/org/drools/compiler/builder/impl/ProcessorTemplate.java
@@ -1,0 +1,62 @@
+/*
+ * Copyright 2015 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.drools.compiler.builder.impl;
+
+import org.drools.compiler.builder.impl.errors.MissingImplementationException;
+import org.drools.drl.ast.descr.PackageDescr;
+import org.drools.drl.extensions.GuidedRuleTemplateFactory;
+import org.drools.drl.extensions.GuidedRuleTemplateProvider;
+import org.drools.drl.extensions.ResourceConversionResult;
+import org.drools.drl.parser.DroolsParserException;
+import org.drools.drl.parser.lang.dsl.DefaultExpander;
+import org.kie.api.builder.ReleaseId;
+import org.kie.api.io.Resource;
+import org.kie.api.io.ResourceType;
+
+import java.io.IOException;
+import java.io.StringReader;
+
+public class ProcessorTemplate extends Processor{
+
+    public ProcessorTemplate(KnowledgeBuilderConfigurationImpl configuration, ReleaseId releaseId) {
+        super(configuration, releaseId);
+    }
+
+    public PackageDescr process(Resource resource, DefaultExpander expander) throws DroolsParserException, IOException {
+        GuidedRuleTemplateProvider guidedRuleTemplateProvider = GuidedRuleTemplateFactory.getGuidedRuleTemplateProvider();
+        if (guidedRuleTemplateProvider == null) {
+            throw new MissingImplementationException(resource, "drools-workbench-models-guided-template");
+        }
+        ResourceConversionResult conversionResult = guidedRuleTemplateProvider.loadFromInputStream(resource.getInputStream());
+        return conversionResultToPackageDescr(resource, conversionResult, expander);
+    }
+
+    private PackageDescr conversionResultToPackageDescr(Resource resource, ResourceConversionResult resourceConversionResult, DefaultExpander expander)
+            throws DroolsParserException {
+        ResourceType resourceType = resourceConversionResult.getType();
+        if (ResourceType.DSLR.equals(resourceType)) {
+            return generatedDslrToPackageDescr(resource, resourceConversionResult.getContent(), expander);
+        } else if (ResourceType.DRL.equals(resourceType)) {
+            return generatedDrlToPackageDescr(resource, resourceConversionResult.getContent());
+        } else {
+            throw new RuntimeException("Converting generated " + resourceType + " into PackageDescr is not supported!");
+        }
+    }
+
+    PackageDescr generatedDslrToPackageDescr(Resource resource, String dslr, DefaultExpander expander) throws DroolsParserException {
+        return dslrReaderToPackageDescr(resource, new StringReader(dslr), expander);
+    }
+}

--- a/drools-compiler/src/main/java/org/drools/compiler/builder/impl/ProcessorXml.java
+++ b/drools-compiler/src/main/java/org/drools/compiler/builder/impl/ProcessorXml.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright 2015 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.drools.compiler.builder.impl;
+
+import org.drools.drl.parser.DroolsParserException;
+import org.drools.compiler.compiler.xml.XmlPackageReader;
+import org.drools.drl.ast.descr.PackageDescr;
+import org.kie.api.io.Resource;
+import org.xml.sax.SAXException;
+import java.io.IOException;
+import java.io.Reader;
+
+public class ProcessorXml extends Processor {
+    public ProcessorXml(KnowledgeBuilderConfigurationImpl configuration){
+        super(configuration);
+    }
+
+    public PackageDescr process(Resource resource) throws DroolsParserException, IOException {
+        final XmlPackageReader xmlReader = new XmlPackageReader(this.configuration.getSemanticModules());
+        xmlReader.getParser().setClassLoader(this.configuration.getClassLoader());
+
+        try (Reader reader = resource.getReader()) {
+            xmlReader.read(reader);
+        } catch (final SAXException e) {
+            throw new DroolsParserException(e.toString(),
+                    e.getCause());
+        }
+        return xmlReader.getPackageDescr();
+    }
+}


### PR DESCRIPTION
`ResourceToPkgDescrMapper` is a nested interface within CompositeKnowledgeBuilderImpl class in the drools-compiler module. Each (public static final) field within this interface defines a lambda function of the form:
`PackageDescr map(KnowledgeBuilderImpl kBuilder, ResourceDescr resourceDescr) throws Exception;`, 
for instance 
`ResourceToPkgDescrMapper DRL_TO_PKG_DESCR = ( kBuilder, resourceDescr ) -> kBuilder.drlToPackageDescr(resourceDescr.resource);`.

The dependency on the entire `kBuilder` object is often unnecessary for most of these methods. In fact, in this case the entire `kBuilder` is passed, but only the `configuration` field is really necessary in the `drlToPackageDescr` method. 

Therefore, this method can be moved in a new class, e.g. `class ProcessorDrl`, that will be instantiated with a reference to  the `kBuilder.configuration` field, and have a `process(Resource resource)` method implemented to replace  the corresponding `drlToPackageDescr` method of the kBuilder class.
Then the entire lambda can be substituted by something in the form:
`ResourceToPkgDescrMapper DRL_TO_PKG_DESCR = ( kBuilder, resourceDescr ) -> {`
            `ProcessorDrl processor = new ProcessorDrl(kBuilder.getBuilderConfiguration());`
            `PackageDescr pkg = processor.process(resourceDescr.resource);`
            `processor.getResults().forEach(kBuilder::addBuilderResult);`
            `return pkg;};`

The goal of this PR is the refactoring of such methods from the `KnowledgeBuilderImpl` class to a series of `Processor` classes similar to `ProcessorDrl`, and update the lambdas in a similar way.