### PR TITLE
[DROOLS-6920] Fails to parse a constraint connected with OR with a bi…

### DIFF
--- a/drools-model/drools-model-compiler/src/main/java/org/drools/modelcompiler/builder/generator/drlxparse/ConstraintParser.java
+++ b/drools-model/drools-model-compiler/src/main/java/org/drools/modelcompiler/builder/generator/drlxparse/ConstraintParser.java
@@ -96,6 +96,7 @@ import static org.drools.modelcompiler.builder.generator.drlxparse.MultipleDrlxP
 import static org.drools.modelcompiler.builder.generator.drlxparse.SpecialComparisonCase.specialComparisonFactory;
 import static org.drools.modelcompiler.builder.generator.expressiontyper.FlattenScope.transformFullyQualifiedInlineCastExpr;
 import static org.drools.mvel.parser.printer.PrintUtil.printNode;
+import static org.drools.mvel.parser.utils.AstUtils.isLogicalOperator;
 
 /**
  * Parses the MVEL String Constraint and compiles it to a Java Expression
@@ -640,7 +641,7 @@ public class ConstraintParser {
 
     private boolean isMultipleResult(DrlxParseResult leftResult, BinaryExpr.Operator operator, DrlxParseResult rightResult) {
         return leftResult.isSuccess() && rightResult.isSuccess() && (
-                (operator == AND && (((DrlxParseSuccess) leftResult).getExprBinding() != null || ((DrlxParseSuccess) rightResult).getExprBinding() != null)) ||
+                (isLogicalOperator(operator) && (((DrlxParseSuccess) leftResult).getExprBinding() != null || ((DrlxParseSuccess) rightResult).getExprBinding() != null)) ||
                 ((DrlxParseSuccess) leftResult).isTemporal() || ((DrlxParseSuccess) rightResult).isTemporal()
         );
     }
@@ -674,10 +675,6 @@ public class ConstraintParser {
 
     private boolean isCombinable( BinaryExpr binaryExpr ) {
         return !(binaryExpr.getRight() instanceof HalfBinaryExpr) && ( !(binaryExpr.getRight() instanceof HalfPointFreeExpr) || binaryExpr.getLeft() instanceof PointFreeExpr );
-    }
-
-    private static boolean isLogicalOperator( BinaryExpr.Operator operator ) {
-        return operator == BinaryExpr.Operator.AND || operator == BinaryExpr.Operator.OR;
     }
 
     private static PointFreeExpr completeHalfExpr(Expression left, HalfPointFreeExpr halfRight) {

--- a/drools-model/drools-mvel-parser/src/main/javacc/mvel.jj
+++ b/drools-model/drools-mvel-parser/src/main/javacc/mvel.jj
@@ -6279,7 +6279,7 @@ DrlxExpression DrlxExpression():
   |
   expr = Expression() { ret = new DrlxExpression(decl, expr); }
   )
-  ( ":" right = Expression() { ret = parseBindingAfterAnd(range(ret, token()), ret, right); } )*
+  ( ":" right = Expression() { ret = parseBindingAfterAndOr(range(ret, token()), ret, right); } )*
   { return ret; }
 }
 

--- a/drools-model/drools-mvel-parser/src/test/java/org/drools/mvel/parser/DroolsMvelParserTest.java
+++ b/drools-model/drools-mvel-parser/src/test/java/org/drools/mvel/parser/DroolsMvelParserTest.java
@@ -1310,4 +1310,82 @@ public class DroolsMvelParserTest {
         assertEquals("null", toString(binaryExpr.getRight()));
         assertEquals(Operator.NOT_EQUALS, binaryExpr.getOperator());
     }
+
+    @Test
+    public void testBindingOnRightWithOr() {
+        String expr = "$n : name == \"Mario\" || $a : age > 20";
+
+        DrlxExpression drlxExpression = parseExpression(parser, expr);
+        Expression bExpr = drlxExpression.getExpr();
+        assertTrue(bExpr instanceof BinaryExpr);
+        assertTrue(((BinaryExpr) bExpr).getOperator() == BinaryExpr.Operator.OR);
+
+        Node left = ((BinaryExpr) bExpr).getLeft();
+        assertTrue(left instanceof DrlxExpression);
+        DrlxExpression leftExpr = (DrlxExpression) left;
+
+        SimpleName leftBind = leftExpr.getBind();
+        assertEquals("$n", leftBind.asString());
+
+        Expression expression = leftExpr.getExpr();
+        BinaryExpr binaryExpr = ((BinaryExpr) expression);
+        assertEquals("name", toString(binaryExpr.getLeft()));
+        assertEquals("\"Mario\"", toString(binaryExpr.getRight()));
+        assertEquals(Operator.EQUALS, binaryExpr.getOperator());
+
+        Node right = ((BinaryExpr) bExpr).getRight();
+        assertTrue(right instanceof DrlxExpression);
+        DrlxExpression rightExpr = (DrlxExpression) right;
+
+        SimpleName rightBind = rightExpr.getBind();
+        assertEquals("$a", rightBind.asString());
+
+        BinaryExpr binaryExpr2 = ((BinaryExpr) rightExpr.getExpr());
+        assertEquals("age", toString(binaryExpr2.getLeft()));
+        assertEquals("20", toString(binaryExpr2.getRight()));
+        assertEquals(Operator.GREATER, binaryExpr2.getOperator());
+    }
+
+    @Test
+    public void test3BindingOn3ConditionsWithOrAnd() {
+        String expr = "$n : name == \"Mario\" || $a : age > 20 && $l : likes != null";
+
+        DrlxExpression drlxExpression = parseExpression(parser, expr);
+        Expression bExpr = drlxExpression.getExpr();
+        assertTrue(bExpr instanceof BinaryExpr);
+        assertTrue(((BinaryExpr) bExpr).getOperator() == BinaryExpr.Operator.OR);
+
+        Expression left = ((BinaryExpr) bExpr).getLeft();
+        assertTrue(left instanceof DrlxExpression);
+
+        Expression right = ((BinaryExpr) bExpr).getRight();
+        assertTrue(right instanceof BinaryExpr);
+        BinaryExpr rightExpr = (BinaryExpr) right;
+        assertTrue(rightExpr.getOperator() == BinaryExpr.Operator.AND);
+
+        DrlxExpression first = (DrlxExpression) left;
+        DrlxExpression second = (DrlxExpression) rightExpr.getLeft();
+        DrlxExpression third = (DrlxExpression) rightExpr.getRight();
+
+        SimpleName bind = first.getBind();
+        assertEquals("$n", bind.asString());
+        BinaryExpr binaryExpr = ((BinaryExpr) first.getExpr());
+        assertEquals("name", toString(binaryExpr.getLeft()));
+        assertEquals("\"Mario\"", toString(binaryExpr.getRight()));
+        assertEquals(Operator.EQUALS, binaryExpr.getOperator());
+
+        bind = second.getBind();
+        assertEquals("$a", bind.asString());
+        binaryExpr = ((BinaryExpr) second.getExpr());
+        assertEquals("age", toString(binaryExpr.getLeft()));
+        assertEquals("20", toString(binaryExpr.getRight()));
+        assertEquals(Operator.GREATER, binaryExpr.getOperator());
+
+        bind = third.getBind();
+        assertEquals("$l", bind.asString());
+        binaryExpr = ((BinaryExpr) third.getExpr());
+        assertEquals("likes", toString(binaryExpr.getLeft()));
+        assertEquals("null", toString(binaryExpr.getRight()));
+        assertEquals(Operator.NOT_EQUALS, binaryExpr.getOperator());
+    }
 }


### PR DESCRIPTION
…… (#4341)

* [DROOLS-6920] Fails to parse a constraint connected with OR with a bind variable on right side in executable-model

* - Additional test


**Ports** 
Forward-port of https://github.com/kiegroup/drools/pull/4341

**JIRA**: 
https://issues.redhat.com/browse/DROOLS-6920


<details>
<summary>
How to replicate CI configuration locally?
</summary>

Build Chain tool does "simple" maven build(s), the builds are just Maven commands, but because the repositories relates and depends on each other and any change in API or class method could affect several of those repositories there is a need to use [build-chain tool](https://github.com/kiegroup/github-action-build-chain) to handle cross repository builds and be sure that we always use latest version of the code for each repository.
 
[build-chain tool](https://github.com/kiegroup/github-action-build-chain) is a build tool which can be used on command line locally or in Github Actions workflow(s), in case you need to change multiple repositories and send multiple dependent pull requests related with a change you can easily reproduce the same build by executing it on Github hosted environment or locally in your development environment. See [local execution](https://github.com/kiegroup/github-action-build-chain#local-execution) details to get more information about it.
</details>

<details>
<summary>
How to retest this PR or trigger a specific build:
</summary>

- for <b>pull request checks</b>  
  Please add comment: <b>Jenkins retest this</b>

- for a <b>specific pull request check</b>  
  Please add comment: <b>Jenkins (re)run [drools|kogito-runtimes|optaplanner|kogito-apps|kogito-examples|optaplanner-quickstarts|optaweb-employee-rostering|optaweb-vehicle-routing] tests</b>

- for a <b>full downstream build</b> 
  - for <b>jenkins</b> job: please add comment: <b>Jenkins run fdb</b>
  - for <b>github actions</b> job: add the label `run_fdb`

- <b>a compile downstream build</b> please  add comment: <b>Jenkins run cdb</b>

- <b>a full production downstream build</b> please add comment: <b>Jenkins execute product fdb</b>

- <b>an upstream build</b> please add comment: <b>Jenkins run upstream</b>

- for <b>quarkus branch checks</b>  
  Run checks against Quarkus current used branch  
  Please add comment: <b>Jenkins run quarkus-branch</b>

- for a <b>quarkus branch specific check</b>  
  Run checks against Quarkus current used branch  
  Please add comment: <b>Jenkins (re)run [drools|kogito-runtimes|optaplanner|kogito-apps|kogito-examples|optaplanner-quickstarts|optaweb-employee-rostering|optaweb-vehicle-routing] quarkus-branch</b>

- for <b>quarkus main checks</b>  
  Run checks against Quarkus main branch  
  Please add comment: <b>Jenkins run quarkus-main</b>

- for a <b>specific quarkus main check</b>  
  Run checks against Quarkus main branch  
  Please add comment: <b>Jenkins (re)run [drools|kogito-runtimes|optaplanner|kogito-apps|kogito-examples|optaplanner-quickstarts|optaweb-employee-rostering|optaweb-vehicle-routing] quarkus-branch</b>

- for <b>native checks</b>  
  Run native checks  
  Please add comment: <b>Jenkins run native</b>

- for a <b>specific native check</b>  
  Run native checks 
  Please add comment: <b>Jenkins (re)run [drools|kogito-runtimes|optaplanner|kogito-apps|kogito-examples|optaplanner-quickstarts|optaweb-employee-rostering|optaweb-vehicle-routing] native</b>

- for <b>mandrel checks</b>  
  Run native checks against Mandrel image
  Please add comment: <b>Jenkins run mandrel</b>

- for a <b>specific mandrel check</b>  
  Run native checks against Mandrel image  
  Please add comment: <b>Jenkins (re)run [drools|kogito-runtimes|optaplanner|kogito-apps|kogito-examples|optaplanner-quickstarts|optaweb-employee-rostering|optaweb-vehicle-routing] mandrel</b>
</details>
