### PR TITLE
[8.21.x] Bump Quarkus version to 2.9.0.Final (#4347)

### DIFF
--- a/build-parent/pom.xml
+++ b/build-parent/pom.xml
@@ -58,7 +58,7 @@
     <version.guru.nidi>0.18.0</version.guru.nidi>
     <version.info.picocli>4.6.3</version.info.picocli>
     <version.io.micrometer>1.8.5</version.io.micrometer>
-    <version.io.quarkus>2.8.2.Final</version.io.quarkus>
+    <version.io.quarkus>2.9.0.Final</version.io.quarkus>
     <version.io.smallrye.openapi.core>2.1.22</version.io.smallrye.openapi.core>
     <version.junit>4.13.1</version.junit>
     <version.net.java.dev.glazedlists>1.8.0</version.net.java.dev.glazedlists>
@@ -89,13 +89,13 @@
     <!--This needs to be in sync with JUnit-->
     <version.org.hamcrest>1.3</version.org.hamcrest>
     <version.org.javassist>3.26.0-GA</version.org.javassist>
-    <version.org.jboss.narayana.tomcat>5.12.4.Final</version.org.jboss.narayana.tomcat>
+    <version.org.jboss.narayana.tomcat>5.12.6.Final</version.org.jboss.narayana.tomcat>
     <version.org.jboss.transaction.spi>7.6.1.Final</version.org.jboss.transaction.spi>
     <!-- DROOLS-6678: make sure weld is used only for test -->
     <version.org.jboss.weld.weld>3.1.6.Final</version.org.jboss.weld.weld>
     <version.jakarta.enterprise.cdi-api>2.0.2</version.jakarta.enterprise.cdi-api>
-    <version.jakarta.activation-api>1.2.2</version.jakarta.activation-api>
-    <version.jakarta.inject-api>1.0.3</version.jakarta.inject-api>
+    <version.jakarta.activation-api>1.2.1</version.jakarta.activation-api>
+    <version.jakarta.inject-api>1.0</version.jakarta.inject-api>
     <version.jakarta.annotation-api>1.3.5</version.jakarta.annotation-api>
     <version.jakarta.ejb-api>3.2.6</version.jakarta.ejb-api>
     <version.jakarta.security.jacc-api>1.6.1</version.jakarta.security.jacc-api>
@@ -164,7 +164,7 @@
     <version.org.asciidoctor.asciidoctorj>2.2.0</version.org.asciidoctor.asciidoctorj>
     <version.org.asciidoctor.asciidoctorj-pdf>1.5.0</version.org.asciidoctor.asciidoctorj-pdf>
     <version.org.w3c.dom>2.3.0-jaxb-1.0.6</version.org.w3c.dom>
-    <version.org.mockito>4.4.0</version.org.mockito>
+    <version.org.mockito>4.5.1</version.org.mockito>
     <!-- Version of JMH -->
     <version.org.openjdk.jmh>1.21</version.org.openjdk.jmh>
 
@@ -221,7 +221,7 @@
 
     <version.net.byte-buddy>1.12.9</version.net.byte-buddy>
 
-    <version.org.postgresql>42.3.4</version.org.postgresql>
+    <version.org.postgresql>42.3.3</version.org.postgresql>
 
     <version.ch.obermuhlner>2.0.1</version.ch.obermuhlner>
     <version.org.jboss.jandex>2.4.2.Final</version.org.jboss.jandex>


### PR DESCRIPTION
cherry-pick: https://github.com/kiegroup/drools/pull/4347

Related PRs:
- https://github.com/kiegroup/kogito-pipelines/pull/437
- https://github.com/kiegroup/drools/pull/4357
- https://github.com/kiegroup/kogito-runtimes/pull/2188
- https://github.com/kiegroup/optaplanner/pull/1967
- https://github.com/kiegroup/optaplanner-quickstarts/pull/330
- https://github.com/kiegroup/kogito-apps/pull/1331
- https://github.com/kiegroup/kogito-examples/pull/1245