### PR TITLE
[DROOLS-6596] Negative BigDecimalLiteral in mvel dialect causes Class…

### DIFF
--- a/drools-model/drools-model-compiler/src/test/java/org/drools/modelcompiler/bigdecimaltest/BigDecimalTest.java
+++ b/drools-model/drools-model-compiler/src/test/java/org/drools/modelcompiler/bigdecimaltest/BigDecimalTest.java
@@ -1,3 +1,20 @@
+/*
+ * Copyright 2018 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ *
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.drools.modelcompiler.bigdecimaltest;
 
 import java.math.BigDecimal;
@@ -365,6 +382,10 @@ public class BigDecimalTest extends BaseModelTest {
         private BigDecimal bd1;
         private BigDecimal bd2;
 
+        public BdHolder() {
+            super();
+        }
+
         public BdHolder(BigDecimal bd1, BigDecimal bd2) {
             super();
             this.bd1 = bd1;
@@ -458,5 +479,47 @@ public class BigDecimalTest extends BaseModelTest {
         ksession.insert(holder);
 
         assertEquals(1, ksession.fireAllRules());
+    }
+
+    @Test
+    public void testBigDecimalLiteralLhsNegative() {
+        // DROOLS-6596
+        String str =
+                "package org.drools.modelcompiler.bigdecimals\n" +
+                     "import " + BdHolder.class.getCanonicalName() + ";\n" +
+                     "rule R1 dialect \"mvel\" when\n" +
+                     "    $holder : BdHolder(bd1 > -10.5B)\n" +
+                     "then\n" +
+                     "end";
+
+        KieSession ksession = getKieSession(str);
+
+        BdHolder holder = new BdHolder();
+        holder.setBd1(new BigDecimal("10"));
+        ksession.insert(holder);
+        int fired = ksession.fireAllRules();
+
+        assertEquals(1, fired);
+    }
+
+    @Test
+    public void testBigDecimalLiteralRhsNegative() {
+        // DROOLS-6596
+        String str =
+                "package org.drools.modelcompiler.bigdecimals\n" +
+                     "import " + BdHolder.class.getCanonicalName() + ";\n" +
+                     "rule R1 dialect \"mvel\" when\n" +
+                     "    $holder : BdHolder()\n" +
+                     "then\n" +
+                     "    $holder.bd1 = -10.5B;\n" +
+                     "end";
+
+        KieSession ksession = getKieSession(str);
+
+        BdHolder holder = new BdHolder();
+        ksession.insert(holder);
+        ksession.fireAllRules();
+
+        assertEquals(new BigDecimal("-10.5"), holder.getBd1());
     }
 }

--- a/drools-model/drools-model-compiler/src/test/java/org/drools/modelcompiler/bigintegertest/BigIntegerTest.java
+++ b/drools-model/drools-model-compiler/src/test/java/org/drools/modelcompiler/bigintegertest/BigIntegerTest.java
@@ -1,0 +1,107 @@
+/*
+ * Copyright 2022 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ *
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.drools.modelcompiler.bigintegertest;
+
+import java.math.BigInteger;
+
+import org.drools.modelcompiler.BaseModelTest;
+import org.junit.Test;
+import org.kie.api.runtime.KieSession;
+
+import static org.junit.Assert.assertEquals;
+
+public class BigIntegerTest extends BaseModelTest {
+
+    public BigIntegerTest(RUN_TYPE testRunType) {
+        super(testRunType);
+    }
+
+    public static class BiHolder {
+
+        private BigInteger bi1;
+        private BigInteger bi2;
+
+        public BiHolder() {
+            super();
+        }
+
+        public BiHolder(BigInteger bi1, BigInteger bi2) {
+            super();
+            this.bi1 = bi1;
+            this.bi2 = bi2;
+        }
+
+        public BigInteger getBi1() {
+            return bi1;
+        }
+
+        public void setBi1(BigInteger bi1) {
+            this.bi1 = bi1;
+        }
+
+        public BigInteger getBi2() {
+            return bi2;
+        }
+
+        public void setBi2(BigInteger bi2) {
+            this.bi2 = bi2;
+        }
+    }
+
+    @Test
+    public void testBigIntegerLiteralLhsNegative() {
+        // DROOLS-6596
+        String str =
+                "package org.drools.modelcompiler.bigintegerss\n" +
+                     "import " + BiHolder.class.getCanonicalName() + ";\n" +
+                     "rule R1 dialect \"mvel\" when\n" +
+                     "    $holder : BiHolder(bi1 > -10I)\n" +
+                     "then\n" +
+                     "end";
+
+        KieSession ksession = getKieSession(str);
+
+        BiHolder holder = new BiHolder();
+        holder.setBi1(new BigInteger("10"));
+        ksession.insert(holder);
+        int fired = ksession.fireAllRules();
+
+        assertEquals(1, fired);
+    }
+
+    @Test
+    public void testBigIntegerLiteralRhsNegative() {
+        // DROOLS-6596
+        String str =
+                "package org.drools.modelcompiler.bigdecimals\n" +
+                     "import " + BiHolder.class.getCanonicalName() + ";\n" +
+                     "rule R1 dialect \"mvel\" when\n" +
+                     "    $holder : BiHolder()\n" +
+                     "then\n" +
+                     "    $holder.bi1 = -10I;\n" +
+                     "end";
+
+        KieSession ksession = getKieSession(str);
+
+        BiHolder holder = new BiHolder();
+        ksession.insert(holder);
+        ksession.fireAllRules();
+
+        assertEquals(new BigInteger("-10"), holder.getBi1());
+    }
+}

--- a/drools-model/drools-mvel-compiler/src/main/java/org/drools/mvelcompiler/RHSPhase.java
+++ b/drools-model/drools-mvel-compiler/src/main/java/org/drools/mvelcompiler/RHSPhase.java
@@ -43,6 +43,7 @@ import com.github.javaparser.ast.expr.PatternExpr;
 import com.github.javaparser.ast.expr.SimpleName;
 import com.github.javaparser.ast.expr.StringLiteralExpr;
 import com.github.javaparser.ast.expr.TextBlockLiteralExpr;
+import com.github.javaparser.ast.expr.UnaryExpr;
 import com.github.javaparser.ast.expr.VariableDeclarationExpr;
 import com.github.javaparser.ast.stmt.ExpressionStmt;
 import com.github.javaparser.ast.stmt.YieldStmt;
@@ -364,6 +365,19 @@ public class RHSPhase implements DrlGenericVisitor<TypedExpression, RHSPhase.Con
     @Override
     public TypedExpression visit(BigIntegerLiteralExpr n, Context arg) {
         return new BigIntegerConvertedExprT(new StringLiteralExpressionT(new StringLiteralExpr(n.getValue())));
+    }
+
+    @Override
+    public TypedExpression visit(UnaryExpr n, Context arg) {
+        Expression innerExpr = n.getExpression();
+        UnaryExpr.Operator operator = n.getOperator();
+        if (innerExpr instanceof BigDecimalLiteralExpr && operator == UnaryExpr.Operator.MINUS) {
+            return new BigDecimalConvertedExprT(new StringLiteralExpressionT(new StringLiteralExpr(operator.asString() + ((BigDecimalLiteralExpr) innerExpr).getValue())));
+        } else if (innerExpr instanceof BigIntegerLiteralExpr && operator == UnaryExpr.Operator.MINUS) {
+            return new BigIntegerConvertedExprT(new StringLiteralExpressionT(new StringLiteralExpr(operator.asString() + ((BigIntegerLiteralExpr) innerExpr).getValue())));
+        } else {
+            return defaultMethod(n, arg);
+        }
     }
 
     private Class<?> resolveType(com.github.javaparser.ast.type.Type type) {

--- a/drools-model/drools-mvel-compiler/src/test/java/org/drools/mvelcompiler/MvelCompilerTest.java
+++ b/drools-model/drools-mvel-compiler/src/test/java/org/drools/mvelcompiler/MvelCompilerTest.java
@@ -354,6 +354,14 @@ public class MvelCompilerTest implements CompilerTest {
     }
 
     @Test
+    public void testSetterBigDecimalLiteralModifyNegative() {
+        test(ctx -> ctx.addDeclaration("$p", Person.class),
+             "{ modify ( $p )  { salary = -50000B }; }",
+             "{ { $p.setSalary(new java.math.BigDecimal(\"-50000\")); } }",
+             result -> assertThat(allUsedBindings(result)).containsExactlyInAnyOrder("$p"));
+    }
+
+    @Test
     public void testBigDecimalModulo() {
         test(ctx -> ctx.addDeclaration("$b1", BigDecimal.class),
              "{ java.math.BigDecimal result = $b1 % 2; }",


### PR DESCRIPTION
…CastException (#4351)

**Ports**

forward-port PR of https://github.com/kiegroup/drools/pull/4351

**JIRA**:
https://issues.redhat.com/browse/DROOLS-6596

<details>
<summary>
How to replicate CI configuration locally?
</summary>

Build Chain tool does "simple" maven build(s), the builds are just Maven commands, but because the repositories relates and depends on each other and any change in API or class method could affect several of those repositories there is a need to use [build-chain tool](https://github.com/kiegroup/github-action-build-chain) to handle cross repository builds and be sure that we always use latest version of the code for each repository.
 
[build-chain tool](https://github.com/kiegroup/github-action-build-chain) is a build tool which can be used on command line locally or in Github Actions workflow(s), in case you need to change multiple repositories and send multiple dependent pull requests related with a change you can easily reproduce the same build by executing it on Github hosted environment or locally in your development environment. See [local execution](https://github.com/kiegroup/github-action-build-chain#local-execution) details to get more information about it.
</details>

<details>
<summary>
How to retest this PR or trigger a specific build:
</summary>

- for <b>pull request checks</b>  
  Please add comment: <b>Jenkins retest this</b>

- for a <b>specific pull request check</b>  
  Please add comment: <b>Jenkins (re)run [drools|kogito-runtimes|optaplanner|kogito-apps|kogito-examples|optaplanner-quickstarts|optaweb-employee-rostering|optaweb-vehicle-routing] tests</b>

- for a <b>full downstream build</b> 
  - for <b>jenkins</b> job: please add comment: <b>Jenkins run fdb</b>
  - for <b>github actions</b> job: add the label `run_fdb`

- <b>a compile downstream build</b> please  add comment: <b>Jenkins run cdb</b>

- <b>a full production downstream build</b> please add comment: <b>Jenkins execute product fdb</b>

- <b>an upstream build</b> please add comment: <b>Jenkins run upstream</b>

- for <b>quarkus branch checks</b>  
  Run checks against Quarkus current used branch  
  Please add comment: <b>Jenkins run quarkus-branch</b>

- for a <b>quarkus branch specific check</b>  
  Run checks against Quarkus current used branch  
  Please add comment: <b>Jenkins (re)run [drools|kogito-runtimes|optaplanner|kogito-apps|kogito-examples|optaplanner-quickstarts|optaweb-employee-rostering|optaweb-vehicle-routing] quarkus-branch</b>

- for <b>quarkus main checks</b>  
  Run checks against Quarkus main branch  
  Please add comment: <b>Jenkins run quarkus-main</b>

- for a <b>specific quarkus main check</b>  
  Run checks against Quarkus main branch  
  Please add comment: <b>Jenkins (re)run [drools|kogito-runtimes|optaplanner|kogito-apps|kogito-examples|optaplanner-quickstarts|optaweb-employee-rostering|optaweb-vehicle-routing] quarkus-branch</b>

- for <b>native checks</b>  
  Run native checks  
  Please add comment: <b>Jenkins run native</b>

- for a <b>specific native check</b>  
  Run native checks 
  Please add comment: <b>Jenkins (re)run [drools|kogito-runtimes|optaplanner|kogito-apps|kogito-examples|optaplanner-quickstarts|optaweb-employee-rostering|optaweb-vehicle-routing] native</b>

- for <b>mandrel checks</b>  
  Run native checks against Mandrel image
  Please add comment: <b>Jenkins run mandrel</b>

- for a <b>specific mandrel check</b>  
  Run native checks against Mandrel image  
  Please add comment: <b>Jenkins (re)run [drools|kogito-runtimes|optaplanner|kogito-apps|kogito-examples|optaplanner-quickstarts|optaweb-employee-rostering|optaweb-vehicle-routing] mandrel</b>
</details>
