### PR TITLE
[8.21.x] Bump Quarkus version to 2.8.2.Final (#4326)

### DIFF
--- a/build-parent/pom.xml
+++ b/build-parent/pom.xml
@@ -35,18 +35,18 @@
     <version.commons-logging>1.1.1</version.commons-logging>
     <version.commons-io>2.11.0</version.commons-io>
     <version.common-text>1.9</version.common-text>
-    <version.com.fasterxml.jackson>2.12.5</version.com.fasterxml.jackson>
-    <version.com.fasterxml.jackson.databind>${version.com.fasterxml.jackson}</version.com.fasterxml.jackson.databind>
-    <version.com.fasterxml.jackson.annotations>${version.com.fasterxml.jackson}</version.com.fasterxml.jackson.annotations>
+    <version.com.fasterxml.jackson>2.13.2</version.com.fasterxml.jackson>
+    <version.com.fasterxml.jackson.databind>2.13.2.2</version.com.fasterxml.jackson.databind>
+    <version.com.fasterxml.jackson.annotations>2.13.2</version.com.fasterxml.jackson.annotations>
     <!-- DROOLS-6678: only used in one drools-examples -->
-    <version.com.google.code.gson>2.8.6</version.com.google.code.gson>
+    <version.com.google.code.gson>2.9.0</version.com.google.code.gson>
     <version.org.jresearch.gwt.time>2.0.3</version.org.jresearch.gwt.time>
     <version.domino-slf4j-logger>1.0.1</version.domino-slf4j-logger>
     <!-- DROOLS-6678: only used by drools-verifier and drools-examples -->
     <version.com.google.guava>30.1.1-jre</version.com.google.guava>
     <version.com.google.inject.guice>4.0</version.com.google.inject.guice>
     <version.com.google.gwt>2.9.0</version.com.google.gwt>
-    <version.com.google.protobuf>3.17.3</version.com.google.protobuf>
+    <version.com.google.protobuf>3.19.3</version.com.google.protobuf>
     <version.com.h2database>2.1.210</version.com.h2database>
     <!-- DROOLS-6678: only used by drools-verifier -->
     <version.com.lowagie.itext>2.1.7</version.com.lowagie.itext>
@@ -56,10 +56,10 @@
     <version.com.sun.xml.bind>2.3.0</version.com.sun.xml.bind>
     <version.com.thoughtworks.xstream>1.4.19</version.com.thoughtworks.xstream>
     <version.guru.nidi>0.18.0</version.guru.nidi>
-    <version.info.picocli>4.6.1</version.info.picocli>
-    <version.io.micrometer>1.7.4</version.io.micrometer>
-    <version.io.quarkus>2.7.3.Final</version.io.quarkus>
-    <version.io.smallrye.openapi.core>2.1.15</version.io.smallrye.openapi.core>
+    <version.info.picocli>4.6.3</version.info.picocli>
+    <version.io.micrometer>1.8.5</version.io.micrometer>
+    <version.io.quarkus>2.8.2.Final</version.io.quarkus>
+    <version.io.smallrye.openapi.core>2.1.22</version.io.smallrye.openapi.core>
     <version.junit>4.13.1</version.junit>
     <version.net.java.dev.glazedlists>1.8.0</version.net.java.dev.glazedlists>
     <version.antlr>2.7.7</version.antlr>
@@ -73,23 +73,23 @@
 
     <!-- DROOLS-6678: only used by kie-util-maven-support and kie-util-maven-integration -->
     <version.org.apache.httpcomponents.httpclient>4.5.13</version.org.apache.httpcomponents.httpclient>
-    <version.org.apache.httpcomponents.httpcore>4.4.14</version.org.apache.httpcomponents.httpcore>
+    <version.org.apache.httpcomponents.httpcore>4.4.15</version.org.apache.httpcomponents.httpcore>
     <version.org.apache.maven>3.8.4</version.org.apache.maven>
     <version.org.apache.maven.resolver>1.7.3</version.org.apache.maven.resolver>
-    <version.org.apache.maven.wagon>3.0.0</version.org.apache.maven.wagon>
+    <version.org.apache.maven.wagon>3.4.3</version.org.apache.maven.wagon>
     <version.org.apache.poi>5.1.0</version.org.apache.poi>
     <!-- DROOLS-6678: only used by kie-test-util -->
     <version.org.apache.tomcat.tomcat-dbcp>9.0.21</version.org.apache.tomcat.tomcat-dbcp>
     <version.org.assertj>3.20.2</version.org.assertj>
     <version.org.eclipse.jdt>3.18.0</version.org.eclipse.jdt>
     <!-- DROOLS-6678: only used by kie-ci, kie-util-maven-support and kie-util-maven-integration -->
-    <version.org.eclipse.sisu>0.3.4</version.org.eclipse.sisu>
+    <version.org.eclipse.sisu>0.3.5</version.org.eclipse.sisu>
     <version.org.glassfish.jaxb>2.3.6</version.org.glassfish.jaxb>
     <version.org.hibernate>5.6.0.Final</version.org.hibernate>
     <!--This needs to be in sync with JUnit-->
     <version.org.hamcrest>1.3</version.org.hamcrest>
     <version.org.javassist>3.26.0-GA</version.org.javassist>
-    <version.org.jboss.narayana.tomcat>5.12.0.Final</version.org.jboss.narayana.tomcat>
+    <version.org.jboss.narayana.tomcat>5.12.4.Final</version.org.jboss.narayana.tomcat>
     <version.org.jboss.transaction.spi>7.6.1.Final</version.org.jboss.transaction.spi>
     <!-- DROOLS-6678: make sure weld is used only for test -->
     <version.org.jboss.weld.weld>3.1.6.Final</version.org.jboss.weld.weld>
@@ -113,7 +113,7 @@
     <version.jakarta.jws-api>2.1.0</version.jakarta.jws-api>
     <version.jakarta.json-api>1.1.6</version.jakarta.json-api>
     <version.org.jpmml.model>1.5.1</version.org.jpmml.model> <!-- jpmml-model BSD 3C license - ATTENTION 1.5.1 intentional, because 1.5.1 evaluators works with 1.5.1 -->
-    <version.org.junit>5.8.0</version.org.junit>
+    <version.org.junit>5.8.2</version.org.junit>
     <version.org.mvel>2.4.14.Final</version.org.mvel>
     <version.org.powermock>2.0.7</version.org.powermock>
     <version.org.slf4j>1.7.30</version.org.slf4j>
@@ -164,7 +164,7 @@
     <version.org.asciidoctor.asciidoctorj>2.2.0</version.org.asciidoctor.asciidoctorj>
     <version.org.asciidoctor.asciidoctorj-pdf>1.5.0</version.org.asciidoctor.asciidoctorj-pdf>
     <version.org.w3c.dom>2.3.0-jaxb-1.0.6</version.org.w3c.dom>
-    <version.org.mockito>3.12.4</version.org.mockito>
+    <version.org.mockito>4.4.0</version.org.mockito>
     <!-- Version of JMH -->
     <version.org.openjdk.jmh>1.21</version.org.openjdk.jmh>
 
@@ -183,9 +183,9 @@
     <version.surefire.plugin>2.22.1</version.surefire.plugin>
     <!-- Add for kie-maven-plugin -->
     <version.plugin.plugin>3.6.4</version.plugin.plugin>
-    <version.plugin.annotations>3.4</version.plugin.annotations>
+    <version.plugin.annotations>3.6.0</version.plugin.annotations>
     <version.artifact.transfer>0.9.1</version.artifact.transfer>
-    <version.shared.utils>3.2.1</version.shared.utils>
+    <version.shared.utils>3.3.4</version.shared.utils>
     <version.common.compress>1.21</version.common.compress>
     <version.common.exec>1.3</version.common.exec>
     <!-- -->
@@ -219,13 +219,13 @@
 
     <version.compiler.plugin>3.8.1</version.compiler.plugin>
 
-    <version.net.byte-buddy>1.10.3</version.net.byte-buddy>
+    <version.net.byte-buddy>1.12.9</version.net.byte-buddy>
 
-    <version.org.postgresql>42.3.3</version.org.postgresql>
+    <version.org.postgresql>42.3.4</version.org.postgresql>
 
     <version.ch.obermuhlner>2.0.1</version.ch.obermuhlner>
-    <version.org.jboss.jandex>2.4.0.Final</version.org.jboss.jandex>
-    <version.org.eclipse.yasson>1.0.9</version.org.eclipse.yasson>
+    <version.org.jboss.jandex>2.4.2.Final</version.org.jboss.jandex>
+    <version.org.eclipse.yasson>1.0.11</version.org.eclipse.yasson>
 
     <version.com.github.javaparser>3.23.1</version.com.github.javaparser>
 
@@ -234,7 +234,7 @@
     <project.root.dir>${maven.multiModuleProjectDirectory}</project.root.dir>
     <jacoco.exec.file>${project.root.dir}/target/jacoco.exec</jacoco.exec.file>
 
-    <version.org.awaitility>4.1.0</version.org.awaitility>
+    <version.org.awaitility>4.2.0</version.org.awaitility>
     <version.io.github.bonigarcia>5.0.3</version.io.github.bonigarcia>
   </properties>
 

--- a/drools-drl-quarkus-extension/drools-drl-quarkus-integration-test-hotreload/pom.xml
+++ b/drools-drl-quarkus-extension/drools-drl-quarkus-integration-test-hotreload/pom.xml
@@ -25,22 +25,10 @@
         <dependency>
             <groupId>io.quarkus</groupId>
             <artifactId>quarkus-resteasy</artifactId>
-            <exclusions>
-                <exclusion>
-                    <groupId>org.jboss.spec.javax.xml.bind</groupId>
-                    <artifactId>jboss-jaxb-api_2.3_spec</artifactId>
-                </exclusion>
-            </exclusions>
         </dependency>
         <dependency>
             <groupId>io.quarkus</groupId>
             <artifactId>quarkus-resteasy-jackson</artifactId>
-            <exclusions>
-                <exclusion>
-                    <groupId>org.jboss.spec.javax.xml.bind</groupId>
-                    <artifactId>jboss-jaxb-api_2.3_spec</artifactId>
-                </exclusion>
-            </exclusions>
         </dependency>
 
         <dependency>


### PR DESCRIPTION
cherry-pick: https://github.com/kiegroup/drools/pull/4326

Related PRs:
- https://github.com/kiegroup/drools/pull/4342
- https://github.com/kiegroup/optaplanner/pull/1958
- https://github.com/kiegroup/optaplanner-quickstarts/pull/327
- https://github.com/kiegroup/kogito-runtimes/pull/2174
- https://github.com/kiegroup/kogito-apps/pull/1315
- https://github.com/kiegroup/kogito-examples/pull/1238