### PR TITLE
DROOLS-6943 DMN doc update built-in function DMNv1.4

### DIFF
--- a/kie-dmn/ref-dmn-feel-builtin-functions.adoc
+++ b/kie-dmn/ref-dmn-feel-builtin-functions.adoc
@@ -2601,3 +2601,46 @@ today()
 ----
 --
 // ----------------------------------------------------------------------------
+
+== KIE Extended functions
+
+These functions are provided as extension to the DMN Standard to enable support for several miscellaneous use-cases on top of the Drools DMN Engine.
+
+invoke( namespace, modelName, decisionName, parameters )::
++
+--
+Returns the result of the decision evaluation in the specified DMN model available to the `DMNRuntime` environment the current DMN model is executed in.
+
+This function is _deprecated_ in favour of encouraging the usage of DMN Standard capabilities wherever possible; since DMNv1.2 it shall be possible to use the DMN standard's _Import_ functionality to import Business Knowledge Model (BKM) nodes and Decision Service nodes, in order to be invoked from another model.
+
+.Parameters
+[cols="30%,70%", options="header"]
+|===
+|Parameter
+|Type
+
+|`namespace`
+|`string`
+
+|`modelName`
+|`string`
+
+|`decisionName`
+|`string`
+
+|`parameter`
+|`context`
+|===
+
+.Examples
+[source]
+----
+invoke(
+    "http://namespace_of_model",
+    "my model name",
+    "my decision name",
+    { a:1, b:2 }
+)
+----
+--
+// ----------------------------------------------------------------------------

--- a/kie-dmn/ref-dmn-feel-builtin-functions.adoc
+++ b/kie-dmn/ref-dmn-feel-builtin-functions.adoc
@@ -1305,7 +1305,7 @@ product( n1, n2, ..., nN )
 [source,FEEL]
 ----
 product( [2, 3, 4] ) = 24
-product([]) = null
+product( [] ) = null
 product( 2, 3, 4 ) = 24
 ----
 --

--- a/kie-dmn/ref-dmn-feel-builtin-functions.adoc
+++ b/kie-dmn/ref-dmn-feel-builtin-functions.adoc
@@ -2573,7 +2573,7 @@ For example, when a decision depends on the current date, like deciding the supp
 
 It is important to note that the functions in this section are intended to be side-effect-free, but they are not deterministic and not idempotent from the perspective of an external observer.
 
-As a user you are encouraged to isolate the decision logic that uses these functions in specific DRG elements, such as Decisions.
+As a user, you are encouraged to isolate the decision logic that uses these functions in specific DRG elements, such as Decisions.
 The encapsulation enables them to be overridden with synthetic values during Scenario Testing, that remain constant across executions of the DMN model's test cases.
 
 now()::

--- a/kie-dmn/ref-dmn-feel-builtin-functions.adoc
+++ b/kie-dmn/ref-dmn-feel-builtin-functions.adoc
@@ -2609,7 +2609,7 @@ These functions are provided as extension to the DMN Standard to enable support 
 invoke( namespace, modelName, decisionName, parameters )::
 +
 --
-Returns the result of the decision evaluation in the specified DMN model available to the `DMNRuntime` environment the current DMN model is executed in.
+Returns the result of the decision evaluation in the specified DMN model available to the `DMNRuntime` environment in the current DMN model is executed.
 
 This function is _deprecated_ in favour of encouraging the usage of DMN Standard capabilities wherever possible; since DMNv1.2 it shall be possible to use the DMN standard's _Import_ functionality to import Business Knowledge Model (BKM) nodes and Decision Service nodes, in order to be invoked from another model.
 

--- a/kie-dmn/ref-dmn-feel-builtin-functions.adoc
+++ b/kie-dmn/ref-dmn-feel-builtin-functions.adoc
@@ -2565,3 +2565,39 @@ context merge([{x:1, y:0}, {y:2}]) = {x:1, y:2}
 ----
 --
 // ----------------------------------------------------------------------------
+
+== Miscellaneous functions
+
+These functions provide support utilities for several miscellaneous use-cases.
+For example, when a decision depends on the current date, like deciding the support SLA over the weekends, additional charges for weekend delivery, etc.
+
+It is important to note that the functions in this section are intended to be side-effect-free, but they are not deterministic and not idempotent from the perspective of an external observer.
+
+As a user you are encouraged to isolate the decision logic that uses these functions in specific DRG elements, such as Decisions.
+The encapsulation enables them to be overridden with synthetic values during Scenario Testing, that remain constant across executions of the DMN model's test cases.
+
+now()::
++
+--
+Returns the current `date and time`.
+
+.Examples
+[source]
+----
+now()
+----
+--
+// ----------------------------------------------------------------------------
+
+today()::
++
+--
+Returns the current `date`.
+
+.Examples
+[source]
+----
+today()
+----
+--
+// ----------------------------------------------------------------------------

--- a/kie-dmn/ref-dmn-feel-builtin-functions.adoc
+++ b/kie-dmn/ref-dmn-feel-builtin-functions.adoc
@@ -1964,7 +1964,7 @@ Returns `true` when an element `A` overlaps an element `B` and when the relevant
 a. `overlaps( range1, range2 )`
 
 .Requirements for evaluating to `true`
-a. `( range1.end > range2.start or (range1.end = range2.start and (range1.end included or range2.end included)) ) and ( range1.start < range2.end or (range1.start = range2.end and range1.start included and range2.end included) )`
+a. `( range1.end > range2.start or (range1.end = range2.start and range1.end included and range2.end included) ) and ( range1.start < range2.end or (range1.start = range2.end and range1.start included and range2.end included) )`
 
 .Examples
 [source,FEEL]
@@ -1996,7 +1996,7 @@ Returns `true` when an element `A` overlaps before an element `B` and when the r
 a. `overlaps before( range1 range2 )`
 
 .Requirements for evaluating to `true`
-a. `( range1.start < range2.start or (range1.start = range2.start and range1.start included and range2.start included) ) and ( range1.end > range2.start or (range1.end = range2.start and range1.end included and range2.start included) ) and ( range1.end < range2.end or (range1.end = range2.end and (not(range1.end included) or range2.end included )) )`
+a. `( range1.start < range2.start or (range1.start = range2.start and range1.start included and not(range2.start included)) ) and ( range1.end > range2.start or (range1.end = range2.start and range1.end included and range2.start included) ) and ( range1.end < range2.end or (range1.end = range2.end and (not(range1.end included) or range2.end included )) )`
 
 .Examples
 [source,FEEL]

--- a/kie-dmn/ref-dmn-feel-builtin-functions.adoc
+++ b/kie-dmn/ref-dmn-feel-builtin-functions.adoc
@@ -1305,6 +1305,7 @@ product( n1, n2, ..., nN )
 [source,FEEL]
 ----
 product( [2, 3, 4] ) = 24
+product([]) = null
 product( 2, 3, 4 ) = 24
 ----
 --

--- a/kie-dmn/ref-dmn-feel-builtin-functions.adoc
+++ b/kie-dmn/ref-dmn-feel-builtin-functions.adoc
@@ -1828,6 +1828,7 @@ Returns `true` if both values are the same element in the FEEL semantic domain.
 is( date( "2012-12-25" ), time( "23:00:50" ) ) = false
 is( date( "2012-12-25" ), date( "2012-12-25" ) ) = true
 is( time( "23:00:50z" ), time( "23:00:50" ) ) = false
+is( time( "23:00:50z" ), time( "23:00:50+00:00" ) ) = true
 ----
 --
 // ----------------------------------------------------------------------------

--- a/kie-dmn/ref-dmn-feel-builtin-functions.adoc
+++ b/kie-dmn/ref-dmn-feel-builtin-functions.adoc
@@ -723,6 +723,68 @@ split( "a;b;c;;", ";" ) = ["a","b","c","",""]
 --
 // ----------------------------------------------------------------------------
 
+string join( list, delimiter )::
++
+--
+Returns a string which is composed by joining all the string elements from the list parameter, separated by the delimiter.
+The `delimiter` can be an empty string.
+Null elements in the list parameter are ignored.
+If `list` is empty, the result is the empty string.
+If `delimiter` is null, the string elements are joined without a separator.
+
+.Parameters
+[cols="30%,70%", options="header"]
+|===
+|Parameter
+|Type
+
+|`list`
+|`list` of `string`
+
+|`delimiter`
+|`string`
+|===
+
+.Examples
+[source,FEEL]
+----
+string join(["a","b","c"], "_and_") = "a_and_b_and_c"
+string join(["a","b","c"], "") = "abc"
+string join(["a","b","c"], null) = "abc"
+string join(["a"], "X") = "a"
+string join(["a",null,"c"], "X") = "aXc"
+string join([], "X") = ""
+----
+--
+// ----------------------------------------------------------------------------
+
+string join( list )::
++
+--
+Returns a string which is composed by joining all the string elements from the list parameter.
+Null elements in the `list` parameter are ignored.
+If `list` is empty, the result is the empty string.
+
+.Parameters
+[cols="30%,70%", options="header"]
+|===
+|Parameter
+|Type
+
+|`list`
+|`list` of `string`
+|===
+
+.Examples
+[source,FEEL]
+----
+string join(["a","b","c"]) = "abc"
+string join(["a",null,"c"]) = "ac"
+string join([]) = ""
+----
+--
+// ----------------------------------------------------------------------------
+
 == List functions
 
 The following functions support list operations.

--- a/kie-dmn/ref-dmn-feel-builtin-functions.adoc
+++ b/kie-dmn/ref-dmn-feel-builtin-functions.adoc
@@ -576,6 +576,7 @@ NOTE: This function uses regular expression parameters as defined in https://www
 .Example
 [source,FEEL]
 ----
+replace( "banana", "a", "o" ) = "bonono"
 replace( "abcd", "(ab)|(a)", "[1=$1][2=$2]" ) = "[1=ab][2=]cd"
 ----
 --

--- a/kie-dmn/ref-dmn-feel-builtin-functions.adoc
+++ b/kie-dmn/ref-dmn-feel-builtin-functions.adoc
@@ -2436,3 +2436,132 @@ get entries( {key1 : "value1", key2 : "value2"} ) = [ { key : "key1", value : "v
 ----
 --
 // ----------------------------------------------------------------------------
+
+context( entries )::
++
+--
+Returns a new context that includes all specified entries.
+If a context item contains additional entries beyond the required "key" and "value" entries, the additional entries are ignored.
+If a context item is missing the required "key" and "value" entries, the final result is null.
+See also: get entries() built-in function.
+
+.Parameters
+[cols="30%,70%", options="header"]
+|===
+|Parameter
+|Type
+
+|`entries`
+|`list` of `context` , each item SHALL have two entries having keys named "key" and "value" respectively
+|===
+
+.Examples
+[source,FEEL]
+----
+context([{key:"a", value:1}, {key:"b", value:2}]) = {a:1, b:2}
+context([{key:"a", value:1}, {key:"b", value:2, something: "else"}]) = {a:1, b:2}
+context([{key:"a", value:1}, {key:"b"}]) = null
+----
+--
+// ----------------------------------------------------------------------------
+
+context put( context, key, value )::
++
+--
+Returns a new context that includes the new entry, or overriding the existing value if an entry for the same key already exists in the supplied context parameter.
+A new entry is added as the last entry of the new context.
+If overriding an existing entry, the order of the keys maintains the same order as in the original context.
+
+.Parameters
+[cols="30%,70%", options="header"]
+|===
+|Parameter
+|Type
+
+|`context`
+|`context`
+
+|`key`
+|`string`
+
+|`value`
+|`Any` type
+|===
+
+.Examples
+[source,FEEL]
+----
+context put({x:1}, "y", 2) = {x:1, y:2}
+context put({x:1, y:0}, "y", 2) = {x:1, y:2}
+context put({x:1, y:0, z:0}, "y", 2) = {x:1, y:2, z:0}
+----
+--
+// ----------------------------------------------------------------------------
+
+context put( context, keys, value )::
++
+--
+Returns the composite of nested invocations to `context put()` for each item in `keys` hierarchy in context.
+
+If `keys` is a list of 1 element, this is equivalent to `context put(context, key', value)`, where `key'` is the only element in the list keys.
+
+If `keys` is a list of 2 or more elements, this is equivalent of calling `context put(context, key', value')`, with: +
+`key'` is the head element in the list keys, +
+`value'` is the result of invocation of `context put(context', keys', value)`, where: +
+`context'` is the result of `context.key'`, +
+`keys'` is the remainder of the list keys without the head element `key'`.
+
+If `keys` is an empty list or null, the result is null.
+
+.Parameters
+[cols="30%,70%", options="header"]
+|===
+|Parameter
+|Type
+
+|`context`
+|`context`
+
+|`keys`
+|`list` of `string`
+
+|`value`
+|`Any` type
+|===
+
+.Examples
+[source,FEEL]
+----
+context put({x:1}, ["y"], 2) = context put({x:1}, "y", 2)
+context put({x:1}, ["y"], 2) = {x:1, y:2}
+context put({x:1, y: {a: 0} }, ["y", "a"], 2) = context put({x:1, y: {a: 0} }, "y", context put({a: 0}, ["a"], 2))
+context put({x:1, y: {a: 0} }, ["y", "a"], 2) = {x:1, y: {a: 2} }
+context put({x:1, y: {a: 0} }, [], 2) = null
+----
+--
+// ----------------------------------------------------------------------------
+
+context merge( contexts )::
++
+--
+Returns a new context that includes all entries from the given contexts; if some of the keys are equal, the entries are overriden.
+The entries are overridden in the same order as specified by the supplied parameter, with new entries added as the last entry in the new context.
+
+.Parameters
+[cols="30%,70%", options="header"]
+|===
+|Parameter
+|Type
+
+|`contexts`
+|`list` of `context`
+|===
+
+.Examples
+[source,FEEL]
+----
+context merge([{x:1}, {y:2}]) = {x:1, y:2}
+context merge([{x:1, y:0}, {y:2}]) = {x:1, y:2}
+----
+--
+// ----------------------------------------------------------------------------

--- a/kie-dmn/ref-dmn-feel-builtin-functions.adoc
+++ b/kie-dmn/ref-dmn-feel-builtin-functions.adoc
@@ -1443,7 +1443,8 @@ decimal( 1.065, 2 ) = 1.06
 floor( n )::
 +
 --
-Returns the greatest integer that is less than or equal to the specified number.
+Returns `n` with given scale and rounding mode _flooring_.
+If at least one of `n` or `scale` is null, the result is null.
 
 .Parameters
 [cols="30%,70%", options="header"]
@@ -1455,10 +1456,16 @@ Returns the greatest integer that is less than or equal to the specified number.
 |`number`
 |===
 
+.Alternative signature
+----
+floor( n, scale )
+----
+
 .Examples
 [source,FEEL]
 ----
 floor( 1.5 ) = 1
+floor( -1.56, 1 ) = -1.6
 floor( -1.5 ) = -2
 ----
 --
@@ -1467,7 +1474,8 @@ floor( -1.5 ) = -2
 ceiling( n )::
 +
 --
-Returns the smallest integer that is greater than or equal to the specified number.
+Returns `n` with given scale and rounding mode _ceiling_.
+If at least one of `n` or `scale` is null, the result is null.
 
 .Parameters
 [cols="30%,70%", options="header"]
@@ -1479,11 +1487,137 @@ Returns the smallest integer that is greater than or equal to the specified numb
 |`number`
 |===
 
+.Alternative signature
+----
+ceiling( n, scale )
+----
+
 .Examples
 [source,FEEL]
 ----
 ceiling( 1.5 ) = 2
+ceiling( -1.56, 1 ) = -1.5
 ceiling( -1.5 ) = -1
+----
+--
+// ----------------------------------------------------------------------------
+
+round up( n, scale )::
++
+--
+Returns `n` with given scale and rounding mode _round up_.
+If at least one of `n` or `scale` is null, the result is null.
+
+.Parameters
+[cols="30%,70%", options="header"]
+|===
+|Parameter
+|Type
+
+|`n`
+|`number`
+
+|`scale`
+|`number`
+|===
+
+.Examples
+[source,FEEL]
+----
+round up( 5.5, 0 ) = 6 
+round up( -5.5, 0 ) = -6 
+round up( 1.121, 2 ) = 1.13
+round up( -1.126, 2 ) = -1.13
+----
+--
+// ----------------------------------------------------------------------------
+
+round down( n, scale )::
++
+--
+Returns `n` with given scale and rounding mode _round down_.
+If at least one of `n` or `scale` is null, the result is null.
+
+.Parameters
+[cols="30%,70%", options="header"]
+|===
+|Parameter
+|Type
+
+|`n`
+|`number`
+
+|`scale`
+|`number`
+|===
+
+.Examples
+[source,FEEL]
+----
+round down( 5.5, 0 ) = 5 
+round down( -5.5, 0 ) = -5 
+round down( 1.121, 2 ) = 1.12
+round down( -1.126, 2 ) = -1.12
+----
+--
+// ----------------------------------------------------------------------------
+
+round half up( n, scale )::
++
+--
+Returns `n` with given scale and rounding mode _round half up_.
+If at least one of `n` or `scale` is null, the result is null.
+
+.Parameters
+[cols="30%,70%", options="header"]
+|===
+|Parameter
+|Type
+
+|`n`
+|`number`
+
+|`scale`
+|`number`
+|===
+
+.Examples
+[source,FEEL]
+----
+round half up( 5.5, 0 ) = 6 
+round half up( -5.5, 0 ) = -6 
+round half up( 1.121, 2 ) = 1.12
+round half up( -1.126, 2 ) = -1.13
+----
+--
+// ----------------------------------------------------------------------------
+
+round half down( n, scale )::
++
+--
+Returns `n` with given scale and rounding mode _round half down_.
+If at least one of `n` or `scale` is null, the result is null.
+
+.Parameters
+[cols="30%,70%", options="header"]
+|===
+|Parameter
+|Type
+
+|`n`
+|`number`
+
+|`scale`
+|`number`
+|===
+
+.Examples
+[source,FEEL]
+----
+round half down( 5.5, 0 ) = 5 
+round half down( -5.5, 0 ) = -5 
+round half down( 1.121, 2 ) = 1.12
+round half down( -1.126, 2 ) = -1.13
 ----
 --
 // ----------------------------------------------------------------------------

--- a/kie-dmn/ref-dmn-feel-builtin-functions.adoc
+++ b/kie-dmn/ref-dmn-feel-builtin-functions.adoc
@@ -2611,7 +2611,7 @@ invoke( namespace, modelName, decisionName, parameters )::
 --
 Returns the result of the decision evaluation in the specified DMN model available to the `DMNRuntime` environment in the current DMN model is executed.
 
-This function is _deprecated_ in favour of encouraging the usage of DMN Standard capabilities wherever possible; since DMNv1.2 it shall be possible to use the DMN standard's _Import_ functionality to import Business Knowledge Model (BKM) nodes and Decision Service nodes, in order to be invoked from another model.
+This function is _deprecated_ in favor of encouraging the usage of DMN Standard capabilities wherever possible; since DMNv1.2 it shall be possible to use the DMN standard's _Import_ functionality to import Business Knowledge Model (BKM) nodes and Decision Service nodes, to be invoked from another model.
 
 .Parameters
 [cols="30%,70%", options="header"]


### PR DESCRIPTION
@kaldesai before I go and sync this very same file inside of kie-docs repo, can we kindly agree on the changes on this first PR, here. Once this is merged I will update the kie-docs repo file copy as usual.

**JIRA**: https://issues.redhat.com/browse/DROOLS-6943

**referenced Pull Requests**: none

<details>
<summary>
How to replicate CI configuration locally?
</summary>

Build Chain tool does "simple" maven build(s), the builds are just Maven commands, but because the repositories relates and depends on each other and any change in API or class method could affect several of those repositories there is a need to use [build-chain tool](https://github.com/kiegroup/github-action-build-chain) to handle cross repository builds and be sure that we always use latest version of the code for each repository.
 
[build-chain tool](https://github.com/kiegroup/github-action-build-chain) is a build tool which can be used on command line locally or in Github Actions workflow(s), in case you need to change multiple repositories and send multiple dependent pull requests related with a change you can easily reproduce the same build by executing it on Github hosted environment or locally in your development environment. See [local execution](https://github.com/kiegroup/github-action-build-chain#local-execution) details to get more information about it.
</details>

<details>
<summary>
How to retest this PR or trigger a specific build:
</summary>

- for <b>pull request checks</b>  
  Please add comment: <b>Jenkins retest this</b>

- for a <b>specific pull request check</b>  
  Please add comment: <b>Jenkins (re)run [drools|kogito-runtimes|optaplanner|kogito-apps|kogito-examples|optaplanner-quickstarts|optaweb-employee-rostering|optaweb-vehicle-routing] tests</b>

- for a <b>full downstream build</b> 
  - for <b>jenkins</b> job: please add comment: <b>Jenkins run fdb</b>
  - for <b>github actions</b> job: add the label `run_fdb`

- <b>a compile downstream build</b> please  add comment: <b>Jenkins run cdb</b>

- <b>a full production downstream build</b> please add comment: <b>Jenkins execute product fdb</b>

- <b>an upstream build</b> please add comment: <b>Jenkins run upstream</b>

- for <b>quarkus branch checks</b>  
  Run checks against Quarkus current used branch  
  Please add comment: <b>Jenkins run quarkus-branch</b>

- for a <b>quarkus branch specific check</b>  
  Run checks against Quarkus current used branch  
  Please add comment: <b>Jenkins (re)run [drools|kogito-runtimes|optaplanner|kogito-apps|kogito-examples|optaplanner-quickstarts|optaweb-employee-rostering|optaweb-vehicle-routing] quarkus-branch</b>

- for <b>quarkus main checks</b>  
  Run checks against Quarkus main branch  
  Please add comment: <b>Jenkins run quarkus-main</b>

- for a <b>specific quarkus main check</b>  
  Run checks against Quarkus main branch  
  Please add comment: <b>Jenkins (re)run [drools|kogito-runtimes|optaplanner|kogito-apps|kogito-examples|optaplanner-quickstarts|optaweb-employee-rostering|optaweb-vehicle-routing] quarkus-branch</b>

- for <b>native checks</b>  
  Run native checks  
  Please add comment: <b>Jenkins run native</b>

- for a <b>specific native check</b>  
  Run native checks 
  Please add comment: <b>Jenkins (re)run [drools|kogito-runtimes|optaplanner|kogito-apps|kogito-examples|optaplanner-quickstarts|optaweb-employee-rostering|optaweb-vehicle-routing] native</b>

- for <b>mandrel checks</b>  
  Run native checks against Mandrel image
  Please add comment: <b>Jenkins run mandrel</b>

- for a <b>specific mandrel check</b>  
  Run native checks against Mandrel image  
  Please add comment: <b>Jenkins (re)run [drools|kogito-runtimes|optaplanner|kogito-apps|kogito-examples|optaplanner-quickstarts|optaweb-employee-rostering|optaweb-vehicle-routing] mandrel</b>
</details>
