### PR TITLE
Add length check back to EvaluatorWrapper#getFactHandle

### DIFF
--- a/drools-core/src/main/java/org/drools/core/base/EvaluatorWrapper.java
+++ b/drools-core/src/main/java/org/drools/core/base/EvaluatorWrapper.java
@@ -257,6 +257,6 @@ public class EvaluatorWrapper
 
     private static InternalFactHandle getFactHandle( Declaration declaration,
                                                     InternalFactHandle[] handles ) {
-        return handles[declaration.getObjectIndex()];
+        return handles != null && handles.length > declaration.getObjectIndex() ? handles[declaration.getObjectIndex()] : null;
     }
 }


### PR DESCRIPTION
Add length check removed in 54c3bf1a0b1297b3d1594cf3229d9e6218dd1ebc to avoid `ArrayIndexOutOfBoundsException` exception.

**JIRA**: https://issues.redhat.com/browse/DROOLS-6925.
