### PR TITLE
[7.x][DROOLS-6917] Remove use of hamcrest in drools tests (#4336)

### DIFF
--- a/drools-alphanetwork-compiler/pom.xml
+++ b/drools-alphanetwork-compiler/pom.xml
@@ -44,13 +44,6 @@
       <artifactId>kie-internal</artifactId>
     </dependency>
 
-    <dependency>
-      <groupId>org.hamcrest</groupId>
-      <artifactId>hamcrest-library</artifactId>
-      <scope>test</scope>
-    </dependency>
-
-
     <!-- Logging -->
     <dependency>
       <groupId>org.slf4j</groupId>

--- a/drools-core/src/test/java/org/drools/core/common/ClassAwareObjectStoreTest.java
+++ b/drools-core/src/test/java/org/drools/core/common/ClassAwareObjectStoreTest.java
@@ -14,11 +14,7 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
 
-import static org.hamcrest.CoreMatchers.equalTo;
-import static org.hamcrest.CoreMatchers.hasItem;
-import static org.hamcrest.CoreMatchers.is;
-import static org.hamcrest.CoreMatchers.isA;
-import static org.hamcrest.MatcherAssert.assertThat;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.Assert.assertTrue;
 
 @RunWith(Parameterized.class)
@@ -35,7 +31,7 @@ public class ClassAwareObjectStoreTest {
         insertObjectWithFactHandle(bigDecimalValue);
 
         Collection<Object> result = collect(underTest.iterateObjects());
-        assertThat(result.size(), is(equalTo(2)));
+        assertThat(result).hasSize(2);
     }
 
     @Test
@@ -46,8 +42,8 @@ public class ClassAwareObjectStoreTest {
         insertObjectWithFactHandle(object);
         Collection<Object> results = collect(underTest.iterateObjects(SimpleClass.class));
 
-        assertThat(results.size(), is(equalTo(1)));
-        assertThat(results, hasItem(object));
+        assertThat(results).hasSize(1);
+        assertThat(results).contains(object);
     }
 
     @Test
@@ -57,9 +53,9 @@ public class ClassAwareObjectStoreTest {
 
         Collection<Object> result = collect(underTest.iterateObjects(SuperClass.class));
 
-        assertThat(result.size(), is(equalTo(2)));
-        assertThat(result, hasItem(isA(SubClass.class)));
-        assertThat(result, hasItem(isA(SuperClass.class)));
+        assertThat(result).hasSize(2);
+        assertThat(result).hasAtLeastOneElementOfType(SubClass.class);
+        assertThat(result).hasAtLeastOneElementOfType(SuperClass.class);
     }
 
     @Test
@@ -69,8 +65,8 @@ public class ClassAwareObjectStoreTest {
 
         Collection<Object> result = collect(underTest.iterateObjects(SubClass.class));
 
-        assertThat(result.size(), is(equalTo(1)));
-        assertThat(result, hasItem(isA(SubClass.class)));
+        assertThat(result).hasSize(1);
+        assertThat(result).hasAtLeastOneElementOfType(SubClass.class);
     }
 
     /**
@@ -84,9 +80,9 @@ public class ClassAwareObjectStoreTest {
 
         Collection<Object> result = collect(underTest.iterateObjects(SuperClass.class));
 
-        assertThat(result.size(), is(equalTo(2)));
-        assertThat(result, hasItem(isA(SubClass.class)));
-        assertThat(result, hasItem(isA(SuperClass.class)));
+        assertThat(result).hasSize(2);
+        assertThat(result).hasAtLeastOneElementOfType(SubClass.class);
+        assertThat(result).hasAtLeastOneElementOfType(SuperClass.class);
     }
 
     @Test
@@ -95,8 +91,8 @@ public class ClassAwareObjectStoreTest {
 
         Collection<Object> result = collect(underTest.iterateObjects(SuperClass.class));
 
-        assertThat(result.size(), is(equalTo(1)));
-        assertThat(result, hasItem(isA(SubClass.class)));
+        assertThat(result).hasSize(1);
+        assertThat(result).hasAtLeastOneElementOfType(SubClass.class);
     }
 
     @Test
@@ -107,9 +103,9 @@ public class ClassAwareObjectStoreTest {
 
         Collection<Object> result = collect(underTest.iterateObjects(SuperClass.class));
 
-        assertThat(result.size(), is(equalTo(2)));
+        assertThat(result).hasSize(2);
         // Check there's no duplication of results
-        assertThat(new HashSet<Object>(result).size(), is(equalTo(2)));
+        assertThat(new HashSet<Object>(result)).hasSize(2);
     }
 
     @Test
@@ -122,19 +118,19 @@ public class ClassAwareObjectStoreTest {
 
         Collection<Object> result = collect(underTest.iterateObjects(SuperClass.class));
 
-        assertThat(result.size(), is(equalTo(2)));
+        assertThat(result).hasSize(2);
         // Check there's no duplication of results
-        assertThat(new HashSet<Object>(result).size(), is(equalTo(2)));
+        assertThat(new HashSet<Object>(result)).hasSize(2);
     }
 
     @Test
     public void clearRemovesInsertedObjects() throws Exception {
         insertObjectWithFactHandle(new SimpleClass());
-        assertThat(collect(underTest.iterateObjects()).size(), is(equalTo(1)));
+        assertThat(collect(underTest.iterateObjects())).hasSize(1);
 
         underTest.clear();
 
-        assertThat(collect(underTest.iterateObjects()).size(), is(equalTo(0)));
+        assertThat(collect(underTest.iterateObjects())).hasSize(0);
     }
 
     @Test
@@ -149,8 +145,8 @@ public class ClassAwareObjectStoreTest {
             }
         }));
 
-        assertThat(result.size(), is(equalTo(1)));
-        assertThat(result, hasItem(isA(SubClass.class)));
+        assertThat(result).hasSize(1);
+        assertThat(result).hasAtLeastOneElementOfType(SubClass.class);
     }
 
     @Test
@@ -158,8 +154,8 @@ public class ClassAwareObjectStoreTest {
         insertObjectWithFactHandle(new SuperClass());
         insertObjectWithFactHandle(new SubClass());
 
-        assertThat(collect(underTest.iterateFactHandles(SubClass.class)).size(), is(equalTo(1)));
-        assertThat(collect(underTest.iterateFactHandles(SuperClass.class)).size(), is(equalTo(2)));
+        assertThat(collect(underTest.iterateFactHandles(SubClass.class))).hasSize(1);
+        assertThat(collect(underTest.iterateFactHandles(SuperClass.class))).hasSize(2);
     }
 
 

--- a/drools-core/src/test/java/org/drools/core/time/impl/PseudoClockSchedulerTest.java
+++ b/drools-core/src/test/java/org/drools/core/time/impl/PseudoClockSchedulerTest.java
@@ -26,8 +26,7 @@ import org.drools.core.time.JobHandle;
 import org.drools.core.time.Trigger;
 import org.junit.Test;
 
-import static org.hamcrest.core.Is.is;
-import static org.hamcrest.MatcherAssert.assertThat;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.atLeast;
 import static org.mockito.Mockito.atLeastOnce;
 import static org.mockito.Mockito.mock;
@@ -52,10 +51,10 @@ public class PseudoClockSchedulerTest {
         when( mockTrigger_1.hasNextFireTime() ).thenReturn(triggerTime);
 
         JobHandle jobHandle = scheduler.scheduleJob(mockJob_1, this.mockContext_1, mockTrigger_1);
-        assertThat(scheduler.getTimeToNextJob(), is(triggerTime.getTime()));
+        assertThat(scheduler.getTimeToNextJob()).isEqualTo(triggerTime.getTime());
 
         scheduler.removeJob(jobHandle);
-        assertThat(scheduler.getTimeToNextJob(), is(-1L));
+        assertThat(scheduler.getTimeToNextJob()).isEqualTo(-1L);
         
         verify( mockTrigger_1, atLeastOnce()).hasNextFireTime();
     }
@@ -69,13 +68,13 @@ public class PseudoClockSchedulerTest {
 
         JobHandle jobHandle_1 = scheduler.scheduleJob(mockJob_1, this.mockContext_1, mockTrigger_1);
         JobHandle jobHandle_2 = scheduler.scheduleJob(mockJob_2, this.mockContext_2, mockTrigger_2);
-        assertThat(scheduler.getTimeToNextJob(), is(triggerTime_1.getTime()));
+        assertThat(scheduler.getTimeToNextJob()).isEqualTo(triggerTime_1.getTime());
 
         scheduler.removeJob(jobHandle_1);
-        assertThat(scheduler.getTimeToNextJob(), is(triggerTime_2.getTime()));
+        assertThat(scheduler.getTimeToNextJob()).isEqualTo(triggerTime_2.getTime());
 
         scheduler.removeJob(jobHandle_2);
-        assertThat(scheduler.getTimeToNextJob(), is(-1L));
+        assertThat(scheduler.getTimeToNextJob()).isEqualTo(-1L);
         
         verify( mockTrigger_1, atLeastOnce()).hasNextFireTime();
         verify( mockTrigger_2, atLeastOnce()).hasNextFireTime();
@@ -91,7 +90,7 @@ public class PseudoClockSchedulerTest {
             public void execute(JobContext ctx) {
                 // Even though the clock has been advanced to 5000, the job should run
                 // with the time set its trigger time.
-                assertThat(scheduler.getCurrentTime(), is(1000L));
+                assertThat(scheduler.getCurrentTime()).isEqualTo(1000L);
             }
         };
 
@@ -100,7 +99,7 @@ public class PseudoClockSchedulerTest {
         scheduler.advanceTime(5000, TimeUnit.MILLISECONDS);
 
         // Now, after the job has been executed the time should be what it was advanced to
-        assertThat(scheduler.getCurrentTime(), is(5000L));
+        assertThat(scheduler.getCurrentTime()).isEqualTo(5000L);
         
         verify( mockTrigger_1, atLeast(2) ).hasNextFireTime();
         verify( mockTrigger_1, times(1) ).nextFireTime();
@@ -114,7 +113,7 @@ public class PseudoClockSchedulerTest {
 
         Job job = new Job() {
             public void execute(JobContext ctx) {
-                assertThat(scheduler.getCurrentTime(), is(1000L));
+                assertThat(scheduler.getCurrentTime()).isEqualTo(1000L);
                 throw new RuntimeException("for test");
             }
         };
@@ -124,7 +123,7 @@ public class PseudoClockSchedulerTest {
         scheduler.advanceTime(5000, TimeUnit.MILLISECONDS);
 
         // The time must be advanced correctly even when the job throws an exception
-        assertThat(scheduler.getCurrentTime(), is(5000L));
+        assertThat(scheduler.getCurrentTime()).isEqualTo(5000L);
         verify( mockTrigger_1, atLeast(2) ).hasNextFireTime();
         verify( mockTrigger_1, times(1) ).nextFireTime();
     }

--- a/drools-core/src/test/java/org/drools/core/util/BinaryHeapQueueTest.java
+++ b/drools-core/src/test/java/org/drools/core/util/BinaryHeapQueueTest.java
@@ -15,6 +15,9 @@
 
 package org.drools.core.util;
 
+import java.util.ArrayList;
+import java.util.List;
+
 import org.drools.core.beliefsystem.ModedAssertion;
 import org.drools.core.beliefsystem.simple.SimpleMode;
 import org.drools.core.common.ActivationGroupNode;
@@ -30,16 +33,9 @@ import org.drools.core.spi.Activation;
 import org.drools.core.spi.ConflictResolver;
 import org.drools.core.spi.Consequence;
 import org.drools.core.spi.PropagationContext;
-import org.hamcrest.BaseMatcher;
-import org.hamcrest.Description;
-import org.hamcrest.Matcher;
 import org.junit.Before;
 import org.junit.Test;
 import org.kie.api.runtime.rule.FactHandle;
-
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.List;
 
 import static org.junit.Assert.assertTrue;
 
@@ -207,43 +203,6 @@ public class BinaryHeapQueueTest {
         }
     }
 
-    public static class IsTuple extends BaseMatcher<List<InternalFactHandle>> {
-        private final InternalFactHandle[] expected;
-
-        public IsTuple(List<InternalFactHandle> tupleAsList) {
-            expected = tupleAsList.toArray( new InternalFactHandle[tupleAsList.size()] );
-        }
-
-        public IsTuple(InternalFactHandle[] tuple) {
-            expected = tuple;
-        }
-
-        public boolean matches(Object arg) {
-            if ( arg == null || !(arg.getClass().isArray() && InternalFactHandle.class.isAssignableFrom( arg.getClass().getComponentType() )) ) {
-                return false;
-            }
-            InternalFactHandle[] actual = (InternalFactHandle[]) arg;
-            return Arrays.equals( expected,
-                                  actual );
-        }
-
-        public void describeTo(Description description) {
-            description.appendValue( expected );
-        }
-
-        /**
-         * Is the value equal to another value, as tested by the
-         * {@link java.lang.Object#equals} invokedMethod?
-         */
-        
-        public static Matcher<List<InternalFactHandle>> isTuple(List<InternalFactHandle> operand) {
-            return new IsTuple( operand );
-        }
-
-        public static Matcher< ? super List<InternalFactHandle>> isTuple(InternalFactHandle... operands) {
-            return new IsTuple( operands );
-        }
-    }
 
     public static class Item<T extends ModedAssertion<T>>
             implements

--- a/drools-model/drools-model-compiler/pom.xml
+++ b/drools-model/drools-model-compiler/pom.xml
@@ -103,11 +103,6 @@
       <scope>test</scope>
     </dependency>
     <dependency>
-      <groupId>org.hamcrest</groupId>
-      <artifactId>hamcrest-library</artifactId>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
       <groupId>org.assertj</groupId>
       <artifactId>assertj-core</artifactId>
       <scope>test</scope>

--- a/drools-model/drools-model-compiler/src/test/java/org/drools/modelcompiler/AccumulateTest.java
+++ b/drools-model/drools-model-compiler/src/test/java/org/drools/modelcompiler/AccumulateTest.java
@@ -65,8 +65,6 @@ import org.kie.api.runtime.rule.FactHandle;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.fail;
-import static org.hamcrest.CoreMatchers.hasItem;
-import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
@@ -368,8 +366,8 @@ public class AccumulateTest extends BaseModelTest {
         ksession.fireAllRules();
 
         Collection<Result> results = getObjectsIntoList(ksession, Result.class);
-        assertThat(results, hasItem(new Result(38.5)));
-        assertThat(results, hasItem(new Result(77)));
+        assertThat(results).contains(new Result(38.5));
+        assertThat(results).contains(new Result(77));
     }
 
     @Test
@@ -396,8 +394,8 @@ public class AccumulateTest extends BaseModelTest {
         ksession.fireAllRules();
 
         Collection<Result> results = getObjectsIntoList(ksession, Result.class);
-        assertThat(results, hasItem(new Result(38.5d)));
-        assertThat(results, hasItem(new Result(77)));
+        assertThat(results).contains(new Result(38.5d));
+        assertThat(results).contains(new Result(77));
     }
 
     @Test
@@ -425,8 +423,8 @@ public class AccumulateTest extends BaseModelTest {
         ksession.fireAllRules();
 
         Collection<Result> results = getObjectsIntoList(ksession, Result.class);
-        assertThat(results, hasItem(new Result(37)));
-        assertThat(results, hasItem(new Result(77)));
+        assertThat(results).contains(new Result(37));
+        assertThat(results).contains(new Result(77));
     }
 
     @Test
@@ -451,7 +449,7 @@ public class AccumulateTest extends BaseModelTest {
         ksession.fireAllRules();
 
         Collection<Result> results = getObjectsIntoList(ksession, Result.class);
-        assertThat(results, hasItem(new Result(43)));
+        assertThat(results).contains(new Result(43));
     }
 
     @Test
@@ -586,7 +584,7 @@ public class AccumulateTest extends BaseModelTest {
         ksession.fireAllRules();
 
         Collection<Result> results = getObjectsIntoList(ksession, Result.class);
-        assertThat(results, hasItem(new Result(1)));
+        assertThat(results).contains(new Result(1));
     }
 
     public static class TestFunction implements AccumulateFunction<Serializable> {
@@ -774,7 +772,7 @@ public class AccumulateTest extends BaseModelTest {
 
         List<Integer> results = getObjectsIntoList(ksession, Integer.class);
         assertEquals(1, results.size());
-        assertThat(results, hasItem(112));
+        assertThat(results).contains(112);
 
         if (performReverse) {
             ksession.delete(fh_Mario);
@@ -782,7 +780,7 @@ public class AccumulateTest extends BaseModelTest {
 
             results = getObjectsIntoList(ksession, Integer.class);
             assertEquals(2, results.size());
-            assertThat(results, hasItem(72));
+            assertThat(results).contains(72);
         }
     }
 
@@ -809,14 +807,14 @@ public class AccumulateTest extends BaseModelTest {
 
         List<Integer> results = getObjectsIntoList(ksession, Integer.class);
         assertEquals(1, results.size());
-        assertThat(results, hasItem(38));
+        assertThat(results).contains(38);
 
         ksession.delete(fh_Mario);
         ksession.fireAllRules();
 
         results = getObjectsIntoList(ksession, Integer.class);
         assertEquals(2, results.size());
-        assertThat(results, hasItem(36));
+        assertThat(results).contains(36);
     }
 
     @Test
@@ -843,14 +841,14 @@ public class AccumulateTest extends BaseModelTest {
 
         List<Integer> results = getObjectsIntoList(ksession, Integer.class);
         assertEquals(1, results.size());
-        assertThat(results, hasItem(38 + 14));
+        assertThat(results).contains(38 + 14);
 
         ksession.delete(fh_Mario);
         ksession.fireAllRules();
 
         results = getObjectsIntoList(ksession, Integer.class);
         assertEquals(2, results.size());
-        assertThat(results, hasItem(36 + 14));
+        assertThat(results).contains(36 + 14);
     }
 
 
@@ -876,7 +874,7 @@ public class AccumulateTest extends BaseModelTest {
 
         List<Integer> results = getObjectsIntoList(ksession, Integer.class);
         assertEquals(1, results.size());
-        assertThat(results, hasItem(8));
+        assertThat(results).contains(8);
     }
 
     @Test
@@ -900,7 +898,7 @@ public class AccumulateTest extends BaseModelTest {
 
         List<String> results = getObjectsIntoList(ksession, String.class);
         assertEquals(1, results.size());
-        assertThat(results, hasItem("Milan"));
+        assertThat(results).contains("Milan");
     }
 
     @Test
@@ -928,7 +926,7 @@ public class AccumulateTest extends BaseModelTest {
 
         List<Integer> results = getObjectsIntoList(ksession, Integer.class);
 
-        assertThat(results, hasItem(4));
+        assertThat(results).contains(4);
     }
 
     @Test
@@ -981,7 +979,7 @@ public class AccumulateTest extends BaseModelTest {
 
         List<Integer> results = getObjectsIntoList(ksession, Integer.class);
         assertEquals(1, results.size());
-        assertThat(results, hasItem(112));
+        assertThat(results).contains(112);
 
     }
 
@@ -1007,7 +1005,7 @@ public class AccumulateTest extends BaseModelTest {
 
         List<Integer> results = getObjectsIntoList(ksession, Integer.class);
         assertEquals(1, results.size());
-        assertThat(results, hasItem(112));
+        assertThat(results).contains(112);
 
     }
 
@@ -4020,14 +4018,14 @@ public class AccumulateTest extends BaseModelTest {
 
         List<Integer> results = getObjectsIntoList(ksession, Integer.class);
         assertEquals(1, results.size());
-        assertThat(results, hasItem(38));
+        assertThat(results).contains(38);
 
         ksession.delete(fh_Mario);
         ksession.fireAllRules();
 
         results = getObjectsIntoList(ksession, Integer.class);
         assertEquals(2, results.size());
-        assertThat(results, hasItem(36));
+        assertThat(results).contains(36);
     }
 
     @Test

--- a/drools-model/drools-model-compiler/src/test/java/org/drools/modelcompiler/ChannelTest.java
+++ b/drools-model/drools-model-compiler/src/test/java/org/drools/modelcompiler/ChannelTest.java
@@ -25,8 +25,8 @@ import org.junit.Test;
 import org.kie.api.runtime.Channel;
 import org.kie.api.runtime.KieSession;
 
-import static org.hamcrest.CoreMatchers.hasItem;
-import static org.hamcrest.MatcherAssert.assertThat;
+import static org.assertj.core.api.Assertions.assertThat;
+
 
 public class ChannelTest extends BaseModelTest {
 
@@ -54,7 +54,7 @@ public class ChannelTest extends BaseModelTest {
         ksession.insert(me);
         ksession.fireAllRules();
 
-        assertThat(testChannel.getChannelMessages(), hasItem("Test Message"));
+        assertThat(testChannel.getChannelMessages()).contains("Test Message");
     }
 
     @Test

--- a/drools-model/drools-model-compiler/src/test/java/org/drools/modelcompiler/CompilerTest.java
+++ b/drools-model/drools-model-compiler/src/test/java/org/drools/modelcompiler/CompilerTest.java
@@ -51,8 +51,7 @@ import org.kie.api.runtime.process.ProcessContext;
 import org.kie.api.runtime.rule.FactHandle;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.hamcrest.CoreMatchers.containsString;
-import static org.hamcrest.CoreMatchers.equalTo;
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
@@ -2814,9 +2813,6 @@ public class CompilerTest extends BaseModelTest {
 
     @Test
     public void testNPEOnConstraint() {
-        exceptionRule.expect(RuntimeException.class);
-        exceptionRule.expectMessage(equalTo("Error evaluating constraint 'money < salary * 20' in [Rule \"R\" in r0.drl]"));
-
         String str =
                 "import " + Person.class.getCanonicalName() + ";" +
                         "rule R when\n" +
@@ -2829,14 +2825,12 @@ public class CompilerTest extends BaseModelTest {
         Person me = new Person( "Luca");
         me.setMoney(null);
         ksession.insert( me );
-        ksession.fireAllRules();
-    }
+        assertThatExceptionOfType(RuntimeException.class)
+    		.isThrownBy(() -> ksession.fireAllRules())
+    		.withMessage("Error evaluating constraint 'money < salary * 20' in [Rule \"R\" in r0.drl]");    }
 
     @Test
     public void testSharedPredicateInformation() {
-        exceptionRule.expect(RuntimeException.class);
-        exceptionRule.expectMessage(equalTo("Error evaluating constraint 'money < salary * 20' in [Rule \"R1\", \"R2\" in r0.drl]"));
-
         String str =
                 "import " + Person.class.getCanonicalName() + ";" +
                      "rule R1 when\n" +
@@ -2854,13 +2848,14 @@ public class CompilerTest extends BaseModelTest {
         me.setSalary(null);
         me.setMoney(null);
         ksession.insert(me);
-        ksession.fireAllRules();
+        
+        assertThatExceptionOfType(RuntimeException.class)
+        	.isThrownBy(() -> ksession.fireAllRules())
+        	.withMessage("Error evaluating constraint 'money < salary * 20' in [Rule \"R1\", \"R2\" in r0.drl]");
     }
 
     @Test
     public void testSharedPredicateInformationWithNonSharedRule() {
-        exceptionRule.expect(RuntimeException.class);
-        exceptionRule.expectMessage(equalTo("Error evaluating constraint 'money < salary * 20' in [Rule \"R1\", \"R3\" in r0.drl]"));
 
         String str =
                 "import " + Person.class.getCanonicalName() + ";" +
@@ -2883,13 +2878,15 @@ public class CompilerTest extends BaseModelTest {
         me.setSalary(null);
         me.setMoney(null);
         ksession.insert(me);
-        ksession.fireAllRules();
+        
+        assertThatExceptionOfType(RuntimeException.class)
+    	.isThrownBy(() -> ksession.fireAllRules())
+    	.withMessage("Error evaluating constraint 'money < salary * 20' in [Rule \"R1\", \"R3\" in r0.drl]");
+    	
     }
 
     @Test
     public void testSharedPredicateInformationWithMultipleFiles() {
-        exceptionRule.expect(RuntimeException.class);
-        exceptionRule.expectMessage(equalTo("Error evaluating constraint 'money < salary * 20' in [Rule \"R1\", \"R2\" in r0.drl] [Rule \"R3\", \"R4\" in r1.drl]"));
 
         String str1 =
                 "import " + Person.class.getCanonicalName() + ";" +
@@ -2918,14 +2915,15 @@ public class CompilerTest extends BaseModelTest {
         me.setSalary(null);
         me.setMoney(null);
         ksession.insert(me);
-        ksession.fireAllRules();
+        
+        assertThatExceptionOfType(RuntimeException.class)
+    		.isThrownBy(() -> ksession.fireAllRules())
+    		.withMessage("Error evaluating constraint 'money < salary * 20' in [Rule \"R1\", \"R2\" in r0.drl] [Rule \"R3\", \"R4\" in r1.drl]");   
+        
     }
 
     @Test
     public void testSharedBetaPredicateInformationWithMultipleFiles() {
-        exceptionRule.expect(RuntimeException.class);
-        exceptionRule.expectMessage(equalTo("Error evaluating constraint '$i < salary * 20' in [Rule \"R1\", \"R2\" in r0.drl] [Rule \"R3\", \"R4\" in r1.drl]"));
-
         String str1 =
                 "import " + Person.class.getCanonicalName() + ";" +
                      "rule R1 when\n" +
@@ -2958,15 +2956,14 @@ public class CompilerTest extends BaseModelTest {
         me.setMoney(null);
         ksession.insert(Integer.valueOf(10));
         ksession.insert(me);
-        ksession.fireAllRules();
+
+        assertThatExceptionOfType(RuntimeException.class)
+    		.isThrownBy(() -> ksession.fireAllRules())
+    		.withMessage("Error evaluating constraint '$i < salary * 20' in [Rule \"R1\", \"R2\" in r0.drl] [Rule \"R3\", \"R4\" in r1.drl]");   
     }
 
     @Test
     public void testSharedPredicateInformationExceedMaxRuleDefs() {
-        exceptionRule.expect(RuntimeException.class);
-        exceptionRule.expectMessage(containsString("Error evaluating constraint '$i < salary * 20' in "));
-        exceptionRule.expectMessage(containsString(" and in more rules"));
-
         // shared by 11 rules
         String str1 =
                 "import " + Person.class.getCanonicalName() + ";" +
@@ -3037,7 +3034,12 @@ public class CompilerTest extends BaseModelTest {
         me.setMoney(null);
         ksession.insert(Integer.valueOf(10));
         ksession.insert(me);
-        ksession.fireAllRules();
+        
+        assertThatExceptionOfType(RuntimeException.class)
+    		.isThrownBy(() -> ksession.fireAllRules())
+    		.withMessageContaining("Error evaluating constraint '$i < salary * 20' in ")
+    		.withMessageContaining(" and in more rules");       
+        
     }
 
     @Test

--- a/drools-model/drools-model-compiler/src/test/java/org/drools/modelcompiler/FactTemplateTest.java
+++ b/drools-model/drools-model-compiler/src/test/java/org/drools/modelcompiler/FactTemplateTest.java
@@ -38,21 +38,20 @@ import org.kie.api.KieBase;
 import org.kie.api.runtime.KieSession;
 import org.kie.api.runtime.rule.FactHandle;
 
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.drools.model.DSL.declarationOf;
 import static org.drools.model.DSL.field;
+import static org.drools.model.DSL.on;
 import static org.drools.model.DSL.prototype;
 import static org.drools.model.PatternDSL.alphaIndexedBy;
 import static org.drools.model.PatternDSL.betaIndexedBy;
-import static org.drools.model.PatternDSL.declarationOf;
-import static org.drools.model.PatternDSL.on;
 import static org.drools.model.PatternDSL.pattern;
 import static org.drools.model.PatternDSL.reactOn;
 import static org.drools.model.PatternDSL.rule;
 import static org.drools.modelcompiler.BaseModelTest.getObjectsIntoList;
 import static org.drools.modelcompiler.facttemplate.FactFactory.createMapBasedFact;
-import static org.hamcrest.CoreMatchers.hasItem;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNull;
-import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.Assert.assertTrue;
 
 public class FactTemplateTest {
@@ -89,7 +88,7 @@ public class FactTemplateTest {
         ksession.fireAllRules();
 
         Collection<Result> results = getObjectsIntoList(ksession, Result.class);
-        assertThat(results, hasItem(new Result("Found a 40 years old Mark")));
+        assertThat(results).contains(new Result("Found a 40 years old Mark"));
     }
 
     @Test
@@ -199,7 +198,7 @@ public class FactTemplateTest {
         ksession.fireAllRules();
 
         Collection<Result> results = getObjectsIntoList(ksession, Result.class);
-        assertThat(results, hasItem(new Result("Mario is older than Mark")));
+        assertThat(results).contains(new Result("Mario is older than Mark"));
     }
 
     private boolean hasFactTemplateObjectType( KieSession ksession, String name ) {
@@ -210,5 +209,6 @@ public class FactTemplateTest {
             }
         }
         return false;
+
     }
 }

--- a/drools-model/drools-model-compiler/src/test/java/org/drools/modelcompiler/MapInitializationDrools3800Test.java
+++ b/drools-model/drools-model-compiler/src/test/java/org/drools/modelcompiler/MapInitializationDrools3800Test.java
@@ -6,9 +6,8 @@ import java.util.Objects;
 import org.junit.Test;
 import org.kie.api.runtime.KieSession;
 
-import static org.hamcrest.CoreMatchers.is;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.Assert.assertEquals;
-import static org.hamcrest.MatcherAssert.assertThat;
 
 public class MapInitializationDrools3800Test extends BaseModelTest {
 
@@ -69,7 +68,7 @@ public class MapInitializationDrools3800Test extends BaseModelTest {
 
         ksession.fireAllRules();
 
-        assertThat(fact.getResult(), is("OK"));
+        assertThat(fact.getResult()).isEqualTo("OK");
     }
 
     @Test
@@ -99,6 +98,6 @@ public class MapInitializationDrools3800Test extends BaseModelTest {
 
         assertEquals(1, ksession.fireAllRules(3));
 
-        assertThat(fact.getResult(), is("OK"));
+        assertThat(fact.getResult()).isEqualTo("OK");
     }
 }

--- a/drools-model/drools-model-compiler/src/test/java/org/drools/modelcompiler/PatternDSLTest.java
+++ b/drools-model/drools-model-compiler/src/test/java/org/drools/modelcompiler/PatternDSLTest.java
@@ -90,8 +90,6 @@ import static org.drools.model.PatternDSL.reactOn;
 import static org.drools.model.PatternDSL.rule;
 import static org.drools.model.PatternDSL.when;
 import static org.drools.modelcompiler.BaseModelTest.getObjectsIntoList;
-import static org.hamcrest.CoreMatchers.hasItem;
-import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertSame;
@@ -352,7 +350,7 @@ public class PatternDSLTest {
         ksession.fireAllRules();
 
         Collection<Result> results = getObjectsIntoList(ksession, Result.class);
-        assertThat(results, hasItem(new Result(49)));
+        assertThat(results).contains(new Result(49));
     }
 
     @Test

--- a/drools-model/drools-model-compiler/src/test/java/org/drools/modelcompiler/builder/generator/declaredtype/generator/GeneratedClassDeclarationTest.java
+++ b/drools-model/drools-model-compiler/src/test/java/org/drools/modelcompiler/builder/generator/declaredtype/generator/GeneratedClassDeclarationTest.java
@@ -23,11 +23,9 @@ import com.github.javaparser.ast.body.ClassOrInterfaceDeclaration;
 import org.drools.modelcompiler.builder.generator.declaredtype.api.FieldDefinition;
 import org.drools.modelcompiler.builder.generator.declaredtype.api.MethodDefinition;
 import org.drools.modelcompiler.builder.generator.declaredtype.api.TypeDefinition;
-import org.hamcrest.MatcherAssert;
 import org.junit.Test;
 
-import static org.hamcrest.Matchers.equalTo;
-import static org.hamcrest.Matchers.equalToIgnoringWhiteSpace;
+import static org.assertj.core.api.Assertions.assertThat;
 
 public class GeneratedClassDeclarationTest {
 
@@ -201,9 +199,9 @@ public class GeneratedClassDeclarationTest {
     // TODO DT-ANC remove duplication
     void verifyBodyWithBetterDiff(Object expected, Object actual) {
         try {
-            MatcherAssert.assertThat(actual.toString(), equalToIgnoringWhiteSpace(expected.toString()));
+            assertThat(actual).asString().isEqualToIgnoringWhitespace(expected.toString());
         } catch (AssertionError e) {
-            MatcherAssert.assertThat(actual, equalTo(expected));
+            assertThat(actual).isEqualTo(expected);
         }
     }
 }

--- a/drools-model/drools-model-compiler/src/test/java/org/drools/modelcompiler/util/lambdareplace/MaterializedLambdaTestUtils.java
+++ b/drools-model/drools-model-compiler/src/test/java/org/drools/modelcompiler/util/lambdareplace/MaterializedLambdaTestUtils.java
@@ -18,11 +18,8 @@ package org.drools.modelcompiler.util.lambdareplace;
 
 import com.github.javaparser.StaticJavaParser;
 import com.github.javaparser.ast.body.MethodDeclaration;
-import org.hamcrest.MatcherAssert;
 
-import static org.hamcrest.Matchers.equalTo;
-import static org.hamcrest.Matchers.equalToIgnoringWhiteSpace;
-import static org.junit.Assert.assertEquals;
+import static org.assertj.core.api.Assertions.assertThat;
 
 /* The diff produced while using equalToIgnoringWhiteSpace is abysmal but is correct, while the one
  * produced by JavaParser's equals is better but it fails also on identical ASTs.
@@ -33,17 +30,17 @@ public class MaterializedLambdaTestUtils {
 
     public static void verifyCreatedClass(CreatedClass aClass, String expectedResult) {
         try {
-            MatcherAssert.assertThat(aClass.getCompilationUnitAsString(), equalToIgnoringWhiteSpace(expectedResult));
+            assertThat(aClass.getCompilationUnitAsString()).isEqualToIgnoringWhitespace(expectedResult);
         } catch (AssertionError e) {
-            assertEquals(StaticJavaParser.parse(expectedResult), aClass.getCompilationUnit());
+        	assertThat(StaticJavaParser.parse(expectedResult)).isEqualTo(aClass.getCompilationUnit());
         }
     }
 
     public static void verifyCreatedClass(MethodDeclaration expected, MethodDeclaration actual) {
         try {
-            MatcherAssert.assertThat(actual.toString(), equalToIgnoringWhiteSpace(expected.toString()));
+        	assertThat(actual).asString().isEqualToIgnoringWhitespace(expected.toString());
         } catch (AssertionError e) {
-            MatcherAssert.assertThat(actual, equalTo(expected));
+        	assertThat(actual).isEqualTo(expected);
         }
     }
 }

--- a/drools-model/drools-mvel-compiler/pom.xml
+++ b/drools-model/drools-mvel-compiler/pom.xml
@@ -38,12 +38,6 @@
     </dependency>
 
     <dependency>
-      <groupId>org.hamcrest</groupId>
-      <artifactId>hamcrest-library</artifactId>
-      <scope>test</scope>
-    </dependency>
-
-    <dependency>
       <groupId>org.assertj</groupId>
       <artifactId>assertj-core</artifactId>
       <scope>test</scope>

--- a/drools-model/drools-mvel-compiler/src/test/java/org/drools/mvelcompiler/CompilerTest.java
+++ b/drools-model/drools-mvel-compiler/src/test/java/org/drools/mvelcompiler/CompilerTest.java
@@ -24,13 +24,11 @@ import java.util.function.Consumer;
 
 import org.drools.Gender;
 import org.drools.Person;
+import org.drools.mvelcompiler.context.MvelCompilerContext;
 import org.drools.core.addon.ClassTypeResolver;
 import org.drools.core.addon.TypeResolver;
-import org.drools.mvelcompiler.context.MvelCompilerContext;
-import org.hamcrest.MatcherAssert;
 
-import static org.hamcrest.Matchers.equalTo;
-import static org.hamcrest.Matchers.equalToIgnoringWhiteSpace;
+import static org.assertj.core.api.Assertions.assertThat;
 
 interface CompilerTest {
 
@@ -57,9 +55,9 @@ interface CompilerTest {
 
     default void verifyBodyWithBetterDiff(Object expected, Object actual) {
         try {
-            MatcherAssert.assertThat(actual.toString(), equalToIgnoringWhiteSpace(expected.toString()));
+            assertThat(actual).asString().isEqualToIgnoringWhitespace(expected.toString());
         } catch (AssertionError e) {
-            MatcherAssert.assertThat(actual, equalTo(expected));
+            assertThat(actual).isEqualTo(expected);
         }
     }
 

--- a/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/compiler/integrationtests/PropertyChangeSupportTest.java
+++ b/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/compiler/integrationtests/PropertyChangeSupportTest.java
@@ -24,8 +24,7 @@ import org.kie.api.io.ResourceType;
 import org.kie.api.runtime.KieSession;
 import org.kie.internal.utils.KieHelper;
 
-import static org.hamcrest.CoreMatchers.is;
-import static org.hamcrest.MatcherAssert.assertThat;
+import static org.assertj.core.api.Assertions.assertThat;
 
 public class PropertyChangeSupportTest {
 
@@ -94,8 +93,8 @@ public class PropertyChangeSupportTest {
         ksession.insert(fact);
         ksession.fireAllRules(10);
 
-        assertThat(fact.getName(), is("user2"));
+        assertThat(fact.getName()).isEqualTo("user2");
 
-        assertThat(fact.getValue(), is("VAL1"));
+        assertThat(fact.getValue()).isEqualTo("VAL1");
     }
 }

--- a/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/compiler/integrationtests/RuleChainingTest.java
+++ b/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/compiler/integrationtests/RuleChainingTest.java
@@ -35,9 +35,8 @@ import org.kie.api.runtime.KieSession;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Mockito;
 
-import static org.hamcrest.CoreMatchers.is;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.Assert.assertEquals;
-import static org.hamcrest.MatcherAssert.assertThat;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.times;
@@ -116,9 +115,9 @@ public class RuleChainingTest {
             final ArgumentCaptor<AfterMatchFiredEvent> actvs = ArgumentCaptor.forClass(AfterMatchFiredEvent.class);
             verify(ael, times(3)).afterMatchFired(actvs.capture());
             final List<AfterMatchFiredEvent> values = actvs.getAllValues();
-            assertThat(values.get(0).getMatch().getRule().getName(), is("init"));
-            assertThat(values.get(1).getMatch().getRule().getName(), is("r1"));
-            assertThat(values.get(2).getMatch().getRule().getName(), is("r2"));
+            assertThat(values.get(0).getMatch().getRule().getName()).isEqualTo("init");
+            assertThat(values.get(1).getMatch().getRule().getName()).isEqualTo("r1");
+            assertThat(values.get(2).getMatch().getRule().getName()).isEqualTo("r2");
 
             verify(ael, never()).matchCancelled(any(org.kie.api.event.rule.MatchCancelledEvent.class));
             verify(wml, times(2)).objectInserted(any(ObjectInsertedEvent.class));

--- a/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/compiler/integrationtests/TimerAndCalendarWithRealTimeTest.java
+++ b/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/compiler/integrationtests/TimerAndCalendarWithRealTimeTest.java
@@ -32,7 +32,6 @@ import org.drools.testcoverage.common.util.KieBaseUtil;
 import org.drools.testcoverage.common.util.KieSessionTestConfiguration;
 import org.drools.testcoverage.common.util.TestParametersUtil;
 import org.junit.After;
-import org.junit.Ignore;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
@@ -40,12 +39,8 @@ import org.kie.api.KieBase;
 import org.kie.api.runtime.KieSession;
 import org.kie.api.runtime.KieSessionConfiguration;
 import org.kie.api.runtime.conf.TimedRuleExecutionOption;
-import org.kie.api.runtime.rule.FactHandle;
 
-import static java.util.Arrays.asList;
 import static org.awaitility.Awaitility.await;
-import static org.hamcrest.Matchers.equalTo;
-import static org.hamcrest.Matchers.greaterThanOrEqualTo;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 
@@ -227,7 +222,7 @@ public class TimerAndCalendarWithRealTimeTest {
         await().until(agendaIsNotEmpty());
         ksession.fireAllRules();
 
-        await().until(list::size, greaterThanOrEqualTo(1));
+        await().until(() -> list.size() >= 1);
 
         kbase.removeRule("org.drools.compiler.test", "TimerRule");
         ksession.fireAllRules();
@@ -268,7 +263,7 @@ public class TimerAndCalendarWithRealTimeTest {
 
         long start = System.currentTimeMillis();
 
-        await().until(list::size, equalTo(1));
+        await().until(() -> list.size()  == 1);
 
         long end = System.currentTimeMillis();
 

--- a/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/compiler/integrationtests/drl/ConsequenceTest.java
+++ b/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/compiler/integrationtests/drl/ConsequenceTest.java
@@ -40,8 +40,6 @@ import org.mockito.ArgumentCaptor;
 import org.mockito.Mockito;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.hamcrest.CoreMatchers.is;
-import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.fail;
 import static org.mockito.Mockito.times;
@@ -223,8 +221,8 @@ public class ConsequenceTest {
             final ArgumentCaptor<ObjectDeletedEvent> retracts = ArgumentCaptor.forClass(ObjectDeletedEvent.class);
             verify(wml, times(2)).objectDeleted(retracts.capture());
             final List<ObjectDeletedEvent> values = retracts.getAllValues();
-            assertThat(values.get(0).getFactHandle(), is(personFH));
-            assertThat(values.get(1).getFactHandle(), is(petFH));
+            assertThat(values.get(0).getFactHandle()).isEqualTo(personFH);
+            assertThat(values.get(1).getFactHandle()).isEqualTo(petFH);
         } finally {
             ksession.dispose();
         }

--- a/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/compiler/integrationtests/drl/DRLTest.java
+++ b/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/compiler/integrationtests/drl/DRLTest.java
@@ -44,8 +44,6 @@ import org.kie.api.definition.type.FactType;
 import org.kie.api.runtime.KieSession;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.hamcrest.CoreMatchers.is;
-import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
@@ -126,9 +124,9 @@ public class DRLTest {
             final Rule rule = kbase.getRule("org.drools.compiler.integrationtests.drl", "test meta attributes");
 
             assertNotNull(rule);
-            assertThat(rule.getMetaData().get("id"), is(1234));
-            assertThat(rule.getMetaData().get("author"), is("john_doe"));
-            assertThat(rule.getMetaData().get("text"), is("It's an escaped\" string"));
+            assertThat(rule.getMetaData().get("id")).isEqualTo(1234);
+            assertThat(rule.getMetaData().get("author")).isEqualTo("john_doe");
+            assertThat(rule.getMetaData().get("text")).isEqualTo("It's an escaped\" string");
         } finally {
             ksession.dispose();
         }

--- a/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/LeftTupleIndexHashTableIteratorTest.java
+++ b/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/LeftTupleIndexHashTableIteratorTest.java
@@ -36,9 +36,7 @@ import org.junit.Test;
 import org.kie.api.KieBase;
 import org.kie.api.runtime.KieSession;
 
-import static org.hamcrest.CoreMatchers.is;
-import static org.hamcrest.CoreMatchers.sameInstance;
-import static org.hamcrest.MatcherAssert.assertThat;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.Assert.assertEquals;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
@@ -160,13 +158,9 @@ public class LeftTupleIndexHashTableIteratorTest extends BaseTupleIndexHashTable
         FieldIndexHashTableFullIterator iterator = new FieldIndexHashTableFullIterator(table);
 
         // test it
-        assertThat(iterator.next(),
-                   sameInstance((Object) tuples[0]));
-        assertThat(iterator.next(),
-                   sameInstance((Object) tuples[1]));
-        assertThat(iterator.next(),
-                   sameInstance((Object) tuples[2]));
-        assertThat(iterator.next(),
-                   is((Object) null));
+        assertThat(iterator.next()).isSameAs(tuples[0]);
+        assertThat(iterator.next()).isSameAs(tuples[1]);
+        assertThat(iterator.next()).isSameAs(tuples[2]);
+        assertThat(iterator.next()).isNull();
     }
 }

--- a/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/RightTupleIndexHashTableIteratorTest.java
+++ b/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/RightTupleIndexHashTableIteratorTest.java
@@ -38,9 +38,7 @@ import org.junit.Test;
 import org.kie.api.KieBase;
 import org.kie.api.runtime.KieSession;
 
-import static org.hamcrest.CoreMatchers.is;
-import static org.hamcrest.CoreMatchers.sameInstance;
-import static org.hamcrest.MatcherAssert.assertThat;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.Assert.assertEquals;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
@@ -162,13 +160,9 @@ public class RightTupleIndexHashTableIteratorTest extends BaseTupleIndexHashTabl
         FieldIndexHashTableFullIterator iterator = new FieldIndexHashTableFullIterator(table);
 
         // test it
-        assertThat(iterator.next(),
-                   sameInstance((Object) tuples[0]));
-        assertThat(iterator.next(),
-                   sameInstance((Object) tuples[1]));
-        assertThat(iterator.next(),
-                   sameInstance((Object) tuples[2]));
-        assertThat(iterator.next(),
-                   is((Object) null));
+        assertThat(iterator.next()).isSameAs(tuples[0]);
+        assertThat(iterator.next()).isSameAs(tuples[1]);
+        assertThat(iterator.next()).isSameAs(tuples[2]);
+        assertThat(iterator.next()).isNull();
     }
 }

--- a/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/compiler/NestedAccessorsTest.java
+++ b/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/compiler/NestedAccessorsTest.java
@@ -31,8 +31,7 @@ import org.kie.api.event.rule.AfterMatchFiredEvent;
 import org.kie.api.runtime.KieSession;
 import org.mockito.ArgumentCaptor;
 
-import static org.hamcrest.CoreMatchers.is;
-import static org.hamcrest.MatcherAssert.assertThat;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertSame;
 import static org.mockito.Mockito.mock;
@@ -220,8 +219,8 @@ public class NestedAccessorsTest extends CommonTestMethodBase {
         verify(ael, times(2)).afterMatchFired(captor.capture());
 
         final List<org.kie.api.event.rule.AfterMatchFiredEvent> values = captor.getAllValues();
-        assertThat(values.get(0).getMatch().getObjects().get(0), is(c1));
-        assertThat(values.get(1).getMatch().getObjects().get(0), is(c2));
+        assertThat(values.get(0).getMatch().getObjects().get(0)).isEqualTo(c1);
+        assertThat(values.get(1).getMatch().getObjects().get(0)).isEqualTo(c2);
 
         ksession.dispose();
     }

--- a/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/compiler/builder/impl/KnowledgeBuilderConfigurationImplTest.java
+++ b/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/compiler/builder/impl/KnowledgeBuilderConfigurationImplTest.java
@@ -19,8 +19,7 @@ import org.drools.compiler.builder.impl.KnowledgeBuilderConfigurationImpl;
 import org.junit.Test;
 import org.kie.internal.builder.conf.ParallelRulesBuildThresholdOption;
 
-import static org.hamcrest.CoreMatchers.is;
-import static org.hamcrest.MatcherAssert.assertThat;
+import static org.assertj.core.api.Assertions.assertThat;
 
 public class KnowledgeBuilderConfigurationImplTest {
 
@@ -29,7 +28,7 @@ public class KnowledgeBuilderConfigurationImplTest {
         try {
             System.getProperties().put(ParallelRulesBuildThresholdOption.PROPERTY_NAME, "20");
             KnowledgeBuilderConfigurationImpl kbConfigImpl = new KnowledgeBuilderConfigurationImpl();
-            assertThat(kbConfigImpl.getParallelRulesBuildThreshold(), is(20));
+            assertThat(kbConfigImpl.getParallelRulesBuildThreshold()).isEqualTo(20);
         } finally {
             System.getProperties().remove(ParallelRulesBuildThresholdOption.PROPERTY_NAME);
         }
@@ -40,7 +39,7 @@ public class KnowledgeBuilderConfigurationImplTest {
         try {
             System.getProperties().put(ParallelRulesBuildThresholdOption.PROPERTY_NAME, "-1");
             KnowledgeBuilderConfigurationImpl kbConfigImpl = new KnowledgeBuilderConfigurationImpl();
-            assertThat(kbConfigImpl.getParallelRulesBuildThreshold(), is(-1));
+            assertThat(kbConfigImpl.getParallelRulesBuildThreshold()).isEqualTo(-1);
         } finally {
             System.getProperties().remove(ParallelRulesBuildThresholdOption.PROPERTY_NAME); 
         }

--- a/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/compiler/builder/impl/KnowledgeBuilderImplTest.java
+++ b/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/compiler/builder/impl/KnowledgeBuilderImplTest.java
@@ -1,16 +1,13 @@
 package org.drools.mvel.compiler.builder.impl;
 
 import java.io.File;
-import java.io.IOException;
 
 import org.drools.compiler.builder.impl.KnowledgeBuilderImpl;
-import org.hamcrest.BaseMatcher;
-import org.hamcrest.Description;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
 
-import static org.hamcrest.MatcherAssert.assertThat;
+import static org.assertj.core.api.Assertions.assertThat;
 
 public class KnowledgeBuilderImplTest {
 
@@ -20,42 +17,12 @@ public class KnowledgeBuilderImplTest {
     @Test
     public void testCreateDumpDrlGeneratedFileRemovingInvalidCharacters() throws Exception {
         final File dumpDir = temporaryFolder.getRoot();
-        assertThat( KnowledgeBuilderImpl.createDumpDrlFile(dumpDir, "xxx", ".drl"), fileEndsWith(File.separator + "xxx.drl"));
-        assertThat(KnowledgeBuilderImpl.createDumpDrlFile(dumpDir, "x?x?", ".drl"), fileEndsWith(File.separator + "x_x_.drl"));
-        assertThat(KnowledgeBuilderImpl.createDumpDrlFile(dumpDir, "x/x/", ".drl"), fileEndsWith(File.separator + "x_x_.drl"));
-        assertThat(KnowledgeBuilderImpl.createDumpDrlFile(dumpDir, "x\\x\\", ".drl"), fileEndsWith(File.separator + "x_x_.drl"));
-        assertThat(KnowledgeBuilderImpl.createDumpDrlFile(dumpDir, "x*x*", ".drl"), fileEndsWith(File.separator + "x_x_.drl"));
-        assertThat(KnowledgeBuilderImpl.createDumpDrlFile(dumpDir, "aa.AA01-_", ".drl"), fileEndsWith(File.separator + "aa.AA01-_.drl"));
+        assertThat(KnowledgeBuilderImpl.createDumpDrlFile(dumpDir, "xxx", ".drl")).hasName("xxx.drl");
+        assertThat(KnowledgeBuilderImpl.createDumpDrlFile(dumpDir, "x?x?", ".drl")).hasName("x_x_.drl");
+        assertThat(KnowledgeBuilderImpl.createDumpDrlFile(dumpDir, "x/x/", ".drl")).hasName("x_x_.drl");
+        assertThat(KnowledgeBuilderImpl.createDumpDrlFile(dumpDir, "x\\x\\", ".drl")).hasName("x_x_.drl");
+        assertThat(KnowledgeBuilderImpl.createDumpDrlFile(dumpDir, "x*x*", ".drl")).hasName("x_x_.drl");
+        assertThat(KnowledgeBuilderImpl.createDumpDrlFile(dumpDir, "aa.AA01-_", ".drl")).hasName("aa.AA01-_.drl");
     }
 
-    private static FileEndsWithMatcher fileEndsWith(String endsWithString) {
-        return new FileEndsWithMatcher(endsWithString);
-    }
-
-    private static class FileEndsWithMatcher extends BaseMatcher<File> {
-
-        private final String endsWithString;
-
-        private FileEndsWithMatcher(String endsWithString) {
-            this.endsWithString = endsWithString;
-        }
-
-        @Override
-        public boolean matches(Object item) {
-            if (item instanceof File) {
-                try {
-                    return ((File) item).getCanonicalPath().endsWith(endsWithString);
-                } catch (IOException e) {
-                    return false;
-                }
-            } else {
-                return false;
-            }
-        }
-
-        @Override
-        public void describeTo(Description description) {
-            description.appendValue(endsWithString);
-        }
-    }
 }

--- a/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/compiler/kie/util/ChangeSetBuilderTest.java
+++ b/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/compiler/kie/util/ChangeSetBuilderTest.java
@@ -37,11 +37,8 @@ import org.kie.internal.builder.ResourceChange;
 import org.kie.internal.builder.ResourceChange.Type;
 import org.kie.internal.builder.ResourceChangeSet;
 
-import static org.hamcrest.CoreMatchers.is;
-import static org.hamcrest.CoreMatchers.not;
-import static org.hamcrest.CoreMatchers.nullValue;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.Assert.assertEquals;
-import static org.hamcrest.MatcherAssert.assertThat;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
@@ -66,7 +63,7 @@ public class ChangeSetBuilderTest {
 
         KieJarChangeSet changes = ChangeSetBuilder.build( kieJar1, kieJar2 );
         
-        assertThat( changes.getChanges().size(), is(0));
+        assertThat(changes.getChanges()).hasSize(0);
     }
 
     @Test
@@ -96,13 +93,13 @@ public class ChangeSetBuilderTest {
         
         String modifiedFile = (String) kieJar2.getFileNames().toArray()[1];
         
-        assertThat( changes.getChanges().size(), is(1));
+        assertThat(changes.getChanges()).hasSize(1);
         ResourceChangeSet cs = changes.getChanges().get( modifiedFile );
-        assertThat( cs, not( nullValue() ) );
-        assertThat( cs.getChangeType(), is( ChangeType.UPDATED ) );
-        assertThat( cs.getChanges().size(), is(2) );
-        assertThat( cs.getChanges().get( 1 ), is( new ResourceChange(ChangeType.ADDED, Type.RULE, "R3") ) );
-        assertThat( cs.getChanges().get( 0 ), is( new ResourceChange(ChangeType.REMOVED, Type.RULE, "R2") ) );
+        assertThat(cs).isNotNull();
+        assertThat(cs.getChangeType()).isEqualTo(ChangeType.UPDATED);
+        assertThat(cs.getChanges()).hasSize(2);
+        assertThat(cs.getChanges().get(1)).isEqualTo(new ResourceChange(ChangeType.ADDED, Type.RULE, "R3"));
+        assertThat(cs.getChanges().get(0)).isEqualTo(new ResourceChange(ChangeType.REMOVED, Type.RULE, "R2"));
         
 //        ChangeSetBuilder builder = new ChangeSetBuilder();
 //        System.out.println( builder.toProperties( changes ) );
@@ -129,10 +126,10 @@ public class ChangeSetBuilderTest {
 
         String removedFile = (String) kieJar1.getFileNames().toArray()[1];
         
-        assertThat( changes.getChanges().size(), is(1));
+        assertThat(changes.getChanges()).hasSize(1);
         ResourceChangeSet cs = changes.getChanges().get( removedFile );
-        assertThat( cs, not( nullValue() ) );
-        assertThat( cs.getChangeType(), is( ChangeType.REMOVED ) );
+        assertThat(cs).isNotNull();
+        assertThat(cs.getChangeType()).isEqualTo(ChangeType.REMOVED);
     }
     
     @Test
@@ -189,21 +186,21 @@ public class ChangeSetBuilderTest {
         String addedFile = (String) kieJar2.getFileNames().toArray()[1];
         String removedFile = (String) kieJar1.getFileNames().toArray()[1];
         
-        assertThat( changes.getChanges().size(), is(3));
+        assertThat(changes.getChanges()).hasSize(3);
 
         ResourceChangeSet cs = changes.getChanges().get( removedFile );
-        assertThat( cs, not( nullValue() ) );
-        assertThat( cs.getChangeType(), is( ChangeType.REMOVED) );
-        assertThat( cs.getChanges().size(), is(0) );
+        assertThat(cs).isNotNull();
+        assertThat(cs.getChangeType()).isEqualTo(ChangeType.REMOVED);
+        assertThat(cs.getChanges()).hasSize(0);
 
         cs = changes.getChanges().get( addedFile );
-        assertThat( cs, not( nullValue() ) );
-        assertThat( cs.getChangeType(), is( ChangeType.ADDED ) );
-        assertThat( cs.getChanges().size(), is(0) );
+        assertThat(cs).isNotNull();
+        assertThat(cs.getChangeType()).isEqualTo(ChangeType.ADDED);
+        assertThat(cs.getChanges()).hasSize(0);
 
         cs = changes.getChanges().get( modifiedFile );
-        assertThat( cs, not( nullValue() ) );
-        assertThat( cs.getChangeType(), is( ChangeType.UPDATED ) );
+        assertThat(cs).isNotNull();
+        assertThat(cs.getChangeType()).isEqualTo(ChangeType.UPDATED);
 //        assertThat( cs.getChanges().size(), is(3) );
 //        assertThat( cs.getChanges().get( 0 ), is( new ResourceChange(ChangeType.ADDED, Type.RULE, "An added rule") ) );
 //        assertThat( cs.getChanges().get( 1 ), is( new ResourceChange(ChangeType.REMOVED, Type.RULE, "A removed rule") ) );

--- a/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/compiler/lang/api/DescrBuilderTest.java
+++ b/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/compiler/lang/api/DescrBuilderTest.java
@@ -53,8 +53,6 @@ import org.kie.internal.io.ResourceFactory;
 import org.mockito.ArgumentCaptor;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.hamcrest.CoreMatchers.is;
-import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
@@ -470,8 +468,8 @@ public class DescrBuilderTest {
         ArgumentCaptor<AfterMatchFiredEvent> cap = ArgumentCaptor.forClass( AfterMatchFiredEvent.class );
         verify( ael ).afterMatchFired(cap.capture());
         
-        assertThat( ((Number) cap.getValue().getMatch().getDeclarationValue( "$sum" )).intValue(), is( 180 ) );
-        assertThat( ((Number) cap.getValue().getMatch().getDeclarationValue( "$cnt" )).intValue(), is( 2 ) );
+        assertThat(((Number) cap.getValue().getMatch().getDeclarationValue("$sum")).intValue()).isEqualTo(180);
+        assertThat(((Number) cap.getValue().getMatch().getDeclarationValue("$cnt")).intValue()).isEqualTo(2);
     }
     
     @Test

--- a/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/compiler/rule/builder/dialect/java/JavaDialectBinaryEqualityTest.java
+++ b/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/compiler/rule/builder/dialect/java/JavaDialectBinaryEqualityTest.java
@@ -38,9 +38,7 @@ import org.kie.api.KieBase;
 import org.kie.api.definition.KiePackage;
 import org.kie.api.runtime.KieSession;
 
-import static org.hamcrest.CoreMatchers.equalTo;
-import static org.hamcrest.CoreMatchers.not;
-import static org.hamcrest.MatcherAssert.assertThat;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotSame;
 
@@ -85,7 +83,7 @@ public class JavaDialectBinaryEqualityTest{
         Constraint rvc3 = p3.getConstraints().get( 0 );
         
         assertNotSame( rvc1, rvc3 );
-        assertThat(rvc1, not( equalTo( rvc3 ) ) );
+        assertThat(rvc1).isNotEqualTo(rvc3);
         
         // test inline eval
         PredicateConstraint pc1 = getPredicateConstraint(p1);
@@ -99,7 +97,7 @@ public class JavaDialectBinaryEqualityTest{
         PredicateConstraint pc3 = getPredicateConstraint(p3);
         PredicateExpression pe3 = ( PredicateExpression ) pc3.getPredicateExpression();
         assertNotSame( pe1, pe3 );
-        assertThat(pe1, not( equalTo( pe3 ) ) );
+        assertThat(pe1).isNotEqualTo(pe3);
         
        // test eval
         EvalCondition ec1 = ( EvalCondition ) rule1.getLhs().getChildren().get( 1 );
@@ -113,20 +111,20 @@ public class JavaDialectBinaryEqualityTest{
         EvalCondition ec3 = ( EvalCondition ) rule3.getLhs().getChildren().get( 1 );
         EvalExpression ee3 =( EvalExpression) ec3.getEvalExpression();
         assertNotSame( ee1,ee3 );
-        assertThat(ee1, not( equalTo( ee3 ) ) );
+        assertThat(ee1).isNotEqualTo(ee3);
         
         // test consequence
         assertNotSame( rule1.getConsequence(), rule2.getConsequence() );
         assertEquals(rule1.getConsequence(), rule2.getConsequence() );
         assertNotSame( rule1.getConsequence(), rule3.getConsequence() );
-        assertThat(rule1.getConsequence(), not( equalTo( rule3.getConsequence() ) ) );
+        assertThat(rule1.getConsequence()).isNotEqualTo(rule3.getConsequence());
         
         // check LHS equals
         assertNotSame(  rule1.getLhs(), rule2.getLhs() );
         assertEquals( rule1.getLhs(), rule2.getLhs() );
         
         assertNotSame( rule1.getLhs(), rule3.getLhs() );
-        assertThat(rule1.getLhs(), not( equalTo( rule3.getLhs() ) ) );
+        assertThat(rule1.getLhs()).isNotEqualTo(rule3.getLhs());
     }
 
     private PredicateConstraint getPredicateConstraint(Pattern pattern) {

--- a/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/integrationtests/DynamicRulesTest.java
+++ b/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/integrationtests/DynamicRulesTest.java
@@ -62,8 +62,7 @@ import org.kie.api.runtime.rule.EntryPoint;
 import org.kie.api.runtime.rule.FactHandle;
 import org.mockito.ArgumentCaptor;
 
-import static org.hamcrest.CoreMatchers.is;
-import static org.hamcrest.MatcherAssert.assertThat;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
@@ -1181,14 +1180,14 @@ public class DynamicRulesTest {
         ksession.fireAllRules();
         ArgumentCaptor<AfterMatchFiredEvent> capt = ArgumentCaptor.forClass( AfterMatchFiredEvent.class );
         verify( ael, times(1) ).afterMatchFired( capt.capture() );
-        assertThat( "R1", is( capt.getValue().getMatch().getRule().getName() ) );
+        assertThat(capt.getValue().getMatch().getRule().getName()).isEqualTo("R1");
 
         kpkgs = KieBaseUtil.getKieBaseFromKieModuleFromDrl("tmp", kieBaseTestConfiguration, type, r2).getKiePackages();
         kbase.addPackages(kpkgs);
         
         ksession.fireAllRules();
         verify( ael, times(2) ).afterMatchFired( capt.capture() );
-        assertThat( "R2", is( capt.getAllValues().get( 2 ).getMatch().getRule().getName() ) );
+        assertThat(capt.getAllValues().get(2).getMatch().getRule().getName()).isEqualTo("R2");
         
         ksession.dispose();
         

--- a/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/integrationtests/MapConstraintTest.java
+++ b/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/integrationtests/MapConstraintTest.java
@@ -41,8 +41,7 @@ import org.kie.api.event.rule.AfterMatchFiredEvent;
 import org.kie.api.runtime.KieSession;
 import org.mockito.ArgumentCaptor;
 
-import static org.hamcrest.CoreMatchers.is;
-import static org.hamcrest.MatcherAssert.assertThat;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
@@ -147,14 +146,14 @@ public class MapConstraintTest {
         final ArgumentCaptor<AfterMatchFiredEvent> arg = ArgumentCaptor.forClass(org.kie.api.event.rule.AfterMatchFiredEvent.class);
         verify(ael, times(4)).afterMatchFired(arg.capture());
         org.kie.api.event.rule.AfterMatchFiredEvent aaf = arg.getAllValues().get(0);
-        assertThat(aaf.getMatch().getRule().getName(), is("1. home != null"));
+        assertThat(aaf.getMatch().getRule().getName()).isEqualTo("1. home != null");
         aaf = arg.getAllValues().get(1);
-        assertThat(aaf.getMatch().getRule().getName(), is("2. not home == null"));
+        assertThat(aaf.getMatch().getRule().getName()).isEqualTo("2. not home == null");
 
         aaf = arg.getAllValues().get(2);
-        assertThat(aaf.getMatch().getRule().getName(), is("7. work == null"));
+        assertThat(aaf.getMatch().getRule().getName()).isEqualTo("7. work == null");
         aaf = arg.getAllValues().get(3);
-        assertThat(aaf.getMatch().getRule().getName(), is("8. not work != null"));
+        assertThat(aaf.getMatch().getRule().getName()).isEqualTo("8. not work != null");
     }
 
     @Test

--- a/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/integrationtests/session/AgendaFilterTest.java
+++ b/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/integrationtests/session/AgendaFilterTest.java
@@ -37,9 +37,8 @@ import org.kie.api.runtime.conf.DirectFiringOption;
 import org.kie.api.runtime.rule.AgendaFilter;
 import org.mockito.ArgumentCaptor;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.fail;
-import static org.hamcrest.CoreMatchers.is;
-import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.Assert.assertEquals;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
@@ -94,7 +93,7 @@ public class AgendaFilterTest {
 
         final ArgumentCaptor<org.kie.api.event.rule.AfterMatchFiredEvent> arg = ArgumentCaptor.forClass(org.kie.api.event.rule.AfterMatchFiredEvent.class);
         verify(ael).afterMatchFired(arg.capture());
-        assertThat(arg.getValue().getMatch().getRule().getName(), is(expectedMatchingRuleName));
+        assertThat(arg.getValue().getMatch().getRule().getName()).isEqualTo(expectedMatchingRuleName);
     }
 
     @Test

--- a/drools-traits/pom.xml
+++ b/drools-traits/pom.xml
@@ -93,6 +93,13 @@
       <type>test-jar</type>
       <scope>test</scope>
     </dependency>
+    
+    <dependency>
+      <groupId>org.assertj</groupId>
+      <artifactId>assertj-core</artifactId>
+      <scope>test</scope>
+    </dependency>
+    
 
     <!-- Logging -->
     <dependency>

--- a/drools-traits/src/test/java/org/drools/traits/compiler/factmodel/traits/TraitTest.java
+++ b/drools-traits/src/test/java/org/drools/traits/compiler/factmodel/traits/TraitTest.java
@@ -99,8 +99,6 @@ import org.kie.internal.utils.KieHelper;
 import org.mockito.ArgumentCaptor;
 
 import static org.drools.serialization.protobuf.SerializationHelper.serializeObject;
-import static org.hamcrest.CoreMatchers.is;
-import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
@@ -111,6 +109,7 @@ import static org.junit.Assert.fail;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
+import static org.assertj.core.api.Assertions.assertThat;
 
 @RunWith(Parameterized.class)
 public class TraitTest extends CommonTraitTest {
@@ -1444,12 +1443,9 @@ public class TraitTest extends CommonTraitTest {
 
         List<AfterMatchFiredEvent> values = cap.getAllValues();
 
-        assertThat( values.get( 0 ).getMatch().getRule().getName(),
-                    is( "create student" ) );
-        assertThat( values.get( 1 ).getMatch().getRule().getName(),
-                    is( "print student" ) );
-        assertThat( values.get( 2 ).getMatch().getRule().getName(),
-                    is( "print school" ) );
+        assertThat(values.get(0).getMatch().getRule().getName()).isEqualTo("create student");
+        assertThat(values.get(1).getMatch().getRule().getName()).isEqualTo("print student");
+        assertThat(values.get(2).getMatch().getRule().getName()).isEqualTo("print school");
 
     }
 

--- a/kie-ci/pom.xml
+++ b/kie-ci/pom.xml
@@ -204,6 +204,12 @@
       <artifactId>junit</artifactId>
       <scope>test</scope>
     </dependency>
+
+    <dependency>
+      <groupId>org.assertj</groupId>
+      <artifactId>assertj-core</artifactId>
+      <scope>test</scope>
+    </dependency>    
   </dependencies>
 
   <build>

--- a/kie-ci/src/test/java/org/kie/scanner/KieRepositoryScannerTest.java
+++ b/kie-ci/src/test/java/org/kie/scanner/KieRepositoryScannerTest.java
@@ -30,7 +30,6 @@ import org.drools.compiler.kie.builder.impl.InternalKieModule;
 import org.drools.compiler.kie.builder.impl.InternalKieScanner;
 import org.drools.compiler.kie.builder.impl.KieFileSystemImpl;
 import org.drools.core.util.FileManager;
-import org.hamcrest.CoreMatchers;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Ignore;
@@ -58,10 +57,10 @@ import org.slf4j.LoggerFactory;
 import static java.util.Arrays.asList;
 
 import static org.appformer.maven.integration.MavenRepository.getMavenRepository;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
-import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 import static org.kie.scanner.KieMavenRepository.getKieMavenRepository;
@@ -349,8 +348,8 @@ public class KieRepositoryScannerTest extends AbstractKieCiTest {
         
         scanner.scanNow();
         // Because 1.0.2 does not exist, will perform a scan but will NOT update.
-        assertThat( events, CoreMatchers.hasItem( new KieScannerStatusChangeEventImpl(KieScanner.Status.SCANNING) ) );
-        assertThat( events, CoreMatchers.not( CoreMatchers.hasItem( new KieScannerStatusChangeEventImpl(KieScanner.Status.UPDATING) )) );
+        assertThat( events).contains(new KieScannerStatusChangeEventImpl(KieScanner.Status.SCANNING));
+        assertThat( events).doesNotContain(new KieScannerStatusChangeEventImpl(KieScanner.Status.UPDATING));
         events.clear();
         
         repository.installArtifact(releaseId1, kJar1, createKPom(fileManager, releaseId1));
@@ -377,8 +376,8 @@ public class KieRepositoryScannerTest extends AbstractKieCiTest {
         KieSession ksession2 = kieContainer.newKieSession("KSession1");
         checkKSession(ksession2, "rule2", "rule3");
         
-        assertThat( events, CoreMatchers.hasItem( new KieScannerStatusChangeEventImpl(KieScanner.Status.SCANNING) ) );
-        assertThat( events, CoreMatchers.hasItem( new KieScannerStatusChangeEventImpl(KieScanner.Status.UPDATING) ) );
+        assertThat( events).contains(new KieScannerStatusChangeEventImpl(KieScanner.Status.SCANNING));
+        assertThat( events).contains(new KieScannerStatusChangeEventImpl(KieScanner.Status.UPDATING));
         assertTrue( events.get(2) instanceof KieScannerUpdateResultsEventImpl );
         assertFalse( ((KieScannerUpdateResultsEventImpl)events.get(2)).getResults().hasMessages(Message.Level.ERROR) );
         events.clear();
@@ -424,8 +423,8 @@ public class KieRepositoryScannerTest extends AbstractKieCiTest {
         
         scanner.scanNow();
         // Because 1.0.2 does not exist, will perform a scan but will NOT update.
-        assertThat( events, CoreMatchers.hasItem( new KieScannerStatusChangeEventImpl(KieScanner.Status.SCANNING) ) );
-        assertThat( events, CoreMatchers.not( CoreMatchers.hasItem( new KieScannerStatusChangeEventImpl(KieScanner.Status.UPDATING) )) );
+        assertThat( events).contains(new KieScannerStatusChangeEventImpl(KieScanner.Status.SCANNING));
+        assertThat( events).doesNotContain(new KieScannerStatusChangeEventImpl(KieScanner.Status.UPDATING));
         events.clear();
         
         repository.installArtifact(releaseId1, kJar1, createKPom(fileManager, releaseId1));
@@ -470,8 +469,8 @@ public class KieRepositoryScannerTest extends AbstractKieCiTest {
 
         // there should be no update performed.
         
-        assertThat( events, CoreMatchers.hasItem( new KieScannerStatusChangeEventImpl(KieScanner.Status.SCANNING) ) );
-        assertThat( events, CoreMatchers.hasItem( new KieScannerStatusChangeEventImpl(KieScanner.Status.UPDATING) ) );
+        assertThat( events).contains(new KieScannerStatusChangeEventImpl(KieScanner.Status.SCANNING));
+        assertThat( events).contains(new KieScannerStatusChangeEventImpl(KieScanner.Status.UPDATING));
         assertTrue( events.get(2) instanceof KieScannerUpdateResultsEventImpl );
         assertTrue( ((KieScannerUpdateResultsEventImpl)events.get(2)).getResults().hasMessages(Message.Level.ERROR) );
         events.clear();

--- a/kie-dmn/kie-dmn-backend/pom.xml
+++ b/kie-dmn/kie-dmn-backend/pom.xml
@@ -55,6 +55,12 @@
       <artifactId>xmlunit-core</artifactId>
       <scope>test</scope>
     </dependency>
+    
+    <dependency>
+      <groupId>org.assertj</groupId>
+      <artifactId>assertj-core</artifactId>
+      <scope>test</scope>
+    </dependency>    
 
     <dependency>
       <groupId>org.slf4j</groupId>

--- a/kie-dmn/kie-dmn-backend/src/test/java/org/kie/dmn/backend/marshalling/v1_1/DMNXMLLoaderTest.java
+++ b/kie-dmn/kie-dmn-backend/src/test/java/org/kie/dmn/backend/marshalling/v1_1/DMNXMLLoaderTest.java
@@ -32,12 +32,8 @@ import org.kie.dmn.model.api.Definitions;
 import org.kie.dmn.model.api.InputData;
 import org.kie.dmn.model.api.LiteralExpression;
 
-import static org.hamcrest.CoreMatchers.instanceOf;
-import static org.hamcrest.CoreMatchers.is;
-import static org.hamcrest.CoreMatchers.not;
-import static org.hamcrest.CoreMatchers.nullValue;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.Assert.assertNotNull;
-import static org.hamcrest.MatcherAssert.assertThat;
 
 public class DMNXMLLoaderTest {
 
@@ -49,36 +45,37 @@ public class DMNXMLLoaderTest {
         final InputStreamReader isr = new InputStreamReader( is );
         final Definitions def = DMNMarshaller.unmarshal( isr );
 
-        assertThat( def, not( nullValue() ) );
-        assertThat( def.getName(), is("0001-input-data-string") );
-        assertThat( def.getId(), is("_0001-input-data-string") );
-        assertThat( def.getNamespace(), is("https://github.com/agilepro/dmn-tck") );
+        assertThat(def).isNotNull();
+        assertThat(def.getName()).isEqualTo("0001-input-data-string");
+        assertThat(def.getId()).isEqualTo("_0001-input-data-string");
+        assertThat(def.getNamespace()).isEqualTo("https://github.com/agilepro/dmn-tck");
 
-        assertThat( def.getDrgElement().size(), is( 2 ) );
-        assertThat( def.getDrgElement().get( 0 ), is( instanceOf( Decision.class ) ) );
+        assertThat(def.getDrgElement()).hasSize(2);
+        assertThat(def.getDrgElement().get(0)).isInstanceOf(Decision.class) ;
 
         Decision dec = (Decision) def.getDrgElement().get( 0 );
-        assertThat( dec.getName(), is("Greeting Message") );
-        assertThat( dec.getId(), is("d_GreetingMessage") );
-        assertThat( dec.getVariable().getName(), is("Greeting Message") );
-        assertThat( dec.getVariable().getTypeRef().getPrefix(), is( "feel" ) );
-        assertThat( dec.getVariable().getTypeRef().getLocalPart(), is( "string" ) );
-        assertThat( dec.getVariable().getTypeRef().getNamespaceURI(), is( XMLConstants.NULL_NS_URI ) );
+        assertThat(dec.getName()).isEqualTo("Greeting Message");
+        assertThat(dec.getId()).isEqualTo("d_GreetingMessage");        
+        assertThat(dec.getVariable().getName()).isEqualTo("Greeting Message");
+        assertThat(dec.getVariable().getTypeRef().getPrefix()).isEqualTo( "feel");
+        assertThat(dec.getVariable().getTypeRef().getLocalPart()).isEqualTo( "string");
+        assertThat(dec.getVariable().getTypeRef().getNamespaceURI()).isEqualTo(XMLConstants.NULL_NS_URI);
 
-        assertThat( dec.getInformationRequirement().size(), is( 1 ) );
-        assertThat( dec.getInformationRequirement().get( 0 ).getRequiredInput().getHref(), is( "#i_FullName" ) );
-        assertThat( dec.getExpression(), is( instanceOf( LiteralExpression.class ) ) );
+        assertThat(dec.getInformationRequirement()).hasSize(1);
+        assertThat(dec.getInformationRequirement().get(0).getRequiredInput().getHref()).isEqualTo( "#i_FullName");
+        
+        assertThat(dec.getExpression()).isInstanceOf(LiteralExpression.class);
 
         LiteralExpression le = (LiteralExpression) dec.getExpression();
-        assertThat( le.getText(), is("\"Hello \" + Full Name") );
+        assertThat(le.getText()).isEqualTo("\"Hello \" + Full Name");
 
         InputData idata = (InputData) def.getDrgElement().get( 1 );
-        assertThat( idata.getId(), is( "i_FullName" ) );
-        assertThat( idata.getName(), is( "Full Name" ) );
-        assertThat( idata.getVariable().getName(), is( "Full Name" ) );
-        assertThat( idata.getVariable().getTypeRef().getPrefix(), is( "feel" ) );
-        assertThat( idata.getVariable().getTypeRef().getLocalPart(), is( "string" ) );
-        assertThat( idata.getVariable().getTypeRef().getNamespaceURI(), is( XMLConstants.NULL_NS_URI ) );
+        assertThat(idata.getId()).isEqualTo( "i_FullName");
+        assertThat(idata.getName()).isEqualTo( "Full Name");
+        assertThat(idata.getVariable().getName()).isEqualTo( "Full Name");
+        assertThat(idata.getVariable().getTypeRef().getPrefix()).isEqualTo( "feel");
+        assertThat(idata.getVariable().getTypeRef().getLocalPart()).isEqualTo( "string");
+        assertThat(idata.getVariable().getTypeRef().getNamespaceURI()).isEqualTo( XMLConstants.NULL_NS_URI);
     }
 
     @Test
@@ -89,27 +86,27 @@ public class DMNXMLLoaderTest {
         final InputStreamReader isr = new InputStreamReader(is);
         final Definitions def = DMNMarshaller.unmarshal(isr);
 
-        assertThat(def.getDecisionService().size(), is(2));
+        assertThat(def.getDecisionService()).hasSize(2);
 
         DecisionService decisionService1 = def.getDecisionService().get(0);
-        assertThat(decisionService1.getId(), is("_70386614-9838-420b-a2ae-ff901ada63fb"));
-        assertThat(decisionService1.getName(), is("A Only Knowing B and C"));
-        assertThat(decisionService1.getDescription(), is("Description of A (BC)"));
-        assertThat(decisionService1.getOutputDecision().size(), is(1));
-        assertThat(decisionService1.getEncapsulatedDecision().size(), is(0));
-        assertThat(decisionService1.getInputDecision().size(), is(2));
-        assertThat(decisionService1.getInputData().size(), is(0));
-        assertThat(decisionService1.getOutputDecision().get(0).getHref(), is("#_c2b44706-d479-4ceb-bb74-73589d26dd04"));
+        assertThat(decisionService1.getId()).isEqualTo("_70386614-9838-420b-a2ae-ff901ada63fb");
+        assertThat(decisionService1.getName()).isEqualTo("A Only Knowing B and C");
+        assertThat(decisionService1.getDescription()).isEqualTo("Description of A (BC)");
+        assertThat(decisionService1.getOutputDecision()).hasSize(1);
+        assertThat(decisionService1.getEncapsulatedDecision()).hasSize(0);
+        assertThat(decisionService1.getInputDecision()).hasSize(2);
+        assertThat(decisionService1.getInputData()).hasSize(0);
+        assertThat(decisionService1.getOutputDecision().get(0).getHref()).isEqualTo("#_c2b44706-d479-4ceb-bb74-73589d26dd04");
 
         DecisionService decisionService2 = def.getDecisionService().get(1);
-        assertThat(decisionService2.getId(), is("_4620ef13-248a-419e-bc68-6b601b725a03"));
-        assertThat(decisionService2.getName(), is("A only as output knowing D and E"));
-        assertThat(decisionService2.getOutputDecision().size(), is(1));
-        assertThat(decisionService2.getEncapsulatedDecision().size(), is(2));
-        assertThat(decisionService2.getInputDecision().size(), is(0));
-        assertThat(decisionService2.getInputData().size(), is(2));
-        assertThat(decisionService2.getInputData().get(0).getHref(), is("#_bcea16fb-6c19-4bde-b37d-73407002c064"));
-        assertThat(decisionService2.getInputData().get(1).getHref(), is("#_207b9195-a441-47f2-9414-2fad64b463f9"));
+        assertThat(decisionService2.getId()).isEqualTo("_4620ef13-248a-419e-bc68-6b601b725a03");
+        assertThat(decisionService2.getName()).isEqualTo("A only as output knowing D and E");
+        assertThat(decisionService2.getOutputDecision()).hasSize(1);
+        assertThat(decisionService2.getEncapsulatedDecision()).hasSize(2);
+        assertThat(decisionService2.getInputDecision()).hasSize(0);
+        assertThat(decisionService2.getInputData()).hasSize(2);
+        assertThat(decisionService2.getInputData().get(0).getHref()).isEqualTo("#_bcea16fb-6c19-4bde-b37d-73407002c064");
+        assertThat(decisionService2.getInputData().get(1).getHref()).isEqualTo("#_207b9195-a441-47f2-9414-2fad64b463f9");
 
     }
 
@@ -121,7 +118,7 @@ public class DMNXMLLoaderTest {
         final InputStreamReader isr = new InputStreamReader(is);
         final Definitions def = DMNMarshaller.unmarshal(isr);
 
-        assertThat(def.getDecisionService().size(), is(0)); // check if No DecisionServices in extended v1.1 does not NPE.
+        assertThat(def.getDecisionService()).hasSize(0); // check if No DecisionServices in extended v1.1 does not NPE.
     }
 
     @Test
@@ -132,7 +129,7 @@ public class DMNXMLLoaderTest {
         final InputStreamReader isr = new InputStreamReader(is);
         final Definitions def = marshaller.unmarshal(isr);
 
-        assertThat(def.getExtensionElements().getAny().size(), is(1));
+        assertThat(def.getExtensionElements().getAny()).hasSize(1);
         // if arrived here, means it did not fail with exception while trying to unmarshall unknown rss extension element, hence it just skipped it.
     }
 

--- a/kie-dmn/kie-dmn-backend/src/test/java/org/kie/dmn/backend/marshalling/v1_1/MarshallingUtilsTest.java
+++ b/kie-dmn/kie-dmn-backend/src/test/java/org/kie/dmn/backend/marshalling/v1_1/MarshallingUtilsTest.java
@@ -25,8 +25,7 @@ import org.kie.dmn.model.api.DMNModelInstrumentedBase;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import static org.hamcrest.CoreMatchers.is;
-import static org.hamcrest.MatcherAssert.assertThat;
+import static org.assertj.core.api.Assertions.assertThat;
 
 
 public class MarshallingUtilsTest {
@@ -50,17 +49,17 @@ public class MarshallingUtilsTest {
      */
     private void checkAndRoundTrip(QName qname, String formatQName) {
         String formatted = MarshallingUtils.formatQName(qname);
-        assertThat(formatted, is(formatQName));
+        assertThat(formatted).isEqualTo(formatQName);
 
         QName roundTrip = MarshallingUtils.parseQNameString(formatted);
-        assertThat(roundTrip.getLocalPart(), is(qname.getLocalPart()));
+        assertThat(roundTrip.getLocalPart()).isEqualTo(qname.getLocalPart());
 
         if (roundTrip.getPrefix() != XMLConstants.DEFAULT_NS_PREFIX) {
-            assertThat(roundTrip.getPrefix(), is(qname.getPrefix()));
+            assertThat(roundTrip.getPrefix()).isEqualTo(qname.getPrefix());
         }
 
         if (roundTrip.getNamespaceURI() != XMLConstants.NULL_NS_URI) {
-            assertThat(roundTrip.getNamespaceURI(), is(qname.getNamespaceURI()));
+            assertThat(roundTrip.getNamespaceURI()).isEqualTo(qname.getNamespaceURI());
         }
     }
 

--- a/kie-dmn/kie-dmn-core/pom.xml
+++ b/kie-dmn/kie-dmn-core/pom.xml
@@ -205,11 +205,6 @@
       <scope>test</scope>
     </dependency>
     <dependency>
-      <groupId>org.hamcrest</groupId>
-      <artifactId>hamcrest-library</artifactId>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
       <groupId>org.kie</groupId>
       <artifactId>kie-ci</artifactId>
       <scope>test</scope>

--- a/kie-dmn/kie-dmn-core/src/test/java/org/kie/dmn/core/BaseVariantTest.java
+++ b/kie-dmn/kie-dmn-core/src/test/java/org/kie/dmn/core/BaseVariantTest.java
@@ -37,8 +37,7 @@ import org.kie.dmn.typesafe.DMNTypeSafePackageName;
 import org.kie.dmn.typesafe.DMNTypeSafeTypeGenerator;
 import org.kie.memorycompiler.KieMemoryCompiler;
 
-import static org.hamcrest.CoreMatchers.notNullValue;
-import static org.hamcrest.MatcherAssert.assertThat;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.kie.dmn.core.BaseVariantTest.VariantTestConf.BUILDER_DEFAULT_NOCL_TYPECHECK;
 import static org.kie.dmn.core.BaseVariantTest.VariantTestConf.BUILDER_DEFAULT_NOCL_TYPECHECK_TYPESAFE;
 import static org.kie.dmn.core.BaseVariantTest.VariantTestConf.BUILDER_STRICT;
@@ -318,7 +317,7 @@ public abstract class BaseVariantTest {
 
     protected FEELPropertyAccessible createInstanceFromCompiledClasses(Map<String, Class<?>> compile, DMNTypeSafePackageName packageName, String className) throws Exception {
         Class<?> inputSetClass = compile.get(packageName.appendPackage(className));
-        assertThat(inputSetClass, notNullValue());
+        assertThat(inputSetClass).isNotNull();
         Object inputSetInstance = inputSetClass.getDeclaredConstructor().newInstance();
         return (FEELPropertyAccessible) inputSetInstance;
     }

--- a/kie-dmn/kie-dmn-core/src/test/java/org/kie/dmn/core/DMNAndCanonicalModelTest.java
+++ b/kie-dmn/kie-dmn-core/src/test/java/org/kie/dmn/core/DMNAndCanonicalModelTest.java
@@ -29,9 +29,7 @@ import org.kie.dmn.core.util.KieHelper;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import static org.hamcrest.CoreMatchers.is;
-import static org.hamcrest.Matchers.hasSize;
-import static org.hamcrest.MatcherAssert.assertThat;
+import static org.assertj.core.api.Assertions.assertThat;
 
 public class DMNAndCanonicalModelTest extends BaseInterpretedVsCompiledTestCanonicalKieModule {
 
@@ -54,13 +52,13 @@ public class DMNAndCanonicalModelTest extends BaseInterpretedVsCompiledTestCanon
 
         DMNRuntime runtime = kieContainer.newKieSession().getKieRuntime(DMNRuntime.class);
         Assert.assertNotNull(runtime);
-        assertThat(runtime.getModels(), hasSize(1));
+        assertThat(runtime.getModels()).hasSize(1);
 
         final DMNContext dmnContext = runtime.newContext();
         dmnContext.set("Full Name", "John Doe");
         final DMNResult evaluateAll = runtime.evaluateAll(runtime.getModels().get(0), dmnContext);
         LOG.debug("{}", evaluateAll);
-        assertThat(evaluateAll.getDecisionResultByName("Greeting Message").getResult(), is("Hello John Doe"));
+        assertThat(evaluateAll.getDecisionResultByName("Greeting Message").getResult()).isEqualTo("Hello John Doe");
     }
 
     @Test
@@ -76,7 +74,7 @@ public class DMNAndCanonicalModelTest extends BaseInterpretedVsCompiledTestCanon
 
         DMNRuntime runtime = kieContainer.newKieSession().getKieRuntime(DMNRuntime.class);
         Assert.assertNotNull(runtime);
-        assertThat(runtime.getModels(), hasSize(1));
+        assertThat(runtime.getModels()).hasSize(1);
 
         final DMNContext dmnContext = DMNFactory.newContext();
         dmnContext.set("Age", 18);
@@ -84,6 +82,6 @@ public class DMNAndCanonicalModelTest extends BaseInterpretedVsCompiledTestCanon
         dmnContext.set("isAffordable", true);
         final DMNResult evaluateAll = runtime.evaluateAll(runtime.getModels().get(0), dmnContext);
         LOG.debug("{}", evaluateAll);
-        assertThat(evaluateAll.getDecisionResultByName("Approval Status").getResult(), is("Approved"));
+        assertThat(evaluateAll.getDecisionResultByName("Approval Status").getResult()).isEqualTo("Approved");
     }
 }

--- a/kie-dmn/kie-dmn-core/src/test/java/org/kie/dmn/core/DMNCompilerTest.java
+++ b/kie-dmn/kie-dmn-core/src/test/java/org/kie/dmn/core/DMNCompilerTest.java
@@ -19,7 +19,6 @@ package org.kie.dmn.core;
 import java.util.Arrays;
 import java.util.Map;
 
-import org.hamcrest.Matchers;
 import org.junit.Test;
 import org.kie.dmn.api.core.DMNContext;
 import org.kie.dmn.api.core.DMNMessage;
@@ -44,13 +43,8 @@ import org.kie.dmn.feel.util.ClassLoaderUtil;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import static org.hamcrest.CoreMatchers.instanceOf;
-import static org.hamcrest.CoreMatchers.is;
-import static org.hamcrest.CoreMatchers.notNullValue;
-import static org.hamcrest.CoreMatchers.nullValue;
-import static org.hamcrest.Matchers.hasSize;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.Assert.assertFalse;
-import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.Assert.fail;
 import static org.kie.dmn.core.util.DynamicTypeUtils.entry;
 import static org.kie.dmn.core.util.DynamicTypeUtils.mapOf;
@@ -67,21 +61,21 @@ public class DMNCompilerTest extends BaseVariantTest {
     public void testJavadocSimple() {
         final DMNRuntime runtime = createRuntime("javadocSimple.dmn", this.getClass());
         final DMNModel dmnModel = runtime.getModel("https://kiegroup.org/dmn/_55F8F74F-3E9F-4FAA-BBF4-E6F9534B6B19", "new-file");
-        assertThat(dmnModel, notNullValue());
+        assertThat(dmnModel).isNotNull();
 
         final DMNType tVowel = dmnModel.getItemDefinitionByName("tVowel").getType();
-        assertThat(tVowel, is(notNullValue()));
-        assertThat(tVowel.isComposite(), is(false));
-        assertThat(tVowel, is(instanceOf(SimpleTypeImpl.class)));
-        assertThat(tVowel.getBaseType(), notNullValue());
-        assertThat(tVowel.getFields().size(), is(0));
+        assertThat(tVowel).isNotNull();
+        assertThat(tVowel.isComposite()).isFalse();
+        assertThat(tVowel).isInstanceOf(SimpleTypeImpl.class);
+        assertThat(tVowel.getBaseType()).isNotNull();
+        assertThat(tVowel.getFields()).hasSize(0);
 
         final DMNType tNumbers = dmnModel.getItemDefinitionByName("tNumbers").getType();
-        assertThat(tNumbers, is(notNullValue()));
-        assertThat(tNumbers.isComposite(), is(false));
-        assertThat(tNumbers, is(instanceOf(SimpleTypeImpl.class)));
-        assertThat(tNumbers.getBaseType(), notNullValue());
-        assertThat(tNumbers.getFields().size(), is(0));
+        assertThat(tNumbers).isNotNull();
+        assertThat(tNumbers.isComposite()).isFalse();
+        assertThat(tNumbers).isInstanceOf(SimpleTypeImpl.class);
+        assertThat(tNumbers.getBaseType()).isNotNull();
+        assertThat(tNumbers.getFields()).hasSize(0);
 
         final DMNContext context = runtime.newContext();
         context.set("a vowel", "a");
@@ -90,60 +84,60 @@ public class DMNCompilerTest extends BaseVariantTest {
 
         final DMNResult evaluateAll = evaluateModel(runtime, dmnModel, context);
         LOG.debug("{}", evaluateAll);
-        assertThat(evaluateAll.hasErrors(), is(false));
+        assertThat(evaluateAll.hasErrors()).isFalse();
     }
 
     @Test
     public void testJavadocComposite() {
         final DMNRuntime runtime = createRuntime("javadocComposite.dmn", this.getClass());
         final DMNModel dmnModel = runtime.getModel("https://kiegroup.org/dmn/_7EC096B1-878B-4E85-8334-58B440BB6AD9", "new-file");
-        assertThat(dmnModel, notNullValue());
+        assertThat(dmnModel).isNotNull();
 
         final DMNType tPerson = dmnModel.getItemDefinitionByName("tPerson").getType();
-        assertThat(tPerson, is(notNullValue()));
-        assertThat(tPerson.isComposite(), is(true));
-        assertThat(tPerson, is(instanceOf(CompositeTypeImpl.class)));
-        assertThat(tPerson.getBaseType(), nullValue());
-        assertThat(tPerson.getFields().size(), is(2));
+        assertThat(tPerson).isNotNull();
+        assertThat(tPerson.isComposite()).isTrue();
+        assertThat(tPerson).isInstanceOf(CompositeTypeImpl.class);
+        assertThat(tPerson.getBaseType()).isNull();
+        assertThat(tPerson.getFields()).hasSize(2);
 
         final DMNContext context = runtime.newContext();
         context.set("a person", mapOf(entry("full name", "John Doe"), entry("age", 47)));
 
         final DMNResult evaluateAll = evaluateModel(runtime, dmnModel, context);
         LOG.debug("{}", evaluateAll);
-        assertThat(DMNRuntimeUtil.formatMessages(evaluateAll.getMessages()), evaluateAll.hasErrors(), is(false));
+        assertThat(evaluateAll.hasErrors()).as(DMNRuntimeUtil.formatMessages(evaluateAll.getMessages())).isFalse();
     }
 
     @Test
     public void testJavadocInnerComposite() {
         final DMNRuntime runtime = createRuntime("javadocInnerComposite.dmn", this.getClass());
         final DMNModel dmnModel = runtime.getModel("https://kiegroup.org/dmn/_7EC096B1-878B-4E85-8334-58B440BB6AD9bis", "new-file");
-        assertThat(dmnModel, notNullValue());
+        assertThat(dmnModel).isNotNull();
         
         DMNTypeRegistry typeRegistry = ((DMNModelImpl) dmnModel).getTypeRegistry();
 
         final DMNType tPerson = dmnModel.getItemDefinitionByName("tPerson").getType();
-        assertThat(tPerson, is(notNullValue()));
-        assertThat(tPerson.isComposite(), is(true));
-        assertThat(tPerson, is(instanceOf(CompositeTypeImpl.class)));
-        assertThat(tPerson.getBaseType(), nullValue());
-        assertThat(tPerson.getFields().size(), is(2));
-        assertThat(typeRegistry.resolveType(tPerson.getNamespace(), tPerson.getName()), notNullValue());
+        assertThat(tPerson).isNotNull();
+        assertThat(tPerson.isComposite()).isTrue();
+        assertThat(tPerson).isInstanceOf(CompositeTypeImpl.class);
+        assertThat(tPerson.getBaseType()).isNull();
+        assertThat(tPerson.getFields()).hasSize(2);
+        assertThat(typeRegistry.resolveType(tPerson.getNamespace(), tPerson.getName())).isNotNull();
         final DMNType addressType = tPerson.getFields().get("address");
-        assertThat(addressType, is(instanceOf(CompositeTypeImpl.class)));
-        assertThat(addressType.getName(), is("address"));
-        assertThat(addressType.getFields().size(), is(2));
-        assertThat(typeRegistry.resolveType(addressType.getNamespace(), addressType.getName()), nullValue());
+        assertThat(addressType).isInstanceOf(CompositeTypeImpl.class);
+        assertThat(addressType.getName()).isEqualTo("address");
+        assertThat(addressType.getFields()).hasSize(2);
+        assertThat(typeRegistry.resolveType(addressType.getNamespace(), addressType.getName())).isNull();
 
         final DMNType tPart = dmnModel.getItemDefinitionByName("tPart").getType();
-        assertThat(tPart, is(notNullValue()));
-        assertThat(tPart.isComposite(), is(true));
-        assertThat(tPart, is(instanceOf(CompositeTypeImpl.class)));
-        assertThat(typeRegistry.resolveType(tPart.getNamespace(), tPart.getName()), notNullValue());
+        assertThat(tPart).isNotNull();
+        assertThat(tPart.isComposite()).isTrue();
+        assertThat(tPart).isInstanceOf(CompositeTypeImpl.class);
+        assertThat(typeRegistry.resolveType(tPart.getNamespace(), tPart.getName())).isNotNull();
         final DMNType gradeType = tPart.getFields().get("grade");
-        assertThat(gradeType, is(instanceOf(SimpleTypeImpl.class)));
-        assertThat(gradeType.getName(), is("grade"));
-        assertThat(typeRegistry.resolveType(gradeType.getNamespace(), gradeType.getName()), nullValue());
+        assertThat(gradeType).isInstanceOf(SimpleTypeImpl.class);
+        assertThat(gradeType.getName()).isEqualTo("grade");
+        assertThat(typeRegistry.resolveType(gradeType.getNamespace(), gradeType.getName())).isNull();
 
         final DMNContext context = runtime.newContext();
         context.set("a person", mapOf(entry("full name", "John Doe"), entry("address", mapOf(entry("country", "IT"), entry("zip", "abcde")))));
@@ -151,74 +145,74 @@ public class DMNCompilerTest extends BaseVariantTest {
         
         final DMNResult evaluateAll = evaluateModel(runtime, dmnModel, context);
         LOG.debug("{}", evaluateAll);
-        assertThat(DMNRuntimeUtil.formatMessages(evaluateAll.getMessages()), evaluateAll.hasErrors(), is(false));
+        assertThat(evaluateAll.hasErrors()).as(DMNRuntimeUtil.formatMessages(evaluateAll.getMessages())).isFalse();
     }
 
     @Test
     public void testItemDefAllowedValuesString() {
         final DMNRuntime runtime = createRuntime("0003-input-data-string-allowed-values.dmn", this.getClass());
         final DMNModel dmnModel = runtime.getModel("https://github.com/kiegroup/kie-dmn", "0003-input-data-string-allowed-values" );
-        assertThat( dmnModel, notNullValue() );
+        assertThat(dmnModel).isNotNull();
 
         final ItemDefNode itemDef = dmnModel.getItemDefinitionByName("tEmploymentStatus" );
 
-        assertThat( itemDef.getName(), is( "tEmploymentStatus" ) );
-        assertThat( itemDef.getId(), is( nullValue() ) );
+        assertThat(itemDef.getName()).isEqualTo("tEmploymentStatus");
+        assertThat(itemDef.getId()).isNull();
 
         final DMNType type = itemDef.getType();
 
-        assertThat( type, is( notNullValue() ) );
-        assertThat( type.getName(), is( "tEmploymentStatus" ) );
-        assertThat( type.getId(), is( nullValue() ) );
-        assertThat( type, is( instanceOf( SimpleTypeImpl.class ) ) );
+        assertThat(type).isNotNull();
+        assertThat(type.getName()).isEqualTo("tEmploymentStatus");
+        assertThat(type.getId()).isNull();
+        assertThat(type).isInstanceOf(SimpleTypeImpl.class);
 
         final SimpleTypeImpl feelType = (SimpleTypeImpl) type;
 
         final EvaluationContext ctx = new EvaluationContextImpl(ClassLoaderUtil.findDefaultClassLoader(), null);
-        assertThat( feelType.getFeelType(), is(instanceOf(AliasFEELType.class)));
-        assertThat( feelType.getFeelType().getName(), is("tEmploymentStatus"));
-        assertThat( feelType.getAllowedValuesFEEL().size(), is( 4 ) );
-        assertThat( feelType.getAllowedValuesFEEL().get( 0 ).apply( ctx, "UNEMPLOYED" ), is( true ) );
-        assertThat( feelType.getAllowedValuesFEEL().get( 1 ).apply( ctx, "EMPLOYED" ), is( true )   );
-        assertThat( feelType.getAllowedValuesFEEL().get( 2 ).apply( ctx, "SELF-EMPLOYED" ), is( true )  );
-        assertThat( feelType.getAllowedValuesFEEL().get( 3 ).apply( ctx, "STUDENT" ), is( true )  );
+        assertThat(feelType.getFeelType()).isInstanceOf(AliasFEELType.class);
+        assertThat(feelType.getFeelType().getName()).isEqualTo("tEmploymentStatus");
+        assertThat(feelType.getAllowedValuesFEEL()).hasSize(4);
+        assertThat(feelType.getAllowedValuesFEEL().get(0).apply(ctx, "UNEMPLOYED")).isTrue();
+        assertThat(feelType.getAllowedValuesFEEL().get(1).apply(ctx, "EMPLOYED")).isTrue();
+        assertThat(feelType.getAllowedValuesFEEL().get(2).apply(ctx, "SELF-EMPLOYED")).isTrue();
+        assertThat(feelType.getAllowedValuesFEEL().get(3).apply(ctx, "STUDENT")).isTrue();
     }
 
     @Test
     public void testCompositeItemDefinition() {
         final DMNRuntime runtime = createRuntime("0008-LX-arithmetic.dmn", this.getClass());
         final DMNModel dmnModel = runtime.getModel("https://github.com/kiegroup/kie-dmn", "0008-LX-arithmetic" );
-        assertThat( dmnModel, notNullValue() );
+        assertThat(dmnModel).isNotNull();
 
         final ItemDefNode itemDef = dmnModel.getItemDefinitionByName("tLoan" );
 
-        assertThat( itemDef.getName(), is( "tLoan" ) );
-        assertThat( itemDef.getId(), is( "tLoan" ) );
+        assertThat(itemDef.getName()).isEqualTo("tLoan");
+        assertThat(itemDef.getId()).isEqualTo("tLoan");
 
         final DMNType type = itemDef.getType();
 
-        assertThat( type, is( notNullValue() ) );
-        assertThat( type.getName(), is( "tLoan" ) );
-        assertThat( type.getId(), is( "tLoan" ) );
-        assertThat( type, is( instanceOf( CompositeTypeImpl.class ) ) );
+        assertThat(type).isNotNull();
+        assertThat(type.getName()).isEqualTo("tLoan");
+        assertThat(type.getId()).isEqualTo("tLoan");
+        assertThat(type).isInstanceOf(CompositeTypeImpl.class);
 
         final CompositeTypeImpl compType = (CompositeTypeImpl) type;
 
-        assertThat( compType.getFields().size(), is( 3 ) );
+        assertThat(compType.getFields()).hasSize(3);
         final DMNType principal = compType.getFields().get("principal" );
-        assertThat( principal, is( notNullValue() ) );
-        assertThat( principal.getName(), is( "number" ) );
-        assertThat( ((SimpleTypeImpl)principal).getFeelType(), is( BuiltInType.NUMBER ) );
+        assertThat(principal).isNotNull();
+        assertThat(principal.getName()).isEqualTo("number");
+        assertThat(((SimpleTypeImpl)principal).getFeelType()).isEqualTo(BuiltInType.NUMBER);
 
         final DMNType rate = compType.getFields().get("rate" );
-        assertThat( rate, is( notNullValue() ) );
-        assertThat( rate.getName(), is( "number" ) );
-        assertThat( ((SimpleTypeImpl)rate).getFeelType(), is( BuiltInType.NUMBER ) );
+        assertThat(rate).isNotNull();
+        assertThat(rate.getName()).isEqualTo("number");
+        assertThat(((SimpleTypeImpl)rate).getFeelType()).isEqualTo(BuiltInType.NUMBER);
 
         final DMNType termMonths = compType.getFields().get("termMonths" );
-        assertThat( termMonths, is( notNullValue() ) );
-        assertThat( termMonths.getName(), is( "number" ) );
-        assertThat( ((SimpleTypeImpl)termMonths).getFeelType(), is( BuiltInType.NUMBER ) );
+        assertThat(termMonths).isNotNull();
+        assertThat(termMonths.getName()).isEqualTo("number");
+        assertThat(((SimpleTypeImpl)termMonths).getFeelType()).isEqualTo(BuiltInType.NUMBER);
     }
 
     @Test
@@ -227,7 +221,7 @@ public class DMNCompilerTest extends BaseVariantTest {
             createRuntime("compilationThrowsNPE.dmn", this.getClass());
             fail("shouldn't have reached here.");
         } catch (final Exception ex) {
-            assertThat(ex.getMessage(), Matchers.containsString("Unable to compile DMN model for the resource"));
+            assertThat(ex.getMessage()).containsSequence("Unable to compile DMN model for the resource");
         }
     }
 
@@ -236,7 +230,7 @@ public class DMNCompilerTest extends BaseVariantTest {
         // DROOLS-2161
         final DMNRuntime runtime = createRuntime("Recursive.dmn", this.getClass());
         final DMNModel dmnModel = runtime.getModel("https://github.com/kiegroup/kie-dmn", "Recursive" );
-        assertThat( dmnModel, notNullValue() );
+        assertThat(dmnModel).isNotNull();
         assertFalse( evaluateModel(runtime, dmnModel, DMNFactory.newContext() ).hasErrors() );
     }
 
@@ -248,14 +242,14 @@ public class DMNCompilerTest extends BaseVariantTest {
 
         final DMNModel importedModel = runtime.getModel("http://www.trisotech.com/dmn/definitions/_f27bb64b-6fc7-4e1f-9848-11ba35e0df36",
                                                         "Imported Model");
-        assertThat(importedModel, notNullValue());
+        assertThat(importedModel).isNotNull();
         for (final DMNMessage message : importedModel.getMessages()) {
             LOG.debug("{}", message);
         }
 
         final DMNModel dmnModel = runtime.getModel("http://www.trisotech.com/dmn/definitions/_f79aa7a4-f9a3-410a-ac95-bea496edab52",
                                                    "Importing Model");
-        assertThat(dmnModel, notNullValue());
+        assertThat(dmnModel).isNotNull();
         for (final DMNMessage message : dmnModel.getMessages()) {
             LOG.debug("{}", message);
         }
@@ -268,12 +262,12 @@ public class DMNCompilerTest extends BaseVariantTest {
             LOG.debug("{}", message);
         }
         LOG.debug("{}", evaluateAll);
-        assertThat(evaluateAll.getDecisionResultByName("Greeting").getResult(), is("Hello John!"));
+        assertThat(evaluateAll.getDecisionResultByName("Greeting").getResult()).isEqualTo("Hello John!");
 
         if (isTypeSafe()) {
             FEELPropertyAccessible outputSet = ((DMNContextFPAImpl)evaluateAll.getContext()).getFpa();
             Map<String, Object> allProperties = outputSet.allFEELProperties();
-            assertThat(allProperties.get("Greeting"), is("Hello John!"));
+            assertThat(allProperties.get("Greeting")).isEqualTo("Hello John!");
         }
     }
 
@@ -281,18 +275,16 @@ public class DMNCompilerTest extends BaseVariantTest {
     public void testWrongComparisonOps() {
         final DMNRuntime runtime = createRuntime("WrongComparisonOps.dmn", this.getClass());
         final DMNModel dmnModel = runtime.getModel("http://www.trisotech.com/definitions/_a937d093-86d3-4306-8db8-1e7a33588b68", "Drawing 1");
-        assertThat(dmnModel, notNullValue());
-        assertThat(DMNRuntimeUtil.formatMessages(dmnModel.getMessages()), dmnModel.hasErrors(), is(false));
-        assertThat(DMNRuntimeUtil.formatMessages(dmnModel.getMessages()), dmnModel.getMessages(), hasSize(4));
-        assertThat(DMNRuntimeUtil.formatMessages(dmnModel.getMessages()), dmnModel.getMessages(DMNMessage.Severity.WARN), hasSize(4));
-        assertThat(DMNRuntimeUtil.formatMessages(dmnModel.getMessages()),
-                   dmnModel.getMessages(DMNMessage.Severity.WARN)
+        assertThat(dmnModel).isNotNull();
+        assertThat(dmnModel.hasErrors()).as(DMNRuntimeUtil.formatMessages(dmnModel.getMessages())).isFalse();
+        assertThat(dmnModel.getMessages()).as(DMNRuntimeUtil.formatMessages(dmnModel.getMessages())).hasSize(4);
+        assertThat(dmnModel.getMessages(DMNMessage.Severity.WARN)).as(DMNRuntimeUtil.formatMessages(dmnModel.getMessages())).hasSize(4);
+        assertThat(dmnModel.getMessages(DMNMessage.Severity.WARN)
                            .stream()
                            .filter(m -> m.getSourceId().equals("_d72d6fab-1e67-4fe7-9c12-54800d6fe294") ||
                                         m.getSourceId().equals("_2390dd99-094d-4f97-aecc-9cccb697ce05") ||
                                         m.getSourceId().equals("_0c292d34-498e-4b08-ae99-3c694197b69f") ||
                                         m.getSourceId().equals("_21c7d800-b806-4b2e-9a10-00828de7f2d2"))
-                           .count(),
-                   is(4L));
+                           .count()).as(DMNRuntimeUtil.formatMessages(dmnModel.getMessages())).isEqualTo(4L);
     }
 }

--- a/kie-dmn/kie-dmn-core/src/test/java/org/kie/dmn/core/DMNDecisionTableHitPolicyNoExecModelTest.java
+++ b/kie-dmn/kie-dmn-core/src/test/java/org/kie/dmn/core/DMNDecisionTableHitPolicyNoExecModelTest.java
@@ -21,7 +21,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
 
-import org.assertj.core.api.Assertions;
 import org.junit.Test;
 import org.kie.api.builder.Message;
 import org.kie.dmn.api.core.DMNContext;
@@ -37,17 +36,7 @@ import org.kie.dmn.feel.runtime.events.HitPolicyViolationEvent;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import static org.hamcrest.CoreMatchers.containsString;
-import static org.hamcrest.CoreMatchers.hasItems;
-import static org.hamcrest.CoreMatchers.is;
-import static org.hamcrest.CoreMatchers.isA;
-import static org.hamcrest.CoreMatchers.notNullValue;
-import static org.hamcrest.CoreMatchers.nullValue;
-import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.contains;
-import static org.hamcrest.Matchers.hasEntry;
-import static org.hamcrest.Matchers.hasSize;
-import static org.hamcrest.Matchers.isEmptyOrNullString;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 
@@ -63,14 +52,14 @@ public class DMNDecisionTableHitPolicyNoExecModelTest extends BaseVariantNonType
     public void testShortCircuitFIRST() {
         final DMNRuntime runtime = createRuntime("First DT not stopping.dmn", this.getClass());
         final DMNModel dmnModel = runtime.getModel("http://www.trisotech.com/definitions/_e56151c4-d522-4974-88e8-f6c88ffaaba4", "Drawing 1");
-        assertThat(dmnModel, notNullValue());
+        assertThat(dmnModel).isNotNull();
 
         final DMNContext emptyContext = DMNFactory.newContext();
         final DMNResult dmnResult = runtime.evaluateAll(dmnModel, emptyContext);
         LOG.debug("{}", dmnResult);
-        assertThat(dmnResult.hasErrors(), is(false));
+        assertThat(dmnResult.hasErrors()).isFalse();
 
         final DMNContext result = dmnResult.getContext();
-        Assertions.assertThat(result.getAll()).extracting("First Decision Table.nn abs").isEqualTo(BigDecimal.ZERO);
+        assertThat(result.getAll()).extracting("First Decision Table.nn abs").isEqualTo(BigDecimal.ZERO);
     }
 }

--- a/kie-dmn/kie-dmn-core/src/test/java/org/kie/dmn/core/DMNDecisionTableRuntimeTest.java
+++ b/kie-dmn/kie-dmn-core/src/test/java/org/kie/dmn/core/DMNDecisionTableRuntimeTest.java
@@ -20,7 +20,6 @@ import java.io.InputStreamReader;
 import java.math.BigDecimal;
 import java.math.RoundingMode;
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
@@ -66,12 +65,6 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.hamcrest.CoreMatchers.instanceOf;
-import static org.hamcrest.CoreMatchers.is;
-import static org.hamcrest.CoreMatchers.notNullValue;
-import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.empty;
-import static org.hamcrest.Matchers.hasEntry;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNull;
@@ -95,7 +88,7 @@ public class DMNDecisionTableRuntimeTest extends BaseInterpretedVsCompiledTest {
 
     private void checkDecisionTableWithCalculatedResult(final DMNRuntime runtime) {
         final DMNModel dmnModel = runtime.getModel( "http://www.trisotech.com/definitions/_77ae284e-ce52-4579-a50f-f3cc584d7f4b", "Calculation1" );
-        assertThat( dmnModel, notNullValue() );
+        assertThat(dmnModel).isNotNull();
 
         final DMNContext context = DMNFactory.newContext();
         context.set( "MonthlyDeptPmt", BigDecimal.valueOf( 200 ) );
@@ -103,10 +96,10 @@ public class DMNDecisionTableRuntimeTest extends BaseInterpretedVsCompiledTest {
         context.set( "MonthlyIncome", BigDecimal.valueOf( 600 ) );
 
         final DMNResult dmnResult = runtime.evaluateAll( dmnModel, context );
-        assertThat( dmnResult.hasErrors(), is( false ) );
+        assertThat(dmnResult.hasErrors()).isFalse();
 
         final DMNContext result = dmnResult.getContext();
-        assertThat( ((BigDecimal) result.get( "Logique de décision 1" )).setScale( 1, RoundingMode.CEILING ), is( BigDecimal.valueOf( 0.5 ) ) );
+        assertThat( ((BigDecimal) result.get( "Logique de décision 1" )).setScale( 1, RoundingMode.CEILING )).isEqualTo(BigDecimal.valueOf( 0.5 ) );
     }
     
     @Test(timeout = 30_000L)
@@ -134,7 +127,7 @@ public class DMNDecisionTableRuntimeTest extends BaseInterpretedVsCompiledTest {
         runtime.addListener( listener );
 
         final DMNModel dmnModel = runtime.getModel( "http://www.trisotech.com/definitions/_820611e9-c21c-47cd-8e52-5cba2be9f9cc", "Car Damage Responsibility" );
-        assertThat( dmnModel, notNullValue() );
+        assertThat(dmnModel).isNotNull();
 
         final DMNContext context = DMNFactory.newContext();
         context.set( "Membership Level", "Silver" );
@@ -142,30 +135,30 @@ public class DMNDecisionTableRuntimeTest extends BaseInterpretedVsCompiledTest {
         context.set( "Responsible", "Driver" );
 
         final DMNResult dmnResult = runtime.evaluateAll( dmnModel, context );
-        assertThat( dmnResult.hasErrors(), is( false ) );
+        assertThat(dmnResult.hasErrors()).isFalse();
 
         final DMNContext result = dmnResult.getContext();
-        assertThat( (Map<String, Object>) result.get( "Car Damage Responsibility" ), hasEntry( is( "EU Rent" ), is( BigDecimal.valueOf( 40 ) ) ) );
-        assertThat( (Map<String, Object>) result.get( "Car Damage Responsibility" ), hasEntry( is( "Renter" ), is( BigDecimal.valueOf( 60 ) ) ) );
-        assertThat( result.get( "Payment method" ), is( "Check" ) );
+        assertThat( (Map<String, Object>) result.get( "Car Damage Responsibility" )).containsEntry("EU Rent", BigDecimal.valueOf(40));
+        assertThat( (Map<String, Object>) result.get( "Car Damage Responsibility" )).containsEntry("Renter", BigDecimal.valueOf(60));
+        assertThat( result.get( "Payment method" )).isEqualTo("Check" );
 
         final ArgumentCaptor<AfterEvaluateDecisionTableEvent> captor = ArgumentCaptor.forClass( AfterEvaluateDecisionTableEvent.class );
         verify( listener, times( 2 ) ).afterEvaluateDecisionTable( captor.capture() );
 
         final AfterEvaluateDecisionTableEvent first = captor.getAllValues().get( 0 );
-        assertThat( first.getMatches(), is( Collections.singletonList( 5 ) ) );
-        assertThat( first.getSelected(), is( Collections.singletonList( 5 ) ) );
+        assertThat( first.getMatches()).containsExactly(5);
+        assertThat( first.getSelected()).containsExactly(5);
 
         final AfterEvaluateDecisionTableEvent second = captor.getAllValues().get( 1 );
-        assertThat( second.getMatches(), is( Collections.singletonList( 3 ) ) );
-        assertThat( second.getSelected(), is( Collections.singletonList( 3 ) ) );
+        assertThat( second.getMatches()).containsExactly(3);
+        assertThat( second.getSelected()).containsExactly(3);
     }
 
     @Test
     public void testSimpleDecisionTableMultipleOutputWrongOutputType() {
         final DMNRuntime runtime = DMNRuntimeUtil.createRuntime( "0004-simpletable-P-multiple-outputs-wrong-output.dmn", this.getClass() );
         final DMNModel dmnModel = runtime.getModel( "https://github.com/kiegroup/kie-dmn", "0004-simpletable-P-multiple-outputs-wrong-output" );
-        assertThat( dmnModel, notNullValue() );
+        assertThat(dmnModel).isNotNull();
 
         final DMNContext context = DMNFactory.newContext();
         context.set( "Age", BigDecimal.valueOf( 18 ) );
@@ -173,9 +166,9 @@ public class DMNDecisionTableRuntimeTest extends BaseInterpretedVsCompiledTest {
         context.set( "isAffordable", true );
 
         final DMNResult dmnResult = runtime.evaluateAll( dmnModel, context );
-        assertThat( dmnResult.hasErrors(), is( true ) );
+        assertThat( dmnResult.hasErrors()).isTrue();
         assertThat( dmnResult.getMessages().stream().filter(
-                message -> message.getFeelEvent().getSourceException() instanceof NullPointerException ).count(), is( 0L ) );
+                message -> message.getFeelEvent().getSourceException() instanceof NullPointerException ).count()).isEqualTo(0L );
     }
 
     @Test
@@ -208,13 +201,13 @@ public class DMNDecisionTableRuntimeTest extends BaseInterpretedVsCompiledTest {
     private void testDecisionTableInvalidInput(final DMNContext inputContext) {
         final DMNRuntime runtime = DMNRuntimeUtil.createRuntime( "InvalidInput.dmn", this.getClass() );
         final DMNModel dmnModel = runtime.getModel( "http://www.trisotech.com/dmn/definitions/_cdf29af2-959b-4004-8271-82a9f5a62147", "Dessin 1" );
-        assertThat( dmnModel, notNullValue() );
+        assertThat(dmnModel).isNotNull();
 
         final DMNResult dmnResult = runtime.evaluateAll( dmnModel, inputContext );
-        assertThat( dmnResult.hasErrors(), is( true ) );
+        assertThat( dmnResult.hasErrors()).isTrue();
 
         final DMNContext result = dmnResult.getContext();
-        assertThat( result.isDefined( "Branches distribution" ), is( false ) );
+        assertThat( result.isDefined( "Branches distribution" )).isEqualTo(Boolean.FALSE);
     }
 
     @Test
@@ -224,8 +217,8 @@ public class DMNDecisionTableRuntimeTest extends BaseInterpretedVsCompiledTest {
         runtime.addListener( listener );
 
         final DMNModel dmnModel = runtime.getModel( "https://github.com/kiegroup/kie-dmn", "decisiontable-default-value" );
-        assertThat( dmnModel, notNullValue() );
-        assertThat( dmnModel.getMessages().toString(), dmnModel.hasErrors(), is( false ) );
+        assertThat(dmnModel).isNotNull();
+        assertThat(dmnModel.hasErrors()).as(DMNRuntimeUtil.formatMessages(dmnModel.getMessages())).isFalse();
 
         final DMNContext context = DMNFactory.newContext();
         context.set( "Age", new BigDecimal( 16 ) );
@@ -233,16 +226,16 @@ public class DMNDecisionTableRuntimeTest extends BaseInterpretedVsCompiledTest {
         context.set( "isAffordable", true );
 
         final DMNResult dmnResult = runtime.evaluateAll( dmnModel, context );
-        assertThat( dmnResult.getMessages().toString(), dmnResult.hasErrors(), is( false ) );
+        assertThat(dmnResult.hasErrors()).as(DMNRuntimeUtil.formatMessages(dmnResult.getMessages())).isFalse();
 
         final DMNContext result = dmnResult.getContext();
-        assertThat( result.get( "Approval Status" ), is( "Declined" ) );
+        assertThat( result.get( "Approval Status" )).isEqualTo("Declined" );
 
         final ArgumentCaptor<AfterEvaluateDecisionTableEvent> captor = ArgumentCaptor.forClass( AfterEvaluateDecisionTableEvent.class );
         verify( listener ).afterEvaluateDecisionTable( captor.capture() );
 
-        assertThat( captor.getValue().getMatches(), is( empty() ) );
-        assertThat( captor.getValue().getSelected(), is( empty() ) );
+        assertThat( captor.getValue().getMatches()).isEmpty();
+        assertThat( captor.getValue().getSelected()).isEmpty();
     }
 
     @Test
@@ -252,24 +245,24 @@ public class DMNDecisionTableRuntimeTest extends BaseInterpretedVsCompiledTest {
         runtime.addListener( listener );
 
         final DMNModel dmnModel = runtime.getModel( "http://www.trisotech.com/definitions/_bbb692e7-3d95-407a-bf39-353085bf57f0", "Invocation with two decision table as parameters" );
-        assertThat( dmnModel, notNullValue() );
-        assertThat( dmnModel.getMessages().toString(), dmnModel.hasErrors(), is( false ) );
+        assertThat(dmnModel).isNotNull();
+        assertThat(dmnModel.hasErrors()).as(DMNRuntimeUtil.formatMessages(dmnModel.getMessages())).isFalse();
 
         final DMNContext context = DMNFactory.newContext();
         context.set( "Number", 50 );
 
         final DMNResult dmnResult = runtime.evaluateAll( dmnModel, context );
-        assertThat( dmnResult.getMessages().toString(), dmnResult.hasErrors(), is( false ) );
+        assertThat(dmnResult.hasErrors()).as(DMNRuntimeUtil.formatMessages(dmnResult.getMessages())).isFalse();
 
         final DMNContext result = dmnResult.getContext();
-        assertThat( (Map<String, Object>) result.get( "Decision Logic 2" ), hasEntry( "the 5 analysis", "A number greater than 5" ) );
-        assertThat( (Map<String, Object>) result.get( "Decision Logic 2" ), hasEntry( "the 100 analysis", "A number smaller than 100" ) );
+        assertThat( (Map<String, Object>) result.get( "Decision Logic 2" )).containsEntry("the 5 analysis", "A number greater than 5");
+        assertThat( (Map<String, Object>) result.get( "Decision Logic 2" )).containsEntry("the 100 analysis", "A number smaller than 100");
 
         final ArgumentCaptor<AfterEvaluateDecisionTableEvent> captor = ArgumentCaptor.forClass( AfterEvaluateDecisionTableEvent.class );
         verify( listener, times( 2 ) ).afterEvaluateDecisionTable( captor.capture() );
 
-        assertThat( captor.getAllValues().get( 0 ).getDecisionTableName(), is( "a" ) );
-        assertThat( captor.getAllValues().get( 1 ).getDecisionTableName(), is( "b" ) );
+        assertThat( captor.getAllValues().get( 0 ).getDecisionTableName()).isEqualTo("a" );
+        assertThat( captor.getAllValues().get( 1 ).getDecisionTableName()).isEqualTo("b" );
     }
 
     @Test
@@ -278,41 +271,41 @@ public class DMNDecisionTableRuntimeTest extends BaseInterpretedVsCompiledTest {
         final DMNModel dmnModel = runtime.getModel(
                 "https://www.drools.org/kie-dmn/definitions",
                 "definitions" );
-        assertThat( dmnModel, notNullValue() );
-        assertThat( DMNRuntimeUtil.formatMessages( dmnModel.getMessages() ), dmnModel.hasErrors(), is( false ) );
+        assertThat(dmnModel).isNotNull();
+        assertThat(dmnModel.hasErrors()).as(DMNRuntimeUtil.formatMessages(dmnModel.getMessages())).isFalse();
 
         final DMNContext context = runtime.newContext();
         context.set( "MyInput", "a" );
 
         final DMNResult dmnResult = runtime.evaluateAll(dmnModel, context );
 
-        assertThat( DMNRuntimeUtil.formatMessages( dmnResult.getMessages() ), dmnResult.hasErrors(), is( false ) );
+        assertThat(dmnResult.hasErrors()).as(DMNRuntimeUtil.formatMessages(dmnResult.getMessages())).isFalse();
         final DMNContext result = dmnResult.getContext();
-        assertThat( result.get( "MyDecision" ), is( "Decision taken" ) );
+        assertThat( result.get( "MyDecision" )).isEqualTo("Decision taken" );
     }
 
     @Test
     public void testDTInContext() {
         final DMNRuntime runtime = DMNRuntimeUtil.createRuntime("DT_in_context.dmn", this.getClass() );
         final DMNModel dmnModel = runtime.getModel("http://www.trisotech.com/dmn/definitions/_4acdcb25-b298-435e-abd5-efd00ed686a5", "Drawing 1" );
-        assertThat( dmnModel, notNullValue() );
+        assertThat(dmnModel).isNotNull();
 
         final DMNContext context = DMNFactory.newContext();
         final DMNResult dmnResult = runtime.evaluateAll(dmnModel, context );
 
-        assertThat( dmnResult.getDecisionResults().size(), is( 1 ) );
-        assertThat( dmnResult.getDecisionResultByName( "D1" ).getResult(), is( instanceOf( Map.class ) ) );
+        assertThat( dmnResult.getDecisionResults()).hasSize(1);
+        assertThat( dmnResult.getDecisionResultByName( "D1" ).getResult()).isInstanceOf(Map.class);
 
         final DMNContext result = dmnResult.getContext();
-        assertThat( ((Map) result.get( "D1" )).get( "Text color" ), is( "red" ) );
+        assertThat( ((Map) result.get( "D1" )).get( "Text color" )).isEqualTo("red" );
     }
 
     @Test
     public void testDTUsingEqualsUnaryTestWithVariable1() {
         final DMNRuntime runtime = DMNRuntimeUtil.createRuntime("DT_using_variables.dmn", this.getClass() );
         final DMNModel dmnModel = runtime.getModel("http://www.trisotech.com/definitions/_ed1ec15b-40aa-424d-b1d0-4936df80b135", "DT Using variables" );
-        assertThat( dmnModel, notNullValue() );
-        assertThat( DMNRuntimeUtil.formatMessages( dmnModel.getMessages() ), dmnModel.hasErrors(), is( false ) );
+        assertThat(dmnModel).isNotNull();
+        assertThat(dmnModel.hasErrors()).as(DMNRuntimeUtil.formatMessages(dmnModel.getMessages())).isFalse();
 
         final Map<String, Object> complex = new HashMap<>();
         complex.put( "aBoolean", true );
@@ -327,17 +320,17 @@ public class DMNDecisionTableRuntimeTest extends BaseInterpretedVsCompiledTest {
         final DMNResult dmnResult = runtime.evaluateAll(dmnModel, context );
 
         final DMNContext result = dmnResult.getContext();
-        assertThat( result.get( "Compare Boolean" ), is( "Same boolean" ) );
-        assertThat( result.get( "Compare Number" ), is( "Equals" ) );
-        assertThat( result.get( "Compare String" ), is( "Same String" ) );
+        assertThat( result.get( "Compare Boolean" )).isEqualTo("Same boolean" );
+        assertThat( result.get( "Compare Number" )).isEqualTo("Equals" );
+        assertThat( result.get( "Compare String" )).isEqualTo("Same String" );
     }
 
     @Test
     public void testDTUsingEqualsUnaryTestWithVariable2() {
         final DMNRuntime runtime = DMNRuntimeUtil.createRuntime("DT_using_variables.dmn", this.getClass() );
         final DMNModel dmnModel = runtime.getModel("http://www.trisotech.com/definitions/_ed1ec15b-40aa-424d-b1d0-4936df80b135", "DT Using variables" );
-        assertThat( dmnModel, notNullValue() );
-        assertThat( dmnModel.hasErrors(), is( false ) );
+        assertThat(dmnModel).isNotNull();
+        assertThat( dmnModel.hasErrors()).isFalse();
 
         final Map<String, Object> complex = new HashMap<>();
         complex.put( "aBoolean", true );
@@ -352,23 +345,23 @@ public class DMNDecisionTableRuntimeTest extends BaseInterpretedVsCompiledTest {
         final DMNResult dmnResult = runtime.evaluateAll(dmnModel, context );
 
         final DMNContext result = dmnResult.getContext();
-        assertThat( result.get( "Compare Boolean" ), is( "Not same boolean" ) );
-        assertThat( result.get( "Compare Number" ), is( "Bigger" ) );
-        assertThat( result.get( "Compare String" ), is( "Different String" ) );
+        assertThat( result.get( "Compare Boolean" )).isEqualTo("Not same boolean" );
+        assertThat( result.get( "Compare Number" )).isEqualTo("Bigger" );
+        assertThat( result.get( "Compare String" )).isEqualTo("Different String" );
     }
 
     @Test
     public void testEmptyOutputCell() {
         final DMNRuntime runtime = DMNRuntimeUtil.createRuntime( "DT_empty_output_cell.dmn", this.getClass() );
         final DMNModel dmnModel = runtime.getModel( "http://www.trisotech.com/definitions/_77ae284e-ce52-4579-a50f-f3cc584d7f4b", "Calculation1" );
-        assertThat( dmnModel, notNullValue() );
+        assertThat(dmnModel).isNotNull();
         final DMNContext context = DMNFactory.newContext();
         context.set( "MonthlyDeptPmt", BigDecimal.valueOf( 1 ) );
         context.set( "MonthlyPmt", BigDecimal.valueOf( 1 ) );
         context.set( "MonthlyIncome", BigDecimal.valueOf( 1 ) );
         final DMNResult dmnResult = runtime.evaluateAll( dmnModel, context );
         LOG.debug("{}", dmnResult);
-        assertThat( dmnResult.hasErrors(), is( false ) );
+        assertThat(dmnResult.hasErrors()).isFalse();
         assertNull( dmnResult.getContext().get("Logique de décision 1") );
     }
 
@@ -376,12 +369,12 @@ public class DMNDecisionTableRuntimeTest extends BaseInterpretedVsCompiledTest {
     public void testNullRelation() {
         final DMNRuntime runtime = DMNRuntimeUtil.createRuntime("nullrelation.dmn", getClass());
         final DMNModel model = runtime.getModel("http://www.trisotech.com/definitions/_946a2145-89ae-4197-88b4-40e6f88c8101", "Null in relations");
-        assertThat(model, notNullValue());
-        assertThat(DMNRuntimeUtil.formatMessages(model.getMessages()), model.hasErrors(), is(false));
+        assertThat(model).isNotNull();
+        assertThat(model.hasErrors()).as(DMNRuntimeUtil.formatMessages(model.getMessages())).isFalse();
         final DMNContext context = DMNFactory.newContext();
         context.set("Value", "a3");
         final DMNResult result = runtime.evaluateByName(model, context, "Mapping");
-        assertThat(DMNRuntimeUtil.formatMessages(result.getMessages()), result.hasErrors(), is(false));
+        assertThat(result.hasErrors()).as(DMNRuntimeUtil.formatMessages(result.getMessages())).isFalse();
     }
 
     @Test
@@ -389,17 +382,17 @@ public class DMNDecisionTableRuntimeTest extends BaseInterpretedVsCompiledTest {
         // DROOLS-2359
         final DMNRuntime runtime = DMNRuntimeUtil.createRuntime("DecisionTableOutputDMNTypeCollection.dmn", this.getClass());
         final DMNModel dmnModel = runtime.getModel("http://www.trisotech.com/dmn/definitions/_ae5d2033-c6d0-411f-a394-da33a70e5638", "Drawing 1");
-        assertThat(dmnModel, notNullValue());
-        assertThat(DMNRuntimeUtil.formatMessages(dmnModel.getMessages()), dmnModel.hasErrors(), is(false));
+        assertThat(dmnModel).isNotNull();
+        assertThat(dmnModel.hasErrors()).as(DMNRuntimeUtil.formatMessages(dmnModel.getMessages())).isFalse();
 
         final DMNContext context = DMNFactory.newContext();
         context.set("selector", "asd");
 
         final DMNResult dmnResult = runtime.evaluateAll(dmnModel, context);
-        assertThat(DMNRuntimeUtil.formatMessages(dmnResult.getMessages()), dmnResult.hasErrors(), is(false));
+        assertThat(dmnResult.hasErrors()).as(DMNRuntimeUtil.formatMessages(dmnResult.getMessages())).isFalse();
 
         final DMNContext result = dmnResult.getContext();
-        assertThat(result.get("a decision"), is(Arrays.asList("abc", "xyz")));
+        assertThat(result.get("a decision")).asList().containsExactly("abc", "xyz");
     }
 
     @Test
@@ -411,17 +404,17 @@ public class DMNDecisionTableRuntimeTest extends BaseInterpretedVsCompiledTest {
                                                                     ks.getResources().newClassPathResource("DecisionTableOutputDMNTypeCollection.dmn", this.getClass()));
         final DMNRuntime runtime = kieContainer.newKieSession().getKieRuntime(DMNRuntime.class);
         final DMNModel dmnModel = runtime.getModel("http://www.trisotech.com/dmn/definitions/_ae5d2033-c6d0-411f-a394-da33a70e5638", "Drawing 1");
-        assertThat(dmnModel, notNullValue());
-        assertThat(DMNRuntimeUtil.formatMessages(dmnModel.getMessages()), dmnModel.hasErrors(), is(false));
+        assertThat(dmnModel).isNotNull();
+        assertThat(dmnModel.hasErrors()).as(DMNRuntimeUtil.formatMessages(dmnModel.getMessages())).isFalse();
 
         final DMNContext context = DMNFactory.newContext();
         context.set("selector", "asd");
 
         final DMNResult dmnResult = runtime.evaluateAll(dmnModel, context);
-        assertThat(DMNRuntimeUtil.formatMessages(dmnResult.getMessages()), dmnResult.hasErrors(), is(false));
+        assertThat(dmnResult.hasErrors()).as(DMNRuntimeUtil.formatMessages(dmnResult.getMessages())).isFalse();
 
         final DMNContext result = dmnResult.getContext();
-        assertThat(result.get("a decision"), is(Arrays.asList("abc", "xyz")));
+        assertThat(result.get("a decision")).asList().containsExactly("abc", "xyz");
     }
 
     @Test
@@ -429,17 +422,17 @@ public class DMNDecisionTableRuntimeTest extends BaseInterpretedVsCompiledTest {
         // DROOLS-2359
         final DMNRuntime runtime = DMNRuntimeUtil.createRuntime("DecisionTableOutputDMNTypeCollectionWithLOV.dmn", this.getClass());
         final DMNModel dmnModel = runtime.getModel("http://www.trisotech.com/dmn/definitions/_ae5d2033-c6d0-411f-a394-da33a70e5638", "List of Words in DT");
-        assertThat(dmnModel, notNullValue());
-        assertThat(DMNRuntimeUtil.formatMessages(dmnModel.getMessages()), dmnModel.hasErrors(), is(false));
+        assertThat(dmnModel).isNotNull();
+        assertThat(dmnModel.hasErrors()).as(DMNRuntimeUtil.formatMessages(dmnModel.getMessages())).isFalse();
 
         final DMNContext context = DMNFactory.newContext();
         context.set("selector", "asd");
 
         final DMNResult dmnResult = runtime.evaluateAll(dmnModel, context);
-        assertThat(DMNRuntimeUtil.formatMessages(dmnResult.getMessages()), dmnResult.hasErrors(), is(false));
+        assertThat(dmnResult.hasErrors()).as(DMNRuntimeUtil.formatMessages(dmnResult.getMessages())).isFalse();
 
         final DMNContext result = dmnResult.getContext();
-        assertThat(result.get("a decision"), is(Arrays.asList("abc", "a")));
+        assertThat(result.get("a decision")).asList().containsExactly("abc", "a");
     }
 
     @Test
@@ -451,17 +444,17 @@ public class DMNDecisionTableRuntimeTest extends BaseInterpretedVsCompiledTest {
                                                                     ks.getResources().newClassPathResource("DecisionTableOutputDMNTypeCollectionWithLOV.dmn", this.getClass()));
         final DMNRuntime runtime = kieContainer.newKieSession().getKieRuntime(DMNRuntime.class);
         final DMNModel dmnModel = runtime.getModel("http://www.trisotech.com/dmn/definitions/_ae5d2033-c6d0-411f-a394-da33a70e5638", "List of Words in DT");
-        assertThat(dmnModel, notNullValue());
-        assertThat(DMNRuntimeUtil.formatMessages(dmnModel.getMessages()), dmnModel.hasErrors(), is(false));
+        assertThat(dmnModel).isNotNull();
+        assertThat(dmnModel.hasErrors()).as(DMNRuntimeUtil.formatMessages(dmnModel.getMessages())).isFalse();
 
         final DMNContext context = DMNFactory.newContext();
         context.set("selector", "asd");
 
         final DMNResult dmnResult = runtime.evaluateAll(dmnModel, context);
-        assertThat(DMNRuntimeUtil.formatMessages(dmnResult.getMessages()), dmnResult.hasErrors(), is(false));
+        assertThat(dmnResult.hasErrors()).as(DMNRuntimeUtil.formatMessages(dmnResult.getMessages())).isFalse();
 
         final DMNContext result = dmnResult.getContext();
-        assertThat(result.get("a decision"), is(Arrays.asList("abc", "a")));
+        assertThat(result.get("a decision")).asList().containsExactly("abc", "a");
     }
 
     @Test
@@ -586,8 +579,8 @@ public class DMNDecisionTableRuntimeTest extends BaseInterpretedVsCompiledTest {
                                                         final DMNDecisionResult.DecisionEvaluationStatus expectedStatus) {
         final DMNRuntime runtime = DMNRuntimeUtil.createRuntime(dmnResourcePath, this.getClass() );
         final DMNModel model = runtime.getModel("http://www.trisotech.com/definitions/_88a36f38-4494-4fd8-aaea-f7a6b4c91825", "Enabling question marks" );
-        assertThat( model, notNullValue() );
-        assertThat( DMNRuntimeUtil.formatMessages( model.getMessages() ), model.hasErrors(), is( false ) );
+        assertThat(model).isNotNull();
+        assertThat(model.hasErrors()).as(DMNRuntimeUtil.formatMessages(model.getMessages())).isFalse();
         final DMNContext context = DMNFactory.newContext();
         final DMNDecisionResult result = runtime.evaluateByName(model, context, "Result").getDecisionResultByName("Result");
 
@@ -601,8 +594,8 @@ public class DMNDecisionTableRuntimeTest extends BaseInterpretedVsCompiledTest {
         // DROOLS-5606 DMN wrong rule index in message when not conforming
         final DMNRuntime runtime = DMNRuntimeUtil.createRuntime("DecisionTableOutputMessageRowIndex.dmn", this.getClass());
         final DMNModel dmnModel = runtime.getModel("https://kiegroup.org/dmn/_D7A4B999-3178-4929-834F-8979E3C5000F", "DecisionTableOutputMessageRowIndex");
-        assertThat(dmnModel, notNullValue());
-        assertThat(DMNRuntimeUtil.formatMessages(dmnModel.getMessages()), dmnModel.hasErrors(), is(false));
+        assertThat(dmnModel).isNotNull();
+        assertThat(dmnModel.hasErrors()).as(DMNRuntimeUtil.formatMessages(dmnModel.getMessages())).isFalse();
 
         final DMNContext context = DMNFactory.newContext();
         context.set("InputData-1", "asd");
@@ -610,7 +603,7 @@ public class DMNDecisionTableRuntimeTest extends BaseInterpretedVsCompiledTest {
         final DMNResult dmnResult = runtime.evaluateAll(dmnModel, context);
         LOG.debug("{}", dmnResult);
         LOG.debug("{}", dmnResult.getMessages());
-        assertThat(DMNRuntimeUtil.formatMessages(dmnResult.getMessages()), dmnResult.hasErrors(), is(true));
+        assertThat(dmnResult.hasErrors()).as(DMNRuntimeUtil.formatMessages(dmnResult.getMessages())).isTrue();
         DMNMessage msg0 = dmnResult.getMessages().get(0);
         assertThat(msg0.getText()).containsIgnoringCase("Invalid result value on rule #1, output #1."); // there is only 1 row, 1 output column
     }
@@ -619,23 +612,23 @@ public class DMNDecisionTableRuntimeTest extends BaseInterpretedVsCompiledTest {
     public void testDTand() {
         final DMNRuntime runtime = DMNRuntimeUtil.createRuntime("DTand.dmn", this.getClass());
         final DMNModel dmnModel = runtime.getModel("https://kiegroup.org/dmn/_6697FFDC-B3D9-4B0B-BC07-AE5E5AC96CB4", "DTand");
-        assertThat(dmnModel, notNullValue());
-        assertThat(DMNRuntimeUtil.formatMessages(dmnModel.getMessages()), dmnModel.hasErrors(), is(false));
+        assertThat(dmnModel).isNotNull();
+        assertThat(dmnModel.hasErrors()).as(DMNRuntimeUtil.formatMessages(dmnModel.getMessages())).isFalse();
 
         final DMNContext context = DMNFactory.newContext();
         context.set("in1", null);
         final DMNResult dmnResult = runtime.evaluateAll(dmnModel, context);
         LOG.debug("{}", dmnResult);
-        assertThat(DMNRuntimeUtil.formatMessages(dmnResult.getMessages()), dmnResult.hasErrors(), is(false));
-        assertThat(dmnResult.getDecisionResultByName("out1").getResult(), is("PASS"));
+        assertThat(dmnResult.hasErrors()).as(DMNRuntimeUtil.formatMessages(dmnResult.getMessages())).isFalse();
+        assertThat(dmnResult.getDecisionResultByName("out1").getResult()).isEqualTo("PASS");
     }
 
     @Test
     public void testQMarkAndNullShouldNotThrowNPEs() {
         final DMNRuntime runtime = DMNRuntimeUtil.createRuntime("questionmarkunarytest/qmarkMatches.dmn", this.getClass());
         final DMNModel dmnModel = runtime.getModel("https://kiegroup.org/dmn/_D1CF8332-8443-41C8-B214-D282B82C7632", "qmarkMatches");
-        assertThat(dmnModel, notNullValue());
-        assertThat(DMNRuntimeUtil.formatMessages(dmnModel.getMessages()), dmnModel.hasErrors(), is(false));
+        assertThat(dmnModel).isNotNull();
+        assertThat(dmnModel.hasErrors()).as(DMNRuntimeUtil.formatMessages(dmnModel.getMessages())).isFalse();
 
         List<NullPointerException> feelNPEs = new ArrayList<>();
         DMNRuntimeImpl runtimeImpl = (DMNRuntimeImpl) runtime;
@@ -658,11 +651,9 @@ public class DMNDecisionTableRuntimeTest extends BaseInterpretedVsCompiledTest {
         context.set("MyInput", null);
         final DMNResult dmnResult = runtime.evaluateAll(dmnModel, context);
         LOG.debug("{}", dmnResult);
-        assertThat(DMNRuntimeUtil.formatMessages(dmnResult.getMessages()), dmnResult.hasErrors(), is(true));
+        assertThat(dmnResult.hasErrors()).as(DMNRuntimeUtil.formatMessages(dmnResult.getMessages())).isTrue();
 
-        assertThat("while it's okay to have error-ed on evaluation of FEEL, there should not be any sort of NPEs when reporting the human friendly message",
-                   feelNPEs.isEmpty(),
-                   is(true));
+        assertThat(feelNPEs).as("while it's okay to have error-ed on evaluation of FEEL, there should not be any sort of NPEs when reporting the human friendly message").isEmpty();
     }
 
     @Test
@@ -696,14 +687,14 @@ public class DMNDecisionTableRuntimeTest extends BaseInterpretedVsCompiledTest {
         final KieContainer container = ks.newKieContainer(kjarReleaseId);
         final DMNRuntime runtime = KieRuntimeFactory.of(container.getKieBase()).get(DMNRuntime.class);
         final DMNModel dmnModel = runtime.getModel("https://kiegroup.org/dmn/_943A3581-5FD1-4BCF-9A52-AC7242CC451C", "multipleOutputsCollectDT");
-        assertThat(dmnModel, notNullValue());
-        assertThat(DMNRuntimeUtil.formatMessages(dmnModel.getMessages()), dmnModel.hasErrors(), is(false));
+        assertThat(dmnModel).isNotNull();
+        assertThat(dmnModel.hasErrors()).as(DMNRuntimeUtil.formatMessages(dmnModel.getMessages())).isFalse();
 
         final DMNContext context = DMNFactory.newContext();
         context.set("level", level);
         final DMNResult dmnResult = runtime.evaluateAll(dmnModel, context);
         LOG.debug("{}", dmnResult);
-        assertThat(DMNRuntimeUtil.formatMessages(dmnResult.getMessages()), dmnResult.hasErrors(), is(false));
+        assertThat(dmnResult.hasErrors()).as(DMNRuntimeUtil.formatMessages(dmnResult.getMessages())).isFalse();
         Object decision1 = dmnResult.getDecisionResultByName("Decision-1").getResult();
         assertThat(decision1).hasFieldOrPropertyWithValue("a", new BigDecimal(a));
         assertThat(decision1).hasFieldOrPropertyWithValue("b", new BigDecimal(b));

--- a/kie-dmn/kie-dmn-core/src/test/java/org/kie/dmn/core/DMNDecisionTableWithSymbolsTest.java
+++ b/kie-dmn/kie-dmn-core/src/test/java/org/kie/dmn/core/DMNDecisionTableWithSymbolsTest.java
@@ -24,9 +24,7 @@ import org.kie.dmn.api.core.DMNRuntime;
 import org.kie.dmn.core.api.DMNFactory;
 import org.kie.dmn.core.util.DMNRuntimeUtil;
 
-import static org.hamcrest.Matchers.is;
-import static org.hamcrest.core.IsNull.notNullValue;
-import static org.hamcrest.MatcherAssert.assertThat;
+import static org.assertj.core.api.Assertions.assertThat;
 
 public class DMNDecisionTableWithSymbolsTest extends BaseInterpretedVsCompiledTest {
 
@@ -38,7 +36,7 @@ public class DMNDecisionTableWithSymbolsTest extends BaseInterpretedVsCompiledTe
     public void testDecisionWithArgumentsOnOutput() {
         final DMNRuntime runtime = DMNRuntimeUtil.createRuntime("Decide with symbols.dmn", this.getClass());
         final DMNModel dmnModel = runtime.getModel("http://www.trisotech.com/dmn/definitions/_79b16a68-013b-484c-98f5-49ff77808800", "Decide with symbols");
-        assertThat(dmnModel, notNullValue());
+        assertThat(dmnModel).isNotNull();
 
         final DMNContext context = DMNFactory.newContext();
         context.set("Person age", 44);
@@ -46,6 +44,6 @@ public class DMNDecisionTableWithSymbolsTest extends BaseInterpretedVsCompiledTe
 
         final DMNResult dmnResult = runtime.evaluateAll(dmnModel, context);
         final DMNContext result = dmnResult.getContext();
-        assertThat(result.get("Decide with symbol"), is("Hello, Mario"));
+        assertThat(result.get("Decide with symbol")).isEqualTo("Hello, Mario");
     }
 }

--- a/kie-dmn/kie-dmn-core/src/test/java/org/kie/dmn/core/DMNInputRuntimeTest.java
+++ b/kie-dmn/kie-dmn-core/src/test/java/org/kie/dmn/core/DMNInputRuntimeTest.java
@@ -38,10 +38,7 @@ import org.kie.dmn.api.core.ast.ItemDefNode;
 import org.kie.dmn.core.api.DMNFactory;
 import org.kie.dmn.core.util.DMNRuntimeUtil;
 
-import static org.hamcrest.CoreMatchers.is;
-import static org.hamcrest.CoreMatchers.notNullValue;
-import static org.hamcrest.CoreMatchers.nullValue;
-import static org.hamcrest.MatcherAssert.assertThat;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.Assert.assertTrue;
 import static org.kie.dmn.core.util.DynamicTypeUtils.entry;
 import static org.kie.dmn.core.util.DynamicTypeUtils.prototype;
@@ -56,88 +53,88 @@ public class DMNInputRuntimeTest extends BaseInterpretedVsCompiledTest {
     public void testInputStringEvaluateAll() {
         final DMNRuntime runtime = DMNRuntimeUtil.createRuntime( "0001-input-data-string.dmn", this.getClass() );
         final DMNModel dmnModel = runtime.getModel( "https://github.com/kiegroup/drools/kie-dmn", "_0001-input-data-string" );
-        assertThat( dmnModel, notNullValue() );
+        assertThat(dmnModel).isNotNull();
 
         final DMNContext context = DMNFactory.newContext();
         context.set( "Full Name", "John Doe" );
 
         final DMNResult dmnResult = runtime.evaluateAll( dmnModel, context );
 
-        assertThat( dmnResult.getDecisionResults().size(), is(1) );
-        assertThat( dmnResult.getDecisionResultByName( "Greeting Message" ).getResult(), is( "Hello John Doe" ) );
+        assertThat( dmnResult.getDecisionResults()).hasSize(1);
+        assertThat( dmnResult.getDecisionResultByName( "Greeting Message" ).getResult()).isEqualTo("Hello John Doe" );
 
         final DMNContext result = dmnResult.getContext();
 
-        assertThat( result.get( "Greeting Message" ), is( "Hello John Doe" ) );
+        assertThat( result.get( "Greeting Message" )).isEqualTo("Hello John Doe" );
     }
 
     @Test
     public void testInputStringEvaluateDecisionByName() {
         final DMNRuntime runtime = DMNRuntimeUtil.createRuntime( "0001-input-data-string.dmn", this.getClass() );
         final DMNModel dmnModel = runtime.getModel( "https://github.com/kiegroup/drools/kie-dmn", "_0001-input-data-string" );
-        assertThat( dmnModel, notNullValue() );
+        assertThat(dmnModel).isNotNull();
 
         final DMNContext context = DMNFactory.newContext();
         context.set( "Full Name", "John Doe" );
 
         DMNResult dmnResult = runtime.evaluateByName( dmnModel, context, "Greeting Message");
 
-        assertThat( dmnResult.getDecisionResults().size(), is(1) );
-        assertThat( dmnResult.getDecisionResultByName( "Greeting Message" ).getResult(), is( "Hello John Doe" ) );
+        assertThat( dmnResult.getDecisionResults()).hasSize(1);
+        assertThat( dmnResult.getDecisionResultByName( "Greeting Message" ).getResult()).isEqualTo("Hello John Doe" );
 
         final DMNContext result = dmnResult.getContext();
 
-        assertThat( result.get( "Greeting Message" ), is( "Hello John Doe" ) );
+        assertThat( result.get( "Greeting Message" )).isEqualTo("Hello John Doe" );
 
         dmnResult = runtime.evaluateByName( dmnModel, context, "nonExistantName");
-        assertThat( dmnResult.getDecisionResults().size(), is(1) );
-        assertThat( dmnResult.getDecisionResultByName( "Greeting Message" ).getEvaluationStatus(), is( DMNDecisionResult.DecisionEvaluationStatus.NOT_EVALUATED ) );
+        assertThat( dmnResult.getDecisionResults()).hasSize(1);
+        assertThat( dmnResult.getDecisionResultByName( "Greeting Message" ).getEvaluationStatus()).isEqualTo(DMNDecisionResult.DecisionEvaluationStatus.NOT_EVALUATED );
 
         dmnResult = runtime.evaluateByName( dmnModel, context, "" );
-        assertThat( dmnResult.getDecisionResults().size(), is(1) );
-        assertThat( dmnResult.getDecisionResultByName( "Greeting Message" ).getEvaluationStatus(), is( DMNDecisionResult.DecisionEvaluationStatus.NOT_EVALUATED ) );
+        assertThat( dmnResult.getDecisionResults()).hasSize(1);
+        assertThat( dmnResult.getDecisionResultByName( "Greeting Message" ).getEvaluationStatus()).isEqualTo(DMNDecisionResult.DecisionEvaluationStatus.NOT_EVALUATED );
 
         dmnResult = runtime.evaluateByName( dmnModel, context, (String) null);
-        assertThat( dmnResult.getDecisionResults().size(), is(1) );
-        assertThat( dmnResult.getDecisionResultByName( "Greeting Message" ).getEvaluationStatus(), is( DMNDecisionResult.DecisionEvaluationStatus.NOT_EVALUATED ) );
+        assertThat( dmnResult.getDecisionResults()).hasSize(1);
+        assertThat( dmnResult.getDecisionResultByName( "Greeting Message" ).getEvaluationStatus()).isEqualTo(DMNDecisionResult.DecisionEvaluationStatus.NOT_EVALUATED );
     }
 
     @Test
     public void testInputStringEvaluateDecisionById() {
         final DMNRuntime runtime = DMNRuntimeUtil.createRuntime( "0001-input-data-string.dmn", this.getClass() );
         final DMNModel dmnModel = runtime.getModel( "https://github.com/kiegroup/drools/kie-dmn", "_0001-input-data-string" );
-        assertThat( dmnModel, notNullValue() );
+        assertThat(dmnModel).isNotNull();
 
         final DMNContext context = DMNFactory.newContext();
         context.set( "Full Name", "John Doe" );
 
         DMNResult dmnResult = runtime.evaluateById( dmnModel, context, "d_GreetingMessage" );
 
-        assertThat( dmnResult.getDecisionResults().size(), is(1) );
-        assertThat( dmnResult.getDecisionResultById( "d_GreetingMessage" ).getResult(), is( "Hello John Doe" ) );
+        assertThat( dmnResult.getDecisionResults()).hasSize(1);
+        assertThat( dmnResult.getDecisionResultById( "d_GreetingMessage" ).getResult()).isEqualTo("Hello John Doe" );
 
         final DMNContext result = dmnResult.getContext();
 
-        assertThat( result.get( "Greeting Message" ), is( "Hello John Doe" ) );
+        assertThat( result.get( "Greeting Message" )).isEqualTo("Hello John Doe" );
 
         dmnResult = runtime.evaluateById( dmnModel, context, "nonExistantId" );
-        assertThat( dmnResult.getDecisionResults().size(), is(1) );
-        assertThat( dmnResult.getDecisionResultByName( "Greeting Message" ).getEvaluationStatus(), is( DMNDecisionResult.DecisionEvaluationStatus.NOT_EVALUATED ) );
+        assertThat( dmnResult.getDecisionResults()).hasSize(1);
+        assertThat( dmnResult.getDecisionResultByName( "Greeting Message" ).getEvaluationStatus()).isEqualTo(DMNDecisionResult.DecisionEvaluationStatus.NOT_EVALUATED );
 
         dmnResult = runtime.evaluateById( dmnModel, context, "" );
-        assertThat( dmnResult.getDecisionResults().size(), is(1) );
-        assertThat( dmnResult.getDecisionResultByName( "Greeting Message" ).getEvaluationStatus(), is( DMNDecisionResult.DecisionEvaluationStatus.NOT_EVALUATED ) );
+        assertThat( dmnResult.getDecisionResults()).hasSize(1);
+        assertThat( dmnResult.getDecisionResultByName( "Greeting Message" ).getEvaluationStatus()).isEqualTo(DMNDecisionResult.DecisionEvaluationStatus.NOT_EVALUATED );
 
         dmnResult = runtime.evaluateById( dmnModel, context, (String) null);
-        assertThat( dmnResult.getDecisionResults().size(), is(1) );
-        assertThat( dmnResult.getDecisionResultByName( "Greeting Message" ).getEvaluationStatus(), is( DMNDecisionResult.DecisionEvaluationStatus.NOT_EVALUATED ) );
+        assertThat( dmnResult.getDecisionResults()).hasSize(1);
+        assertThat( dmnResult.getDecisionResultByName( "Greeting Message" ).getEvaluationStatus()).isEqualTo(DMNDecisionResult.DecisionEvaluationStatus.NOT_EVALUATED );
     }
 
     @Test
     public void testInputStringAllowedValuesEvaluateAll() {
         final DMNRuntime runtime = DMNRuntimeUtil.createRuntime( "0003-input-data-string-allowed-values.dmn", this.getClass() );
         final DMNModel dmnModel = runtime.getModel( "https://github.com/kiegroup/kie-dmn", "0003-input-data-string-allowed-values" );
-        assertThat( dmnModel, notNullValue() );
+        assertThat(dmnModel).isNotNull();
 
         final DMNContext context = DMNFactory.newContext();
         context.set( "Employment Status", "SELF-EMPLOYED" );
@@ -146,7 +143,7 @@ public class DMNInputRuntimeTest extends BaseInterpretedVsCompiledTest {
 
         final DMNContext result = dmnResult.getContext();
 
-        assertThat( result.get( "Employment Status Statement" ), is( "You are SELF-EMPLOYED" ) );
+        assertThat( result.get( "Employment Status Statement" )).isEqualTo("You are SELF-EMPLOYED" );
     }
 
     @Test
@@ -162,26 +159,26 @@ public class DMNInputRuntimeTest extends BaseInterpretedVsCompiledTest {
     private void testInputStringNotAllowedValuesEvaluateAll(final Object inputValue) {
         final DMNRuntime runtime = DMNRuntimeUtil.createRuntime( "0003-input-data-string-allowed-values.dmn", this.getClass() );
         final DMNModel dmnModel = runtime.getModel( "https://github.com/kiegroup/kie-dmn", "0003-input-data-string-allowed-values" );
-        assertThat( dmnModel, notNullValue() );
+        assertThat(dmnModel).isNotNull();
 
         final DMNContext context = DMNFactory.newContext();
         context.set( "Employment Status", inputValue );
 
         final DMNResult dmnResult = runtime.evaluateAll( dmnModel, context );
 
-        assertThat( dmnResult.getDecisionResults().size(), is(1) );
-        assertThat( dmnResult.getDecisionResultByName( "Employment Status Statement" ).getResult(), is((String) null) );
-        assertThat( dmnResult.getMessages().size(), is(1) );
-        assertThat( dmnResult.getMessages().get(0).getSeverity(), is(DMNMessage.Severity.ERROR) );
-        assertThat( dmnResult.getDecisionResults().get(0).getMessages().size(), is(1) );
-        assertThat( dmnResult.getDecisionResults().get(0).getMessages().get(0).getSeverity(), is(DMNMessage.Severity.ERROR) );
+        assertThat(dmnResult.getDecisionResults()).hasSize(1);
+        assertThat(dmnResult.getDecisionResultByName( "Employment Status Statement" ).getResult()).isNull();
+        assertThat(dmnResult.getMessages()).hasSize(1);
+        assertThat(dmnResult.getMessages().get(0).getSeverity()).isEqualTo(DMNMessage.Severity.ERROR);
+        assertThat(dmnResult.getDecisionResults().get(0).getMessages()).hasSize(1);
+        assertThat(dmnResult.getDecisionResults().get(0).getMessages().get(0).getSeverity()).isEqualTo(DMNMessage.Severity.ERROR);
     }
 
     @Test
     public void testInputNumberEvaluateAll() {
         final DMNRuntime runtime = DMNRuntimeUtil.createRuntime( "0002-input-data-number.dmn", this.getClass() );
         final DMNModel dmnModel = runtime.getModel( "https://github.com/kiegroup/kie-dmn", "0002-input-data-number" );
-        assertThat( dmnModel, notNullValue() );
+        assertThat(dmnModel).isNotNull();
 
         final DMNContext context = DMNFactory.newContext();
         context.set( "Monthly Salary", new BigDecimal( 1000 ) );
@@ -190,56 +187,56 @@ public class DMNInputRuntimeTest extends BaseInterpretedVsCompiledTest {
 
         final DMNContext result = dmnResult.getContext();
 
-        assertThat( result.get( "Yearly Salary" ), is( new BigDecimal( 12000 ) ) );
+        assertThat( result.get( "Yearly Salary" )).isEqualTo(new BigDecimal( 12000 ) );
     }
 
     @Test
     public void testGetRequiredInputsByName() {
         final DMNRuntime runtime = DMNRuntimeUtil.createRuntime( "0001-input-data-string.dmn", this.getClass() );
         final DMNModel dmnModel = runtime.getModel( "https://github.com/kiegroup/drools/kie-dmn", "_0001-input-data-string" );
-        assertThat( dmnModel, notNullValue() );
+        assertThat(dmnModel).isNotNull();
 
         Set<InputDataNode> inputs = dmnModel.getRequiredInputsForDecisionName( "Greeting Message" );
 
-        assertThat( inputs.size(), is(1) );
-        assertThat( inputs.iterator().next().getName(), is("Full Name") );
+        assertThat( inputs).hasSize(1);
+        assertThat( inputs.iterator().next().getName()).isEqualTo("Full Name");
 
         inputs = dmnModel.getRequiredInputsForDecisionName("nonExistantDecisionName");
-        assertThat( inputs.size(), is(0) );
+        assertThat( inputs).hasSize(0);
     }
 
     @Test
     public void testGetRequiredInputsById() {
         final DMNRuntime runtime = DMNRuntimeUtil.createRuntime( "0001-input-data-string.dmn", this.getClass() );
         final DMNModel dmnModel = runtime.getModel( "https://github.com/kiegroup/drools/kie-dmn", "_0001-input-data-string" );
-        assertThat( dmnModel, notNullValue() );
+        assertThat(dmnModel).isNotNull();
 
         Set<InputDataNode> inputs = dmnModel.getRequiredInputsForDecisionId( "d_GreetingMessage" );
 
-        assertThat( inputs.size(), is(1) );
-        assertThat( inputs.iterator().next().getName(), is("Full Name") );
+        assertThat( inputs).hasSize(1);
+        assertThat( inputs.iterator().next().getName()).isEqualTo("Full Name");
 
         inputs = dmnModel.getRequiredInputsForDecisionId( "nonExistantId" );
-        assertThat( inputs.size(), is(0) );
+        assertThat( inputs).hasSize(0);
     }
 
     @Test
     public void testNonexistantInputNodeName() {
         final DMNRuntime runtime = DMNRuntimeUtil.createRuntime( "0001-input-data-string.dmn", this.getClass() );
         final DMNModel dmnModel = runtime.getModel( "https://github.com/kiegroup/drools/kie-dmn", "_0001-input-data-string" );
-        assertThat( dmnModel, notNullValue() );
+        assertThat(dmnModel).isNotNull();
 
         final DMNContext context = DMNFactory.newContext();
         context.set( "Nonexistant Input", "John Doe" );
 
         final DMNResult dmnResult = runtime.evaluateAll( dmnModel, context );
 
-        assertThat( dmnResult.getDecisionResults().size(), is(1) );
-        assertThat( dmnResult.getDecisionResultByName( "Greeting Message" ).getResult(), is((String) null) );
-        assertThat( dmnResult.getMessages().size(), is(1) );
-        assertThat( dmnResult.getMessages().get(0).getSeverity(), is(DMNMessage.Severity.ERROR) );
-        assertThat( dmnResult.getDecisionResults().get(0).getMessages().size(), is(1) );
-        assertThat( dmnResult.getDecisionResults().get(0).getMessages().get(0).getSeverity(), is(DMNMessage.Severity.ERROR) );
+        assertThat( dmnResult.getDecisionResults()).hasSize(1);
+        assertThat( dmnResult.getDecisionResultByName( "Greeting Message" ).getResult()).isNull();
+        assertThat( dmnResult.getMessages()).hasSize(1);
+        assertThat( dmnResult.getMessages().get(0).getSeverity()).isEqualTo(DMNMessage.Severity.ERROR);
+        assertThat( dmnResult.getDecisionResults().get(0).getMessages()).hasSize(1);
+        assertThat( dmnResult.getDecisionResults().get(0).getMessages().get(0).getSeverity()).isEqualTo(DMNMessage.Severity.ERROR);
     }
 
     @Test
@@ -248,32 +245,32 @@ public class DMNInputRuntimeTest extends BaseInterpretedVsCompiledTest {
         final DMNModel dmnModel = runtime.getModel(
                 "http://www.trisotech.com/definitions/_238bd96d-47cd-4746-831b-504f3e77b442",
                 "AllowedValuesChecks" );
-        assertThat( dmnModel, notNullValue() );
-        assertThat( DMNRuntimeUtil.formatMessages( dmnModel.getMessages() ), dmnModel.hasErrors(), is( false ) );
+        assertThat(dmnModel).isNotNull();
+        assertThat(dmnModel.hasErrors()).as(DMNRuntimeUtil.formatMessages(dmnModel.getMessages())).isFalse();
 
         final DMNContext ctx1 = runtime.newContext();
         ctx1.set("p1", prototype(entry("Name", "P1"), entry("Interests", Collections.singletonList("Golf"))));
         final DMNResult dmnResult1 = runtime.evaluateAll( dmnModel, ctx1 );
-        assertThat( DMNRuntimeUtil.formatMessages( dmnResult1.getMessages() ), dmnResult1.hasErrors(), is( false ) );
-        assertThat( dmnResult1.getContext().get( "MyDecision" ), is( "The Person P1 likes 1 thing(s)." ) );
+        assertThat(dmnResult1.hasErrors()).as(DMNRuntimeUtil.formatMessages(dmnResult1.getMessages())).isFalse();
+        assertThat( dmnResult1.getContext().get( "MyDecision" )).isEqualTo("The Person P1 likes 1 thing(s)." );
 
         final DMNContext ctx2 = runtime.newContext();
         ctx2.set("p1", prototype(entry("Name", "P2"), entry("Interests", Collections.singletonList("x"))));
         final DMNResult dmnResult2 = runtime.evaluateAll( dmnModel, ctx2 );
-        assertThat( DMNRuntimeUtil.formatMessages( dmnResult2.getMessages() ), dmnResult2.hasErrors(), is( true ) );
-        assertThat( dmnResult2.getMessages().stream().anyMatch( m -> m.getMessageType().equals( DMNMessageType.ERROR_EVAL_NODE ) ), is( true ) );
+        assertThat(dmnResult2.hasErrors()).as(DMNRuntimeUtil.formatMessages(dmnResult2.getMessages())).isTrue();
+        assertThat(dmnResult2.getMessages().stream().anyMatch(m -> m.getMessageType().equals(DMNMessageType.ERROR_EVAL_NODE))).isTrue();
 
         final DMNContext ctx3 = runtime.newContext();
         ctx3.set("p1", prototype(entry("Name", "P3"), entry("Interests", Arrays.asList("Golf", "Computer"))));
         final DMNResult dmnResult3 = runtime.evaluateAll( dmnModel, ctx3 );
-        assertThat( DMNRuntimeUtil.formatMessages( dmnResult3.getMessages() ), dmnResult3.hasErrors(), is( false ) );
-        assertThat( dmnResult3.getContext().get( "MyDecision" ), is( "The Person P3 likes 2 thing(s)." ) );
+        assertThat(dmnResult3.hasErrors()).as(DMNRuntimeUtil.formatMessages(dmnResult3.getMessages())).isFalse();
+        assertThat( dmnResult3.getContext().get( "MyDecision" )).isEqualTo("The Person P3 likes 2 thing(s)." );
 
         final DMNContext ctx4 = runtime.newContext();
         ctx4.set("p1", prototype(entry("Name", "P4"), entry("Interests", Arrays.asList("Golf", "x"))));
         final DMNResult dmnResult4 = runtime.evaluateAll( dmnModel, ctx4 );
-        assertThat( DMNRuntimeUtil.formatMessages( dmnResult4.getMessages() ), dmnResult4.hasErrors(), is( true ) );
-        assertThat( dmnResult4.getMessages().stream().anyMatch( m -> m.getMessageType().equals( DMNMessageType.ERROR_EVAL_NODE ) ), is( true ) );
+        assertThat(dmnResult4.hasErrors()).as(DMNRuntimeUtil.formatMessages(dmnResult4.getMessages())).isTrue();
+        assertThat(dmnResult4.getMessages().stream().anyMatch(m -> m.getMessageType().equals(DMNMessageType.ERROR_EVAL_NODE))).isTrue();
     }
 
     @Test
@@ -283,77 +280,77 @@ public class DMNInputRuntimeTest extends BaseInterpretedVsCompiledTest {
         final String MODEL_NAMESPACE = "http://www.trisotech.com/definitions/_17396034-163a-48aa-9a7f-c6eb17f9cc6c";
         final String FEEL_NAMESPACE = org.kie.dmn.model.v1_2.KieDMNModelInstrumentedBase.URI_FEEL;
         final DMNModel dmnModel = runtime.getModel(MODEL_NAMESPACE, "DMNInputDataNodeTypeTest");
-        assertThat(dmnModel, notNullValue());
-        assertThat(DMNRuntimeUtil.formatMessages(dmnModel.getMessages()), dmnModel.hasErrors(), is(false));
+        assertThat(dmnModel).isNotNull();
+        assertThat(dmnModel.hasErrors()).as(DMNRuntimeUtil.formatMessages(dmnModel.getMessages())).isFalse();
 
         final InputDataNode idnMembership = dmnModel.getInputs().stream().filter(idn -> idn.getName().equals("Membership Level")).findFirst().get();
-        assertThat(idnMembership.getType().getBaseType().getNamespace(), is(FEEL_NAMESPACE));
-        assertThat(idnMembership.getType().getBaseType().getName(), is("string"));
-        assertThat(idnMembership.getType().isCollection(), is(false));
-        assertThat(idnMembership.getType().isComposite(), is(false));
-        assertThat(idnMembership.getType().getAllowedValues().size(), is(3));
-        assertThat(idnMembership.getType().getAllowedValues().get(0).toString(), is("\"Gold\""));
-        assertThat(idnMembership.getType().getAllowedValues().get(1).toString(), is("\"Silver\""));
-        assertThat(idnMembership.getType().getAllowedValues().get(2).toString(), is("\"None\""));
+        assertThat(idnMembership.getType().getBaseType().getNamespace()).isEqualTo(FEEL_NAMESPACE);
+        assertThat(idnMembership.getType().getBaseType().getName()).isEqualTo("string");
+        assertThat(idnMembership.getType().isCollection()).isFalse();
+        assertThat(idnMembership.getType().isComposite()).isFalse();
+        assertThat(idnMembership.getType().getAllowedValues()).hasSize(3);
+        assertThat(idnMembership.getType().getAllowedValues().get(0).toString()).isEqualTo("\"Gold\"");
+        assertThat(idnMembership.getType().getAllowedValues().get(1).toString()).isEqualTo("\"Silver\"");
+        assertThat(idnMembership.getType().getAllowedValues().get(2).toString()).isEqualTo("\"None\"");
 
         final InputDataNode idnMembershipLevels = dmnModel.getInputs().stream().filter(idn -> idn.getName().equals("Membership Levels")).findFirst().get();
-        assertThat(idnMembershipLevels.getType().getBaseType().getNamespace(), is(MODEL_NAMESPACE));
-        assertThat(idnMembershipLevels.getType().getBaseType().getName(), is("tMembershipLevel"));
-        assertThat(idnMembershipLevels.getType().isCollection(), is(true));
-        assertThat(idnMembershipLevels.getType().isComposite(), is(false));
-        assertThat(idnMembershipLevels.getType().getAllowedValues().isEmpty(), is(true));
+        assertThat(idnMembershipLevels.getType().getBaseType().getNamespace()).isEqualTo(MODEL_NAMESPACE);
+        assertThat(idnMembershipLevels.getType().getBaseType().getName()).isEqualTo("tMembershipLevel");
+        assertThat(idnMembershipLevels.getType().isCollection()).isTrue();
+        assertThat(idnMembershipLevels.getType().isComposite()).isFalse();
+        assertThat(idnMembershipLevels.getType().getAllowedValues().isEmpty()).isTrue();
 
         final InputDataNode idnPercent = dmnModel.getInputs().stream().filter(idn -> idn.getName().equals("Percent")).findFirst().get();
-        assertThat(idnPercent.getType().getBaseType().getNamespace(), is(FEEL_NAMESPACE));
-        assertThat(idnPercent.getType().getBaseType().getName(), is("number"));
-        assertThat(idnPercent.getType().isCollection(), is(false));
-        assertThat(idnPercent.getType().isComposite(), is(false));
-        assertThat(idnPercent.getType().getAllowedValues().size(), is(1));
-        assertThat(idnPercent.getType().getAllowedValues().get(0).toString(), is("[0..100]"));
+        assertThat(idnPercent.getType().getBaseType().getNamespace()).isEqualTo(FEEL_NAMESPACE);
+        assertThat(idnPercent.getType().getBaseType().getName()).isEqualTo("number");
+        assertThat(idnPercent.getType().isCollection()).isFalse();
+        assertThat(idnPercent.getType().isComposite()).isFalse();
+        assertThat(idnPercent.getType().getAllowedValues()).hasSize(1);
+        assertThat(idnPercent.getType().getAllowedValues().get(0).toString()).isEqualTo("[0..100]");
 
         final InputDataNode idnCarDamageResponsibility = dmnModel.getInputs().stream().filter(idn -> idn.getName().equals("Car Damage Responsibility")).findFirst().get();
-        assertThat(idnCarDamageResponsibility.getType().getBaseType(), is(nullValue()));
-        assertThat(idnCarDamageResponsibility.getType().isCollection(), is(false));
-        assertThat(idnCarDamageResponsibility.getType().isComposite(), is(true));
+        assertThat(idnCarDamageResponsibility.getType().getBaseType()).isNull();
+        assertThat(idnCarDamageResponsibility.getType().isCollection()).isFalse();
+        assertThat(idnCarDamageResponsibility.getType().isComposite()).isTrue();
     }
 
     @Test
     public void testInputClauseTypeRefWithAllowedValues() {
         final DMNRuntime runtime = DMNRuntimeUtil.createRuntime("actualInputMatchInputValues-forTypeRef.dmn", this.getClass());
         final DMNModel dmnModel = runtime.getModel("https://www.drools.org/kie-dmn/definitions", "definitions");
-        assertThat(dmnModel, notNullValue());
-        assertThat(DMNRuntimeUtil.formatMessages(dmnModel.getMessages()), dmnModel.hasErrors(), is(false));
+        assertThat(dmnModel).isNotNull();
+        assertThat(dmnModel.hasErrors()).as(DMNRuntimeUtil.formatMessages(dmnModel.getMessages())).isFalse();
 
         final DMNContext context = runtime.newContext();
         context.set("MyInput", "a");
 
         final DMNResult dmnResult = runtime.evaluateAll(dmnModel, context);
 
-        assertThat(DMNRuntimeUtil.formatMessages(dmnResult.getMessages()), dmnResult.hasErrors(), is(false));
+        assertThat(dmnResult.hasErrors()).as(DMNRuntimeUtil.formatMessages(dmnResult.getMessages())).isFalse();
         final DMNContext result = dmnResult.getContext();
-        assertThat(result.get("MyDecision"), is("Decision taken"));
+        assertThat(result.get("MyDecision")).isEqualTo("Decision taken");
     }
 
     @Test
     public void testInputDataTypeRefWithAllowedValues() {
         final DMNRuntime runtime = DMNRuntimeUtil.createRuntime("actualInputMatchInputValues-forTypeRef.dmn", this.getClass());
         final DMNModel dmnModel = runtime.getModel("https://www.drools.org/kie-dmn/definitions", "definitions");
-        assertThat(dmnModel, notNullValue());
-        assertThat(DMNRuntimeUtil.formatMessages(dmnModel.getMessages()), dmnModel.hasErrors(), is(false));
+        assertThat(dmnModel).isNotNull();
+        assertThat(dmnModel.hasErrors()).as(DMNRuntimeUtil.formatMessages(dmnModel.getMessages())).isFalse();
 
         final DMNContext context = runtime.newContext();
         context.set("MyInput", "zzz");              // <<< `zzz` is NOT in the list of allowed value as declared by the typeRef for this inputdata
 
         final DMNResult dmnResult = runtime.evaluateAll(dmnModel, context);
-        assertThat(DMNRuntimeUtil.formatMessages(dmnResult.getMessages()), dmnResult.hasErrors(), is(true));
-        assertThat(dmnResult.getMessages().size(), is(1));
-        assertThat(dmnResult.getMessages().get(0).getSourceId(), is("_3d560678-a126-4654-a686-bc6d941fe40b"));
+        assertThat(dmnResult.hasErrors()).as(DMNRuntimeUtil.formatMessages(dmnResult.getMessages())).isTrue();
+        assertThat(dmnResult.getMessages()).hasSize(1);
+        assertThat(dmnResult.getMessages().get(0).getSourceId()).isEqualTo("_3d560678-a126-4654-a686-bc6d941fe40b");
     }
 
     @Test
     public void testMissingInputData() {
         final List<DMNMessage> messages = DMNRuntimeUtil.createExpectingDMNMessages("missing_input_data.dmn", getClass());
-        assertThat(messages.get(0).getMessageType(), is(DMNMessageType.ERR_COMPILING_FEEL));
+        assertThat(messages.get(0).getMessageType()).isEqualTo(DMNMessageType.ERR_COMPILING_FEEL);
     }
     
     

--- a/kie-dmn/kie-dmn-core/src/test/java/org/kie/dmn/core/DMNMessagesAPITest.java
+++ b/kie-dmn/kie-dmn-core/src/test/java/org/kie/dmn/core/DMNMessagesAPITest.java
@@ -35,8 +35,7 @@ import org.kie.dmn.core.util.DMNRuntimeUtil;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import static org.hamcrest.CoreMatchers.is;
-import static org.hamcrest.MatcherAssert.assertThat;
+import static org.assertj.core.api.Assertions.assertThat;
 
 public class DMNMessagesAPITest {
 
@@ -53,19 +52,19 @@ public class DMNMessagesAPITest {
         Results verify = kieContainer.verify();
         List<Message> kie_messages = verify.getMessages();
         kie_messages.forEach(m -> LOG.info("{}", m));
-        assertThat(kie_messages.size(), is(3));
-        assertThat(kie_messages.stream().filter(m -> m.getPath().equals("duff.drl")).count(), is(2L));
+        assertThat(kie_messages).hasSize(3);
+        assertThat(kie_messages.stream().filter(m -> m.getPath().equals("duff.drl")).count()).isEqualTo(2L);
 
         List<DMNMessage> dmnMessages = kie_messages.stream()
                                                    .filter(DMNMessage.class::isInstance)
                                                    .map(DMNMessage.class::cast)
                                                    .collect(Collectors.toList());
-        assertThat(dmnMessages.size(), is(1));
+        assertThat(dmnMessages).hasSize(1);
 
         DMNMessage dmnMessage = dmnMessages.get(0);
-        assertThat(dmnMessage.getSourceId(), is("_c990c3b2-e322-4ef9-931d-79bcdac99686"));
-        assertThat(dmnMessage.getMessageType(), is(DMNMessageType.ERR_COMPILING_FEEL));
-        assertThat(dmnMessage.getPath(), is("incomplete_expression.dmn"));
+        assertThat(dmnMessage.getSourceId()).isEqualTo("_c990c3b2-e322-4ef9-931d-79bcdac99686");
+        assertThat(dmnMessage.getMessageType()).isEqualTo(DMNMessageType.ERR_COMPILING_FEEL);
+        assertThat(dmnMessage.getPath()).isEqualTo("incomplete_expression.dmn");
     }
 
     @Test(expected = IllegalStateException.class)

--- a/kie-dmn/kie-dmn-core/src/test/java/org/kie/dmn/core/DMNRuntimeTest.java
+++ b/kie-dmn/kie-dmn-core/src/test/java/org/kie/dmn/core/DMNRuntimeTest.java
@@ -79,17 +79,6 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.hamcrest.CoreMatchers.containsString;
-import static org.hamcrest.CoreMatchers.instanceOf;
-import static org.hamcrest.CoreMatchers.is;
-import static org.hamcrest.CoreMatchers.not;
-import static org.hamcrest.CoreMatchers.notNullValue;
-import static org.hamcrest.CoreMatchers.nullValue;
-import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.anything;
-import static org.hamcrest.Matchers.contains;
-import static org.hamcrest.Matchers.hasEntry;
-import static org.hamcrest.Matchers.hasSize;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
@@ -114,25 +103,25 @@ public class DMNRuntimeTest extends BaseInterpretedVsCompiledTest {
     public void testSimpleItemDefinition() {
         final DMNRuntime runtime = DMNRuntimeUtil.createRuntime("simple-item-def.dmn", this.getClass() );
         final DMNModel dmnModel = runtime.getModel("https://github.com/kiegroup/kie-dmn/itemdef", "simple-item-def" );
-        assertThat( dmnModel, notNullValue() );
-        assertThat( DMNRuntimeUtil.formatMessages( dmnModel.getMessages() ), dmnModel.hasErrors(), is( false ) );
+        assertThat(dmnModel).isNotNull();
+        assertThat(dmnModel.hasErrors()).as(DMNRuntimeUtil.formatMessages(dmnModel.getMessages())).isFalse();
 
         final DMNContext context = DMNFactory.newContext();
         context.set( "Monthly Salary", 1000 );
 
         final DMNResult dmnResult = runtime.evaluateAll(dmnModel, context );
-        assertThat(DMNRuntimeUtil.formatMessages(dmnResult.getMessages()), dmnResult.hasErrors(), is(false));
+        assertThat(dmnResult.hasErrors()).as(DMNRuntimeUtil.formatMessages(dmnResult.getMessages())).isFalse();
 
         final DMNContext result = dmnResult.getContext();
 
-        assertThat( result.get( "Yearly Salary" ), is( new BigDecimal( "12000" ) ) );
+        assertThat( result.get( "Yearly Salary" )).isEqualTo(new BigDecimal( "12000" ) );
     }
 
     @Test
     public void testCompositeItemDefinition() {
         final DMNRuntime runtime = DMNRuntimeUtil.createRuntime("0008-LX-arithmetic.dmn", this.getClass() );
         final DMNModel dmnModel = runtime.getModel("https://github.com/kiegroup/kie-dmn", "0008-LX-arithmetic" );
-        assertThat( dmnModel, notNullValue() );
+        assertThat(dmnModel).isNotNull();
 
         final DMNContext context = DMNFactory.newContext();
         final Map<String, Object> loan = new HashMap<>();
@@ -145,33 +134,33 @@ public class DMNRuntimeTest extends BaseInterpretedVsCompiledTest {
 
         final DMNContext result = dmnResult.getContext();
 
-        assertThat( result.get( "payment" ), is( new BigDecimal( "2778.693549432766768088520383236299" ) ) );
+        assertThat( result.get( "payment" )).isEqualTo(new BigDecimal( "2778.693549432766768088520383236299" ) );
     }
 
     @Test
     public void testTrisotechNamespace() {
         final DMNRuntime runtime = DMNRuntimeUtil.createRuntime("trisotech_namespace.dmn", this.getClass() );
         final DMNModel dmnModel = runtime.getModel("http://www.trisotech.com/dmn/definitions/_b8feec86-dadf-4051-9feb-8e6093bbb530", "Solution 3" );
-        assertThat( dmnModel, notNullValue() );
-        assertThat( DMNRuntimeUtil.formatMessages( dmnModel.getMessages() ), dmnModel.hasErrors(), is( false ) );
+        assertThat(dmnModel).isNotNull();
+        assertThat(dmnModel.hasErrors()).as(DMNRuntimeUtil.formatMessages(dmnModel.getMessages())).isFalse();
         
         final DMNContext context = DMNFactory.newContext();
-        context.set( "IsDoubleHulled", true );
+        context.set( "IsDoubleHulled", Boolean.TRUE );
         context.set( "Residual Cargo Size", BigDecimal.valueOf(0.1) );
         context.set( "Ship Size", new BigDecimal( 50 ) );
         
         final DMNResult dmnResult = runtime.evaluateAll(dmnModel, context );
-        assertThat( DMNRuntimeUtil.formatMessages( dmnResult.getMessages() ), dmnResult.hasErrors(), is( false ) );
+        assertThat(dmnResult.hasErrors()).as(DMNRuntimeUtil.formatMessages(dmnResult.getMessages())).isFalse();
         
         final DMNContext result = dmnResult.getContext();
-        assertThat( result.get( "Ship can enter a Dutch port" ), is( true ) );
+        assertThat( result.get( "Ship can enter a Dutch port" )).isEqualTo(Boolean.TRUE);
     }
 
     @Test
     public void testEmptyDecision1() {
         final DMNRuntime runtime = DMNRuntimeUtil.createRuntime("empty_decision.dmn", this.getClass() );
         final DMNModel dmnModel = runtime.getModel("http://www.trisotech.com/dmn/definitions/_ba9fc4b1-5ced-4d00-9b61-290de4bf3213", "Solution 3" );
-        assertThat( dmnModel, notNullValue() );
+        assertThat(dmnModel).isNotNull();
 
         final DMNContext context = DMNFactory.newContext();
         final Map<String, Object> shipInfo = new HashMap<>();
@@ -184,15 +173,15 @@ public class DMNRuntimeTest extends BaseInterpretedVsCompiledTest {
         // the other decisions in the model are still evaluated
         final DMNResult dmnResult = runtime.evaluateAll(dmnModel, context );
         final DMNContext result = dmnResult.getContext();
-        assertThat( dmnResult.hasErrors(), is( true ) );
-        assertThat( result.get( "Ship Can Enter v2" ), is( true ) );
+        assertThat( dmnResult.hasErrors()).isTrue();
+        assertThat( result.get( "Ship Can Enter v2" )).isEqualTo(Boolean.TRUE);
     }
 
     @Test
     public void testEmptyDecision2() {
         final DMNRuntime runtime = DMNRuntimeUtil.createRuntime("empty_decision.dmn", this.getClass() );
         final DMNModel dmnModel = runtime.getModel("http://www.trisotech.com/dmn/definitions/_ba9fc4b1-5ced-4d00-9b61-290de4bf3213", "Solution 3" );
-        assertThat( dmnModel, notNullValue() );
+        assertThat(dmnModel).isNotNull();
 
         final DMNContext context = DMNFactory.newContext();
         final Map<String, Object> shipInfo = new HashMap<>();
@@ -209,12 +198,12 @@ public class DMNRuntimeTest extends BaseInterpretedVsCompiledTest {
         final DMNResult dmnResult = runtime.evaluateAll(dmnModel, context );
 
         final List<DMNMessage> messages = dmnResult.getMessages(DMNMessage.Severity.WARN );
-        assertThat( messages.size(), is( 1 ) );
-        assertThat( messages.get( 0 ).getSeverity(), is( DMNMessage.Severity.WARN ) );
-        assertThat( messages.get( 0 ).getSourceId(), is( "_42806504-8ed5-488f-b274-de98c1bc67b9" ) );
+        assertThat(messages).hasSize(1);
+        assertThat( messages.get( 0 ).getSeverity()).isEqualTo(DMNMessage.Severity.WARN);
+        assertThat( messages.get( 0 ).getSourceId()).isEqualTo("_42806504-8ed5-488f-b274-de98c1bc67b9" );
 
         final DMNContext result = dmnResult.getContext();
-        assertThat( result.get( "Ship Can Enter v2" ), is( true ) );
+        assertThat( result.get( "Ship Can Enter v2" )).isEqualTo(Boolean.TRUE);
     }
 
     @Test
@@ -226,7 +215,7 @@ public class DMNRuntimeTest extends BaseInterpretedVsCompiledTest {
         runtime.addListener( DMNRuntimeUtil.createListener() );
 
         final DMNModel dmnModel = runtime.getModel("http://www.trisotech.com/definitions/_820611e9-c21c-47cd-8e52-5cba2be9f9cc", "Car Damage Responsibility" );
-        assertThat( dmnModel, notNullValue() );
+        assertThat(dmnModel).isNotNull();
 
         final DMNContext context = DMNFactory.newContext();
         context.set( "Membership Level", "Silver" );
@@ -246,19 +235,19 @@ public class DMNRuntimeTest extends BaseInterpretedVsCompiledTest {
                 .afterEvaluateDecisionTable( argument.capture() );
 
         AfterEvaluateDecisionTableEvent dte = argument.getAllValues().get( 0 );
-        assertThat( dte.getDecisionTableName(), is( "Car Damage Responsibility" ) );
-        assertThat( dte.getMatches(), is(Collections.singletonList(5)) ); // rows are 1-based
+        assertThat(dte.getDecisionTableName()).isEqualTo("Car Damage Responsibility" );
+        assertThat(dte.getMatches()).containsExactly(5); // rows are 1-based
 
         dte = argument.getAllValues().get( 1 );
-        assertThat( dte.getDecisionTableName(), is( "Payment method" ) );
-        assertThat( dte.getMatches(), is(Collections.singletonList(3)) ); // rows are 1-based
+        assertThat(dte.getDecisionTableName()).isEqualTo("Payment method" );
+        assertThat(dte.getMatches()).containsExactly(3); // rows are 1-based
 
-        assertThat( dmnResult.hasErrors(), is( false ) );
+        assertThat(dmnResult.hasErrors()).isFalse();
 
         final DMNContext result = dmnResult.getContext();
-        assertThat( (Map<String, Object>) result.get( "Car Damage Responsibility" ), hasEntry( is( "EU Rent" ), is( BigDecimal.valueOf( 40 ) ) ) );
-        assertThat( (Map<String, Object>) result.get( "Car Damage Responsibility" ), hasEntry( is( "Renter" ), is( BigDecimal.valueOf( 60 ) ) ) );
-        assertThat( result.get( "Payment method" ), is( "Check" ) );
+        assertThat((Map<String, Object>) result.get("Car Damage Responsibility")).containsEntry("EU Rent", BigDecimal.valueOf(40));
+        assertThat((Map<String, Object>) result.get("Car Damage Responsibility")).containsEntry("Renter", BigDecimal.valueOf(60));
+        assertThat(result.get( "Payment method")).isEqualTo("Check");
     }
 
     @Test
@@ -270,7 +259,7 @@ public class DMNRuntimeTest extends BaseInterpretedVsCompiledTest {
         runtime.addListener( DMNRuntimeUtil.createListener() );
 
         final DMNModel dmnModel = runtime.getModel("http://www.trisotech.com/dmn/definitions/_73481d02-76fb-4927-ac11-5d936882e16c", "context listener" );
-        assertThat( dmnModel, notNullValue() );
+        assertThat(dmnModel).isNotNull();
 
         final DMNContext context = DMNFactory.newContext();
 
@@ -287,179 +276,179 @@ public class DMNRuntimeTest extends BaseInterpretedVsCompiledTest {
                 .afterEvaluateContextEntry( argument.capture() );
 
         AfterEvaluateContextEntryEvent aece = argument.getAllValues().get( 0 );
-        assertThat( aece.getNodeName(), is( "d1" ) );
-        assertThat( aece.getVariableName(), is( "a1" ) );
-        assertThat( aece.getVariableId(), is( "_b199c7b1-cb87-4a92-b045-a2954ccc9d01" ) );
-        assertThat( aece.getExpressionId(), is( "_898c24f8-93da-4fe2-827c-924c30956833" ) );
-        assertThat( aece.getExpressionResult(), is( BigDecimal.valueOf( 10 ) ) );
+        assertThat( aece.getNodeName()).isEqualTo("d1");
+        assertThat( aece.getVariableName()).isEqualTo("a1");
+        assertThat( aece.getVariableId()).isEqualTo("_b199c7b1-cb87-4a92-b045-a2954ccc9d01" );
+        assertThat( aece.getExpressionId()).isEqualTo("_898c24f8-93da-4fe2-827c-924c30956833" );
+        assertThat( aece.getExpressionResult()).isEqualTo(BigDecimal.valueOf( 10 ) );
 
         aece = argument.getAllValues().get( 1 );
-        assertThat( aece.getNodeName(), is( "d1" ) );
-        assertThat( aece.getVariableName(), is( "c1" ) );
-        assertThat( aece.getVariableId(), is( "_38a88aef-8b3c-424d-b60c-a139ffb610e1" ) );
-        assertThat( aece.getExpressionId(), is( "_879c4ac6-8b25-4cd1-9b8e-c18d0b0b281c" ) );
-        assertThat( aece.getExpressionResult(), is( "a" ) );
+        assertThat( aece.getNodeName()).isEqualTo("d1");
+        assertThat( aece.getVariableName()).isEqualTo("c1");
+        assertThat( aece.getVariableId()).isEqualTo("_38a88aef-8b3c-424d-b60c-a139ffb610e1" );
+        assertThat( aece.getExpressionId()).isEqualTo("_879c4ac6-8b25-4cd1-9b8e-c18d0b0b281c" );
+        assertThat( aece.getExpressionResult()).isEqualTo("a");
 
         aece = argument.getAllValues().get( 2 );
-        assertThat( aece.getNodeName(), is( "d1" ) );
-        assertThat( aece.getVariableName(), is( "c2" ) );
-        assertThat( aece.getVariableId(), is( "_3aad82f0-74b9-4921-8b2f-d6c277c840db" ) );
-        assertThat( aece.getExpressionId(), is( "_9acf4baf-6c49-4d47-88ab-2e511e598e04" ) );
-        assertThat( aece.getExpressionResult(), is( "b" ) );
+        assertThat( aece.getNodeName()).isEqualTo("d1");
+        assertThat( aece.getVariableName()).isEqualTo("c2");
+        assertThat( aece.getVariableId()).isEqualTo("_3aad82f0-74b9-4921-8b2f-d6c277c840db" );
+        assertThat( aece.getExpressionId()).isEqualTo("_9acf4baf-6c49-4d47-88ab-2e511e598e04" );
+        assertThat( aece.getExpressionResult()).isEqualTo("b");
 
         aece = argument.getAllValues().get( 3 );
-        assertThat( aece.getNodeName(), is( "d1" ) );
-        assertThat( aece.getVariableName(), is( "b1" ) );
-        assertThat( aece.getVariableId(), is( "_f4a6c2ba-e6e9-4dbd-b776-edef2c1a1343" ) );
-        assertThat( aece.getExpressionId(), is( "_c450d947-1874-41fe-9c0a-da5f1cca7fde" ) );
-        assertThat( (Map<String, Object>) aece.getExpressionResult(), hasEntry( is( "c1" ), is( "a" ) ) );
-        assertThat( (Map<String, Object>) aece.getExpressionResult(), hasEntry( is( "c2" ), is( "b" ) ) );
+        assertThat( aece.getNodeName()).isEqualTo("d1");
+        assertThat( aece.getVariableName()).isEqualTo("b1");
+        assertThat( aece.getVariableId()).isEqualTo("_f4a6c2ba-e6e9-4dbd-b776-edef2c1a1343" );
+        assertThat( aece.getExpressionId()).isEqualTo("_c450d947-1874-41fe-9c0a-da5f1cca7fde" );
+        assertThat( (Map<String, Object>) aece.getExpressionResult()).containsEntry("c1", "a");
+        assertThat( (Map<String, Object>) aece.getExpressionResult()).containsEntry("c2", "b");
 
         aece = argument.getAllValues().get( 4 );
-        assertThat( aece.getNodeName(), is( "d1" ) );
-        assertThat( aece.getVariableName(), is( DMNContextEvaluator.RESULT_ENTRY ) );
-        assertThat( aece.getVariableId(), nullValue() );
-        assertThat( aece.getExpressionId(), is( "_4264b25c-d676-4516-ab8a-a4ff34e7a95c" ) );
-        assertThat( aece.getExpressionResult(), is( "a" ) );
+        assertThat( aece.getNodeName()).isEqualTo("d1");
+        assertThat( aece.getVariableName()).isEqualTo(DMNContextEvaluator.RESULT_ENTRY);
+        assertThat( aece.getVariableId()).isNull();
+        assertThat( aece.getExpressionId()).isEqualTo("_4264b25c-d676-4516-ab8a-a4ff34e7a95c" );
+        assertThat( aece.getExpressionResult()).isEqualTo("a");
 
-        assertThat( dmnResult.hasErrors(), is( false ) );
+        assertThat(dmnResult.hasErrors()).isFalse();
 
         final DMNContext result = dmnResult.getContext();
-        assertThat( result.get( "d1" ), is( "a" ) );
+        assertThat( result.get( "d1" )).isEqualTo("a");
     }
 
     @Test
     public void testErrorMessages() {
         final List<DMNMessage> messages = DMNRuntimeUtil.createExpectingDMNMessages("car_damage_responsibility2.dmn", this.getClass());
-        assertThat(messages.isEmpty(), is(false));
+        assertThat(messages).isNotEmpty();
     }
 
     @Test
     public void testOutputReuse() {
         final DMNRuntime runtime = DMNRuntimeUtil.createRuntime("Input_reuse_in_output.dmn", this.getClass() );
         final DMNModel dmnModel = runtime.getModel("http://www.trisotech.com/dmn/definitions/_098bb607-eff7-4772-83ac-6ded8b371fa7", "Input reuse in output" );
-        assertThat( dmnModel, notNullValue() );
+        assertThat(dmnModel).isNotNull();
 
         final DMNContext context = DMNFactory.newContext();
         context.set( "Age", 40 );
         context.set( "Requested Product", "Fixed30" );
 
         final DMNResult dmnResult = runtime.evaluateAll(dmnModel, context );
-        assertThat( dmnResult.hasErrors(), is( false ) );
+        assertThat(dmnResult.hasErrors()).isFalse();
 
         final DMNContext result = dmnResult.getContext();
-        assertThat( result.get( "My Decision" ), is( "Fixed30" ) );
+        assertThat( result.get( "My Decision" )).isEqualTo("Fixed30");
     }
 
     @Test
     public void testSimpleNot() {
         final DMNRuntime runtime = DMNRuntimeUtil.createRuntime("Simple_Not.dmn", this.getClass() );
         final DMNModel dmnModel = runtime.getModel("http://www.trisotech.com/definitions/_98436ebb-7c42-48c0-8d11-d693e2a817c9", "Simple Not" );
-        assertThat( dmnModel, notNullValue() );
+        assertThat(dmnModel).isNotNull();
 
         final DMNContext context = DMNFactory.newContext();
         context.set( "Occupation", "Student" );
 
         final DMNResult dmnResult = runtime.evaluateAll(dmnModel, context );
-        assertThat( dmnResult.hasErrors(), is( false ) );
+        assertThat(dmnResult.hasErrors()).isFalse();
 
         final DMNContext result = dmnResult.getContext();
-        assertThat( result.get( "a" ), is( "Is Student" ) );
+        assertThat( result.get( "a" )).isEqualTo("Is Student" );
     }
 
     @Test
     public void testSimpleNot2() {
         final DMNRuntime runtime = DMNRuntimeUtil.createRuntime("Simple_Not.dmn", this.getClass() );
         final DMNModel dmnModel = runtime.getModel("http://www.trisotech.com/definitions/_98436ebb-7c42-48c0-8d11-d693e2a817c9", "Simple Not" );
-        assertThat( dmnModel, notNullValue() );
+        assertThat(dmnModel).isNotNull();
 
         final DMNContext context = DMNFactory.newContext();
         context.set( "Occupation", "Engineer" );
 
         final DMNResult dmnResult = runtime.evaluateAll(dmnModel, context );
-        assertThat( dmnResult.hasErrors(), is( false ) );
+        assertThat(dmnResult.hasErrors()).isFalse();
 
         final DMNContext result = dmnResult.getContext();
-        assertThat( result.get( "a" ), is( "Is not a Student" ) );
+        assertThat( result.get( "a" )).isEqualTo("Is not a Student" );
     }
 
     @Test
     public void testDinner() {
         final DMNRuntime runtime = DMNRuntimeUtil.createRuntime("Dinner.dmn", this.getClass() );
         final DMNModel dmnModel = runtime.getModel("http://www.trisotech.com/definitions/_0c45df24-0d57-4acc-b296-b4cba8b71a36", "Dinner" );
-        assertThat( dmnModel, notNullValue() );
-        assertThat( dmnModel.hasErrors(), is( false ) );
+        assertThat(dmnModel).isNotNull();
+        assertThat( dmnModel.hasErrors()).isFalse();
 
         final DMNContext context = DMNFactory.newContext();
-        context.set( "Guests with children", true );
+        context.set( "Guests with children", Boolean.TRUE );
         context.set( "Season", "Fall" );
         context.set( "Number of guests", 4 );
         context.set( "Temp", 25 );
         context.set( "Rain Probability", 30 );
 
         final DMNResult dmnResult = runtime.evaluateAll(dmnModel, context );
-        assertThat( dmnResult.hasErrors(), is( false ) );
-        assertThat( dmnResult.getContext().get( "Where to eat" ), is( "Outside" ) );
-        assertThat( dmnResult.getContext().get( "Dish" ), is( "Spareribs" ) );
-        assertThat( dmnResult.getContext().get( "Drinks" ), is( Arrays.asList( "Apero", "Ale", "Juice Boxes" ) ) );
+        assertThat(dmnResult.hasErrors()).isFalse();
+        assertThat(dmnResult.getContext().get("Where to eat")).isEqualTo("Outside");
+        assertThat(dmnResult.getContext().get("Dish")).isEqualTo("Spareribs");
+        assertThat( dmnResult.getContext().get("Drinks")).asList().containsExactly("Apero", "Ale", "Juice Boxes");
     }
 
     @Test
     public void testNotificationsApproved2() {
         final DMNRuntime runtime = DMNRuntimeUtil.createRuntime("NotificationsTest2.dmn", this.getClass() );
         final DMNModel dmnModel = runtime.getModel("https://github.com/kiegroup/kie-dmn", "building-structure-rules" );
-        assertThat( dmnModel, notNullValue() );
+        assertThat(dmnModel).isNotNull();
 
         final DMNContext context = DMNFactory.newContext();
-        context.set( "existingActivityApplicability", true );
+        context.set( "existingActivityApplicability", Boolean.TRUE );
         context.set( "Distance", new BigDecimal( 9999 ) );
-        context.set( "willIncreaseTraffic", true );
+        context.set( "willIncreaseTraffic", Boolean.TRUE );
 
         final DMNResult dmnResult = runtime.evaluateAll(dmnModel, context );
         final DMNContext result = dmnResult.getContext();
-        assertThat( result.get( "Notification Status" ), is( "Notification to Province Approved" ) );
-        assertThat( result.get( "Permit Status" ), is( "Building Activity Province Permit Required" ) );
+        assertThat( result.get( "Notification Status" )).isEqualTo("Notification to Province Approved" );
+        assertThat( result.get( "Permit Status" )).isEqualTo("Building Activity Province Permit Required" );
     }
 
     @Test
     public void testBoxedContext() {
         final DMNRuntime runtime = DMNRuntimeUtil.createRuntime("BoxedContext.dmn", this.getClass() );
         final DMNModel dmnModel = runtime.getModel("http://www.trisotech.com/dmn/definitions/_0de36357-fec0-4b4e-b7f1-382d381e06e9", "Dessin 1" );
-        assertThat( dmnModel, notNullValue() );
-        assertThat( DMNRuntimeUtil.formatMessages( dmnModel.getMessages() ) , dmnModel.hasErrors(), is( false ) );
+        assertThat(dmnModel).isNotNull();
+        assertThat(dmnModel.hasErrors()).as(DMNRuntimeUtil.formatMessages(dmnModel.getMessages())).isFalse();
 
         final DMNContext context = DMNFactory.newContext();
         context.set( "a", 10 );
         context.set( "b", 5 );
 
         final DMNResult dmnResult = runtime.evaluateAll(dmnModel, context );
-        assertThat( DMNRuntimeUtil.formatMessages( dmnResult.getMessages() ), dmnResult.hasErrors(), is( false ) );
-        assertThat( (Map<String, Object>) dmnResult.getContext().get( "Math" ), hasEntry( "Sum", BigDecimal.valueOf( 15 ) ) );
-        assertThat( (Map<String, Object>) dmnResult.getContext().get( "Math" ), hasEntry( "Product", BigDecimal.valueOf( 50 ) ) );
+        assertThat(dmnResult.hasErrors()).as(DMNRuntimeUtil.formatMessages(dmnResult.getMessages())).isFalse();
+        assertThat( (Map<String, Object>) dmnResult.getContext().get( "Math" )).containsEntry( "Sum", BigDecimal.valueOf( 15 ));
+        assertThat( (Map<String, Object>) dmnResult.getContext().get( "Math" )).containsEntry( "Product", BigDecimal.valueOf( 50 ));
     }
 
     @Test
     public void testFunctionDefAndInvocation() {
         final DMNRuntime runtime = DMNRuntimeUtil.createRuntime("FunctionDefinition.dmn", this.getClass() );
         final DMNModel dmnModel = runtime.getModel("http://www.trisotech.com/dmn/definitions/_0de36357-fec0-4b4e-b7f1-382d381e06e9", "Dessin 1" );
-        assertThat( dmnModel, notNullValue() );
-        assertThat( dmnModel.getMessages().toString(), dmnModel.hasErrors(), is( false ) );
+        assertThat(dmnModel).isNotNull();
+        assertThat(dmnModel.hasErrors()).as(dmnModel.getMessages().toString()).isFalse();
 
         final DMNContext context = DMNFactory.newContext();
         context.set( "a", 10 );
         context.set( "b", 5 );
 
         final DMNResult dmnResult = runtime.evaluateAll(dmnModel, context );
-        assertThat( dmnResult.hasErrors(), is( false ) );
-        assertThat( (Map<String, Object>) dmnResult.getContext().get( "Math" ), hasEntry( "Sum", BigDecimal.valueOf( 15 ) ) );
+        assertThat(dmnResult.hasErrors()).isFalse();
+        assertThat((Map<String, Object>) dmnResult.getContext().get("Math")).containsEntry("Sum", BigDecimal.valueOf(15));
     }
 
     @Test
     public void testBuiltInFunctionInvocation() {
         final DMNRuntime runtime = DMNRuntimeUtil.createRuntime("BuiltInFunctionInvocation.dmn", this.getClass() );
         final DMNModel dmnModel = runtime.getModel("http://www.trisotech.com/definitions/_b77219ee-ec28-48e3-b240-8e0dbbabefeb", "built in function invocation" );
-        assertThat( dmnModel, notNullValue() );
-        assertThat( dmnModel.getMessages().toString(), dmnModel.hasErrors(), is( false ) );
+        assertThat(dmnModel).isNotNull();
+        assertThat(dmnModel.hasErrors()).as(dmnModel.getMessages().toString()).isFalse();
 
         final DMNContext context = DMNFactory.newContext();
         context.set( "a", 10 );
@@ -467,10 +456,10 @@ public class DMNRuntimeTest extends BaseInterpretedVsCompiledTest {
         context.set( "x", "Hello, World!" );
 
         final DMNResult dmnResult = runtime.evaluateAll(dmnModel, context );
-        assertThat( dmnResult.hasErrors(), is( false ) );
-        assertThat( dmnResult.getContext().get( "calc min" ), is( BigDecimal.valueOf( 5 ) ) );
-        assertThat( dmnResult.getContext().get( "fixed params" ), is( "World!" ) );
-        assertThat( dmnResult.getContext().get( "out of order" ), is( BigDecimal.valueOf( 5 ) ) );
+        assertThat(dmnResult.hasErrors()).isFalse();
+        assertThat( dmnResult.getContext().get( "calc min" )).isEqualTo(BigDecimal.valueOf( 5 ) );
+        assertThat( dmnResult.getContext().get( "fixed params" )).isEqualTo("World!");
+        assertThat( dmnResult.getContext().get( "out of order" )).isEqualTo(BigDecimal.valueOf( 5 ) );
     }
 
     @Test
@@ -479,8 +468,8 @@ public class DMNRuntimeTest extends BaseInterpretedVsCompiledTest {
 //        runtime.addListener( DMNRuntimeUtil.createListener() );
 
         final DMNModel dmnModel = runtime.getModel("http://www.trisotech.com/definitions/_cb28c255-91cd-4c01-ac7b-1a9cb1ecdb11", "literal invocation1" );
-        assertThat( dmnModel, notNullValue() );
-        assertThat( dmnModel.getMessages().toString(), dmnModel.hasErrors(), is( false ) );
+        assertThat(dmnModel).isNotNull();
+        assertThat(dmnModel.hasErrors()).as(dmnModel.getMessages().toString()).isFalse();
 
         final Map<String, Object> loan = new HashMap<>();
         loan.put( "amount", BigDecimal.valueOf( 600000 ) );
@@ -491,10 +480,10 @@ public class DMNRuntimeTest extends BaseInterpretedVsCompiledTest {
         context.set( "Loan", loan );
 
         final DMNResult dmnResult = runtime.evaluateAll(dmnModel, context );
-        assertThat( dmnResult.hasErrors(), is( false ) );
+        assertThat(dmnResult.hasErrors()).isFalse();
         assertThat(
-                ((BigDecimal) dmnResult.getContext().get( "MonthlyPayment" )).setScale( 8, BigDecimal.ROUND_DOWN ),
-                is( new BigDecimal( "2878.69354943277" ).setScale( 8, BigDecimal.ROUND_DOWN ) ) );
+                ((BigDecimal) dmnResult.getContext().get( "MonthlyPayment" )).setScale( 8, BigDecimal.ROUND_DOWN )).
+                isEqualTo(new BigDecimal("2878.69354943277").setScale(8, BigDecimal.ROUND_DOWN));
     }
 
     @Test
@@ -503,8 +492,8 @@ public class DMNRuntimeTest extends BaseInterpretedVsCompiledTest {
 //        runtime.addListener( DMNRuntimeUtil.createListener() );
 
         final DMNModel dmnModel = runtime.getModel("http://www.trisotech.com/definitions/_f52ca843-504b-4c3b-a6bc-4d377bffef7a", "filter01" );
-        assertThat( dmnModel, notNullValue() );
-        assertThat( dmnModel.getMessages().toString(), dmnModel.hasErrors(), is( false ) );
+        assertThat(dmnModel).isNotNull();
+        assertThat(dmnModel.hasErrors()).as(dmnModel.getMessages().toString()).isFalse();
 
         final Object[][] data = new Object[][]{
                 {1, "Finances", "John"},
@@ -523,8 +512,8 @@ public class DMNRuntimeTest extends BaseInterpretedVsCompiledTest {
         context.set( "Employee", employees );
 
         final DMNResult dmnResult = runtime.evaluateAll(dmnModel, context );
-        assertThat( dmnResult.hasErrors(), is( false ) );
-        assertThat( dmnResult.getContext().get( "filter01" ), is(Collections.singletonList("Mary")) );
+        assertThat(dmnResult.hasErrors()).isFalse();
+        assertThat( dmnResult.getContext().get( "filter01" )).asList().containsExactly("Mary");
     }
 
     @Test
@@ -533,13 +522,13 @@ public class DMNRuntimeTest extends BaseInterpretedVsCompiledTest {
 //        runtime.addListener( DMNRuntimeUtil.createListener() );
 
         final DMNModel dmnModel = runtime.getModel("https://github.com/kiegroup/kie-dmn", "list-expression" );
-        assertThat( dmnModel, notNullValue() );
-        assertThat( dmnModel.getMessages().toString(), dmnModel.hasErrors(), is( false ) );
+        assertThat(dmnModel).isNotNull();
+        assertThat(dmnModel.hasErrors()).as(dmnModel.getMessages().toString()).isFalse();
 
         final DMNContext context = DMNFactory.newContext();
         final DMNResult dmnResult = runtime.evaluateAll(dmnModel, context );
-        assertThat( dmnResult.hasErrors(), is( false ) );
-        assertThat( dmnResult.getContext().get( "Name list" ), is( Arrays.asList( "John", "Mary" ) ) );
+        assertThat(dmnResult.hasErrors()).isFalse();
+        assertThat( dmnResult.getContext().get( "Name list" )).asList().containsExactly("John", "Mary");
     }
 
     @Test
@@ -548,24 +537,24 @@ public class DMNRuntimeTest extends BaseInterpretedVsCompiledTest {
 //        runtime.addListener( DMNRuntimeUtil.createListener() );
 
         final DMNModel dmnModel = runtime.getModel("https://github.com/kiegroup/kie-dmn", "relation-expression" );
-        assertThat( dmnModel, notNullValue() );
-        assertThat( dmnModel.getMessages().toString(), dmnModel.hasErrors(), is( false ) );
+        assertThat(dmnModel).isNotNull();
+        assertThat(dmnModel.hasErrors()).as(dmnModel.getMessages().toString()).isFalse();
 
         final DMNContext context = DMNFactory.newContext();
         final DMNResult dmnResult = runtime.evaluateAll(dmnModel, context );
-        assertThat( dmnResult.hasErrors(), is( false ) );
-        assertThat( dmnResult.getContext().get( "Employee Relation" ), is( instanceOf( List.class ) ) );
+        assertThat(dmnResult.hasErrors()).isFalse();
+        assertThat( dmnResult.getContext().get( "Employee Relation" )).isInstanceOf( List.class);
 
         final List<Map<String, Object>> employees = (List<Map<String, Object>>) dmnResult.getContext().get("Employee Relation" );
         Map<String, Object> e = employees.get( 0 );
-        assertThat( e.get( "Name" ), is( "John" ) );
-        assertThat( e.get( "Dept" ), is( "Sales" ) );
-        assertThat( e.get( "Salary" ), is( BigDecimal.valueOf( 100000 ) ) );
+        assertThat( e.get( "Name" )).isEqualTo("John");
+        assertThat( e.get( "Dept" )).isEqualTo("Sales");
+        assertThat( e.get( "Salary" )).isEqualTo(BigDecimal.valueOf( 100000 ) );
 
         e = employees.get( 1 );
-        assertThat( e.get( "Name" ), is( "Mary" ) );
-        assertThat( e.get( "Dept" ), is( "Finances" ) );
-        assertThat( e.get( "Salary" ), is( BigDecimal.valueOf( 120000 ) ) );
+        assertThat( e.get( "Name" )).isEqualTo("Mary");
+        assertThat( e.get( "Dept" )).isEqualTo("Finances");
+        assertThat( e.get( "Salary" )).isEqualTo(BigDecimal.valueOf( 120000 ) );
     }
 
     @Test
@@ -574,8 +563,8 @@ public class DMNRuntimeTest extends BaseInterpretedVsCompiledTest {
 //        runtime.addListener( DMNRuntimeUtil.createListener() );
 
         final DMNModel dmnModel = runtime.getModel("http://www.trisotech.com/definitions/_4e0f0b70-d31c-471c-bd52-5ca709ed362b", "Lending1" );
-        assertThat( dmnModel, notNullValue() );
-        assertThat( DMNRuntimeUtil.formatMessages( dmnModel.getMessages() ), dmnModel.hasErrors(), is( false ) );
+        assertThat(dmnModel).isNotNull();
+        assertThat(dmnModel.hasErrors()).as(DMNRuntimeUtil.formatMessages(dmnModel.getMessages())).isFalse();
 
         final DMNContext context = DMNFactory.newContext();
         final Map<String, Object> applicant = new HashMap<>();
@@ -585,7 +574,7 @@ public class DMNRuntimeTest extends BaseInterpretedVsCompiledTest {
         monthly.put( "Repayments", 0 );
         applicant.put( "Monthly", monthly );
         applicant.put( "Age", 35 );
-        applicant.put( "ExistingCustomer", true );
+        applicant.put( "ExistingCustomer", Boolean.TRUE );
         applicant.put( "MaritalStatus", "M" );
         applicant.put( "EmploymentStatus", "EMPLOYED" );
         final Map<String, Object> product = new HashMap<>();
@@ -595,7 +584,7 @@ public class DMNRuntimeTest extends BaseInterpretedVsCompiledTest {
         product.put( "Term", 360 );
         final Map<String, Object> bureau = new HashMap<>();
         bureau.put( "CreditScore", 649 );
-        bureau.put( "Bankrupt", false );
+        bureau.put( "Bankrupt", Boolean.FALSE );
 
         context.set( "ApplicantData", applicant );
         context.set( "RequestedProduct", product );
@@ -605,17 +594,16 @@ public class DMNRuntimeTest extends BaseInterpretedVsCompiledTest {
         LOG.debug("{}", dmnResult);
         final DMNContext ctx = dmnResult.getContext();
 
-        assertThat( ctx.get( "ApplicationRiskScore" ), is( BigDecimal.valueOf( 130 ) ) );
-        assertThat( ctx.get( "Pre-bureauRiskCategory" ), is( "LOW" ) );
-        assertThat( ctx.get( "BureauCallType" ), is( "MINI" ) );
-        assertThat( ctx.get( "Post-bureauRiskCategory" ), is( "LOW" ) );
-        assertThat( ((BigDecimal)ctx.get( "RequiredMonthlyInstallment" )).setScale( 5, BigDecimal.ROUND_DOWN ),
-                    is( new BigDecimal( "1680.880325608555" ).setScale( 5, BigDecimal.ROUND_DOWN ) ) );
-        assertThat( ctx.get( "Pre-bureauAffordability" ), is( true ) );
-        assertThat( ctx.get( "Eligibility" ), is( "ELIGIBLE" ) );
-        assertThat( ctx.get( "Strategy" ), is( "BUREAU" ) );
-        assertThat( ctx.get( "Post-bureauAffordability" ), is( true ) );
-        assertThat( ctx.get( "Routing" ), is( "ACCEPT" ) );
+        assertThat(ctx.get("ApplicationRiskScore" )).isEqualTo(BigDecimal.valueOf( 130 ) );
+        assertThat(ctx.get("Pre-bureauRiskCategory" )).isEqualTo("LOW");
+        assertThat(ctx.get("BureauCallType" )).isEqualTo("MINI");
+        assertThat(ctx.get("Post-bureauRiskCategory" )).isEqualTo("LOW");
+        assertThat(((BigDecimal)ctx.get( "RequiredMonthlyInstallment")).setScale(5, BigDecimal.ROUND_DOWN)).isEqualTo(new BigDecimal("1680.880325608555").setScale(5, BigDecimal.ROUND_DOWN));
+        assertThat(ctx.get("Pre-bureauAffordability")).isEqualTo(Boolean.TRUE);
+        assertThat(ctx.get("Eligibility" )).isEqualTo("ELIGIBLE");
+        assertThat(ctx.get("Strategy" )).isEqualTo("BUREAU");
+        assertThat(ctx.get("Post-bureauAffordability" )).isEqualTo(Boolean.TRUE);
+        assertThat(ctx.get("Routing" )).isEqualTo("ACCEPT");
     }
 
     @Test
@@ -624,8 +612,8 @@ public class DMNRuntimeTest extends BaseInterpretedVsCompiledTest {
         runtime.addListener( DMNRuntimeUtil.createListener() );
 
         final DMNModel dmnModel = runtime.getModel("http://www.trisotech.com/definitions/_69430b3e-17b8-430d-b760-c505bf6469f9", "dateTime Table 58" );
-        assertThat( dmnModel, notNullValue() );
-        assertThat( DMNRuntimeUtil.formatMessages( dmnModel.getMessages() ), dmnModel.hasErrors(), is( false ) );
+        assertThat(dmnModel).isNotNull();
+        assertThat(dmnModel.hasErrors()).as(DMNRuntimeUtil.formatMessages(dmnModel.getMessages())).isFalse();
 
         final DMNContext context = DMNFactory.newContext();
         context.set( "dateString", "2015-12-24" );
@@ -643,31 +631,31 @@ public class DMNRuntimeTest extends BaseInterpretedVsCompiledTest {
         final DMNResult dmnResult = runtime.evaluateAll(dmnModel, context );
         final DMNContext ctx = dmnResult.getContext();
 
-        assertThat( DMNRuntimeUtil.formatMessages( dmnResult.getMessages() ), dmnResult.hasErrors(), is( false ) );
-        assertThat( ctx.get("Date-Time"), is( ZonedDateTime.of( 2016, 12, 24, 23, 59, 0, 0, ZoneOffset.ofHours( -5 ) ) ) );
-        assertThat( ctx.get("Date"), is( new HashMap<String, Object>(  ) {{
+        assertThat(dmnResult.hasErrors()).as(DMNRuntimeUtil.formatMessages(dmnResult.getMessages())).isFalse();
+        assertThat(ctx.get("Date-Time")).isEqualTo( ZonedDateTime.of( 2016, 12, 24, 23, 59, 0, 0, ZoneOffset.ofHours( -5 )));
+        assertThat(ctx.get("Date")).isEqualTo( new HashMap<String, Object>(  ) {{
             put( "fromString", LocalDate.of( 2015, 12, 24 ) );
             put( "fromDateTime", LocalDate.of( 2016, 12, 24 ) );
             put( "fromYearMonthDay", LocalDate.of( 1999, 11, 22 ) );
-        }} ) );
-        assertThat( ctx.get("Time"), is( OffsetTime.of(0, 0, 1, 0, ZoneOffset.ofHours(-1 ) ) ) );
-        assertThat( ctx.get("Date-Time2"), is( ZonedDateTime.of(2015, 12, 24, 0, 0, 1, 0, ZoneOffset.ofHours(-1 ) ) ) );
-        assertThat( ctx.get("Time2"), is( OffsetTime.of(0, 0, 1, 0, ZoneOffset.ofHours(-1 ) ) ) );
-        assertThat( ctx.get("Time3"), is( OffsetTime.of( 12, 59, 1, 300000000, ZoneOffset.ofHours( -1 ) )) );
-        assertThat( ctx.get("dtDuration1"), is( Duration.parse( "P13DT2H14S" ) ) );
-        assertThat( ctx.get("dtDuration2"), is( Duration.parse( "P367DT3H58M59S" ) ) );
-        assertThat( ctx.get("hoursInDuration"), is( new BigDecimal( "3" ) ) );
-        assertThat( ctx.get("sumDurations"), is( Duration.parse( "PT9125H59M13S" ) ) );
-        assertThat( ctx.get("ymDuration2"), is( ComparablePeriod.parse( "P1Y" ) ) );
-        assertThat( ctx.get("cDay"), is( BigDecimal.valueOf( 24 ) ) );
-        assertThat( ctx.get("cYear"), is( BigDecimal.valueOf( 2015 ) ) );
-        assertThat( ctx.get("cMonth"), is( BigDecimal.valueOf( 12 ) ) );
-        assertThat( ctx.get("cHour"), is( BigDecimal.valueOf( 0 ) ) );
-        assertThat( ctx.get("cMinute"), is( BigDecimal.valueOf( 0 ) ) );
-        assertThat( ctx.get("cSecond"), is( BigDecimal.valueOf( 1 ) ) );
-        assertThat( ctx.get("cTimezone"), is( "GMT-01:00" ) );
-        assertThat( ctx.get("years"), is( BigDecimal.valueOf( 1 ) ) );
-        assertThat( ctx.get("d1seconds"), is( BigDecimal.valueOf( 14 ) ) );
+        }});
+        assertThat( ctx.get("Time")).isEqualTo( OffsetTime.of(0, 0, 1, 0, ZoneOffset.ofHours(-1)));
+        assertThat( ctx.get("Date-Time2")).isEqualTo( ZonedDateTime.of(2015, 12, 24, 0, 0, 1, 0, ZoneOffset.ofHours(-1)));
+        assertThat( ctx.get("Time2")).isEqualTo( OffsetTime.of(0, 0, 1, 0, ZoneOffset.ofHours(-1)));
+        assertThat( ctx.get("Time3")).isEqualTo( OffsetTime.of( 12, 59, 1, 300000000, ZoneOffset.ofHours( -1)));
+        assertThat( ctx.get("dtDuration1")).isEqualTo(Duration.parse( "P13DT2H14S" ) );
+        assertThat( ctx.get("dtDuration2")).isEqualTo(Duration.parse( "P367DT3H58M59S" ) );
+        assertThat( ctx.get("hoursInDuration")).isEqualTo(new BigDecimal( "3" ) );
+        assertThat( ctx.get("sumDurations")).isEqualTo(Duration.parse( "PT9125H59M13S" ) );
+        assertThat( ctx.get("ymDuration2")).isEqualTo(ComparablePeriod.parse( "P1Y" ) );
+        assertThat( ctx.get("cDay")).isEqualTo(BigDecimal.valueOf( 24 ) );
+        assertThat( ctx.get("cYear")).isEqualTo(BigDecimal.valueOf( 2015 ) );
+        assertThat( ctx.get("cMonth")).isEqualTo(BigDecimal.valueOf( 12 ) );
+        assertThat( ctx.get("cHour")).isEqualTo(BigDecimal.valueOf( 0 ) );
+        assertThat( ctx.get("cMinute")).isEqualTo(BigDecimal.valueOf( 0 ) );
+        assertThat( ctx.get("cSecond")).isEqualTo(BigDecimal.valueOf( 1 ) );
+        assertThat( ctx.get("cTimezone")).isEqualTo("GMT-01:00" );
+        assertThat( ctx.get("years")).isEqualTo(BigDecimal.valueOf( 1 ) );
+        assertThat( ctx.get("d1seconds")).isEqualTo(BigDecimal.valueOf( 14 ) );
 
     }
 
@@ -677,13 +665,13 @@ public class DMNRuntimeTest extends BaseInterpretedVsCompiledTest {
         runtime.addListener( DMNRuntimeUtil.createListener() );
 
         final DMNModel dmnModel = runtime.getModel("http://www.trisotech.com/definitions/_e215ed7a-701b-4c53-b8df-4b4d23d5fe32", "Person filtering by age" );
-        assertThat( dmnModel, notNullValue() );
-        assertThat( DMNRuntimeUtil.formatMessages( dmnModel.getMessages() ), dmnModel.hasErrors(), is( false ) );
+        assertThat(dmnModel).isNotNull();
+        assertThat(dmnModel.hasErrors()).as(DMNRuntimeUtil.formatMessages(dmnModel.getMessages())).isFalse();
 
         final DMNContext context = DMNFactory.newContext();
         context.set( "Min Age", 50 );
         final DMNResult dmnResult = runtime.evaluateAll(dmnModel, context );
-        assertThat( DMNRuntimeUtil.formatMessages( dmnResult.getMessages() ), ((List)dmnResult.getContext().get("Filtering")).size(), is( 2 ) );
+        assertThat(((List)dmnResult.getContext().get("Filtering"))).as(DMNRuntimeUtil.formatMessages(dmnResult.getMessages())).hasSize(2);
     }
 
     @Test
@@ -692,13 +680,13 @@ public class DMNRuntimeTest extends BaseInterpretedVsCompiledTest {
         runtime.addListener( DMNRuntimeUtil.createListener() );
 
         final DMNModel dmnModel = runtime.getModel("http://www.trisotech.com/dmn/definitions/_4ad80959-5fd8-46b7-8c9a-ab2fa58cb5b4", "When is it" );
-        assertThat( dmnModel, notNullValue() );
-        assertThat( DMNRuntimeUtil.formatMessages( dmnModel.getMessages() ), dmnModel.hasErrors(), is( false ) );
+        assertThat(dmnModel).isNotNull();
+        assertThat(dmnModel.hasErrors()).as(DMNRuntimeUtil.formatMessages(dmnModel.getMessages())).isFalse();
 
         final DMNContext context = DMNFactory.newContext();
         context.set( "The date", LocalDate.of(2017, 1, 12 ) );
         final DMNResult dmnResult = runtime.evaluateAll(dmnModel, context );
-        assertThat( DMNRuntimeUtil.formatMessages( dmnResult.getMessages() ), dmnResult.getContext().get("When is it"), is( "It is in the past" ) );
+        assertThat(dmnResult.getContext().get("When is it")).as(DMNRuntimeUtil.formatMessages( dmnResult.getMessages())).isEqualTo("It is in the past");
     }
 
     @Test
@@ -707,54 +695,54 @@ public class DMNRuntimeTest extends BaseInterpretedVsCompiledTest {
         runtime.addListener( DMNRuntimeUtil.createListener() );
 
         final DMNModel dmnModel = runtime.getModel("http://www.trisotech.com/dmn/definitions/_ecf4ea54-2abc-4e2f-a101-4fe14e356a46", "Dessin 1" );
-        assertThat( dmnModel, notNullValue() );
-        assertThat( DMNRuntimeUtil.formatMessages( dmnModel.getMessages() ), dmnModel.hasErrors(), is( false ) );
+        assertThat(dmnModel).isNotNull();
+        assertThat(dmnModel.hasErrors()).as(DMNRuntimeUtil.formatMessages(dmnModel.getMessages())).isFalse();
 
         final DMNContext context = DMNFactory.newContext();
         context.set( "datetimestring", "2016-07-29T05:48:23" );
         final DMNResult dmnResult = runtime.evaluateAll(dmnModel, context );
-        assertThat( DMNRuntimeUtil.formatMessages( dmnResult.getMessages() ), dmnResult.getContext().get("time"), is( LocalTime.of( 5, 48, 23 ) ) );
+        assertThat(dmnResult.getContext().get("time")).as(DMNRuntimeUtil.formatMessages(dmnResult.getMessages())).isEqualTo(LocalTime.of(5, 48, 23));
     }
 
     @Test
     public void testAlternativeNSDecl() {
         final DMNRuntime runtime = DMNRuntimeUtil.createRuntime("alternative_feel_ns_declaration.dmn", this.getClass() );
         final DMNModel dmnModel = runtime.getModel("https://github.com/kiegroup/kie-dmn", "0001-input-data-string" );
-        assertThat( dmnModel, notNullValue() );
+        assertThat(dmnModel).isNotNull();
 
         final DMNContext context = DMNFactory.newContext();
         context.set( "Full Name", "John Doe" );
 
         final DMNResult dmnResult = runtime.evaluateAll(dmnModel, context );
 
-        assertThat( dmnResult.getDecisionResults().size(), is( 1 ) );
-        assertThat( dmnResult.getDecisionResultByName( "Greeting Message" ).getResult(), is( "Hello John Doe" ) );
+        assertThat( dmnResult.getDecisionResults()).hasSize(1);
+        assertThat( dmnResult.getDecisionResultByName( "Greeting Message" ).getResult()).isEqualTo("Hello John Doe" );
 
         final DMNContext result = dmnResult.getContext();
 
-        assertThat( result.get( "Greeting Message" ), is( "Hello John Doe" ) );
+        assertThat( result.get( "Greeting Message" )).isEqualTo("Hello John Doe" );
     }
 
     @Test
     public void testLoanComparison() {
         final DMNRuntime runtime = DMNRuntimeUtil.createRuntime("loanComparison.dmn", this.getClass() );
         final DMNModel dmnModel = runtime.getModel("http://www.trisotech.com/definitions/_3a1fd8f4-ea04-4453-aa30-ff14140e3441", "loanComparison" );
-        assertThat( dmnModel, notNullValue() );
-        assertThat( DMNRuntimeUtil.formatMessages( dmnModel.getMessages() ), dmnModel.hasErrors(), is( false ) );
+        assertThat(dmnModel).isNotNull();
+        assertThat(dmnModel.hasErrors()).as(DMNRuntimeUtil.formatMessages(dmnModel.getMessages())).isFalse();
 
         final DMNContext context = DMNFactory.newContext();
         context.set( "RequestedAmt", 500000 );
 
         final DMNResult dmnResult = runtime.evaluateAll(dmnModel, context );
-        assertThat( DMNRuntimeUtil.formatMessages( dmnResult.getMessages() ), dmnResult.hasErrors(), is( false ) );
+        assertThat(dmnResult.hasErrors()).as(DMNRuntimeUtil.formatMessages(dmnResult.getMessages())).isFalse();
     }
 
     @Test
     public void testGetViableLoanProducts() {
         final DMNRuntime runtime = DMNRuntimeUtil.createRuntime("Get_Viable_Loan_Products.dmn", this.getClass() );
         final DMNModel dmnModel = runtime.getModel("http://www.trisotech.com/definitions/_3e1a628d-36bc-45f1-8464-b201735e5ce0", "Get Viable Loan Products" );
-        assertThat( dmnModel, notNullValue() );
-        assertThat( DMNRuntimeUtil.formatMessages( dmnModel.getMessages() ), dmnModel.hasErrors(), is( false ) );
+        assertThat(dmnModel).isNotNull();
+        assertThat(dmnModel.hasErrors()).as(DMNRuntimeUtil.formatMessages(dmnModel.getMessages())).isFalse();
 
         final Map<String, Object> requested = new HashMap<>(  );
         requested.put( "PropertyZIP", "91001" );
@@ -766,19 +754,19 @@ public class DMNRuntimeTest extends BaseInterpretedVsCompiledTest {
         context.set( "Requested", requested );
 
         final DMNResult dmnResult = runtime.evaluateAll(dmnModel, context );
-        assertThat( dmnResult.hasErrors(), is( false ) );
+        assertThat(dmnResult.hasErrors()).isFalse();
 
         final DMNContext result = dmnResult.getContext();
-        assertThat( result.get( "isConforming" ), is( true ) );
-        assertThat( (Collection<Object>) result.get( "LoanTypes" ), hasSize( 3 ) );
+        assertThat( result.get( "isConforming" )).isEqualTo(Boolean.TRUE);
+        assertThat( (Collection<Object>) result.get( "LoanTypes" )).hasSize(3);
     }
 
     @Test
     public void testYearsAndMonthsDuration() {
         final DMNRuntime runtime = DMNRuntimeUtil.createRuntime("yearMonthDuration.dmn", this.getClass() );
         final DMNModel dmnModel = runtime.getModel("http://www.trisotech.com/dmn/definitions/_6eda1490-21ca-441e-8a26-ab3ca800e43c", "Drawing 1" );
-        assertThat( dmnModel, notNullValue() );
-        assertThat( DMNRuntimeUtil.formatMessages( dmnModel.getMessages() ), dmnModel.hasErrors(), is( false ) );
+        assertThat(dmnModel).isNotNull();
+        assertThat(dmnModel.hasErrors()).as(DMNRuntimeUtil.formatMessages(dmnModel.getMessages())).isFalse();
 
         final BuiltInType feelType = (BuiltInType) BuiltInType.determineTypeFromName("yearMonthDuration" );
         final ChronoPeriod period = (ChronoPeriod) feelType.fromString("P2Y1M");
@@ -787,40 +775,40 @@ public class DMNRuntimeTest extends BaseInterpretedVsCompiledTest {
         context.set( "iDuration", period );
 
         final DMNResult dmnResult = runtime.evaluateAll(dmnModel, context );
-        assertThat( DMNRuntimeUtil.formatMessages( dmnResult.getMessages() ), dmnResult.hasErrors(), is( false ) );
+        assertThat(dmnResult.hasErrors()).as(DMNRuntimeUtil.formatMessages(dmnResult.getMessages())).isFalse();
 
         final DMNContext result = dmnResult.getContext();
-        assertThat( result.get( "How long" ), is( "Longer than a year" ) );
+        assertThat( result.get( "How long" )).isEqualTo("Longer than a year" );
     }
 
     @Test
     public void testInvalidVariableNames() {
         final List<DMNMessage> messages = DMNRuntimeUtil.createExpectingDMNMessages("invalid-variable-names.dmn", this.getClass());
-        assertThat(messages.isEmpty(), is(false));
+        assertThat(messages).isNotEmpty();
     }
 
     @Test
     public void testNull() {
         final DMNRuntime runtime = DMNRuntimeUtil.createRuntime("null_values.dmn", this.getClass() );
         final DMNModel dmnModel = runtime.getModel("https://github.com/kiegroup/kie-dmn", "Null values model" );
-        assertThat( dmnModel, notNullValue() );
-        assertThat( DMNRuntimeUtil.formatMessages( dmnModel.getMessages() ), dmnModel.hasErrors(), is( false ) );
+        assertThat(dmnModel).isNotNull();
+        assertThat(dmnModel.hasErrors()).as(DMNRuntimeUtil.formatMessages(dmnModel.getMessages())).isFalse();
 
         DMNContext context = runtime.newContext();
         context.set( "Null Input", null );
 
         DMNResult dmnResult = runtime.evaluateAll( dmnModel, context );
-        assertThat( DMNRuntimeUtil.formatMessages( dmnResult.getMessages() ), dmnResult.hasErrors(), is( false ) );
+        assertThat(dmnResult.hasErrors()).as(DMNRuntimeUtil.formatMessages(dmnResult.getMessages())).isFalse();
         DMNContext result = dmnResult.getContext();
-        assertThat( result.get( "Null value" ), is( "Input is null" ) );
+        assertThat( result.get( "Null value" )).isEqualTo("Input is null" );
 
         context = runtime.newContext();
         context.set( "Null Input", "foo" );
 
         dmnResult = runtime.evaluateAll( dmnModel, context );
-        assertThat( DMNRuntimeUtil.formatMessages( dmnResult.getMessages() ), dmnResult.hasErrors(), is( false ) );
+        assertThat(dmnResult.hasErrors()).as(DMNRuntimeUtil.formatMessages(dmnResult.getMessages())).isFalse();
         result = dmnResult.getContext();
-        assertThat( result.get( "Null value" ), is( "Input is not null" ) );
+        assertThat( result.get( "Null value" )).isEqualTo("Input is not null" );
 
     }
 
@@ -828,58 +816,58 @@ public class DMNRuntimeTest extends BaseInterpretedVsCompiledTest {
     public void testInvalidUHitPolicy() {
         final DMNRuntime runtime = DMNRuntimeUtil.createRuntime("Invalid_U_hit_policy.dmn", this.getClass() );
         final DMNModel dmnModel = runtime.getModel("http://www.trisotech.com/definitions/_7cf49108-9b55-4f35-b5ef-f83448061757", "Greater than 5 - Invalid U hit policy" );
-        assertThat( dmnModel, notNullValue() );
-        assertThat( DMNRuntimeUtil.formatMessages( dmnModel.getMessages() ), dmnModel.hasErrors(), is( false ) );
+        assertThat(dmnModel).isNotNull();
+        assertThat(dmnModel.hasErrors()).as(DMNRuntimeUtil.formatMessages(dmnModel.getMessages())).isFalse();
 
         final DMNContext context = runtime.newContext();
         context.set( "Number", 5 );
 
         final DMNResult dmnResult = runtime.evaluateAll(dmnModel, context );
-        assertThat( DMNRuntimeUtil.formatMessages( dmnResult.getMessages() ), dmnResult.hasErrors(), is( true ) );
-        assertThat( dmnResult.getMessages().size(), is( 2 ) );
-        assertThat( dmnResult.getMessages().get( 0 ).getSourceId(), is("_c5eda7c3-7f22-43c2-8c1e-a3cc79bb7a74" )  );
-        assertThat( dmnResult.getMessages().get( 1 ).getSourceId(), is("_5bac3e4c-b59a-4f14-b5cf-d4d88c60877f" )  );
+        assertThat(dmnResult.hasErrors()).as(dmnResult.getMessages().toString()).isTrue();
+        assertThat( dmnResult.getMessages()).hasSize(2);
+        assertThat( dmnResult.getMessages().get( 0 ).getSourceId()).isEqualTo("_c5eda7c3-7f22-43c2-8c1e-a3cc79bb7a74" );
+        assertThat( dmnResult.getMessages().get( 1 ).getSourceId()).isEqualTo("_5bac3e4c-b59a-4f14-b5cf-d4d88c60877f" );
     }
 
     @Test
     public void testInvalidModel() {
         final List<DMNMessage> messages = DMNRuntimeUtil.createExpectingDMNMessages("Loan_Prequalification_Condensed_Invalid.dmn", this.getClass());
-        assertThat(messages.size(), is(2));
-        assertThat(messages.get(0).getSourceId(), is("_8b5cac9e-c8ca-4817-b05a-c70fa79a8d48"));
-        assertThat(messages.get(1).getSourceId(), is("_ef09d90e-e1a4-4ec9-885b-482d1f4a1cee"));
+        assertThat(messages).hasSize(2);
+        assertThat(messages.get(0).getSourceId()).isEqualTo("_8b5cac9e-c8ca-4817-b05a-c70fa79a8d48");
+        assertThat(messages.get(1).getSourceId()).isEqualTo("_ef09d90e-e1a4-4ec9-885b-482d1f4a1cee");
     }
 
     @Test
     public void testNullOnNumber() {
         final DMNRuntime runtime = DMNRuntimeUtil.createRuntime("Number_and_null_entry.dmn", this.getClass() );
         final DMNModel dmnModel = runtime.getModel("http://www.trisotech.com/definitions/_a293b9f9-c912-41ee-8147-eae59ba86ac5", "Number and null entry" );
-        assertThat( dmnModel, notNullValue() );
-        assertThat( DMNRuntimeUtil.formatMessages( dmnModel.getMessages() ), dmnModel.hasErrors(), is( false ) );
+        assertThat(dmnModel).isNotNull();
+        assertThat(dmnModel.hasErrors()).as(DMNRuntimeUtil.formatMessages(dmnModel.getMessages())).isFalse();
 
         DMNContext context = runtime.newContext();
 
         context.set( "num", null );
 
         DMNResult dmnResult = runtime.evaluateAll( dmnModel, context );
-        assertThat( DMNRuntimeUtil.formatMessages( dmnResult.getMessages() ), dmnResult.hasErrors(), is( false ) );
+        assertThat(dmnResult.hasErrors()).as(DMNRuntimeUtil.formatMessages(dmnResult.getMessages())).isFalse();
         DMNContext result = dmnResult.getContext();
-        assertThat( result.get( "Decision Logic 1" ), is( "Null" ) );
+        assertThat( result.get( "Decision Logic 1" )).isEqualTo("Null");
 
         context = runtime.newContext();
         context.set( "num", 4 );
 
         dmnResult = runtime.evaluateAll( dmnModel, context );
-        assertThat( DMNRuntimeUtil.formatMessages( dmnResult.getMessages() ), dmnResult.hasErrors(), is( false ) );
+        assertThat(dmnResult.hasErrors()).as(DMNRuntimeUtil.formatMessages(dmnResult.getMessages())).isFalse();
         result = dmnResult.getContext();
-        assertThat( result.get( "Decision Logic 1" ), is( "Positive number" ) );
+        assertThat( result.get( "Decision Logic 1" )).isEqualTo("Positive number" );
     }
 
     @Test
     public void testLoan_Recommendation2() {
         final DMNRuntime runtime = DMNRuntimeUtil.createRuntime("Loan_Recommendation2.dmn", this.getClass() );
         final DMNModel dmnModel = runtime.getModel("http://www.trisotech.com/definitions/_35c7339b-b868-43da-8f06-eb481708c73c", "Loan Recommendation2" );
-        assertThat( dmnModel, notNullValue() );
-        assertThat( DMNRuntimeUtil.formatMessages( dmnModel.getMessages() ), dmnModel.hasErrors(), is( false ) );
+        assertThat(dmnModel).isNotNull();
+        assertThat(dmnModel.hasErrors()).as(DMNRuntimeUtil.formatMessages(dmnModel.getMessages())).isFalse();
 
         final Map<String,Object> loan = new HashMap<>(  );
         loan.put( "Amount", 100000);
@@ -902,9 +890,9 @@ public class DMNRuntimeTest extends BaseInterpretedVsCompiledTest {
         context.set( "Borrower", borrower );
 
         final DMNResult dmnResult = runtime.evaluateAll(dmnModel, context );
-        assertThat( DMNRuntimeUtil.formatMessages( dmnResult.getMessages() ), dmnResult.hasErrors(), is( false ) );
+        assertThat(dmnResult.hasErrors()).as(DMNRuntimeUtil.formatMessages(dmnResult.getMessages())).isFalse();
         final DMNContext result = dmnResult.getContext();
-        assertThat( result.get( "Loan Recommendation" ), is( "Decline" ) );
+        assertThat( result.get( "Loan Recommendation" )).isEqualTo("Decline");
     }
     
     @Test
@@ -913,16 +901,16 @@ public class DMNRuntimeTest extends BaseInterpretedVsCompiledTest {
         final DMNModel dmnModel = runtime.getModel(
                 "http://www.trisotech.com/definitions/_ff54a44d-b8f5-48fc-b2b7-43db767e8a1c",
                 "not quite all or nothing P" );
-        assertThat( dmnModel, notNullValue() );
-        assertThat( DMNRuntimeUtil.formatMessages( dmnModel.getMessages() ), dmnModel.hasErrors(), is( false ) );
+        assertThat(dmnModel).isNotNull();
+        assertThat(dmnModel.hasErrors()).as(DMNRuntimeUtil.formatMessages(dmnModel.getMessages())).isFalse();
         
         final DMNContext context = runtime.newContext();
-        context.set("isAffordable", false);
+        context.set("isAffordable", Boolean.FALSE);
         context.set("RiskCategory", "Medium");
         
         final DMNResult dmnResult = runtime.evaluateAll(dmnModel, context );
         final DMNContext result = dmnResult.getContext();
-        assertThat( result.get( "Approval Status" ), is( "Declined" ) );
+        assertThat( result.get( "Approval Status" )).isEqualTo("Declined");
     }
     
     @Test
@@ -931,22 +919,22 @@ public class DMNRuntimeTest extends BaseInterpretedVsCompiledTest {
         final DMNModel dmnModel = runtime.getModel(
                 "http://www.trisotech.com/definitions/_ff54a44d-b8f5-48fc-b2b7-43db767e8a1c",
                 "not quite all or nothing P" );
-        assertThat( dmnModel, notNullValue() );
-        assertThat( DMNRuntimeUtil.formatMessages( dmnModel.getMessages() ), dmnModel.hasErrors(), is( false ) );
+        assertThat(dmnModel).isNotNull();
+        assertThat(dmnModel.hasErrors()).as(DMNRuntimeUtil.formatMessages(dmnModel.getMessages())).isFalse();
         
         final DMNContext context = runtime.newContext();
-        context.set("isAffordable", false);
+        context.set("isAffordable", Boolean.FALSE);
         context.set("RiskCategory", "Medium");
         
         final DMNResult dmnResult = runtime.evaluateAll(dmnModel, context );
         final DMNContext result = dmnResult.getContext();
-        assertThat( result.get( "Approval Status" ), is( "Declined" ) );
+        assertThat( result.get( "Approval Status" )).isEqualTo("Declined");
     }
     
     @Test
     public void testPriority_table_missing_output_values() {
         final List<DMNMessage> messages = DMNRuntimeUtil.createExpectingDMNMessages("DTABLE_PRIORITY_MISSING_OUTVALS.dmn", this.getClass());
-        assertThat(messages.size(), is(1));
+        assertThat(messages).hasSize(1);
     }
 
     @Test
@@ -955,8 +943,8 @@ public class DMNRuntimeTest extends BaseInterpretedVsCompiledTest {
         final DMNModel dmnModel = runtime.getModel(
         "https://github.com/kiegroup/kie-dmn",
         "DTABLE_NON_PRIORITY_MISSING_OUTVALS" );
-        assertThat( dmnModel, notNullValue() );
-        assertThat( DMNRuntimeUtil.formatMessages( dmnModel.getMessages() ), dmnModel.hasErrors(), is( false ) );
+        assertThat(dmnModel).isNotNull();
+        assertThat(dmnModel.hasErrors()).as(DMNRuntimeUtil.formatMessages(dmnModel.getMessages())).isFalse();
     }
 
     @Test
@@ -965,8 +953,8 @@ public class DMNRuntimeTest extends BaseInterpretedVsCompiledTest {
         final DMNModel dmnModel = runtime.getModel(
         "https://github.com/kiegroup/kie-dmn",
         "DTABLE_PRIORITY_ONE_OUTVAL" );
-        assertThat( dmnModel, notNullValue() );
-        assertThat( DMNRuntimeUtil.formatMessages( dmnModel.getMessages() ), dmnModel.hasErrors(), is( false ) );
+        assertThat(dmnModel).isNotNull();
+        assertThat(dmnModel.hasErrors()).as(DMNRuntimeUtil.formatMessages(dmnModel.getMessages())).isFalse();
     }
     
     @Test
@@ -975,32 +963,32 @@ public class DMNRuntimeTest extends BaseInterpretedVsCompiledTest {
         final DMNModel dmnModel = runtime.getModel(
                 "https://www.drools.org/kie-dmn/definitions",
                 "definitions" );
-        assertThat( dmnModel, notNullValue() );
-        assertThat( DMNRuntimeUtil.formatMessages( dmnModel.getMessages() ), dmnModel.hasErrors(), is( false ) );
+        assertThat(dmnModel).isNotNull();
+        assertThat(dmnModel.hasErrors()).as(DMNRuntimeUtil.formatMessages(dmnModel.getMessages())).isFalse();
         
         final DMNContext context = runtime.newContext();
         context.set("MyInput", "a");
 
         final DMNResult dmnResult = runtime.evaluateAll(dmnModel, context );
         
-        assertThat( DMNRuntimeUtil.formatMessages( dmnResult.getMessages() ), dmnResult.hasErrors(), is( false ) );
+        assertThat(dmnResult.hasErrors()).as(DMNRuntimeUtil.formatMessages(dmnResult.getMessages())).isFalse();
         final DMNContext result = dmnResult.getContext();
-        assertThat( result.get( "MyDecision" ), is( "Decision taken" ) );
+        assertThat( result.get( "MyDecision" )).isEqualTo("Decision taken" );
     }
     
     @Test
     public void testWrongConstraintsInItemDefinition() {
         // DROOLS-1503
         final List<DMNMessage> messages = DMNRuntimeUtil.createExpectingDMNMessages("WrongConstraintsInItemDefinition.dmn", this.getClass());
-        assertThat(DMNRuntimeUtil.formatMessages(messages), messages.size(), is(3));
-        assertThat(messages.get(0).getSourceReference(), is(instanceOf(ItemDefinition.class)));
-        assertThat(messages.get(0).getMessageType(), is(DMNMessageType.ERR_COMPILING_FEEL));
-        assertThat(messages.get(1).getSourceId(), is("_e794c655-4fdf-45d1-b7b7-d990df513f92"));
-        assertThat(messages.get(1).getMessageType(), is(DMNMessageType.ERR_COMPILING_FEEL));
+        assertThat(messages).as(DMNRuntimeUtil.formatMessages(messages)).hasSize(3);
+        assertThat(messages.get(0).getSourceReference()).isInstanceOf(ItemDefinition.class);
+        assertThat(messages.get(0).getMessageType()).isEqualTo(DMNMessageType.ERR_COMPILING_FEEL);
+        assertThat(messages.get(1).getSourceId()).isEqualTo("_e794c655-4fdf-45d1-b7b7-d990df513f92");
+        assertThat(messages.get(1).getMessageType()).isEqualTo(DMNMessageType.ERR_COMPILING_FEEL);
         
         // The DecisionTable does not define typeRef for the single OutputClause, but neither the enclosing Decision define typeRef for its variable
-        assertThat(messages.get(2).getSourceId(), is("_31911de7-e184-411c-99d1-f33977971270"));
-        assertThat(messages.get(2).getMessageType(), is(DMNMessageType.MISSING_TYPE_REF));
+        assertThat(messages.get(2).getSourceId()).isEqualTo("_31911de7-e184-411c-99d1-f33977971270");
+        assertThat(messages.get(2).getMessageType()).isEqualTo(DMNMessageType.MISSING_TYPE_REF);
     }
     
     @Test
@@ -1010,8 +998,8 @@ public class DMNRuntimeTest extends BaseInterpretedVsCompiledTest {
         final DMNModel dmnModel = runtime.getModel(
                 "https://www.drools.org/kie-dmn/definitions",
                 "definitions" );
-        assertThat( dmnModel, notNullValue() );
-        assertThat( DMNRuntimeUtil.formatMessages( dmnModel.getMessages() ), dmnModel.hasErrors(), is( false ) );
+        assertThat(dmnModel).isNotNull();
+        assertThat(dmnModel.hasErrors()).as(DMNRuntimeUtil.formatMessages(dmnModel.getMessages())).isFalse();
         
         final DMNContext context = runtime.newContext();
         final Map<String, String> person = new HashMap<>();
@@ -1021,9 +1009,9 @@ public class DMNRuntimeTest extends BaseInterpretedVsCompiledTest {
 
         final DMNResult dmnResult = runtime.evaluateAll(dmnModel, context );
         
-        assertThat( DMNRuntimeUtil.formatMessages( dmnResult.getMessages() ), dmnResult.hasErrors(), is( false ) );
+        assertThat(dmnResult.hasErrors()).as(DMNRuntimeUtil.formatMessages(dmnResult.getMessages())).isFalse();
         final DMNContext result = dmnResult.getContext();
-        assertThat( result.get( "Further Decision" ), is( "The person was greeted with: 'Ciao John Doe'" ) );
+        assertThat( result.get( "Further Decision" )).isEqualTo( "The person was greeted with: 'Ciao John Doe'");
     }
 
     @Test
@@ -1032,8 +1020,9 @@ public class DMNRuntimeTest extends BaseInterpretedVsCompiledTest {
         final DMNModel dmnModel = runtime.getModel(
                 "https://github.com/kiegroup/kie-dmn",
                 "out-of-order" );
-        assertThat( dmnModel, notNullValue() );
-        assertThat( DMNRuntimeUtil.formatMessages( dmnModel.getMessages() ), dmnModel.getMessages().stream().anyMatch( m -> m.getMessageType().equals( DMNMessageType.FAILED_VALIDATOR ) ), is( false ) );
+        assertThat(dmnModel).isNotNull();
+        assertThat(dmnModel.getMessages().stream().anyMatch( m -> m.getMessageType().equals( DMNMessageType.FAILED_VALIDATOR)))
+        .as(DMNRuntimeUtil.formatMessages(dmnModel.getMessages())).isFalse();
     }
   
     @Test
@@ -1043,8 +1032,8 @@ public class DMNRuntimeTest extends BaseInterpretedVsCompiledTest {
         final DMNModel dmnModel = runtime.getModel(
                 "http://www.trisotech.com/definitions/_2374ee6d-75ed-4e9d-95d3-a88c135e1c43",
                 "Drawing 1a" );
-        assertThat( dmnModel, notNullValue() );
-        assertThat( DMNRuntimeUtil.formatMessages( dmnModel.getMessages() ), dmnModel.hasErrors(), is( false ) );
+        assertThat(dmnModel).isNotNull();
+        assertThat(dmnModel.hasErrors()).as(DMNRuntimeUtil.formatMessages(dmnModel.getMessages())).isFalse();
 
         final DMNContext context = runtime.newContext();
         final Map<String, String> person = new HashMap<>();
@@ -1054,9 +1043,9 @@ public class DMNRuntimeTest extends BaseInterpretedVsCompiledTest {
 
         final DMNResult dmnResult = runtime.evaluateAll(dmnModel, context );
 
-        assertThat( DMNRuntimeUtil.formatMessages( dmnResult.getMessages() ), dmnResult.hasErrors(), is( false ) );
+        assertThat(dmnResult.hasErrors()).as(DMNRuntimeUtil.formatMessages(dmnResult.getMessages())).isFalse();
         final DMNContext result = dmnResult.getContext();
-        assertThat( result.get( "My Decision" ), is( "The person John Doe is located at 100 East Davie Street" ) );
+        assertThat( result.get( "My Decision" )).isEqualTo("The person John Doe is located at 100 East Davie Street" );
     }
     
     @Test
@@ -1066,9 +1055,9 @@ public class DMNRuntimeTest extends BaseInterpretedVsCompiledTest {
         final DMNModel dmnModel = runtime.getModel(
                 "http://www.trisotech.com/dmn/definitions/_591d49d0-26e1-4a1c-9f72-b65bec09964a",
                 "Loan Recommendation Multi-step" );
-        assertThat( dmnModel, notNullValue() );
+        assertThat(dmnModel).isNotNull();
         System.out.println(DMNRuntimeUtil.formatMessages( dmnModel.getMessages() ));
-        assertThat( DMNRuntimeUtil.formatMessages( dmnModel.getMessages() ), dmnModel.hasErrors(), is( false ) );
+        assertThat(dmnModel.hasErrors()).as(DMNRuntimeUtil.formatMessages(dmnModel.getMessages())).isFalse();
         
         final DMNContext context = runtime.newContext();
         final Map<String, Number> loan = new HashMap<>();
@@ -1078,10 +1067,10 @@ public class DMNRuntimeTest extends BaseInterpretedVsCompiledTest {
         context.set("Loan", loan);
 
         final DMNResult dmnResult = runtime.evaluateByName(dmnModel, context, "Loan Payment");
-        assertThat( DMNRuntimeUtil.formatMessages( dmnResult.getMessages() ), dmnResult.hasErrors(), is( true ) );
-        assertThat( dmnResult.getMessages().size(), is( 1 ) );
-        assertThat( dmnResult.getMessages().get( 0 ).getSourceId(), is("_93062144-ebc7-4ef7-a156-c342aeffac49") );
-        assertThat( dmnResult.getMessages().get( 0 ).getMessageType(), is( DMNMessageType.ERROR_EVAL_NODE ) );
+        assertThat(dmnResult.hasErrors()).as(dmnResult.getMessages().toString()).isTrue();
+        assertThat( dmnResult.getMessages()).hasSize(1);
+        assertThat( dmnResult.getMessages().get( 0 ).getSourceId()).isEqualTo("_93062144-ebc7-4ef7-a156-c342aeffac49");
+        assertThat( dmnResult.getMessages().get( 0 ).getMessageType()).isEqualTo(DMNMessageType.ERROR_EVAL_NODE);
     }
 
     @Test
@@ -1091,14 +1080,14 @@ public class DMNRuntimeTest extends BaseInterpretedVsCompiledTest {
         final DMNModel dmnModel = runtime.getModel(
                 "http://www.trisotech.com/dmn/definitions/_95b7ee22-1964-4be5-b7db-7db66692c707",
                 "Dessin 1" );
-        assertThat( dmnModel, notNullValue() );
-        assertThat( DMNRuntimeUtil.formatMessages( dmnModel.getMessages() ), dmnModel.hasErrors(), is( false ) );
+        assertThat(dmnModel).isNotNull();
+        assertThat(dmnModel.hasErrors()).as(DMNRuntimeUtil.formatMessages(dmnModel.getMessages())).isFalse();
 
         final DMNContext context = runtime.newContext();
         final DMNResult dmnResult = runtime.evaluateAll(dmnModel, context );
 
-        assertThat( DMNRuntimeUtil.formatMessages( dmnResult.getMessages() ), dmnResult.hasErrors(), is( true ) );
-        assertThat( dmnResult.getMessages().stream().anyMatch( m -> m.getMessageType().equals( DMNMessageType.REQ_NOT_FOUND ) ), is( true ) );
+        assertThat(dmnResult.hasErrors()).as(dmnResult.getMessages().toString()).isTrue();
+        assertThat(dmnResult.getMessages().stream().anyMatch( m -> m.getMessageType().equals( DMNMessageType.REQ_NOT_FOUND))).isTrue();
     }
     
     @Test
@@ -1107,22 +1096,22 @@ public class DMNRuntimeTest extends BaseInterpretedVsCompiledTest {
         final DMNModel dmnModel = runtime.getModel(
                 "http://www.trisotech.com/definitions/_76362694-41e8-400c-8dea-e5f033d4f405",
                 "Union of letters" );
-        assertThat( dmnModel, notNullValue() );
-        assertThat( DMNRuntimeUtil.formatMessages( dmnModel.getMessages() ), dmnModel.hasErrors(), is( false ) );
+        assertThat(dmnModel).isNotNull();
+        assertThat(dmnModel.hasErrors()).as(DMNRuntimeUtil.formatMessages(dmnModel.getMessages())).isFalse();
 
         final DMNContext ctx1 = runtime.newContext();
         ctx1.set("A1", Arrays.asList("a", "b"));
         ctx1.set("A2", Arrays.asList("b", "c"));
         final DMNResult dmnResult1 = runtime.evaluateAll(dmnModel, ctx1 );
-        assertThat( DMNRuntimeUtil.formatMessages( dmnResult1.getMessages() ), dmnResult1.hasErrors(), is( false ) );
-        assertThat( (List<?>) dmnResult1.getContext().get( "D1" ), contains( "a", "b", "c" ) );
+        assertThat(dmnResult1.hasErrors()).as(DMNRuntimeUtil.formatMessages(dmnResult1.getMessages())).isFalse();
+        assertThat( (List<?>) dmnResult1.getContext().get( "D1" )).asList().contains( "a", "b", "c" );
         
         final DMNContext ctx2 = runtime.newContext();
         ctx2.set("A1", Arrays.asList("a", "b"));
         ctx2.set("A2", Arrays.asList("b", "x"));
         final DMNResult dmnResult2 = runtime.evaluateAll(dmnModel, ctx2 );
-        assertThat( DMNRuntimeUtil.formatMessages( dmnResult2.getMessages() ), dmnResult2.hasErrors(), is( true ) );
-        assertThat( dmnResult2.getMessages().stream().anyMatch( m -> m.getMessageType().equals( DMNMessageType.ERROR_EVAL_NODE ) ), is( true ) );
+        assertThat(dmnResult2.hasErrors()).as(DMNRuntimeUtil.formatMessages(dmnResult2.getMessages())).isTrue();
+        assertThat(dmnResult2.getMessages().stream().anyMatch(m -> m.getMessageType().equals(DMNMessageType.ERROR_EVAL_NODE))).isTrue();
     }
 
     @Test
@@ -1136,8 +1125,8 @@ public class DMNRuntimeTest extends BaseInterpretedVsCompiledTest {
     @Test
     public void testUnknownVariable2() {
         final List<DMNMessage> messages = DMNRuntimeUtil.createExpectingDMNMessages("unknown_variable2.dmn", this.getClass());
-        assertThat(messages.get(0).getMessageType(), is(DMNMessageType.ERR_COMPILING_FEEL));
-        assertThat(messages.get(0).getMessage(), containsString("Unknown variable 'Borrower.liquidAssetsAmt'"));
+        assertThat(messages.get(0).getMessageType()).isEqualTo(DMNMessageType.ERR_COMPILING_FEEL);
+        assertThat(messages.get(0).getMessage()).containsSequence("Unknown variable 'Borrower.liquidAssetsAmt'");
     }
 
     @Test
@@ -1146,15 +1135,15 @@ public class DMNRuntimeTest extends BaseInterpretedVsCompiledTest {
         final DMNModel dmnModel = runtime.getModel(
                 "http://www.trisotech.com/definitions/_71af58db-e1df-4b0f-aee2-48e0e8d89672",
                 "SingleDecisionWithContext" );
-        assertThat( dmnModel, notNullValue() );
-        assertThat( DMNRuntimeUtil.formatMessages( dmnModel.getMessages() ), dmnModel.hasErrors(), is( false ) );
+        assertThat(dmnModel).isNotNull();
+        assertThat(dmnModel.hasErrors()).as(DMNRuntimeUtil.formatMessages(dmnModel.getMessages())).isFalse();
         
         final DMNContext emptyContext = runtime.newContext();
         final DMNResult dmnResult = runtime.evaluateAll(dmnModel, emptyContext );
        
-        assertThat( DMNRuntimeUtil.formatMessages( dmnResult.getMessages() ), dmnResult.hasErrors(), is( false ) );
+        assertThat(dmnResult.hasErrors()).as(DMNRuntimeUtil.formatMessages(dmnResult.getMessages())).isFalse();
         final DMNContext result = dmnResult.getContext();
-        assertThat( result.get( "MyDecision" ), is( "Hello John Doe" ) );
+        assertThat( result.get( "MyDecision" )).isEqualTo("Hello John Doe" );
     }
 
     @Test
@@ -1163,8 +1152,8 @@ public class DMNRuntimeTest extends BaseInterpretedVsCompiledTest {
         final DMNModel dmnModel = runtime.getModel(
                 "http://www.trisotech.com/definitions/_5f1269c8-1e6f-4748-9eca-26aa1b1278ef",
                 "Ex 6-1" );
-        assertThat( dmnModel, notNullValue() );
-        assertThat( DMNRuntimeUtil.formatMessages( dmnModel.getMessages() ), dmnModel.hasErrors(), is( false ) );
+        assertThat(dmnModel).isNotNull();
+        assertThat(dmnModel.hasErrors()).as(DMNRuntimeUtil.formatMessages(dmnModel.getMessages())).isFalse();
         
         final DMNContext ctx = runtime.newContext();
         final Map<String, Object> t1 = new HashMap<>();
@@ -1182,15 +1171,15 @@ public class DMNRuntimeTest extends BaseInterpretedVsCompiledTest {
         ctx.set("NBA Pacific", Arrays.asList(t1, t2));
         final DMNResult dmnResult = runtime.evaluateAll(dmnModel, ctx );
        
-        assertThat( DMNRuntimeUtil.formatMessages( dmnResult.getMessages() ), dmnResult.hasErrors(), is( false ) );
+        assertThat(dmnResult.hasErrors()).as(DMNRuntimeUtil.formatMessages(dmnResult.getMessages())).isFalse();
         final DMNContext result = dmnResult.getContext();
-        assertThat( result.get( "Number of distinct cities" ), is( new BigDecimal(2) ) );
-        assertThat( result.get( "Second place losses" ), is( new BigDecimal(0) ) );
-        assertThat( result.get( "Max wins" ), is( new BigDecimal(1) ) );
-        assertThat( result.get( "Mean wins" ), is( new BigDecimal(0.5) ) );
-        assertThat( (List<?>) result.get( "Positions of Los Angeles teams" ), contains( new BigDecimal(1) ) );
-        assertThat( result.get( "Number of teams" ), is( new BigDecimal(2) ) );
-        assertThat( result.get( "Sum of bonus points" ), is( new BigDecimal(47) ) );
+        assertThat( result.get( "Number of distinct cities" )).isEqualTo(new BigDecimal(2) );
+        assertThat( result.get( "Second place losses" )).isEqualTo(new BigDecimal(0) );
+        assertThat( result.get( "Max wins" )).isEqualTo(new BigDecimal(1) );
+        assertThat( result.get( "Mean wins" )).isEqualTo(new BigDecimal(0.5) );
+        assertThat( (List<?>) result.get( "Positions of Los Angeles teams" )).asList().contains(new BigDecimal(1));
+        assertThat( result.get( "Number of teams" )).isEqualTo(new BigDecimal(2) );
+        assertThat( result.get( "Sum of bonus points" )).isEqualTo(new BigDecimal(47) );
     }
     
     @Test
@@ -1199,26 +1188,26 @@ public class DMNRuntimeTest extends BaseInterpretedVsCompiledTest {
         final DMNModel dmnModel = runtime.getModel(
                 "http://www.trisotech.com/definitions/_0768879b-5ee1-410f-92f0-7732573b069d",
                 "expression function subst [a] with a" );
-        assertThat( dmnModel, notNullValue() );
-        assertThat( DMNRuntimeUtil.formatMessages( dmnModel.getMessages() ), dmnModel.hasErrors(), is( false ) );
+        assertThat(dmnModel).isNotNull();
+        assertThat(dmnModel.hasErrors()).as(DMNRuntimeUtil.formatMessages(dmnModel.getMessages())).isFalse();
         
         final DMNContext ctx = runtime.newContext();
         ctx.set("InputLineItem", prototype(entry("Line", "0015"), entry("Description", "additional Battery")));
         final DMNResult dmnResult = runtime.evaluateAll(dmnModel, ctx );
        
-        assertThat( DMNRuntimeUtil.formatMessages( dmnResult.getMessages() ), dmnResult.hasErrors(), is( false ) );
+        assertThat(dmnResult.hasErrors()).as(DMNRuntimeUtil.formatMessages(dmnResult.getMessages())).isFalse();
         final DMNContext result = dmnResult.getContext();
-        assertThat( result.get("The Battery"), is( prototype(entry("Line", "0010"), entry("Description", "Battery")) ) );
-        assertThat( (List<?>)result.get("Remove Battery"), contains( prototype(entry("Line", "0020"), entry("Description", "Case")),
+        assertThat(result.get("The Battery")).isEqualTo( prototype(entry("Line", "0010"), entry("Description", "Battery")) ) ;
+        assertThat((List<?>)result.get("Remove Battery")).asList().contains( prototype(entry("Line", "0020"), entry("Description", "Case")),
                                                                      prototype(entry("Line", "0030"), entry("Description", "Power Supply"))
-                                                                     ) );
-        assertThat( (List<?>)result.get("Remove Battery"), not( contains( prototype(entry("Line", "0010"), entry("Description", "Battery")) ) ) );
+                                                                     );
+        assertThat((List<?>)result.get("Remove Battery")).asList().doesNotContain(prototype(entry("Line", "0010"), entry("Description", "Battery")));
         
-        assertThat( (List<?>)result.get("Insert before Line 0020"), contains( prototype(entry("Line", "0010"), entry("Description", "Battery")), 
+        assertThat((List<?>)result.get("Insert before Line 0020")).asList().contains(prototype(entry("Line", "0010"), entry("Description", "Battery")), 
                                                                               prototype(entry("Line", "0015"), entry("Description", "additional Battery")), 
                                                                               prototype(entry("Line", "0020"), entry("Description", "Case")),
                                                                               prototype(entry("Line", "0030"), entry("Description", "Power Supply"))
-                                                                              ) );
+                                                                              );
     }
 
     @Test
@@ -1227,24 +1216,24 @@ public class DMNRuntimeTest extends BaseInterpretedVsCompiledTest {
         final DMNModel dmnModel = runtime.getModel(
                 "http://www.trisotech.com/dmn/definitions/_b42317c4-4f0c-474e-a0bf-2895b0b3c314",
                 "Dessin 1" );
-        assertThat( dmnModel, notNullValue() );
-        assertThat( DMNRuntimeUtil.formatMessages( dmnModel.getMessages() ), dmnModel.hasErrors(), is( false ) );
+        assertThat(dmnModel).isNotNull();
+        assertThat(dmnModel.hasErrors()).as(DMNRuntimeUtil.formatMessages(dmnModel.getMessages())).isFalse();
 
         final DMNContext ctx = runtime.newContext();
         ctx.set( "Input", 3.14 );
         final DMNResult dmnResult = runtime.evaluateAll(dmnModel, ctx );
 
-        assertThat( DMNRuntimeUtil.formatMessages( dmnResult.getMessages() ), dmnResult.hasErrors(), is( false ) );
+        assertThat(dmnResult.hasErrors()).as(DMNRuntimeUtil.formatMessages(dmnResult.getMessages())).isFalse();
         final DMNContext result = dmnResult.getContext();
-        assertThat( ((BigDecimal) result.get( "D1" )).setScale( 4, BigDecimal.ROUND_HALF_UP ), is( new BigDecimal( "-1.0000" ) ) );
-        assertThat( ((BigDecimal) result.get( "D2" )).setScale( 4, BigDecimal.ROUND_HALF_UP ), is( new BigDecimal( "-1.0000" ) ) );
+        assertThat( ((BigDecimal) result.get( "D1" )).setScale( 4, BigDecimal.ROUND_HALF_UP )).isEqualTo(new BigDecimal( "-1.0000" ) );
+        assertThat( ((BigDecimal) result.get( "D2" )).setScale( 4, BigDecimal.ROUND_HALF_UP )).isEqualTo(new BigDecimal( "-1.0000" ) );
     }
     
     @Test
     public void testJavaFunctionContext_withErrors() {
         // DROOLS-1568
         final List<DMNMessage> messages = DMNRuntimeUtil.createExpectingDMNMessages("java_function_context_with_errors.dmn", this.getClass());
-        assertThat(messages.size(), is(1));
+        assertThat(messages).hasSize(1);
 
         final List<String> sourceIDs = messages.stream().map(DMNMessage::getSourceId).collect(Collectors.toList());
         // notice the other BKM in the DMN model is a LiteralExpression, would have failed only at runtime accordingly as expected:
@@ -1256,7 +1245,7 @@ public class DMNRuntimeTest extends BaseInterpretedVsCompiledTest {
     @Test
     public void testJavaFunctionContext_withErrorsInParamType() {
         final List<DMNMessage> messages = DMNRuntimeUtil.createExpectingDMNMessages("java_function_context_with_errors_in_param_type.dmn", this.getClass());
-        assertThat(messages.size(), is(1));
+        assertThat(messages).hasSize(1);
 
         final List<String> sourceIDs = messages.stream().map(DMNMessage::getSourceId).collect(Collectors.toList());
         assertTrue( sourceIDs.contains( "_a72a7aff-48c3-4806-83ca-fc1f1fe34321" ) );
@@ -1268,15 +1257,15 @@ public class DMNRuntimeTest extends BaseInterpretedVsCompiledTest {
         final DMNRuntime runtime = DMNRuntimeUtil.createRuntime("nestingFnDef.dmn", this.getClass());
         final DMNModel dmnModel = runtime.getModel("https://kiegroup.org/dmn/_FC72DC4B-DC64-4E43-9685-945FC3B7E4BC",
                                                    "new-file");
-        assertThat(dmnModel, notNullValue());
-        assertThat(DMNRuntimeUtil.formatMessages(dmnModel.getMessages()), dmnModel.hasErrors(), is(false));
+        assertThat(dmnModel).isNotNull();
+        assertThat(dmnModel.hasErrors()).as(DMNRuntimeUtil.formatMessages(dmnModel.getMessages())).isFalse();
 
         final DMNContext ctx = runtime.newContext();
 
         final DMNResult dmnResult = runtime.evaluateAll(dmnModel, ctx);
         LOG.debug("{}", dmnResult);
-        assertThat(DMNRuntimeUtil.formatMessages(dmnResult.getMessages()), dmnResult.hasErrors(), is(false));
-        assertThat(dmnResult.getDecisionResultByName("Decision-1").getResult(), is(new BigDecimal(3)));
+        assertThat(dmnResult.hasErrors()).as(DMNRuntimeUtil.formatMessages(dmnResult.getMessages())).isFalse();
+        assertThat(dmnResult.getDecisionResultByName("Decision-1").getResult()).isEqualTo(new BigDecimal(3));
     }
 
     @Test
@@ -1284,16 +1273,16 @@ public class DMNRuntimeTest extends BaseInterpretedVsCompiledTest {
         final DMNRuntime runtime = DMNRuntimeUtil.createRuntime("bkmCurried.dmn", this.getClass());
         final DMNModel dmnModel = runtime.getModel("https://kiegroup.org/dmn/_A7F17D7B-F0AB-4C0B-B521-02EA26C2FB7D",
                                                    "new-file");
-        assertThat(dmnModel, notNullValue());
-        assertThat(DMNRuntimeUtil.formatMessages(dmnModel.getMessages()), dmnModel.hasErrors(), is(false));
+        assertThat(dmnModel).isNotNull();
+        assertThat(dmnModel.hasErrors()).as(DMNRuntimeUtil.formatMessages(dmnModel.getMessages())).isFalse();
 
         final DMNContext ctx = runtime.newContext();
 
         final DMNResult dmnResult = runtime.evaluateAll(dmnModel, ctx);
         LOG.debug("{}", dmnResult);
-        assertThat(DMNRuntimeUtil.formatMessages(dmnResult.getMessages()), dmnResult.hasErrors(), is(false));
-        assertThat(dmnResult.getDecisionResultByName("usingNormal").getResult(), is(new BigDecimal(3)));
-        assertThat(dmnResult.getDecisionResultByName("usingCurried").getResult(), is(new BigDecimal(3)));
+        assertThat(dmnResult.hasErrors()).as(DMNRuntimeUtil.formatMessages(dmnResult.getMessages())).isFalse();
+        assertThat(dmnResult.getDecisionResultByName("usingNormal").getResult()).isEqualTo(new BigDecimal(3));
+        assertThat(dmnResult.getDecisionResultByName("usingCurried").getResult()).isEqualTo(new BigDecimal(3));
     }
 
     @Test
@@ -1301,8 +1290,8 @@ public class DMNRuntimeTest extends BaseInterpretedVsCompiledTest {
         final DMNRuntime runtime = DMNRuntimeUtil.createRuntime("bkmWithDotsInName.dmn", this.getClass());
         final DMNModel dmnModel = runtime.getModel("https://kiegroup.org/dmn/_E035C5C5-3571-453D-BD8F-FFF30E74A7F8",
                                                    "bkmWithDotsInName");
-        assertThat(dmnModel, notNullValue());
-        assertThat(DMNRuntimeUtil.formatMessages(dmnModel.getMessages()), dmnModel.hasErrors(), is(false));
+        assertThat(dmnModel).isNotNull();
+        assertThat(dmnModel.hasErrors()).as(DMNRuntimeUtil.formatMessages(dmnModel.getMessages())).isFalse();
 
         final DMNContext ctx = runtime.newContext();
         ctx.set("Number one", new BigDecimal(1));
@@ -1310,8 +1299,8 @@ public class DMNRuntimeTest extends BaseInterpretedVsCompiledTest {
 
         final DMNResult dmnResult = runtime.evaluateAll(dmnModel, ctx);
         LOG.debug("{}", dmnResult);
-        assertThat(DMNRuntimeUtil.formatMessages(dmnResult.getMessages()), dmnResult.hasErrors(), is(false));
-        assertThat(dmnResult.getDecisionResultByName("Total Sum").getResult(), is(new BigDecimal(3)));
+        assertThat(dmnResult.hasErrors()).as(DMNRuntimeUtil.formatMessages(dmnResult.getMessages())).isFalse();
+        assertThat(dmnResult.getDecisionResultByName("Total Sum").getResult()).isEqualTo(new BigDecimal(3));
     }
 
     @Ignore("the purpose of this work is to enable PMML execution.")
@@ -1321,11 +1310,11 @@ public class DMNRuntimeTest extends BaseInterpretedVsCompiledTest {
         final DMNModel dmnModel = runtime.getModel(
                 "http://www.trisotech.com/dmn/definitions/_b42317c4-4f0c-474e-a0bf-2895b0b3c314",
                 "Dessin 1" );
-        assertThat( dmnModel, notNullValue() );
-        assertThat( DMNRuntimeUtil.formatMessages( dmnModel.getMessages() ), dmnModel.hasErrors(), is( false ) );
-        assertThat( dmnModel.getMessages().size(), is( 1 ) );
-        assertThat( dmnModel.getMessages().get( 0 ).getMessageType(), is( DMNMessageType.INVALID_ATTRIBUTE_VALUE ) );
-        assertThat( dmnModel.getMessages().get( 0 ).getSeverity(), is( DMNMessage.Severity.WARN ) );
+        assertThat(dmnModel).isNotNull();
+        assertThat(dmnModel.hasErrors()).as(DMNRuntimeUtil.formatMessages(dmnModel.getMessages())).isFalse();
+        assertThat( dmnModel.getMessages()).hasSize(1);
+        assertThat( dmnModel.getMessages().get( 0 ).getMessageType()).isEqualTo(DMNMessageType.INVALID_ATTRIBUTE_VALUE);
+        assertThat( dmnModel.getMessages().get( 0 ).getSeverity()).isEqualTo(DMNMessage.Severity.WARN);
     }
     
     @Test
@@ -1335,8 +1324,8 @@ public class DMNRuntimeTest extends BaseInterpretedVsCompiledTest {
         final DMNModel dmnModel = runtime.getModel(
                 "http://www.trisotech.com/definitions/_1a7d184c-2e38-4462-ae28-15591ef6d534",
                 "countCSATradeRatings" );
-        assertThat( dmnModel, notNullValue() );
-        assertThat( DMNRuntimeUtil.formatMessages( dmnModel.getMessages() ), dmnModel.hasErrors(), is( false ) );
+        assertThat(dmnModel).isNotNull();
+        assertThat(dmnModel.hasErrors()).as(DMNRuntimeUtil.formatMessages(dmnModel.getMessages())).isFalse();
         
         final DMNContext ctx = runtime.newContext();
         final List<Map<?, ?>> ratings = new ArrayList<>();
@@ -1345,22 +1334,22 @@ public class DMNRuntimeTest extends BaseInterpretedVsCompiledTest {
         ctx.set("CSA Trade Ratings", ratings);
         final DMNResult dmnResult = runtime.evaluateAll(dmnModel, ctx );
        
-        assertThat( DMNRuntimeUtil.formatMessages( dmnResult.getMessages() ), dmnResult.hasErrors(), is( false ) );
+        assertThat(dmnResult.hasErrors()).as(DMNRuntimeUtil.formatMessages(dmnResult.getMessages())).isFalse();
         final DMNContext result = dmnResult.getContext();
-        assertThat( result.get("Trade Ratings"), is( new BigDecimal(2) ) );
+        assertThat( result.get("Trade Ratings")).isEqualTo(new BigDecimal(2) );
         
         
         final DMNContext ctx2 = runtime.newContext();
         ctx2.set("CSA Trade Ratings", null);
         final DMNResult dmnResult2 = runtime.evaluateAll(dmnModel, ctx2 );
-        assertThat(DMNRuntimeUtil.formatMessages(dmnResult2.getMessages()), dmnResult2.hasErrors(), is(true));
-        assertThat(dmnResult2.getMessages().stream().anyMatch(m -> m.getMessageType().equals(DMNMessageType.FEEL_EVALUATION_ERROR)), is(true));
-        assertThat(dmnResult2.getDecisionResultByName("Trade Ratings").getEvaluationStatus(), is(DecisionEvaluationStatus.FAILED));
+        assertThat(dmnResult2.hasErrors()).as(DMNRuntimeUtil.formatMessages(dmnResult2.getMessages())).isTrue();
+        assertThat(dmnResult2.getMessages().stream().anyMatch(m -> m.getMessageType().equals(DMNMessageType.FEEL_EVALUATION_ERROR))).isTrue();
+        assertThat(dmnResult2.getDecisionResultByName("Trade Ratings").getEvaluationStatus()).isEqualTo(DecisionEvaluationStatus.FAILED);
         
                 
         final DMNResult dmnResult3 = runtime.evaluateAll(dmnModel, runtime.newContext() );
-        assertThat( DMNRuntimeUtil.formatMessages( dmnResult3.getMessages() ), dmnResult3.hasErrors(), is( true ) );
-        assertThat( dmnResult3.getMessages().stream().anyMatch( m -> m.getMessageType().equals( DMNMessageType.REQ_NOT_FOUND ) ), is( true ) );
+        assertThat(dmnResult3.hasErrors()).as(DMNRuntimeUtil.formatMessages( dmnResult3.getMessages())).isTrue();
+        assertThat(dmnResult3.getMessages().stream().anyMatch( m -> m.getMessageType().equals( DMNMessageType.REQ_NOT_FOUND ) )).isTrue();
     }
     
     @Test
@@ -1370,8 +1359,8 @@ public class DMNRuntimeTest extends BaseInterpretedVsCompiledTest {
         final DMNModel dmnModel = runtime.getModel(
                 "http://www.trisotech.com/definitions/_ec5a78c7-a317-4c39-8310-db59be60f1c8",
                 "PersonListHelloBKM" );
-        assertThat( dmnModel, notNullValue() );
-        assertThat( DMNRuntimeUtil.formatMessages( dmnModel.getMessages() ), dmnModel.hasErrors(), is( false ) );
+        assertThat(dmnModel).isNotNull();
+        assertThat(dmnModel.hasErrors()).as(DMNRuntimeUtil.formatMessages(dmnModel.getMessages())).isFalse();
         
         final DMNContext context = runtime.newContext();
         
@@ -1382,9 +1371,9 @@ public class DMNRuntimeTest extends BaseInterpretedVsCompiledTest {
         final DMNResult dmnResult = runtime.evaluateAll(dmnModel, context );
         final DMNContext result = dmnResult.getContext();
 
-        assertThat( DMNRuntimeUtil.formatMessages( dmnResult.getMessages() ), dmnResult.hasErrors(), is( false ) );
-        assertThat( (List<?>)result.get("My Decision"), contains( "The person named John Doe is 33 years old.",
-                                                                  "The person named 47 is 47 years old.") );
+        assertThat(dmnResult.hasErrors()).as(DMNRuntimeUtil.formatMessages(dmnResult.getMessages())).isFalse();
+        assertThat( (List<?>)result.get("My Decision")).asList().contains( "The person named John Doe is 33 years old.",
+                                                                  "The person named 47 is 47 years old.");
     }
     
     @Test
@@ -1394,8 +1383,8 @@ public class DMNRuntimeTest extends BaseInterpretedVsCompiledTest {
         final DMNModel dmnModel = runtime.getModel(
                 "http://www.trisotech.com/definitions/_7e41a76e-2df6-4899-bf81-ae098757a3b6",
                 "PersonListHelloBKM2" );
-        assertThat( dmnModel, notNullValue() );
-        assertThat( DMNRuntimeUtil.formatMessages( dmnModel.getMessages() ), dmnModel.hasErrors(), is( false ) );
+        assertThat(dmnModel).isNotNull();
+        assertThat(dmnModel.hasErrors()).as(DMNRuntimeUtil.formatMessages(dmnModel.getMessages())).isFalse();
         
         final DMNContext context = runtime.newContext();
         
@@ -1406,10 +1395,9 @@ public class DMNRuntimeTest extends BaseInterpretedVsCompiledTest {
         final DMNResult dmnResult = runtime.evaluateAll(dmnModel, context );
         final DMNContext result = dmnResult.getContext();
 
-        assertThat( DMNRuntimeUtil.formatMessages( dmnResult.getMessages() ), dmnResult.hasErrors(), is( false ) );
-        assertThat( (List<?>)result.get("My Decision"), contains( prototype( entry("Full Name", "Prof. John Doe"), entry("Age", EvalHelper.coerceNumber(33)) ),
-                                                                  prototype( entry("Full Name", "Prof. 47"), entry("Age", EvalHelper.coerceNumber(47)) ) 
-                                                                  ) );
+        assertThat(dmnResult.hasErrors()).as(DMNRuntimeUtil.formatMessages(dmnResult.getMessages())).isFalse();
+        assertThat( (List<?>)result.get("My Decision")).asList().containsExactly( prototype( entry("Full Name", "Prof. John Doe"), entry("Age", EvalHelper.coerceNumber(33)) ),
+                                                                  prototype( entry("Full Name", "Prof. 47"), entry("Age", EvalHelper.coerceNumber(47))));
     }
 
     @Test
@@ -1419,20 +1407,20 @@ public class DMNRuntimeTest extends BaseInterpretedVsCompiledTest {
         final DMNModel dmnModel = runtime.getModel(
                 "http://www.trisotech.com/definitions/_09a13244-114d-43fb-9e00-cda89a2000dd",
                 "same every type check" );
-        assertThat( dmnModel, notNullValue() );
-        assertThat( DMNRuntimeUtil.formatMessages( dmnModel.getMessages() ), dmnModel.hasErrors(), is( false ) );
+        assertThat(dmnModel).isNotNull();
+        assertThat(dmnModel.hasErrors()).as(DMNRuntimeUtil.formatMessages(dmnModel.getMessages())).isFalse();
         
         final DMNContext emptyContext = runtime.newContext();
         final DMNResult dmnResult = runtime.evaluateAll(dmnModel, emptyContext );
         final DMNContext result = dmnResult.getContext();
         
-        assertThat( DMNRuntimeUtil.formatMessages( dmnResult.getMessages() ), dmnResult.hasErrors(), is( false ) );
-        assertThat( result.get("Some are even"), is( true ) );
-        assertThat( result.get("Every are even"), is( false ) );
-        assertThat( result.get("Some are positive"), is( true ) );
-        assertThat( result.get("Every are positive"), is( true ) );
-        assertThat( result.get("Some are negative"), is( false ) );
-        assertThat( result.get("Every are negative"), is( false ) );
+        assertThat(dmnResult.hasErrors()).as(DMNRuntimeUtil.formatMessages(dmnResult.getMessages())).isFalse();
+        assertThat( result.get("Some are even")).isEqualTo(Boolean.TRUE);
+        assertThat( result.get("Every are even")).isEqualTo(Boolean.FALSE);
+        assertThat( result.get("Some are positive")).isEqualTo(Boolean.TRUE);
+        assertThat( result.get("Every are positive")).isEqualTo(Boolean.TRUE);
+        assertThat( result.get("Some are negative")).isEqualTo(Boolean.FALSE);
+        assertThat( result.get("Every are negative")).isEqualTo(Boolean.FALSE);
     }
 
     @Test
@@ -1441,8 +1429,8 @@ public class DMNRuntimeTest extends BaseInterpretedVsCompiledTest {
         final DMNModel dmnModel = runtime.getModel(
                 "http://www.trisotech.com/definitions/_fbf002a3-615b-4f02-98e4-c28d4676225a",
                 "Error with constraints verification" );
-        assertThat( dmnModel, notNullValue() );
-        assertThat( DMNRuntimeUtil.formatMessages( dmnModel.getMessages() ), dmnModel.hasErrors(), is( false ) );
+        assertThat(dmnModel).isNotNull();
+        assertThat(dmnModel.hasErrors()).as(DMNRuntimeUtil.formatMessages(dmnModel.getMessages())).isFalse();
 
         final DMNContext ctx = runtime.newContext();
         final Object duration = BuiltInType.DURATION.fromString("P20Y" );
@@ -1452,35 +1440,35 @@ public class DMNRuntimeTest extends BaseInterpretedVsCompiledTest {
         final DMNResult dmnResult = runtime.evaluateAll(dmnModel, ctx );
         final DMNContext result = dmnResult.getContext();
 
-        assertThat( DMNRuntimeUtil.formatMessages( dmnResult.getMessages() ), dmnResult.hasErrors(), is( false ) );
-        assertThat( (Map<String,Object>) result.get( "Decision Logic 1" ), hasEntry( "years and months", duration ) );
-        assertThat( (Map<String,Object>) result.get( "Decision Logic 1" ), hasEntry( "Date Time", dateTime ) );
+        assertThat(dmnResult.hasErrors()).as(DMNRuntimeUtil.formatMessages(dmnResult.getMessages())).isFalse();
+        assertThat((Map<String,Object>) result.get( "Decision Logic 1")).containsEntry("years and months", duration);
+        assertThat((Map<String,Object>) result.get( "Decision Logic 1")).containsEntry("Date Time", dateTime);
     }
     
     @Test
     public void testArtificialAttributes() {
         final DMNRuntime runtime = DMNRuntimeUtil.createRuntime("0001-input-data-string-artificial-attributes.dmn", this.getClass() );
         final DMNModel dmnModel = runtime.getModel("https://github.com/kiegroup/drools", "0001-input-data-string" );
-        assertThat( dmnModel, notNullValue() );
+        assertThat(dmnModel).isNotNull();
 
         final DMNContext context = DMNFactory.newContext();
         context.set( "Full Name", "John Doe" );
 
         final DMNResult dmnResult = runtime.evaluateAll(dmnModel, context );
 
-        assertThat( dmnResult.getDecisionResults().size(), is( 1 ) );
-        assertThat( dmnResult.getDecisionResultByName( "Greeting Message" ).getResult(), is( "Hello John Doe" ) );
+        assertThat( dmnResult.getDecisionResults()).hasSize(1);
+        assertThat( dmnResult.getDecisionResultByName( "Greeting Message" ).getResult()).isEqualTo("Hello John Doe" );
 
         final DMNContext result = dmnResult.getContext();
 
-        assertThat( result.get( "Greeting Message" ), is( "Hello John Doe" ) );
+        assertThat( result.get( "Greeting Message" )).isEqualTo("Hello John Doe" );
     }
     
     @Test
     public void testInvokeFunctionSuccess() {
         final DMNRuntime runtime = DMNRuntimeUtil.createRuntimeWithAdditionalResources("Caller.dmn", this.getClass(), "Calling.dmn" );
         final DMNModel dmnModel = runtime.getModel("http://www.trisotech.com/definitions/_b0a696d6-3d57-4e97-b5d4-b44a63909d67", "Caller" );
-        assertThat( dmnModel, notNullValue() );
+        assertThat(dmnModel).isNotNull();
 
         final DMNContext context = DMNFactory.newContext();
         context.set( "My Name", "John Doe" );
@@ -1490,17 +1478,17 @@ public class DMNRuntimeTest extends BaseInterpretedVsCompiledTest {
         context.set( "Invoke decision", "Final Result" );
 
         final DMNResult dmnResult = runtime.evaluateAll(dmnModel, context );
-        assertThat( DMNRuntimeUtil.formatMessages( dmnResult.getMessages() ), dmnResult.hasErrors(), is( false ) );
+        assertThat(dmnResult.hasErrors()).as(DMNRuntimeUtil.formatMessages(dmnResult.getMessages())).isFalse();
             
         final DMNContext result = dmnResult.getContext();
-        assertThat( result.get( "Final decision" ), is( "The final decision is: Hello, John Doe your number once double is equal to: 6" ) );
+        assertThat( result.get( "Final decision" )).isEqualTo( "The final decision is: Hello, John Doe your number once double is equal to: 6");
     }
 
     @Test
     public void testInvokeFunctionWrongNamespace() {
         final DMNRuntime runtime = DMNRuntimeUtil.createRuntimeWithAdditionalResources("Caller.dmn", this.getClass(), "Calling.dmn" );
         final DMNModel dmnModel = runtime.getModel("http://www.trisotech.com/definitions/_b0a696d6-3d57-4e97-b5d4-b44a63909d67", "Caller" );
-        assertThat( dmnModel, notNullValue() );
+        assertThat(dmnModel).isNotNull();
 
         final DMNContext wrongContext = DMNFactory.newContext();
         wrongContext.set( "My Name", "John Doe" );
@@ -1510,16 +1498,16 @@ public class DMNRuntimeTest extends BaseInterpretedVsCompiledTest {
         wrongContext.set( "Invoke decision", "Final Result" );
 
         final DMNResult dmnResult = runtime.evaluateAll(dmnModel, wrongContext );
-        assertThat( DMNRuntimeUtil.formatMessages( dmnResult.getMessages() ), dmnResult.hasErrors(), is( true ) );
+        assertThat(dmnResult.hasErrors()).as(dmnResult.getMessages().toString()).isTrue();
         // total of: 2. x1 error in calling external decision, and x1 error in making final decision as it depends on the former.
-        assertThat( DMNRuntimeUtil.formatMessages( dmnResult.getMessages() ), dmnResult.getMessages().size(), is( 2 ) );
+        assertThat(dmnResult.getMessages()).as(DMNRuntimeUtil.formatMessages( dmnResult.getMessages())).hasSize(2);
     }
 
     @Test
     public void testInvokeFunctionWrongDecisionName() {
         final DMNRuntime runtime = DMNRuntimeUtil.createRuntimeWithAdditionalResources("Caller.dmn", this.getClass(), "Calling.dmn" );
         final DMNModel dmnModel = runtime.getModel("http://www.trisotech.com/definitions/_b0a696d6-3d57-4e97-b5d4-b44a63909d67", "Caller" );
-        assertThat( dmnModel, notNullValue() );
+        assertThat(dmnModel).isNotNull();
 
         final DMNContext wrongContext = DMNFactory.newContext();
         wrongContext.set( "My Name", "John Doe" );
@@ -1529,9 +1517,9 @@ public class DMNRuntimeTest extends BaseInterpretedVsCompiledTest {
         wrongContext.set("Invoke decision", "<unexistent decision>");
 
         final DMNResult dmnResult = runtime.evaluateAll(dmnModel, wrongContext );
-        assertThat( DMNRuntimeUtil.formatMessages( dmnResult.getMessages() ), dmnResult.hasErrors(), is( true ) );
+        assertThat(dmnResult.hasErrors()).as(dmnResult.getMessages().toString()).isTrue();
         // total of: 2. x1 error in calling external decision, and x1 error in making final decision as it depends on the former.
-        assertThat( DMNRuntimeUtil.formatMessages( dmnResult.getMessages() ), dmnResult.getMessages().size(), is( 2 ) );
+        assertThat(dmnResult.getMessages()).as(DMNRuntimeUtil.formatMessages( dmnResult.getMessages())).hasSize(2);
 
     }
 
@@ -1540,7 +1528,7 @@ public class DMNRuntimeTest extends BaseInterpretedVsCompiledTest {
 
         final DMNRuntime runtime = DMNRuntimeUtil.createRuntimeWithAdditionalResources("Caller.dmn", this.getClass(), "Calling.dmn" );
         final DMNModel dmnModel = runtime.getModel("http://www.trisotech.com/definitions/_b0a696d6-3d57-4e97-b5d4-b44a63909d67", "Caller" );
-        assertThat( dmnModel, notNullValue() );
+        assertThat(dmnModel).isNotNull();
 
         final DMNContext wrongContext = DMNFactory.newContext();
         wrongContext.set( "My Name", "John Doe" );
@@ -1550,17 +1538,17 @@ public class DMNRuntimeTest extends BaseInterpretedVsCompiledTest {
         wrongContext.set( "Invoke decision", "Final Result" );
 
         final DMNResult dmnResult = runtime.evaluateAll(dmnModel, wrongContext );
-        assertThat( DMNRuntimeUtil.formatMessages( dmnResult.getMessages() ), dmnResult.hasErrors(), is( true ) );
+        assertThat(dmnResult.hasErrors()).as(dmnResult.getMessages().toString()).isTrue();
         // total of: 2. x1 error in calling external decision, and x1 error in making final decision as it depends on the former.
         // please notice it will print 4 lines in the log, 2x are the "external invocation" and then 2x are the one by the caller, checked herebelow:
-        assertThat( DMNRuntimeUtil.formatMessages( dmnResult.getMessages() ), dmnResult.getMessages().size(), is( 2 ) );
+        assertThat(dmnResult.getMessages()).as(DMNRuntimeUtil.formatMessages( dmnResult.getMessages())).hasSize(2);
     }
 
     @Test
     public void testInvalidFunction() {
         final DMNRuntime runtime = DMNRuntimeUtil.createRuntimeWithAdditionalResources( "InvalidFunction.dmn", this.getClass() );
         final DMNModel model = runtime.getModel( "http://www.trisotech.com/definitions/_84453b71-5d23-479f-9481-5196d92bacae", "0003-iteration-augmented" );
-        assertThat( model, notNullValue() );
+        assertThat(model).isNotNull();
         final DMNContext context = DMNFactory.newContext();
         context.set( "Loans", new HashMap<>() );
         final DMNResult result = runtime.evaluateAll(model, context);
@@ -1658,19 +1646,19 @@ public class DMNRuntimeTest extends BaseInterpretedVsCompiledTest {
     public void testEx_4_3simplified() {
         final DMNRuntime runtime = DMNRuntimeUtil.createRuntime("Ex_4_3simplified.dmn", this.getClass());
         final DMNModel dmnModel = runtime.getModel("http://www.trisotech.com/definitions/_5c5a9c72-627e-4666-ae85-31356fed3658", "Ex_4_3simplified");
-        assertThat(dmnModel, notNullValue());
-        assertThat(DMNRuntimeUtil.formatMessages(dmnModel.getMessages()), dmnModel.hasErrors(), is(false));
+        assertThat(dmnModel).isNotNull();
+        assertThat(dmnModel.hasErrors()).as(DMNRuntimeUtil.formatMessages(dmnModel.getMessages())).isFalse();
 
         final DMNContext context = DMNFactory.newContext();
         context.set("number", 123.123456d);
 
         final DMNResult dmnResult = runtime.evaluateAll(dmnModel, context);
         System.out.println(dmnResult);
-        assertThat(DMNRuntimeUtil.formatMessages(dmnResult.getMessages()), dmnResult.hasErrors(), is(false));
+        assertThat(dmnResult.hasErrors()).as(DMNRuntimeUtil.formatMessages(dmnResult.getMessages())).isFalse();
 
         final DMNContext result = dmnResult.getContext();
 
-        assertThat(result.get("Formatted Monthly Payment"), is("€123.12"));
+        assertThat(result.get("Formatted Monthly Payment")).isEqualTo("€123.12");
     }
 
     @Test
@@ -1678,20 +1666,20 @@ public class DMNRuntimeTest extends BaseInterpretedVsCompiledTest {
         // DROOLS-2117 improve Msg.ERROR_EVAL_NODE_DEP_WRONG_TYPE
         final DMNRuntime runtime = DMNRuntimeUtil.createRuntime("Ex_4_3simplified.dmn", this.getClass());
         final DMNModel dmnModel = runtime.getModel("http://www.trisotech.com/definitions/_5c5a9c72-627e-4666-ae85-31356fed3658", "Ex_4_3simplified");
-        assertThat(dmnModel, notNullValue());
-        assertThat(DMNRuntimeUtil.formatMessages(dmnModel.getMessages()), dmnModel.hasErrors(), is(false));
+        assertThat(dmnModel).isNotNull();
+        assertThat(dmnModel.hasErrors()).as(DMNRuntimeUtil.formatMessages(dmnModel.getMessages())).isFalse();
 
         final DMNContext context = DMNFactory.newContext();
         context.set("number", "ciao");
 
         final DMNResult dmnResult = runtime.evaluateAll(dmnModel, context);
         System.out.println(dmnResult);
-        assertThat(DMNRuntimeUtil.formatMessages(dmnResult.getMessages()), dmnResult.hasErrors(), is(true));
+        assertThat(dmnResult.hasErrors()).as(DMNRuntimeUtil.formatMessages(dmnResult.getMessages())).isTrue();
 
         // we want the error message to include not only which value was incompatible, but the type which was expected.
         // in this case the value is `ciao` for a String
         // but should have been a FEEL:number.
-        assertThat(dmnResult.getMessages().stream().filter(m -> m.getMessageType() == DMNMessageType.ERROR_EVAL_NODE).anyMatch(m -> m.getMessage().contains("is not allowed by the declared type")), is(true));
+        assertThat(dmnResult.getMessages().stream().filter(m -> m.getMessageType() == DMNMessageType.ERROR_EVAL_NODE).anyMatch(m -> m.getMessage().contains("is not allowed by the declared type"))).isTrue();
     }
 
     @Test
@@ -1699,22 +1687,22 @@ public class DMNRuntimeTest extends BaseInterpretedVsCompiledTest {
         // DROOLS-2125
         final DMNRuntime runtime = DMNRuntimeUtil.createRuntime("drools2125.dmn", this.getClass());
         final DMNModel dmnModel = runtime.getModel("http://www.trisotech.com/definitions/_9f976b29-4cdd-42e9-8737-0ccbc2ad9498", "drools2125");
-        assertThat(dmnModel, notNullValue());
-        assertThat(DMNRuntimeUtil.formatMessages(dmnModel.getMessages()), dmnModel.hasErrors(), is(false));
+        assertThat(dmnModel).isNotNull();
+        assertThat(dmnModel.hasErrors()).as(DMNRuntimeUtil.formatMessages(dmnModel.getMessages())).isFalse();
 
         final DMNContext context = DMNFactory.newContext();
         context.set("person", "Bob");
         context.set("list of persons", Arrays.asList("Bob", "John"));
 
         final DMNResult dmnResult = runtime.evaluateAll(dmnModel, context);
-        assertThat(DMNRuntimeUtil.formatMessages(dmnResult.getMessages()), dmnResult.hasErrors(), is(false));
+        assertThat(dmnResult.hasErrors()).as(DMNRuntimeUtil.formatMessages(dmnResult.getMessages())).isFalse();
 
         final DMNContext result = dmnResult.getContext();
-        assertThat(result.get("person is Bob"), is("yes"));
-        assertThat(result.get("persons complies with UT list"), is("yes"));
-        assertThat(result.get("person on the list of persons"), is("yes"));
-        assertThat(result.get("persons complies with hardcoded list"), is("yes"));
-        assertThat(result.get("person is person"), is("yes"));
+        assertThat(result.get("person is Bob")).isEqualTo("yes");
+        assertThat(result.get("persons complies with UT list")).isEqualTo("yes");
+        assertThat(result.get("person on the list of persons")).isEqualTo("yes");
+        assertThat(result.get("persons complies with hardcoded list")).isEqualTo("yes");
+        assertThat(result.get("person is person")).isEqualTo("yes");
     }
 
     @Test
@@ -1722,13 +1710,13 @@ public class DMNRuntimeTest extends BaseInterpretedVsCompiledTest {
         // DROOLS-2147
         final DMNRuntime runtime = DMNRuntimeUtil.createRuntime("DROOLS-2147.dmn", this.getClass());
         final DMNModel dmnModel = runtime.getModel("http://www.trisotech.com/dmn/definitions/_cbdacb7b-f72d-457d-b4f4-54020a06db24", "Drawing 1");
-        assertThat(dmnModel, notNullValue());
-        assertThat(DMNRuntimeUtil.formatMessages(dmnModel.getMessages()), dmnModel.hasErrors(), is(false));
+        assertThat(dmnModel).isNotNull();
+        assertThat(dmnModel.hasErrors()).as(DMNRuntimeUtil.formatMessages(dmnModel.getMessages())).isFalse();
 
         final DMNContext context = DMNFactory.newContext();
 
         final DMNResult dmnResult = runtime.evaluateAll(dmnModel, context);
-        assertThat(DMNRuntimeUtil.formatMessages(dmnResult.getMessages()), dmnResult.hasErrors(), is(false));
+        assertThat(dmnResult.hasErrors()).as(DMNRuntimeUtil.formatMessages(dmnResult.getMessages())).isFalse();
 
         final DMNContext resultContext = dmnResult.getContext();
         final List people = (List) resultContext.get("People");
@@ -1747,8 +1735,8 @@ public class DMNRuntimeTest extends BaseInterpretedVsCompiledTest {
         // DROOLS-2147 truncate message length
         final DMNRuntime runtime = DMNRuntimeUtil.createRuntime("Ex_4_3simplified.dmn", this.getClass());
         final DMNModel dmnModel = runtime.getModel("http://www.trisotech.com/definitions/_5c5a9c72-627e-4666-ae85-31356fed3658", "Ex_4_3simplified");
-        assertThat(dmnModel, notNullValue());
-        assertThat(DMNRuntimeUtil.formatMessages(dmnModel.getMessages()), dmnModel.hasErrors(), is(false));
+        assertThat(dmnModel).isNotNull();
+        assertThat(dmnModel.hasErrors()).as(DMNRuntimeUtil.formatMessages(dmnModel.getMessages())).isFalse();
 
         final DMNContext context = DMNFactory.newContext();
         final StringBuilder sb = new StringBuilder("abcdefghijklmnopqrstuvwxyz");
@@ -1759,9 +1747,9 @@ public class DMNRuntimeTest extends BaseInterpretedVsCompiledTest {
 
         final DMNResult dmnResult = runtime.evaluateAll(dmnModel, context);
         System.out.println(dmnResult);
-        assertThat(DMNRuntimeUtil.formatMessages(dmnResult.getMessages()), dmnResult.hasErrors(), is(true));
+        assertThat(dmnResult.hasErrors()).as(DMNRuntimeUtil.formatMessages(dmnResult.getMessages())).isTrue();
 
-        assertThat(dmnResult.getMessages().stream().filter(m -> m.getMessageType() == DMNMessageType.ERROR_EVAL_NODE).anyMatch(m -> m.getMessage().contains("... [string clipped after 50 chars, total length is")), is(true));
+        assertThat(dmnResult.getMessages().stream().filter(m -> m.getMessageType() == DMNMessageType.ERROR_EVAL_NODE).anyMatch(m -> m.getMessage().contains("... [string clipped after 50 chars, total length is"))).isTrue();
     }
 
     @Test
@@ -1769,16 +1757,16 @@ public class DMNRuntimeTest extends BaseInterpretedVsCompiledTest {
         // DROOLS-2192
         final DMNRuntime runtime = DMNRuntimeUtil.createRuntime("hardcoded_function_definition.dmn", this.getClass());
         final DMNModel dmnModel = runtime.getModel("http://www.trisotech.com/definitions/_99854980-65c8-4e9b-b365-bd30ded69f40", "hardcoded_function_definition");
-        assertThat(dmnModel, notNullValue());
-        assertThat(DMNRuntimeUtil.formatMessages(dmnModel.getMessages()), dmnModel.hasErrors(), is(false));
+        assertThat(dmnModel).isNotNull();
+        assertThat(dmnModel.hasErrors()).as(DMNRuntimeUtil.formatMessages(dmnModel.getMessages())).isFalse();
 
         final DMNContext emptyContext = DMNFactory.newContext();
 
         final DMNResult dmnResult = runtime.evaluateAll(dmnModel, emptyContext);
-        assertThat(DMNRuntimeUtil.formatMessages(dmnResult.getMessages()), dmnResult.hasErrors(), is(false));
+        assertThat(dmnResult.hasErrors()).as(DMNRuntimeUtil.formatMessages(dmnResult.getMessages())).isFalse();
 
         final DMNContext resultContext = dmnResult.getContext();
-        assertThat(((BigDecimal) resultContext.get("hardcoded decision")).intValue(), is(47));
+        assertThat(((BigDecimal) resultContext.get("hardcoded decision")).intValue()).isEqualTo(47);
     }
 
     @Test
@@ -1786,18 +1774,18 @@ public class DMNRuntimeTest extends BaseInterpretedVsCompiledTest {
         // DROOLS-2200
         final DMNRuntime runtime = DMNRuntimeUtil.createRuntime("will_be_null_if_negative.dmn", this.getClass());
         final DMNModel dmnModel = runtime.getModel("http://www.trisotech.com/definitions/_c5889555-7ae5-4a67-a872-3a9492caf6e7", "will be null if negative");
-        assertThat(dmnModel, notNullValue());
-        assertThat(DMNRuntimeUtil.formatMessages(dmnModel.getMessages()), dmnModel.hasErrors(), is(false));
+        assertThat(dmnModel).isNotNull();
+        assertThat(dmnModel.hasErrors()).as(DMNRuntimeUtil.formatMessages(dmnModel.getMessages())).isFalse();
 
         final DMNContext context = DMNFactory.newContext();
         context.set("a number", -1);
 
         final DMNResult dmnResult = runtime.evaluateAll(dmnModel, context);
-        assertThat(DMNRuntimeUtil.formatMessages(dmnResult.getMessages()), dmnResult.hasErrors(), is(false));
+        assertThat(dmnResult.hasErrors()).as(DMNRuntimeUtil.formatMessages(dmnResult.getMessages())).isFalse();
 
         final DMNContext resultContext = dmnResult.getContext();
-        assertThat(((Map) resultContext.get("will be null if negative")).get("s1"), nullValue());
-        assertThat(((Map) resultContext.get("will be null if negative")).get("s2"), is("negative"));
+        assertThat(((Map) resultContext.get("will be null if negative")).get("s1")).isNull();
+        assertThat(((Map) resultContext.get("will be null if negative")).get("s2")).isEqualTo("negative");
     }
 
     @Test
@@ -1810,17 +1798,17 @@ public class DMNRuntimeTest extends BaseInterpretedVsCompiledTest {
         final DMNRuntime runtime = kieContainer.newKieSession().getKieRuntime(DMNRuntime.class);
 
         final DMNModel dmnModel = runtime.getModel("http://www.trisotech.com/definitions/_42bf043d-df86-48bd-9045-dfc08aa8ba0d", "typecheck in context result");
-        assertThat(dmnModel, notNullValue());
-        assertThat(DMNRuntimeUtil.formatMessages(dmnModel.getMessages()), dmnModel.hasErrors(), is(false));
+        assertThat(dmnModel).isNotNull();
+        assertThat(dmnModel.hasErrors()).as(DMNRuntimeUtil.formatMessages(dmnModel.getMessages())).isFalse();
 
         final DMNContext emptyContext = DMNFactory.newContext();
 
         final DMNResult dmnResult = runtime.evaluateAll(dmnModel, emptyContext);
-        assertThat(DMNRuntimeUtil.formatMessages(dmnResult.getMessages()), dmnResult.hasErrors(), is(false));
+        assertThat(dmnResult.hasErrors()).as(DMNRuntimeUtil.formatMessages(dmnResult.getMessages())).isFalse();
 
         final DMNContext resultContext = dmnResult.getContext();
-        assertThat(((Map<String, Object>) resultContext.get("an hardcoded person")).keySet(), contains("name", "age"));
-        assertThat(((Map<String, Object>) resultContext.get("an hardcoded person with no name")).keySet(), contains("age"));
+        assertThat(((Map<String, Object>) resultContext.get("an hardcoded person"))).containsKeys("name", "age");
+        assertThat(((Map<String, Object>) resultContext.get("an hardcoded person with no name"))).containsKeys("age");
     }
 
     @Test
@@ -1833,17 +1821,17 @@ public class DMNRuntimeTest extends BaseInterpretedVsCompiledTest {
         final DMNRuntime runtime = kieContainer.newKieSession().getKieRuntime(DMNRuntime.class);
 
         final DMNModel dmnModel = runtime.getModel("http://www.trisotech.com/definitions/_99ccd4df-41ac-43c3-a563-d58f43149829", "typecheck in DT");
-        assertThat(dmnModel, notNullValue());
-        assertThat(DMNRuntimeUtil.formatMessages(dmnModel.getMessages()), dmnModel.hasErrors(), is(false));
+        assertThat(dmnModel).isNotNull();
+        assertThat(dmnModel.hasErrors()).as(DMNRuntimeUtil.formatMessages(dmnModel.getMessages())).isFalse();
 
         final DMNContext context = DMNFactory.newContext();
         context.set("a number", 0);
 
         final DMNResult dmnResult = runtime.evaluateAll(dmnModel, context);
-        assertThat(DMNRuntimeUtil.formatMessages(dmnResult.getMessages()), dmnResult.hasErrors(), is(false));
+        assertThat(dmnResult.hasErrors()).as(DMNRuntimeUtil.formatMessages(dmnResult.getMessages())).isFalse();
 
         final DMNContext resultContext = dmnResult.getContext();
-        assertThat(((BigDecimal) resultContext.get("an odd decision")).intValue(), is(47));
+        assertThat(((BigDecimal) resultContext.get("an odd decision")).intValue()).isEqualTo(47);
     }
 
     public static class DROOLS2286 {
@@ -1914,15 +1902,15 @@ public class DMNRuntimeTest extends BaseInterpretedVsCompiledTest {
         // DROOLS-2322
         final DMNRuntime runtime = DMNRuntimeUtil.createRuntime("just_now.dmn", this.getClass());
         final DMNModel dmnModel = runtime.getModel("http://www.trisotech.com/definitions/_56fd6445-ff6a-4c28-8206-71fce7f80436", "just now");
-        assertThat(dmnModel, notNullValue());
-        assertThat(DMNRuntimeUtil.formatMessages(dmnModel.getMessages()), dmnModel.hasErrors(), is(false));
+        assertThat(dmnModel).isNotNull();
+        assertThat(dmnModel.hasErrors()).as(DMNRuntimeUtil.formatMessages(dmnModel.getMessages())).isFalse();
 
         final DMNContext emptyContext = DMNFactory.newContext();
 
         final DMNResult dmnResult = runtime.evaluateAll(dmnModel, emptyContext);
-        assertThat(DMNRuntimeUtil.formatMessages(dmnResult.getMessages()), dmnResult.hasErrors(), is(false));
+        assertThat(dmnResult.hasErrors()).as(DMNRuntimeUtil.formatMessages(dmnResult.getMessages())).isFalse();
 
-        assertThat(dmnResult.getDecisionResultByName("a decision just now").getResult(), notNullValue());
+        assertThat(dmnResult.getDecisionResultByName("a decision just now").getResult()).isNotNull();
     }
 
     @Test
@@ -1931,17 +1919,17 @@ public class DMNRuntimeTest extends BaseInterpretedVsCompiledTest {
         final DMNRuntime runtime = DMNRuntimeUtil.createRuntime("is office open.dmn", this.getClass());
         final DMNModel dmnModel = runtime.getModel("https://github.com/kiegroup/drools/kie-dmn/_19170B18-B561-4EB2-9D38-714E2442710E",
                                                    "is office open");
-        assertThat(DMNRuntimeUtil.formatMessages(dmnModel.getMessages()), dmnModel.hasErrors(), is(false));
+        assertThat(dmnModel.hasErrors()).as(DMNRuntimeUtil.formatMessages(dmnModel.getMessages())).isFalse();
 
         final DMNContext context = DMNFactory.newContext();
         context.set("an office", prototype(entry("opened from", LocalDateTime.of(2018, 12, 31, 8, 0)),
                                            entry("opened till", LocalDateTime.of(2018, 12, 31, 16, 0))));
 
         final DMNResult dmnResult = runtime.evaluateAll(dmnModel, context);
-        assertThat(DMNRuntimeUtil.formatMessages(dmnResult.getMessages()), dmnResult.hasErrors(), is(false));
+        assertThat(dmnResult.hasErrors()).as(DMNRuntimeUtil.formatMessages(dmnResult.getMessages())).isFalse();
         LOG.debug("{}", dmnResult);
-        assertThat(dmnResult.getDecisionResultByName("is open").getEvaluationStatus(), is(DecisionEvaluationStatus.SUCCEEDED));
-        assertThat(dmnResult.getDecisionResultByName("is open").getResult(), notNullValue());
+        assertThat(dmnResult.getDecisionResultByName("is open").getEvaluationStatus()).isEqualTo(DecisionEvaluationStatus.SUCCEEDED);
+        assertThat(dmnResult.getDecisionResultByName("is open").getResult()).isNotNull();
     }
 
     @Test
@@ -1949,15 +1937,15 @@ public class DMNRuntimeTest extends BaseInterpretedVsCompiledTest {
         // DROOLS-2322
         final DMNRuntime runtime = DMNRuntimeUtil.createRuntime("just_today.dmn", this.getClass());
         final DMNModel dmnModel = runtime.getModel("http://www.trisotech.com/definitions/_56fd6445-ff6a-4c28-8206-71fce7f80436", "just today");
-        assertThat(dmnModel, notNullValue());
-        assertThat(DMNRuntimeUtil.formatMessages(dmnModel.getMessages()), dmnModel.hasErrors(), is(false));
+        assertThat(dmnModel).isNotNull();
+        assertThat(dmnModel.hasErrors()).as(DMNRuntimeUtil.formatMessages(dmnModel.getMessages())).isFalse();
 
         final DMNContext emptyContext = DMNFactory.newContext();
 
         final DMNResult dmnResult = runtime.evaluateAll(dmnModel, emptyContext);
-        assertThat(DMNRuntimeUtil.formatMessages(dmnResult.getMessages()), dmnResult.hasErrors(), is(false));
+        assertThat(dmnResult.hasErrors()).as(DMNRuntimeUtil.formatMessages(dmnResult.getMessages())).isFalse();
 
-        assertThat(dmnResult.getDecisionResultByName("a decision just today").getResult(), notNullValue());
+        assertThat(dmnResult.getDecisionResultByName("a decision just today").getResult()).isNotNull();
     }
 
     @Test
@@ -1965,16 +1953,16 @@ public class DMNRuntimeTest extends BaseInterpretedVsCompiledTest {
         // DROOLS-2307
         final DMNRuntime runtime = DMNRuntimeUtil.createRuntime("drools2307.dmn", this.getClass());
         final DMNModel dmnModel = runtime.getModel("http://www.trisotech.com/dmn/definitions/_03d9481e-dcfc-4a59-9bdd-4f021cb2f0d8", "Drawing 1");
-        assertThat(dmnModel, notNullValue());
-        assertThat(DMNRuntimeUtil.formatMessages(dmnModel.getMessages()), dmnModel.hasErrors(), is(false));
+        assertThat(dmnModel).isNotNull();
+        assertThat(dmnModel.hasErrors()).as(DMNRuntimeUtil.formatMessages(dmnModel.getMessages())).isFalse();
 
         final DMNContext emptyContext = DMNFactory.newContext();
 
         final DMNResult dmnResult = runtime.evaluateAll(dmnModel, emptyContext);
-        assertThat(DMNRuntimeUtil.formatMessages(dmnResult.getMessages()), dmnResult.hasErrors(), is(false));
+        assertThat(dmnResult.hasErrors()).as(DMNRuntimeUtil.formatMessages(dmnResult.getMessages())).isFalse();
 
         final DMNContext result = dmnResult.getContext();
-        assertThat(result.get("an hardcoded forloop"), is(Arrays.asList(new BigDecimal(2), new BigDecimal(3), new BigDecimal(4))));
+        assertThat(result.get("an hardcoded forloop")).asList().containsExactly(new BigDecimal(2), new BigDecimal(3), new BigDecimal(4));
     }
 
     @Test
@@ -1982,29 +1970,29 @@ public class DMNRuntimeTest extends BaseInterpretedVsCompiledTest {
         // DROOLS-2357
         final DMNRuntime runtime = DMNRuntimeUtil.createRuntime("List_of_Vowels.dmn", this.getClass());
         final DMNModel dmnModel = runtime.getModel("http://www.trisotech.com/dmn/definitions/_c5f007ce-4d45-4aac-8729-991d4abc7826", "List of Vowels");
-        assertThat(dmnModel, notNullValue());
-        assertThat(DMNRuntimeUtil.formatMessages(dmnModel.getMessages()), dmnModel.hasErrors(), is(false));
+        assertThat(dmnModel).isNotNull();
+        assertThat(dmnModel.hasErrors()).as(DMNRuntimeUtil.formatMessages(dmnModel.getMessages())).isFalse();
 
         final DMNContext emptyContext = DMNFactory.newContext();
 
         final DMNResult dmnResult = runtime.evaluateAll(dmnModel, emptyContext);
-        assertThat(DMNRuntimeUtil.formatMessages(dmnResult.getMessages()), dmnResult.hasErrors(), is(true));
+        assertThat(dmnResult.hasErrors()).as(DMNRuntimeUtil.formatMessages(dmnResult.getMessages())).isTrue();
         assertThat(dmnResult.getMessages().stream()
                             .filter(m -> m.getMessageType() == DMNMessageType.ERROR_EVAL_NODE)
-                            .anyMatch(m -> m.getSourceId().equals("_b2205027-d06c-41b5-8419-e14b501e14a6")),
-                   is(true));
+                            .anyMatch(m -> m.getSourceId().equals("_b2205027-d06c-41b5-8419-e14b501e14a6")))
+                   .isTrue();
 
         final DMNContext result = dmnResult.getContext();
-        assertThat(result.get("Decide Vowel a"), is("a"));
-        assertThat(result.get("Decide BAD"), nullValue());
+        assertThat(result.get("Decide Vowel a")).isEqualTo("a");
+        assertThat(result.get("Decide BAD")).isNull();
     }
 
     @Test
     public void testEnhancedForLoop2() {
         final DMNRuntime runtime = DMNRuntimeUtil.createRuntime("MACD-enhanced_iteration.dmn", this.getClass());
         final DMNModel dmnModel = runtime.getModel("http://www.trisotech.com/definitions/_6cfe7d88-6741-45d1-968c-b61a597d0964", "MACD-enhanced iteration");
-        assertThat(dmnModel, notNullValue());
-        assertThat(DMNRuntimeUtil.formatMessages(dmnModel.getMessages()), dmnModel.hasErrors(), is(false));
+        assertThat(dmnModel).isNotNull();
+        assertThat(dmnModel.hasErrors()).as(DMNRuntimeUtil.formatMessages(dmnModel.getMessages())).isFalse();
 
         final DMNContext context = DMNFactory.newContext();
         final Map<String, Object> d1 = prototype(entry("aDate", LocalDate.of(2018, 3, 5)), entry("Close", 1010));
@@ -2013,13 +2001,13 @@ public class DMNRuntimeTest extends BaseInterpretedVsCompiledTest {
         context.set("DailyTable", Arrays.asList(d1, d2, d3));
 
         final DMNResult dmnResult = runtime.evaluateAll(dmnModel, context);
-        assertThat(DMNRuntimeUtil.formatMessages(dmnResult.getMessages()), dmnResult.hasErrors(), is(false));
+        assertThat(dmnResult.hasErrors()).as(DMNRuntimeUtil.formatMessages(dmnResult.getMessages())).isFalse();
         LOG.debug("{}", dmnResult);
 
         final DMNContext resultContext = dmnResult.getContext();
-        assertThat(((Map<String, Object>) ((List) resultContext.get("MACDTable")).get(0)).get("aDate"), is(LocalDate.of(2018, 3, 5)));
-        assertThat(((Map<String, Object>) ((List) resultContext.get("MACDTable")).get(1)).get("aDate"), is(LocalDate.of(2018, 3, 6)));
-        assertThat(((Map<String, Object>) ((List) resultContext.get("MACDTable")).get(2)).get("aDate"), is(LocalDate.of(2018, 3, 7)));
+        assertThat(((Map<String, Object>) ((List) resultContext.get("MACDTable")).get(0)).get("aDate")).isEqualTo(LocalDate.of(2018, 3, 5));
+        assertThat(((Map<String, Object>) ((List) resultContext.get("MACDTable")).get(1)).get("aDate")).isEqualTo(LocalDate.of(2018, 3, 6));
+        assertThat(((Map<String, Object>) ((List) resultContext.get("MACDTable")).get(2)).get("aDate")).isEqualTo(LocalDate.of(2018, 3, 7));
     }
 
     @Test
@@ -2027,17 +2015,17 @@ public class DMNRuntimeTest extends BaseInterpretedVsCompiledTest {
         // DROOLS-2416
         final DMNRuntime runtime = DMNRuntimeUtil.createRuntime("anot.dmn", this.getClass());
         final DMNModel dmnModel = runtime.getModel("http://www.trisotech.com/dmn/definitions/_292c1c7b-6b38-415d-938f-e9ca51d30b2b", "anot");
-        assertThat(dmnModel, notNullValue());
-        assertThat(DMNRuntimeUtil.formatMessages(dmnModel.getMessages()), dmnModel.hasErrors(), is(false));
+        assertThat(dmnModel).isNotNull();
+        assertThat(dmnModel.hasErrors()).as(DMNRuntimeUtil.formatMessages(dmnModel.getMessages())).isFalse();
 
         final DMNContext context = DMNFactory.newContext();
         context.set("a letter", "a");
 
         final DMNResult dmnResult = runtime.evaluateAll(dmnModel, context);
-        assertThat(DMNRuntimeUtil.formatMessages(dmnResult.getMessages()), dmnResult.hasErrors(), is(false));
+        assertThat(dmnResult.hasErrors()).as(DMNRuntimeUtil.formatMessages(dmnResult.getMessages())).isFalse();
 
         final DMNContext result = dmnResult.getContext();
-        assertThat(result.get("what letter decision"), is("vowel"));
+        assertThat(result.get("what letter decision")).isEqualTo("vowel");
     }
 
     @Test
@@ -2045,17 +2033,17 @@ public class DMNRuntimeTest extends BaseInterpretedVsCompiledTest {
         // DROOLS-2416
         final DMNRuntime runtime = DMNRuntimeUtil.createRuntime("list_containment_DT.dmn", this.getClass());
         final DMNModel dmnModel = runtime.getModel("http://www.trisotech.com/definitions/_6ab2bd6d-adaa-45c4-a141-a84382a201eb", "list containment DT");
-        assertThat(dmnModel, notNullValue());
-        assertThat(DMNRuntimeUtil.formatMessages(dmnModel.getMessages()), dmnModel.hasErrors(), is(false));
+        assertThat(dmnModel).isNotNull();
+        assertThat(dmnModel.hasErrors()).as(DMNRuntimeUtil.formatMessages(dmnModel.getMessages())).isFalse();
 
         final DMNContext context = DMNFactory.newContext();
         context.set("Passenger", prototype(entry("name", "Osama bin Laden")));
 
         final DMNResult dmnResult = runtime.evaluateAll(dmnModel, context);
-        assertThat(DMNRuntimeUtil.formatMessages(dmnResult.getMessages()), dmnResult.hasErrors(), is(false));
+        assertThat(dmnResult.hasErrors()).as(DMNRuntimeUtil.formatMessages(dmnResult.getMessages())).isFalse();
 
         final DMNContext result = dmnResult.getContext();
-        assertThat(result.get("Boarding Status"), is("Denied"));
+        assertThat(result.get("Boarding Status")).isEqualTo("Denied");
     }
 
     @Test
@@ -2063,17 +2051,17 @@ public class DMNRuntimeTest extends BaseInterpretedVsCompiledTest {
         final DMNRuntime runtime = DMNRuntimeUtil.createRuntime("structure-containtment.dmn", this.getClass());
         final DMNModel dmnModel = runtime.getModel("https://github.com/kiegroup/drools/kie-dmn/_7FB5C3E4-4DF8-42A6-A7FA-28315DECCDD0",
                                                    "structure-containtment");
-        assertThat(dmnModel, notNullValue());
-        assertThat(DMNRuntimeUtil.formatMessages(dmnModel.getMessages()), dmnModel.hasErrors(), is(false));
+        assertThat(dmnModel).isNotNull();
+        assertThat(dmnModel.hasErrors()).as(DMNRuntimeUtil.formatMessages(dmnModel.getMessages())).isFalse();
 
         final DMNContext context = DMNFactory.newContext();
         context.set("an employee", prototype(entry("age", BigDecimal.valueOf(50))));
 
         final DMNResult dmnResult = runtime.evaluateAll(dmnModel, context);
-        assertThat(DMNRuntimeUtil.formatMessages(dmnResult.getMessages()), dmnResult.hasErrors(), is(false));
+        assertThat(dmnResult.hasErrors()).as(DMNRuntimeUtil.formatMessages(dmnResult.getMessages())).isFalse();
 
         final DMNContext result = dmnResult.getContext();
-        assertThat(result.get("is there"), is(true));
+        assertThat(result.get("is there")).isEqualTo(Boolean.TRUE);
     }
 
     @Test
@@ -2081,20 +2069,20 @@ public class DMNRuntimeTest extends BaseInterpretedVsCompiledTest {
         // DROOLS-2439
         final DMNRuntime runtime = DMNRuntimeUtil.createRuntime("relation_with_empty_cell.dmn", this.getClass());
         final DMNModel dmnModel = runtime.getModel("http://www.trisotech.com/dmn/definitions/_99a00903-2943-47df-bab1-a32f276617ea", "Relation with empty cell");
-        assertThat(dmnModel, notNullValue());
-        assertThat(DMNRuntimeUtil.formatMessages(dmnModel.getMessages()), dmnModel.hasErrors(), is(false));
+        assertThat(dmnModel).isNotNull();
+        assertThat(dmnModel.hasErrors()).as(DMNRuntimeUtil.formatMessages(dmnModel.getMessages())).isFalse();
 
         final DMNContext context = DMNFactory.newContext();
 
         final DMNResult dmnResult = runtime.evaluateAll(dmnModel, context);
         System.out.println(dmnResult);
-        assertThat(DMNRuntimeUtil.formatMessages(dmnResult.getMessages()), dmnResult.hasErrors(), is(false));
+        assertThat(dmnResult.hasErrors()).as(DMNRuntimeUtil.formatMessages(dmnResult.getMessages())).isFalse();
 
         final DMNContext result = dmnResult.getContext();
-        assertThat(result.get("Decision A"), is(Arrays.asList(prototype(entry("name", null), entry("age", null)),
+        assertThat(result.get("Decision A")).asList().containsExactly(prototype(entry("name", null), entry("age", null)),
                                                               prototype(entry("name", "John"), entry("age", new BigDecimal(1))),
                                                               prototype(entry("name", null), entry("age", null)),
-                                                              prototype(entry("name", "Matteo"), entry("age", null)))));
+                                                              prototype(entry("name", "Matteo"), entry("age", null)));
     }
 
     @Test
@@ -2102,8 +2090,8 @@ public class DMNRuntimeTest extends BaseInterpretedVsCompiledTest {
         // DROOLS-2317
         final DMNRuntime runtime = DMNRuntimeUtil.createRuntime("Dynamic composition.dmn", this.getClass());
         final DMNModel dmnModel = runtime.getModel("http://www.trisotech.com/definitions/_c2d86765-c3c7-4e1d-b1fa-b830fa5bc529", "Dynamic composition");
-        assertThat(dmnModel, notNullValue());
-        assertThat(DMNRuntimeUtil.formatMessages(dmnModel.getMessages()), dmnModel.hasErrors(), is(false));
+        assertThat(dmnModel).isNotNull();
+        assertThat(dmnModel.hasErrors()).as(DMNRuntimeUtil.formatMessages(dmnModel.getMessages())).isFalse();
     }
 
     @Test
@@ -2111,24 +2099,24 @@ public class DMNRuntimeTest extends BaseInterpretedVsCompiledTest {
         // DROOLS-2317 FEEL Syntax error on function(bkm) containing `for` keyword
         final DMNRuntime runtime = DMNRuntimeUtil.createRuntime("say_for_hello.dmn", this.getClass());
         final DMNModel dmnModel = runtime.getModel("http://www.trisotech.com/dmn/definitions/_b6f2a9ca-a246-4f27-896a-e8ef04ea439c", "say for hello");
-        assertThat(dmnModel, notNullValue());
-        assertThat(DMNRuntimeUtil.formatMessages(dmnModel.getMessages()), dmnModel.hasErrors(), is(false));
+        assertThat(dmnModel).isNotNull();
+        assertThat(dmnModel.hasErrors()).as(DMNRuntimeUtil.formatMessages(dmnModel.getMessages())).isFalse();
 
         final DMNContext emptyContext = DMNFactory.newContext();
 
         final DMNResult dmnResult = runtime.evaluateAll(dmnModel, emptyContext);
-        assertThat(DMNRuntimeUtil.formatMessages(dmnResult.getMessages()), dmnResult.hasErrors(), is(false));
+        assertThat(dmnResult.hasErrors()).as(DMNRuntimeUtil.formatMessages(dmnResult.getMessages())).isFalse();
 
         final DMNContext result = dmnResult.getContext();
-        assertThat(result.get("just say"), is(Arrays.asList("Hello", "Hello", "Hello")));
+        assertThat(result.get("just say")).asList().containsExactly("Hello", "Hello", "Hello");
     }
 
     @Test
     public void testProductFunction() {
         final DMNRuntime runtime = DMNRuntimeUtil.createRuntime("product.dmn", this.getClass() );
         final DMNModel model = runtime.getModel("http://www.trisotech.com/dmn/definitions/_40fdbc2c-a631-4ba4-8435-17571b5d1942", "Drawing 1" );
-        assertThat( model, notNullValue() );
-        assertThat( DMNRuntimeUtil.formatMessages( model.getMessages() ), model.hasErrors(), is( false ) );
+        assertThat(model).isNotNull();
+        assertThat(model.hasErrors()).as(DMNRuntimeUtil.formatMessages(model.getMessages())).isFalse();
         final DMNContext context = DMNFactory.newContext();
         context.set("product", new HashMap<String, Object>(){{
             put("name", "Product1");
@@ -2144,22 +2132,22 @@ public class DMNRuntimeTest extends BaseInterpretedVsCompiledTest {
         // DROOLS-2605
         final DMNRuntime runtime = DMNRuntimeUtil.createRuntime("test20180601.dmn", this.getClass());
         final DMNModel dmnModel = runtime.getModel("http://www.trisotech.com/dmn/definitions/_9b8f2642-2597-4a99-9fcd-f9302692d3dc", "Drawing 1");
-        assertThat(dmnModel, notNullValue());
-        assertThat(DMNRuntimeUtil.formatMessages(dmnModel.getMessages()), dmnModel.hasErrors(), is(false));
+        assertThat(dmnModel).isNotNull();
+        assertThat(dmnModel.hasErrors()).as(DMNRuntimeUtil.formatMessages(dmnModel.getMessages())).isFalse();
 
         final DMNContext context3 = DMNFactory.newContext();
         context3.set("my num", new BigDecimal(3));
 
         final DMNResult dmnResult3 = runtime.evaluateAll(dmnModel, context3);
-        assertThat(DMNRuntimeUtil.formatMessages(dmnResult3.getMessages()), dmnResult3.hasErrors(), is(false));
-        assertThat(dmnResult3.getDecisionResultByName("my decision").getResult(), is(false));
+        assertThat(dmnResult3.hasErrors()).as(DMNRuntimeUtil.formatMessages(dmnResult3.getMessages())).isFalse();
+        assertThat(dmnResult3.getDecisionResultByName("my decision").getResult()).isEqualTo(Boolean.FALSE);
 
         final DMNContext context10 = DMNFactory.newContext();
         context10.set("my num", new BigDecimal(10));
 
         final DMNResult dmnResult10 = runtime.evaluateAll(dmnModel, context10);
-        assertThat(DMNRuntimeUtil.formatMessages(dmnResult10.getMessages()), dmnResult10.hasErrors(), is(false));
-        assertThat(dmnResult10.getDecisionResultByName("my decision").getResult(), is(true));
+        assertThat(dmnResult10.hasErrors()).as(DMNRuntimeUtil.formatMessages(dmnResult10.getMessages())).isFalse();
+        assertThat(dmnResult10.getDecisionResultByName("my decision").getResult()).isEqualTo(Boolean.TRUE);
     }
 
     @Test
@@ -2167,8 +2155,8 @@ public class DMNRuntimeTest extends BaseInterpretedVsCompiledTest {
         // DROOLS-2605
         final DMNRuntime runtime = DMNRuntimeUtil.createRuntime("BruceTask20180601.dmn", this.getClass());
         final DMNModel dmnModel = runtime.getModel("http://www.trisotech.com/definitions/_3802fcb2-5b93-4502-aff4-0f5c61244eab", "Bruce Task");
-        assertThat(dmnModel, notNullValue());
-        assertThat(DMNRuntimeUtil.formatMessages(dmnModel.getMessages()), dmnModel.hasErrors(), is(false));
+        assertThat(dmnModel).isNotNull();
+        assertThat(dmnModel.hasErrors()).as(DMNRuntimeUtil.formatMessages(dmnModel.getMessages())).isFalse();
 
         final DMNContext context = DMNFactory.newContext();
         context.set("TheBook", Arrays.asList(prototype(entry("Title", "55"), entry("Price", new BigDecimal(5)), entry("Quantity", new BigDecimal(5))),
@@ -2178,10 +2166,10 @@ public class DMNRuntimeTest extends BaseInterpretedVsCompiledTest {
                                              prototype(entry("Title", "66"), entry("Price", new BigDecimal(6)), entry("Quantity", new BigDecimal(6)))));
 
         final DMNResult dmnResult = runtime.evaluateAll(dmnModel, context);
-        assertThat(DMNRuntimeUtil.formatMessages(dmnResult.getMessages()), dmnResult.hasErrors(), is(false));
+        assertThat(dmnResult.hasErrors()).as(DMNRuntimeUtil.formatMessages(dmnResult.getMessages())).isFalse();
 
         final DMNContext result = dmnResult.getContext();
-        assertThat(result.get("Bruce"), is(instanceOf(Map.class)));
+        assertThat(result.get("Bruce")).isInstanceOf(Map.class);
         final Map<String, Object> bruce = (Map<String, Object>) result.get("Bruce");
 
         assertEquals(2, ((List) bruce.get("one")).size());
@@ -2213,8 +2201,8 @@ public class DMNRuntimeTest extends BaseInterpretedVsCompiledTest {
     public void testModelById() {
         final DMNRuntime runtime = DMNRuntimeUtil.createRuntime("simple-item-def.dmn", this.getClass() );
         final DMNModel dmnModel = runtime.getModelById("https://github.com/kiegroup/kie-dmn/itemdef", "_simple-item-def" );
-        assertThat( dmnModel, notNullValue() );
-        assertThat( DMNRuntimeUtil.formatMessages( dmnModel.getMessages() ), dmnModel.hasErrors(), is( false ) );
+        assertThat(dmnModel).isNotNull();
+        assertThat(dmnModel.hasErrors()).as(DMNRuntimeUtil.formatMessages(dmnModel.getMessages())).isFalse();
 
     }
 
@@ -2223,8 +2211,8 @@ public class DMNRuntimeTest extends BaseInterpretedVsCompiledTest {
         // DROOLS-2648 DMN v1.2 weekday on 'date', 'date and time'
         final DMNRuntime runtime = DMNRuntimeUtil.createRuntime("weekday-on-date.dmn", this.getClass());
         final DMNModel dmnModel = runtime.getModel("http://www.trisotech.com/definitions/_55a2dafd-ab4d-4154-bace-826d426da251", "weekday on date");
-        assertThat(dmnModel, notNullValue());
-        assertThat(DMNRuntimeUtil.formatMessages(dmnModel.getMessages()), dmnModel.hasErrors(), is(false));
+        assertThat(dmnModel).isNotNull();
+        assertThat(dmnModel.hasErrors()).as(DMNRuntimeUtil.formatMessages(dmnModel.getMessages())).isFalse();
 
         for (int i = 0; i < 7; i++) {
             final DMNContext context = DMNFactory.newContext();
@@ -2232,10 +2220,10 @@ public class DMNRuntimeTest extends BaseInterpretedVsCompiledTest {
 
             final DMNResult dmnResult = runtime.evaluateAll(dmnModel, context);
             LOG.debug("{}", dmnResult);
-            assertThat(DMNRuntimeUtil.formatMessages(dmnResult.getMessages()), dmnResult.hasErrors(), is(false));
+            assertThat(dmnResult.hasErrors()).as(DMNRuntimeUtil.formatMessages(dmnResult.getMessages())).isFalse();
 
             final DMNContext result = dmnResult.getContext();
-            assertThat(result.get("Weekday"), is(new BigDecimal(i + 1)));
+            assertThat(result.get("Weekday")).isEqualTo(new BigDecimal(i + 1));
         }
     }
 
@@ -2244,8 +2232,8 @@ public class DMNRuntimeTest extends BaseInterpretedVsCompiledTest {
         // DROOLS-2665
         final DMNRuntime runtime = DMNRuntimeUtil.createRuntime("Instance_of.dmn", this.getClass());
         final DMNModel dmnModel = runtime.getModel("http://www.trisotech.com/definitions/_b5c4d644-5a15-4528-8028-86537cb1c836", "Instance of");
-        assertThat(dmnModel, notNullValue());
-        assertThat(DMNRuntimeUtil.formatMessages(dmnModel.getMessages()), dmnModel.hasErrors(), is(false));
+        assertThat(dmnModel).isNotNull();
+        assertThat(dmnModel.hasErrors()).as(DMNRuntimeUtil.formatMessages(dmnModel.getMessages())).isFalse();
 
         final DMNContext context = DMNFactory.newContext();
         context.set("input year month duration", Duration.parse("P12D"));
@@ -2255,13 +2243,13 @@ public class DMNRuntimeTest extends BaseInterpretedVsCompiledTest {
 
         final DMNResult dmnResult = runtime.evaluateAll(dmnModel, context);
         LOG.debug("{}", dmnResult);
-        assertThat(DMNRuntimeUtil.formatMessages(dmnResult.getMessages()), dmnResult.hasErrors(), is(false));
+        assertThat(dmnResult.hasErrors()).as(DMNRuntimeUtil.formatMessages(dmnResult.getMessages())).isFalse();
 
         final DMNContext result = dmnResult.getContext();
-        assertThat(result.get("Decision Logic 1"), is(true));
-        assertThat(result.get("Decision Logic 2"), is(true));
-        assertThat(result.get("Decision Logic 3"), is(true));
-        assertThat(result.get("Decision Logic 4"), is(true));
+        assertThat(result.get("Decision Logic 1")).isEqualTo(Boolean.TRUE);
+        assertThat(result.get("Decision Logic 2")).isEqualTo(Boolean.TRUE);
+        assertThat(result.get("Decision Logic 3")).isEqualTo(Boolean.TRUE);
+        assertThat(result.get("Decision Logic 4")).isEqualTo(Boolean.TRUE);
     }
 
     @Test
@@ -2269,17 +2257,17 @@ public class DMNRuntimeTest extends BaseInterpretedVsCompiledTest {
         // DROOLS-2732 FEEL invoking a function on a literal context
         final DMNRuntime runtime = DMNRuntimeUtil.createRuntime("invokingAFunctionOnALiteralContext.dmn", this.getClass());
         final DMNModel dmnModel = runtime.getModel("http://www.trisotech.com/dmn/definitions/_781968dd-64dc-4231-9cd0-2ce590881f2c", "Drawing 1");
-        assertThat(dmnModel, notNullValue());
-        assertThat(DMNRuntimeUtil.formatMessages(dmnModel.getMessages()), dmnModel.hasErrors(), is(false));
+        assertThat(dmnModel).isNotNull();
+        assertThat(dmnModel.hasErrors()).as(DMNRuntimeUtil.formatMessages(dmnModel.getMessages())).isFalse();
 
         final DMNContext emptyContext = DMNFactory.newContext();
 
         final DMNResult dmnResult = runtime.evaluateAll(dmnModel, emptyContext);
         LOG.debug("{}", dmnResult);
-        assertThat(DMNRuntimeUtil.formatMessages(dmnResult.getMessages()), dmnResult.hasErrors(), is(false));
+        assertThat(dmnResult.hasErrors()).as(DMNRuntimeUtil.formatMessages(dmnResult.getMessages())).isFalse();
 
         final DMNContext result = dmnResult.getContext();
-        assertThat(result.get("invoking a function on a literal context"), is(new BigDecimal(3)));
+        assertThat(result.get("invoking a function on a literal context")).isEqualTo(new BigDecimal(3));
     }
 
     @Test
@@ -2295,35 +2283,35 @@ public class DMNRuntimeTest extends BaseInterpretedVsCompiledTest {
         // DROOLS-2822 FEEL augment not() heuristic for function invocation
         final DMNRuntime runtime = DMNRuntimeUtil.createRuntime("Not-heuristic-for-function-invocation-drools-2822.dmn", this.getClass());
         final DMNModel dmnModel = runtime.getModel("http://www.trisotech.com/dmn/definitions/_82f7e67e-0a8c-492d-aa78-94851c10eee6", "Drawing 1");
-        assertThat(dmnModel, notNullValue());
-        assertThat(DMNRuntimeUtil.formatMessages(dmnModel.getMessages()), dmnModel.hasErrors(), is(false));
+        assertThat(dmnModel).isNotNull();
+        assertThat(dmnModel.hasErrors()).as(DMNRuntimeUtil.formatMessages(dmnModel.getMessages())).isFalse();
 
         final DMNContext emptyContext = DMNFactory.newContext();
 
         final DMNResult dmnResult = runtime.evaluateAll(dmnModel, emptyContext);
         LOG.debug("{}", dmnResult);
-        assertThat(DMNRuntimeUtil.formatMessages(dmnResult.getMessages()), dmnResult.hasErrors(), is(false));
+        assertThat(dmnResult.hasErrors()).as(DMNRuntimeUtil.formatMessages(dmnResult.getMessages())).isFalse();
 
         final DMNContext result = dmnResult.getContext();
-        assertThat(result.get("Not working"), is(false));
+        assertThat(result.get("Not working")).isEqualTo(Boolean.FALSE);
     }
 
     @Test
     public void testDMNv1_2_ch11Modified() {
         final DMNRuntime runtime = DMNRuntimeUtil.createRuntime("v1_2/ch11MODIFIED.dmn", this.getClass());
         final DMNModel dmnModel = runtime.getModel("http://www.trisotech.com/definitions/_3068644b-d2c7-4b81-ab9d-64f011f81f47", "DMN Specification Chapter 11 Example");
-        assertThat(dmnModel, notNullValue());
-        assertThat(DMNRuntimeUtil.formatMessages(dmnModel.getMessages()), dmnModel.hasErrors(), is(false));
+        assertThat(dmnModel).isNotNull();
+        assertThat(dmnModel.hasErrors()).as(DMNRuntimeUtil.formatMessages(dmnModel.getMessages())).isFalse();
 
         final DMNContext context = DMNFactory.newContext();
         context.set("Applicant data", mapOf(entry("Age", new BigDecimal(51)),
                                             entry("MaritalStatus", "M"),
                                             entry("EmploymentStatus", "EMPLOYED"),
-                                            entry("ExistingCustomer", false),
+                                            entry("ExistingCustomer", Boolean.FALSE),
                                             entry("Monthly", mapOf(entry("Income", new BigDecimal(100_000)),
                                                                    entry("Repayments", new BigDecimal(2_500)),
                                                                    entry("Expenses", new BigDecimal(10_000)))))); // DMN v1.2 spec page 181, first image: errata corrige values for Income and Expenses are likely inverted, corrected here.
-        context.set("Bureau data", mapOf(entry("Bankrupt", false),
+        context.set("Bureau data", mapOf(entry("Bankrupt", Boolean.FALSE),
                                          entry("CreditScore", new BigDecimal(600))));
         context.set("Requested product", mapOf(entry("ProductType", "STANDARD LOAN"),
                                                entry("Rate", new BigDecimal(0.08)),
@@ -2332,19 +2320,19 @@ public class DMNRuntimeTest extends BaseInterpretedVsCompiledTest {
         context.set("Supporting documents", null);
         final DMNResult dmnResult = runtime.evaluateAll(dmnModel, context);
         LOG.debug("{}", dmnResult);
-        assertThat(DMNRuntimeUtil.formatMessages(dmnResult.getMessages()), dmnResult.hasErrors(), is(false));
+        assertThat(dmnResult.hasErrors()).as(DMNRuntimeUtil.formatMessages(dmnResult.getMessages())).isFalse();
 
         final DMNContext result = dmnResult.getContext();
-        assertThat(result.get("Strategy"), is("THROUGH"));
-        assertThat(result.get("Routing"), is("ACCEPT"));
+        assertThat(result.get("Strategy")).isEqualTo("THROUGH");
+        assertThat(result.get("Routing")).isEqualTo("ACCEPT");
     }
     
     @Test(timeout = 30_000L)
     public void testAccessorCache() {
         final DMNRuntime runtime = DMNRuntimeUtil.createRuntime("20180731-pr1997.dmn", this.getClass());
         final DMNModel dmnModel = runtime.getModel("http://www.trisotech.com/dmn/definitions/_7a39d775-bce9-45e3-aa3b-147d6f0028c7", "20180731-pr1997");
-        assertThat(dmnModel, notNullValue());
-        assertThat(DMNRuntimeUtil.formatMessages(dmnModel.getMessages()), dmnModel.hasErrors(), is(false));
+        assertThat(dmnModel).isNotNull();
+        assertThat(dmnModel.hasErrors()).as(DMNRuntimeUtil.formatMessages(dmnModel.getMessages())).isFalse();
 
         for (int i = 0; i < 10_000; i++) {
             final DMNContext context = DMNFactory.newContext();
@@ -2352,10 +2340,10 @@ public class DMNRuntimeTest extends BaseInterpretedVsCompiledTest {
 
             final DMNResult dmnResult = runtime.evaluateAll(dmnModel, context);
             LOG.debug("{}", dmnResult);
-            assertThat(DMNRuntimeUtil.formatMessages(dmnResult.getMessages()), dmnResult.hasErrors(), is(false));
+            assertThat(dmnResult.hasErrors()).as(DMNRuntimeUtil.formatMessages(dmnResult.getMessages())).isFalse();
 
             final DMNContext result = dmnResult.getContext();
-            assertThat(result.get("Say hello and age"), is("Hello John Doe, your age is: " + i));
+            assertThat(result.get("Say hello and age")).isEqualTo("Hello John Doe, your age is: " + i);
         }
     }
 
@@ -2364,10 +2352,10 @@ public class DMNRuntimeTest extends BaseInterpretedVsCompiledTest {
         // DROOLS-2917 DMN resolveTypeRef returning null in BKM causes NPE during KieContainer compilation
         final List<DMNMessage> messages = DMNRuntimeUtil.createExpectingDMNMessages("WrongTypeRefForDRGElement.dmn", this.getClass());
         DMNRuntimeUtil.formatMessages(messages);
-        assertThat(messages.isEmpty(), is(false));
-        assertThat(messages.stream().anyMatch(m -> m.getMessageType().equals(DMNMessageType.TYPE_DEF_NOT_FOUND)), is(true));
-        assertThat(messages.stream().anyMatch(m -> m.getSourceId().equals("_561d31ba-a34b-4cf3-b9a4-537e21ce1013")), is(true));
-        assertThat(messages.stream().anyMatch(m -> m.getSourceId().equals("_45fa8674-f4f0-4c06-b2fd-52bbd17d8550")), is(true));
+        assertThat(messages).isNotEmpty();
+        assertThat(messages.stream().anyMatch(m -> m.getMessageType().equals(DMNMessageType.TYPE_DEF_NOT_FOUND))).isEqualTo(Boolean.TRUE);
+        assertThat(messages.stream().anyMatch(m -> m.getSourceId().equals("_561d31ba-a34b-4cf3-b9a4-537e21ce1013"))).isEqualTo(Boolean.TRUE);
+        assertThat(messages.stream().anyMatch(m -> m.getSourceId().equals("_45fa8674-f4f0-4c06-b2fd-52bbd17d8550"))).isEqualTo(Boolean.TRUE);
     }
 
     @Test
@@ -2377,8 +2365,8 @@ public class DMNRuntimeTest extends BaseInterpretedVsCompiledTest {
                                                                                        this.getClass(),
                                                                                        "imports/Importing_Person_DT_with_Person.dmn");
         final DMNModel dmnModel = runtime.getModel("http://www.trisotech.com/dmn/definitions/_3d586cb1-3ed0-4bc4-a1a7-070b70ece398", "Importing Person DT with Person");
-        assertThat(dmnModel, notNullValue());
-        assertThat(DMNRuntimeUtil.formatMessages(dmnModel.getMessages()), dmnModel.hasErrors(), is(false));
+        assertThat(dmnModel).isNotNull();
+        assertThat(dmnModel.hasErrors()).as(DMNRuntimeUtil.formatMessages(dmnModel.getMessages())).isFalse();
 
         final DMNContext context = DMNFactory.newContext();
         context.set("A Person here", mapOf(entry("age", new BigDecimal(17)),
@@ -2386,10 +2374,10 @@ public class DMNRuntimeTest extends BaseInterpretedVsCompiledTest {
 
         final DMNResult dmnResult = runtime.evaluateAll(dmnModel, context);
         LOG.debug("{}", dmnResult);
-        assertThat(DMNRuntimeUtil.formatMessages(dmnResult.getMessages()), dmnResult.hasErrors(), is(false));
+        assertThat(dmnResult.hasErrors()).as(DMNRuntimeUtil.formatMessages(dmnResult.getMessages())).isFalse();
 
         final DMNContext result = dmnResult.getContext();
-        assertThat(result.get("A Decision Table"), is("NOT Allowed"));
+        assertThat(result.get("A Decision Table")).isEqualTo("NOT Allowed");
     }
 
     @Test
@@ -2397,17 +2385,17 @@ public class DMNRuntimeTest extends BaseInterpretedVsCompiledTest {
         // DROOLS-3132 DMN assign null to ItemDefinition with allowedValues
         final DMNRuntime runtime = DMNRuntimeUtil.createRuntime("assignNullToAllowedValues.dmn", this.getClass());
         final DMNModel dmnModel = runtime.getModel("http://www.trisotech.com/dmn/definitions/_700a46e0-01ed-4361-9034-4afdb2537ea4", "Drawing 1");
-        assertThat(dmnModel, notNullValue());
-        assertThat(DMNRuntimeUtil.formatMessages(dmnModel.getMessages()), dmnModel.hasErrors(), is(false));
+        assertThat(dmnModel).isNotNull();
+        assertThat(dmnModel.hasErrors()).as(DMNRuntimeUtil.formatMessages(dmnModel.getMessages())).isFalse();
 
         final DMNContext context = DMNFactory.newContext();
         context.set("an input letter", null);
         final DMNResult dmnResult = runtime.evaluateAll(dmnModel, context);
         LOG.debug("{}", dmnResult);
         DMNRuntimeUtil.formatMessages(dmnResult.getMessages());
-        assertThat(dmnResult.hasErrors(), is(true));
-        assertThat(dmnResult.getMessages().stream().anyMatch(m -> m.getSourceId().equals("_24e8b31b-9505-4f52-93af-6dd9ef39c72a")), is(true));
-        assertThat(dmnResult.getMessages().stream().anyMatch(m -> m.getSourceId().equals("_09945fda-2b89-4148-8758-0bcb91a66e4a")), is(true));
+        assertThat(dmnResult.hasErrors()).isTrue();
+        assertThat(dmnResult.getMessages().stream().anyMatch(m -> m.getSourceId().equals("_24e8b31b-9505-4f52-93af-6dd9ef39c72a"))).isEqualTo(Boolean.TRUE);
+        assertThat(dmnResult.getMessages().stream().anyMatch(m -> m.getSourceId().equals("_09945fda-2b89-4148-8758-0bcb91a66e4a"))).isEqualTo(Boolean.TRUE);
     }
 
     @Test
@@ -2415,18 +2403,18 @@ public class DMNRuntimeTest extends BaseInterpretedVsCompiledTest {
         // DROOLS-3132 DMN assign null to ItemDefinition with allowedValues
         final DMNRuntime runtime = DMNRuntimeUtil.createRuntime("assignNullToAllowedValuesExplicitingNull.dmn", this.getClass());
         final DMNModel dmnModel = runtime.getModel("http://www.trisotech.com/dmn/definitions/_700a46e0-01ed-4361-9034-4afdb2537ea4", "Drawing 1");
-        assertThat(dmnModel, notNullValue());
-        assertThat(DMNRuntimeUtil.formatMessages(dmnModel.getMessages()), dmnModel.hasErrors(), is(false));
+        assertThat(dmnModel).isNotNull();
+        assertThat(dmnModel.hasErrors()).as(DMNRuntimeUtil.formatMessages(dmnModel.getMessages())).isFalse();
 
         final DMNContext context = DMNFactory.newContext();
         context.set("an input letter", null);
         final DMNResult dmnResult = runtime.evaluateAll(dmnModel, context);
         LOG.debug("{}", dmnResult);
-        assertThat(DMNRuntimeUtil.formatMessages(dmnResult.getMessages()), dmnResult.hasErrors(), is(false));
-        assertThat(dmnResult.getDecisionResultByName("hardcoded letter").getEvaluationStatus(), is(DecisionEvaluationStatus.SUCCEEDED));
-        assertThat(dmnResult.getDecisionResultByName("hardcoded letter").getResult(), nullValue());
-        assertThat(dmnResult.getDecisionResultByName("decision over the input letter").getEvaluationStatus(), is(DecisionEvaluationStatus.SUCCEEDED));
-        assertThat(dmnResult.getDecisionResultByName("decision over the input letter").getResult(), nullValue());
+        assertThat(dmnResult.hasErrors()).as(DMNRuntimeUtil.formatMessages(dmnResult.getMessages())).isFalse();
+        assertThat(dmnResult.getDecisionResultByName("hardcoded letter").getEvaluationStatus()).isEqualTo(DecisionEvaluationStatus.SUCCEEDED);
+        assertThat(dmnResult.getDecisionResultByName("hardcoded letter").getResult()).isNull();
+        assertThat(dmnResult.getDecisionResultByName("decision over the input letter").getEvaluationStatus()).isEqualTo(DecisionEvaluationStatus.SUCCEEDED);
+        assertThat(dmnResult.getDecisionResultByName("decision over the input letter").getResult()).isNull();
     }
 
     @Test
@@ -2434,8 +2422,8 @@ public class DMNRuntimeTest extends BaseInterpretedVsCompiledTest {
         // DROOLS-
         final DMNRuntime runtime = DMNRuntimeUtil.createRuntime("EmptyinputValuesoutputValuesdefaultOutputEntry.dmn", this.getClass());
         final DMNModel dmnModel = runtime.getModel("http://www.trisotech.com/dmn/definitions/_31f2dde9-b27c-41f8-97b4-5c8dd728942e", "Drawing 1");
-        assertThat(dmnModel, notNullValue());
-        assertThat(DMNRuntimeUtil.formatMessages(dmnModel.getMessages()), dmnModel.hasErrors(), is(false));
+        assertThat(dmnModel).isNotNull();
+        assertThat(dmnModel.hasErrors()).as(DMNRuntimeUtil.formatMessages(dmnModel.getMessages())).isFalse();
 
         checkEmptyinputValuesoutputValuesdefaultOutputEntry(runtime, dmnModel, 47, "positive");
         checkEmptyinputValuesoutputValuesdefaultOutputEntry(runtime, dmnModel, -1, "negative");
@@ -2447,10 +2435,10 @@ public class DMNRuntimeTest extends BaseInterpretedVsCompiledTest {
 
         final DMNResult dmnResult = runtime.evaluateAll(dmnModel, context);
         LOG.debug("{}", dmnResult);
-        assertThat(DMNRuntimeUtil.formatMessages(dmnResult.getMessages()), dmnResult.hasErrors(), is(false));
+        assertThat(dmnResult.hasErrors()).as(DMNRuntimeUtil.formatMessages(dmnResult.getMessages())).isFalse();
 
         final DMNContext result = dmnResult.getContext();
-        assertThat(result.get("my DT"), is(my_DT));
+        assertThat(result.get("my DT")).isEqualTo(my_DT);
     }
 
     @Test
@@ -2458,15 +2446,15 @@ public class DMNRuntimeTest extends BaseInterpretedVsCompiledTest {
         // DROOLS-3279 DMN DRGElement typeRef to allow FEEL Any
         final DMNRuntime runtime = DMNRuntimeUtil.createRuntime("any-expression.dmn", this.getClass());
         final DMNModel dmnModel = runtime.getModel("https://github.com/kiegroup/drools/kie-dmn/_D8154592-7406-4E5A-B7F7-347984A92288", "_40F20B8D-84C1-4AC2-B28C-267892C15077");
-        assertThat(dmnModel, notNullValue());
-        assertThat(DMNRuntimeUtil.formatMessages(dmnModel.getMessages()), dmnModel.hasErrors(), is(false));
+        assertThat(dmnModel).isNotNull();
+        assertThat(dmnModel.hasErrors()).as(DMNRuntimeUtil.formatMessages(dmnModel.getMessages())).isFalse();
 
         final DMNContext emptyContext = DMNFactory.newContext();
         final DMNResult dmnResult = runtime.evaluateAll(dmnModel, emptyContext);
         LOG.debug("{}", dmnResult);
-        assertThat(DMNRuntimeUtil.formatMessages(dmnResult.getMessages()), dmnResult.hasErrors(), is(false));
-        assertThat(dmnResult.getDecisionResultByName("Decision-1").getEvaluationStatus(), is(DecisionEvaluationStatus.SUCCEEDED));
-        assertThat(dmnResult.getDecisionResultByName("Decision-1").getResult(), is("Hello World"));
+        assertThat(dmnResult.hasErrors()).as(DMNRuntimeUtil.formatMessages(dmnResult.getMessages())).isFalse();
+        assertThat(dmnResult.getDecisionResultByName("Decision-1").getEvaluationStatus()).isEqualTo(DecisionEvaluationStatus.SUCCEEDED);
+        assertThat(dmnResult.getDecisionResultByName("Decision-1").getResult()).isEqualTo("Hello World");
     }
 
     @Test
@@ -2478,9 +2466,9 @@ public class DMNRuntimeTest extends BaseInterpretedVsCompiledTest {
         final DMNContext emptyContext = DMNFactory.newContext();
         final DMNResult dmnResult = runtime.evaluateAll(dmnModel, emptyContext);
         LOG.debug("{}", dmnResult);
-        assertThat(DMNRuntimeUtil.formatMessages(dmnResult.getMessages()), dmnResult.hasErrors(), is(false));
-        assertThat(dmnResult.getDecisionResultByName("using get entries").getEvaluationStatus(), is(DecisionEvaluationStatus.SUCCEEDED));
-        assertThat(dmnResult.getDecisionResultByName("using get entries").getResult(), is(Arrays.asList("value2")));
+        assertThat(dmnResult.hasErrors()).as(DMNRuntimeUtil.formatMessages(dmnResult.getMessages())).isFalse();
+        assertThat(dmnResult.getDecisionResultByName("using get entries").getEvaluationStatus()).isEqualTo(DecisionEvaluationStatus.SUCCEEDED);
+        assertThat(dmnResult.getDecisionResultByName("using get entries").getResult()).asList().containsExactly("value2");
     }
 
     @Test
@@ -2492,9 +2480,9 @@ public class DMNRuntimeTest extends BaseInterpretedVsCompiledTest {
         final DMNContext emptyContext = DMNFactory.newContext();
         final DMNResult dmnResult = runtime.evaluateAll(dmnModel, emptyContext);
         LOG.debug("{}", dmnResult);
-        assertThat(DMNRuntimeUtil.formatMessages(dmnResult.getMessages()), dmnResult.hasErrors(), is(false));
-        assertThat(dmnResult.getDecisionResultByName("using get value").getEvaluationStatus(), is(DecisionEvaluationStatus.SUCCEEDED));
-        assertThat(dmnResult.getDecisionResultByName("using get value").getResult(), is("value2"));
+        assertThat(dmnResult.hasErrors()).as(DMNRuntimeUtil.formatMessages(dmnResult.getMessages())).isFalse();
+        assertThat(dmnResult.getDecisionResultByName("using get value").getEvaluationStatus()).isEqualTo(DecisionEvaluationStatus.SUCCEEDED);
+        assertThat(dmnResult.getDecisionResultByName("using get value").getResult()).isEqualTo("value2");
     }
 
     @Test
@@ -2524,11 +2512,11 @@ public class DMNRuntimeTest extends BaseInterpretedVsCompiledTest {
         myContext.set("period2", period2);
         final DMNResult dmnResult = runtime.evaluateDecisionService(dmnModel, myContext, "Decision Service 1");
         LOG.debug("{}", dmnResult);
-        assertThat(dmnResult.getContext().getAll(), not(hasEntry(is("Decision1"), anything()))); // we invoked only the Decision Service, not this other Decision in the model.
-        assertThat(dmnResult.getDecisionResultByName("Decision2").getEvaluationStatus(), is(DecisionEvaluationStatus.SUCCEEDED));
-        assertThat(dmnResult.getDecisionResultByName("Decision2").getResult(), is(instanceOf(ChronoPeriod.class)));
-        assertThat(((ChronoPeriod) dmnResult.getDecisionResultByName("Decision2").getResult()).get(ChronoUnit.YEARS), is(2L));
-        assertThat(((ChronoPeriod) dmnResult.getDecisionResultByName("Decision2").getResult()).get(ChronoUnit.MONTHS), is(1L));
+        assertThat(dmnResult.getContext().getAll()).doesNotContainKey("Decision1"); // we invoked only the Decision Service, not this other Decision in the model.
+        assertThat(dmnResult.getDecisionResultByName("Decision2").getEvaluationStatus()).isEqualTo(DecisionEvaluationStatus.SUCCEEDED);
+        assertThat(dmnResult.getDecisionResultByName("Decision2").getResult()).isInstanceOf(ChronoPeriod.class);
+        assertThat(((ChronoPeriod) dmnResult.getDecisionResultByName("Decision2").getResult()).get(ChronoUnit.YEARS)).isEqualTo(2L);
+        assertThat(((ChronoPeriod) dmnResult.getDecisionResultByName("Decision2").getResult()).get(ChronoUnit.MONTHS)).isEqualTo(1L);
     }
 
     private void checkChronoPeriodEvaluateAll(final DMNRuntime runtime, final DMNModel dmnModel, ChronoPeriod period1, ChronoPeriod period2) {
@@ -2537,15 +2525,15 @@ public class DMNRuntimeTest extends BaseInterpretedVsCompiledTest {
         myContext.set("period2", period2);
         final DMNResult dmnResult = runtime.evaluateAll(dmnModel, myContext);
         LOG.debug("{}", dmnResult);
-        assertThat(DMNRuntimeUtil.formatMessages(dmnResult.getMessages()), dmnResult.hasErrors(), is(false));
-        assertThat(dmnResult.getDecisionResultByName("Decision1").getEvaluationStatus(), is(DecisionEvaluationStatus.SUCCEEDED));
-        assertThat(dmnResult.getDecisionResultByName("Decision1").getResult(), is(instanceOf(ChronoPeriod.class)));
-        assertThat(((ChronoPeriod) dmnResult.getDecisionResultByName("Decision1").getResult()).get(ChronoUnit.YEARS), is(1L));
-        assertThat(((ChronoPeriod) dmnResult.getDecisionResultByName("Decision1").getResult()).get(ChronoUnit.MONTHS), is(1L));
-        assertThat(dmnResult.getDecisionResultByName("Decision2").getEvaluationStatus(), is(DecisionEvaluationStatus.SUCCEEDED));
-        assertThat(dmnResult.getDecisionResultByName("Decision2").getResult(), is(instanceOf(ChronoPeriod.class)));
-        assertThat(((ChronoPeriod) dmnResult.getDecisionResultByName("Decision2").getResult()).get(ChronoUnit.YEARS), is(2L));
-        assertThat(((ChronoPeriod) dmnResult.getDecisionResultByName("Decision2").getResult()).get(ChronoUnit.MONTHS), is(1L));
+        assertThat(dmnResult.hasErrors()).as(DMNRuntimeUtil.formatMessages(dmnResult.getMessages())).isFalse();
+        assertThat(dmnResult.getDecisionResultByName("Decision1").getEvaluationStatus()).isEqualTo(DecisionEvaluationStatus.SUCCEEDED);
+        assertThat(dmnResult.getDecisionResultByName("Decision1").getResult()).isInstanceOf(ChronoPeriod.class);
+        assertThat(((ChronoPeriod) dmnResult.getDecisionResultByName("Decision1").getResult()).get(ChronoUnit.YEARS)).isEqualTo(1L);
+        assertThat(((ChronoPeriod) dmnResult.getDecisionResultByName("Decision1").getResult()).get(ChronoUnit.MONTHS)).isEqualTo(1L);
+        assertThat(dmnResult.getDecisionResultByName("Decision2").getEvaluationStatus()).isEqualTo(DecisionEvaluationStatus.SUCCEEDED);
+        assertThat(dmnResult.getDecisionResultByName("Decision2").getResult()).isInstanceOf(ChronoPeriod.class);
+        assertThat(((ChronoPeriod) dmnResult.getDecisionResultByName("Decision2").getResult()).get(ChronoUnit.YEARS)).isEqualTo(2L);
+        assertThat(((ChronoPeriod) dmnResult.getDecisionResultByName("Decision2").getResult()).get(ChronoUnit.MONTHS)).isEqualTo(1L);
     }
 
     @Test
@@ -2553,8 +2541,8 @@ public class DMNRuntimeTest extends BaseInterpretedVsCompiledTest {
         // DROOLS-3998 DMN FEEL parser Table61 error with aliased type
         final DMNRuntime runtime = DMNRuntimeUtil.createRuntime("Table61ForAliasFeelType.dmn", this.getClass());
         final DMNModel dmnModel = runtime.getModel("http://www.trisotech.com/definitions/_aaff9a5f-a654-40d3-a209-8a7dc1d74eeb", "Drawing 1");
-        assertThat(dmnModel, notNullValue());
-        assertThat(DMNRuntimeUtil.formatMessages(dmnModel.getMessages()), dmnModel.hasErrors(), is(false));
+        assertThat(dmnModel).isNotNull();
+        assertThat(dmnModel.hasErrors()).as(DMNRuntimeUtil.formatMessages(dmnModel.getMessages())).isFalse();
 
         final DMNContext context = DMNFactory.newContext();
         context.set("my input", mapOf(entry("Date", LocalDate.of(2019, 5, 10)),
@@ -2562,10 +2550,10 @@ public class DMNRuntimeTest extends BaseInterpretedVsCompiledTest {
 
         final DMNResult dmnResult = runtime.evaluateAll(dmnModel, context);
         LOG.debug("{}", dmnResult);
-        assertThat(DMNRuntimeUtil.formatMessages(dmnResult.getMessages()), dmnResult.hasErrors(), is(false));
+        assertThat(dmnResult.hasErrors()).as(DMNRuntimeUtil.formatMessages(dmnResult.getMessages())).isFalse();
 
         final DMNContext result = dmnResult.getContext();
-        assertThat(result.get("my decision"), is(new BigDecimal("2019")));
+        assertThat(result.get("my decision")).isEqualTo(new BigDecimal("2019"));
     }
 
     @Test
@@ -2573,19 +2561,19 @@ public class DMNRuntimeTest extends BaseInterpretedVsCompiledTest {
         // DROOLS-4173 DMN composite recursive ItemDefinition
         final DMNRuntime runtime = DMNRuntimeUtil.createRuntime("cItemDef.dmn", this.getClass());
         final DMNModel dmnModel = runtime.getModel("http://www.trisotech.com/definitions/_f776b6fb-31bc-43b6-9c89-2bbc2973babf", "Drawing 1");
-        assertThat(dmnModel, notNullValue());
-        assertThat(DMNRuntimeUtil.formatMessages(dmnModel.getMessages()), dmnModel.hasErrors(), is(false));
+        assertThat(dmnModel).isNotNull();
+        assertThat(dmnModel.hasErrors()).as(DMNRuntimeUtil.formatMessages(dmnModel.getMessages())).isFalse();
 
         final DMNContext context = DMNFactory.newContext();
         final DMNResult dmnResult = runtime.evaluateAll(dmnModel, context);
         LOG.debug("{}", dmnResult);
-        assertThat(DMNRuntimeUtil.formatMessages(dmnResult.getMessages()), dmnResult.hasErrors(), is(false));
+        assertThat(dmnResult.hasErrors()).as(DMNRuntimeUtil.formatMessages(dmnResult.getMessages())).isFalse();
 
         final DMNContext result = dmnResult.getContext();
-        assertThat((Map<?, ?>) result.get("hardcoded decision"), hasEntry(is("full name"), is("John Doe")));
-        assertThat((Map<?, ?>) result.get("hardcoded decision"), hasEntry(is("supervisor"), anything()));
-        assertThat((Map<?, ?>) ((Map<?, ?>) result.get("hardcoded decision")).get("supervisor"), hasEntry(is("full name"), is("supervisor of John")));
-        assertThat((Map<?, ?>) ((Map<?, ?>) result.get("hardcoded decision")).get("supervisor"), hasEntry(is("supervisor"), nullValue()));
+        assertThat((Map<String, Object>) result.get("hardcoded decision")).containsEntry("full name", "John Doe");
+        assertThat((Map<String, Object>) result.get("hardcoded decision")).containsKey("supervisor");
+        assertThat((Map<String, Object>) ((Map<?, ?>) result.get("hardcoded decision")).get("supervisor")).containsEntry("full name", "supervisor of John");
+        assertThat((Map<String, Object>) ((Map<?, ?>) result.get("hardcoded decision")).get("supervisor")).containsEntry("supervisor", null);
     }
 
     @Test
@@ -2603,18 +2591,18 @@ public class DMNRuntimeTest extends BaseInterpretedVsCompiledTest {
     private void testDTinputExprCollectionWithAllowedValues(final DMNRuntime runtime) {
         // DROOLS-4379 DMN decision table input expr collection with allowedValues
         final DMNModel dmnModel = runtime.getModel("http://www.trisotech.com/definitions/_95436b7a-7268-4713-bf84-58bff10407b4", "Dessin 1");
-        assertThat(dmnModel, notNullValue());
-        assertThat(DMNRuntimeUtil.formatMessages(dmnModel.getMessages()), dmnModel.hasErrors(), is(false));
+        assertThat(dmnModel).isNotNull();
+        assertThat(dmnModel.hasErrors()).as(DMNRuntimeUtil.formatMessages(dmnModel.getMessages())).isFalse();
 
         final DMNContext context = DMNFactory.newContext();
         context.set("test", Arrays.asList("r2", "r1"));
         final DMNResult dmnResult = runtime.evaluateAll(dmnModel, context);
         LOG.debug("{}", dmnResult);
-        assertThat(DMNRuntimeUtil.formatMessages(dmnResult.getMessages()), dmnResult.hasErrors(), is(false));
+        assertThat(dmnResult.hasErrors()).as(DMNRuntimeUtil.formatMessages(dmnResult.getMessages())).isFalse();
 
         final DMNContext result = dmnResult.getContext();
-        assertThat(result.get("D4"), is("Contains r1"));
-        assertThat((List<?>) result.get("D5"), contains(is("r1"), is("r2")));
+        assertThat(result.get("D4")).isEqualTo("Contains r1");
+        assertThat((List<?>) result.get("D5")).asList().contains("r1", "r2");
     }
 
     @Test
@@ -2622,19 +2610,19 @@ public class DMNRuntimeTest extends BaseInterpretedVsCompiledTest {
         // DROOLS-4390 DMN correct FEEL grammar exclusion
         final DMNRuntime runtime = DMNRuntimeUtil.createRuntime("Slash.dmn", this.getClass());
         final DMNModel dmnModel = runtime.getModel("http://www.trisotech.com/definitions/_efb0df9e-cd3a-4bda-b731-e6b184a6cd73", "Drawing 1");
-        assertThat(dmnModel, notNullValue());
-        assertThat(DMNRuntimeUtil.formatMessages(dmnModel.getMessages()), dmnModel.hasErrors(), is(false));
+        assertThat(dmnModel).isNotNull();
+        assertThat(dmnModel.hasErrors()).as(DMNRuntimeUtil.formatMessages(dmnModel.getMessages())).isFalse();
 
         final DMNContext context = DMNFactory.newContext();
         context.set("A/B", "A");
 
         final DMNResult dmnResult = runtime.evaluateAll(dmnModel, context);
         LOG.debug("{}", dmnResult);
-        assertThat(DMNRuntimeUtil.formatMessages(dmnResult.getMessages()), dmnResult.hasErrors(), is(false));
+        assertThat(dmnResult.hasErrors()).as(DMNRuntimeUtil.formatMessages(dmnResult.getMessages())).isFalse();
 
         final DMNContext result = dmnResult.getContext();
-        assertThat(result.get("Decision Table"), is("A"));
-        assertThat(result.get("Litteral Expression"), is("A"));
+        assertThat(result.get("Decision Table")).isEqualTo("A");
+        assertThat(result.get("Litteral Expression")).isEqualTo("A");
     }
 
     @Test
@@ -2642,20 +2630,20 @@ public class DMNRuntimeTest extends BaseInterpretedVsCompiledTest {
         // DROOLS-4504 DMN time offset accessor from decl variable type
         final DMNRuntime runtime = DMNRuntimeUtil.createRuntime("ContextEntryTypeCascade.dmn", this.getClass());
         final DMNModel dmnModel = runtime.getModel("http://www.trisotech.com/definitions/_8a15bd3c-c732-42c8-a2e4-60f1a23a1c5a", "Drawing 1");
-        assertThat(dmnModel, notNullValue());
-        assertThat(DMNRuntimeUtil.formatMessages(dmnModel.getMessages()), dmnModel.hasErrors(), is(false));
+        assertThat(dmnModel).isNotNull();
+        assertThat(dmnModel.hasErrors()).as(DMNRuntimeUtil.formatMessages(dmnModel.getMessages())).isFalse();
 
         final DMNContext context = DMNFactory.newContext();
 
         final DMNResult dmnResult = runtime.evaluateAll(dmnModel, context);
         LOG.debug("{}", dmnResult);
-        assertThat(DMNRuntimeUtil.formatMessages(dmnResult.getMessages()), dmnResult.hasErrors(), is(false));
+        assertThat(dmnResult.hasErrors()).as(DMNRuntimeUtil.formatMessages(dmnResult.getMessages())).isFalse();
 
         final DMNContext result = dmnResult.getContext();
-        assertThat(((Map<?, ?>) result.get("Date and Time")).get("Working DT hours"), is(new BigDecimal("-9")));
-        assertThat(((Map<?, ?>) result.get("Date and Time")).get("Not working DT hours from Variable"), is(new BigDecimal("-9")));
-        assertThat(((Map<?, ?>) result.get("Time")).get("Working Time hours"), is(new BigDecimal("-11")));
-        assertThat(((Map<?, ?>) result.get("Time")).get("Not working Time hours from Variable"), is(new BigDecimal("-11")));
+        assertThat(((Map<?, ?>) result.get("Date and Time")).get("Working DT hours")).isEqualTo(new BigDecimal("-9"));
+        assertThat(((Map<?, ?>) result.get("Date and Time")).get("Not working DT hours from Variable")).isEqualTo(new BigDecimal("-9"));
+        assertThat(((Map<?, ?>) result.get("Time")).get("Working Time hours")).isEqualTo(new BigDecimal("-11"));
+        assertThat(((Map<?, ?>) result.get("Time")).get("Not working Time hours from Variable")).isEqualTo(new BigDecimal("-11"));
     }
 
     @Test
@@ -2663,8 +2651,8 @@ public class DMNRuntimeTest extends BaseInterpretedVsCompiledTest {
         // DROOLS-4679 DMN FEEL list contains() invocation from DMN layer fixes
         final DMNRuntime runtime = DMNRuntimeUtil.createRuntime("so58507157.dmn", this.getClass());
         final DMNModel dmnModel = runtime.getModel("http://sample.dmn", "DecisionNumberInList");
-        assertThat(dmnModel, notNullValue());
-        assertThat(DMNRuntimeUtil.formatMessages(dmnModel.getMessages()), dmnModel.hasErrors(), is(false));
+        assertThat(dmnModel).isNotNull();
+        assertThat(dmnModel.hasErrors()).as(DMNRuntimeUtil.formatMessages(dmnModel.getMessages())).isFalse();
 
         final DMNContext context = DMNFactory.newContext();
         context.set("inputNumber", 1);
@@ -2672,13 +2660,13 @@ public class DMNRuntimeTest extends BaseInterpretedVsCompiledTest {
 
         final DMNResult dmnResult = runtime.evaluateAll(dmnModel, context);
         LOG.debug("{}", dmnResult);
-        assertThat(DMNRuntimeUtil.formatMessages(dmnResult.getMessages()), dmnResult.hasErrors(), is(false));
+        assertThat(dmnResult.hasErrors()).as(DMNRuntimeUtil.formatMessages(dmnResult.getMessages())).isFalse();
 
         final DMNContext result = dmnResult.getContext();
-        assertThat((Map<?, ?>) result.get("DecisionNumberInList"), hasEntry(is("Result_1_OK"), is(true)));
-        assertThat((Map<?, ?>) result.get("DecisionNumberInList"), hasEntry(is("Result_2_OK"), is(true)));
-        assertThat((Map<?, ?>) result.get("DecisionNumberInList"), hasEntry(is("Result_3"), is(true)));
-        assertThat((Map<?, ?>) result.get("DecisionNumberInList"), hasEntry(is("Result_4"), is(true)));
+        assertThat((Map<String, Object>) result.get("DecisionNumberInList")).containsEntry("Result_1_OK",Boolean.TRUE);
+        assertThat((Map<String, Object>) result.get("DecisionNumberInList")).containsEntry("Result_2_OK",Boolean.TRUE);
+        assertThat((Map<String, Object>) result.get("DecisionNumberInList")).containsEntry("Result_3",Boolean.TRUE);
+        assertThat((Map<String, Object>) result.get("DecisionNumberInList")).containsEntry("Result_4",Boolean.TRUE);
     }
 
     @Test
@@ -2686,24 +2674,22 @@ public class DMNRuntimeTest extends BaseInterpretedVsCompiledTest {
         // DROOLS-4765 DMN validation rule alignment for missing expression
         final DMNRuntime runtime = DMNRuntimeUtil.createRuntime("noExpr.dmn", this.getClass());
         final DMNModel dmnModel = runtime.getModel("http://www.trisotech.com/definitions/_461041dc-9ab9-4e23-ae01-3366a7544cd3", "Drawing 1");
-        assertThat(dmnModel, notNullValue());
-        assertThat(DMNRuntimeUtil.formatMessages(dmnModel.getMessages()), dmnModel.hasErrors(), is(false));
-        assertThat(DMNRuntimeUtil.formatMessages(dmnModel.getMessages()), dmnModel.getMessages(DMNMessage.Severity.WARN).size(), is(1));
+        assertThat(dmnModel).isNotNull();
+        assertThat(dmnModel.hasErrors()).as(DMNRuntimeUtil.formatMessages(dmnModel.getMessages())).isFalse();
+        assertThat(dmnModel.getMessages(DMNMessage.Severity.WARN)).as(DMNRuntimeUtil.formatMessages(dmnModel.getMessages())).hasSize(1);
 
         final DMNContext context = DMNFactory.newContext();
 
         final DMNResult dmnResult = runtime.evaluateAll(dmnModel, context);
         LOG.debug("{}", dmnResult);
-        assertThat(DMNRuntimeUtil.formatMessages(dmnResult.getMessages()), dmnResult.hasErrors(), is(false));
-        assertThat(DMNRuntimeUtil.formatMessages(dmnModel.getMessages()), dmnModel.getMessages(DMNMessage.Severity.WARN).size(), is(1));
-        assertThat(DMNRuntimeUtil.formatMessages(dmnModel.getMessages()),
-                   dmnModel.getMessages(DMNMessage.Severity.WARN)
+        assertThat(dmnResult.hasErrors()).as(DMNRuntimeUtil.formatMessages(dmnResult.getMessages())).isFalse();
+        assertThat(dmnModel.getMessages(DMNMessage.Severity.WARN)).as(DMNRuntimeUtil.formatMessages(dmnModel.getMessages())).hasSize(1);
+        assertThat(dmnModel.getMessages(DMNMessage.Severity.WARN)
                            .stream()
                            .filter(m -> m.getSourceId().equals("_cdd03786-d1ab-47b5-ba05-df830458dc62"))
-                           .count(),
-                   is(1L));
-        assertThat(dmnResult.getDecisionResultByName("is it raining?").getEvaluationStatus(), is(DecisionEvaluationStatus.SUCCEEDED));
-        assertThat(dmnResult.getDecisionResultByName("what to do today?").getEvaluationStatus(), is(DecisionEvaluationStatus.SKIPPED));
+                           .count()).as(DMNRuntimeUtil.formatMessages(dmnModel.getMessages())).isEqualTo(1L);
+        assertThat(dmnResult.getDecisionResultByName("is it raining?").getEvaluationStatus()).isEqualTo(DecisionEvaluationStatus.SUCCEEDED);
+        assertThat(dmnResult.getDecisionResultByName("what to do today?").getEvaluationStatus()).isEqualTo(DecisionEvaluationStatus.SKIPPED);
     }
 
     @Test
@@ -2722,46 +2708,46 @@ public class DMNRuntimeTest extends BaseInterpretedVsCompiledTest {
 
     private void verify_testItemDefinitionInXmlns(final DMNRuntime runtime) {
         final DMNModel dmnModel = runtime.getModel("http://sample.dmn", "MyDecision");
-        assertThat(dmnModel, notNullValue());
-        assertThat(DMNRuntimeUtil.formatMessages(dmnModel.getMessages()), dmnModel.hasErrors(), is(false));
+        assertThat(dmnModel).isNotNull();
+        assertThat(dmnModel.hasErrors()).as(DMNRuntimeUtil.formatMessages(dmnModel.getMessages())).isFalse();
 
         final DMNContext context = DMNFactory.newContext();
         context.set("person", mapOf(entry("name", "John"), entry("age", new BigDecimal(9))));
 
         final DMNResult dmnResult = runtime.evaluateAll(dmnModel, context);
         LOG.debug("{}", dmnResult);
-        assertThat(DMNRuntimeUtil.formatMessages(dmnResult.getMessages()), dmnResult.hasErrors(), is(false));
-        assertThat(DMNRuntimeUtil.formatMessages(dmnResult.getMessages()), dmnResult.getDecisionResultByName("greet").getResult(), is("Hello, John"));
+        assertThat(dmnResult.hasErrors()).as(DMNRuntimeUtil.formatMessages(dmnResult.getMessages())).isFalse();
+        assertThat(dmnResult.getDecisionResultByName("greet").getResult()).as(DMNRuntimeUtil.formatMessages(dmnResult.getMessages())).isEqualTo("Hello, John");
     }
 
     @Test
     public void testOpInNames1() {
         final DMNRuntime runtime = DMNRuntimeUtil.createRuntime("OpInNames1.dmn", this.getClass());
         final DMNModel dmnModel = runtime.getModel("http://www.trisotech.com/definitions/_dae806ec-f00e-41a8-b6d1-2754fcd7fa2d", "Drawing 1");
-        assertThat(dmnModel, notNullValue());
-        assertThat(DMNRuntimeUtil.formatMessages(dmnModel.getMessages()), dmnModel.hasErrors(), is(false));
+        assertThat(dmnModel).isNotNull();
+        assertThat(dmnModel.hasErrors()).as(DMNRuntimeUtil.formatMessages(dmnModel.getMessages())).isFalse();
 
         final DMNContext context = DMNFactory.newContext();
 
         final DMNResult dmnResult = runtime.evaluateAll(dmnModel, context);
         LOG.debug("{}", dmnResult);
-        assertThat(DMNRuntimeUtil.formatMessages(dmnResult.getMessages()), dmnResult.hasErrors(), is(false));
-        assertThat(DMNRuntimeUtil.formatMessages(dmnResult.getMessages()), dmnResult.getDecisionResultByName("decision1").getResult(), is("make and model"));
+        assertThat(dmnResult.hasErrors()).as(DMNRuntimeUtil.formatMessages(dmnResult.getMessages())).isFalse();
+        assertThat(dmnResult.getDecisionResultByName("decision1").getResult()).as(DMNRuntimeUtil.formatMessages(dmnResult.getMessages())).isEqualTo("make and model");
     }
 
     @Test
     public void testOpInNames2() {
         final DMNRuntime runtime = DMNRuntimeUtil.createRuntime("OpInNames2.dmn", this.getClass());
         final DMNModel dmnModel = runtime.getModel("http://www.trisotech.com/definitions/_dae806ec-f00e-41a8-b6d1-2754fcd7fa2d", "Drawing 1");
-        assertThat(dmnModel, notNullValue());
-        assertThat(DMNRuntimeUtil.formatMessages(dmnModel.getMessages()), dmnModel.hasErrors(), is(false));
+        assertThat(dmnModel).isNotNull();
+        assertThat(dmnModel.hasErrors()).as(DMNRuntimeUtil.formatMessages(dmnModel.getMessages())).isFalse();
 
         final DMNContext context = DMNFactory.newContext();
 
         final DMNResult dmnResult = runtime.evaluateAll(dmnModel, context);
         LOG.debug("{}", dmnResult);
-        assertThat(DMNRuntimeUtil.formatMessages(dmnResult.getMessages()), dmnResult.hasErrors(), is(false));
-        assertThat(DMNRuntimeUtil.formatMessages(dmnResult.getMessages()), dmnResult.getDecisionResultByName("decision1").getResult(), is("DMN"));
+        assertThat(dmnResult.hasErrors()).as(DMNRuntimeUtil.formatMessages(dmnResult.getMessages())).isFalse();
+        assertThat(dmnResult.getDecisionResultByName("decision1").getResult()).as(DMNRuntimeUtil.formatMessages(dmnResult.getMessages())).isEqualTo("DMN");
     }
 
     @Test
@@ -2769,30 +2755,28 @@ public class DMNRuntimeTest extends BaseInterpretedVsCompiledTest {
         // DROOLS-4825 DMN v1.3 verify DMN13-132 type conversions
         final DMNRuntime runtime = DMNRuntimeUtil.createRuntime("v1_3/DMN13-132.dmn", this.getClass());
         final DMNModel dmnModel = runtime.getModel("http://www.trisotech.com/definitions/_9d01a0c4-f529-4ad8-ad8e-ec5fb5d96ad4", "DMN13-132");
-        assertThat(dmnModel, notNullValue());
-        assertThat(DMNRuntimeUtil.formatMessages(dmnModel.getMessages()), dmnModel.hasErrors(), is(false));
+        assertThat(dmnModel).isNotNull();
+        assertThat(dmnModel.hasErrors()).as(DMNRuntimeUtil.formatMessages(dmnModel.getMessages())).isFalse();
 
         final DMNContext context = DMNFactory.newContext();
 
         final DMNResult dmnResult = runtime.evaluateAll(dmnModel, context);
         LOG.debug("{}", dmnResult);
-        assertThat(DMNRuntimeUtil.formatMessages(dmnResult.getMessages()), dmnResult.hasErrors(), is(true));
-        assertThat(DMNRuntimeUtil.formatMessages(dmnResult.getMessages()),
-                   dmnResult.getMessages(DMNMessage.Severity.ERROR)
+        assertThat(dmnResult.hasErrors()).as(DMNRuntimeUtil.formatMessages(dmnResult.getMessages())).isTrue();
+        assertThat(dmnResult.getMessages(DMNMessage.Severity.ERROR)
                             .stream()
                             .filter(m -> m.getSourceId().equals("_decision_003"))
-                            .count(),
-                   is(1L));
-        assertThat(dmnResult.getDecisionResultByName("decision_003").getEvaluationStatus(), is(DecisionEvaluationStatus.FAILED));
-        assertThat(dmnResult.getDecisionResultByName("decision_003").getResult(), nullValue());
+                            .count()).as(DMNRuntimeUtil.formatMessages(dmnResult.getMessages())).isEqualTo(1L);
+        assertThat(dmnResult.getDecisionResultByName("decision_003").getEvaluationStatus()).isEqualTo(DecisionEvaluationStatus.FAILED);
+        assertThat(dmnResult.getDecisionResultByName("decision_003").getResult()).isNull();
     }
 
     @Test
     public void testClassicComparisonVsRange() {
         final DMNRuntime runtime = DMNRuntimeUtil.createRuntime("classicComparisonVsRange.dmn", this.getClass());
         final DMNModel dmnModel = runtime.getModel("http://www.trisotech.com/definitions/_ac6efb68-08ed-43ec-b427-e99e78f51ba1", "Drawing 1");
-        assertThat(dmnModel, notNullValue());
-        assertThat(DMNRuntimeUtil.formatMessages(dmnModel.getMessages()), dmnModel.hasErrors(), is(false));
+        assertThat(dmnModel).isNotNull();
+        assertThat(dmnModel.hasErrors()).as(DMNRuntimeUtil.formatMessages(dmnModel.getMessages())).isFalse();
 
         for (int i = 1; i <= 10; i++) {
             for (int j = 1; j <= 10; j++) {
@@ -2807,9 +2791,9 @@ public class DMNRuntimeTest extends BaseInterpretedVsCompiledTest {
 
                 final DMNResult dmnResult = runtime.evaluateAll(dmnModel, context);
                 LOG.debug("{}", dmnResult);
-                assertThat(DMNRuntimeUtil.formatMessages(dmnResult.getMessages()), dmnResult.hasErrors(), is(false));
-                assertThat(DMNRuntimeUtil.formatMessages(dmnResult.getMessages()), dmnResult.getDecisionResultByName("classic comparison").getResult(), is(expectedResult));
-                assertThat(DMNRuntimeUtil.formatMessages(dmnResult.getMessages()), dmnResult.getDecisionResultByName("using range").getResult(), is(expectedResult));
+                assertThat(dmnResult.hasErrors()).as(DMNRuntimeUtil.formatMessages(dmnResult.getMessages())).isFalse();
+                assertThat(dmnResult.getDecisionResultByName("classic comparison").getResult()).as(DMNRuntimeUtil.formatMessages(dmnResult.getMessages())).isEqualTo(expectedResult);
+                assertThat(dmnResult.getDecisionResultByName("using range").getResult()).as(DMNRuntimeUtil.formatMessages(dmnResult.getMessages())).isEqualTo(expectedResult);
             }
         }
     }
@@ -2818,23 +2802,23 @@ public class DMNRuntimeTest extends BaseInterpretedVsCompiledTest {
     public void testFunctionDefinitionParameterTrailingSpace() {
         final DMNRuntime runtime = DMNRuntimeUtil.createRuntime("DROOLS4555.dmn", this.getClass());
         final DMNModel dmnModel = runtime.getModel("http://www.trisotech.com/definitions/_e1645e17-7e28-4226-ad60-95e6f81cb50b", "Drawing 1");
-        assertThat(dmnModel, notNullValue());
-        assertThat(DMNRuntimeUtil.formatMessages(dmnModel.getMessages()), dmnModel.hasErrors(), is(false));
+        assertThat(dmnModel).isNotNull();
+        assertThat(dmnModel.hasErrors()).as(DMNRuntimeUtil.formatMessages(dmnModel.getMessages())).isFalse();
 
         final DMNContext context = DMNFactory.newContext();
 
         final DMNResult dmnResult = runtime.evaluateAll(dmnModel, context);
         LOG.debug("{}", dmnResult);
-        assertThat(DMNRuntimeUtil.formatMessages(dmnResult.getMessages()), dmnResult.hasErrors(), is(false));
-        assertThat(DMNRuntimeUtil.formatMessages(dmnResult.getMessages()), dmnResult.getDecisionResultByName("hardcoded").getResult(), is("Hello, x"));
+        assertThat(dmnResult.hasErrors()).as(DMNRuntimeUtil.formatMessages(dmnResult.getMessages())).isFalse();
+        assertThat(dmnResult.getDecisionResultByName("hardcoded").getResult()).as(DMNRuntimeUtil.formatMessages(dmnResult.getMessages())).isEqualTo("Hello, x");
     }
 
     @Test(expected = IllegalArgumentException.class)
     public void testEvaluateByNameWithEmptyParam() {
         final DMNRuntime runtime = DMNRuntimeUtil.createRuntime("simple-item-def.dmn", this.getClass());
         final DMNModel dmnModel = runtime.getModel("https://github.com/kiegroup/kie-dmn/itemdef", "simple-item-def");
-        assertThat(dmnModel, notNullValue());
-        assertThat(DMNRuntimeUtil.formatMessages(dmnModel.getMessages()), dmnModel.hasErrors(), is(false));
+        assertThat(dmnModel).isNotNull();
+        assertThat(dmnModel.hasErrors()).as(DMNRuntimeUtil.formatMessages(dmnModel.getMessages())).isFalse();
 
         final DMNContext context = DMNFactory.newContext();
         context.set("Monthly Salary", 1000);
@@ -2847,8 +2831,8 @@ public class DMNRuntimeTest extends BaseInterpretedVsCompiledTest {
     public void testEvaluateByIdWithEmptyParam() {
         final DMNRuntime runtime = DMNRuntimeUtil.createRuntime("simple-item-def.dmn", this.getClass());
         final DMNModel dmnModel = runtime.getModel("https://github.com/kiegroup/kie-dmn/itemdef", "simple-item-def");
-        assertThat(dmnModel, notNullValue());
-        assertThat(DMNRuntimeUtil.formatMessages(dmnModel.getMessages()), dmnModel.hasErrors(), is(false));
+        assertThat(dmnModel).isNotNull();
+        assertThat(dmnModel.hasErrors()).as(DMNRuntimeUtil.formatMessages(dmnModel.getMessages())).isFalse();
 
         final DMNContext context = DMNFactory.newContext();
         context.set("Monthly Salary", 1000);
@@ -2888,42 +2872,42 @@ public class DMNRuntimeTest extends BaseInterpretedVsCompiledTest {
     public void testJavaPojoCharUtilDate() {
         final DMNRuntime runtime = DMNRuntimeUtil.createRuntime("javaPojoCharUtilDate.dmn", this.getClass());
         final DMNModel dmnModel = runtime.getModel("http://www.trisotech.com/definitions/_5eaccc88-cbf0-4c58-945a-952d8bf974ed", "Drawing 1");
-        assertThat(dmnModel, notNullValue());
-        assertThat(DMNRuntimeUtil.formatMessages(dmnModel.getMessages()), dmnModel.hasErrors(), is(false));
+        assertThat(dmnModel).isNotNull();
+        assertThat(dmnModel.hasErrors()).as(DMNRuntimeUtil.formatMessages(dmnModel.getMessages())).isFalse();
 
         final DMNContext context = DMNFactory.newContext();
         context.set("my data", new JavaPojoCharUtilDate("Doe", new Character('J'), new java.util.Date(2020, 0, 28, 10, 15)));
 
         final DMNResult dmnResult = runtime.evaluateAll(dmnModel, context);
         LOG.debug("{}", dmnResult);
-        assertThat(DMNRuntimeUtil.formatMessages(dmnResult.getMessages()), dmnResult.hasErrors(), is(false));
-        assertThat(DMNRuntimeUtil.formatMessages(dmnResult.getMessages()), dmnResult.getDecisionResultByName("my decision").getResult(), is("The person: Doe J., on the 28 of the month 1 at the 10 hour."));
+        assertThat(dmnResult.hasErrors()).as(DMNRuntimeUtil.formatMessages(dmnResult.getMessages())).isFalse();
+        assertThat(dmnResult.getDecisionResultByName("my decision").getResult()).as(DMNRuntimeUtil.formatMessages(dmnResult.getMessages())).isEqualTo("The person: Doe J., on the 28 of the month 1 at the 10 hour.");
     }
 
     @Test
     public void testInstanceOfItemDefBasic() {
         final DMNRuntime runtime = DMNRuntimeUtil.createRuntime("instanceOfItemDefBasic.dmn", this.getClass());
         final DMNModel dmnModel = runtime.getModel("https://kiegroup.org/dmn/_CF9357D4-C83F-4F7E-83E3-510310EB16F4", "testItemDefName");
-        assertThat(dmnModel, notNullValue());
-        assertThat(DMNRuntimeUtil.formatMessages(dmnModel.getMessages()), dmnModel.hasErrors(), is(false));
+        assertThat(dmnModel).isNotNull();
+        assertThat(dmnModel.hasErrors()).as(DMNRuntimeUtil.formatMessages(dmnModel.getMessages())).isFalse();
 
         final DMNContext context = DMNFactory.newContext();
         context.set("name", "John Doe");
 
         final DMNResult dmnResult = runtime.evaluateAll(dmnModel, context);
         LOG.debug("{}", dmnResult);
-        assertThat(DMNRuntimeUtil.formatMessages(dmnResult.getMessages()), dmnResult.hasErrors(), is(false));
-        assertThat(dmnResult.getDecisionResultByName("Decision-2").getResult(), is(true));
+        assertThat(dmnResult.hasErrors()).as(DMNRuntimeUtil.formatMessages(dmnResult.getMessages())).isFalse();
+        assertThat(dmnResult.getDecisionResultByName("Decision-2").getResult()).isEqualTo(Boolean.TRUE);
     }
 
     @Test
     public void testUniqueMissingMatchDefaultEmpty() {
         final DMNRuntime runtime = DMNRuntimeUtil.createRuntime("uniqueNoMatch.dmn", this.getClass());
         final DMNModel dmnModel = runtime.getModel("http://activiti.org/schema/1.0/dmn", "decisionmulti");
-        assertThat(dmnModel, notNullValue());
-        assertThat(DMNRuntimeUtil.formatMessages(dmnModel.getMessages()), dmnModel.hasErrors(), is(false));
+        assertThat(dmnModel).isNotNull();
+        assertThat(dmnModel.hasErrors()).as(DMNRuntimeUtil.formatMessages(dmnModel.getMessages())).isFalse();
 
-        checkUniqueMissingMatchDefaultEmpty(runtime, dmnModel, 11, true);
+        checkUniqueMissingMatchDefaultEmpty(runtime, dmnModel, 11, Boolean.TRUE);
         checkUniqueMissingMatchDefaultEmpty(runtime, dmnModel, 12, null);
     }
 
@@ -2933,8 +2917,8 @@ public class DMNRuntimeTest extends BaseInterpretedVsCompiledTest {
 
         final DMNResult dmnResult = runtime.evaluateAll(dmnModel, context);
         LOG.debug("{}", dmnResult);
-        assertThat(DMNRuntimeUtil.formatMessages(dmnResult.getMessages()), dmnResult.hasErrors(), is(false));
-        assertThat(dmnResult.getDecisionResultByName("Decision_decisionboolean").getResult(), is(output));
+        assertThat(dmnResult.hasErrors()).as(DMNRuntimeUtil.formatMessages(dmnResult.getMessages())).isFalse();
+        assertThat(dmnResult.getDecisionResultByName("Decision_decisionboolean").getResult()).isEqualTo(output);
     }
 
     @Test
@@ -2942,23 +2926,23 @@ public class DMNRuntimeTest extends BaseInterpretedVsCompiledTest {
         final DMNRuntime runtime = DMNRuntimeUtil.createRuntime("errorWhileLiteral.dmn", this.getClass());
         runtime.addListener(new DMNRuntimeEventListener() {});
         final DMNModel dmnModel = runtime.getModel("https://kiegroup.org/dmn/_8DF63435-B34B-4C19-A06B-C6A3416194A9", "testBasic");
-        assertThat(dmnModel, notNullValue());
-        assertThat(DMNRuntimeUtil.formatMessages(dmnModel.getMessages()), dmnModel.hasErrors(), is(false));
+        assertThat(dmnModel).isNotNull();
+        assertThat(dmnModel.hasErrors()).as(DMNRuntimeUtil.formatMessages(dmnModel.getMessages())).isFalse();
 
         final DMNContext context = DMNFactory.newContext();
 
         final DMNResult dmnResult = runtime.evaluateAll(dmnModel, context);
         LOG.debug("{}", dmnResult);
-        assertThat(DMNRuntimeUtil.formatMessages(dmnResult.getMessages()), dmnResult.hasErrors(), is(true));
-        assertThat(dmnResult.getDecisionResultByName("Decision-1").getEvaluationStatus(), is(DecisionEvaluationStatus.FAILED));
+        assertThat(dmnResult.hasErrors()).as(DMNRuntimeUtil.formatMessages(dmnResult.getMessages())).isTrue();
+        assertThat(dmnResult.getDecisionResultByName("Decision-1").getEvaluationStatus()).isEqualTo(DecisionEvaluationStatus.FAILED);
     }
 
     @Test
     public void testXAsType() {
         final DMNRuntime runtime = DMNRuntimeUtil.createRuntime("xAsType.dmn", this.getClass());
         final DMNModel dmnModel = runtime.getModel("https://kiegroup.org/dmn/_CA816D47-2D7A-41AA-B019-E4B4C5488385", "FEC85B35-BAC9-4FCC-A446-0D546CCAD1A4");
-        assertThat(dmnModel, notNullValue());
-        assertThat(DMNRuntimeUtil.formatMessages(dmnModel.getMessages()), dmnModel.hasErrors(), is(false));
+        assertThat(dmnModel).isNotNull();
+        assertThat(dmnModel.hasErrors()).as(DMNRuntimeUtil.formatMessages(dmnModel.getMessages())).isFalse();
 
         final DMNContext context = DMNFactory.newContext();
         context.set("a x", "a x");
@@ -2966,8 +2950,8 @@ public class DMNRuntimeTest extends BaseInterpretedVsCompiledTest {
 
         final DMNResult dmnResult = runtime.evaluateAll(dmnModel, context);
         LOG.debug("{}", dmnResult);
-        assertThat(DMNRuntimeUtil.formatMessages(dmnResult.getMessages()), dmnResult.hasErrors(), is(false));
-        assertThat(dmnResult.getDecisionResultByName("Decision-1").getResult(), is("a x, 2020"));
+        assertThat(dmnResult.hasErrors()).as(DMNRuntimeUtil.formatMessages(dmnResult.getMessages())).isFalse();
+        assertThat(dmnResult.getDecisionResultByName("Decision-1").getResult()).isEqualTo("a x, 2020");
     }
 
     @Test
@@ -2975,22 +2959,22 @@ public class DMNRuntimeTest extends BaseInterpretedVsCompiledTest {
         // the scope of this test: if an exception occurs while evaluating a ContextEntry, report a DMN message. Before was only SLF4j logged so user no DMN Message at all just null.
         final DMNRuntime runtime = DMNRuntimeUtil.createRuntime("exceptionInContextEntry.dmn", this.getClass());
         final DMNModel dmnModel = runtime.getModel("http://www.trisotech.com/definitions/_001031e1-9f0e-4156-afad-3ee970139021", "Drawing 1");
-        assertThat(dmnModel, notNullValue());
-        assertThat(DMNRuntimeUtil.formatMessages(dmnModel.getMessages()), dmnModel.hasErrors(), is(false));
+        assertThat(dmnModel).isNotNull();
+        assertThat(dmnModel.hasErrors()).as(DMNRuntimeUtil.formatMessages(dmnModel.getMessages())).isFalse();
 
         final DMNContext context = DMNFactory.newContext();
         final DMNResult dmnResult = runtime.evaluateAll(dmnModel, context);
         LOG.debug("{}", dmnResult);
-        assertThat(DMNRuntimeUtil.formatMessages(dmnResult.getMessages()), dmnResult.hasErrors(), is(true));
-        assertThat(dmnResult.getDecisionResultByName("hardcoded").getEvaluationStatus(), is(DecisionEvaluationStatus.FAILED));
+        assertThat(dmnResult.hasErrors()).as(DMNRuntimeUtil.formatMessages(dmnResult.getMessages())).isTrue();
+        assertThat(dmnResult.getDecisionResultByName("hardcoded").getEvaluationStatus()).isEqualTo(DecisionEvaluationStatus.FAILED);
     }
 
     @Test
     public void testPersonInReq1() {
         final DMNRuntime runtime = DMNRuntimeUtil.createRuntime("personInReq1.dmn", this.getClass());
         final DMNModel dmnModel = runtime.getModel("https://kiegroup.org/dmn/_EA9DA906-5A01-4AAA-B341-792486A67097", "personInReq1");
-        assertThat(dmnModel, notNullValue());
-        assertThat(DMNRuntimeUtil.formatMessages(dmnModel.getMessages()), dmnModel.hasErrors(), is(false));
+        assertThat(dmnModel).isNotNull();
+        assertThat(dmnModel.hasErrors()).as(DMNRuntimeUtil.formatMessages(dmnModel.getMessages())).isFalse();
 
         final DMNContext context = DMNFactory.newContext();
         context.set("a person", mapOf(entry("age", new BigDecimal(47)),
@@ -3000,16 +2984,16 @@ public class DMNRuntimeTest extends BaseInterpretedVsCompiledTest {
                                                                       entry("UB", new BigDecimal(99)))))));
         final DMNResult dmnResult = runtime.evaluateAll(dmnModel, context);
         LOG.debug("{}", dmnResult);
-        assertThat(DMNRuntimeUtil.formatMessages(dmnResult.getMessages()), dmnResult.hasErrors(), is(false));
-        assertThat(dmnResult.getDecisionResultByName("Decision-1").getResult(), is(Boolean.TRUE));
+        assertThat(dmnResult.hasErrors()).as(DMNRuntimeUtil.formatMessages(dmnResult.getMessages())).isFalse();
+        assertThat(dmnResult.getDecisionResultByName("Decision-1").getResult()).isEqualTo(Boolean.TRUE);
     }
 
     @Test
     public void testArthimeticSub1() {
         final DMNRuntime runtime = DMNRuntimeUtil.createRuntime("arithmeticSub1.dmn", this.getClass());
         final DMNModel dmnModel = runtime.getModel("https://kiegroup.org/dmn/_7B82BF58-74D1-4727-820F-9925FA3F7812", "arithmeticSub1");
-        assertThat(dmnModel, notNullValue());
-        assertThat(DMNRuntimeUtil.formatMessages(dmnModel.getMessages()), dmnModel.hasErrors(), is(false));
+        assertThat(dmnModel).isNotNull();
+        assertThat(dmnModel.hasErrors()).as(DMNRuntimeUtil.formatMessages(dmnModel.getMessages())).isFalse();
 
         final DMNContext context = DMNFactory.newContext();
         context.set("var3", 3);
@@ -3017,38 +3001,38 @@ public class DMNRuntimeTest extends BaseInterpretedVsCompiledTest {
 
         final DMNResult dmnResult = runtime.evaluateAll(dmnModel, context);
         LOG.debug("{}", dmnResult);
-        assertThat(DMNRuntimeUtil.formatMessages(dmnResult.getMessages()), dmnResult.hasErrors(), is(false));
-        assertThat(dmnResult.getDecisionResultByName("ExpressionTest").getResult(), is(new BigDecimal("-10")));
+        assertThat(dmnResult.hasErrors()).as(DMNRuntimeUtil.formatMessages(dmnResult.getMessages())).isFalse();
+        assertThat(dmnResult.getDecisionResultByName("ExpressionTest").getResult()).isEqualTo(new BigDecimal("-10"));
     }
 
     @Test
     public void testArthimeticSub2() {
         final DMNRuntime runtime = DMNRuntimeUtil.createRuntime("arithmeticSub2.dmn", this.getClass());
         final DMNModel dmnModel = runtime.getModel("https://kiegroup.org/dmn/_FCE6849C-6535-4629-A132-8DFD292A4765", "arithmeticSub2");
-        assertThat(dmnModel, notNullValue());
-        assertThat(DMNRuntimeUtil.formatMessages(dmnModel.getMessages()), dmnModel.hasErrors(), is(false));
+        assertThat(dmnModel).isNotNull();
+        assertThat(dmnModel.hasErrors()).as(DMNRuntimeUtil.formatMessages(dmnModel.getMessages())).isFalse();
 
         final DMNContext emptyContext = DMNFactory.newContext();
         final DMNResult dmnResult = runtime.evaluateAll(dmnModel, emptyContext);
         LOG.debug("{}", dmnResult);
-        assertThat(DMNRuntimeUtil.formatMessages(dmnResult.getMessages()), dmnResult.hasErrors(), is(false));
-        assertThat(dmnResult.getDecisionResultByName("ExpressionTest").getResult(), is(new BigDecimal("-3")));
+        assertThat(dmnResult.hasErrors()).as(DMNRuntimeUtil.formatMessages(dmnResult.getMessages())).isFalse();
+        assertThat(dmnResult.getDecisionResultByName("ExpressionTest").getResult()).isEqualTo(new BigDecimal("-3"));
     }
 
     @Test
     public void testInvokeJavaReturnArray() {
         final DMNRuntime runtime = DMNRuntimeUtil.createRuntime("invokeJavaReturnArray.dmn", this.getClass());
         final DMNModel dmnModel = runtime.getModel("https://kiegroup.org/dmn/_C90046D5-8581-4B16-992D-0472F840EFAF", "invokeJavaReturnArray");
-        assertThat(dmnModel, notNullValue());
-        assertThat(DMNRuntimeUtil.formatMessages(dmnModel.getMessages()), dmnModel.hasErrors(), is(false));
+        assertThat(dmnModel).isNotNull();
+        assertThat(dmnModel.hasErrors()).as(DMNRuntimeUtil.formatMessages(dmnModel.getMessages())).isFalse();
 
         final DMNContext emptyContext = DMNFactory.newContext();
         final DMNResult dmnResult = runtime.evaluateAll(dmnModel, emptyContext);
         LOG.debug("{}", dmnResult);
-        assertThat(DMNRuntimeUtil.formatMessages(dmnResult.getMessages()), dmnResult.hasErrors(), is(false));
-        assertThat(DMNRuntimeUtil.formatMessages(dmnResult.getMessages()), dmnResult.getMessages(Severity.WARN).isEmpty(), is(true));
-        assertThat(dmnResult.getDecisionResultByName("Decision1").getResult(), is(notNullValue()));
-        assertThat(dmnResult.getDecisionResultByName("Decision2").getResult(), is("cd"));
+        assertThat(dmnResult.hasErrors()).as(DMNRuntimeUtil.formatMessages(dmnResult.getMessages())).isFalse();
+        assertThat(dmnResult.getMessages(Severity.WARN)).as(DMNRuntimeUtil.formatMessages(dmnResult.getMessages())).isEmpty();
+        assertThat(dmnResult.getDecisionResultByName("Decision1").getResult()).isNotNull();
+        assertThat(dmnResult.getDecisionResultByName("Decision2").getResult()).isEqualTo("cd");
     }
     
     @Test
@@ -3056,8 +3040,8 @@ public class DMNRuntimeTest extends BaseInterpretedVsCompiledTest {
         final DMNRuntime runtime = DMNRuntimeUtil.createRuntime("notInvocable.dmn", this.getClass());
         runtime.addListener(new DMNRuntimeEventListener() {});
         final DMNModel dmnModel = runtime.getModel("https://kiegroup.org/dmn/_4B70E98C-E74E-48A1-88C6-F3FB1F0C026B", "notInvocable");
-        assertThat(dmnModel, notNullValue());
-        assertThat(DMNRuntimeUtil.formatMessages(dmnModel.getMessages()), dmnModel.hasErrors(), is(false));
+        assertThat(dmnModel).isNotNull();
+        assertThat(dmnModel.hasErrors()).as(DMNRuntimeUtil.formatMessages(dmnModel.getMessages())).isFalse();
 
         final DMNContext context = DMNFactory.newContext();
         context.set("something", "something");
@@ -3065,8 +3049,8 @@ public class DMNRuntimeTest extends BaseInterpretedVsCompiledTest {
 
         final DMNResult dmnResult = runtime.evaluateAll(dmnModel, context);
         LOG.debug("{}", dmnResult);
-        assertThat(DMNRuntimeUtil.formatMessages(dmnResult.getMessages()), dmnResult.hasErrors(), is(true));
-        assertThat(dmnResult.getDecisionResultByName("Decision-1").getEvaluationStatus(), is(DecisionEvaluationStatus.FAILED));
+        assertThat(dmnResult.hasErrors()).as(DMNRuntimeUtil.formatMessages(dmnResult.getMessages())).isTrue();
+        assertThat(dmnResult.getDecisionResultByName("Decision-1").getEvaluationStatus()).isEqualTo(DecisionEvaluationStatus.FAILED);
     }
     
     @Test
@@ -3074,15 +3058,15 @@ public class DMNRuntimeTest extends BaseInterpretedVsCompiledTest {
         final DMNRuntime runtime = DMNRuntimeUtil.createRuntime("decisiontable-with-now.dmn", this.getClass());
         runtime.addListener(new DMNRuntimeEventListener() {});
         final DMNModel dmnModel = runtime.getModel("http://www.trisotech.com/definitions/_fce3104a-30df-41f4-8c8f-0b67d4d996d4", "Drawing 1");
-        assertThat(dmnModel, notNullValue());
-        assertThat(DMNRuntimeUtil.formatMessages(dmnModel.getMessages()), dmnModel.hasErrors(), is(false));
+        assertThat(dmnModel).isNotNull();
+        assertThat(dmnModel.hasErrors()).as(DMNRuntimeUtil.formatMessages(dmnModel.getMessages())).isFalse();
 
         final DMNContext emptyContext = DMNFactory.newContext();
 
         final DMNResult dmnResult = runtime.evaluateAll(dmnModel, emptyContext);
         LOG.debug("{}", dmnResult);
-        assertThat(DMNRuntimeUtil.formatMessages(dmnResult.getMessages()), dmnResult.hasErrors(), is(false));
-        assertThat(dmnResult.getDecisionResultByName("Compare").getResult(), is(true));
+        assertThat(dmnResult.hasErrors()).as(DMNRuntimeUtil.formatMessages(dmnResult.getMessages())).isFalse();
+        assertThat(dmnResult.getDecisionResultByName("Compare").getResult()).isEqualTo(Boolean.TRUE);
     }
     
     @Test
@@ -3090,15 +3074,15 @@ public class DMNRuntimeTest extends BaseInterpretedVsCompiledTest {
         final DMNRuntime runtime = DMNRuntimeUtil.createRuntime("dupContextEntryKey.dmn", this.getClass());
         runtime.addListener(new DMNRuntimeEventListener() {});
         final DMNModel dmnModel = runtime.getModel("https://kiegroup.org/dmn/_730A7A75-F473-4083-93B9-85E0DAF7F4BD", "dupContextEntryKey");
-        assertThat(dmnModel, notNullValue());
-        assertThat(DMNRuntimeUtil.formatMessages(dmnModel.getMessages()), dmnModel.hasErrors(), is(false));
+        assertThat(dmnModel).isNotNull();
+        assertThat(dmnModel.hasErrors()).as(DMNRuntimeUtil.formatMessages(dmnModel.getMessages())).isFalse();
 
         final DMNContext emptyContext = DMNFactory.newContext();
 
         final DMNResult dmnResult = runtime.evaluateAll(dmnModel, emptyContext);
         LOG.debug("{}", dmnResult);
-        assertThat(DMNRuntimeUtil.formatMessages(dmnResult.getMessages()), dmnResult.hasErrors(), is(true));
-        assertThat(dmnResult.getDecisionResultByName("hardcoded").getEvaluationStatus(), is(DecisionEvaluationStatus.FAILED));
+        assertThat(dmnResult.hasErrors()).as(DMNRuntimeUtil.formatMessages(dmnResult.getMessages())).isTrue();
+        assertThat(dmnResult.getDecisionResultByName("hardcoded").getEvaluationStatus()).isEqualTo(DecisionEvaluationStatus.FAILED);
     }
     
     @Test
@@ -3106,20 +3090,20 @@ public class DMNRuntimeTest extends BaseInterpretedVsCompiledTest {
         final DMNRuntime runtime = DMNRuntimeUtil.createRuntime("testHyphenInPropertyOfCollectionForAccessor.dmn", this.getClass());
         runtime.addListener(new DMNRuntimeEventListener() {});
         final DMNModel dmnModel = runtime.getModel("http://www.trisotech.com/definitions/_b5362305-17be-42d8-acec-f2621e3cc0e0", "Drawing 1");
-        assertThat(dmnModel, notNullValue());
-        assertThat(DMNRuntimeUtil.formatMessages(dmnModel.getMessages()), dmnModel.hasErrors(), is(false));
+        assertThat(dmnModel).isNotNull();
+        assertThat(dmnModel.hasErrors()).as(DMNRuntimeUtil.formatMessages(dmnModel.getMessages())).isFalse();
 
         final DMNContext context = DMNFactory.newContext();
         context.set("input", Arrays.asList(prototype(entry("Primary-Key", "k987"), entry("Value", "v47"))) );
         
         final DMNResult dmnResult = runtime.evaluateAll(dmnModel, context);
         LOG.debug("{}", dmnResult);
-        assertThat(DMNRuntimeUtil.formatMessages(dmnResult.getMessages()), dmnResult.hasErrors(), is(false));
+        assertThat(dmnResult.hasErrors()).as(DMNRuntimeUtil.formatMessages(dmnResult.getMessages())).isFalse();
         /*
          * input.Primary-Key is a list projection: take all elements, and Stream+map using the accessor
          * input[1].Primary-Key is picking the first element in the list, and using the accessor (only on the first element index=1)
          */
-        assertThat(dmnResult.getDecisionResultByName("decision").getResult(), is(prototype(entry("correct", Arrays.asList("k987")),entry("incorrect", "k987"))));
+        assertThat((Map<String, Object>) dmnResult.getDecisionResultByName("decision").getResult()).containsExactly(entry("correct", Arrays.asList("k987")),entry("incorrect", "k987"));
     }
     
     @Test
@@ -3127,19 +3111,19 @@ public class DMNRuntimeTest extends BaseInterpretedVsCompiledTest {
         final DMNRuntime runtime = DMNRuntimeUtil.createRuntime("testHyphenInPropertyOfCollectionForAccessorMultiple.dmn", this.getClass());
         runtime.addListener(new DMNRuntimeEventListener() {});
         final DMNModel dmnModel = runtime.getModel("http://www.trisotech.com/definitions/_b5362305-17be-42d8-acec-f2621e3cc0e0", "Drawing 1");
-        assertThat(dmnModel, notNullValue());
-        assertThat(DMNRuntimeUtil.formatMessages(dmnModel.getMessages()), dmnModel.hasErrors(), is(false));
+        assertThat(dmnModel).isNotNull();
+        assertThat(dmnModel.hasErrors()).as(DMNRuntimeUtil.formatMessages(dmnModel.getMessages())).isFalse();
 
         final DMNContext context = DMNFactory.newContext();
         context.set("input", Arrays.asList(prototype(entry("Primary-Key", "k1"), entry("Value", 47)), prototype(entry("Primary-Key", "k2"), entry("Value", -9)), prototype(entry("Primary-Key", "k3"), entry("Value", 1))));
         
         final DMNResult dmnResult = runtime.evaluateAll(dmnModel, context);
         LOG.debug("{}", dmnResult);
-        assertThat(DMNRuntimeUtil.formatMessages(dmnResult.getMessages()), dmnResult.hasErrors(), is(false));
+        assertThat(dmnResult.hasErrors()).as(DMNRuntimeUtil.formatMessages(dmnResult.getMessages())).isFalse();
         /*
          * input.Primary-Key is a list projection: take all elements, and Stream+map using the accessor
          * input[Value>0].Primary-Key is filtering, then projecting
          */
-        assertThat(dmnResult.getDecisionResultByName("decision").getResult(), is(prototype(entry("correct", Arrays.asList("k1", "k2", "k3")),entry("incorrect", Arrays.asList("k1", "k3")))));
+        assertThat((Map<String, Object>)dmnResult.getDecisionResultByName("decision").getResult()).containsExactly(entry("correct", Arrays.asList("k1", "k2", "k3")),entry("incorrect", Arrays.asList("k1", "k3")));
     }
 }

--- a/kie-dmn/kie-dmn-core/src/test/java/org/kie/dmn/core/DMNRuntimeTypeCheckTest.java
+++ b/kie-dmn/kie-dmn-core/src/test/java/org/kie/dmn/core/DMNRuntimeTypeCheckTest.java
@@ -44,10 +44,6 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.hamcrest.CoreMatchers.is;
-import static org.hamcrest.CoreMatchers.notNullValue;
-import static org.hamcrest.CoreMatchers.nullValue;
-import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
@@ -141,7 +137,7 @@ public class DMNRuntimeTypeCheckTest extends BaseInterpretedVsCompiledTest {
 
         final KieBuilder kieBuilder = ks.newKieBuilder(kfs).buildAll();
         final Results results = kieBuilder.getResults();
-        assertThat(results.getMessages().toString(), results.hasMessages(org.kie.api.builder.Message.Level.ERROR), is(false));
+        assertThat(results.hasMessages(org.kie.api.builder.Message.Level.ERROR)).as(results.getMessages().toString()).isFalse();
 
         final KieContainer kieContainer = ks.newKieContainer(ks.getRepository().getDefaultReleaseId());
         return kieContainer.newKieSession().getKieRuntime(DMNRuntime.class);
@@ -149,50 +145,48 @@ public class DMNRuntimeTypeCheckTest extends BaseInterpretedVsCompiledTest {
 
     private void assertNoTypeCheck(final DMNRuntime runtime) {
         final DMNModel dmnModel = runtime.getModel("http://www.trisotech.com/definitions/_6d8af9a2-dcf4-4b9e-8d90-6ccddc8c1bbd", "forTypeCheckTest");
-        assertThat(dmnModel, notNullValue());
-        assertThat(DMNRuntimeUtil.formatMessages(dmnModel.getMessages()), dmnModel.hasErrors(), is(false));
+        assertThat(dmnModel).isNotNull();
+        assertThat(dmnModel.hasErrors()).as(DMNRuntimeUtil.formatMessages(dmnModel.getMessages())).isFalse();
 
         final DMNContext context = DMNFactory.newContext();
         context.set("a number", "ciao");
 
         final DMNResult dmnResult = runtime.evaluateAll(dmnModel, context);
 
-        assertThat(DMNRuntimeUtil.formatMessages(dmnResult.getMessages()),
-                   dmnResult.getMessages(DMNMessage.Severity.ERROR)
+        assertThat(dmnResult.getMessages(DMNMessage.Severity.ERROR)
                             .stream()
-                            .allMatch(m -> m.getSourceId().equals(dmnModel.getDecisionByName("hundred minus number").getId())),
-                   is(true));
+                            .allMatch(m -> m.getSourceId().equals(dmnModel.getDecisionByName("hundred minus number").getId())))
+        .as(DMNRuntimeUtil.formatMessages(dmnResult.getMessages())).isTrue();
 
         final DMNDecisionResult textPlusNumberDR = dmnResult.getDecisionResultByName("text plus number");
-        assertThat(textPlusNumberDR.getEvaluationStatus(), is(DecisionEvaluationStatus.SUCCEEDED));
-        assertThat(textPlusNumberDR.getResult(), is("The input number is: ciao"));
+        assertThat(textPlusNumberDR.getEvaluationStatus()).isEqualTo(DecisionEvaluationStatus.SUCCEEDED);
+        assertThat(textPlusNumberDR.getResult()).isEqualTo("The input number is: ciao");
 
         final DMNDecisionResult hundredMinusNumber = dmnResult.getDecisionResultByName("hundred minus number");
-        assertThat(hundredMinusNumber.getEvaluationStatus(), is(DecisionEvaluationStatus.SUCCEEDED));
-        assertThat(hundredMinusNumber.getResult(), nullValue());
+        assertThat(hundredMinusNumber.getEvaluationStatus()).isEqualTo(DecisionEvaluationStatus.SUCCEEDED);
+        assertThat(hundredMinusNumber.getResult()).isNull();
     }
 
     private void assertPerformTypeCheck(final DMNRuntime runtime) {
         final DMNModel dmnModel = runtime.getModel("http://www.trisotech.com/definitions/_6d8af9a2-dcf4-4b9e-8d90-6ccddc8c1bbd", "forTypeCheckTest");
-        assertThat(dmnModel, notNullValue());
-        assertThat(DMNRuntimeUtil.formatMessages(dmnModel.getMessages()), dmnModel.hasErrors(), is(false));
+        assertThat(dmnModel).isNotNull();
+        assertThat(dmnModel.hasErrors()).as(DMNRuntimeUtil.formatMessages(dmnModel.getMessages())).isFalse();
 
         final DMNContext context = DMNFactory.newContext();
         context.set("a number", "ciao");
 
         final DMNResult dmnResult = runtime.evaluateAll(dmnModel, context);
 
-        assertThat("Should throw several errors, not only for 1 specific Decision: " + DMNRuntimeUtil.formatMessages(dmnResult.getMessages()),
-                   dmnResult.getMessages(DMNMessage.Severity.ERROR)
+        assertThat(dmnResult.getMessages(DMNMessage.Severity.ERROR)
                             .stream()
-                            .allMatch(m -> m.getSourceId().equals(dmnModel.getDecisionByName("hundred minus number").getId())),
-                   is(false));
+                            .allMatch(m -> m.getSourceId().equals(dmnModel.getDecisionByName("hundred minus number").getId())))
+        .as("Should throw several errors, not only for 1 specific Decision: " + DMNRuntimeUtil.formatMessages(dmnResult.getMessages())).isFalse();
 
         final DMNDecisionResult textPlusNumberDR = dmnResult.getDecisionResultByName("text plus number");
-        assertThat(textPlusNumberDR.getEvaluationStatus(), is(DecisionEvaluationStatus.SKIPPED)); // dependency failed type check
+        assertThat(textPlusNumberDR.getEvaluationStatus()).isEqualTo(DecisionEvaluationStatus.SKIPPED); // dependency failed type check
 
         final DMNDecisionResult hundredMinusNumber = dmnResult.getDecisionResultByName("hundred minus number");
-        assertThat(hundredMinusNumber.getEvaluationStatus(), is(DecisionEvaluationStatus.SKIPPED)); // dependency failed type check
+        assertThat(hundredMinusNumber.getEvaluationStatus()).isEqualTo(DecisionEvaluationStatus.SKIPPED); // dependency failed type check
     }
 
     @Test

--- a/kie-dmn/kie-dmn-core/src/test/java/org/kie/dmn/core/DMNStronglyTypedSupportTest.java
+++ b/kie-dmn/kie-dmn-core/src/test/java/org/kie/dmn/core/DMNStronglyTypedSupportTest.java
@@ -43,14 +43,8 @@ import org.kie.dmn.core.model.Person;
 import org.kie.dmn.core.util.DMNRuntimeUtil;
 import org.kie.dmn.feel.lang.types.impl.ComparablePeriod;
 
-import static org.hamcrest.CoreMatchers.instanceOf;
-import static org.hamcrest.CoreMatchers.is;
-import static org.hamcrest.CoreMatchers.notNullValue;
-import static org.hamcrest.CoreMatchers.nullValue;
-import static org.hamcrest.Matchers.contains;
-import static org.hamcrest.Matchers.hasEntry;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.Assert.assertEquals;
-import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.Assert.assertTrue;
 import static org.kie.dmn.core.BaseVariantTest.VariantTestConf.BUILDER_DEFAULT_NOCL_TYPECHECK;
 import static org.kie.dmn.core.BaseVariantTest.VariantTestConf.BUILDER_DEFAULT_NOCL_TYPECHECK_TYPESAFE;
@@ -78,38 +72,38 @@ public class DMNStronglyTypedSupportTest extends BaseVariantTest {
         final String MODEL_NAMESPACE = "http://www.trisotech.com/definitions/_17396034-163a-48aa-9a7f-c6eb17f9cc6c";
         final String FEEL_NAMESPACE = org.kie.dmn.model.v1_2.KieDMNModelInstrumentedBase.URI_FEEL;
         final DMNModel dmnModel = runtime.getModel(MODEL_NAMESPACE, "DMNInputDataNodeTypeTest");
-        assertThat(dmnModel, notNullValue());
-        assertThat(DMNRuntimeUtil.formatMessages(dmnModel.getMessages()), dmnModel.hasErrors(), is(false));
+        assertThat(dmnModel).isNotNull();
+        assertThat(dmnModel.hasErrors()).as(DMNRuntimeUtil.formatMessages(dmnModel.getMessages())).isFalse();
 
         final InputDataNode idnMembership = dmnModel.getInputs().stream().filter(idn -> idn.getName().equals("Membership Level")).findFirst().get();
-        assertThat(idnMembership.getType().getBaseType().getNamespace(), is(FEEL_NAMESPACE));
-        assertThat(idnMembership.getType().getBaseType().getName(), is("string"));
-        assertThat(idnMembership.getType().isCollection(), is(false));
-        assertThat(idnMembership.getType().isComposite(), is(false));
-        assertThat(idnMembership.getType().getAllowedValues().size(), is(3));
-        assertThat(idnMembership.getType().getAllowedValues().get(0).toString(), is("\"Gold\""));
-        assertThat(idnMembership.getType().getAllowedValues().get(1).toString(), is("\"Silver\""));
-        assertThat(idnMembership.getType().getAllowedValues().get(2).toString(), is("\"None\""));
+        assertThat(idnMembership.getType().getBaseType().getNamespace()).isEqualTo(FEEL_NAMESPACE);
+        assertThat(idnMembership.getType().getBaseType().getName()).isEqualTo("string");
+        assertThat(idnMembership.getType().isCollection()).isFalse();
+        assertThat(idnMembership.getType().isComposite()).isFalse();
+        assertThat(idnMembership.getType().getAllowedValues()).hasSize(3);
+        assertThat(idnMembership.getType().getAllowedValues().get(0).toString()).isEqualTo("\"Gold\"");
+        assertThat(idnMembership.getType().getAllowedValues().get(1).toString()).isEqualTo("\"Silver\"");
+        assertThat(idnMembership.getType().getAllowedValues().get(2).toString()).isEqualTo("\"None\"");
 
         final InputDataNode idnMembershipLevels = dmnModel.getInputs().stream().filter(idn -> idn.getName().equals("Membership Levels")).findFirst().get();
-        assertThat(idnMembershipLevels.getType().getBaseType().getNamespace(), is(MODEL_NAMESPACE));
-        assertThat(idnMembershipLevels.getType().getBaseType().getName(), is("tMembershipLevel"));
-        assertThat(idnMembershipLevels.getType().isCollection(), is(true));
-        assertThat(idnMembershipLevels.getType().isComposite(), is(false));
-        assertThat(idnMembershipLevels.getType().getAllowedValues().isEmpty(), is(true));
+        assertThat(idnMembershipLevels.getType().getBaseType().getNamespace()).isEqualTo(MODEL_NAMESPACE);
+        assertThat(idnMembershipLevels.getType().getBaseType().getName()).isEqualTo("tMembershipLevel");
+        assertThat(idnMembershipLevels.getType().isCollection()).isTrue();
+        assertThat(idnMembershipLevels.getType().isComposite()).isFalse();
+        assertThat(idnMembershipLevels.getType().getAllowedValues().isEmpty()).isTrue();
 
         final InputDataNode idnPercent = dmnModel.getInputs().stream().filter(idn -> idn.getName().equals("Percent")).findFirst().get();
-        assertThat(idnPercent.getType().getBaseType().getNamespace(), is(FEEL_NAMESPACE));
-        assertThat(idnPercent.getType().getBaseType().getName(), is("number"));
-        assertThat(idnPercent.getType().isCollection(), is(false));
-        assertThat(idnPercent.getType().isComposite(), is(false));
-        assertThat(idnPercent.getType().getAllowedValues().size(), is(1));
-        assertThat(idnPercent.getType().getAllowedValues().get(0).toString(), is("[0..100]"));
+        assertThat(idnPercent.getType().getBaseType().getNamespace()).isEqualTo(FEEL_NAMESPACE);
+        assertThat(idnPercent.getType().getBaseType().getName()).isEqualTo("number");
+        assertThat(idnPercent.getType().isCollection()).isFalse();
+        assertThat(idnPercent.getType().isComposite()).isFalse();
+        assertThat(idnPercent.getType().getAllowedValues()).hasSize(1);
+        assertThat(idnPercent.getType().getAllowedValues().get(0).toString()).isEqualTo("[0..100]");
 
         final InputDataNode idnCarDamageResponsibility = dmnModel.getInputs().stream().filter(idn -> idn.getName().equals("Car Damage Responsibility")).findFirst().get();
-        assertThat(idnCarDamageResponsibility.getType().getBaseType(), is(nullValue()));
-        assertThat(idnCarDamageResponsibility.getType().isCollection(), is(false));
-        assertThat(idnCarDamageResponsibility.getType().isComposite(), is(true));
+        assertThat(idnCarDamageResponsibility.getType().getBaseType()).isNull();
+        assertThat(idnCarDamageResponsibility.getType().isCollection()).isFalse();
+        assertThat(idnCarDamageResponsibility.getType().isComposite()).isTrue();
     }
 
     @Test
@@ -118,8 +112,8 @@ public class DMNStronglyTypedSupportTest extends BaseVariantTest {
         runtime.addListener(DMNRuntimeUtil.createListener());
 
         final DMNModel dmnModel = runtime.getModel("http://www.trisotech.com/definitions/_69430b3e-17b8-430d-b760-c505bf6469f9", "dateTime Table 58");
-        assertThat(dmnModel, notNullValue());
-        assertThat(DMNRuntimeUtil.formatMessages(dmnModel.getMessages()), dmnModel.hasErrors(), is(false));
+        assertThat(dmnModel).isNotNull();
+        assertThat(dmnModel.hasErrors()).as(DMNRuntimeUtil.formatMessages(dmnModel.getMessages())).isFalse();
 
         final DMNContext context = DMNFactory.newContext();
         context.set("dateString", "2015-12-24");
@@ -138,60 +132,60 @@ public class DMNStronglyTypedSupportTest extends BaseVariantTest {
         final DMNResult dmnResult = evaluateModel(runtime, dmnModel, context);
         final DMNContext ctx = dmnResult.getContext();
 
-        assertThat(DMNRuntimeUtil.formatMessages(dmnResult.getMessages()), dmnResult.hasErrors(), is(false));
+        assertThat(dmnResult.hasErrors()).as(DMNRuntimeUtil.formatMessages(dmnResult.getMessages())).isFalse();
 
         if (isTypeSafe()) {
             FEELPropertyAccessible outputSet = ((DMNContextFPAImpl)dmnResult.getContext()).getFpa();
             Map<String, Object> allProperties = outputSet.allFEELProperties();
-            assertThat(allProperties.get("Date-Time"), is(ZonedDateTime.of(2016, 12, 24, 23, 59, 0, 0, ZoneOffset.ofHours(-5))));
+            assertThat(allProperties.get("Date-Time")).isEqualTo(ZonedDateTime.of(2016, 12, 24, 23, 59, 0, 0, ZoneOffset.ofHours(-5)));
             FEELPropertyAccessible resultDate = (FEELPropertyAccessible)allProperties.get("Date");
-            assertThat(resultDate.getClass().getSimpleName(), is("TDateVariants"));
-            assertThat(resultDate.getFEELProperty("fromString").toOptional().get(), is(LocalDate.of(2015, 12, 24)));
-            assertThat(resultDate.getFEELProperty("fromDateTime").toOptional().get(), is(LocalDate.of(2016, 12, 24)));
-            assertThat(resultDate.getFEELProperty("fromYearMonthDay").toOptional().get(), is(LocalDate.of(1999, 11, 22)));
-            assertThat(allProperties.get("Time"), is(OffsetTime.of(0, 0, 1, 0, ZoneOffset.ofHours(-1))));
-            assertThat(allProperties.get("Date-Time2"), is(ZonedDateTime.of(2015, 12, 24, 0, 0, 1, 0, ZoneOffset.ofHours(-1))));
-            assertThat(allProperties.get("Time2"), is(OffsetTime.of(0, 0, 1, 0, ZoneOffset.ofHours(-1))));
-            assertThat(allProperties.get("Time3"), is(OffsetTime.of(12, 59, 1, 300000000, ZoneOffset.ofHours(-1))));
-            assertThat(allProperties.get("dtDuration1"), is(Duration.parse("P13DT2H14S")));
-            assertThat(allProperties.get("dtDuration2"), is(Duration.parse("P367DT3H58M59S")));
-            assertThat(allProperties.get("hoursInDuration"), is(new BigDecimal("3")));
-            assertThat(allProperties.get("sumDurations"), is(Duration.parse("PT9125H59M13S")));
-            assertThat(allProperties.get("ymDuration2"), is(ComparablePeriod.parse("P1Y")));
-            assertThat(allProperties.get("cDay"), is(BigDecimal.valueOf(24)));
-            assertThat(allProperties.get("cYear"), is(BigDecimal.valueOf(2015)));
-            assertThat(allProperties.get("cMonth"), is(BigDecimal.valueOf(12)));
-            assertThat(allProperties.get("cHour"), is(BigDecimal.valueOf(0)));
-            assertThat(allProperties.get("cMinute"), is(BigDecimal.valueOf(0)));
-            assertThat(allProperties.get("cSecond"), is(BigDecimal.valueOf(1)));
-            assertThat(allProperties.get("cTimezone"), is("GMT-01:00"));
-            assertThat(allProperties.get("years"), is(BigDecimal.valueOf(1)));
-            assertThat(allProperties.get("d1seconds"), is(BigDecimal.valueOf(14)));
+            assertThat(resultDate.getClass().getSimpleName()).isEqualTo("TDateVariants");
+            assertThat(resultDate.getFEELProperty("fromString").toOptional().get()).isEqualTo(LocalDate.of(2015, 12, 24));
+            assertThat(resultDate.getFEELProperty("fromDateTime").toOptional().get()).isEqualTo(LocalDate.of(2016, 12, 24));
+            assertThat(resultDate.getFEELProperty("fromYearMonthDay").toOptional().get()).isEqualTo(LocalDate.of(1999, 11, 22));
+            assertThat(allProperties.get("Time")).isEqualTo(OffsetTime.of(0, 0, 1, 0, ZoneOffset.ofHours(-1)));
+            assertThat(allProperties.get("Date-Time2")).isEqualTo(ZonedDateTime.of(2015, 12, 24, 0, 0, 1, 0, ZoneOffset.ofHours(-1)));
+            assertThat(allProperties.get("Time2")).isEqualTo(OffsetTime.of(0, 0, 1, 0, ZoneOffset.ofHours(-1)));
+            assertThat(allProperties.get("Time3")).isEqualTo(OffsetTime.of(12, 59, 1, 300000000, ZoneOffset.ofHours(-1)));
+            assertThat(allProperties.get("dtDuration1")).isEqualTo(Duration.parse("P13DT2H14S"));
+            assertThat(allProperties.get("dtDuration2")).isEqualTo(Duration.parse("P367DT3H58M59S"));
+            assertThat(allProperties.get("hoursInDuration")).isEqualTo(new BigDecimal("3"));
+            assertThat(allProperties.get("sumDurations")).isEqualTo(Duration.parse("PT9125H59M13S"));
+            assertThat(allProperties.get("ymDuration2")).isEqualTo(ComparablePeriod.parse("P1Y"));
+            assertThat(allProperties.get("cDay")).isEqualTo(BigDecimal.valueOf(24));
+            assertThat(allProperties.get("cYear")).isEqualTo(BigDecimal.valueOf(2015));
+            assertThat(allProperties.get("cMonth")).isEqualTo(BigDecimal.valueOf(12));
+            assertThat(allProperties.get("cHour")).isEqualTo(BigDecimal.valueOf(0));
+            assertThat(allProperties.get("cMinute")).isEqualTo(BigDecimal.valueOf(0));
+            assertThat(allProperties.get("cSecond")).isEqualTo(BigDecimal.valueOf(1));
+            assertThat(allProperties.get("cTimezone")).isEqualTo("GMT-01:00");
+            assertThat(allProperties.get("years")).isEqualTo(BigDecimal.valueOf(1));
+            assertThat(allProperties.get("d1seconds")).isEqualTo(BigDecimal.valueOf(14));
         } else {
-            assertThat(ctx.get("Date-Time"), is(ZonedDateTime.of(2016, 12, 24, 23, 59, 0, 0, ZoneOffset.ofHours(-5))));
-            assertThat(ctx.get("Date"), is(new HashMap<String, Object>() {{
+            assertThat(ctx.get("Date-Time")).isEqualTo(ZonedDateTime.of(2016, 12, 24, 23, 59, 0, 0, ZoneOffset.ofHours(-5)));
+            assertThat(ctx.get("Date")).isEqualTo(new HashMap<String, Object>() {{
                 put("fromString", LocalDate.of(2015, 12, 24));
                 put("fromDateTime", LocalDate.of(2016, 12, 24));
                 put("fromYearMonthDay", LocalDate.of(1999, 11, 22));
-            }}));
-            assertThat(ctx.get("Time"), is(OffsetTime.of(0, 0, 1, 0, ZoneOffset.ofHours(-1))));
-            assertThat(ctx.get("Date-Time2"), is(ZonedDateTime.of(2015, 12, 24, 0, 0, 1, 0, ZoneOffset.ofHours(-1))));
-            assertThat(ctx.get("Time2"), is(OffsetTime.of(0, 0, 1, 0, ZoneOffset.ofHours(-1))));
-            assertThat(ctx.get("Time3"), is(OffsetTime.of(12, 59, 1, 300000000, ZoneOffset.ofHours(-1))));
-            assertThat(ctx.get("dtDuration1"), is(Duration.parse("P13DT2H14S")));
-            assertThat(ctx.get("dtDuration2"), is(Duration.parse("P367DT3H58M59S")));
-            assertThat(ctx.get("hoursInDuration"), is(new BigDecimal("3")));
-            assertThat(ctx.get("sumDurations"), is(Duration.parse("PT9125H59M13S")));
-            assertThat(ctx.get("ymDuration2"), is(ComparablePeriod.parse("P1Y")));
-            assertThat(ctx.get("cDay"), is(BigDecimal.valueOf(24)));
-            assertThat(ctx.get("cYear"), is(BigDecimal.valueOf(2015)));
-            assertThat(ctx.get("cMonth"), is(BigDecimal.valueOf(12)));
-            assertThat(ctx.get("cHour"), is(BigDecimal.valueOf(0)));
-            assertThat(ctx.get("cMinute"), is(BigDecimal.valueOf(0)));
-            assertThat(ctx.get("cSecond"), is(BigDecimal.valueOf(1)));
-            assertThat(ctx.get("cTimezone"), is("GMT-01:00"));
-            assertThat(ctx.get("years"), is(BigDecimal.valueOf(1)));
-            assertThat(ctx.get("d1seconds"), is(BigDecimal.valueOf(14)));
+            }});
+            assertThat(ctx.get("Time")).isEqualTo(OffsetTime.of(0, 0, 1, 0, ZoneOffset.ofHours(-1)));
+            assertThat(ctx.get("Date-Time2")).isEqualTo(ZonedDateTime.of(2015, 12, 24, 0, 0, 1, 0, ZoneOffset.ofHours(-1)));
+            assertThat(ctx.get("Time2")).isEqualTo(OffsetTime.of(0, 0, 1, 0, ZoneOffset.ofHours(-1)));
+            assertThat(ctx.get("Time3")).isEqualTo(OffsetTime.of(12, 59, 1, 300000000, ZoneOffset.ofHours(-1)));
+            assertThat(ctx.get("dtDuration1")).isEqualTo(Duration.parse("P13DT2H14S"));
+            assertThat(ctx.get("dtDuration2")).isEqualTo(Duration.parse("P367DT3H58M59S"));
+            assertThat(ctx.get("hoursInDuration")).isEqualTo(new BigDecimal("3"));
+            assertThat(ctx.get("sumDurations")).isEqualTo(Duration.parse("PT9125H59M13S"));
+            assertThat(ctx.get("ymDuration2")).isEqualTo(ComparablePeriod.parse("P1Y"));
+            assertThat(ctx.get("cDay")).isEqualTo(BigDecimal.valueOf(24));
+            assertThat(ctx.get("cYear")).isEqualTo(BigDecimal.valueOf(2015));
+            assertThat(ctx.get("cMonth")).isEqualTo(BigDecimal.valueOf(12));
+            assertThat(ctx.get("cHour")).isEqualTo(BigDecimal.valueOf(0));
+            assertThat(ctx.get("cMinute")).isEqualTo(BigDecimal.valueOf(0));
+            assertThat(ctx.get("cSecond")).isEqualTo(BigDecimal.valueOf(1));
+            assertThat(ctx.get("cTimezone")).isEqualTo("GMT-01:00");
+            assertThat(ctx.get("years")).isEqualTo(BigDecimal.valueOf(1));
+            assertThat(ctx.get("d1seconds")).isEqualTo(BigDecimal.valueOf(14));
         }
     }
 
@@ -201,18 +195,18 @@ public class DMNStronglyTypedSupportTest extends BaseVariantTest {
         runtime.addListener(DMNRuntimeUtil.createListener());
 
         final DMNModel dmnModel = runtime.getModel("http://www.trisotech.com/dmn/definitions/_ecf4ea54-2abc-4e2f-a101-4fe14e356a46", "Dessin 1");
-        assertThat(dmnModel, notNullValue());
-        assertThat(DMNRuntimeUtil.formatMessages(dmnModel.getMessages()), dmnModel.hasErrors(), is(false));
+        assertThat(dmnModel).isNotNull();
+        assertThat(dmnModel.hasErrors()).as(DMNRuntimeUtil.formatMessages(dmnModel.getMessages())).isFalse();
 
         final DMNContext context = DMNFactory.newContext();
         context.set("datetimestring", "2016-07-29T05:48:23");
         final DMNResult dmnResult = evaluateModel(runtime, dmnModel, context);
-        assertThat(DMNRuntimeUtil.formatMessages(dmnResult.getMessages()), dmnResult.getContext().get("time"), is(LocalTime.of(5, 48, 23)));
+        assertThat(dmnResult.getContext().get("time")).as(DMNRuntimeUtil.formatMessages(dmnResult.getMessages())).isEqualTo(LocalTime.of(5, 48, 23));
 
         if (isTypeSafe()) {
             FEELPropertyAccessible outputSet = ((DMNContextFPAImpl)dmnResult.getContext()).getFpa();
             Map<String, Object> allProperties = outputSet.allFEELProperties();
-            assertThat(allProperties.get("time"), is(LocalTime.of(5, 48, 23)));
+            assertThat(allProperties.get("time")).isEqualTo(LocalTime.of(5, 48, 23));
         }
     }
 
@@ -221,30 +215,30 @@ public class DMNStronglyTypedSupportTest extends BaseVariantTest {
         // DROOLS-4679 DMN FEEL list contains() invocation from DMN layer fixes
         final DMNRuntime runtime = createRuntime("so58507157.dmn", this.getClass());
         final DMNModel dmnModel = runtime.getModel("http://sample.dmn", "DecisionNumberInList");
-        assertThat(dmnModel, notNullValue());
-        assertThat(DMNRuntimeUtil.formatMessages(dmnModel.getMessages()), dmnModel.hasErrors(), is(false));
+        assertThat(dmnModel).isNotNull();
+        assertThat(dmnModel.hasErrors()).as(DMNRuntimeUtil.formatMessages(dmnModel.getMessages())).isFalse();
 
         final DMNContext context = DMNFactory.newContext();
         context.set("inputNumber", 1);
         context.set("inputNumberList", Arrays.asList(0, 1));
 
         final DMNResult dmnResult = evaluateModel(runtime, dmnModel, context);
-        assertThat(DMNRuntimeUtil.formatMessages(dmnResult.getMessages()), dmnResult.hasErrors(), is(false));
+        assertThat(dmnResult.hasErrors()).as(DMNRuntimeUtil.formatMessages(dmnResult.getMessages())).isFalse();
 
         final DMNContext result = dmnResult.getContext();
-        assertThat((Map<?, ?>) result.get("DecisionNumberInList"), hasEntry(is("Result_1_OK"), is(true)));
-        assertThat((Map<?, ?>) result.get("DecisionNumberInList"), hasEntry(is("Result_2_OK"), is(true)));
-        assertThat((Map<?, ?>) result.get("DecisionNumberInList"), hasEntry(is("Result_3"), is(true)));
-        assertThat((Map<?, ?>) result.get("DecisionNumberInList"), hasEntry(is("Result_4"), is(true)));
+        assertThat((Map<String, Object>) result.get("DecisionNumberInList")).containsEntry("Result_1_OK", Boolean.TRUE);
+        assertThat((Map<String, Object>) result.get("DecisionNumberInList")).containsEntry("Result_2_OK", Boolean.TRUE);
+        assertThat((Map<String, Object>) result.get("DecisionNumberInList")).containsEntry("Result_3", Boolean.TRUE);
+        assertThat((Map<String, Object>) result.get("DecisionNumberInList")).containsEntry("Result_4", Boolean.TRUE);
 
         if (isTypeSafe()) {
             FEELPropertyAccessible outputSet = ((DMNContextFPAImpl)dmnResult.getContext()).getFpa();
             Map<String, Object> allProperties = outputSet.allFEELProperties();
-            Map<?, ?> resultMap = (Map<?, ?>) allProperties.get("DecisionNumberInList");
-            assertThat(resultMap, hasEntry(is("Result_1_OK"), is(true)));
-            assertThat(resultMap, hasEntry(is("Result_2_OK"), is(true)));
-            assertThat(resultMap, hasEntry(is("Result_3"), is(true)));
-            assertThat(resultMap, hasEntry(is("Result_4"), is(true)));
+            Map<String, Object> resultMap = (Map<String, Object>) allProperties.get("DecisionNumberInList");
+            assertThat(resultMap).containsEntry("Result_1_OK", Boolean.TRUE);
+            assertThat(resultMap).containsEntry("Result_2_OK", Boolean.TRUE);
+            assertThat(resultMap).containsEntry("Result_3", Boolean.TRUE);
+            assertThat(resultMap).containsEntry("Result_4", Boolean.TRUE);
         }
     }
 
@@ -253,23 +247,23 @@ public class DMNStronglyTypedSupportTest extends BaseVariantTest {
         final DMNRuntime runtime = createRuntime("DROOLS-4379.dmn", this.getClass());
         // DROOLS-4379 DMN decision table input expr collection with allowedValues
         final DMNModel dmnModel = runtime.getModel("http://www.trisotech.com/definitions/_95436b7a-7268-4713-bf84-58bff10407b4", "Dessin 1");
-        assertThat(dmnModel, notNullValue());
-        assertThat(DMNRuntimeUtil.formatMessages(dmnModel.getMessages()), dmnModel.hasErrors(), is(false));
+        assertThat(dmnModel).isNotNull();
+        assertThat(dmnModel.hasErrors()).as(DMNRuntimeUtil.formatMessages(dmnModel.getMessages())).isFalse();
 
         final DMNContext context = DMNFactory.newContext();
         context.set("test", Arrays.asList("r2", "r1"));
         final DMNResult dmnResult = evaluateModel(runtime, dmnModel, context);
-        assertThat(DMNRuntimeUtil.formatMessages(dmnResult.getMessages()), dmnResult.hasErrors(), is(false));
+        assertThat(dmnResult.hasErrors()).as(DMNRuntimeUtil.formatMessages(dmnResult.getMessages())).isFalse();
 
         final DMNContext result = dmnResult.getContext();
-        assertThat(result.get("D4"), is("Contains r1"));
-        assertThat((List<?>) result.get("D5"), contains(is("r1"), is("r2")));
+        assertThat(result.get("D4")).isEqualTo("Contains r1");
+        assertThat((List<?>) result.get("D5")).asList().contains("r1", "r2");
 
         if (isTypeSafe()) {
             FEELPropertyAccessible outputSet = ((DMNContextFPAImpl)dmnResult.getContext()).getFpa();
             Map<String, Object> allProperties = outputSet.allFEELProperties();
-            assertThat(allProperties.get("D4"), is("Contains r1"));
-            assertThat((List<?>) allProperties.get("D5"), contains(is("r1"), is("r2")));
+            assertThat(allProperties.get("D4")).isEqualTo("Contains r1");
+            assertThat((List<?>) allProperties.get("D5")).asList().contains("r1", "r2");
         }
     }
 
@@ -278,18 +272,18 @@ public class DMNStronglyTypedSupportTest extends BaseVariantTest {
     public void testAccessorCache() {
         final DMNRuntime runtime = createRuntime("20180731-pr1997.dmn", this.getClass());
         final DMNModel dmnModel = runtime.getModel("http://www.trisotech.com/dmn/definitions/_7a39d775-bce9-45e3-aa3b-147d6f0028c7", "20180731-pr1997");
-        assertThat(dmnModel, notNullValue());
-        assertThat(DMNRuntimeUtil.formatMessages(dmnModel.getMessages()), dmnModel.hasErrors(), is(false));
+        assertThat(dmnModel).isNotNull();
+        assertThat(dmnModel.hasErrors()).as(DMNRuntimeUtil.formatMessages(dmnModel.getMessages())).isFalse();
 
         for (int i = 0; i < 10_000; i++) {
             final DMNContext context = DMNFactory.newContext();
             context.set("a Person", new Person("John", "Doe", i));
 
             final DMNResult dmnResult = evaluateModel(runtime, dmnModel, context);
-            assertThat(DMNRuntimeUtil.formatMessages(dmnResult.getMessages()), dmnResult.hasErrors(), is(false));
+            assertThat(dmnResult.hasErrors()).as(DMNRuntimeUtil.formatMessages(dmnResult.getMessages())).isFalse();
 
             final DMNContext result = dmnResult.getContext();
-            assertThat(result.get("Say hello and age"), is("Hello John Doe, your age is: " + i));
+            assertThat(result.get("Say hello and age")).isEqualTo("Hello John Doe, your age is: " + i);
         }
     }
 
@@ -299,8 +293,8 @@ public class DMNStronglyTypedSupportTest extends BaseVariantTest {
         // DROOLS-2605
         final DMNRuntime runtime = createRuntime("BruceTask20180601.dmn", this.getClass());
         final DMNModel dmnModel = runtime.getModel("http://www.trisotech.com/definitions/_3802fcb2-5b93-4502-aff4-0f5c61244eab", "Bruce Task");
-        assertThat(dmnModel, notNullValue());
-        assertThat(DMNRuntimeUtil.formatMessages(dmnModel.getMessages()), dmnModel.hasErrors(), is(false));
+        assertThat(dmnModel).isNotNull();
+        assertThat(dmnModel.hasErrors()).as(DMNRuntimeUtil.formatMessages(dmnModel.getMessages())).isFalse();
 
         final DMNContext context = DMNFactory.newContext();
         context.set("TheBook", Arrays.asList(prototype(entry("Title", "55"), entry("Price", new BigDecimal(5)), entry("Quantity", new BigDecimal(5))),
@@ -310,10 +304,10 @@ public class DMNStronglyTypedSupportTest extends BaseVariantTest {
                                              prototype(entry("Title", "66"), entry("Price", new BigDecimal(6)), entry("Quantity", new BigDecimal(6)))));
 
         final DMNResult dmnResult = evaluateModel(runtime, dmnModel, context);
-        assertThat(DMNRuntimeUtil.formatMessages(dmnResult.getMessages()), dmnResult.hasErrors(), is(false));
+        assertThat(dmnResult.hasErrors()).as(DMNRuntimeUtil.formatMessages(dmnResult.getMessages())).isFalse();
 
         final DMNContext result = dmnResult.getContext();
-        assertThat(result.get("Bruce"), is(instanceOf(Map.class)));
+        assertThat(result.get("Bruce")).isInstanceOf(Map.class);
         final Map<String, Object> bruce = (Map<String, Object>) result.get("Bruce");
 
         assertEquals(2, ((List) bruce.get("one")).size());

--- a/kie-dmn/kie-dmn-core/src/test/java/org/kie/dmn/core/DMNUpdateTest.java
+++ b/kie-dmn/kie-dmn-core/src/test/java/org/kie/dmn/core/DMNUpdateTest.java
@@ -45,10 +45,7 @@ import org.kie.dmn.core.util.KieHelper;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import static org.hamcrest.CoreMatchers.is;
-import static org.hamcrest.CoreMatchers.notNullValue;
-import static org.hamcrest.Matchers.hasSize;
-import static org.hamcrest.MatcherAssert.assertThat;
+import static org.assertj.core.api.Assertions.assertThat;
 
 public class DMNUpdateTest extends BaseInterpretedVsCompiledTest {
 
@@ -68,7 +65,7 @@ public class DMNUpdateTest extends BaseInterpretedVsCompiledTest {
 
         DMNRuntime runtime = kieContainer.newKieSession().getKieRuntime(DMNRuntime.class);
         Assert.assertNotNull(runtime);
-        assertThat(runtime.getModels(), hasSize(1));
+        assertThat(runtime.getModels()).hasSize(1);
 
         check0001_input_data_string(runtime);
 
@@ -78,17 +75,17 @@ public class DMNUpdateTest extends BaseInterpretedVsCompiledTest {
                                      ks.getResources().newClassPathResource("0001-input-data-string-itIT.dmn", this.getClass()));
 
         final Results updateResults = kieContainer.updateToVersion(v101);
-        assertThat(updateResults.hasMessages(Level.ERROR), is(false));
+        assertThat(updateResults.hasMessages(Level.ERROR)).isFalse();
 
         runtime = kieContainer.newKieSession().getKieRuntime(DMNRuntime.class);
         Assert.assertNotNull(runtime);
-        assertThat(runtime.getModels(), hasSize(1));
+        assertThat(runtime.getModels()).hasSize(1);
 
         final DMNContext dmnContext2 = runtime.newContext();
         dmnContext2.set("Full Name", "John Doe");
 
         final DMNResult evaluateAll2 = runtime.evaluateAll(runtime.getModels().get(0), dmnContext2);
-        assertThat(evaluateAll2.getDecisionResultByName("Greeting Message").getResult(), is("Salve John Doe"));
+        assertThat(evaluateAll2.getDecisionResultByName("Greeting Message").getResult()).isEqualTo("Salve John Doe");
     }
 
     @Test
@@ -101,7 +98,7 @@ public class DMNUpdateTest extends BaseInterpretedVsCompiledTest {
 
         DMNRuntime runtime = kieContainer.newKieSession().getKieRuntime(DMNRuntime.class);
         Assert.assertNotNull(runtime);
-        assertThat(runtime.getModels(), hasSize(1));
+        assertThat(runtime.getModels()).hasSize(1);
 
         check0001_input_data_string(runtime);
 
@@ -113,17 +110,17 @@ public class DMNUpdateTest extends BaseInterpretedVsCompiledTest {
                                      newClassPathResource);
 
         final Results updateResults = kieContainer.updateToVersion(v101);
-        assertThat(updateResults.hasMessages(Level.ERROR), is(false));
+        assertThat(updateResults.hasMessages(Level.ERROR)).isFalse();
 
         runtime = kieContainer.newKieSession().getKieRuntime(DMNRuntime.class);
         Assert.assertNotNull(runtime);
-        assertThat(runtime.getModels(), hasSize(1));
+        assertThat(runtime.getModels()).hasSize(1);
 
         final DMNContext dmnContext2 = runtime.newContext();
         dmnContext2.set("Full Name", "John Doe");
 
         final DMNResult evaluateAll2 = runtime.evaluateAll(runtime.getModels().get(0), dmnContext2);
-        assertThat(evaluateAll2.getDecisionResultByName("Greeting Message").getResult(), is("Salve John Doe"));
+        assertThat(evaluateAll2.getDecisionResultByName("Greeting Message").getResult()).isEqualTo("Salve John Doe");
     }
 
     @Test
@@ -136,7 +133,7 @@ public class DMNUpdateTest extends BaseInterpretedVsCompiledTest {
 
         DMNRuntime runtime = kieContainer.newKieSession().getKieRuntime(DMNRuntime.class);
         Assert.assertNotNull(runtime);
-        assertThat(runtime.getModels(), hasSize(1));
+        assertThat(runtime.getModels()).hasSize(1);
 
         check0001_input_data_string(runtime);
 
@@ -148,39 +145,39 @@ public class DMNUpdateTest extends BaseInterpretedVsCompiledTest {
                                      newClassPathResource);
 
         Results updateResults = kieContainer.updateToVersion(v101);
-        assertThat(updateResults.hasMessages(Level.ERROR), is(false));
+        assertThat(updateResults.hasMessages(Level.ERROR)).isFalse();
 
         runtime = kieContainer.newKieSession().getKieRuntime(DMNRuntime.class);
         Assert.assertNotNull(runtime);
-        assertThat(runtime.getModels(), hasSize(1));
+        assertThat(runtime.getModels()).hasSize(1);
 
         final DMNContext dmnContext2 = runtime.newContext();
         dmnContext2.set("Full Name", "John Doe");
 
         final DMNResult evaluateAll2 = runtime.evaluateAll(runtime.getModels().get(0), dmnContext2);
-        assertThat(evaluateAll2.getDecisionResultByName("Greeting Message").getResult(), is("Salve John Doe"));
+        assertThat(evaluateAll2.getDecisionResultByName("Greeting Message").getResult()).isEqualTo("Salve John Doe");
 
         kieContainer.dispose();
 
         kieContainer = ks.newKieContainer(v100);
         runtime = kieContainer.newKieSession().getKieRuntime(DMNRuntime.class);
         Assert.assertNotNull(runtime);
-        assertThat(runtime.getModels(), hasSize(1));
+        assertThat(runtime.getModels()).hasSize(1);
 
         check0001_input_data_string(runtime);
 
         updateResults = kieContainer.updateToVersion(v101);
-        assertThat(updateResults.hasMessages(Level.ERROR), is(false));
+        assertThat(updateResults.hasMessages(Level.ERROR)).isFalse();
 
         runtime = kieContainer.newKieSession().getKieRuntime(DMNRuntime.class);
         Assert.assertNotNull(runtime);
-        assertThat(runtime.getModels(), hasSize(1));
+        assertThat(runtime.getModels()).hasSize(1);
 
         final DMNContext dmnContext4 = runtime.newContext();
         dmnContext4.set("Full Name", "John Doe");
 
         final DMNResult evaluateAll4 = runtime.evaluateAll(runtime.getModels().get(0), dmnContext4);
-        assertThat(evaluateAll4.getDecisionResultByName("Greeting Message").getResult(), is("Salve John Doe"));
+        assertThat(evaluateAll4.getDecisionResultByName("Greeting Message").getResult()).isEqualTo("Salve John Doe");
     }
 
     @Test
@@ -196,7 +193,7 @@ public class DMNUpdateTest extends BaseInterpretedVsCompiledTest {
 
         DMNRuntime runtime = kieContainer.newKieSession().getKieRuntime(DMNRuntime.class);
         Assert.assertNotNull(runtime);
-        assertThat(runtime.getModels(), hasSize(1));
+        assertThat(runtime.getModels()).hasSize(1);
 
         kieContainer.dispose();
 
@@ -204,7 +201,7 @@ public class DMNUpdateTest extends BaseInterpretedVsCompiledTest {
 
         runtime = kieContainer.newKieSession().getKieRuntime(DMNRuntime.class);
         Assert.assertNotNull(runtime);
-        assertThat(runtime.getModels(), hasSize(1));
+        assertThat(runtime.getModels()).hasSize(1);
     }
 
     @Test
@@ -220,7 +217,7 @@ public class DMNUpdateTest extends BaseInterpretedVsCompiledTest {
 
         DMNRuntime runtime = kieContainer.newKieSession().getKieRuntime(DMNRuntime.class);
         Assert.assertNotNull(runtime);
-        assertThat(runtime.getModels(), hasSize(1));
+        assertThat(runtime.getModels()).hasSize(1);
 
         kieContainer.dispose();
 
@@ -228,7 +225,7 @@ public class DMNUpdateTest extends BaseInterpretedVsCompiledTest {
 
         runtime = kieContainer.newKieSession().getKieRuntime(DMNRuntime.class);
         Assert.assertNotNull(runtime);
-        assertThat(runtime.getModels(), hasSize(1));
+        assertThat(runtime.getModels()).hasSize(1);
 
         final ReleaseId v101 = ks.newReleaseId("org.kie", "dmn-test", "1.0.1");
         final Resource newClassPathResource = ks.getResources().newClassPathResource("0001-input-data-string-itIT.dmn", this.getClass());
@@ -238,11 +235,11 @@ public class DMNUpdateTest extends BaseInterpretedVsCompiledTest {
                                      newClassPathResource);
 
         final Results updateResults = kieContainer.updateToVersion(v101);
-        assertThat(updateResults.hasMessages(Level.ERROR), is(false));
+        assertThat(updateResults.hasMessages(Level.ERROR)).isFalse();
 
         runtime = kieContainer.newKieSession().getKieRuntime(DMNRuntime.class);
         Assert.assertNotNull(runtime);
-        assertThat(runtime.getModels(), hasSize(1));
+        assertThat(runtime.getModels()).hasSize(1);
     }
 
     @Test
@@ -259,7 +256,7 @@ public class DMNUpdateTest extends BaseInterpretedVsCompiledTest {
         KieBase kieBase = kieSession.getKieBase();
         DMNRuntime runtime = kieSession.getKieRuntime(DMNRuntime.class);
         Assert.assertNotNull(runtime);
-        assertThat(runtime.getModels(), hasSize(1));
+        assertThat(runtime.getModels()).hasSize(1);
 
         check0001_input_data_string(runtime);
 
@@ -274,7 +271,7 @@ public class DMNUpdateTest extends BaseInterpretedVsCompiledTest {
 
         runtime = kieSession.getKieRuntime(DMNRuntime.class);
         Assert.assertNotNull(runtime);
-        assertThat(runtime.getModels(), hasSize(1));
+        assertThat(runtime.getModels()).hasSize(1);
 
         check0001_input_data_string(runtime);
     }
@@ -292,7 +289,7 @@ public class DMNUpdateTest extends BaseInterpretedVsCompiledTest {
         final KieSession kieSession = kieContainer.newKieSession();
         final DMNRuntime runtime = kieSession.getKieRuntime(DMNRuntime.class);
         Assert.assertNotNull(runtime);
-        assertThat(runtime.getModels(), hasSize(1));
+        assertThat(runtime.getModels()).hasSize(1);
 
         check0001_input_data_string(runtime);
 
@@ -302,7 +299,7 @@ public class DMNUpdateTest extends BaseInterpretedVsCompiledTest {
         final KieSession kieSession2 = kieContainer2.newKieSession(); // exhibit the issue.
         final DMNRuntime runtime2 = kieSession2.getKieRuntime(DMNRuntime.class);
         Assert.assertNotNull(runtime2);
-        assertThat(runtime2.getModels(), hasSize(1));
+        assertThat(runtime2.getModels()).hasSize(1);
 
         check0001_input_data_string(runtime2);
     }
@@ -312,7 +309,7 @@ public class DMNUpdateTest extends BaseInterpretedVsCompiledTest {
         dmnContext.set("Full Name", "John Doe");
         final DMNResult evaluateAll = runtime.evaluateAll(runtime.getModels().get(0), dmnContext);
         LOG.debug("{}", evaluateAll);
-        assertThat(evaluateAll.getDecisionResultByName("Greeting Message").getResult(), is("Hello John Doe"));
+        assertThat(evaluateAll.getDecisionResultByName("Greeting Message").getResult()).isEqualTo("Hello John Doe");
     }
 
     @Test
@@ -328,7 +325,7 @@ public class DMNUpdateTest extends BaseInterpretedVsCompiledTest {
         final KieSession kieSession = kieContainer.newKieSession();
         final DMNRuntime runtime = kieSession.getKieRuntime(DMNRuntime.class);
         Assert.assertNotNull(runtime);
-        assertThat(runtime.getModels(), hasSize(1));
+        assertThat(runtime.getModels()).hasSize(1);
 
         checkDMNHotColdDMN12WithNSScattered(runtime);
 
@@ -338,21 +335,21 @@ public class DMNUpdateTest extends BaseInterpretedVsCompiledTest {
         final KieSession kieSession2 = kieContainer2.newKieSession(); // exhibit the issue.
         final DMNRuntime runtime2 = kieSession2.getKieRuntime(DMNRuntime.class);
         Assert.assertNotNull(runtime2);
-        assertThat(runtime2.getModels(), hasSize(1));
+        assertThat(runtime2.getModels()).hasSize(1);
 
         checkDMNHotColdDMN12WithNSScattered(runtime2);
     }
 
     private void checkDMNHotColdDMN12WithNSScattered(final DMNRuntime runtime) {
         final DMNModel dmnModel = runtime.getModel("https://github.com/kiegroup/drools/kie-dmn/_41A586D4-CEE9-420F-9289-7E0249B2EA34", "dmn1");
-        assertThat(dmnModel, notNullValue());
-        assertThat(dmnModel.getMessages().toString(), dmnModel.hasErrors(), is(false));
+        assertThat(dmnModel).isNotNull();
+        assertThat(dmnModel.hasErrors()).as(dmnModel.getMessages().toString()).isFalse();
         final DMNContext context = DMNFactory.newContext();
         context.set("temperature", 3);
 
         final DMNResult dmnResult = runtime.evaluateAll(dmnModel, context);
         LOG.info("{}", dmnResult);
-        assertThat(dmnResult.hasErrors(), is(false));
-        assertThat(dmnResult.getContext().get("is it cold?"), is("hot"));
+        assertThat(dmnResult.hasErrors()).isFalse();
+        assertThat(dmnResult.getContext().get("is it cold?")).isEqualTo("hot");
     }
 }

--- a/kie-dmn/kie-dmn-core/src/test/java/org/kie/dmn/core/FlightRebookingTest.java
+++ b/kie-dmn/kie-dmn-core/src/test/java/org/kie/dmn/core/FlightRebookingTest.java
@@ -32,9 +32,7 @@ import org.kie.dmn.api.core.DMNRuntime;
 import org.kie.dmn.core.api.DMNFactory;
 import org.kie.dmn.core.util.DMNRuntimeUtil;
 
-import static org.hamcrest.CoreMatchers.is;
-import static org.hamcrest.CoreMatchers.notNullValue;
-import static org.hamcrest.MatcherAssert.assertThat;
+import static org.assertj.core.api.Assertions.assertThat;
 
 public class FlightRebookingTest extends BaseInterpretedVsCompiledTest {
 
@@ -46,8 +44,8 @@ public class FlightRebookingTest extends BaseInterpretedVsCompiledTest {
     public void testSolution1() {
         final DMNRuntime runtime = DMNRuntimeUtil.createRuntime("0019-flight-rebooking.dmn", this.getClass() );
         final DMNModel dmnModel = runtime.getModel("https://www.drools.org/kie-dmn", "0019-flight-rebooking" );
-        assertThat( dmnModel, notNullValue() );
-        assertThat( DMNRuntimeUtil.formatMessages( dmnModel.getMessages() ), dmnModel.hasErrors(), is(false) ); // need proper type support to enable this
+        assertThat(dmnModel).isNotNull();
+        assertThat(dmnModel.hasErrors()).as(DMNRuntimeUtil.formatMessages(dmnModel.getMessages())).isFalse();// need proper type support to enable this
 
         final DMNContext context = DMNFactory.newContext();
 
@@ -61,15 +59,15 @@ public class FlightRebookingTest extends BaseInterpretedVsCompiledTest {
 
         final DMNContext result = dmnResult.getContext();
 
-        assertThat( result.get( "Rebooked Passengers" ), is( loadExpectedResult() ) );
+        assertThat(result.get( "Rebooked Passengers")).isEqualTo(loadExpectedResult());
     }
 
     @Test
     public void testSolutionAlternate() {
         final DMNRuntime runtime = DMNRuntimeUtil.createRuntime("0019-flight-rebooking-alternative.dmn", this.getClass() );
         final DMNModel dmnModel = runtime.getModel("https://www.drools.org/kie-dmn", "0019-flight-rebooking" );
-        assertThat( dmnModel, notNullValue() );
-        assertThat( DMNRuntimeUtil.formatMessages( dmnModel.getMessages() ), dmnModel.hasErrors(), is(false) );
+        assertThat(dmnModel).isNotNull();
+        assertThat(dmnModel.hasErrors()).as(DMNRuntimeUtil.formatMessages(dmnModel.getMessages())).isFalse();
 
         final DMNContext context = DMNFactory.newContext();
 
@@ -83,15 +81,15 @@ public class FlightRebookingTest extends BaseInterpretedVsCompiledTest {
 
         final DMNContext result = dmnResult.getContext();
 
-        assertThat( result.get( "Rebooked Passengers" ), is( loadExpectedResult() ) );
+        assertThat(result.get( "Rebooked Passengers")).isEqualTo(loadExpectedResult());
     }
 
     @Test
     public void testSolutionSingletonLists() {
         final DMNRuntime runtime = DMNRuntimeUtil.createRuntime("0019-flight-rebooking-singleton-lists.dmn", this.getClass() );
         final DMNModel dmnModel = runtime.getModel("https://www.drools.org/kie-dmn", "0019-flight-rebooking" );
-        assertThat( dmnModel, notNullValue() );
-        assertThat( DMNRuntimeUtil.formatMessages( dmnModel.getMessages() ), dmnModel.hasErrors(), is(false) );
+        assertThat(dmnModel).isNotNull();
+        assertThat(dmnModel.hasErrors()).as(DMNRuntimeUtil.formatMessages(dmnModel.getMessages())).isFalse();
         
         final DMNContext context = DMNFactory.newContext();
 
@@ -105,15 +103,15 @@ public class FlightRebookingTest extends BaseInterpretedVsCompiledTest {
 
         final DMNContext result = dmnResult.getContext();
 
-        assertThat( result.get( "Rebooked Passengers" ), is( loadExpectedResult() ) );
+        assertThat(result.get("Rebooked Passengers")).isEqualTo(loadExpectedResult());
     }
 
     @Test
     public void testSolutionBadExample() {
         final DMNRuntime runtime = DMNRuntimeUtil.createRuntime("0019-flight-rebooking-bad-example.dmn", this.getClass() );
         final DMNModel dmnModel = runtime.getModel("https://www.drools.org/kie-dmn", "0019-flight-rebooking" );
-        assertThat( dmnModel, notNullValue() );
-        assertThat( DMNRuntimeUtil.formatMessages( dmnModel.getMessages() ), dmnModel.hasErrors(), is(false) );
+        assertThat(dmnModel).isNotNull();
+        assertThat(dmnModel.hasErrors()).as(DMNRuntimeUtil.formatMessages(dmnModel.getMessages())).isFalse();
 
         final DMNContext context = DMNFactory.newContext();
 
@@ -127,7 +125,7 @@ public class FlightRebookingTest extends BaseInterpretedVsCompiledTest {
 
         final DMNContext result = dmnResult.getContext();
 
-        assertThat( result.get( "Rebooked Passengers" ), is( loadExpectedResult() ) );
+        assertThat(result.get( "Rebooked Passengers")).isEqualTo(loadExpectedResult());
     }
 
     @Test
@@ -135,8 +133,8 @@ public class FlightRebookingTest extends BaseInterpretedVsCompiledTest {
         final DMNRuntime runtime = DMNRuntimeUtil.createRuntime("0019-flight-rebooking-uninterpreted.dmn", this.getClass() );
         final DMNModel dmnModel = runtime.getModel("http://www.trisotech.com/dmn/definitions/_188d6caf-a355-49b5-a692-bd6ce713da08", "0019-flight-rebooking" );
         runtime.addListener( DMNRuntimeUtil.createListener() );
-        assertThat( dmnModel, notNullValue() );
-        assertThat( DMNRuntimeUtil.formatMessages( dmnModel.getMessages() ), dmnModel.hasErrors(), is(false) );
+        assertThat(dmnModel).isNotNull();
+        assertThat(dmnModel.hasErrors()).as(DMNRuntimeUtil.formatMessages(dmnModel.getMessages())).isFalse();
 
         final DMNContext context = DMNFactory.newContext();
 
@@ -148,7 +146,7 @@ public class FlightRebookingTest extends BaseInterpretedVsCompiledTest {
 
         final DMNResult dmnResult = runtime.evaluateAll(dmnModel, context );
 
-        assertThat( dmnResult.getDecisionResultByName( "Rebooked Passengers" ).getEvaluationStatus(), is( DMNDecisionResult.DecisionEvaluationStatus.SKIPPED ) );
+        assertThat(dmnResult.getDecisionResultByName("Rebooked Passengers").getEvaluationStatus()).isEqualTo(DMNDecisionResult.DecisionEvaluationStatus.SKIPPED);
     }
 
     private List loadPassengerList() {

--- a/kie-dmn/kie-dmn-core/src/test/java/org/kie/dmn/core/VacationDaysTest.java
+++ b/kie-dmn/kie-dmn-core/src/test/java/org/kie/dmn/core/VacationDaysTest.java
@@ -26,9 +26,7 @@ import org.kie.dmn.api.core.DMNRuntime;
 import org.kie.dmn.core.api.DMNFactory;
 import org.kie.dmn.core.util.DMNRuntimeUtil;
 
-import static org.hamcrest.CoreMatchers.is;
-import static org.hamcrest.CoreMatchers.notNullValue;
-import static org.hamcrest.MatcherAssert.assertThat;
+import static org.assertj.core.api.Assertions.assertThat;
 
 public class VacationDaysTest extends BaseInterpretedVsCompiledTest {
 
@@ -74,7 +72,7 @@ public class VacationDaysTest extends BaseInterpretedVsCompiledTest {
     private void executeTest(final int age, final int yearsService, final int expectedVacationDays ) {
         final DMNRuntime runtime = DMNRuntimeUtil.createRuntime("0020-vacation-days.dmn", this.getClass() );
         final DMNModel dmnModel = runtime.getModel("https://www.drools.org/kie-dmn", "0020-vacation-days" );
-        assertThat( dmnModel, notNullValue() );
+        assertThat(dmnModel).isNotNull();
 
         final DMNContext context = DMNFactory.newContext();
 
@@ -85,7 +83,7 @@ public class VacationDaysTest extends BaseInterpretedVsCompiledTest {
 
         final DMNContext result = dmnResult.getContext();
 
-        assertThat( result.get( "Total Vacation Days" ), is( BigDecimal.valueOf( expectedVacationDays ) ) );
+        assertThat(result.get("Total Vacation Days")).isEqualTo(BigDecimal.valueOf(expectedVacationDays));
     }
 }
 

--- a/kie-dmn/kie-dmn-core/src/test/java/org/kie/dmn/core/WBCommonServicesBackendTest.java
+++ b/kie-dmn/kie-dmn-core/src/test/java/org/kie/dmn/core/WBCommonServicesBackendTest.java
@@ -40,9 +40,7 @@ import org.kie.dmn.core.util.KieHelper;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import static org.hamcrest.CoreMatchers.is;
-import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.hasSize;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.kie.dmn.core.util.DynamicTypeUtils.entry;
 import static org.kie.dmn.core.util.DynamicTypeUtils.mapOf;
 
@@ -68,7 +66,7 @@ public class WBCommonServicesBackendTest extends BaseInterpretedVsCompiledTest {
         final KieSession kieSession = kieContainer.newKieSession();
         final DMNRuntime runtime = kieSession.getKieRuntime(DMNRuntime.class);
         Assert.assertNotNull(runtime);
-        assertThat(runtime.getModels(), hasSize(2));
+        assertThat(runtime.getModels()).hasSize(2);
 
         checkApp(runtime);
 
@@ -78,7 +76,7 @@ public class WBCommonServicesBackendTest extends BaseInterpretedVsCompiledTest {
         final KieSession kieSession2 = kieContainer2.newKieSession(); // exhibit the issue.
         final DMNRuntime runtime2 = kieSession2.getKieRuntime(DMNRuntime.class);
         Assert.assertNotNull(runtime2);
-        assertThat(runtime2.getModels(), hasSize(2));
+        assertThat(runtime2.getModels()).hasSize(2);
 
         checkApp(runtime2);
     }
@@ -91,10 +89,10 @@ public class WBCommonServicesBackendTest extends BaseInterpretedVsCompiledTest {
 
         final DMNResult dmnResult = runtime.evaluateAll(dmnModel, context);
         LOG.debug("{}", dmnResult);
-        assertThat(DMNRuntimeUtil.formatMessages(dmnResult.getMessages()), dmnResult.hasErrors(), is(false));
+        assertThat(dmnResult.hasErrors()).as(DMNRuntimeUtil.formatMessages(dmnResult.getMessages())).isFalse();
 
         final DMNContext result = dmnResult.getContext();
-        assertThat(result.get("the shortest distance"), is(new BigDecimal("5")));
+        assertThat(result.get("the shortest distance")).isEqualTo(new BigDecimal("5"));
     }
     
     @Test
@@ -109,7 +107,7 @@ public class WBCommonServicesBackendTest extends BaseInterpretedVsCompiledTest {
         final KieContainer kieContainer = ks.newKieContainer(v100);
         final DMNRuntime runtime = KieRuntimeFactory.of(kieContainer.getKieBase()).get(DMNRuntime.class);
         Assert.assertNotNull(runtime);
-        assertThat(runtime.getModels(), hasSize(1));
+        assertThat(runtime.getModels()).hasSize(1);
 
         check_nowGT1970(runtime);
 
@@ -118,7 +116,7 @@ public class WBCommonServicesBackendTest extends BaseInterpretedVsCompiledTest {
         final KieContainer kieContainer2 = new KieContainerImpl(kieProject, ks.getRepository(), v100);
         final DMNRuntime runtime2 = KieRuntimeFactory.of(kieContainer2.getKieBase()).get(DMNRuntime.class);
         Assert.assertNotNull(runtime2);
-        assertThat(runtime2.getModels(), hasSize(1));
+        assertThat(runtime2.getModels()).hasSize(1);
 
         check_nowGT1970(runtime2);
     }
@@ -129,9 +127,9 @@ public class WBCommonServicesBackendTest extends BaseInterpretedVsCompiledTest {
 
         final DMNResult dmnResult = runtime.evaluateAll(dmnModel, context);
         LOG.debug("{}", dmnResult);
-        assertThat(DMNRuntimeUtil.formatMessages(dmnResult.getMessages()), dmnResult.hasErrors(), is(false));
+        assertThat(dmnResult.hasErrors()).as(DMNRuntimeUtil.formatMessages(dmnResult.getMessages())).isFalse();
 
         final DMNContext result = dmnResult.getContext();
-        assertThat(result.get("Decision-1"), is(true));
+        assertThat(result.get("Decision-1")).isEqualTo(Boolean.TRUE);
     }
 }

--- a/kie-dmn/kie-dmn-core/src/test/java/org/kie/dmn/core/alphanetwork/DMNDecisionTableAlphaSupportingTest.java
+++ b/kie-dmn/kie-dmn-core/src/test/java/org/kie/dmn/core/alphanetwork/DMNDecisionTableAlphaSupportingTest.java
@@ -18,8 +18,6 @@ package org.kie.dmn.core.alphanetwork;
 
 import java.math.BigDecimal;
 
-import org.hamcrest.MatcherAssert;
-import org.junit.Before;
 import org.junit.Test;
 import org.kie.dmn.api.core.DMNContext;
 import org.kie.dmn.api.core.DMNModel;
@@ -30,9 +28,7 @@ import org.kie.dmn.core.api.DMNFactory;
 import org.kie.dmn.core.util.DMNRuntimeUtil;
 import org.slf4j.Logger;
 
-import static org.hamcrest.CoreMatchers.is;
-import static org.hamcrest.CoreMatchers.notNullValue;
-import static org.hamcrest.MatcherAssert.assertThat;
+import static org.assertj.core.api.Assertions.assertThat;
 
 public class DMNDecisionTableAlphaSupportingTest extends BaseInterpretedVsAlphaNetworkTest {
 
@@ -46,21 +42,21 @@ public class DMNDecisionTableAlphaSupportingTest extends BaseInterpretedVsAlphaN
     public void testSimpleDecision() {
         DMNRuntime runtime = DMNRuntimeUtil.createRuntime("alphasupport.dmn", this.getClass());
         DMNModel dmnModel = runtime.getModel("http://www.trisotech.com/definitions/_c0cf6e20-0b43-43ce-9def-c759a5f86df2", "DMN Specification Chapter 11 Example Reduced");
-        assertThat(dmnModel, notNullValue());
+        assertThat(dmnModel).isNotNull();
 
         final DMNContext context = runtime.newContext();
         context.set("Existing Customer", "s");
         context.set("Application Risk Score", new BigDecimal("123"));
         final DMNResult dmnResult = runtime.evaluateAll(dmnModel, context);
         LOG.debug("{}", dmnResult);
-        assertThat(dmnResult.getContext().get("Pre-bureau risk category table"), is("LOW"));
+        assertThat(dmnResult.getContext().get("Pre-bureau risk category table")).isEqualTo("LOW");
     }
 
     @Test
     public void testSimpleTableMultipleTests() {
         final DMNRuntime runtime = DMNRuntimeUtil.createRuntime("an-simpletable-multipletests.dmn", this.getClass());
         final DMNModel dmnModel = runtime.getModel("https://github.com/kiegroup/kie-dmn", "an-simpletable-multipletests");
-        MatcherAssert.assertThat(dmnModel, notNullValue());
+        assertThat(dmnModel).isNotNull();
 
         final DMNContext context = DMNFactory.newContext();
         context.set("Age", 21);
@@ -68,6 +64,6 @@ public class DMNDecisionTableAlphaSupportingTest extends BaseInterpretedVsAlphaN
         context.set("isAffordable", true);
         final DMNResult dmnResult = runtime.evaluateAll(dmnModel, context);
         final DMNContext result = dmnResult.getContext();
-        MatcherAssert.assertThat(result.get("Approval Status"), is("Approved"));
+        assertThat(result.get("Approval Status")).isEqualTo("Approved");
     }
 }

--- a/kie-dmn/kie-dmn-core/src/test/java/org/kie/dmn/core/classloader/DMNClassloaderTest.java
+++ b/kie-dmn/kie-dmn-core/src/test/java/org/kie/dmn/core/classloader/DMNClassloaderTest.java
@@ -36,9 +36,7 @@ import org.kie.dmn.core.util.DMNRuntimeUtil;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import static org.hamcrest.CoreMatchers.is;
-import static org.hamcrest.CoreMatchers.notNullValue;
-import static org.hamcrest.MatcherAssert.assertThat;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.Assert.assertTrue;
 
 public class DMNClassloaderTest extends BaseInterpretedVsCompiledTest {
@@ -87,19 +85,19 @@ public class DMNClassloaderTest extends BaseInterpretedVsCompiledTest {
         final KieContainer container = ks.newKieContainer(kjarReleaseId);
         final DMNRuntime runtime = container.newKieSession().getKieRuntime(DMNRuntime.class);
         final DMNModel dmnModel = runtime.getModel("http://www.trisotech.com/dmn/definitions/_48c4b6e2-25da-44bc-97b2-1e842ff28c71", "Standard Deviation");
-        assertThat(dmnModel, notNullValue());
-        assertThat(DMNRuntimeUtil.formatMessages(dmnModel.getMessages()), dmnModel.hasErrors(), is(false));
+        assertThat(dmnModel).isNotNull();
+        assertThat(dmnModel.hasErrors()).as(DMNRuntimeUtil.formatMessages(dmnModel.getMessages())).isFalse();
 
         final DMNContext context = DMNFactory.newContext();
         context.set("Values", Arrays.asList(new BigDecimal(1), new BigDecimal(2), new BigDecimal(3)));
 
         final DMNResult dmnResult = runtime.evaluateAll(dmnModel, context);
         LOG.info("{}", dmnResult);
-        assertThat(DMNRuntimeUtil.formatMessages(dmnResult.getMessages()), dmnResult.hasErrors(), is(false));
+        assertThat(dmnResult.hasErrors()).as(DMNRuntimeUtil.formatMessages(dmnResult.getMessages())).isFalse();
 
         final DMNContext result = dmnResult.getContext();
-        assertThat(result.get("Standard Deviation"), is(new BigDecimal(1)));
-        assertThat(result.get("using ignoring"), is(new BigDecimal(2)));
+        assertThat(result.get("Standard Deviation")).isEqualTo(new BigDecimal(1));
+        assertThat(result.get("using ignoring")).isEqualTo(new BigDecimal(2));
     }
 
     public static String getPom(final ReleaseId releaseId, final ReleaseId... dependencies) {
@@ -159,18 +157,18 @@ public class DMNClassloaderTest extends BaseInterpretedVsCompiledTest {
         final KieContainer container = ks.newKieContainer(kjarReleaseId);
         final DMNRuntime runtime = container.newKieSession().getKieRuntime(DMNRuntime.class);
         final DMNModel dmnModel = runtime.getModel("https://kiegroup.org/dmn/_8B620EB6-9E5E-4095-B990-19827F316887", "invokeJavaReturnArrayPrimitives");
-        assertThat(dmnModel, notNullValue());
-        assertThat(DMNRuntimeUtil.formatMessages(dmnModel.getMessages()), dmnModel.hasErrors(), is(false));
+        assertThat(dmnModel).isNotNull();
+        assertThat(dmnModel.hasErrors()).as(DMNRuntimeUtil.formatMessages(dmnModel.getMessages())).isFalse();
 
         final DMNContext context = DMNFactory.newContext();
         context.set("my index", 2);
 
         final DMNResult dmnResult = runtime.evaluateAll(dmnModel, context);
         LOG.info("{}", dmnResult);
-        assertThat(DMNRuntimeUtil.formatMessages(dmnResult.getMessages()), dmnResult.hasErrors(), is(false));
+        assertThat(dmnResult.hasErrors()).as(DMNRuntimeUtil.formatMessages(dmnResult.getMessages())).isFalse();
 
         final DMNContext result = dmnResult.getContext();
-        assertThat(result.get("IndexedS"), is("e"));
-        assertThat(result.get("IndexedI"), is(new BigDecimal(8)));
+        assertThat(result.get("IndexedS")).isEqualTo("e");
+        assertThat(result.get("IndexedI")).isEqualTo(new BigDecimal(8));
     }
 }

--- a/kie-dmn/kie-dmn-core/src/test/java/org/kie/dmn/core/classloader/DMNEvalHelperAccessorCacheTest.java
+++ b/kie-dmn/kie-dmn-core/src/test/java/org/kie/dmn/core/classloader/DMNEvalHelperAccessorCacheTest.java
@@ -35,9 +35,7 @@ import org.kie.dmn.core.util.DMNRuntimeUtil;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import static org.hamcrest.CoreMatchers.is;
-import static org.hamcrest.CoreMatchers.notNullValue;
-import static org.hamcrest.MatcherAssert.assertThat;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.Assert.assertTrue;
 
 public class DMNEvalHelperAccessorCacheTest extends BaseInterpretedVsCompiledTest {
@@ -120,8 +118,8 @@ public class DMNEvalHelperAccessorCacheTest extends BaseInterpretedVsCompiledTes
     private void checkKieContainer1(KieContainer container) throws Exception {
         final DMNRuntime runtime = KieRuntimeFactory.of(container.getKieBase()).get(DMNRuntime.class);
         final DMNModel dmnModel = runtime.getModel("https://kiegroup.org/dmn/_78BDCBE4-32EA-486E-9D81-CCC0D2378C61", "personCL");
-        assertThat(dmnModel, notNullValue());
-        assertThat(DMNRuntimeUtil.formatMessages(dmnModel.getMessages()), dmnModel.hasErrors(), is(false));
+        assertThat(dmnModel).isNotNull();
+        assertThat(dmnModel.hasErrors()).as(DMNRuntimeUtil.formatMessages(dmnModel.getMessages())).isFalse();
 
         final Object johnDoePerson = container.getClassLoader().loadClass("org.acme.Person").getConstructor(String.class, String.class).newInstance("John", "Doe");
 
@@ -178,8 +176,8 @@ public class DMNEvalHelperAccessorCacheTest extends BaseInterpretedVsCompiledTes
     private void checkKieContainer2(KieContainer container2) throws Exception {
         final DMNRuntime runtime2 = KieRuntimeFactory.of(container2.getKieBase()).get(DMNRuntime.class);
         final DMNModel dmnModel2 = runtime2.getModel("ns2", "personCL2");
-        assertThat(dmnModel2, notNullValue());
-        assertThat(DMNRuntimeUtil.formatMessages(dmnModel2.getMessages()), dmnModel2.hasErrors(), is(false));
+        assertThat(dmnModel2).isNotNull();
+        assertThat(dmnModel2.hasErrors()).as(DMNRuntimeUtil.formatMessages(dmnModel2.getMessages())).isFalse();
 
         final Object johnDoePerson2 = container2.getClassLoader().loadClass("org.acme.Person").getConstructor(String.class).newInstance("John Doe");
 
@@ -192,10 +190,10 @@ public class DMNEvalHelperAccessorCacheTest extends BaseInterpretedVsCompiledTes
 
         final DMNResult dmnResult2 = runtime2.evaluateAll(dmnModel2, context2);
         LOG.debug("{}", dmnResult2);
-        assertThat(DMNRuntimeUtil.formatMessages(dmnResult2.getMessages()), dmnResult2.hasErrors(), is(false));
+        assertThat(dmnResult2.hasErrors()).as(DMNRuntimeUtil.formatMessages(dmnResult2.getMessages())).isFalse();
 
         final DMNContext result = dmnResult2.getContext();
-        assertThat(result.get("Decision-1"), is("Hello, John Doe"));
+        assertThat(result.get("Decision-1")).isEqualTo("Hello, John Doe");
     }
 
 }

--- a/kie-dmn/kie-dmn-core/src/test/java/org/kie/dmn/core/classloader/DMNRuntimeListenerBKMTest.java
+++ b/kie-dmn/kie-dmn-core/src/test/java/org/kie/dmn/core/classloader/DMNRuntimeListenerBKMTest.java
@@ -37,9 +37,6 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.hamcrest.CoreMatchers.is;
-import static org.hamcrest.CoreMatchers.notNullValue;
-import static org.hamcrest.MatcherAssert.assertThat;
 
 public class DMNRuntimeListenerBKMTest {
 
@@ -77,8 +74,8 @@ public class DMNRuntimeListenerBKMTest {
         final DMNRuntime runtime = DMNRuntimeUtil.createRuntime("sumWithBKM.dmn", this.getClass());
         runtime.addListener(listenerUT);
         final DMNModel dmnModel = runtime.getModel("https://kiegroup.org/dmn/_FD426696-6811-494E-9938-10EE9C58DDEA", "sumWithBKM");
-        assertThat(dmnModel, notNullValue());
-        assertThat(DMNRuntimeUtil.formatMessages(dmnModel.getMessages()), dmnModel.hasErrors(), is(false));
+        assertThat(dmnModel).isNotNull();
+        assertThat(dmnModel.hasErrors()).as(DMNRuntimeUtil.formatMessages(dmnModel.getMessages())).isFalse();
 
         final DMNContext context = DMNFactory.newContext();
         context.set("a", 1);
@@ -86,7 +83,7 @@ public class DMNRuntimeListenerBKMTest {
 
         final DMNResult dmnResult = runtime.evaluateAll(dmnModel, context);
         LOG.debug("{}", dmnResult);
-        assertThat(DMNRuntimeUtil.formatMessages(dmnResult.getMessages()), dmnResult.hasErrors(), is(false));
+        assertThat(dmnResult.hasErrors()).as(DMNRuntimeUtil.formatMessages(dmnResult.getMessages())).isFalse();
         assertThat(dmnResult.getDecisionResultByName("Decision-1").getResult()).isEqualTo(new BigDecimal(3));
 
         Map<String, Object> expectedParameters = new LinkedHashMap<String, Object>();

--- a/kie-dmn/kie-dmn-core/src/test/java/org/kie/dmn/core/classloader/DMNRuntimeListenerDSTest.java
+++ b/kie-dmn/kie-dmn-core/src/test/java/org/kie/dmn/core/classloader/DMNRuntimeListenerDSTest.java
@@ -36,9 +36,6 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.hamcrest.CoreMatchers.is;
-import static org.hamcrest.CoreMatchers.notNullValue;
-import static org.hamcrest.MatcherAssert.assertThat;
 
 public class DMNRuntimeListenerDSTest {
 
@@ -78,15 +75,15 @@ public class DMNRuntimeListenerDSTest {
         final DMNRuntime runtime = DMNRuntimeUtil.createRuntime("helloDS.dmn", this.getClass());
         runtime.addListener(listenerUT);
         final DMNModel dmnModel = runtime.getModel("https://kiegroup.org/dmn/_4D937A56-2648-4AA8-A252-EBD405CFC6A8", "helloDS");
-        assertThat(dmnModel, notNullValue());
-        assertThat(DMNRuntimeUtil.formatMessages(dmnModel.getMessages()), dmnModel.hasErrors(), is(false));
+        assertThat(dmnModel).isNotNull();
+        assertThat(dmnModel.hasErrors()).as(DMNRuntimeUtil.formatMessages(dmnModel.getMessages())).isFalse();
 
         final DMNContext context = DMNFactory.newContext();
         context.set("my name", "John Doe");
 
         final DMNResult dmnResult = runtime.evaluateAll(dmnModel, context);
         LOG.debug("{}", dmnResult);
-        assertThat(DMNRuntimeUtil.formatMessages(dmnResult.getMessages()), dmnResult.hasErrors(), is(false));
+        assertThat(dmnResult.hasErrors()).as(DMNRuntimeUtil.formatMessages(dmnResult.getMessages())).isFalse();
         assertThat(dmnResult.getDecisionResultByName("greeting").getResult()).isEqualTo("Hello, John Doe");
         assertThat(dmnResult.getDecisionResultByName("hardcoded").getResult()).isEqualTo("Hello, hc");
 
@@ -112,15 +109,15 @@ public class DMNRuntimeListenerDSTest {
         final DMNRuntime runtime = DMNRuntimeUtil.createRuntime("helloDS.dmn", this.getClass());
         runtime.addListener(listenerUT);
         final DMNModel dmnModel = runtime.getModel("https://kiegroup.org/dmn/_4D937A56-2648-4AA8-A252-EBD405CFC6A8", "helloDS");
-        assertThat(dmnModel, notNullValue());
-        assertThat(DMNRuntimeUtil.formatMessages(dmnModel.getMessages()), dmnModel.hasErrors(), is(false));
+        assertThat(dmnModel).isNotNull();
+        assertThat(dmnModel.hasErrors()).as(DMNRuntimeUtil.formatMessages(dmnModel.getMessages())).isFalse();
 
         final DMNContext context = DMNFactory.newContext();
         context.set("my name", "Alice");
 
         final DMNResult dmnResult = runtime.evaluateDecisionService(dmnModel, context, "myDS");
         LOG.debug("{}", dmnResult);
-        assertThat(DMNRuntimeUtil.formatMessages(dmnResult.getMessages()), dmnResult.hasErrors(), is(false));
+        assertThat(dmnResult.hasErrors()).as(DMNRuntimeUtil.formatMessages(dmnResult.getMessages())).isFalse();
         assertThat(dmnResult.getDecisionResultByName("greeting").getResult()).isEqualTo("Hello, Alice");
 
         assertThat(listenerUT.getInvParams()).hasSize(1);

--- a/kie-dmn/kie-dmn-core/src/test/java/org/kie/dmn/core/classloader/DMNRuntimeListenerPropertyTest.java
+++ b/kie-dmn/kie-dmn-core/src/test/java/org/kie/dmn/core/classloader/DMNRuntimeListenerPropertyTest.java
@@ -35,10 +35,7 @@ import org.kie.dmn.core.util.DMNRuntimeUtil;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import static org.hamcrest.CoreMatchers.is;
-import static org.hamcrest.CoreMatchers.notNullValue;
-import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.contains;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.Assert.assertTrue;
 
 public class DMNRuntimeListenerPropertyTest {
@@ -88,19 +85,19 @@ public class DMNRuntimeListenerPropertyTest {
         try {
             final DMNRuntime runtime = setup();
             final DMNModel dmnModel = runtime.getModel("http://www.trisotech.com/definitions/_2027051c-0030-40f1-8b96-1b1422f8b257", "Drawing 1");
-            assertThat(dmnModel, notNullValue());
-            assertThat(DMNRuntimeUtil.formatMessages(dmnModel.getMessages()), dmnModel.hasErrors(), is(false));
+            assertThat(dmnModel).isNotNull();
+            assertThat(dmnModel.hasErrors()).as(DMNRuntimeUtil.formatMessages(dmnModel.getMessages())).isFalse();
 
             final DMNContext context = DMNFactory.newContext();
             context.set("Name", "John Doe");
 
             final DMNResult dmnResult = runtime.evaluateAll(dmnModel, context);
-            assertThat(DMNRuntimeUtil.formatMessages(dmnResult.getMessages()), dmnResult.hasErrors(), is(false));
+            assertThat(dmnResult.hasErrors()).as(DMNRuntimeUtil.formatMessages(dmnResult.getMessages())).isFalse();
 
             Object listenerInstance = runtime.getRootClassLoader().loadClass(LISTENER_VALUE).newInstance();
             @SuppressWarnings("unchecked") // this was by necessity classloaded
             List<Object> results = (List<Object>) listenerInstance.getClass().getMethod("getResults").invoke(listenerInstance);
-            assertThat(results, contains("Hello John Doe"));
+            assertThat(results).contains("Hello John Doe");
         } catch (Exception e) {
             e.printStackTrace();
         } finally {

--- a/kie-dmn/kie-dmn-core/src/test/java/org/kie/dmn/core/classloader/DMNRuntimeListenerTest.java
+++ b/kie-dmn/kie-dmn-core/src/test/java/org/kie/dmn/core/classloader/DMNRuntimeListenerTest.java
@@ -17,7 +17,6 @@
 package org.kie.dmn.core.classloader;
 
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -53,13 +52,9 @@ import org.kie.dmn.core.util.DMNRuntimeUtil;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import static org.hamcrest.CoreMatchers.instanceOf;
-import static org.hamcrest.CoreMatchers.is;
-import static org.hamcrest.CoreMatchers.notNullValue;
-import static org.hamcrest.Matchers.contains;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
-import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.Assert.assertTrue;
 
 public class DMNRuntimeListenerTest extends BaseInterpretedVsCompiledTest {
@@ -126,24 +121,24 @@ public class DMNRuntimeListenerTest extends BaseInterpretedVsCompiledTest {
         Assert.assertNotNull(runtime);
 
         final DMNModel dmnModel = runtime.getModel("http://www.trisotech.com/definitions/_2027051c-0030-40f1-8b96-1b1422f8b257", "Drawing 1");
-        assertThat(dmnModel, notNullValue());
-        assertThat(DMNRuntimeUtil.formatMessages(dmnModel.getMessages()), dmnModel.hasErrors(), is(false));
+        assertThat(dmnModel).isNotNull();
+        assertThat(dmnModel.hasErrors()).as(DMNRuntimeUtil.formatMessages(dmnModel.getMessages())).isFalse();
 
         final DMNContext context = newEmptyContextWithTestMetadata();
         context.set("Name", "John Doe");
 
         final DMNResult dmnResult = runtime.evaluateAll(dmnModel, context);
         LOG.debug("{}", dmnResult);
-        assertThat(DMNRuntimeUtil.formatMessages(dmnResult.getMessages()), dmnResult.hasErrors(), is(false));
+        assertThat(dmnResult.hasErrors()).as(DMNRuntimeUtil.formatMessages(dmnResult.getMessages())).isFalse();
 
         final DMNContext result = dmnResult.getContext();
-        assertThat(result.get("Greeting the Name"), is("Hello John Doe"));
-        assertThat(result.getMetadata().asMap(), is(TEST_METADATA));
+        assertThat(result.get("Greeting the Name")).isEqualTo("Hello John Doe");
+        assertThat(result.getMetadata().asMap()).isEqualTo(TEST_METADATA);
 
         Object listenerInstance = kieContainer.getClassLoader().loadClass("com.acme.TestListener").newInstance();
         @SuppressWarnings("unchecked") // this was by necessity classloaded
         List<Object> results = (List<Object>) listenerInstance.getClass().getMethod("getResults").invoke(listenerInstance);
-        assertThat(results, contains("Hello John Doe"));
+        assertThat(results).contains("Hello John Doe");
     }
 
     @Test
@@ -152,60 +147,60 @@ public class DMNRuntimeListenerTest extends BaseInterpretedVsCompiledTest {
         TestEventListener listener = new TestEventListener();
         runtime.addListener(listener);
         final DMNModel dmnModel = runtime.getModel("http://www.trisotech.com/dmn/definitions/_b6f2a9ca-a246-4f27-896a-e8ef04ea439c", "say for hello");
-        assertThat(dmnModel, notNullValue());
-        assertThat(DMNRuntimeUtil.formatMessages(dmnModel.getMessages()), dmnModel.hasErrors(), is(false));
+        assertThat(dmnModel).isNotNull();
+        assertThat(dmnModel.hasErrors()).as(DMNRuntimeUtil.formatMessages(dmnModel.getMessages())).isFalse();
 
         final DMNContext emptyContext = newEmptyContextWithTestMetadata();
 
         final DMNResult dmnResult = runtime.evaluateAll(dmnModel, emptyContext);
-        assertThat(DMNRuntimeUtil.formatMessages(dmnResult.getMessages()), dmnResult.hasErrors(), is(false));
+        assertThat(dmnResult.hasErrors()).as(DMNRuntimeUtil.formatMessages(dmnResult.getMessages())).isFalse();
 
         final DMNContext result = dmnResult.getContext();
-        assertThat(result.get("just say"), is(Arrays.asList("Hello", "Hello", "Hello")));
-        assertThat(result.getMetadata().asMap(), is(TEST_METADATA));
+        assertThat(result.get("just say")).asList().containsExactly("Hello", "Hello", "Hello");
+        assertThat(result.getMetadata().asMap()).isEqualTo(TEST_METADATA);
 
         List<DMNEvent> eventList = listener.getEventList();
-        assertThat(eventList.get(0), instanceOf(BeforeEvaluateDecisionEvent.class));
-        assertThat(eventList.get(0).getResult().getContext().getMetadata().asMap(), is(TEST_METADATA));
-        assertThat(((BeforeEvaluateDecisionEvent) eventList.get(0)).getDecision().getName(), is("just say"));
+        assertThat(eventList.get(0)).isInstanceOf(BeforeEvaluateDecisionEvent.class);
+        assertThat(eventList.get(0).getResult().getContext().getMetadata().asMap()).isEqualTo(TEST_METADATA);
+        assertThat(((BeforeEvaluateDecisionEvent) eventList.get(0)).getDecision().getName()).isEqualTo("just say");
 
         // Evaluate 2 BKMs
-        assertThat(eventList.get(1), instanceOf(BeforeEvaluateBKMEvent.class));
-        assertThat(eventList.get(1).getResult().getContext().getMetadata().asMap(), is(TEST_METADATA));
-        assertThat(((BeforeEvaluateBKMEvent) eventList.get(1)).getBusinessKnowledgeModel().getName(), is("prefix say for hello"));
-        assertThat(eventList.get(2), instanceOf(AfterEvaluateBKMEvent.class));
-        assertThat(eventList.get(2).getResult().getContext().getMetadata().asMap(), is(TEST_METADATA));
-        assertThat(((AfterEvaluateBKMEvent) eventList.get(2)).getBusinessKnowledgeModel().getName(), is("prefix say for hello"));
-        assertThat(eventList.get(3), instanceOf(BeforeEvaluateBKMEvent.class));
-        assertThat(eventList.get(3).getResult().getContext().getMetadata().asMap(), is(TEST_METADATA));
-        assertThat(((BeforeEvaluateBKMEvent) eventList.get(3)).getBusinessKnowledgeModel().getName(), is("prefix aaa for hello"));
-        assertThat(eventList.get(4), instanceOf(AfterEvaluateBKMEvent.class));
-        assertThat(eventList.get(4).getResult().getContext().getMetadata().asMap(), is(TEST_METADATA));
-        assertThat(((AfterEvaluateBKMEvent) eventList.get(4)).getBusinessKnowledgeModel().getName(), is("prefix aaa for hello"));
+        assertThat(eventList.get(1)).isInstanceOf(BeforeEvaluateBKMEvent.class);
+        assertThat(eventList.get(1).getResult().getContext().getMetadata().asMap()).isEqualTo(TEST_METADATA);
+        assertThat(((BeforeEvaluateBKMEvent) eventList.get(1)).getBusinessKnowledgeModel().getName()).isEqualTo("prefix say for hello");
+        assertThat(eventList.get(2)).isInstanceOf(AfterEvaluateBKMEvent.class);
+        assertThat(eventList.get(2).getResult().getContext().getMetadata().asMap()).isEqualTo(TEST_METADATA);
+        assertThat(((AfterEvaluateBKMEvent) eventList.get(2)).getBusinessKnowledgeModel().getName()).isEqualTo("prefix say for hello");
+        assertThat(eventList.get(3)).isInstanceOf(BeforeEvaluateBKMEvent.class);
+        assertThat(eventList.get(3).getResult().getContext().getMetadata().asMap()).isEqualTo(TEST_METADATA);
+        assertThat(((BeforeEvaluateBKMEvent) eventList.get(3)).getBusinessKnowledgeModel().getName()).isEqualTo("prefix aaa for hello");
+        assertThat(eventList.get(4)).isInstanceOf(AfterEvaluateBKMEvent.class);
+        assertThat(eventList.get(4).getResult().getContext().getMetadata().asMap()).isEqualTo(TEST_METADATA);
+        assertThat(((AfterEvaluateBKMEvent) eventList.get(4)).getBusinessKnowledgeModel().getName()).isEqualTo("prefix aaa for hello");
 
         // Invoke function 3 times
-        assertThat(eventList.get(5), instanceOf(BeforeInvokeBKMEvent.class));
-        assertThat(eventList.get(5).getResult().getContext().getMetadata().asMap(), is(TEST_METADATA));
-        assertThat(((BeforeInvokeBKMEvent) eventList.get(5)).getBusinessKnowledgeModel().getName(), is("prefix say for hello"));
-        assertThat(eventList.get(6), instanceOf(AfterInvokeBKMEvent.class));
-        assertThat(eventList.get(6).getResult().getContext().getMetadata().asMap(), is(TEST_METADATA));
-        assertThat(((AfterInvokeBKMEvent) eventList.get(6)).getBusinessKnowledgeModel().getName(), is("prefix say for hello"));
-        assertThat(eventList.get(7), instanceOf(BeforeInvokeBKMEvent.class));
-        assertThat(eventList.get(7).getResult().getContext().getMetadata().asMap(), is(TEST_METADATA));
-        assertThat(((BeforeInvokeBKMEvent) eventList.get(7)).getBusinessKnowledgeModel().getName(), is("prefix say for hello"));
-        assertThat(eventList.get(8), instanceOf(AfterInvokeBKMEvent.class));
-        assertThat(eventList.get(8).getResult().getContext().getMetadata().asMap(), is(TEST_METADATA));
-        assertThat(((AfterInvokeBKMEvent) eventList.get(8)).getBusinessKnowledgeModel().getName(), is("prefix say for hello"));
-        assertThat(eventList.get(9), instanceOf(BeforeInvokeBKMEvent.class));
-        assertThat(eventList.get(9).getResult().getContext().getMetadata().asMap(), is(TEST_METADATA));
-        assertThat(((BeforeInvokeBKMEvent) eventList.get(9)).getBusinessKnowledgeModel().getName(), is("prefix say for hello"));
-        assertThat(eventList.get(10), instanceOf(AfterInvokeBKMEvent.class));
-        assertThat(eventList.get(10).getResult().getContext().getMetadata().asMap(), is(TEST_METADATA));
-        assertThat(((AfterInvokeBKMEvent) eventList.get(10)).getBusinessKnowledgeModel().getName(), is("prefix say for hello"));
+        assertThat(eventList.get(5)).isInstanceOf(BeforeInvokeBKMEvent.class);
+        assertThat(eventList.get(5).getResult().getContext().getMetadata().asMap()).isEqualTo(TEST_METADATA);
+        assertThat(((BeforeInvokeBKMEvent) eventList.get(5)).getBusinessKnowledgeModel().getName()).isEqualTo("prefix say for hello");
+        assertThat(eventList.get(6)).isInstanceOf(AfterInvokeBKMEvent.class);
+        assertThat(eventList.get(6).getResult().getContext().getMetadata().asMap()).isEqualTo(TEST_METADATA);
+        assertThat(((AfterInvokeBKMEvent) eventList.get(6)).getBusinessKnowledgeModel().getName()).isEqualTo("prefix say for hello");
+        assertThat(eventList.get(7)).isInstanceOf(BeforeInvokeBKMEvent.class);
+        assertThat(eventList.get(7).getResult().getContext().getMetadata().asMap()).isEqualTo(TEST_METADATA);
+        assertThat(((BeforeInvokeBKMEvent) eventList.get(7)).getBusinessKnowledgeModel().getName()).isEqualTo("prefix say for hello");
+        assertThat(eventList.get(8)).isInstanceOf(AfterInvokeBKMEvent.class);
+        assertThat(eventList.get(8).getResult().getContext().getMetadata().asMap()).isEqualTo(TEST_METADATA);
+        assertThat(((AfterInvokeBKMEvent) eventList.get(8)).getBusinessKnowledgeModel().getName()).isEqualTo("prefix say for hello");
+        assertThat(eventList.get(9)).isInstanceOf(BeforeInvokeBKMEvent.class);
+        assertThat(eventList.get(9).getResult().getContext().getMetadata().asMap()).isEqualTo(TEST_METADATA);
+        assertThat(((BeforeInvokeBKMEvent) eventList.get(9)).getBusinessKnowledgeModel().getName()).isEqualTo("prefix say for hello");
+        assertThat(eventList.get(10)).isInstanceOf(AfterInvokeBKMEvent.class);
+        assertThat(eventList.get(10).getResult().getContext().getMetadata().asMap()).isEqualTo(TEST_METADATA);
+        assertThat(((AfterInvokeBKMEvent) eventList.get(10)).getBusinessKnowledgeModel().getName()).isEqualTo("prefix say for hello");
 
-        assertThat(eventList.get(11), instanceOf(AfterEvaluateDecisionEvent.class));
-        assertThat(eventList.get(11).getResult().getContext().getMetadata().asMap(), is(TEST_METADATA));
-        assertThat(((AfterEvaluateDecisionEvent) eventList.get(11)).getDecision().getName(), is("just say"));
+        assertThat(eventList.get(11)).isInstanceOf(AfterEvaluateDecisionEvent.class);
+        assertThat(eventList.get(11).getResult().getContext().getMetadata().asMap()).isEqualTo(TEST_METADATA);
+        assertThat(((AfterEvaluateDecisionEvent) eventList.get(11)).getDecision().getName()).isEqualTo("just say");
     }
 
     @Test
@@ -214,45 +209,45 @@ public class DMNRuntimeListenerTest extends BaseInterpretedVsCompiledTest {
         TestEventListener listener = new TestEventListener();
         runtime.addListener(listener);
         final DMNModel dmnModel = runtime.getModel("http://www.trisotech.com/dmn/definitions/_2443d3f5-f178-47c6-a0c9-b1fd1c933f60", "Drawing 1");
-        assertThat(dmnModel, notNullValue());
-        assertThat(DMNRuntimeUtil.formatMessages(dmnModel.getMessages()), dmnModel.hasErrors(), is(false));
+        assertThat(dmnModel).isNotNull();
+        assertThat(dmnModel.hasErrors()).as(DMNRuntimeUtil.formatMessages(dmnModel.getMessages())).isFalse();
 
         final DMNContext context = newEmptyContextWithTestMetadata();
 
         final DMNResult dmnResult = runtime.evaluateByName(dmnModel, context, "Invoking Decision");
 
-        assertThat(DMNRuntimeUtil.formatMessages(dmnResult.getMessages()), dmnResult.hasErrors(), is(false));
+        assertThat(dmnResult.hasErrors()).as(DMNRuntimeUtil.formatMessages(dmnResult.getMessages())).isFalse();
 
         final DMNContext result = dmnResult.getContext();
 
-        assertThat(result.get("Invoking Decision"), is("abc"));
+        assertThat(result.get("Invoking Decision")).isEqualTo("abc");
 
         List<DMNEvent> eventList = listener.getEventList();
 
-        assertThat(eventList.get(0), instanceOf(BeforeEvaluateDecisionEvent.class));
-        assertThat(eventList.get(0).getResult().getContext().getMetadata().asMap(), is(TEST_METADATA));
-        assertThat(((BeforeEvaluateDecisionEvent) eventList.get(0)).getDecision().getName(), is("Invoking Decision"));
+        assertThat(eventList.get(0)).isInstanceOf(BeforeEvaluateDecisionEvent.class);
+        assertThat(eventList.get(0).getResult().getContext().getMetadata().asMap()).isEqualTo(TEST_METADATA);
+        assertThat(((BeforeEvaluateDecisionEvent) eventList.get(0)).getDecision().getName()).isEqualTo("Invoking Decision");
 
         // Evaluate DecisionService
-        assertThat(eventList.get(1), instanceOf(BeforeEvaluateDecisionServiceEvent.class));
-        assertThat(eventList.get(1).getResult().getContext().getMetadata().asMap(), is(TEST_METADATA));
-        assertThat(((BeforeEvaluateDecisionServiceEvent) eventList.get(1)).getDecisionService().getName(), is("Decision Service ABC"));
+        assertThat(eventList.get(1)).isInstanceOf(BeforeEvaluateDecisionServiceEvent.class);
+        assertThat(eventList.get(1).getResult().getContext().getMetadata().asMap()).isEqualTo(TEST_METADATA);
+        assertThat(((BeforeEvaluateDecisionServiceEvent) eventList.get(1)).getDecisionService().getName()).isEqualTo("Decision Service ABC");
 
         // Evaluate internal Decision
-        assertThat(eventList.get(2), instanceOf(BeforeEvaluateDecisionEvent.class));
-        assertThat(eventList.get(2).getResult().getContext().getMetadata().asMap(), is(TEST_METADATA));
-        assertThat(((BeforeEvaluateDecisionEvent) eventList.get(2)).getDecision().getName(), is("ABC"));
-        assertThat(eventList.get(3), instanceOf(AfterEvaluateDecisionEvent.class));
-        assertThat(eventList.get(3).getResult().getContext().getMetadata().asMap(), is(TEST_METADATA));
-        assertThat(((AfterEvaluateDecisionEvent) eventList.get(3)).getDecision().getName(), is("ABC"));
+        assertThat(eventList.get(2)).isInstanceOf(BeforeEvaluateDecisionEvent.class);
+        assertThat(eventList.get(2).getResult().getContext().getMetadata().asMap()).isEqualTo(TEST_METADATA);
+        assertThat(((BeforeEvaluateDecisionEvent) eventList.get(2)).getDecision().getName()).isEqualTo("ABC");
+        assertThat(eventList.get(3)).isInstanceOf(AfterEvaluateDecisionEvent.class);
+        assertThat(eventList.get(3).getResult().getContext().getMetadata().asMap()).isEqualTo(TEST_METADATA);
+        assertThat(((AfterEvaluateDecisionEvent) eventList.get(3)).getDecision().getName()).isEqualTo("ABC");
 
-        assertThat(eventList.get(4), instanceOf(AfterEvaluateDecisionServiceEvent.class));
-        assertThat(eventList.get(4).getResult().getContext().getMetadata().asMap(), is(TEST_METADATA));
-        assertThat(((AfterEvaluateDecisionServiceEvent) eventList.get(4)).getDecisionService().getName(), is("Decision Service ABC"));
+        assertThat(eventList.get(4)).isInstanceOf(AfterEvaluateDecisionServiceEvent.class);
+        assertThat(eventList.get(4).getResult().getContext().getMetadata().asMap()).isEqualTo(TEST_METADATA);
+        assertThat(((AfterEvaluateDecisionServiceEvent) eventList.get(4)).getDecisionService().getName()).isEqualTo("Decision Service ABC");
 
-        assertThat(eventList.get(5), instanceOf(AfterEvaluateDecisionEvent.class));
-        assertThat(eventList.get(5).getResult().getContext().getMetadata().asMap(), is(TEST_METADATA));
-        assertThat(((AfterEvaluateDecisionEvent) eventList.get(5)).getDecision().getName(), is("Invoking Decision"));
+        assertThat(eventList.get(5)).isInstanceOf(AfterEvaluateDecisionEvent.class);
+        assertThat(eventList.get(5).getResult().getContext().getMetadata().asMap()).isEqualTo(TEST_METADATA);
+        assertThat(((AfterEvaluateDecisionEvent) eventList.get(5)).getDecision().getName()).isEqualTo("Invoking Decision");
     }
 
     @Test
@@ -274,13 +269,13 @@ public class DMNRuntimeListenerTest extends BaseInterpretedVsCompiledTest {
         assertEquals(listener.beforeEvent.getModelNamespace(), modelNamespace);
         assertEquals(listener.beforeEvent.getModelName(), modelName);
         assertNotNull(listener.beforeEvent.getResult());
-        assertThat(listener.beforeEvent.getResult().getContext().getMetadata().asMap(), is(TEST_METADATA));
+        assertThat(listener.beforeEvent.getResult().getContext().getMetadata().asMap()).isEqualTo(TEST_METADATA);
 
         assertNotNull(listener.afterEvent);
         assertEquals(listener.afterEvent.getModelNamespace(), modelNamespace);
         assertEquals(listener.afterEvent.getModelName(), modelName);
         assertNotNull(listener.afterEvent.getResult());
-        assertThat(listener.afterEvent.getResult().getContext().getMetadata().asMap(), is(TEST_METADATA));
+        assertThat(listener.afterEvent.getResult().getContext().getMetadata().asMap()).isEqualTo(TEST_METADATA);
     }
 
     private static DMNContext newEmptyContextWithTestMetadata() {

--- a/kie-dmn/kie-dmn-core/src/test/java/org/kie/dmn/core/classloader/DTAnnotationListenerTest.java
+++ b/kie-dmn/kie-dmn-core/src/test/java/org/kie/dmn/core/classloader/DTAnnotationListenerTest.java
@@ -40,9 +40,6 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.hamcrest.CoreMatchers.is;
-import static org.hamcrest.CoreMatchers.notNullValue;
-import static org.hamcrest.MatcherAssert.assertThat;
 import static org.kie.dmn.core.util.DynamicTypeUtils.entry;
 import static org.kie.dmn.core.util.DynamicTypeUtils.mapOf;
 
@@ -95,15 +92,15 @@ public class DTAnnotationListenerTest {
         final DMNRuntime runtime = DMNRuntimeUtil.createRuntime("license.dmn", this.getClass());
         runtime.addListener(listenerUT);
         final DMNModel dmnModel = runtime.getModel("https://kiegroup.org/dmn/_1F095E5D-0E50-4564-9A76-DD4735BF938A", "license");
-        assertThat(dmnModel, notNullValue());
-        assertThat(DMNRuntimeUtil.formatMessages(dmnModel.getMessages()), dmnModel.hasErrors(), is(false));
+        assertThat(dmnModel).isNotNull();
+        assertThat(dmnModel.hasErrors()).as(DMNRuntimeUtil.formatMessages(dmnModel.getMessages())).isFalse();
 
         final DMNContext context = DMNFactory.newContext();
         context.set("a person", mapOf(entry("name", "John Doe"), entry("age", 47)));
 
         final DMNResult dmnResult = runtime.evaluateAll(dmnModel, context);
         LOG.debug("{}", dmnResult);
-        assertThat(DMNRuntimeUtil.formatMessages(dmnResult.getMessages()), dmnResult.hasErrors(), is(false));
+        assertThat(dmnResult.hasErrors()).as(DMNRuntimeUtil.formatMessages(dmnResult.getMessages())).isFalse();
 
         assertThat(dmnResult.getDecisionResultByName("can get license").getResult()).isEqualTo(Boolean.TRUE);
 

--- a/kie-dmn/kie-dmn-core/src/test/java/org/kie/dmn/core/compiler/ItemDefinitionDependenciesTest.java
+++ b/kie-dmn/kie-dmn-core/src/test/java/org/kie/dmn/core/compiler/ItemDefinitionDependenciesTest.java
@@ -25,9 +25,7 @@ import org.junit.Test;
 import org.kie.dmn.model.api.ItemDefinition;
 import org.kie.dmn.model.v1_1.TItemDefinition;
 
-import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.contains;
-import static org.hamcrest.Matchers.containsInAnyOrder;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.Assert.assertTrue;
 
 
@@ -69,8 +67,8 @@ public class ItemDefinitionDependenciesTest {
         
         final List<ItemDefinition> orderedList = orderingStrategy(originalList);
 
-        assertThat(orderedList.subList(0, 2), containsInAnyOrder(a,b));
-        assertThat(orderedList.subList(2, 4), contains(c,d));
+        assertThat(orderedList.subList(0, 2)).contains(a,b);
+        assertThat(orderedList.subList(2, 4)).contains(c,d);
     }
     
     @Test
@@ -225,7 +223,7 @@ public class ItemDefinitionDependenciesTest {
 
         final List<ItemDefinition> orderedList = orderingStrategy(originalList);
 
-        assertThat(orderedList.subList(0, 2), containsInAnyOrder(fhirAge, fhirExtension));
-        assertThat(orderedList.subList(2, 3), contains(fhirT1));
+        assertThat(orderedList.subList(0, 2)).contains(fhirAge, fhirExtension);
+        assertThat(orderedList.subList(2, 3)).contains(fhirT1);
     }
 }

--- a/kie-dmn/kie-dmn-core/src/test/java/org/kie/dmn/core/compiler/extensions/DMNExtensionRegisterTest.java
+++ b/kie-dmn/kie-dmn-core/src/test/java/org/kie/dmn/core/compiler/extensions/DMNExtensionRegisterTest.java
@@ -36,12 +36,10 @@ import org.kie.dmn.model.api.InputData;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import static org.hamcrest.CoreMatchers.is;
-import static org.hamcrest.CoreMatchers.notNullValue;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
-import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.Assert.assertTrue;
 
 public class DMNExtensionRegisterTest {
@@ -55,8 +53,8 @@ public class DMNExtensionRegisterTest {
             
             final DMNRuntime runtime = DMNRuntimeUtil.createRuntime("0001-input-data-string-with-extensions.dmn", this.getClass() );
             final DMNModel dmnModel = runtime.getModel("https://github.com/kiegroup/kie-dmn", "0001-input-data-string" );
-            assertThat( dmnModel, notNullValue() );
-            assertThat( formatMessages( dmnModel.getMessages() ), dmnModel.hasErrors(), is( false ) );
+            assertThat(dmnModel).isNotNull();
+            assertThat(dmnModel.hasErrors()).as(DMNRuntimeUtil.formatMessages(dmnModel.getMessages())).isFalse();
             
             assertEquals(3, dmnModel.getDefinitions().getDrgElement().size());
             
@@ -107,8 +105,8 @@ public class DMNExtensionRegisterTest {
         
         final DMNRuntime runtime = kieContainer.newKieSession().getKieRuntime(DMNRuntime.class);
         final DMNModel dmnModel = runtime.getModel("https://github.com/kiegroup/kie-dmn", "0001-input-data-string" );
-        assertThat( dmnModel, notNullValue() );
-        assertThat( formatMessages( dmnModel.getMessages() ), dmnModel.hasErrors(), is( false ) );
+        assertThat(dmnModel).isNotNull();
+        assertThat(dmnModel.hasErrors()).as(DMNRuntimeUtil.formatMessages(dmnModel.getMessages())).isFalse();
         
         assertEquals(3, dmnModel.getDefinitions().getDrgElement().size());
         
@@ -152,8 +150,8 @@ public class DMNExtensionRegisterTest {
         
         final DMNRuntime runtime = kieContainer.newKieSession().getKieRuntime(DMNRuntime.class);
         final DMNModel dmnModel = runtime.getModel("https://github.com/kiegroup/kie-dmn", "0001-input-data-string" );
-        assertThat( dmnModel, notNullValue() );
-        assertThat( formatMessages( dmnModel.getMessages() ), dmnModel.hasErrors(), is( false ) );
+        assertThat(dmnModel).isNotNull();
+        assertThat(dmnModel.hasErrors()).as(DMNRuntimeUtil.formatMessages(dmnModel.getMessages())).isFalse();
         
         assertEquals(3, dmnModel.getDefinitions().getDrgElement().size());
         final InputData inputData1 = (InputData) dmnModel.getDefinitions().getDrgElement().get(1);

--- a/kie-dmn/kie-dmn-core/src/test/java/org/kie/dmn/core/compiler/profiles/DMNProfilesTest.java
+++ b/kie-dmn/kie-dmn-core/src/test/java/org/kie/dmn/core/compiler/profiles/DMNProfilesTest.java
@@ -35,9 +35,7 @@ import org.kie.dmn.core.util.DMNRuntimeUtil;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import static org.hamcrest.CoreMatchers.is;
-import static org.hamcrest.CoreMatchers.notNullValue;
-import static org.hamcrest.MatcherAssert.assertThat;
+import static org.assertj.core.api.Assertions.assertThat;
 
 public class DMNProfilesTest extends BaseInterpretedVsCompiledTest {
 
@@ -59,24 +57,24 @@ public class DMNProfilesTest extends BaseInterpretedVsCompiledTest {
 
         final KieBuilder kieBuilder = ks.newKieBuilder(kfs).buildAll();
         final Results results = kieBuilder.getResults();
-        assertThat(results.getMessages().toString(), results.hasMessages(org.kie.api.builder.Message.Level.ERROR), is(false));
+        assertThat(results.hasMessages(org.kie.api.builder.Message.Level.ERROR)).as(results.getMessages().toString()).isFalse();
 
         final KieContainer kieContainer = ks.newKieContainer(ks.getRepository().getDefaultReleaseId());
         final DMNRuntime runtime = kieContainer.newKieSession().getKieRuntime(DMNRuntime.class);
 
         final DMNModel dmnModel = runtime.getModel("http://www.trisotech.com/definitions/_ae46e75f-efc5-48f8-8e82-4f48bf16afc0", "just 47");
-        assertThat(dmnModel, notNullValue());
-        assertThat(DMNRuntimeUtil.formatMessages(dmnModel.getMessages()), dmnModel.hasErrors(), is(false));
+        assertThat(dmnModel).isNotNull();
+        assertThat(dmnModel.hasErrors()).as(DMNRuntimeUtil.formatMessages(dmnModel.getMessages())).isFalse();
 
         final DMNContext context = DMNFactory.newContext();
         context.set("number", 123.123456d);
 
         final DMNResult dmnResult = runtime.evaluateAll(dmnModel, context);
         LOG.debug("{}", dmnResult);
-        assertThat(DMNRuntimeUtil.formatMessages(dmnResult.getMessages()), dmnResult.hasErrors(), is(false));
+        assertThat(dmnResult.hasErrors()).as(DMNRuntimeUtil.formatMessages(dmnResult.getMessages())).isFalse();
 
         final DMNContext result = dmnResult.getContext();
-        assertThat(result.get("decision result"), is(new BigDecimal(47)));
+        assertThat(result.get("decision result")).isEqualTo(new BigDecimal(47));
     }
 
     @Test
@@ -91,22 +89,22 @@ public class DMNProfilesTest extends BaseInterpretedVsCompiledTest {
 
         final KieBuilder kieBuilder = ks.newKieBuilder(kfs).buildAll();
         final Results results = kieBuilder.getResults();
-        assertThat(results.getMessages().toString(), results.hasMessages(org.kie.api.builder.Message.Level.ERROR), is(false));
+        assertThat(results.hasMessages(org.kie.api.builder.Message.Level.ERROR)).as(results.getMessages().toString()).isFalse();
 
         final KieContainer kieContainer = ks.newKieContainer(ks.getRepository().getDefaultReleaseId());
         final DMNRuntime runtime = kieContainer.newKieSession().getKieRuntime(DMNRuntime.class);
 
         final DMNModel dmnModel = runtime.getModel("http://www.trisotech.com/definitions/_5d9e63ac-e73a-4b9e-8635-760f0c23c0ad", "Drawing 1");
-        assertThat(dmnModel, notNullValue());
-        assertThat(DMNRuntimeUtil.formatMessages(dmnModel.getMessages()), dmnModel.hasErrors(), is(false));
+        assertThat(dmnModel).isNotNull();
+        assertThat(dmnModel.hasErrors()).as(DMNRuntimeUtil.formatMessages(dmnModel.getMessages())).isFalse();
 
         final DMNContext context = DMNFactory.newContext();
 
         final DMNResult dmnResult = runtime.evaluateAll(dmnModel, context);
         LOG.debug("{}", dmnResult);
-        assertThat(DMNRuntimeUtil.formatMessages(dmnResult.getMessages()), dmnResult.hasErrors(), is(false));
+        assertThat(dmnResult.hasErrors()).as(DMNRuntimeUtil.formatMessages(dmnResult.getMessages())).isFalse();
 
         final DMNContext result = dmnResult.getContext();
-        assertThat(result.get("main decision"), is(new BigDecimal(1)));
+        assertThat(result.get("main decision")).isEqualTo(new BigDecimal(1));
     }
 }

--- a/kie-dmn/kie-dmn-core/src/test/java/org/kie/dmn/core/compiler/profiles/ExtendedDMNProfileTest.java
+++ b/kie-dmn/kie-dmn-core/src/test/java/org/kie/dmn/core/compiler/profiles/ExtendedDMNProfileTest.java
@@ -24,7 +24,6 @@ import java.time.format.DateTimeFormatter;
 import java.util.Arrays;
 import java.util.Collections;
 
-import org.hamcrest.Matchers;
 import org.junit.Assert;
 import org.junit.Test;
 import org.kie.dmn.feel.runtime.functions.AbsFunction;
@@ -44,7 +43,7 @@ import org.kie.dmn.feel.runtime.functions.extended.DateFunction;
 import org.kie.dmn.feel.runtime.functions.extended.TimeFunction;
 
 import static java.math.BigDecimal.valueOf;
-import static org.hamcrest.MatcherAssert.assertThat;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.Assert.assertTrue;
 
 public class ExtendedDMNProfileTest {
@@ -165,12 +164,12 @@ public class ExtendedDMNProfileTest {
 
     private static <T> void assertResult(final FEELFnResult<T> result, final T val) {
         assertTrue(result.isRight());
-        assertThat(result.getOrElse(null), Matchers.equalTo(val));
+        assertThat(result.getOrElse(null)).isEqualTo(val);
     }
 
     private static void assertResultDoublePrecision(final FEELFnResult<BigDecimal> result, final BigDecimal val) {
         assertTrue(result.isRight());
-        assertThat(Double.compare(result.getOrElse(null).doubleValue(), val.doubleValue()), Matchers.equalTo(0));
+        assertThat(Double.compare(result.getOrElse(null).doubleValue(), val.doubleValue())).isEqualTo(0);
     }
 
     private static void assertNull(final FEELFnResult<?> result) {

--- a/kie-dmn/kie-dmn-core/src/test/java/org/kie/dmn/core/decisionservices/DMNDecisionServicesTest.java
+++ b/kie-dmn/kie-dmn-core/src/test/java/org/kie/dmn/core/decisionservices/DMNDecisionServicesTest.java
@@ -32,14 +32,7 @@ import org.kie.dmn.core.util.DMNRuntimeUtil;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import static org.hamcrest.CoreMatchers.is;
-import static org.hamcrest.CoreMatchers.notNullValue;
-import static org.hamcrest.CoreMatchers.nullValue;
-import static org.hamcrest.Matchers.anything;
-import static org.hamcrest.Matchers.hasEntry;
-import static org.hamcrest.Matchers.not;
-import static org.junit.Assert.assertNull;
-import static org.hamcrest.MatcherAssert.assertThat;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.kie.dmn.core.util.DynamicTypeUtils.entry;
 import static org.kie.dmn.core.util.DynamicTypeUtils.mapOf;
 
@@ -55,8 +48,8 @@ public class DMNDecisionServicesTest extends BaseInterpretedVsCompiledTest {
     public void testBasic() {
         final DMNRuntime runtime = DMNRuntimeUtil.createRuntime("0004-decision-services.dmn", this.getClass());
         final DMNModel dmnModel = runtime.getModel("http://www.trisotech.com/definitions/_686f58d4-4ec3-4c65-8c06-0e4fd8983def", "Decision Services");
-        assertThat(dmnModel, notNullValue());
-        assertThat(DMNRuntimeUtil.formatMessages(dmnModel.getMessages()), dmnModel.hasErrors(), is(false));
+        assertThat(dmnModel).isNotNull();
+        assertThat(dmnModel.hasErrors()).as(DMNRuntimeUtil.formatMessages(dmnModel.getMessages())).isFalse();
 
         checkDSwithInputData(runtime, dmnModel);
 
@@ -72,10 +65,10 @@ public class DMNDecisionServicesTest extends BaseInterpretedVsCompiledTest {
         final DMNResult dmnResult = runtime.evaluateDecisionService(dmnModel, context, "A only as output knowing D and E");
         LOG.debug("{}", dmnResult);
         dmnResult.getDecisionResults().forEach(x -> LOG.debug("{}", x));
-        assertThat(DMNRuntimeUtil.formatMessages(dmnResult.getMessages()), dmnResult.hasErrors(), is(false));
+        assertThat(dmnResult.hasErrors()).as(DMNRuntimeUtil.formatMessages(dmnResult.getMessages())).isFalse();
 
         final DMNContext result = dmnResult.getContext();
-        assertThat(result.get("A"), is("de"));
+        assertThat(result.get("A")).isEqualTo("de");
     }
 
     private void checkDSwithInputDecision(final DMNRuntime runtime, final DMNModel dmnModel) {
@@ -86,10 +79,10 @@ public class DMNDecisionServicesTest extends BaseInterpretedVsCompiledTest {
         final DMNResult dmnResult = runtime.evaluateDecisionService(dmnModel, context, "A Only Knowing B and C");
         LOG.debug("{}", dmnResult);
         dmnResult.getDecisionResults().forEach(x -> LOG.debug("{}", x));
-        assertThat(DMNRuntimeUtil.formatMessages(dmnResult.getMessages()), dmnResult.hasErrors(), is(false));
+        assertThat(dmnResult.hasErrors()).as(DMNRuntimeUtil.formatMessages(dmnResult.getMessages())).isFalse();
 
         final DMNContext result = dmnResult.getContext();
-        assertThat(result.get("A"), nullValue()); // because B and C are not defined in input.
+        assertThat(result.get("A")).isNull(); // because B and C are not defined in input.
     }
 
     private void checkDSwithInputDecision2(final DMNRuntime runtime, final DMNModel dmnModel) {
@@ -102,18 +95,18 @@ public class DMNDecisionServicesTest extends BaseInterpretedVsCompiledTest {
         final DMNResult dmnResult = runtime.evaluateDecisionService(dmnModel, context, "A Only Knowing B and C");
         LOG.debug("{}", dmnResult);
         dmnResult.getDecisionResults().forEach(x -> LOG.debug("{}", x));
-        assertThat(DMNRuntimeUtil.formatMessages(dmnResult.getMessages()), dmnResult.hasErrors(), is(false));
+        assertThat(dmnResult.hasErrors()).as(DMNRuntimeUtil.formatMessages(dmnResult.getMessages())).isFalse();
 
         final DMNContext result = dmnResult.getContext();
-        assertThat(result.get("A"), is("inBinC"));
+        assertThat(result.get("A")).isEqualTo("inBinC");
     }
 
     @Test
     public void testDSInLiteralExpression() {
         final DMNRuntime runtime = DMNRuntimeUtil.createRuntime("DecisionServicesInLiteralExpression.dmn", this.getClass());
         final DMNModel dmnModel = runtime.getModel("http://www.trisotech.com/definitions/_686f58d4-4ec3-4c65-8c06-0e4fd8983def", "Decision Services");
-        assertThat(dmnModel, notNullValue());
-        assertThat(DMNRuntimeUtil.formatMessages(dmnModel.getMessages()), dmnModel.hasErrors(), is(false));
+        assertThat(dmnModel).isNotNull();
+        assertThat(dmnModel.hasErrors()).as(DMNRuntimeUtil.formatMessages(dmnModel.getMessages())).isFalse();
 
         final DMNContext context = DMNFactory.newContext();
         context.set("D", "d");
@@ -122,18 +115,18 @@ public class DMNDecisionServicesTest extends BaseInterpretedVsCompiledTest {
         final DMNResult dmnResult = runtime.evaluateAll(dmnModel, context);
         LOG.debug("{}", dmnResult);
         dmnResult.getDecisionResults().forEach(x -> LOG.debug("{}", x));
-        assertThat(DMNRuntimeUtil.formatMessages(dmnResult.getMessages()), dmnResult.hasErrors(), is(false));
+        assertThat(dmnResult.hasErrors()).as(DMNRuntimeUtil.formatMessages(dmnResult.getMessages())).isFalse();
 
         final DMNContext result = dmnResult.getContext();
-        assertThat(result.get("Decide based on A and DS"), is("xyde"));
+        assertThat(result.get("Decide based on A and DS")).isEqualTo("xyde");
     }
 
     @Test
     public void testDSInLiteralExpressionWithBKM() {
         final DMNRuntime runtime = DMNRuntimeUtil.createRuntime("DecisionServicesInLiteralExpressionWithBKM.dmn", this.getClass());
         final DMNModel dmnModel = runtime.getModel("http://www.trisotech.com/definitions/_686f58d4-4ec3-4c65-8c06-0e4fd8983def", "Decision Services");
-        assertThat(dmnModel, notNullValue());
-        assertThat(DMNRuntimeUtil.formatMessages(dmnModel.getMessages()), dmnModel.hasErrors(), is(false));
+        assertThat(dmnModel).isNotNull();
+        assertThat(dmnModel.hasErrors()).as(DMNRuntimeUtil.formatMessages(dmnModel.getMessages())).isFalse();
 
         final DMNContext context = DMNFactory.newContext();
         context.set("D", "d");
@@ -142,18 +135,18 @@ public class DMNDecisionServicesTest extends BaseInterpretedVsCompiledTest {
         final DMNResult dmnResult = runtime.evaluateAll(dmnModel, context);
         LOG.debug("{}", dmnResult);
         dmnResult.getDecisionResults().forEach(x -> LOG.debug("{}", x));
-        assertThat(DMNRuntimeUtil.formatMessages(dmnResult.getMessages()), dmnResult.hasErrors(), is(false));
+        assertThat(dmnResult.hasErrors()).as(DMNRuntimeUtil.formatMessages(dmnResult.getMessages())).isFalse();
 
         final DMNContext result = dmnResult.getContext();
-        assertThat(result.get("Decide based on A and DS"), is("xydemn"));
+        assertThat(result.get("Decide based on A and DS")).isEqualTo("xydemn");
     }
 
     @Test
     public void testDSInLiteralExpressionWithBKMUsingInvocation() {
         final DMNRuntime runtime = DMNRuntimeUtil.createRuntime("DecisionServicesInLiteralExpressionWithBKMUsingInvocation.dmn", this.getClass());
         final DMNModel dmnModel = runtime.getModel("http://www.trisotech.com/definitions/_686f58d4-4ec3-4c65-8c06-0e4fd8983def", "Decision Services");
-        assertThat(dmnModel, notNullValue());
-        assertThat(DMNRuntimeUtil.formatMessages(dmnModel.getMessages()), dmnModel.hasErrors(), is(false));
+        assertThat(dmnModel).isNotNull();
+        assertThat(dmnModel.hasErrors()).as(DMNRuntimeUtil.formatMessages(dmnModel.getMessages())).isFalse();
 
         final DMNContext context = DMNFactory.newContext();
         context.set("D", "d");
@@ -162,18 +155,18 @@ public class DMNDecisionServicesTest extends BaseInterpretedVsCompiledTest {
         final DMNResult dmnResult = runtime.evaluateAll(dmnModel, context);
         LOG.debug("{}", dmnResult);
         dmnResult.getDecisionResults().forEach(x -> LOG.debug("{}", x));
-        assertThat(DMNRuntimeUtil.formatMessages(dmnResult.getMessages()), dmnResult.hasErrors(), is(false));
+        assertThat(dmnResult.hasErrors()).as(DMNRuntimeUtil.formatMessages(dmnResult.getMessages())).isFalse();
 
         final DMNContext result = dmnResult.getContext();
-        assertThat(result.get("Decide based on A and DS"), is("xydemn"));
+        assertThat(result.get("Decide based on A and DS")).isEqualTo("xydemn");
     }
 
     @Test
     public void testDSInLiteralExpressionOnlyfromBKMUsingInvocation() {
         final DMNRuntime runtime = DMNRuntimeUtil.createRuntime("DecisionServicesInLiteralExpressionOnlyFromBKMUsingInvocation.dmn", this.getClass());
         final DMNModel dmnModel = runtime.getModel("http://www.trisotech.com/definitions/_686f58d4-4ec3-4c65-8c06-0e4fd8983def", "Decision Services");
-        assertThat(dmnModel, notNullValue());
-        assertThat(DMNRuntimeUtil.formatMessages(dmnModel.getMessages()), dmnModel.hasErrors(), is(false));
+        assertThat(dmnModel).isNotNull();
+        assertThat(dmnModel.hasErrors()).as(DMNRuntimeUtil.formatMessages(dmnModel.getMessages())).isFalse();
 
         final DMNContext context = DMNFactory.newContext();
         context.set("D", "d");
@@ -182,18 +175,18 @@ public class DMNDecisionServicesTest extends BaseInterpretedVsCompiledTest {
         final DMNResult dmnResult = runtime.evaluateAll(dmnModel, context);
         LOG.debug("{}", dmnResult);
         dmnResult.getDecisionResults().forEach(x -> LOG.debug("{}", x));
-        assertThat(DMNRuntimeUtil.formatMessages(dmnResult.getMessages()), dmnResult.hasErrors(), is(false));
+        assertThat(dmnResult.hasErrors()).as(DMNRuntimeUtil.formatMessages(dmnResult.getMessages())).isFalse();
 
         final DMNContext result = dmnResult.getContext();
-        assertThat(result.get("Decide based on A and DS"), is("demn"));
+        assertThat(result.get("Decide based on A and DS")).isEqualTo("demn");
     }
 
     @Test
     public void testMixtypeDS() {
         final DMNRuntime runtime = DMNRuntimeUtil.createRuntime("mixtype-DS.dmn", this.getClass());
         final DMNModel dmnModel = runtime.getModel("http://www.trisotech.com/dmn/definitions/_c9885563-aa54-4c7b-ae8a-738cfd29b544", "mixtype DS");
-        assertThat(dmnModel, notNullValue());
-        assertThat(DMNRuntimeUtil.formatMessages(dmnModel.getMessages()), dmnModel.hasErrors(), is(false));
+        assertThat(dmnModel).isNotNull();
+        assertThat(dmnModel.hasErrors()).as(DMNRuntimeUtil.formatMessages(dmnModel.getMessages())).isFalse();
 
         final DMNContext context = DMNFactory.newContext();
         context.set("Person name", "John");
@@ -202,27 +195,27 @@ public class DMNDecisionServicesTest extends BaseInterpretedVsCompiledTest {
         final DMNResult dmnResult = runtime.evaluateAll(dmnModel, context);
         LOG.debug("{}", dmnResult);
         dmnResult.getDecisionResults().forEach(x -> LOG.debug("{}", x));
-        assertThat(DMNRuntimeUtil.formatMessages(dmnResult.getMessages()), dmnResult.hasErrors(), is(false));
+        assertThat(dmnResult.hasErrors()).as(DMNRuntimeUtil.formatMessages(dmnResult.getMessages())).isFalse();
 
         final DMNContext result = dmnResult.getContext();
-        assertThat(result.get("Greet the Person"), is("Hello, John"));
-        assertThat(result.get("Person age"), is(BigDecimal.valueOf(38)));
-        assertThat(result.get("is Person an adult"), is(true));
+        assertThat(result.get("Greet the Person")).isEqualTo("Hello, John");
+        assertThat(result.get("Person age")).isEqualTo(BigDecimal.valueOf(38));
+        assertThat(result.get("is Person an adult")).isEqualTo(Boolean.TRUE);
 
-        assertThat((Map<String, Object>) result.get("eval DS all"), hasEntry(is("Greet the Person"), is("Hello, ds all")));
-        assertThat((Map<String, Object>) result.get("eval DS all"), hasEntry(is("Person age"), is(BigDecimal.valueOf(18))));
-        assertThat((Map<String, Object>) result.get("eval DS all"), hasEntry(is("is Person an adult"), is(true)));
-        assertThat((Map<String, Object>) result.get("eval DS all"), not(hasEntry(is("hardcoded now"), anything())));
+        assertThat((Map<String, Object>) result.get("eval DS all")).containsEntry("Greet the Person", "Hello, ds all");
+        assertThat((Map<String, Object>) result.get("eval DS all")).containsEntry("Person age", BigDecimal.valueOf(18));
+        assertThat((Map<String, Object>) result.get("eval DS all")).containsEntry("is Person an adult", true);
+        assertThat((Map<String, Object>) result.get("eval DS all")).doesNotContainKey("hardcoded now");
 
-        assertThat((Map<String, Object>) result.get("eval DS encapsulate"), hasEntry(is("Greet the Person"), is("Hello, DS encapsulate")));
-        assertThat((Map<String, Object>) result.get("eval DS encapsulate"), not(hasEntry(is("Person age"), anything())));
-        assertThat((Map<String, Object>) result.get("eval DS encapsulate"), hasEntry(is("is Person an adult"), is(true)));
-        assertThat((Map<String, Object>) result.get("eval DS encapsulate"), not(hasEntry(is("hardcoded now"), anything())));
+        assertThat((Map<String, Object>) result.get("eval DS encapsulate")).containsEntry("Greet the Person", "Hello, DS encapsulate");
+        assertThat((Map<String, Object>) result.get("eval DS encapsulate")).doesNotContainKey("Person age");
+        assertThat((Map<String, Object>) result.get("eval DS encapsulate")).containsEntry("is Person an adult", true);
+        assertThat((Map<String, Object>) result.get("eval DS encapsulate")).doesNotContainKey("hardcoded now");
 
-        assertThat((Map<String, Object>) result.get("eval DS greet adult"), hasEntry(is("Greet the Person"), is("Hello, DS greet adult")));
-        assertThat((Map<String, Object>) result.get("eval DS greet adult"), not(hasEntry(is("Person age"), anything())));
-        assertThat((Map<String, Object>) result.get("eval DS greet adult"), hasEntry(is("is Person an adult"), is(true)));
-        assertThat((Map<String, Object>) result.get("eval DS greet adult"), not(hasEntry(is("hardcoded now"), anything())));
+        assertThat((Map<String, Object>) result.get("eval DS greet adult")).containsEntry("Greet the Person", "Hello, DS greet adult");
+        assertThat((Map<String, Object>) result.get("eval DS greet adult")).doesNotContainKey("Person age");
+        assertThat((Map<String, Object>) result.get("eval DS greet adult")).containsEntry("is Person an adult", true);
+        assertThat((Map<String, Object>) result.get("eval DS greet adult")).doesNotContainKey("hardcoded now");
 
         // additionally check DS one-by-one
         testMixtypeDS_checkDSall(runtime, dmnModel);
@@ -238,13 +231,13 @@ public class DMNDecisionServicesTest extends BaseInterpretedVsCompiledTest {
         final DMNResult dmnResult = runtime.evaluateDecisionService(dmnModel, context, "DS all");
         LOG.debug("{}", dmnResult);
         dmnResult.getDecisionResults().forEach(x -> LOG.debug("{}", x));
-        assertThat(DMNRuntimeUtil.formatMessages(dmnResult.getMessages()), dmnResult.hasErrors(), is(false));
+        assertThat(dmnResult.hasErrors()).as(DMNRuntimeUtil.formatMessages(dmnResult.getMessages())).isFalse();
 
         final DMNContext result = dmnResult.getContext();
-        assertThat(result.getAll(), hasEntry(is("Greet the Person"), is("Hello, John")));
-        assertThat(result.getAll(), hasEntry(is("Person age"), is(BigDecimal.valueOf(10))));
-        assertThat(result.getAll(), hasEntry(is("is Person an adult"), is(false)));
-        assertThat(result.getAll(), not(hasEntry(is("hardcoded now"), anything())));
+        assertThat(result.getAll()).containsEntry("Greet the Person", "Hello, John");
+        assertThat(result.getAll()).containsEntry("Person age", BigDecimal.valueOf(10));
+        assertThat(result.getAll()).containsEntry("is Person an adult", false);
+        assertThat(result.getAll()).doesNotContainKey("hardcoded now");
     }
 
     private void testMixtypeDS_checkDSencapsulate(final DMNRuntime runtime, final DMNModel dmnModel) {
@@ -255,13 +248,13 @@ public class DMNDecisionServicesTest extends BaseInterpretedVsCompiledTest {
         final DMNResult dmnResult = runtime.evaluateDecisionService(dmnModel, context, "DS encapsulate");
         LOG.debug("{}", dmnResult);
         dmnResult.getDecisionResults().forEach(x -> LOG.debug("{}", x));
-        assertThat(DMNRuntimeUtil.formatMessages(dmnResult.getMessages()), dmnResult.hasErrors(), is(false));
+        assertThat(dmnResult.hasErrors()).as(DMNRuntimeUtil.formatMessages(dmnResult.getMessages())).isFalse();
 
         final DMNContext result = dmnResult.getContext();
-        assertThat(result.getAll(), hasEntry(is("Greet the Person"), is("Hello, John")));
-        assertThat(result.getAll(), not(hasEntry(is("Person age"), anything())));
-        assertThat(result.getAll(), hasEntry(is("is Person an adult"), is(false)));
-        assertThat(result.getAll(), not(hasEntry(is("hardcoded now"), anything())));
+        assertThat(result.getAll()).containsEntry("Greet the Person", "Hello, John");
+        assertThat(result.getAll()).doesNotContainKey("Person age");
+        assertThat(result.getAll()).containsEntry("is Person an adult", false);
+        assertThat(result.getAll()).doesNotContainKey("hardcoded now");
     }
 
     private void testMixtypeDS_checkDSgreetadult(final DMNRuntime runtime, final DMNModel dmnModel) {
@@ -272,21 +265,21 @@ public class DMNDecisionServicesTest extends BaseInterpretedVsCompiledTest {
         final DMNResult dmnResult = runtime.evaluateDecisionService(dmnModel, context, "DS greet adult");
         LOG.debug("{}", dmnResult);
         dmnResult.getDecisionResults().forEach(x -> LOG.debug("{}", x));
-        assertThat(DMNRuntimeUtil.formatMessages(dmnResult.getMessages()), dmnResult.hasErrors(), is(false));
+        assertThat(dmnResult.hasErrors()).as(DMNRuntimeUtil.formatMessages(dmnResult.getMessages())).isFalse();
 
         final DMNContext result = dmnResult.getContext();
-        assertThat(result.getAll(), hasEntry(is("Greet the Person"), is("Hello, John")));
-        assertThat(dmnResult.getDecisionResultByName("Person age"), nullValue());
-        assertThat(result.getAll(), hasEntry(is("is Person an adult"), is(false)));
-        assertThat(result.getAll(), not(hasEntry(is("hardcoded now"), anything())));
+        assertThat(result.getAll()).containsEntry("Greet the Person", "Hello, John");
+        assertThat(dmnResult.getDecisionResultByName("Person age")).isNull();
+        assertThat(result.getAll()).containsEntry("is Person an adult", false);
+        assertThat(result.getAll()).doesNotContainKey("hardcoded now");
     }
 
     @Test
     public void testDSForTypeCheck() {
         final DMNRuntime runtime = DMNRuntimeUtil.createRuntime("DecisionService20180718.dmn", this.getClass());
         final DMNModel dmnModel = runtime.getModel("http://www.trisotech.com/dmn/definitions/_6eef3a7c-bb0d-40bb-858d-f9067789c18a", "Decision Service 20180718");
-        assertThat(dmnModel, notNullValue());
-        assertThat(DMNRuntimeUtil.formatMessages(dmnModel.getMessages()), dmnModel.hasErrors(), is(false));
+        assertThat(dmnModel).isNotNull();
+        assertThat(dmnModel.hasErrors()).as(DMNRuntimeUtil.formatMessages(dmnModel.getMessages())).isFalse();
 
         testDSForTypeCheck_runNormal(runtime, dmnModel);
         testDSForTypeCheck_runAllDecisionsWithWrongTypes(runtime, dmnModel);
@@ -302,12 +295,12 @@ public class DMNDecisionServicesTest extends BaseInterpretedVsCompiledTest {
         final DMNResult dmnResult = runtime.evaluateAll(dmnModel, context);
         LOG.debug("{}", dmnResult);
         dmnResult.getDecisionResults().forEach(x -> LOG.debug("{}", x));
-        assertThat(DMNRuntimeUtil.formatMessages(dmnResult.getMessages()), dmnResult.hasErrors(), is(false));
+        assertThat(dmnResult.hasErrors()).as(DMNRuntimeUtil.formatMessages(dmnResult.getMessages())).isFalse();
 
         final DMNContext result = dmnResult.getContext();
-        assertThat(result.get("Greet the person"), is("Hello, John"));
-        assertThat(result.get("is Person at age allowed"), is(true));
-        assertThat(result.get("Final Decision"), is("Hello, John; you are allowed"));
+        assertThat(result.get("Greet the person")).isEqualTo("Hello, John");
+        assertThat(result.get("is Person at age allowed")).isEqualTo(Boolean.TRUE);
+        assertThat(result.get("Final Decision")).isEqualTo("Hello, John; you are allowed");
     }
 
     private void testDSForTypeCheck_runAllDecisionsWithWrongTypes(final DMNRuntime runtime, final DMNModel dmnModel) {
@@ -318,7 +311,7 @@ public class DMNDecisionServicesTest extends BaseInterpretedVsCompiledTest {
         final DMNResult dmnResult = runtime.evaluateAll(dmnModel, context);
         LOG.debug("{}", dmnResult);
         dmnResult.getDecisionResults().forEach(x -> LOG.debug("{}", x));
-        assertThat(DMNRuntimeUtil.formatMessages(dmnResult.getMessages()), dmnResult.hasErrors(), is(true));
+        assertThat(dmnResult.hasErrors()).as(DMNRuntimeUtil.formatMessages(dmnResult.getMessages())).isTrue();
     }
 
     private void testDSForTypeCheck_runDecisionService_Normal(final DMNRuntime runtime, final DMNModel dmnModel) {
@@ -329,12 +322,12 @@ public class DMNDecisionServicesTest extends BaseInterpretedVsCompiledTest {
         final DMNResult dmnResult = runtime.evaluateDecisionService(dmnModel, context, "DS given inputdata");
         LOG.debug("{}", dmnResult);
         dmnResult.getDecisionResults().forEach(x -> LOG.debug("{}", x));
-        assertThat(DMNRuntimeUtil.formatMessages(dmnResult.getMessages()), dmnResult.hasErrors(), is(false));
+        assertThat(dmnResult.hasErrors()).as(DMNRuntimeUtil.formatMessages(dmnResult.getMessages())).isFalse();
 
         final DMNContext result = dmnResult.getContext();
-        assertThat(result.getAll(), not(hasEntry(is("Greet the person"), anything()))); // Decision Service will encapsulate this decision
-        assertThat(result.getAll(), not(hasEntry(is("is Person at age allowed"), anything()))); // Decision Service will encapsulate this decision
-        assertThat(result.get("Final Decision"), is("Hello, John; you are allowed"));
+        assertThat(result.getAll()).doesNotContainKey("Greet the person"); // Decision Service will encapsulate this decision
+        assertThat(result.getAll()).doesNotContainKey("is Person at age allowed"); // Decision Service will encapsulate this decision
+        assertThat(result.get("Final Decision")).isEqualTo("Hello, John; you are allowed");
     }
 
     private void testDSForTypeCheck_runDecisionService_WithWrongTypes(final DMNRuntime runtime, final DMNModel dmnModel) {
@@ -345,48 +338,47 @@ public class DMNDecisionServicesTest extends BaseInterpretedVsCompiledTest {
         final DMNResult dmnResult = runtime.evaluateDecisionService(dmnModel, context, "DS given inputdata");
         LOG.debug("{}", dmnResult);
         dmnResult.getDecisionResults().forEach(x -> LOG.debug("{}", x));
-        assertThat(DMNRuntimeUtil.formatMessages(dmnResult.getMessages()),
-                   dmnResult.getMessages().stream().anyMatch(m -> m.getSourceId().equals("_cf49add9-84a4-40ac-8306-1eea599ff43c") && m.getLevel() == Level.WARNING),
-                   is(true));
+        assertThat(dmnResult.getMessages().stream().anyMatch(m -> m.getSourceId().equals("_cf49add9-84a4-40ac-8306-1eea599ff43c") && m.getLevel() == Level.WARNING))
+        .as(DMNRuntimeUtil.formatMessages(dmnResult.getMessages())).isTrue();
     }
 
     @Test
     public void testDSSingletonOrMultipleOutputDecisions() {
         final DMNRuntime runtime = DMNRuntimeUtil.createRuntime("Decision-Services-singleton-or-multiple-output-decisions.dmn", this.getClass());
         final DMNModel dmnModel = runtime.getModel("http://www.trisotech.com/dmn/definitions/_b4ebfbf2-8608-4297-9662-be70bab01974", "Decision Services singleton or multiple output decisions");
-        assertThat(dmnModel, notNullValue());
-        assertThat(DMNRuntimeUtil.formatMessages(dmnModel.getMessages()), dmnModel.hasErrors(), is(false));
+        assertThat(dmnModel).isNotNull();
+        assertThat(dmnModel.hasErrors()).as(DMNRuntimeUtil.formatMessages(dmnModel.getMessages())).isFalse();
 
         final DMNContext emptyContext = DMNFactory.newContext();
 
         final DMNResult dmnResult = runtime.evaluateAll(dmnModel, emptyContext);
         LOG.debug("{}", dmnResult);
         dmnResult.getDecisionResults().forEach(x -> LOG.debug("{}", x));
-        assertThat(DMNRuntimeUtil.formatMessages(dmnResult.getMessages()), dmnResult.hasErrors(), is(false));
+        assertThat(dmnResult.hasErrors()).as(DMNRuntimeUtil.formatMessages(dmnResult.getMessages())).isFalse();
 
         final DMNContext result = dmnResult.getContext();
-        assertThat(result.get("a Value"), is("a string Value"));
-        assertThat(result.get("a String Value"), is("a String Value"));
-        assertThat(result.get("a Number Value"), is(BigDecimal.valueOf(47)));
-        assertThat(result.get("eval DS with singleton value"), is("a string Value"));
-        assertThat((Map<String, Object>) result.get("eval DS with multiple output decisions"), hasEntry(is("a String Value"), is("a String Value")));
-        assertThat((Map<String, Object>) result.get("eval DS with multiple output decisions"), hasEntry(is("a Number Value"), is(BigDecimal.valueOf(47))));
+        assertThat(result.get("a Value")).isEqualTo("a string Value");
+        assertThat(result.get("a String Value")).isEqualTo("a String Value");
+        assertThat(result.get("a Number Value")).isEqualTo(BigDecimal.valueOf(47));
+        assertThat(result.get("eval DS with singleton value")).isEqualTo("a string Value");
+        assertThat((Map<String, Object>) result.get("eval DS with multiple output decisions")).containsEntry("a String Value", "a String Value");
+        assertThat((Map<String, Object>) result.get("eval DS with multiple output decisions")).containsEntry("a Number Value", BigDecimal.valueOf(47));
 
         final DMNResult dmnResultDSSingleton = runtime.evaluateDecisionService(dmnModel, emptyContext, "DS with singleton value");
         LOG.debug("{}", dmnResultDSSingleton);
         dmnResultDSSingleton.getDecisionResults().forEach(x -> LOG.debug("{}", x));
-        assertThat(DMNRuntimeUtil.formatMessages(dmnResultDSSingleton.getMessages()), dmnResultDSSingleton.hasErrors(), is(false));
-        assertThat(dmnResultDSSingleton.getContext().get("a Value"), is("a string Value"));
-        assertThat(dmnResultDSSingleton.getContext().getAll(), not(hasEntry(is("a String Value"), anything()))); // Decision Service will not expose (nor encapsulate hence not execute) this decision.
-        assertThat(dmnResultDSSingleton.getContext().getAll(), not(hasEntry(is("a Number Value"), anything()))); // Decision Service will not expose (nor encapsulate hence not execute) this decision.
+        assertThat(dmnResultDSSingleton.hasErrors()).as(DMNRuntimeUtil.formatMessages(dmnResultDSSingleton.getMessages())).isFalse();
+        assertThat(dmnResultDSSingleton.getContext().get("a Value")).isEqualTo("a string Value");
+        assertThat(dmnResultDSSingleton.getContext().getAll()).doesNotContainKey("a String Value"); // Decision Service will not expose (nor encapsulate hence not execute) this decision.
+        assertThat(dmnResultDSSingleton.getContext().getAll()).doesNotContainKey("a Number Value"); // Decision Service will not expose (nor encapsulate hence not execute) this decision.
 
         final DMNResult dmnResultMultiple = runtime.evaluateDecisionService(dmnModel, emptyContext, "DS with multiple output decisions");
         LOG.debug("{}", dmnResultMultiple);
         dmnResultMultiple.getDecisionResults().forEach(x -> LOG.debug("{}", x));
-        assertThat(DMNRuntimeUtil.formatMessages(dmnResultMultiple.getMessages()), dmnResultMultiple.hasErrors(), is(false));
-        assertThat(dmnResultMultiple.getContext().get("a String Value"), is("a String Value"));
-        assertThat(dmnResultMultiple.getContext().get("a Number Value"), is(BigDecimal.valueOf(47)));
-        assertThat(dmnResultMultiple.getContext().getAll(), not(hasEntry(is("a Value"), anything()))); // Decision Service will not expose (nor encapsulate hence not execute) this decision.
+        assertThat(dmnResultMultiple.hasErrors()).as(DMNRuntimeUtil.formatMessages(dmnResultMultiple.getMessages())).isFalse();
+        assertThat(dmnResultMultiple.getContext().get("a String Value")).isEqualTo("a String Value");
+        assertThat(dmnResultMultiple.getContext().get("a Number Value")).isEqualTo(BigDecimal.valueOf(47));
+        assertThat(dmnResultMultiple.getContext().getAll()).doesNotContainKey("a Value"); // Decision Service will not expose (nor encapsulate hence not execute) this decision.
     }
 
     @Test
@@ -395,45 +387,45 @@ public class DMNDecisionServicesTest extends BaseInterpretedVsCompiledTest {
             System.setProperty(CoerceDecisionServiceSingletonOutputOption.PROPERTY_NAME, "false");
             final DMNRuntime runtime = DMNRuntimeUtil.createRuntime("Decision-Services-singleton-or-multiple-output-decisions.dmn", this.getClass());
             final DMNModel dmnModel = runtime.getModel("http://www.trisotech.com/dmn/definitions/_b4ebfbf2-8608-4297-9662-be70bab01974", "Decision Services singleton or multiple output decisions");
-            assertThat(dmnModel, notNullValue());
-            assertThat(DMNRuntimeUtil.formatMessages(dmnModel.getMessages()), dmnModel.hasErrors(), is(false));
+            assertThat(dmnModel).isNotNull();
+            assertThat(dmnModel.hasErrors()).as(DMNRuntimeUtil.formatMessages(dmnModel.getMessages())).isFalse();
 
             final DMNContext emptyContext = DMNFactory.newContext();
 
             final DMNResult dmnResult = runtime.evaluateAll(dmnModel, emptyContext);
             LOG.debug("{}", dmnResult);
             dmnResult.getDecisionResults().forEach(x -> LOG.debug("{}", x));
-            assertThat(DMNRuntimeUtil.formatMessages(dmnResult.getMessages()), dmnResult.hasErrors(), is(false));
+            assertThat(dmnResult.hasErrors()).as(DMNRuntimeUtil.formatMessages(dmnResult.getMessages())).isFalse();
 
             final DMNContext result = dmnResult.getContext();
-            assertThat(result.get("a Value"), is("a string Value"));
-            assertThat(result.get("a String Value"), is("a String Value"));
-            assertThat(result.get("a Number Value"), is(BigDecimal.valueOf(47)));
-            assertThat((Map<String, Object>) result.get("eval DS with singleton value"), hasEntry(is("a Value"), is("a string Value"))); // DIFFERENCE with base test
-            assertThat((Map<String, Object>) result.get("eval DS with multiple output decisions"), hasEntry(is("a String Value"), is("a String Value")));
-            assertThat((Map<String, Object>) result.get("eval DS with multiple output decisions"), hasEntry(is("a Number Value"), is(BigDecimal.valueOf(47))));
+            assertThat(result.get("a Value")).isEqualTo("a string Value");
+            assertThat(result.get("a String Value")).isEqualTo("a String Value");
+            assertThat(result.get("a Number Value")).isEqualTo(BigDecimal.valueOf(47));
+            assertThat((Map<String, Object>) result.get("eval DS with singleton value")).containsEntry("a Value", "a string Value"); // DIFFERENCE with base test
+            assertThat((Map<String, Object>) result.get("eval DS with multiple output decisions")).containsEntry("a String Value", "a String Value");
+            assertThat((Map<String, Object>) result.get("eval DS with multiple output decisions")).containsEntry("a Number Value", BigDecimal.valueOf(47));
 
             final DMNResult dmnResultDSSingleton = runtime.evaluateDecisionService(dmnModel, emptyContext, "DS with singleton value");
             LOG.debug("{}", dmnResultDSSingleton);
             dmnResultDSSingleton.getDecisionResults().forEach(x -> LOG.debug("{}", x));
-            assertThat(DMNRuntimeUtil.formatMessages(dmnResultDSSingleton.getMessages()), dmnResultDSSingleton.hasErrors(), is(false));
-            assertThat(dmnResultDSSingleton.getContext().get("a Value"), is("a string Value"));
-            assertThat(dmnResultDSSingleton.getContext().getAll(), not(hasEntry(is("a String Value"), anything()))); // Decision Service will not expose (nor encapsulate hence not execute) this decision.
-            assertThat(dmnResultDSSingleton.getContext().getAll(), not(hasEntry(is("a Number Value"), anything()))); // Decision Service will not expose (nor encapsulate hence not execute) this decision.
+            assertThat(dmnResultDSSingleton.hasErrors()).as(DMNRuntimeUtil.formatMessages(dmnResultDSSingleton.getMessages())).isFalse();
+            assertThat(dmnResultDSSingleton.getContext().get("a Value")).isEqualTo("a string Value");
+            assertThat(dmnResultDSSingleton.getContext().getAll()).doesNotContainKey("a String Value"); // Decision Service will not expose (nor encapsulate hence not execute) this decision.
+            assertThat(dmnResultDSSingleton.getContext().getAll()).doesNotContainKey("a Number Value"); // Decision Service will not expose (nor encapsulate hence not execute) this decision.
 
             final DMNResult dmnResultMultiple = runtime.evaluateDecisionService(dmnModel, emptyContext, "DS with multiple output decisions");
             LOG.debug("{}", dmnResultMultiple);
             dmnResultMultiple.getDecisionResults().forEach(x -> LOG.debug("{}", x));
-            assertThat(DMNRuntimeUtil.formatMessages(dmnResultMultiple.getMessages()), dmnResultMultiple.hasErrors(), is(false));
-            assertThat(dmnResultMultiple.getContext().get("a String Value"), is("a String Value"));
-            assertThat(dmnResultMultiple.getContext().get("a Number Value"), is(BigDecimal.valueOf(47)));
-            assertThat(dmnResultMultiple.getContext().getAll(), not(hasEntry(is("a Value"), anything()))); // Decision Service will not expose (nor encapsulate hence not execute) this decision.
+            assertThat(dmnResultMultiple.hasErrors()).as(DMNRuntimeUtil.formatMessages(dmnResultMultiple.getMessages())).isFalse();
+            assertThat(dmnResultMultiple.getContext().get("a String Value")).isEqualTo("a String Value");
+            assertThat(dmnResultMultiple.getContext().get("a Number Value")).isEqualTo(BigDecimal.valueOf(47));
+            assertThat(dmnResultMultiple.getContext().getAll()).doesNotContainKey("a Value"); // Decision Service will not expose (nor encapsulate hence not execute) this decision.
         } catch (final Exception e) {
             LOG.error("{}", e.getLocalizedMessage(), e);
             throw e;
         } finally {
             System.clearProperty(CoerceDecisionServiceSingletonOutputOption.PROPERTY_NAME);
-            assertNull(System.getProperty(CoerceDecisionServiceSingletonOutputOption.PROPERTY_NAME));
+            assertThat(System.getProperty(CoerceDecisionServiceSingletonOutputOption.PROPERTY_NAME)).isNull();
         }
     }
 
@@ -442,8 +434,8 @@ public class DMNDecisionServicesTest extends BaseInterpretedVsCompiledTest {
         // DROOLS-2768 DMN Decision Service encapsulate Decision which imports a Decision Service
         final DMNRuntime runtime = DMNRuntimeUtil.createRuntimeWithAdditionalResources("DecisionService20180718.dmn", this.getClass(), "ImportDecisionService20180718.dmn");
         final DMNModel dmnModel = runtime.getModel("http://www.trisotech.com/dmn/definitions/_0ff3708a-c861-4a96-b85c-7b882f18b7a1", "Import Decision Service 20180718");
-        assertThat(dmnModel, notNullValue());
-        assertThat(DMNRuntimeUtil.formatMessages(dmnModel.getMessages()), dmnModel.hasErrors(), is(false));
+        assertThat(dmnModel).isNotNull();
+        assertThat(dmnModel.hasErrors()).as(DMNRuntimeUtil.formatMessages(dmnModel.getMessages())).isFalse();
 
         testImportDS_testEvaluateAll(runtime, dmnModel);
         testImportDS_testEvaluateDS(runtime, dmnModel);
@@ -456,12 +448,12 @@ public class DMNDecisionServicesTest extends BaseInterpretedVsCompiledTest {
         final DMNResult dmnResult = runtime.evaluateAll(dmnModel, context);
         LOG.debug("{}", dmnResult);
         dmnResult.getDecisionResults().forEach(x -> LOG.debug("{}", x));
-        assertThat(DMNRuntimeUtil.formatMessages(dmnResult.getMessages()), dmnResult.hasErrors(), is(false));
+        assertThat(dmnResult.hasErrors()).as(DMNRuntimeUtil.formatMessages(dmnResult.getMessages())).isFalse();
 
         final DMNContext result = dmnResult.getContext();
-        assertThat(result.get("invoke imported DS"), is("Hello, L1 Import John; you are allowed"));
-        assertThat(result.get("Prefixing"), is("Hello, L1 Import John"));
-        assertThat(result.get("final Import L1 decision"), is("Hello, L1 Import John the result of invoking the imported DS is: Hello, L1 Import John; you are allowed"));
+        assertThat(result.get("invoke imported DS")).isEqualTo("Hello, L1 Import John; you are allowed");
+        assertThat(result.get("Prefixing")).isEqualTo("Hello, L1 Import John");
+        assertThat(result.get("final Import L1 decision")).isEqualTo("Hello, L1 Import John the result of invoking the imported DS is: Hello, L1 Import John; you are allowed");
     }
 
     private void testImportDS_testEvaluateDS(final DMNRuntime runtime, final DMNModel dmnModel) {
@@ -471,12 +463,12 @@ public class DMNDecisionServicesTest extends BaseInterpretedVsCompiledTest {
         final DMNResult dmnResult = runtime.evaluateDecisionService(dmnModel, context, "Import L1 DS");
         LOG.debug("{}", dmnResult);
         dmnResult.getDecisionResults().forEach(x -> LOG.debug("{}", x));
-        assertThat(DMNRuntimeUtil.formatMessages(dmnResult.getMessages()), dmnResult.hasErrors(), is(false));
+        assertThat(dmnResult.hasErrors()).as(DMNRuntimeUtil.formatMessages(dmnResult.getMessages())).isFalse();
 
         final DMNContext result = dmnResult.getContext();
-        assertThat(result.getAll(), not(hasEntry(is("invoke imported DS"), anything()))); // Decision Service will encapsulate this decision
-        assertThat(result.getAll(), not(hasEntry(is("Prefixing"), anything()))); // Decision Service will encapsulate this decision
-        assertThat(result.get("final Import L1 decision"), is("Hello, L1 Import Evaluate DS NAME the result of invoking the imported DS is: Hello, L1 Import Evaluate DS NAME; you are allowed"));
+        assertThat(result.getAll()).doesNotContainKey("invoke imported DS"); // Decision Service will encapsulate this decision
+        assertThat(result.getAll()).doesNotContainKey("Prefixing"); // Decision Service will encapsulate this decision
+        assertThat(result.get("final Import L1 decision")).isEqualTo("Hello, L1 Import Evaluate DS NAME the result of invoking the imported DS is: Hello, L1 Import Evaluate DS NAME; you are allowed");
     }
 
     @Test
@@ -486,8 +478,8 @@ public class DMNDecisionServicesTest extends BaseInterpretedVsCompiledTest {
                                                                                        "ImportDecisionService20180718.dmn",
                                                                                        "ImportofImportDecisionService20180718.dmn");
         final DMNModel dmnModel = runtime.getModel("http://www.trisotech.com/dmn/definitions/_6698dc07-cc43-47ec-8187-8faa7d8c35ba", "Import of Import Decision Service 20180718");
-        assertThat(dmnModel, notNullValue());
-        assertThat(DMNRuntimeUtil.formatMessages(dmnModel.getMessages()), dmnModel.hasErrors(), is(false));
+        assertThat(dmnModel).isNotNull();
+        assertThat(dmnModel.hasErrors()).as(DMNRuntimeUtil.formatMessages(dmnModel.getMessages())).isFalse();
 
         testTransitiveImportDS_testEvaluateAll(runtime, dmnModel);
         testTransitiveImportDS_testEvaluateDS(runtime, dmnModel);
@@ -500,11 +492,11 @@ public class DMNDecisionServicesTest extends BaseInterpretedVsCompiledTest {
         final DMNResult dmnResult = runtime.evaluateAll(dmnModel, context);
         LOG.debug("{}", dmnResult);
         dmnResult.getDecisionResults().forEach(x -> LOG.debug("{}", x));
-        assertThat(DMNRuntimeUtil.formatMessages(dmnResult.getMessages()), dmnResult.hasErrors(), is(false));
+        assertThat(dmnResult.hasErrors()).as(DMNRuntimeUtil.formatMessages(dmnResult.getMessages())).isFalse();
 
         final DMNContext result = dmnResult.getContext();
-        assertThat(result.get("L2 Invoking the L1 import"), is("Hello, L2 Bob the result of invoking the imported DS is: Hello, L2 Bob; you are allowed"));
-        assertThat(result.get("Final L2 Decision"), is("The result of invoking the L1 DS was: Hello, L2 Bob the result of invoking the imported DS is: Hello, L2 Bob; you are allowed"));
+        assertThat(result.get("L2 Invoking the L1 import")).isEqualTo("Hello, L2 Bob the result of invoking the imported DS is: Hello, L2 Bob; you are allowed");
+        assertThat(result.get("Final L2 Decision")).isEqualTo("The result of invoking the L1 DS was: Hello, L2 Bob the result of invoking the imported DS is: Hello, L2 Bob; you are allowed");
     }
 
     private void testTransitiveImportDS_testEvaluateDS(final DMNRuntime runtime, final DMNModel dmnModel) {
@@ -514,11 +506,11 @@ public class DMNDecisionServicesTest extends BaseInterpretedVsCompiledTest {
         final DMNResult dmnResult = runtime.evaluateDecisionService(dmnModel, context, "L2 DS");
         LOG.debug("{}", dmnResult);
         dmnResult.getDecisionResults().forEach(x -> LOG.debug("{}", x));
-        assertThat(DMNRuntimeUtil.formatMessages(dmnResult.getMessages()), dmnResult.hasErrors(), is(false));
+        assertThat(dmnResult.hasErrors()).as(DMNRuntimeUtil.formatMessages(dmnResult.getMessages())).isFalse();
 
         final DMNContext result = dmnResult.getContext();
-        assertThat(result.getAll(), not(hasEntry(is("L2 Invoking the L1 import"), anything()))); // Decision Service will encapsulate this decision
-        assertThat(result.get("Final L2 Decision"), is("The result of invoking the L1 DS was: Hello, L2 Bob DS the result of invoking the imported DS is: Hello, L2 Bob DS; you are allowed"));
+        assertThat(result.getAll()).doesNotContainKey("L2 Invoking the L1 import"); // Decision Service will encapsulate this decision
+        assertThat(result.get("Final L2 Decision")).isEqualTo("The result of invoking the L1 DS was: Hello, L2 Bob DS the result of invoking the imported DS is: Hello, L2 Bob DS; you are allowed");
     }
 
     @Test
@@ -526,8 +518,8 @@ public class DMNDecisionServicesTest extends BaseInterpretedVsCompiledTest {
         // DROOLS-2943 DMN DecisionServiceCompiler not correctly wired for DMNv1.2 format
         final DMNRuntime runtime = DMNRuntimeUtil.createRuntime("DecisionServiceABC.dmn", this.getClass());
         final DMNModel dmnModel = runtime.getModel("http://www.trisotech.com/dmn/definitions/_2443d3f5-f178-47c6-a0c9-b1fd1c933f60", "Drawing 1");
-        assertThat(dmnModel, notNullValue());
-        assertThat(DMNRuntimeUtil.formatMessages(dmnModel.getMessages()), dmnModel.hasErrors(), is(false));
+        assertThat(dmnModel).isNotNull();
+        assertThat(dmnModel.hasErrors()).as(DMNRuntimeUtil.formatMessages(dmnModel.getMessages())).isFalse();
 
         testDecisionServiceCompiler20180830_testEvaluateDS(runtime, dmnModel);
         testDecisionServiceCompiler20180830_testEvaluateAll(runtime, dmnModel);
@@ -539,11 +531,11 @@ public class DMNDecisionServicesTest extends BaseInterpretedVsCompiledTest {
         final DMNResult dmnResult = runtime.evaluateAll(dmnModel, context);
         LOG.debug("{}", dmnResult);
         dmnResult.getDecisionResults().forEach(x -> LOG.debug("{}", x));
-        assertThat(DMNRuntimeUtil.formatMessages(dmnResult.getMessages()), dmnResult.hasErrors(), is(false));
+        assertThat(dmnResult.hasErrors()).as(DMNRuntimeUtil.formatMessages(dmnResult.getMessages())).isFalse();
 
         final DMNContext result = dmnResult.getContext();
-        assertThat(result.get("ABC"), is("abc"));
-        assertThat(result.get("Invoking Decision"), is("abc"));
+        assertThat(result.get("ABC")).isEqualTo("abc");
+        assertThat(result.get("Invoking Decision")).isEqualTo("abc");
     }
 
     public static void testDecisionServiceCompiler20180830_testEvaluateDS(final DMNRuntime runtime, final DMNModel dmnModel) {
@@ -552,12 +544,12 @@ public class DMNDecisionServicesTest extends BaseInterpretedVsCompiledTest {
         final DMNResult dmnResult = runtime.evaluateDecisionService(dmnModel, context, "Decision Service ABC");
         LOG.debug("{}", dmnResult);
         dmnResult.getDecisionResults().forEach(x -> LOG.debug("{}", x));
-        assertThat(DMNRuntimeUtil.formatMessages(dmnResult.getMessages()), dmnResult.hasErrors(), is(false));
+        assertThat(dmnResult.hasErrors()).as(DMNRuntimeUtil.formatMessages(dmnResult.getMessages())).isFalse();
 
         final DMNContext result = dmnResult.getContext();
         // NOTE: Decision Service "Decision Service ABC" does NOT encapsulate any decision. 
-        assertThat(result.getAll(), not(hasEntry(is("Invoking Decision"), anything()))); // we invoked only the Decision Service, not this other Decision in the model.
-        assertThat(result.get("ABC"), is("abc"));
+        assertThat(result.getAll()).doesNotContainKey("Invoking Decision"); // we invoked only the Decision Service, not this other Decision in the model.
+        assertThat(result.get("ABC")).isEqualTo("abc");
     }
 
     @Test
@@ -567,8 +559,8 @@ public class DMNDecisionServicesTest extends BaseInterpretedVsCompiledTest {
                                                                                        this.getClass(),
                                                                                        "DSWithImportRequiredInput20180920-import-1.dmn");
         final DMNModel dmnModel = runtime.getModel("http://www.trisotech.com/dmn/definitions/_76165d7d-12f8-46d3-b8af-120f1ac8b3fc", "Model B");
-        assertThat(dmnModel, notNullValue());
-        assertThat(DMNRuntimeUtil.formatMessages(dmnModel.getMessages()), dmnModel.hasErrors(), is(false));
+        assertThat(dmnModel).isNotNull();
+        assertThat(dmnModel.hasErrors()).as(DMNRuntimeUtil.formatMessages(dmnModel.getMessages())).isFalse();
 
         testDecisionService20180920_testEvaluateAll(runtime, dmnModel);
         testDecisionService20180920_testEvaluateDS(runtime, dmnModel);
@@ -581,11 +573,11 @@ public class DMNDecisionServicesTest extends BaseInterpretedVsCompiledTest {
         final DMNResult dmnResult = runtime.evaluateAll(dmnModel, context);
         LOG.debug("{}", dmnResult);
         dmnResult.getDecisionResults().forEach(x -> LOG.debug("{}", x));
-        assertThat(DMNRuntimeUtil.formatMessages(dmnResult.getMessages()), dmnResult.hasErrors(), is(false));
+        assertThat(dmnResult.hasErrors()).as(DMNRuntimeUtil.formatMessages(dmnResult.getMessages())).isFalse();
 
         final DMNContext result = dmnResult.getContext();
-        assertThat(result.get("Decision B"), is("input 1 value"));
-        assertThat(result.get("Invoke Decision B DS"), is("A value"));
+        assertThat(result.get("Decision B")).isEqualTo("input 1 value");
+        assertThat(result.get("Invoke Decision B DS")).isEqualTo("A value");
     }
 
     private static void testDecisionService20180920_testEvaluateDS(final DMNRuntime runtime, final DMNModel dmnModel) {
@@ -595,35 +587,35 @@ public class DMNDecisionServicesTest extends BaseInterpretedVsCompiledTest {
         final DMNResult dmnResult = runtime.evaluateDecisionService(dmnModel, context, "Decision B DS");
         LOG.debug("{}", dmnResult);
         dmnResult.getDecisionResults().forEach(x -> LOG.debug("{}", x));
-        assertThat(DMNRuntimeUtil.formatMessages(dmnResult.getMessages()), dmnResult.hasErrors(), is(false));
+        assertThat(dmnResult.hasErrors()).as(DMNRuntimeUtil.formatMessages(dmnResult.getMessages())).isFalse();
 
         final DMNContext result = dmnResult.getContext();
-        assertThat(result.getAll(), not(hasEntry(is("Invoke Decision B DS"), anything()))); // we invoked only the Decision Service, not this other Decision in the model.
-        assertThat(result.get("Decision B"), is("input 1 value"));
+        assertThat(result.getAll()).doesNotContainKey("Invoke Decision B DS"); // we invoked only the Decision Service, not this other Decision in the model.
+        assertThat(result.get("Decision B")).isEqualTo("input 1 value");
     }
 
     @Test
     public void test20190520() {
         final DMNRuntime runtime = DMNRuntimeUtil.createRuntime("DStypecheck.dmn", this.getClass());
         final DMNModel dmnModel = runtime.getModel("http://www.trisotech.com/definitions/_6e76b9ca-ce06-426a-91c0-99b70665321a", "Drawing 1");
-        assertThat(dmnModel, notNullValue());
-        assertThat(DMNRuntimeUtil.formatMessages(dmnModel.getMessages()), dmnModel.hasErrors(), is(false));
+        assertThat(dmnModel).isNotNull();
+        assertThat(dmnModel.hasErrors()).as(DMNRuntimeUtil.formatMessages(dmnModel.getMessages())).isFalse();
 
         final DMNContext emptyContext = DMNFactory.newContext();
 
         final DMNResult dmnResult = runtime.evaluateAll(dmnModel, emptyContext);
         LOG.debug("{}", dmnResult);
         dmnResult.getDecisionResults().forEach(x -> LOG.debug("{}", x));
-        assertThat(DMNRuntimeUtil.formatMessages(dmnResult.getMessages()), dmnResult.hasErrors(), is(false));
-        assertThat((Map<String, Object>) dmnResult.getDecisionResultByName("my invoke DS1").getResult(), hasEntry(is("outDS1"), is(true)));
+        assertThat(dmnResult.hasErrors()).as(DMNRuntimeUtil.formatMessages(dmnResult.getMessages())).isFalse();
+        assertThat((Map<String, Object>) dmnResult.getDecisionResultByName("my invoke DS1").getResult()).containsEntry("outDS1", true);
     }
     
     @Test
     public void testImportingBasic() {
         final DMNRuntime runtime = DMNRuntimeUtil.createRuntimeWithAdditionalResources("0004-decision-services.dmn", this.getClass(), "importing0004.dmn");
         final DMNModel dmnModel = runtime.getModel("https://kiegroup.org/dmn/_346B2E00-71E5-4CEA-ADE1-7A0872481F38", "importing0004");
-        assertThat(dmnModel, notNullValue());
-        assertThat(DMNRuntimeUtil.formatMessages(dmnModel.getMessages()), dmnModel.hasErrors(), is(false));
+        assertThat(dmnModel).isNotNull();
+        assertThat(dmnModel.hasErrors()).as(DMNRuntimeUtil.formatMessages(dmnModel.getMessages())).isFalse();
 
         assertSupplyingBandC(runtime, dmnModel);
     }
@@ -635,18 +627,18 @@ public class DMNDecisionServicesTest extends BaseInterpretedVsCompiledTest {
 
         final DMNResult dmnResult = runtime.evaluateAll(dmnModel, context);
         LOG.debug("{}", dmnResult);
-        assertThat(DMNRuntimeUtil.formatMessages(dmnResult.getMessages()), dmnResult.hasErrors(), is(false));
+        assertThat(dmnResult.hasErrors()).as(DMNRuntimeUtil.formatMessages(dmnResult.getMessages())).isFalse();
 
         final DMNContext result = dmnResult.getContext();
-        assertThat(result.get("Decision1"), is("inBinC"));
+        assertThat(result.get("Decision1")).isEqualTo("inBinC");
     }
     
     @Test
     public void testImportingBoxedInvocation() {
         final DMNRuntime runtime = DMNRuntimeUtil.createRuntimeWithAdditionalResources("0004-decision-services.dmn", this.getClass(), "importing0004boxedInvocation.dmn");
         final DMNModel dmnModel = runtime.getModel("https://kiegroup.org/dmn/_346B2E00-71E5-4CEA-ADE1-7A0872481F38", "importing0004");
-        assertThat(dmnModel, notNullValue());
-        assertThat(DMNRuntimeUtil.formatMessages(dmnModel.getMessages()), dmnModel.hasErrors(), is(false));
+        assertThat(dmnModel).isNotNull();
+        assertThat(dmnModel.hasErrors()).as(DMNRuntimeUtil.formatMessages(dmnModel.getMessages())).isFalse();
 
         assertSupplyingBandC(runtime, dmnModel);
     }
@@ -655,8 +647,8 @@ public class DMNDecisionServicesTest extends BaseInterpretedVsCompiledTest {
     public void testImportingBkmBoxedInvocation() {
         final DMNRuntime runtime = DMNRuntimeUtil.createRuntimeWithAdditionalResources("0004-decision-services.dmn", this.getClass(), "importing0004bkmBoxedInvocation.dmn");
         final DMNModel dmnModel = runtime.getModel("https://kiegroup.org/dmn/_0CA8CCDE-106B-4805-B0C1-8D8D740C80F7", "importing0004bkmBoxedInvocation");
-        assertThat(dmnModel, notNullValue());
-        assertThat(DMNRuntimeUtil.formatMessages(dmnModel.getMessages()), dmnModel.hasErrors(), is(false));
+        assertThat(dmnModel).isNotNull();
+        assertThat(dmnModel.hasErrors()).as(DMNRuntimeUtil.formatMessages(dmnModel.getMessages())).isFalse();
 
         assertSupplyingBandC(runtime, dmnModel);
     }
@@ -665,8 +657,8 @@ public class DMNDecisionServicesTest extends BaseInterpretedVsCompiledTest {
     public void testImportingWithSameDSName() {
         final DMNRuntime runtime = DMNRuntimeUtil.createRuntimeWithAdditionalResources("myHelloDS.dmn", this.getClass(), "importingMyHelloDS.dmn");
         final DMNModel dmnModel = runtime.getModel("https://kiegroup.org/dmn/_3295867F-C02D-4312-849B-844F74C51ADE", "importingMyHelloDS");
-        assertThat(dmnModel, notNullValue());
-        assertThat(DMNRuntimeUtil.formatMessages(dmnModel.getMessages()), dmnModel.hasErrors(), is(false));
+        assertThat(dmnModel).isNotNull();
+        assertThat(dmnModel.hasErrors()).as(DMNRuntimeUtil.formatMessages(dmnModel.getMessages())).isFalse();
 
         assertSupplyingPersonname(runtime, dmnModel);
     }
@@ -677,18 +669,18 @@ public class DMNDecisionServicesTest extends BaseInterpretedVsCompiledTest {
 
         final DMNResult dmnResult = runtime.evaluateAll(dmnModel, context);
         LOG.debug("{}", dmnResult);
-        assertThat(DMNRuntimeUtil.formatMessages(dmnResult.getMessages()), dmnResult.hasErrors(), is(false));
+        assertThat(dmnResult.hasErrors()).as(DMNRuntimeUtil.formatMessages(dmnResult.getMessages())).isFalse();
 
         final DMNContext result = dmnResult.getContext();
-        assertThat(result.get("Decision1"), is("Hello, John Doe"));
+        assertThat(result.get("Decision1")).isEqualTo("Hello, John Doe");
     }
     
     @Test
     public void testImportingWithSameDSNameBoxedInvocation() {
         final DMNRuntime runtime = DMNRuntimeUtil.createRuntimeWithAdditionalResources("myHelloDS.dmn", this.getClass(), "importingMyHelloDSboxedInvocation.dmn");
         final DMNModel dmnModel = runtime.getModel("https://kiegroup.org/dmn/_3295867F-C02D-4312-849B-844F74C51ADE", "importingMyHelloDS");
-        assertThat(dmnModel, notNullValue());
-        assertThat(DMNRuntimeUtil.formatMessages(dmnModel.getMessages()), dmnModel.hasErrors(), is(false));
+        assertThat(dmnModel).isNotNull();
+        assertThat(dmnModel.hasErrors()).as(DMNRuntimeUtil.formatMessages(dmnModel.getMessages())).isFalse();
 
         assertSupplyingPersonname(runtime, dmnModel);
     }
@@ -697,8 +689,8 @@ public class DMNDecisionServicesTest extends BaseInterpretedVsCompiledTest {
     public void testImportingWithSameDSNameBKMBoxedInvocation() {
         final DMNRuntime runtime = DMNRuntimeUtil.createRuntimeWithAdditionalResources("myHelloDS.dmn", this.getClass(), "importingMyHelloDSbkmBoxedInvocation.dmn");
         final DMNModel dmnModel = runtime.getModel("https://kiegroup.org/dmn/_3295867F-C02D-4312-849B-844F74C51ADE", "importingMyHelloDS");
-        assertThat(dmnModel, notNullValue());
-        assertThat(DMNRuntimeUtil.formatMessages(dmnModel.getMessages()), dmnModel.hasErrors(), is(false));
+        assertThat(dmnModel).isNotNull();
+        assertThat(dmnModel.hasErrors()).as(DMNRuntimeUtil.formatMessages(dmnModel.getMessages())).isFalse();
 
         assertSupplyingPersonname(runtime, dmnModel);
     }

--- a/kie-dmn/kie-dmn-core/src/test/java/org/kie/dmn/core/decisionservices/DMNDecisionServicesTypecheckDSxyTest.java
+++ b/kie-dmn/kie-dmn-core/src/test/java/org/kie/dmn/core/decisionservices/DMNDecisionServicesTypecheckDSxyTest.java
@@ -34,10 +34,7 @@ import org.kie.dmn.core.util.DMNRuntimeUtil;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import static org.hamcrest.CoreMatchers.is;
-import static org.hamcrest.CoreMatchers.not;
-import static org.hamcrest.CoreMatchers.notNullValue;
-import static org.hamcrest.MatcherAssert.assertThat;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.kie.dmn.core.util.DynamicTypeUtils.entry;
 import static org.kie.dmn.core.util.DynamicTypeUtils.mapOf;
 
@@ -72,8 +69,8 @@ public class DMNDecisionServicesTypecheckDSxyTest {
         runtime = DMNRuntimeUtil.createRuntime("DSxy.dmn", this.getClass());
         dmnModel = runtime.getModel("https://kiegroup.org/dmn/_127520A0-364A-4ADA-A012-3AB6A7E3585E", "DSxy");
 
-        assertThat(dmnModel, notNullValue());
-        assertThat(DMNRuntimeUtil.formatMessages(dmnModel.getMessages()), dmnModel.hasErrors(), is(false));
+        assertThat(dmnModel).isNotNull();
+        assertThat(dmnModel.hasErrors()).as(DMNRuntimeUtil.formatMessages(dmnModel.getMessages())).isFalse();
     }
 
     @Test
@@ -86,9 +83,9 @@ public class DMNDecisionServicesTypecheckDSxyTest {
 
         LOG.debug("{}", dmnResult);
         dmnResult.getDecisionResults().forEach(x -> LOG.debug("{}", x));
-        assertThat(DMNRuntimeUtil.formatMessages(dmnResult.getMessages()), dmnResult.hasErrors(), is(false));
-        assertThat(dmnResult.getDecisionResultByName("Decision-1").getEvaluationStatus(), is(DecisionEvaluationStatus.SUCCEEDED));
-        assertThat(dmnResult.getDecisionResultByName("Decision-1").getResult(), is(new BigDecimal(1)));
+        assertThat(dmnResult.hasErrors()).as(DMNRuntimeUtil.formatMessages(dmnResult.getMessages())).isFalse();
+        assertThat(dmnResult.getDecisionResultByName("Decision-1").getEvaluationStatus()).isEqualTo(DecisionEvaluationStatus.SUCCEEDED);
+        assertThat(dmnResult.getDecisionResultByName("Decision-1").getResult()).isEqualTo(new BigDecimal(1));
     }
     
     @Test
@@ -100,8 +97,8 @@ public class DMNDecisionServicesTypecheckDSxyTest {
 
         LOG.debug("{}", dmnResult);
         dmnResult.getDecisionResults().forEach(x -> LOG.debug("{}", x));
-        assertThat(DMNRuntimeUtil.formatMessages(dmnResult.getMessages()), dmnResult.getMessages().isEmpty(), is(false));
-        assertThat(dmnResult.getDecisionResultByName("Decision-1").getEvaluationStatus(), not(is(DecisionEvaluationStatus.SUCCEEDED)));
+        assertThat(dmnResult.getMessages()).as(DMNRuntimeUtil.formatMessages(dmnResult.getMessages())).isNotEmpty();
+        assertThat(dmnResult.getDecisionResultByName("Decision-1").getEvaluationStatus()).isNotEqualTo(DecisionEvaluationStatus.SUCCEEDED);
     }
 
     @Test
@@ -116,8 +113,8 @@ public class DMNDecisionServicesTypecheckDSxyTest {
 
         LOG.debug("{}", dmnResult);
         dmnResult.getDecisionResults().forEach(x -> LOG.debug("{}", x));
-        assertThat(DMNRuntimeUtil.formatMessages(dmnResult.getMessages()), dmnResult.hasErrors(), is(false));
-        assertThat(dmnResult.getDecisionResultByName("Decision-1").getEvaluationStatus(), is(DecisionEvaluationStatus.SUCCEEDED));
-        assertThat(dmnResult.getDecisionResultByName("Decision-1").getResult(), is(new BigDecimal(1)));
+        assertThat(dmnResult.hasErrors()).as(DMNRuntimeUtil.formatMessages(dmnResult.getMessages())).isFalse();
+        assertThat(dmnResult.getDecisionResultByName("Decision-1").getEvaluationStatus()).isEqualTo(DecisionEvaluationStatus.SUCCEEDED);
+        assertThat(dmnResult.getDecisionResultByName("Decision-1").getResult()).isEqualTo(new BigDecimal(1));
     }
 }

--- a/kie-dmn/kie-dmn-core/src/test/java/org/kie/dmn/core/extra/DMNRecursionTest.java
+++ b/kie-dmn/kie-dmn-core/src/test/java/org/kie/dmn/core/extra/DMNRecursionTest.java
@@ -30,9 +30,7 @@ import org.kie.dmn.core.util.DMNRuntimeUtil;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import static org.hamcrest.CoreMatchers.is;
-import static org.hamcrest.CoreMatchers.notNullValue;
-import static org.hamcrest.MatcherAssert.assertThat;
+import static org.assertj.core.api.Assertions.assertThat;
 
 public class DMNRecursionTest extends BaseInterpretedVsCompiledTest {
 
@@ -47,16 +45,16 @@ public class DMNRecursionTest extends BaseInterpretedVsCompiledTest {
         final DMNRuntime runtime = DMNRuntimeUtil.createRuntime("basicRecursion.dmn", this.getClass());
         runtime.addListener(new DMNRuntimeEventListener() {});
         final DMNModel dmnModel = runtime.getModel("https://kiegroup.org/dmn/_16EF6BF4-9B59-40E8-8C99-A3A3D58B88CC", "factorial");
-        assertThat(dmnModel, notNullValue());
-        assertThat(DMNRuntimeUtil.formatMessages(dmnModel.getMessages()), dmnModel.hasErrors(), is(false));
+        assertThat(dmnModel).isNotNull();
+        assertThat(dmnModel.hasErrors()).as(DMNRuntimeUtil.formatMessages(dmnModel.getMessages())).isFalse();
 
         final DMNContext context = DMNFactory.newContext();
         context.set("My number", 3);
 
         final DMNResult dmnResult = runtime.evaluateAll(dmnModel, context);
         LOG.debug("{}", dmnResult);
-        assertThat(DMNRuntimeUtil.formatMessages(dmnResult.getMessages()), dmnResult.hasErrors(), is(false));
-        assertThat(dmnResult.getDecisionResultByName("compute factorial").getResult(), is(new BigDecimal(6)));
+        assertThat(dmnResult.hasErrors()).as(DMNRuntimeUtil.formatMessages(dmnResult.getMessages())).isFalse();
+        assertThat(dmnResult.getDecisionResultByName("compute factorial").getResult()).isEqualTo(new BigDecimal(6));
     }
 }
 

--- a/kie-dmn/kie-dmn-core/src/test/java/org/kie/dmn/core/extra/YCombinatorTest.java
+++ b/kie-dmn/kie-dmn-core/src/test/java/org/kie/dmn/core/extra/YCombinatorTest.java
@@ -17,7 +17,6 @@
 package org.kie.dmn.core.extra;
 
 import java.math.BigDecimal;
-import java.util.Arrays;
 
 import org.junit.Test;
 import org.kie.dmn.api.core.DMNContext;
@@ -29,9 +28,7 @@ import org.kie.dmn.core.util.DMNRuntimeUtil;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import static org.hamcrest.CoreMatchers.is;
-import static org.hamcrest.CoreMatchers.notNullValue;
-import static org.hamcrest.MatcherAssert.assertThat;
+import static org.assertj.core.api.Assertions.assertThat;
 
 public class YCombinatorTest extends BaseInterpretedVsCompiledTest {
 
@@ -46,20 +43,20 @@ public class YCombinatorTest extends BaseInterpretedVsCompiledTest {
         final DMNRuntime runtime = DMNRuntimeUtil.createRuntime("Y.dmn", this.getClass());
         final DMNModel dmnModel = runtime.getModel("https://kiegroup.org/dmn/_2E160C58-B13A-4C35-B161-BB4B31E049B4",
                                                    "new-file");
-        assertThat(dmnModel, notNullValue());
-        assertThat(DMNRuntimeUtil.formatMessages(dmnModel.getMessages()), dmnModel.hasErrors(), is(false));
+        assertThat(dmnModel).isNotNull();
+        assertThat(dmnModel.hasErrors()).as(DMNRuntimeUtil.formatMessages(dmnModel.getMessages())).isFalse();
 
         final DMNContext ctx = runtime.newContext();
 
         final DMNResult dmnResult = runtime.evaluateAll(dmnModel, ctx);
         LOG.debug("{}", dmnResult);
-        assertThat(DMNRuntimeUtil.formatMessages(dmnResult.getMessages()), dmnResult.hasErrors(), is(false));
-        assertThat(dmnResult.getDecisionResultByName("fac3").getResult(), is(new BigDecimal(6)));
-        assertThat(dmnResult.getDecisionResultByName("fib5").getResult(), is(Arrays.asList(new BigDecimal(1),
+        assertThat(dmnResult.hasErrors()).as(DMNRuntimeUtil.formatMessages(dmnResult.getMessages())).isFalse();
+        assertThat(dmnResult.getDecisionResultByName("fac3").getResult()).isEqualTo(new BigDecimal(6));
+        assertThat(dmnResult.getDecisionResultByName("fib5").getResult()).asList().containsExactly(new BigDecimal(1),
                                                                                            new BigDecimal(1),
                                                                                            new BigDecimal(2),
                                                                                            new BigDecimal(3),
-                                                                                           new BigDecimal(5))));
+                                                                                           new BigDecimal(5));
     }
 
     @Test
@@ -67,20 +64,20 @@ public class YCombinatorTest extends BaseInterpretedVsCompiledTest {
         final DMNRuntime runtime = DMNRuntimeUtil.createRuntime("Yboxed.dmn", this.getClass());
         final DMNModel dmnModel = runtime.getModel("https://kiegroup.org/dmn/_2E160C58-B13A-4C35-B161-BB4B31E049B4",
                                                    "new-file");
-        assertThat(dmnModel, notNullValue());
-        assertThat(DMNRuntimeUtil.formatMessages(dmnModel.getMessages()), dmnModel.hasErrors(), is(false));
+        assertThat(dmnModel).isNotNull();
+        assertThat(dmnModel.hasErrors()).as(DMNRuntimeUtil.formatMessages(dmnModel.getMessages())).isFalse();
 
         final DMNContext ctx = runtime.newContext();
 
         final DMNResult dmnResult = runtime.evaluateAll(dmnModel, ctx);
         LOG.debug("{}", dmnResult);
-        assertThat(DMNRuntimeUtil.formatMessages(dmnResult.getMessages()), dmnResult.hasErrors(), is(false));
-        assertThat(dmnResult.getDecisionResultByName("fac3").getResult(), is(new BigDecimal(6)));
-        assertThat(dmnResult.getDecisionResultByName("fib5").getResult(), is(Arrays.asList(new BigDecimal(1),
+        assertThat(dmnResult.hasErrors()).as(DMNRuntimeUtil.formatMessages(dmnResult.getMessages())).isFalse();
+        assertThat(dmnResult.getDecisionResultByName("fac3").getResult()).isEqualTo(new BigDecimal(6));
+        assertThat(dmnResult.getDecisionResultByName("fib5").getResult()).asList().containsExactly(new BigDecimal(1),
                                                                                            new BigDecimal(1),
                                                                                            new BigDecimal(2),
                                                                                            new BigDecimal(3),
-                                                                                           new BigDecimal(5))));
+                                                                                           new BigDecimal(5));
     }
 
 }

--- a/kie-dmn/kie-dmn-core/src/test/java/org/kie/dmn/core/imports/ImportsTest.java
+++ b/kie-dmn/kie-dmn-core/src/test/java/org/kie/dmn/core/imports/ImportsTest.java
@@ -32,14 +32,7 @@ import org.kie.dmn.core.util.DMNRuntimeUtil;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import static org.hamcrest.CoreMatchers.is;
-import static org.hamcrest.CoreMatchers.notNullValue;
-import static org.hamcrest.CoreMatchers.nullValue;
-import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.contains;
-import static org.hamcrest.Matchers.containsInAnyOrder;
-import static org.hamcrest.Matchers.hasEntry;
-import static org.hamcrest.Matchers.hasSize;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.kie.dmn.core.util.DMNTestUtil.getAndAssertModelNoErrors;
 import static org.kie.dmn.core.util.DynamicTypeUtils.entry;
 import static org.kie.dmn.core.util.DynamicTypeUtils.mapOf;
@@ -60,22 +53,22 @@ public class ImportsTest extends BaseInterpretedVsCompiledTest {
 
         final DMNModel importedModel = runtime.getModel("http://www.trisotech.com/definitions/_f27bb64b-6fc7-4e1f-9848-11ba35e0df36",
                                                         "Imported Model");
-        assertThat(importedModel, notNullValue());
-        assertThat(DMNRuntimeUtil.formatMessages(importedModel.getMessages()), importedModel.hasErrors(), is(false));
+        assertThat(importedModel).isNotNull();
+        assertThat(importedModel.hasErrors()).as(DMNRuntimeUtil.formatMessages(importedModel.getMessages())).isFalse();
 
         final DMNModel dmnModel = runtime.getModel("http://www.trisotech.com/definitions/_c3e08836-7973-4e4d-af2b-d46b23725c13",
                                                    "Import BKM and have a Decision Ctx with DT");
-        assertThat(dmnModel, notNullValue());
-        assertThat(DMNRuntimeUtil.formatMessages(dmnModel.getMessages()), dmnModel.hasErrors(), is(false));
+        assertThat(dmnModel).isNotNull();
+        assertThat(dmnModel.hasErrors()).as(DMNRuntimeUtil.formatMessages(dmnModel.getMessages())).isFalse();
 
         final DMNContext context = runtime.newContext();
         context.set("A Person", mapOf(entry("name", "John"), entry("age", 47)));
 
         final DMNResult evaluateAll = runtime.evaluateAll(dmnModel, context);
-        assertThat(DMNRuntimeUtil.formatMessages(evaluateAll.getMessages()), evaluateAll.hasErrors(), is(false));
+        assertThat(evaluateAll.hasErrors()).as(DMNRuntimeUtil.formatMessages(evaluateAll.getMessages())).isFalse();
 
         LOG.debug("{}", evaluateAll);
-        assertThat(evaluateAll.getDecisionResultByName("A Decision Ctx with DT").getResult(), is("Respectfully, Hello John!"));
+        assertThat(evaluateAll.getDecisionResultByName("A Decision Ctx with DT").getResult()).isEqualTo("Respectfully, Hello John!");
     }
     
     @Test
@@ -86,23 +79,23 @@ public class ImportsTest extends BaseInterpretedVsCompiledTest {
 
         final DMNModel importedModel = runtime.getModel("http://www.trisotech.com/dmn/definitions/_16a48e7a-0687-4c2d-b402-42925084fa1a",
                                                         "Saying hello 2 bkms");
-        assertThat(importedModel, notNullValue());
-        assertThat(DMNRuntimeUtil.formatMessages(importedModel.getMessages()), importedModel.hasErrors(), is(false));
+        assertThat(importedModel).isNotNull();
+        assertThat(importedModel.hasErrors()).as(DMNRuntimeUtil.formatMessages(importedModel.getMessages())).isFalse();
 
         final DMNModel dmnModel = runtime.getModel("http://www.trisotech.com/dmn/definitions/_01a65215-7e0d-47ac-845a-a768f6abf7fe",
                                                    "Do say hello with 2 bkms");
-        assertThat(dmnModel, notNullValue());
-        assertThat(DMNRuntimeUtil.formatMessages(dmnModel.getMessages()), dmnModel.hasErrors(), is(false));
+        assertThat(dmnModel).isNotNull();
+        assertThat(dmnModel.hasErrors()).as(DMNRuntimeUtil.formatMessages(dmnModel.getMessages())).isFalse();
 
         final DMNContext context = runtime.newContext();
         context.set("Person name", "John");
 
         final DMNResult evaluateAll = runtime.evaluateAll(dmnModel, context);
-        assertThat(DMNRuntimeUtil.formatMessages(evaluateAll.getMessages()), evaluateAll.hasErrors(), is(false));
+        assertThat(evaluateAll.hasErrors()).as(DMNRuntimeUtil.formatMessages(evaluateAll.getMessages())).isFalse();
 
         LOG.debug("{}", evaluateAll);
-        assertThat(evaluateAll.getDecisionResultByName("Say hello decision").getResult(), is("Hello, John"));
-        assertThat(evaluateAll.getDecisionResultByName("what about hello").getResult(), is("Hello"));
+        assertThat(evaluateAll.getDecisionResultByName("Say hello decision").getResult()).isEqualTo("Hello, John");
+        assertThat(evaluateAll.getDecisionResultByName("what about hello").getResult()).isEqualTo("Hello");
     }
 
     @Test
@@ -113,21 +106,21 @@ public class ImportsTest extends BaseInterpretedVsCompiledTest {
 
         final DMNModel importedModel = runtime.getModel("http://www.trisotech.com/dmn/definitions/_16a48e7a-0687-4c2d-b402-42925084fa1a",
                                                         "Saying hello 2 bkms");
-        assertThat(importedModel, notNullValue());
-        assertThat(DMNRuntimeUtil.formatMessages(importedModel.getMessages()), importedModel.hasErrors(), is(false));
+        assertThat(importedModel).isNotNull();
+        assertThat(importedModel.hasErrors()).as(DMNRuntimeUtil.formatMessages(importedModel.getMessages())).isFalse();
 
         final DMNModel dmnModel = runtime.getModel("http://www.trisotech.com/definitions/_eedf6ecc-f113-4333-ace0-79b783e313e5",
                                                    "Do invoke hello with 2 bkms");
-        assertThat(dmnModel, notNullValue());
-        assertThat(DMNRuntimeUtil.formatMessages(dmnModel.getMessages()), dmnModel.hasErrors(), is(false));
+        assertThat(dmnModel).isNotNull();
+        assertThat(dmnModel.hasErrors()).as(DMNRuntimeUtil.formatMessages(dmnModel.getMessages())).isFalse();
 
         final DMNContext emptyContext = runtime.newContext();
 
         final DMNResult evaluateAll = runtime.evaluateAll(dmnModel, emptyContext);
-        assertThat(DMNRuntimeUtil.formatMessages(evaluateAll.getMessages()), evaluateAll.hasErrors(), is(false));
+        assertThat(evaluateAll.hasErrors()).as(DMNRuntimeUtil.formatMessages(evaluateAll.getMessages())).isFalse();
 
         LOG.debug("{}", evaluateAll);
-        assertThat(evaluateAll.getDecisionResultByName("invocation of hello").getResult(), is("Hello, John"));
+        assertThat(evaluateAll.getDecisionResultByName("invocation of hello").getResult()).isEqualTo("Hello, John");
     }
 
     @Test
@@ -139,22 +132,22 @@ public class ImportsTest extends BaseInterpretedVsCompiledTest {
 
         final DMNModel importedModel = runtime.getModel("http://www.trisotech.com/dmn/definitions/_16a48e7a-0687-4c2d-b402-42925084fa1a",
                                                         "Saying hello 2 bkms");
-        assertThat(importedModel, notNullValue());
-        assertThat(DMNRuntimeUtil.formatMessages(importedModel.getMessages()), importedModel.hasErrors(), is(false));
+        assertThat(importedModel).isNotNull();
+        assertThat(importedModel.hasErrors()).as(DMNRuntimeUtil.formatMessages(importedModel.getMessages())).isFalse();
 
         final DMNModel dmnModel = runtime.getModel("http://www.trisotech.com/definitions/_eedf6ecc-f113-4333-ace0-79b783e313e5",
                                                    "Do invoke hello with 2 bkms");
-        assertThat(dmnModel, notNullValue());
-        assertThat(DMNRuntimeUtil.formatMessages(dmnModel.getMessages()), dmnModel.hasErrors(), is(false));
+        assertThat(dmnModel).isNotNull();
+        assertThat(dmnModel.hasErrors()).as(DMNRuntimeUtil.formatMessages(dmnModel.getMessages())).isFalse();
 
         final DMNContext context = runtime.newContext();
         context.set("Person name", "Bob");
 
         final DMNResult evaluateAll = runtime.evaluateAll(dmnModel, context);
-        assertThat(DMNRuntimeUtil.formatMessages(evaluateAll.getMessages()), evaluateAll.hasErrors(), is(false));
+        assertThat(evaluateAll.hasErrors()).as(DMNRuntimeUtil.formatMessages(evaluateAll.getMessages())).isFalse();
 
         LOG.debug("{}", evaluateAll);
-        assertThat(evaluateAll.getDecisionResultByName("what about hello").getResult(), is("Hello, Bob"));
+        assertThat(evaluateAll.getDecisionResultByName("what about hello").getResult()).isEqualTo("Hello, Bob");
     }
 
     @Test
@@ -170,30 +163,30 @@ public class ImportsTest extends BaseInterpretedVsCompiledTest {
 
         final DMNModel importedModel = runtime.getModel("http://www.trisotech.com/dmn/definitions/_16a48e7a-0687-4c2d-b402-42925084fa1a",
                                                         "Saying hello 2 bkms");
-        assertThat(importedModel, notNullValue());
-        assertThat(DMNRuntimeUtil.formatMessages(importedModel.getMessages()), importedModel.hasErrors(), is(false));
+        assertThat(importedModel).isNotNull();
+        assertThat(importedModel.hasErrors()).as(DMNRuntimeUtil.formatMessages(importedModel.getMessages())).isFalse();
 
         final DMNModel dmnModel = runtime.getModel("http://www.trisotech.com/dmn/definitions/_01a65215-7e0d-47ac-845a-a768f6abf7fe",
                                                    "Do say hello with 2 bkms");
-        assertThat(dmnModel, notNullValue());
-        assertThat(DMNRuntimeUtil.formatMessages(dmnModel.getMessages()), dmnModel.hasErrors(), is(false));
+        assertThat(dmnModel).isNotNull();
+        assertThat(dmnModel.hasErrors()).as(DMNRuntimeUtil.formatMessages(dmnModel.getMessages())).isFalse();
 
         final DMNModel dmnModelL3 = runtime.getModel("http://www.trisotech.com/dmn/definitions/_820c548c-377d-463e-a62b-bb95ddc4758c",
                                                      "L3 Do say hello");
-        assertThat(dmnModelL3, notNullValue());
-        assertThat(DMNRuntimeUtil.formatMessages(dmnModelL3.getMessages()), dmnModelL3.hasErrors(), is(false));
+        assertThat(dmnModelL3).isNotNull();
+        assertThat(dmnModelL3.hasErrors()).as(DMNRuntimeUtil.formatMessages(dmnModelL3.getMessages())).isFalse();
 
         final DMNContext context = runtime.newContext();
         context.set("Another Name", "Bob");
         context.set("L2import", mapOf(entry("Person name", "John")));
 
         final DMNResult evaluateAll = runtime.evaluateAll(dmnModelL3, context);
-        assertThat(DMNRuntimeUtil.formatMessages(evaluateAll.getMessages()), evaluateAll.hasErrors(), is(false));
+        assertThat(evaluateAll.hasErrors()).as(DMNRuntimeUtil.formatMessages(evaluateAll.getMessages())).isFalse();
 
         LOG.debug("{}", evaluateAll);
-        assertThat(evaluateAll.getDecisionResultByName("L3 decision").getResult(), is("Hello, Bob"));
-        assertThat(evaluateAll.getDecisionResultByName("L3 view on M2").getResult(), is("Hello, John"));
-        assertThat(evaluateAll.getDecisionResultByName("L3 what about hello").getResult(), is("Hello"));
+        assertThat(evaluateAll.getDecisionResultByName("L3 decision").getResult()).isEqualTo("Hello, Bob");
+        assertThat(evaluateAll.getDecisionResultByName("L3 view on M2").getResult()).isEqualTo("Hello, John");
+        assertThat(evaluateAll.getDecisionResultByName("L3 what about hello").getResult()).isEqualTo("Hello");
     }
 
     @Test
@@ -204,22 +197,22 @@ public class ImportsTest extends BaseInterpretedVsCompiledTest {
 
         final DMNModel importedModel = runtime.getModel("http://www.trisotech.com/dmn/definitions/_88f4fc88-1eb2-4188-a721-5720cf5565ce",
                                                         "Spell Greeting");
-        assertThat(importedModel, notNullValue());
-        assertThat(DMNRuntimeUtil.formatMessages(importedModel.getMessages()), importedModel.hasErrors(), is(false));
+        assertThat(importedModel).isNotNull();
+        assertThat(importedModel.hasErrors()).as(DMNRuntimeUtil.formatMessages(importedModel.getMessages())).isFalse();
 
         final DMNModel dmnModel = runtime.getModel("http://www.trisotech.com/dmn/definitions/_d67f19e9-7835-4cad-9c80-16b8423cc392",
                                                    "Import Spell Greeting");
-        assertThat(dmnModel, notNullValue());
-        assertThat(DMNRuntimeUtil.formatMessages(dmnModel.getMessages()), dmnModel.hasErrors(), is(false));
+        assertThat(dmnModel).isNotNull();
+        assertThat(dmnModel.hasErrors()).as(DMNRuntimeUtil.formatMessages(dmnModel.getMessages())).isFalse();
 
         final DMNContext context = runtime.newContext();
         context.set("Person Name", "John");
 
         final DMNResult evaluateAll = runtime.evaluateAll(dmnModel, context);
-        assertThat(DMNRuntimeUtil.formatMessages(evaluateAll.getMessages()), evaluateAll.hasErrors(), is(false));
+        assertThat(evaluateAll.hasErrors()).as(DMNRuntimeUtil.formatMessages(evaluateAll.getMessages())).isFalse();
 
         LOG.debug("{}", evaluateAll);
-        assertThat(evaluateAll.getDecisionResultByName("Say the Greeting to Person").getResult(), is("Hello, John"));
+        assertThat(evaluateAll.getDecisionResultByName("Say the Greeting to Person").getResult()).isEqualTo("Hello, John");
     }
 
     @Test
@@ -246,9 +239,9 @@ public class ImportsTest extends BaseInterpretedVsCompiledTest {
 
         final DMNResult evaluateAll = runtime.evaluateAll(dmnModel, context);
         LOG.debug("{}", evaluateAll);
-        assertThat(DMNRuntimeUtil.formatMessages(evaluateAll.getMessages()), evaluateAll.hasErrors(), is(false));
+        assertThat(evaluateAll.hasErrors()).as(DMNRuntimeUtil.formatMessages(evaluateAll.getMessages())).isFalse();
 
-        assertThat(evaluateAll.getDecisionResultByName("Evaluating Say Hello").getResult(), is("Evaluating Say Hello to: Hello, John"));
+        assertThat(evaluateAll.getDecisionResultByName("Evaluating Say Hello").getResult()).isEqualTo("Evaluating Say Hello to: Hello, John");
     }
 
     @Test
@@ -266,9 +259,9 @@ public class ImportsTest extends BaseInterpretedVsCompiledTest {
 
         final DMNResult evaluateAll = runtime.evaluateAll(dmnModel, context);
         LOG.debug("{}", evaluateAll);
-        assertThat(DMNRuntimeUtil.formatMessages(evaluateAll.getMessages()), evaluateAll.hasErrors(), is(false));
+        assertThat(evaluateAll.hasErrors()).as(DMNRuntimeUtil.formatMessages(evaluateAll.getMessages())).isFalse();
 
-        assertThat(evaluateAll.getDecisionResultByName("Model C Decision based on Bs").getResult(), is("B: Evaluating Say Hello to: Hello, B.A.John; B2:Evaluating Say Hello to: Hello, B2.A.John2"));
+        assertThat(evaluateAll.getDecisionResultByName("Model C Decision based on Bs").getResult()).isEqualTo("B: Evaluating Say Hello to: Hello, B.A.John; B2:Evaluating Say Hello to: Hello, B2.A.John2");
     }
 
     @Test
@@ -284,9 +277,9 @@ public class ImportsTest extends BaseInterpretedVsCompiledTest {
 
         final DMNResult evaluateAll = runtime.evaluateAll(dmnModel, context);
         LOG.debug("{}", evaluateAll);
-        assertThat(DMNRuntimeUtil.formatMessages(evaluateAll.getMessages()), evaluateAll.hasErrors(), is(false));
+        assertThat(evaluateAll.hasErrors()).as(DMNRuntimeUtil.formatMessages(evaluateAll.getMessages())).isFalse();
 
-        assertThat(evaluateAll.getDecisionResultByName("Hello decision using imported InputData").getResult(), is("Hello, DROOLS-2944"));
+        assertThat(evaluateAll.getDecisionResultByName("Hello decision using imported InputData").getResult()).isEqualTo("Hello, DROOLS-2944");
     }
 
     @Test
@@ -316,10 +309,10 @@ public class ImportsTest extends BaseInterpretedVsCompiledTest {
         final DMNResult evaluateAll = fn.apply(context);
         LOG.debug("{}", evaluateAll);
         LOG.debug("{}", evaluateAll.getDecisionResults());
-        assertThat(DMNRuntimeUtil.formatMessages(evaluateAll.getMessages()), evaluateAll.hasErrors(), is(false));
+        assertThat(evaluateAll.hasErrors()).as(DMNRuntimeUtil.formatMessages(evaluateAll.getMessages())).isFalse();
 
-        assertThat(evaluateAll.getDecisionResultByName("Evaluating Say Hello").getResult(), is("Evaluating Say Hello to: Hello, John"));
-        assertThat(evaluateAll.getDecisionResultByName("modelA.Greet the Person").getResult(), is("Hello, John"));
+        assertThat(evaluateAll.getDecisionResultByName("Evaluating Say Hello").getResult()).isEqualTo("Evaluating Say Hello to: Hello, John");
+        assertThat(evaluateAll.getDecisionResultByName("modelA.Greet the Person").getResult()).isEqualTo("Hello, John");
     }
 
     @Test
@@ -330,19 +323,19 @@ public class ImportsTest extends BaseInterpretedVsCompiledTest {
                                                                                        "ModelB.dmn");
         final DMNModel dmnModel = getAndAssertModelNoErrors(runtime, "http://www.trisotech.com/dmn/definitions/_2a1d771a-a899-4fef-abd6-fc894332337c", "Model B");
 
-        assertThat(dmnModel.getDecisionById("_96df766e-23e1-4aa6-9d5d-545fbe2f1e23").getName(), is("Evaluating Say Hello"));
-        assertThat(dmnModel.getDecisionById("http://www.trisotech.com/dmn/definitions/_ae5b3c17-1ac3-4e1d-b4f9-2cf861aec6d9#_f7fdaec4-d669-4797-b3b4-12b860de2eb5").getName(), is("Greet the Person")); // this is an imported Decision
-        assertThat(dmnModel.getDecisionById("_f7fdaec4-d669-4797-b3b4-12b860de2eb5"), nullValue()); // this is an imported Decision
+        assertThat(dmnModel.getDecisionById("_96df766e-23e1-4aa6-9d5d-545fbe2f1e23").getName()).isEqualTo("Evaluating Say Hello");
+        assertThat(dmnModel.getDecisionById("http://www.trisotech.com/dmn/definitions/_ae5b3c17-1ac3-4e1d-b4f9-2cf861aec6d9#_f7fdaec4-d669-4797-b3b4-12b860de2eb5").getName()).isEqualTo("Greet the Person"); // this is an imported Decision
+        assertThat(dmnModel.getDecisionById("_f7fdaec4-d669-4797-b3b4-12b860de2eb5")).isNull(); // this is an imported Decision
 
-        assertThat(dmnModel.getDecisionByName("Evaluating Say Hello").getId(), is("_96df766e-23e1-4aa6-9d5d-545fbe2f1e23"));
-        assertThat(dmnModel.getDecisionByName("Greet the Person"), nullValue()); // this is an imported Decision
-        assertThat(dmnModel.getDecisionByName("modelA.Greet the Person").getId(), is("_f7fdaec4-d669-4797-b3b4-12b860de2eb5")); // this is an imported Decision
+        assertThat(dmnModel.getDecisionByName("Evaluating Say Hello").getId()).isEqualTo("_96df766e-23e1-4aa6-9d5d-545fbe2f1e23");
+        assertThat(dmnModel.getDecisionByName("Greet the Person")).isNull(); // this is an imported Decision
+        assertThat(dmnModel.getDecisionByName("modelA.Greet the Person").getId()).isEqualTo("_f7fdaec4-d669-4797-b3b4-12b860de2eb5"); // this is an imported Decision
 
-        assertThat(dmnModel.getInputById("http://www.trisotech.com/dmn/definitions/_ae5b3c17-1ac3-4e1d-b4f9-2cf861aec6d9#_4f6c136c-8512-4d71-8bbf-7c9eb6e74063").getName(), is("Person name")); // this is an imported InputData node.
-        assertThat(dmnModel.getInputById("_4f6c136c-8512-4d71-8bbf-7c9eb6e74063"), nullValue()); // this is an imported InputData node.
+        assertThat(dmnModel.getInputById("http://www.trisotech.com/dmn/definitions/_ae5b3c17-1ac3-4e1d-b4f9-2cf861aec6d9#_4f6c136c-8512-4d71-8bbf-7c9eb6e74063").getName()).isEqualTo("Person name"); // this is an imported InputData node.
+        assertThat(dmnModel.getInputById("_4f6c136c-8512-4d71-8bbf-7c9eb6e74063")).isNull(); // this is an imported InputData node.
 
-        assertThat(dmnModel.getInputByName("Person name"), nullValue()); // this is an imported InputData node.
-        assertThat(dmnModel.getInputByName("modelA.Person name").getId(), is("_4f6c136c-8512-4d71-8bbf-7c9eb6e74063")); // this is an imported InputData node.
+        assertThat(dmnModel.getInputByName("Person name")).isNull(); // this is an imported InputData node.
+        assertThat(dmnModel.getInputByName("modelA.Person name").getId()).isEqualTo("_4f6c136c-8512-4d71-8bbf-7c9eb6e74063"); // this is an imported InputData node.
     }
 
     @Test
@@ -355,22 +348,26 @@ public class ImportsTest extends BaseInterpretedVsCompiledTest {
                                                                                        "ModelC.dmn");
 
         final DMNModelImpl modelA = (DMNModelImpl) getAndAssertModelNoErrors(runtime, "http://www.trisotech.com/dmn/definitions/_ae5b3c17-1ac3-4e1d-b4f9-2cf861aec6d9", "Say hello 1ID1D");
-        assertThat(modelA.getImportChainAliases().entrySet(), hasSize(0));
+        assertThat(modelA.getImportChainAliases()).hasSize(0);
 
         final DMNModelImpl modelB = (DMNModelImpl) getAndAssertModelNoErrors(runtime, "http://www.trisotech.com/dmn/definitions/_2a1d771a-a899-4fef-abd6-fc894332337c", "Model B");
-        assertThat(modelB.getImportChainAliases().entrySet(), hasSize(1));
-        assertThat(modelB.getImportChainAliases(), hasEntry(is("http://www.trisotech.com/dmn/definitions/_ae5b3c17-1ac3-4e1d-b4f9-2cf861aec6d9"),
-                                                            contains(Collections.singletonList("modelA"))));
+        assertThat(modelB.getImportChainAliases()).hasSize(1);
+        assertThat(modelB.getImportChainAliases()).containsKey("http://www.trisotech.com/dmn/definitions/_ae5b3c17-1ac3-4e1d-b4f9-2cf861aec6d9");
+        assertThat(modelB.getImportChainAliases().get("http://www.trisotech.com/dmn/definitions/_ae5b3c17-1ac3-4e1d-b4f9-2cf861aec6d9"))
+        	.containsExactly(Collections.singletonList("modelA"));
 
         final DMNModelImpl modelC = (DMNModelImpl) getAndAssertModelNoErrors(runtime, "http://www.trisotech.com/dmn/definitions/_10435dcd-8774-4575-a338-49dd554a0928", "Model C");
-        assertThat(modelC.getImportChainAliases().entrySet(), hasSize(3));
-        assertThat(modelC.getImportChainAliases(), hasEntry(is("http://www.trisotech.com/dmn/definitions/_2a1d771a-a899-4fef-abd6-fc894332337c"),
-                                                            contains(Collections.singletonList("Model B"))));
-        assertThat(modelC.getImportChainAliases(), hasEntry(is("http://www.trisotech.com/definitions/_9d46ece4-a96c-4cb0-abc0-0ca121ac3768"),
-                                                            contains(Collections.singletonList("Model B2"))));
-        assertThat(modelC.getImportChainAliases(), hasEntry(is("http://www.trisotech.com/dmn/definitions/_ae5b3c17-1ac3-4e1d-b4f9-2cf861aec6d9"),
-                                                            containsInAnyOrder(Arrays.asList("Model B2", "modelA"),
-                                                                               Arrays.asList("Model B", "modelA"))));
+        assertThat(modelC.getImportChainAliases()).hasSize(3);
+        assertThat(modelC.getImportChainAliases()).containsKey("http://www.trisotech.com/dmn/definitions/_2a1d771a-a899-4fef-abd6-fc894332337c");
+        assertThat(modelC.getImportChainAliases().get("http://www.trisotech.com/dmn/definitions/_2a1d771a-a899-4fef-abd6-fc894332337c"))
+        	.containsExactly(Collections.singletonList("Model B"));
+        assertThat(modelC.getImportChainAliases()).containsKey("http://www.trisotech.com/definitions/_9d46ece4-a96c-4cb0-abc0-0ca121ac3768");
+        assertThat(modelC.getImportChainAliases().get("http://www.trisotech.com/definitions/_9d46ece4-a96c-4cb0-abc0-0ca121ac3768"))
+        		.containsExactly(Collections.singletonList("Model B2"));
+        assertThat(modelC.getImportChainAliases()).containsKey("http://www.trisotech.com/dmn/definitions/_ae5b3c17-1ac3-4e1d-b4f9-2cf861aec6d9");
+        assertThat(modelC.getImportChainAliases().get("http://www.trisotech.com/dmn/definitions/_ae5b3c17-1ac3-4e1d-b4f9-2cf861aec6d9"))
+                .containsExactlyInAnyOrder(Arrays.asList("Model B2", "modelA"),
+                                   Arrays.asList("Model B", "modelA"));
     }
 
     @Test
@@ -381,23 +378,23 @@ public class ImportsTest extends BaseInterpretedVsCompiledTest {
 
         final DMNModel importedModel = runtime.getModel("http://www.trisotech.com/definitions/_c8fc1424-d3fb-40c5-81df-22b409891192",
                                                         "base join");
-        assertThat(importedModel, notNullValue());
-        assertThat(DMNRuntimeUtil.formatMessages(importedModel.getMessages()), importedModel.hasErrors(), is(false));
+        assertThat(importedModel).isNotNull();
+        assertThat(importedModel.hasErrors()).as(DMNRuntimeUtil.formatMessages(importedModel.getMessages())).isFalse();
 
         final DMNModel dmnModel = runtime.getModel("http://www.trisotech.com/definitions/_2b5e6bbd-2524-4b72-bff9-ca5ecdcea172",
                                                    "use join");
-        assertThat(dmnModel, notNullValue());
-        assertThat(DMNRuntimeUtil.formatMessages(dmnModel.getMessages()), dmnModel.hasErrors(), is(false));
+        assertThat(dmnModel).isNotNull();
+        assertThat(dmnModel.hasErrors()).as(DMNRuntimeUtil.formatMessages(dmnModel.getMessages())).isFalse();
 
         final DMNContext context = runtime.newContext();
         context.set("name", "John Doe");
 
         final DMNResult evaluateAll = runtime.evaluateAll(dmnModel, context);
-        assertThat(DMNRuntimeUtil.formatMessages(evaluateAll.getMessages()), evaluateAll.hasErrors(), is(false));
+        assertThat(evaluateAll.hasErrors()).as(DMNRuntimeUtil.formatMessages(evaluateAll.getMessages())).isFalse();
 
         LOG.debug("{}", evaluateAll);
-        assertThat(evaluateAll.getDecisionResultByName("greet").getResult(), is("Hi, John Doe"));
-        assertThat(evaluateAll.getDecisionResultByName("greet2").getResult(), is("Hello, John Doe"));
+        assertThat(evaluateAll.getDecisionResultByName("greet").getResult()).isEqualTo("Hi, John Doe");
+        assertThat(evaluateAll.getDecisionResultByName("greet2").getResult()).isEqualTo("Hello, John Doe");
     }
 
     @Test
@@ -408,30 +405,30 @@ public class ImportsTest extends BaseInterpretedVsCompiledTest {
 
         final DMNModel importedModel = runtime.getModel("http://www.trisotech.com/definitions/_6ecff8d8-42d6-4e77-9759-83c2f3fae418",
                                                         "base model");
-        assertThat(importedModel, notNullValue());
-        assertThat(DMNRuntimeUtil.formatMessages(importedModel.getMessages()), importedModel.hasErrors(), is(false));
+        assertThat(importedModel).isNotNull();
+        assertThat(importedModel.hasErrors()).as(DMNRuntimeUtil.formatMessages(importedModel.getMessages())).isFalse();
 
         final DMNModel dmnModel = runtime.getModel("http://www.trisotech.com/definitions/_153cb253-2904-468e-b6dc-42bc016c0ddd",
                                                    "checks");
-        assertThat(dmnModel, notNullValue());
-        assertThat(DMNRuntimeUtil.formatMessages(dmnModel.getMessages()), dmnModel.hasErrors(), is(false));
+        assertThat(dmnModel).isNotNull();
+        assertThat(dmnModel.hasErrors()).as(DMNRuntimeUtil.formatMessages(dmnModel.getMessages())).isFalse();
 
         final DMNContext context = runtime.newContext();
 
         final DMNResult evaluateAll = runtime.evaluateAll(dmnModel, context);
-        assertThat(DMNRuntimeUtil.formatMessages(evaluateAll.getMessages()), evaluateAll.hasErrors(), is(false));
+        assertThat(evaluateAll.hasErrors()).as(DMNRuntimeUtil.formatMessages(evaluateAll.getMessages())).isFalse();
 
         LOG.debug("{}", evaluateAll);
-        assertThat(evaluateAll.getDecisionResultByName("is a list?").getResult(), is(true));
-        assertThat(evaluateAll.getDecisionResultByName("is a base person?").getResult(), is(true));
-        assertThat(evaluateAll.getDecisionResultByName("is a this model person?").getResult(), is(true));
-        assertThat(evaluateAll.getDecisionResultByName("with missing age is a base person?").getResult(), is(false));
-        assertThat(evaluateAll.getDecisionResultByName("with missing age is a this model person?").getResult(), is(false));
-        assertThat(evaluateAll.getDecisionResultByName("with address is a this model person?").getResult(), is(true));
-        assertThat(evaluateAll.getDecisionResultByName("is yes no persons?").getResult(), is(false));
-        assertThat(evaluateAll.getDecisionResultByName("is yes no collection of ps?").getResult(), is(false));
-        assertThat(evaluateAll.getDecisionResultByName("is yes yes persons?").getResult(), is(true));
-        assertThat(evaluateAll.getDecisionResultByName("is yes yes collection of ps?").getResult(), is(true));
+        assertThat(evaluateAll.getDecisionResultByName("is a list?").getResult()).isEqualTo(Boolean.TRUE);
+        assertThat(evaluateAll.getDecisionResultByName("is a base person?").getResult()).isEqualTo(Boolean.TRUE);
+        assertThat(evaluateAll.getDecisionResultByName("is a this model person?").getResult()).isEqualTo(Boolean.TRUE);
+        assertThat(evaluateAll.getDecisionResultByName("with missing age is a base person?").getResult()).isEqualTo(Boolean.FALSE);
+        assertThat(evaluateAll.getDecisionResultByName("with missing age is a this model person?").getResult()).isEqualTo(Boolean.FALSE);
+        assertThat(evaluateAll.getDecisionResultByName("with address is a this model person?").getResult()).isEqualTo(Boolean.TRUE);
+        assertThat(evaluateAll.getDecisionResultByName("is yes no persons?").getResult()).isEqualTo(Boolean.FALSE);
+        assertThat(evaluateAll.getDecisionResultByName("is yes no collection of ps?").getResult()).isEqualTo(Boolean.FALSE);
+        assertThat(evaluateAll.getDecisionResultByName("is yes yes persons?").getResult()).isEqualTo(Boolean.TRUE);
+        assertThat(evaluateAll.getDecisionResultByName("is yes yes collection of ps?").getResult()).isEqualTo(Boolean.TRUE);
     }
 
     @Test
@@ -442,23 +439,23 @@ public class ImportsTest extends BaseInterpretedVsCompiledTest {
 
         final DMNModel importedModel = runtime.getModel("https://kiegroup.org/dmn/_FCC62740-4998-47A2-B5F2-CB3E15C98419",
                                                         "baseSum");
-        assertThat(importedModel, notNullValue());
-        assertThat(DMNRuntimeUtil.formatMessages(importedModel.getMessages()), importedModel.hasErrors(), is(false));
+        assertThat(importedModel).isNotNull();
+        assertThat(importedModel.hasErrors()).as(DMNRuntimeUtil.formatMessages(importedModel.getMessages())).isFalse();
 
         final DMNModel dmnModel = runtime.getModel("https://kiegroup.org/dmn/_1D35A3BF-1DBD-4CD0-882A-CA068C6F2A67",
                                                    "importingSum");
-        assertThat(dmnModel, notNullValue());
-        assertThat(DMNRuntimeUtil.formatMessages(dmnModel.getMessages()), dmnModel.hasErrors(), is(false));
+        assertThat(dmnModel).isNotNull();
+        assertThat(dmnModel.hasErrors()).as(DMNRuntimeUtil.formatMessages(dmnModel.getMessages())).isFalse();
 
         final DMNContext context = runtime.newContext();
         context.set("x", new BigDecimal(1));
         context.set("y", new BigDecimal(2));
 
         final DMNResult evaluateAll = runtime.evaluateAll(dmnModel, context);
-        assertThat(DMNRuntimeUtil.formatMessages(evaluateAll.getMessages()), evaluateAll.hasErrors(), is(false));
+        assertThat(evaluateAll.hasErrors()).as(DMNRuntimeUtil.formatMessages(evaluateAll.getMessages())).isFalse();
 
         LOG.debug("{}", evaluateAll);
-        assertThat(evaluateAll.getDecisionResultByName("importing Decision").getResult(), is(new BigDecimal(3)));
+        assertThat(evaluateAll.getDecisionResultByName("importing Decision").getResult()).isEqualTo(new BigDecimal(3));
     }
 
     @Test
@@ -469,23 +466,23 @@ public class ImportsTest extends BaseInterpretedVsCompiledTest {
 
         final DMNModel importedModel = runtime.getModel("https://kiegroup.org/dmn/_33A94A92-E771-4ED3-8C20-A76EA13D6A2E",
                                                         "ComparatorModel");
-        assertThat(importedModel, notNullValue());
-        assertThat(DMNRuntimeUtil.formatMessages(importedModel.getMessages()), importedModel.hasErrors(), is(false));
+        assertThat(importedModel).isNotNull();
+        assertThat(importedModel.hasErrors()).as(DMNRuntimeUtil.formatMessages(importedModel.getMessages())).isFalse();
 
         final DMNModel dmnModel = runtime.getModel("https://kiegroup.org/dmn/_5774C21E-74F2-41D8-9AC6-FE0DAEA5C3DB",
                                                    "Import_ComparatorModel_and_alias_with_dots");
-        assertThat(dmnModel, notNullValue());
-        assertThat(DMNRuntimeUtil.formatMessages(dmnModel.getMessages()), dmnModel.hasErrors(), is(false));
+        assertThat(dmnModel).isNotNull();
+        assertThat(dmnModel.hasErrors()).as(DMNRuntimeUtil.formatMessages(dmnModel.getMessages())).isFalse();
 
         final DMNContext context = runtime.newContext();
         context.set("A", new BigDecimal(2));
         context.set("B", new BigDecimal(1));
 
         final DMNResult evaluateAll = runtime.evaluateAll(dmnModel, context);
-        assertThat(DMNRuntimeUtil.formatMessages(evaluateAll.getMessages()), evaluateAll.hasErrors(), is(false));
+        assertThat(evaluateAll.hasErrors()).as(DMNRuntimeUtil.formatMessages(evaluateAll.getMessages())).isFalse();
 
         LOG.debug("{}", evaluateAll);
-        assertThat(evaluateAll.getDecisionResultByName("Is A Bigger?").getResult(), is(true));
+        assertThat(evaluateAll.getDecisionResultByName("Is A Bigger?").getResult()).isEqualTo(Boolean.TRUE);
     }
 
     @Test
@@ -496,23 +493,23 @@ public class ImportsTest extends BaseInterpretedVsCompiledTest {
 
         final DMNModel importedModel = runtime.getModel("https://kiegroup.org/dmn/_F0CCDEC6-F439-421B-8259-87878AC367C9",
                                                         "ComparatorModelNamedWithDots");
-        assertThat(importedModel, notNullValue());
-        assertThat(DMNRuntimeUtil.formatMessages(importedModel.getMessages()), importedModel.hasErrors(), is(false));
+        assertThat(importedModel).isNotNull();
+        assertThat(importedModel.hasErrors()).as(DMNRuntimeUtil.formatMessages(importedModel.getMessages())).isFalse();
 
         final DMNModel dmnModel = runtime.getModel("https://kiegroup.org/dmn/_8DC3A181-D49E-4752-A898-AB04C2B2A856",
                                                    "Import_ComparatorModelNamedWithDots_and_alias_with_dots");
-        assertThat(dmnModel, notNullValue());
-        assertThat(DMNRuntimeUtil.formatMessages(dmnModel.getMessages()), dmnModel.hasErrors(), is(false));
+        assertThat(dmnModel).isNotNull();
+        assertThat(dmnModel.hasErrors()).as(DMNRuntimeUtil.formatMessages(dmnModel.getMessages())).isFalse();
 
         final DMNContext context = runtime.newContext();
         context.set("A", new BigDecimal(2));
         context.set("B", new BigDecimal(1));
 
         final DMNResult evaluateAll = runtime.evaluateAll(dmnModel, context);
-        assertThat(DMNRuntimeUtil.formatMessages(evaluateAll.getMessages()), evaluateAll.hasErrors(), is(false));
+        assertThat(evaluateAll.hasErrors()).as(DMNRuntimeUtil.formatMessages(evaluateAll.getMessages())).isFalse();
 
         LOG.debug("{}", evaluateAll);
-        assertThat(evaluateAll.getDecisionResultByName("Is A Bigger?").getResult(), is(true));
+        assertThat(evaluateAll.getDecisionResultByName("Is A Bigger?").getResult()).isEqualTo(Boolean.TRUE);
     }
 }
 

--- a/kie-dmn/kie-dmn-core/src/test/java/org/kie/dmn/core/incrementalcompilation/DMNIncrementalCompilationTest.java
+++ b/kie-dmn/kie-dmn-core/src/test/java/org/kie/dmn/core/incrementalcompilation/DMNIncrementalCompilationTest.java
@@ -33,9 +33,7 @@ import org.kie.dmn.core.util.KieHelper;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import static org.hamcrest.CoreMatchers.is;
-import static org.hamcrest.CoreMatchers.notNullValue;
-import static org.hamcrest.MatcherAssert.assertThat;
+import static org.assertj.core.api.Assertions.assertThat;
 
 public class DMNIncrementalCompilationTest extends BaseInterpretedVsCompiledTest {
 
@@ -80,7 +78,7 @@ public class DMNIncrementalCompilationTest extends BaseInterpretedVsCompiledTest
                                   final String sayHelloAndAgeDecisionResultValue) throws Exception {
         // the Model does NOT change in its NAME or ID, but it does change indeed in the LiteralExpression decision logic.
         final DMNModel dmnModel = runtime.getModel("http://www.trisotech.com/dmn/definitions/_7a39d775-bce9-45e3-aa3b-147d6f0028c7", "20180731-pr1997"); //  // NO change v1.0 -> v1.1
-        assertThat(runtime, notNullValue());
+        assertThat(runtime).isNotNull();
 
         final Object personByReflection = kieContainer.getClassLoader().loadClass("acme.Person").newInstance();
         final Method setFirstNameMethod = personByReflection.getClass().getMethod(methodNameForFirstName, String.class);// change v1.0 -> v1.1
@@ -95,10 +93,10 @@ public class DMNIncrementalCompilationTest extends BaseInterpretedVsCompiledTest
 
         final DMNResult dmnResult = runtime.evaluateAll(dmnModel, context);
         LOG.debug("{}", dmnResult);
-        assertThat(DMNRuntimeUtil.formatMessages(dmnResult.getMessages()), dmnResult.hasErrors(), is(false));
+        assertThat(dmnResult.hasErrors()).as(DMNRuntimeUtil.formatMessages(dmnResult.getMessages())).isFalse();
 
         final DMNContext result = dmnResult.getContext();
-        assertThat(result.get("Say hello and age"), is(sayHelloAndAgeDecisionResultValue));// change v1.0 -> v1.1
+        assertThat(result.get("Say hello and age")).isEqualTo(sayHelloAndAgeDecisionResultValue);// change v1.0 -> v1.1
     }
 
     @Test

--- a/kie-dmn/kie-dmn-core/src/test/java/org/kie/dmn/core/internal/utils/DRGAnalysisUtilsTest.java
+++ b/kie-dmn/kie-dmn-core/src/test/java/org/kie/dmn/core/internal/utils/DRGAnalysisUtilsTest.java
@@ -31,9 +31,6 @@ import org.slf4j.LoggerFactory;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
-import static org.hamcrest.CoreMatchers.is;
-import static org.hamcrest.CoreMatchers.notNullValue;
-import static org.hamcrest.MatcherAssert.assertThat;
 
 public class DRGAnalysisUtilsTest {
 
@@ -51,8 +48,8 @@ public class DRGAnalysisUtilsTest {
     public void testCH11usingDMN13() throws Exception {
         final DMNRuntime runtime = createRuntimeWithAdditionalResources("Chapter 11 Example.dmn", DMN13specificTest.class, "Financial.dmn");
         final DMNModel dmnModel = runtime.getModel("http://www.trisotech.com/definitions/_9d01a0c4-f529-4ad8-ad8e-ec5fb5d96ad4", "Chapter 11 Example");
-        assertThat(dmnModel, notNullValue());
-        assertThat(DMNRuntimeUtil.formatMessages(dmnModel.getMessages()), dmnModel.hasErrors(), is(false));
+        assertThat(dmnModel).isNotNull();
+        assertThat(dmnModel.hasErrors()).as(DMNRuntimeUtil.formatMessages(dmnModel.getMessages())).isFalse();
         
         Collection<DRGDependency> reqMonthlyInstallment = DRGAnalysisUtils.dependencies(dmnModel, "Required monthly installment");
         assertThat(reqMonthlyInstallment).hasSize(3);

--- a/kie-dmn/kie-dmn-core/src/test/java/org/kie/dmn/core/internal/utils/DynamicDMNContextBuilderTest.java
+++ b/kie-dmn/kie-dmn-core/src/test/java/org/kie/dmn/core/internal/utils/DynamicDMNContextBuilderTest.java
@@ -21,7 +21,6 @@ import java.time.Duration;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.LocalTime;
-import java.util.Arrays;
 import java.util.Map;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -40,9 +39,7 @@ import org.kie.dmn.feel.lang.types.impl.ComparablePeriod;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import static org.hamcrest.CoreMatchers.is;
-import static org.hamcrest.CoreMatchers.notNullValue;
-import static org.hamcrest.MatcherAssert.assertThat;
+import static org.assertj.core.api.Assertions.assertThat;
 
 public class DynamicDMNContextBuilderTest {
 
@@ -67,8 +64,8 @@ public class DynamicDMNContextBuilderTest {
     public void testOneOfEachType() throws Exception {
         DMNRuntime runtime = createRuntime("OneOfEachType.dmn", DMNRuntimeTypesTest.class);
         final DMNModel dmnModel = runtime.getModel("http://www.trisotech.com/definitions/_4f5608e9-4d74-4c22-a47e-ab657257fc9c", "OneOfEachType");
-        assertThat(dmnModel, notNullValue());
-        assertThat(DMNRuntimeUtil.formatMessages(dmnModel.getMessages()), dmnModel.hasErrors(), is(false));
+        assertThat(dmnModel).isNotNull();
+        assertThat(dmnModel.hasErrors()).as(DMNRuntimeUtil.formatMessages(dmnModel.getMessages())).isFalse();
 
         DMNContext context = runtime.newContext();
         final String JSON = "{\n" +
@@ -85,23 +82,23 @@ public class DynamicDMNContextBuilderTest {
 
         final DMNResult dmnResult = runtime.evaluateAll(dmnModel, context);
         LOG.debug("{}", dmnResult);
-        assertThat(DMNRuntimeUtil.formatMessages(dmnResult.getMessages()), dmnResult.hasErrors(), is(false));
-        assertThat(dmnResult.getDecisionResultByName("DecisionString").getResult(), is("Hello, John Doe"));
-        assertThat(dmnResult.getDecisionResultByName("DecisionNumber").getResult(), is(new BigDecimal(2)));
-        assertThat(dmnResult.getDecisionResultByName("DecisionBoolean").getResult(), is(false));
-        assertThat(dmnResult.getDecisionResultByName("DecisionDTDuration").getResult(), is(Duration.parse("P2D")));
-        assertThat(dmnResult.getDecisionResultByName("DecisionYMDuration").getResult(), is(ComparablePeriod.parse("P2M")));
-        assertThat(dmnResult.getDecisionResultByName("DecisionDateAndTime").getResult(), is(LocalDateTime.of(2020, 4, 2, 10, 0)));
-        assertThat(dmnResult.getDecisionResultByName("DecisionDate").getResult(), is(LocalDate.of(2020, 4, 3)));
-        assertThat(dmnResult.getDecisionResultByName("DecisionTime").getResult(), is(LocalTime.of(10, 0)));
+        assertThat(dmnResult.hasErrors()).as(DMNRuntimeUtil.formatMessages(dmnResult.getMessages())).isFalse();
+        assertThat(dmnResult.getDecisionResultByName("DecisionString").getResult()).isEqualTo("Hello, John Doe");
+        assertThat(dmnResult.getDecisionResultByName("DecisionNumber").getResult()).isEqualTo(new BigDecimal(2));
+        assertThat(dmnResult.getDecisionResultByName("DecisionBoolean").getResult()).isEqualTo(Boolean.FALSE);
+        assertThat(dmnResult.getDecisionResultByName("DecisionDTDuration").getResult()).isEqualTo(Duration.parse("P2D"));
+        assertThat(dmnResult.getDecisionResultByName("DecisionYMDuration").getResult()).isEqualTo(ComparablePeriod.parse("P2M"));
+        assertThat(dmnResult.getDecisionResultByName("DecisionDateAndTime").getResult()).isEqualTo(LocalDateTime.of(2020, 4, 2, 10, 0));
+        assertThat(dmnResult.getDecisionResultByName("DecisionDate").getResult()).isEqualTo(LocalDate.of(2020, 4, 3));
+        assertThat(dmnResult.getDecisionResultByName("DecisionTime").getResult()).isEqualTo(LocalTime.of(10, 0));
     }
 
     @Test
     public void testNextDays() throws Exception {
         final DMNRuntime runtime = createRuntime("nextDays.dmn", DMNRuntimeTypesTest.class);
         final DMNModel dmnModel = runtime.getModel("https://kiegroup.org/dmn/_8A1F9719-02AA-4517-97D4-5C4F5D22FE82", "nextDays");
-        assertThat(dmnModel, notNullValue());
-        assertThat(DMNRuntimeUtil.formatMessages(dmnModel.getMessages()), dmnModel.hasErrors(), is(false));
+        assertThat(dmnModel).isNotNull();
+        assertThat(dmnModel.hasErrors()).as(DMNRuntimeUtil.formatMessages(dmnModel.getMessages())).isFalse();
 
         DMNContext context = runtime.newContext();
         final String JSON = "{\n" +
@@ -111,16 +108,16 @@ public class DynamicDMNContextBuilderTest {
 
         final DMNResult dmnResult = runtime.evaluateAll(dmnModel, context);
         LOG.debug("{}", dmnResult);
-        assertThat(DMNRuntimeUtil.formatMessages(dmnResult.getMessages()), dmnResult.hasErrors(), is(false));
-        assertThat(dmnResult.getDecisionResultByName("Decision-1").getResult(), is(Arrays.asList(LocalDate.of(2020, 1, 1), LocalDate.of(2020, 2, 22))));
+        assertThat(dmnResult.hasErrors()).as(DMNRuntimeUtil.formatMessages(dmnResult.getMessages())).isFalse();
+        assertThat(dmnResult.getDecisionResultByName("Decision-1").getResult()).asList().containsExactly(LocalDate.of(2020, 1, 1), LocalDate.of(2020, 2, 22));
     }
 
     @Test
     public void testTrafficViolationAll() throws Exception {
         final DMNRuntime runtime = createRuntimeWithAdditionalResources("Traffic Violation.dmn", DMNRuntimeTypesTest.class);
         final DMNModel dmnModel = runtime.getModel("https://github.com/kiegroup/drools/kie-dmn/_A4BCA8B8-CF08-433F-93B2-A2598F19ECFF", "Traffic Violation");
-        assertThat(dmnModel, notNullValue());
-        assertThat(DMNRuntimeUtil.formatMessages(dmnModel.getMessages()), dmnModel.hasErrors(), is(false));
+        assertThat(dmnModel).isNotNull();
+        assertThat(dmnModel.hasErrors()).as(DMNRuntimeUtil.formatMessages(dmnModel.getMessages())).isFalse();
 
         DMNContext context = runtime.newContext();
         final String JSON = "{\n" +
@@ -149,8 +146,8 @@ public class DynamicDMNContextBuilderTest {
     public void testTrafficViolationMin() throws Exception {
         final DMNRuntime runtime = createRuntimeWithAdditionalResources("Traffic Violation.dmn", DMNRuntimeTypesTest.class);
         final DMNModel dmnModel = runtime.getModel("https://github.com/kiegroup/drools/kie-dmn/_A4BCA8B8-CF08-433F-93B2-A2598F19ECFF", "Traffic Violation");
-        assertThat(dmnModel, notNullValue());
-        assertThat(DMNRuntimeUtil.formatMessages(dmnModel.getMessages()), dmnModel.hasErrors(), is(false));
+        assertThat(dmnModel).isNotNull();
+        assertThat(dmnModel.hasErrors()).as(DMNRuntimeUtil.formatMessages(dmnModel.getMessages())).isFalse();
 
         DMNContext context = runtime.newContext();
         final String JSON = "{\n" +
@@ -173,8 +170,8 @@ public class DynamicDMNContextBuilderTest {
     public void testTrafficViolationArbitraryFine() throws Exception {
         final DMNRuntime runtime = createRuntimeWithAdditionalResources("Traffic Violation.dmn", DMNRuntimeTypesTest.class);
         final DMNModel dmnModel = runtime.getModel("https://github.com/kiegroup/drools/kie-dmn/_A4BCA8B8-CF08-433F-93B2-A2598F19ECFF", "Traffic Violation");
-        assertThat(dmnModel, notNullValue());
-        assertThat(DMNRuntimeUtil.formatMessages(dmnModel.getMessages()), dmnModel.hasErrors(), is(false));
+        assertThat(dmnModel).isNotNull();
+        assertThat(dmnModel.hasErrors()).as(DMNRuntimeUtil.formatMessages(dmnModel.getMessages())).isFalse();
 
         DMNContext context = runtime.newContext();
         final String JSON = "{\n" +
@@ -202,16 +199,16 @@ public class DynamicDMNContextBuilderTest {
     private void assertTrafficViolationSuspendedCase(final DMNRuntime runtime, final DMNModel dmnModel, DMNContext context) {
         final DMNResult dmnResult = runtime.evaluateAll(dmnModel, context);
         LOG.debug("{}", dmnResult);
-        assertThat(DMNRuntimeUtil.formatMessages(dmnResult.getMessages()), dmnResult.hasErrors(), is(false));
-        assertThat(dmnResult.getDecisionResultByName("Should the driver be suspended?").getResult(), is("Yes"));
+        assertThat(dmnResult.hasErrors()).as(DMNRuntimeUtil.formatMessages(dmnResult.getMessages())).isFalse();
+        assertThat(dmnResult.getDecisionResultByName("Should the driver be suspended?").getResult()).isEqualTo("Yes");
     }
 
     @Test
     public void testDSBasicDS1() throws Exception {
         final DMNRuntime runtime = createRuntime("0004-decision-services.dmn", DMNDecisionServicesTest.class);
         final DMNModel dmnModel = runtime.getModel("http://www.trisotech.com/definitions/_686f58d4-4ec3-4c65-8c06-0e4fd8983def", "Decision Services");
-        assertThat(dmnModel, notNullValue());
-        assertThat(DMNRuntimeUtil.formatMessages(dmnModel.getMessages()), dmnModel.hasErrors(), is(false));
+        assertThat(dmnModel).isNotNull();
+        assertThat(dmnModel.hasErrors()).as(DMNRuntimeUtil.formatMessages(dmnModel.getMessages())).isFalse();
 
         DMNContext context = runtime.newContext();
         final String JSON = "{ \"D\":\"d\", \"E\":\"e\"}";
@@ -219,16 +216,16 @@ public class DynamicDMNContextBuilderTest {
         
         final DMNResult dmnResult = runtime.evaluateDecisionService(dmnModel, context, "A only as output knowing D and E");
         LOG.debug("{}", dmnResult);
-        assertThat(DMNRuntimeUtil.formatMessages(dmnResult.getMessages()), dmnResult.hasErrors(), is(false));
-        assertThat(dmnResult.getDecisionResultByName("A").getResult(), is("de"));
+        assertThat(dmnResult.hasErrors()).as(DMNRuntimeUtil.formatMessages(dmnResult.getMessages())).isFalse();
+        assertThat(dmnResult.getDecisionResultByName("A").getResult()).isEqualTo("de");
     }
 
     @Test
     public void testDSBasicDS2() throws Exception {
         final DMNRuntime runtime = createRuntime("0004-decision-services.dmn", DMNDecisionServicesTest.class);
         final DMNModel dmnModel = runtime.getModel("http://www.trisotech.com/definitions/_686f58d4-4ec3-4c65-8c06-0e4fd8983def", "Decision Services");
-        assertThat(dmnModel, notNullValue());
-        assertThat(DMNRuntimeUtil.formatMessages(dmnModel.getMessages()), dmnModel.hasErrors(), is(false));
+        assertThat(dmnModel).isNotNull();
+        assertThat(dmnModel.hasErrors()).as(DMNRuntimeUtil.formatMessages(dmnModel.getMessages())).isFalse();
 
         DMNContext context = runtime.newContext();
         final String JSON = "{ \"additional\":123, \"D\":\"d\", \"E\":\"e\", \"B\":\"inB\", \"C\":\"inC\"}";
@@ -236,8 +233,8 @@ public class DynamicDMNContextBuilderTest {
 
         final DMNResult dmnResult = runtime.evaluateDecisionService(dmnModel, context, "A Only Knowing B and C");
         LOG.debug("{}", dmnResult);
-        assertThat(DMNRuntimeUtil.formatMessages(dmnResult.getMessages()), dmnResult.hasErrors(), is(false));
-        assertThat(dmnResult.getDecisionResultByName("A").getResult(), is("inBinC"));
+        assertThat(dmnResult.hasErrors()).as(DMNRuntimeUtil.formatMessages(dmnResult.getMessages())).isFalse();
+        assertThat(dmnResult.getDecisionResultByName("A").getResult()).isEqualTo("inBinC");
     }
     
     @Test

--- a/kie-dmn/kie-dmn-core/src/test/java/org/kie/dmn/core/internal/utils/MarshallingStubUtilsTest.java
+++ b/kie-dmn/kie-dmn-core/src/test/java/org/kie/dmn/core/internal/utils/MarshallingStubUtilsTest.java
@@ -29,10 +29,7 @@ import org.kie.dmn.feel.lang.types.impl.ComparablePeriod;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import static org.hamcrest.CoreMatchers.instanceOf;
-import static org.hamcrest.CoreMatchers.is;
-import static org.hamcrest.CoreMatchers.notNullValue;
-import static org.hamcrest.MatcherAssert.assertThat;
+import static org.assertj.core.api.Assertions.assertThat;
 
 public class MarshallingStubUtilsTest extends BaseVariantTest {
 
@@ -46,22 +43,22 @@ public class MarshallingStubUtilsTest extends BaseVariantTest {
     public void testComparablePeriod() {
         final DMNRuntime runtime = createRuntime("comparablePeriod.dmn", this.getClass());
         final DMNModel dmnModel = runtime.getModel("https://kiegroup.org/dmn/_CB283B9C-8581-447E-8625-4D1186F0B3A6", "A1B0FA02-D1C4-4386-AF36-0280AA45A7B7");
-        assertThat(dmnModel, notNullValue());
+        assertThat(dmnModel).isNotNull();
 
         final DMNContext context = runtime.newContext();
 
         final DMNResult evaluateAll = evaluateModel(runtime, dmnModel, context);
         LOG.debug("{}", evaluateAll);
-        assertThat(DMNRuntimeUtil.formatMessages(evaluateAll.getMessages()), evaluateAll.hasErrors(), is(false));
-        assertThat(evaluateAll.getDecisionResultByName("Decision-1").getResult(), is(ComparablePeriod.parse("P3Y")));
+        assertThat(evaluateAll.hasErrors()).as(DMNRuntimeUtil.formatMessages(evaluateAll.getMessages())).isFalse();
+        assertThat(evaluateAll.getDecisionResultByName("Decision-1").getResult()).isEqualTo(ComparablePeriod.parse("P3Y"));
 
         final Object serialized = MarshallingStubUtils.stubDMNResult(evaluateAll.getContext().getAll(), Object::toString);
         LOG.debug("{}", serialized);
-        assertThat(serialized, instanceOf(Map.class));
+        assertThat(serialized).isInstanceOf(Map.class);
         @SuppressWarnings("unchecked")
         Map<String, Object> asMap = (Map<String, Object>) serialized;
-        assertThat(asMap.get("BKM"), instanceOf(String.class));
-        assertThat(asMap.get("Decision-1"), instanceOf(java.time.Period.class));
-        assertThat(asMap.get("Decision-1"), is(java.time.Period.parse("P3Y")));
+        assertThat(asMap.get("BKM")).isInstanceOf(String.class);
+        assertThat(asMap.get("Decision-1")).isInstanceOf(java.time.Period.class);
+        assertThat(asMap.get("Decision-1")).isEqualTo(java.time.Period.parse("P3Y"));
     }
 }

--- a/kie-dmn/kie-dmn-core/src/test/java/org/kie/dmn/core/stronglytyped/DMNRuntimeTypesTest.java
+++ b/kie-dmn/kie-dmn-core/src/test/java/org/kie/dmn/core/stronglytyped/DMNRuntimeTypesTest.java
@@ -51,14 +51,7 @@ import org.kie.dmn.feel.util.EvalHelper;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import static org.hamcrest.CoreMatchers.anyOf;
-import static org.hamcrest.CoreMatchers.instanceOf;
-import static org.hamcrest.CoreMatchers.is;
-import static org.hamcrest.CoreMatchers.not;
-import static org.hamcrest.CoreMatchers.notNullValue;
-import static org.hamcrest.CoreMatchers.nullValue;
-import static org.hamcrest.Matchers.contains;
-import static org.hamcrest.MatcherAssert.assertThat;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.kie.dmn.core.util.DynamicTypeUtils.entry;
 import static org.kie.dmn.core.util.DynamicTypeUtils.mapOf;
 import static org.kie.dmn.core.util.DynamicTypeUtils.prototype;
@@ -76,8 +69,8 @@ public class DMNRuntimeTypesTest extends BaseVariantTest {
     public void testOneOfEachType() throws Exception {
         final DMNRuntime runtime = createRuntime("OneOfEachType.dmn", this.getClass());
         final DMNModel dmnModel = runtime.getModel("http://www.trisotech.com/definitions/_4f5608e9-4d74-4c22-a47e-ab657257fc9c", "OneOfEachType");
-        assertThat(dmnModel, notNullValue());
-        assertThat(DMNRuntimeUtil.formatMessages(dmnModel.getMessages()), dmnModel.hasErrors(), is(false));
+        assertThat(dmnModel).isNotNull();
+        assertThat(dmnModel.hasErrors()).as(DMNRuntimeUtil.formatMessages(dmnModel.getMessages())).isFalse();
 
         DMNContext context = DMNFactory.newContext();
         if (!isTypeSafe()) {
@@ -110,27 +103,27 @@ public class DMNRuntimeTypesTest extends BaseVariantTest {
 
         final DMNResult dmnResult = evaluateModel(runtime, dmnModel, context);
         LOG.debug("{}", dmnResult);
-        assertThat(DMNRuntimeUtil.formatMessages(dmnResult.getMessages()), dmnResult.hasErrors(), is(false));
-        assertThat(dmnResult.getDecisionResultByName("DecisionString").getResult(), is("Hello, John Doe"));
-        assertThat(dmnResult.getDecisionResultByName("DecisionNumber").getResult(), is(new BigDecimal(2)));
-        assertThat(dmnResult.getDecisionResultByName("DecisionBoolean").getResult(), is(false));
-        assertThat(dmnResult.getDecisionResultByName("DecisionDTDuration").getResult(), is(Duration.parse("P2D")));
-        assertThat(dmnResult.getDecisionResultByName("DecisionYMDuration").getResult(), is(ComparablePeriod.parse("P2M")));
-        assertThat(dmnResult.getDecisionResultByName("DecisionDateAndTime").getResult(), is(LocalDateTime.of(2020, 4, 2, 10, 0)));
-        assertThat(dmnResult.getDecisionResultByName("DecisionDate").getResult(), is(LocalDate.of(2020, 4, 3)));
-        assertThat(dmnResult.getDecisionResultByName("DecisionTime").getResult(), is(LocalTime.of(10, 0)));
+        assertThat(dmnResult.hasErrors()).as(DMNRuntimeUtil.formatMessages(dmnResult.getMessages())).isFalse();
+        assertThat(dmnResult.getDecisionResultByName("DecisionString").getResult()).isEqualTo("Hello, John Doe");
+        assertThat(dmnResult.getDecisionResultByName("DecisionNumber").getResult()).isEqualTo(new BigDecimal(2));
+        assertThat(dmnResult.getDecisionResultByName("DecisionBoolean").getResult()).isEqualTo(Boolean.FALSE);
+        assertThat(dmnResult.getDecisionResultByName("DecisionDTDuration").getResult()).isEqualTo(Duration.parse("P2D"));
+        assertThat(dmnResult.getDecisionResultByName("DecisionYMDuration").getResult()).isEqualTo(ComparablePeriod.parse("P2M"));
+        assertThat(dmnResult.getDecisionResultByName("DecisionDateAndTime").getResult()).isEqualTo(LocalDateTime.of(2020, 4, 2, 10, 0));
+        assertThat(dmnResult.getDecisionResultByName("DecisionDate").getResult()).isEqualTo(LocalDate.of(2020, 4, 3));
+        assertThat(dmnResult.getDecisionResultByName("DecisionTime").getResult()).isEqualTo(LocalTime.of(10, 0));
 
         if (isTypeSafe()) {
             FEELPropertyAccessible outputSet = ((DMNContextFPAImpl)dmnResult.getContext()).getFpa();
             Map<String, Object> allProperties = outputSet.allFEELProperties();
-            assertThat(allProperties.get("DecisionString"), is("Hello, John Doe"));
-            assertThat(allProperties.get("DecisionNumber"), is(new BigDecimal(2)));
-            assertThat(allProperties.get("DecisionBoolean"), is(false));
-            assertThat(allProperties.get("DecisionDTDuration"), is(Duration.parse("P2D")));
-            assertThat(allProperties.get("DecisionYMDuration"), is(ComparablePeriod.parse("P2M")));
-            assertThat(allProperties.get("DecisionDateAndTime"), is(LocalDateTime.of(2020, 4, 2, 10, 0)));
-            assertThat(allProperties.get("DecisionDate"), is(LocalDate.of(2020, 4, 3)));
-            assertThat(allProperties.get("DecisionTime"), is(LocalTime.of(10, 0)));
+            assertThat(allProperties.get("DecisionString")).isEqualTo("Hello, John Doe");
+            assertThat(allProperties.get("DecisionNumber")).isEqualTo(new BigDecimal(2));
+            assertThat(allProperties.get("DecisionBoolean")).isEqualTo(Boolean.FALSE);
+            assertThat(allProperties.get("DecisionDTDuration")).isEqualTo(Duration.parse("P2D"));
+            assertThat(allProperties.get("DecisionYMDuration")).isEqualTo(ComparablePeriod.parse("P2M"));
+            assertThat(allProperties.get("DecisionDateAndTime")).isEqualTo(LocalDateTime.of(2020, 4, 2, 10, 0));
+            assertThat(allProperties.get("DecisionDate")).isEqualTo(LocalDate.of(2020, 4, 3));
+            assertThat(allProperties.get("DecisionTime")).isEqualTo(LocalTime.of(10, 0));
         }
     }
 
@@ -138,8 +131,8 @@ public class DMNRuntimeTypesTest extends BaseVariantTest {
     public void testJavaKeywords() {
         final DMNRuntime runtime = createRuntime("javaKeywords.dmn", this.getClass());
         final DMNModel dmnModel = runtime.getModel("https://kiegroup.org/dmn/_C41C1676-0DA9-47EA-90AD-F9BAA257129F", "A1B1A8AD-B0DC-453D-86A7-C9475450C982");
-        assertThat(dmnModel, notNullValue());
-        assertThat(DMNRuntimeUtil.formatMessages(dmnModel.getMessages()), dmnModel.hasErrors(), is(false));
+        assertThat(dmnModel).isNotNull();
+        assertThat(dmnModel.hasErrors()).as(DMNRuntimeUtil.formatMessages(dmnModel.getMessages())).isFalse();
 
         final DMNContext context = DMNFactory.newContext();
         Map<String, Object> aThing = mapOf(entry("name", "name"),
@@ -149,13 +142,13 @@ public class DMNRuntimeTypesTest extends BaseVariantTest {
 
         final DMNResult dmnResult = evaluateModel(runtime, dmnModel, context);
         LOG.debug("{}", dmnResult);
-        assertThat(DMNRuntimeUtil.formatMessages(dmnResult.getMessages()), dmnResult.hasErrors(), is(false));
-        assertThat(dmnResult.getDecisionResultByName("Decision-1").getResult(), is("nameconstclass"));
+        assertThat(dmnResult.hasErrors()).as(DMNRuntimeUtil.formatMessages(dmnResult.getMessages())).isFalse();
+        assertThat(dmnResult.getDecisionResultByName("Decision-1").getResult()).isEqualTo("nameconstclass");
 
         if (isTypeSafe()) {
             FEELPropertyAccessible outputSet = ((DMNContextFPAImpl)dmnResult.getContext()).getFpa();
             Map<String, Object> allProperties = outputSet.allFEELProperties();
-            assertThat(allProperties.get("Decision-1"), is("nameconstclass"));
+            assertThat(allProperties.get("Decision-1")).isEqualTo("nameconstclass");
         }
     }
 
@@ -163,8 +156,8 @@ public class DMNRuntimeTypesTest extends BaseVariantTest {
     public void testInnerComposite() {
         final DMNRuntime runtime = createRuntime("innerComposite.dmn", this.getClass());
         final DMNModel dmnModel = runtime.getModel("https://kiegroup.org/dmn/_641BCEBF-8D10-4E08-B47F-A9181C737A82", "new-file");
-        assertThat(dmnModel, notNullValue());
-        assertThat(DMNRuntimeUtil.formatMessages(dmnModel.getMessages()), dmnModel.hasErrors(), is(false));
+        assertThat(dmnModel).isNotNull();
+        assertThat(dmnModel.hasErrors()).as(DMNRuntimeUtil.formatMessages(dmnModel.getMessages())).isFalse();
 
         final DMNContext context = DMNFactory.newContext();
         Map<String, Object> yearly = mapOf(entry("Q1", 1),
@@ -180,15 +173,15 @@ public class DMNRuntimeTypesTest extends BaseVariantTest {
 
         final DMNResult dmnResult = evaluateModel(runtime, dmnModel, context);
         LOG.debug("{}", dmnResult);
-        assertThat(DMNRuntimeUtil.formatMessages(dmnResult.getMessages()), dmnResult.hasErrors(), is(false));
-        assertThat(dmnResult.getDecisionResultByName("Decision Yearly").getResult(), is("Total Yearly 10"));
-        assertThat(dmnResult.getDecisionResultByName("Decision Employee").getResult(), is("For John Doe total: 3"));
+        assertThat(dmnResult.hasErrors()).as(DMNRuntimeUtil.formatMessages(dmnResult.getMessages())).isFalse();
+        assertThat(dmnResult.getDecisionResultByName("Decision Yearly").getResult()).isEqualTo("Total Yearly 10");
+        assertThat(dmnResult.getDecisionResultByName("Decision Employee").getResult()).isEqualTo("For John Doe total: 3");
 
         if (isTypeSafe()) {
             FEELPropertyAccessible outputSet = ((DMNContextFPAImpl)dmnResult.getContext()).getFpa();
             Map<String, Object> allProperties = outputSet.allFEELProperties();
-            assertThat(allProperties.get("Decision Yearly"), is("Total Yearly 10"));
-            assertThat(allProperties.get("Decision Employee"), is("For John Doe total: 3"));
+            assertThat(allProperties.get("Decision Yearly")).isEqualTo("Total Yearly 10");
+            assertThat(allProperties.get("Decision Employee")).isEqualTo("For John Doe total: 3");
         }
     }
 
@@ -196,8 +189,8 @@ public class DMNRuntimeTypesTest extends BaseVariantTest {
     public void testFixInnerComposite() {
         final DMNRuntime runtime = createRuntime("fixInnerComposite.dmn", this.getClass());
         final DMNModel dmnModel = runtime.getModel("https://kiegroup.org/dmn/_E82058C1-27D3-44F3-B1B3-4C02D17B7A05", "new-file");
-        assertThat(dmnModel, notNullValue());
-        assertThat(DMNRuntimeUtil.formatMessages(dmnModel.getMessages()), dmnModel.hasErrors(), is(false));
+        assertThat(dmnModel).isNotNull();
+        assertThat(dmnModel.hasErrors()).as(DMNRuntimeUtil.formatMessages(dmnModel.getMessages())).isFalse();
 
         final DMNContext context = DMNFactory.newContext();
         Map<String, Object> employee = mapOf(entry("Name", "John Doe"),
@@ -206,13 +199,13 @@ public class DMNRuntimeTypesTest extends BaseVariantTest {
 
         final DMNResult dmnResult = evaluateModel(runtime, dmnModel, context);
         LOG.debug("{}", dmnResult);
-        assertThat(DMNRuntimeUtil.formatMessages(dmnResult.getMessages()), dmnResult.hasErrors(), is(false));
-        assertThat(dmnResult.getDecisionResultByName("Decision-1").getResult(), is("John Doe is S"));
+        assertThat(dmnResult.hasErrors()).as(DMNRuntimeUtil.formatMessages(dmnResult.getMessages())).isFalse();
+        assertThat(dmnResult.getDecisionResultByName("Decision-1").getResult()).isEqualTo("John Doe is S");
 
         if (isTypeSafe()) {
             FEELPropertyAccessible outputSet = ((DMNContextFPAImpl)dmnResult.getContext()).getFpa();
             Map<String, Object> allProperties = outputSet.allFEELProperties();
-            assertThat(allProperties.get("Decision-1"), is("John Doe is S"));
+            assertThat(allProperties.get("Decision-1")).isEqualTo("John Doe is S");
         }
     }
 
@@ -220,8 +213,8 @@ public class DMNRuntimeTypesTest extends BaseVariantTest {
     public void testInnerCompositeCollection() {
         final DMNRuntime runtime = createRuntime("innerCompositeCollection.dmn", this.getClass());
         final DMNModel dmnModel = runtime.getModel("https://kiegroup.org/dmn/_D8AE5AF4-1F9E-4423-873A-B8F3C3BE5FE5", "new-file");
-        assertThat(dmnModel, notNullValue());
-        assertThat(DMNRuntimeUtil.formatMessages(dmnModel.getMessages()), dmnModel.hasErrors(), is(false));
+        assertThat(dmnModel).isNotNull();
+        assertThat(dmnModel.hasErrors()).as(DMNRuntimeUtil.formatMessages(dmnModel.getMessages())).isFalse();
 
         final DMNContext context = DMNFactory.newContext();
         List<?> pairs = Arrays.asList(mapOf(entry("letter", "A"), entry("num", new BigDecimal(1))),
@@ -233,13 +226,13 @@ public class DMNRuntimeTypesTest extends BaseVariantTest {
 
         final DMNResult dmnResult = evaluateModel(runtime, dmnModel, context);
         LOG.debug("{}", dmnResult);
-        assertThat(DMNRuntimeUtil.formatMessages(dmnResult.getMessages()), dmnResult.hasErrors(), is(false));
-        assertThat(dmnResult.getDecisionResultByName("Decision-1").getResult(), is("John Doe has 3 pairs."));
+        assertThat(dmnResult.hasErrors()).as(DMNRuntimeUtil.formatMessages(dmnResult.getMessages())).isFalse();
+        assertThat(dmnResult.getDecisionResultByName("Decision-1").getResult()).isEqualTo("John Doe has 3 pairs.");
 
         if (isTypeSafe()) {
             FEELPropertyAccessible outputSet = ((DMNContextFPAImpl)dmnResult.getContext()).getFpa();
             Map<String, Object> allProperties = outputSet.allFEELProperties();
-            assertThat(allProperties.get("Decision-1"), is("John Doe has 3 pairs."));
+            assertThat(allProperties.get("Decision-1")).isEqualTo("John Doe has 3 pairs.");
         }
     }
 
@@ -247,21 +240,21 @@ public class DMNRuntimeTypesTest extends BaseVariantTest {
     public void testInputAny() {
         final DMNRuntime runtime = createRuntime("inputAny.dmn", this.getClass());
         final DMNModel dmnModel = runtime.getModel("https://kiegroup.org/dmn/_7D9140EF-DC52-4DC1-8983-9C2EC5B89BAE", "new-file");
-        assertThat(dmnModel, notNullValue());
-        assertThat(DMNRuntimeUtil.formatMessages(dmnModel.getMessages()), dmnModel.hasErrors(), is(false));
+        assertThat(dmnModel).isNotNull();
+        assertThat(dmnModel.hasErrors()).as(DMNRuntimeUtil.formatMessages(dmnModel.getMessages())).isFalse();
 
         final DMNContext context = DMNFactory.newContext();
         context.set("Input Any", "John Doe");
 
         final DMNResult dmnResult = evaluateModel(runtime, dmnModel, context);
         LOG.debug("{}", dmnResult);
-        assertThat(DMNRuntimeUtil.formatMessages(dmnResult.getMessages()), dmnResult.hasErrors(), is(false));
-        assertThat(dmnResult.getDecisionResultByName("Decision-1").getResult(), is("Decision: John Doe"));
+        assertThat(dmnResult.hasErrors()).as(DMNRuntimeUtil.formatMessages(dmnResult.getMessages())).isFalse();
+        assertThat(dmnResult.getDecisionResultByName("Decision-1").getResult()).isEqualTo("Decision: John Doe");
 
         if (isTypeSafe()) {
             FEELPropertyAccessible outputSet = ((DMNContextFPAImpl)dmnResult.getContext()).getFpa();
             Map<String, Object> allProperties = outputSet.allFEELProperties();
-            assertThat(allProperties.get("Decision-1"), is("Decision: John Doe"));
+            assertThat(allProperties.get("Decision-1")).isEqualTo("Decision: John Doe");
         }
     }
 
@@ -270,8 +263,8 @@ public class DMNRuntimeTypesTest extends BaseVariantTest {
         final DMNRuntime runtime = createRuntime("recursiveEmployee.dmn", this.getClass());
 
         final DMNModel dmnModel = runtime.getModel("http://www.trisotech.com/definitions/_d1e3d83e-230d-42fb-bc58-313463f7f40b", "Drawing 1");
-        assertThat(dmnModel, notNullValue());
-        assertThat(DMNRuntimeUtil.formatMessages(dmnModel.getMessages()), dmnModel.hasErrors(), is(false));
+        assertThat(dmnModel).isNotNull();
+        assertThat(dmnModel.hasErrors()).as(DMNRuntimeUtil.formatMessages(dmnModel.getMessages())).isFalse();
 
         Map<String, Object> report1 = mapOf(entry("full name", "Bob"),
                                             entry("age", new BigDecimal(48)),
@@ -295,13 +288,13 @@ public class DMNRuntimeTypesTest extends BaseVariantTest {
 
         final DMNResult dmnResult = evaluateModel(runtime, dmnModel, context);
         LOG.debug("{}", dmnResult);
-        assertThat(DMNRuntimeUtil.formatMessages(dmnResult.getMessages()), dmnResult.hasErrors(), is(false));
-        assertThat(dmnResult.getDecisionResultByName("highlights").getResult(), is("John Doe: reports to John's Manager and is manager of 2 : [ Bob, Carl ]"));
+        assertThat(dmnResult.hasErrors()).as(DMNRuntimeUtil.formatMessages(dmnResult.getMessages())).isFalse();
+        assertThat(dmnResult.getDecisionResultByName("highlights").getResult()).isEqualTo("John Doe: reports to John's Manager and is manager of 2 : [ Bob, Carl ]");
 
         if (isTypeSafe()) {
             FEELPropertyAccessible outputSet = ((DMNContextFPAImpl)dmnResult.getContext()).getFpa();
             Map<String, Object> allProperties = outputSet.allFEELProperties();
-            assertThat(allProperties.get("highlights"), is("John Doe: reports to John's Manager and is manager of 2 : [ Bob, Carl ]"));
+            assertThat(allProperties.get("highlights")).isEqualTo("John Doe: reports to John's Manager and is manager of 2 : [ Bob, Carl ]");
         }
     }
 
@@ -309,8 +302,8 @@ public class DMNRuntimeTypesTest extends BaseVariantTest {
     public void testListBasic() {
         final DMNRuntime runtime = createRuntime("listBasic.dmn", this.getClass());
         final DMNModel dmnModel = runtime.getModel("https://kiegroup.org/dmn/_B84B17F3-3E84-4DED-996E-AA630A6BF9C4", "new-file");
-        assertThat(dmnModel, notNullValue());
-        assertThat(DMNRuntimeUtil.formatMessages(dmnModel.getMessages()), dmnModel.hasErrors(), is(false));
+        assertThat(dmnModel).isNotNull();
+        assertThat(dmnModel.hasErrors()).as(DMNRuntimeUtil.formatMessages(dmnModel.getMessages())).isFalse();
 
         final DMNContext context = DMNFactory.newContext();
         context.set("listNumber", Arrays.asList(1, 2, 3));
@@ -321,21 +314,21 @@ public class DMNRuntimeTypesTest extends BaseVariantTest {
 
         final DMNResult dmnResult = evaluateModel(runtime, dmnModel, context);
         LOG.debug("{}", dmnResult);
-        assertThat(DMNRuntimeUtil.formatMessages(dmnResult.getMessages()), dmnResult.hasErrors(), is(false));
-        assertThat(dmnResult.getDecisionResultByName("DecisionListNumber").getResult(), is(new BigDecimal(3)));
-        assertThat(dmnResult.getDecisionResultByName("DecisionVowel").getResult(), is("the e"));
-        assertThat(dmnResult.getDecisionResultByName("DecisionListVowel").getResult(), is(new BigDecimal(2)));
-        assertThat(dmnResult.getDecisionResultByName("DecisionJustA").getResult(), is("the a"));
-        assertThat(dmnResult.getDecisionResultByName("DecisionListOfA").getResult(), is(new BigDecimal(1)));
+        assertThat(dmnResult.hasErrors()).as(DMNRuntimeUtil.formatMessages(dmnResult.getMessages())).isFalse();
+        assertThat(dmnResult.getDecisionResultByName("DecisionListNumber").getResult()).isEqualTo(new BigDecimal(3));
+        assertThat(dmnResult.getDecisionResultByName("DecisionVowel").getResult()).isEqualTo("the e");
+        assertThat(dmnResult.getDecisionResultByName("DecisionListVowel").getResult()).isEqualTo(new BigDecimal(2));
+        assertThat(dmnResult.getDecisionResultByName("DecisionJustA").getResult()).isEqualTo("the a");
+        assertThat(dmnResult.getDecisionResultByName("DecisionListOfA").getResult()).isEqualTo(new BigDecimal(1));
 
         if (isTypeSafe()) {
             FEELPropertyAccessible outputSet = ((DMNContextFPAImpl)dmnResult.getContext()).getFpa();
             Map<String, Object> allProperties = outputSet.allFEELProperties();
-            assertThat(allProperties.get("DecisionListNumber"), is(new BigDecimal(3)));
-            assertThat(allProperties.get("DecisionVowel"), is("the e"));
-            assertThat(allProperties.get("DecisionListVowel"), is(new BigDecimal(2)));
-            assertThat(allProperties.get("DecisionJustA"), is("the a"));
-            assertThat(allProperties.get("DecisionListOfA"), is(new BigDecimal(1)));
+            assertThat(allProperties.get("DecisionListNumber")).isEqualTo(new BigDecimal(3));
+            assertThat(allProperties.get("DecisionVowel")).isEqualTo("the e");
+            assertThat(allProperties.get("DecisionListVowel")).isEqualTo(new BigDecimal(2));
+            assertThat(allProperties.get("DecisionJustA")).isEqualTo("the a");
+            assertThat(allProperties.get("DecisionListOfA")).isEqualTo(new BigDecimal(1));
         }
     }
 
@@ -343,8 +336,8 @@ public class DMNRuntimeTypesTest extends BaseVariantTest {
     public void testListBasic_LOVerror() {
         final DMNRuntime runtime = createRuntime("listBasic.dmn", this.getClass());
         final DMNModel dmnModel = runtime.getModel("https://kiegroup.org/dmn/_B84B17F3-3E84-4DED-996E-AA630A6BF9C4", "new-file");
-        assertThat(dmnModel, notNullValue());
-        assertThat(DMNRuntimeUtil.formatMessages(dmnModel.getMessages()), dmnModel.hasErrors(), is(false));
+        assertThat(dmnModel).isNotNull();
+        assertThat(dmnModel.hasErrors()).as(DMNRuntimeUtil.formatMessages(dmnModel.getMessages())).isFalse();
 
         final DMNContext context = DMNFactory.newContext();
         context.set("listNumber", Arrays.asList(1, 2, 3));
@@ -355,21 +348,21 @@ public class DMNRuntimeTypesTest extends BaseVariantTest {
 
         final DMNResult dmnResult = evaluateModel(runtime, dmnModel, context);
         LOG.debug("{}", dmnResult);
-        assertThat(DMNRuntimeUtil.formatMessages(dmnResult.getMessages()), dmnResult.hasErrors(), is(true));
-        assertThat(dmnResult.getDecisionResultByName("DecisionListNumber").getResult(), is(new BigDecimal(3)));
-        assertThat(dmnResult.getDecisionResultByName("DecisionVowel").getEvaluationStatus(), not(DecisionEvaluationStatus.SUCCEEDED));
-        assertThat(dmnResult.getDecisionResultByName("DecisionListVowel").getEvaluationStatus(), not(DecisionEvaluationStatus.SUCCEEDED));
-        assertThat(dmnResult.getDecisionResultByName("DecisionJustA").getEvaluationStatus(), not(DecisionEvaluationStatus.SUCCEEDED));
-        assertThat(dmnResult.getDecisionResultByName("DecisionListOfA").getEvaluationStatus(), not(DecisionEvaluationStatus.SUCCEEDED));
+        assertThat(dmnResult.hasErrors()).as(DMNRuntimeUtil.formatMessages(dmnResult.getMessages())).isTrue();
+        assertThat(dmnResult.getDecisionResultByName("DecisionListNumber").getResult()).isEqualTo(new BigDecimal(3));
+        assertThat(dmnResult.getDecisionResultByName("DecisionVowel").getEvaluationStatus()).isNotEqualTo(DecisionEvaluationStatus.SUCCEEDED);
+        assertThat(dmnResult.getDecisionResultByName("DecisionListVowel").getEvaluationStatus()).isNotEqualTo(DecisionEvaluationStatus.SUCCEEDED);
+        assertThat(dmnResult.getDecisionResultByName("DecisionJustA").getEvaluationStatus()).isNotEqualTo(DecisionEvaluationStatus.SUCCEEDED);
+        assertThat(dmnResult.getDecisionResultByName("DecisionListOfA").getEvaluationStatus()).isNotEqualTo(DecisionEvaluationStatus.SUCCEEDED);
 
         if (isTypeSafe()) {
             FEELPropertyAccessible outputSet = ((DMNContextFPAImpl)dmnResult.getContext()).getFpa();
             Map<String, Object> allProperties = outputSet.allFEELProperties();
-            assertThat(allProperties.get("DecisionListNumber"), is(new BigDecimal(3)));
-            assertThat(allProperties.get("DecisionVowel"), nullValue());
-            assertThat(allProperties.get("DecisionListVowel"), nullValue());
-            assertThat(allProperties.get("DecisionJustA"), nullValue());
-            assertThat(allProperties.get("DecisionListOfA"), nullValue());
+            assertThat(allProperties.get("DecisionListNumber")).isEqualTo(new BigDecimal(3));
+            assertThat(allProperties.get("DecisionVowel")).isNull();
+            assertThat(allProperties.get("DecisionListVowel")).isNull();
+            assertThat(allProperties.get("DecisionJustA")).isNull();
+            assertThat(allProperties.get("DecisionListOfA")).isNull();
         }
     }
 
@@ -377,12 +370,12 @@ public class DMNRuntimeTypesTest extends BaseVariantTest {
     public void testSameTypeNameMultiple() {
         final DMNRuntime runtime = createRuntimeWithAdditionalResources("class_imported.dmn", this.getClass(), "class_importing.dmn");
         final DMNModel dmnModel0 = runtime.getModel("http://www.trisotech.com/definitions/_b3deed2b-245f-4cc4-a4bf-1e95cd240664", "imported");
-        assertThat(dmnModel0, notNullValue());
-        assertThat(DMNRuntimeUtil.formatMessages(dmnModel0.getMessages()), dmnModel0.hasErrors(), is(false));
+        assertThat(dmnModel0).isNotNull();
+        assertThat(dmnModel0.hasErrors()).as(DMNRuntimeUtil.formatMessages(dmnModel0.getMessages())).isFalse();
 
         final DMNModel dmnModel = runtime.getModel("http://www.trisotech.com/definitions/_17540606-3d41-40f4-85f6-ad9e8faa8a87", "importing");
-        assertThat(dmnModel, notNullValue());
-        assertThat(DMNRuntimeUtil.formatMessages(dmnModel.getMessages()), dmnModel.hasErrors(), is(false));
+        assertThat(dmnModel).isNotNull();
+        assertThat(dmnModel.hasErrors()).as(DMNRuntimeUtil.formatMessages(dmnModel.getMessages())).isFalse();
 
         final DMNContext context = DMNFactory.newContext();
         Map<String, Object> importedClass = mapOf(entry("L1name", "L1name"),
@@ -393,13 +386,13 @@ public class DMNRuntimeTypesTest extends BaseVariantTest {
 
         final DMNResult dmnResult = evaluateModel(runtime, dmnModel, context);
         LOG.debug("{}", dmnResult);
-        assertThat(DMNRuntimeUtil.formatMessages(dmnResult.getMessages()), dmnResult.hasErrors(), is(false));
-        assertThat(dmnResult.getDecisionResultByName("decision1").getResult(), is("L1nameL2namename"));
+        assertThat(dmnResult.hasErrors()).as(DMNRuntimeUtil.formatMessages(dmnResult.getMessages())).isFalse();
+        assertThat(dmnResult.getDecisionResultByName("decision1").getResult()).isEqualTo("L1nameL2namename");
 
         if (isTypeSafe()) {
             FEELPropertyAccessible outputSet = ((DMNContextFPAImpl)dmnResult.getContext()).getFpa();
             Map<String, Object> allProperties = outputSet.allFEELProperties();
-            assertThat(allProperties.get("decision1"), is("L1nameL2namename"));
+            assertThat(allProperties.get("decision1")).isEqualTo("L1nameL2namename");
         }
     }
 
@@ -407,8 +400,8 @@ public class DMNRuntimeTypesTest extends BaseVariantTest {
     public void testFieldCapitalization() {
         final DMNRuntime runtime = createRuntimeWithAdditionalResources("Traffic Violation.dmn", this.getClass());
         final DMNModel dmnModel = runtime.getModel("https://github.com/kiegroup/drools/kie-dmn/_A4BCA8B8-CF08-433F-93B2-A2598F19ECFF", "Traffic Violation");
-        assertThat(dmnModel, notNullValue());
-        assertThat(DMNRuntimeUtil.formatMessages(dmnModel.getMessages()), dmnModel.hasErrors(), is(false));
+        assertThat(dmnModel).isNotNull();
+        assertThat(dmnModel.hasErrors()).as(DMNRuntimeUtil.formatMessages(dmnModel.getMessages())).isFalse();
 
         final DMNContext context = DMNFactory.newContext();
         context.set("Driver",
@@ -429,36 +422,36 @@ public class DMNRuntimeTypesTest extends BaseVariantTest {
 
         final DMNResult dmnResult = evaluateModel(runtime, dmnModel, context);
         LOG.debug("{}", dmnResult);
-        assertThat(DMNRuntimeUtil.formatMessages(dmnResult.getMessages()), dmnResult.hasErrors(), is(false));
-        assertThat(dmnResult.getDecisionResultByName("Should the driver be suspended?").getResult(), is("Yes"));
+        assertThat(dmnResult.hasErrors()).as(DMNRuntimeUtil.formatMessages(dmnResult.getMessages())).isFalse();
+        assertThat(dmnResult.getDecisionResultByName("Should the driver be suspended?").getResult()).isEqualTo("Yes");
 
         if (isTypeSafe()) {
             FEELPropertyAccessible outputSet = ((DMNContextFPAImpl)dmnResult.getContext()).getFpa();
             Map<String, Object> allProperties = outputSet.allFEELProperties();
             FEELPropertyAccessible driver = (FEELPropertyAccessible)allProperties.get("Driver");
-            assertThat(driver.getClass().getSimpleName(), is("TDriver"));
-            assertThat(driver.getFEELProperty("Name").toOptional().get(), is("Luca"));
-            assertThat(driver.getFEELProperty("Age").toOptional().get(), is(35));
-            assertThat(driver.getFEELProperty("State").toOptional().get(), is("Italy"));
-            assertThat(driver.getFEELProperty("City").toOptional().get(), is("Milan"));
-            assertThat(driver.getFEELProperty("Points").toOptional().get(), is(2000));
+            assertThat(driver.getClass().getSimpleName()).isEqualTo("TDriver");
+            assertThat(driver.getFEELProperty("Name").toOptional().get()).isEqualTo("Luca");
+            assertThat(driver.getFEELProperty("Age").toOptional().get()).isEqualTo(35);
+            assertThat(driver.getFEELProperty("State").toOptional().get()).isEqualTo("Italy");
+            assertThat(driver.getFEELProperty("City").toOptional().get()).isEqualTo("Milan");
+            assertThat(driver.getFEELProperty("Points").toOptional().get()).isEqualTo(2000);
 
             FEELPropertyAccessible violation = (FEELPropertyAccessible)allProperties.get("Violation");
-            assertThat(violation.getClass().getSimpleName(), is("TViolation"));
-            assertThat(violation.getFEELProperty("Code").toOptional().get(), is("s"));
-            assertThat(violation.getFEELProperty("Date").toOptional().get(), is(LocalDate.of(1984, 11, 6)));
-            assertThat(violation.getFEELProperty("Type").toOptional().get(), is("speed"));
-            assertThat(violation.getFEELProperty("Actual Speed").toOptional().get(), is(120));
-            assertThat(violation.getFEELProperty("Speed Limit").toOptional().get(), is(100));
+            assertThat(violation.getClass().getSimpleName()).isEqualTo("TViolation");
+            assertThat(violation.getFEELProperty("Code").toOptional().get()).isEqualTo("s");
+            assertThat(violation.getFEELProperty("Date").toOptional().get()).isEqualTo(LocalDate.of(1984, 11, 6));
+            assertThat(violation.getFEELProperty("Type").toOptional().get()).isEqualTo("speed");
+            assertThat(violation.getFEELProperty("Actual Speed").toOptional().get()).isEqualTo(120);
+            assertThat(violation.getFEELProperty("Speed Limit").toOptional().get()).isEqualTo(100);
 
             FEELPropertyAccessible fine = (FEELPropertyAccessible)allProperties.get("Fine");
-            assertThat(fine.getClass().getSimpleName(), is("TFine"));
-            assertThat(fine.getFEELProperty("Amount").toOptional().get(), is(new BigDecimal("500")));
-            assertThat(fine.getFEELProperty("Points").toOptional().get(), is(new BigDecimal("3")));
+            assertThat(fine.getClass().getSimpleName()).isEqualTo("TFine");
+            assertThat(fine.getFEELProperty("Amount").toOptional().get()).isEqualTo(new BigDecimal("500"));
+            assertThat(fine.getFEELProperty("Points").toOptional().get()).isEqualTo(new BigDecimal("3"));
 
             Object suspended = allProperties.get("Should the driver be suspended?");
-            assertThat(suspended, instanceOf(String.class));
-            assertThat(suspended, is("Yes"));
+            assertThat(suspended).isInstanceOf(String.class);
+            assertThat(suspended).isEqualTo("Yes");
         }
     }
 
@@ -466,28 +459,28 @@ public class DMNRuntimeTypesTest extends BaseVariantTest {
     public void testDecisionService() {
         final DMNRuntime runtime = createRuntime("DecisionServiceABC_DMN12.dmn", DMNDecisionServicesTest.class);
         final DMNModel dmnModel = runtime.getModel("http://www.trisotech.com/dmn/definitions/_2443d3f5-f178-47c6-a0c9-b1fd1c933f60", "Drawing 1");
-        assertThat(dmnModel, notNullValue());
-        assertThat(DMNRuntimeUtil.formatMessages(dmnModel.getMessages()), dmnModel.hasErrors(), is(false));
+        assertThat(dmnModel).isNotNull();
+        assertThat(dmnModel.hasErrors()).as(DMNRuntimeUtil.formatMessages(dmnModel.getMessages())).isFalse();
 
         // DecisionService only
         final DMNContext context = DMNFactory.newContext();
 
         final DMNResult dmnResult1 = evaluateDecisionService(runtime, dmnModel, context, "Decision Service ABC");
         LOG.debug("{}", dmnResult1);
-        assertThat(DMNRuntimeUtil.formatMessages(dmnResult1.getMessages()), dmnResult1.hasErrors(), is(false));
+        assertThat(dmnResult1.hasErrors()).as(DMNRuntimeUtil.formatMessages(dmnResult1.getMessages())).isFalse();
 
         final DMNContext result = dmnResult1.getContext();
         // assertThat(result.getAll(), not(hasEntry(is("Invoking Decision"), anything()))); // we invoked only the Decision Service, not this other Decision in the model.
-        assertThat(result.get("Invoking Decision"), nullValue());
-        assertThat(result.get("ABC"), is("abc"));
+        assertThat(result.get("Invoking Decision")).isNull();
+        assertThat(result.get("ABC")).isEqualTo("abc");
 
         if (isTypeSafe()) {
             FEELPropertyAccessible outputSet = ((DMNContextFPAImpl)dmnResult1.getContext()).getFpa();
             Map<String, Object> allProperties = outputSet.allFEELProperties();
-            assertThat(allProperties.get("Invoking Decision"), nullValue());
+            assertThat(allProperties.get("Invoking Decision")).isNull();
             Object abc = allProperties.get("ABC");
-            assertThat(abc, instanceOf(String.class));
-            assertThat(abc, is("abc"));
+            assertThat(abc).isInstanceOf(String.class);
+            assertThat(abc).isEqualTo("abc");
         }
 
         // evaluateAll
@@ -496,24 +489,24 @@ public class DMNRuntimeTypesTest extends BaseVariantTest {
         final DMNResult dmnResult2 = evaluateModel(runtime, dmnModel, context2);
         LOG.debug("{}", dmnResult2);
         dmnResult2.getDecisionResults().forEach(x -> LOG.debug("{}", x));
-        assertThat(DMNRuntimeUtil.formatMessages(dmnResult2.getMessages()), dmnResult2.hasErrors(), is(false));
+        assertThat(dmnResult2.hasErrors()).as(DMNRuntimeUtil.formatMessages(dmnResult2.getMessages())).isFalse();
 
         final DMNContext result2 = dmnResult2.getContext();
-        assertThat(result2.get("ABC"), is("abc"));
-        assertThat(result2.get("Invoking Decision"), is("abc"));
+        assertThat(result2.get("ABC")).isEqualTo("abc");
+        assertThat(result2.get("Invoking Decision")).isEqualTo("abc");
 
         if (isTypeSafe()) {
             FEELPropertyAccessible outputSet = ((DMNContextFPAImpl)dmnResult2.getContext()).getFpa();
             Map<String, Object> allProperties = outputSet.allFEELProperties();
             Object decisionService = allProperties.get("Decision Service ABC");
-            assertThat(decisionService, instanceOf(FEELFunction.class));
-            assertThat(((FEELFunction)decisionService).getName(), is("Decision Service ABC"));
+            assertThat(decisionService).isInstanceOf(FEELFunction.class);
+            assertThat(((FEELFunction)decisionService).getName()).isEqualTo("Decision Service ABC");
             Object invokingDecision = allProperties.get("Invoking Decision");
-            assertThat(invokingDecision, instanceOf(String.class));
-            assertThat(invokingDecision, is("abc"));
+            assertThat(invokingDecision).isInstanceOf(String.class);
+            assertThat(invokingDecision).isEqualTo("abc");
             Object abc = allProperties.get("ABC");
-            assertThat(abc, instanceOf(String.class));
-            assertThat(abc, is("abc"));
+            assertThat(abc).isInstanceOf(String.class);
+            assertThat(abc).isEqualTo("abc");
         }
     }
 
@@ -521,8 +514,8 @@ public class DMNRuntimeTypesTest extends BaseVariantTest {
     public void testBKM() {
         final DMNRuntime runtime = createRuntime("0009-invocation-arithmetic.dmn", DMNRuntimeTest.class);
         final DMNModel dmnModel = runtime.getModel("http://www.trisotech.com/definitions/_cb28c255-91cd-4c01-ac7b-1a9cb1ecdb11", "literal invocation1");
-        assertThat(dmnModel, notNullValue());
-        assertThat(DMNRuntimeUtil.formatMessages(dmnModel.getMessages()), dmnModel.hasErrors(), is(false));
+        assertThat(dmnModel).isNotNull();
+        assertThat(dmnModel.hasErrors()).as(DMNRuntimeUtil.formatMessages(dmnModel.getMessages())).isFalse();
 
         final Map<String, Object> loan = new HashMap<>();
         loan.put("amount", BigDecimal.valueOf(600000));
@@ -533,27 +526,27 @@ public class DMNRuntimeTypesTest extends BaseVariantTest {
         context.set("Loan", loan);
 
         final DMNResult dmnResult = evaluateModel(runtime, dmnModel, context);
-        assertThat(dmnResult.hasErrors(), is(false));
+        assertThat(dmnResult.hasErrors()).isFalse();
         assertThat(
-                   ((BigDecimal) dmnResult.getContext().get("MonthlyPayment")).setScale(8, BigDecimal.ROUND_DOWN),
-                   is(new BigDecimal("2878.69354943277").setScale(8, BigDecimal.ROUND_DOWN)));
+                   ((BigDecimal) dmnResult.getContext().get("MonthlyPayment")).setScale(8, BigDecimal.ROUND_DOWN)).
+                   isEqualTo(new BigDecimal("2878.69354943277").setScale(8, BigDecimal.ROUND_DOWN));
 
         if (isTypeSafe()) {
             FEELPropertyAccessible outputSet = ((DMNContextFPAImpl)dmnResult.getContext()).getFpa();
             Map<String, Object> allProperties = outputSet.allFEELProperties();
             Object fee = allProperties.get("fee");
-            assertThat(fee, is(100));
+            assertThat(fee).isEqualTo(100);
             FEELPropertyAccessible loanOut = (FEELPropertyAccessible)allProperties.get("Loan");
-            assertThat(loanOut.getClass().getSimpleName(), is("TLoan"));
-            assertThat(loanOut.getFEELProperty("amount").toOptional().get(), is(BigDecimal.valueOf(600000)));
-            assertThat(loanOut.getFEELProperty("rate").toOptional().get(), is(new BigDecimal("0.0375")));
-            assertThat(loanOut.getFEELProperty("term").toOptional().get(), is(BigDecimal.valueOf(360)));
+            assertThat(loanOut.getClass().getSimpleName()).isEqualTo("TLoan");
+            assertThat(loanOut.getFEELProperty("amount").toOptional().get()).isEqualTo(BigDecimal.valueOf(600000));
+            assertThat(loanOut.getFEELProperty("rate").toOptional().get()).isEqualTo(new BigDecimal("0.0375"));
+            assertThat(loanOut.getFEELProperty("term").toOptional().get()).isEqualTo(BigDecimal.valueOf(360));
             Object bkm = allProperties.get("PMT");
-            assertThat(bkm, instanceOf(FEELFunction.class));
-            assertThat(((FEELFunction)bkm).getName(), is("PMT"));
+            assertThat(bkm).isInstanceOf(FEELFunction.class);
+            assertThat(((FEELFunction)bkm).getName()).isEqualTo("PMT");
             Object monthlyPayment = allProperties.get("MonthlyPayment");
-            assertThat(((BigDecimal) monthlyPayment).setScale(8, BigDecimal.ROUND_DOWN),
-                       is(new BigDecimal("2878.69354943277").setScale(8, BigDecimal.ROUND_DOWN)));
+            assertThat(((BigDecimal) monthlyPayment).setScale(8, BigDecimal.ROUND_DOWN)).
+                       isEqualTo(new BigDecimal("2878.69354943277").setScale(8, BigDecimal.ROUND_DOWN));
         }
     }
 
@@ -561,8 +554,8 @@ public class DMNRuntimeTypesTest extends BaseVariantTest {
     public void testCapitalLetterConflict() {
         final DMNRuntime runtime = createRuntime("capitalLetterConflict.dmn", this.getClass());
         final DMNModel dmnModel = runtime.getModel("https://kiegroup.org/dmn/_B321C9B1-856E-45DE-B05D-5B4D4D301D37", "capitalLetterConflict");
-        assertThat(dmnModel, notNullValue());
-        assertThat(DMNRuntimeUtil.formatMessages(dmnModel.getMessages()), dmnModel.hasErrors(), is(false));
+        assertThat(dmnModel).isNotNull();
+        assertThat(dmnModel.hasErrors()).as(DMNRuntimeUtil.formatMessages(dmnModel.getMessages())).isFalse();
 
         final Map<String, Object> myPerson = new HashMap<>();
         myPerson.put("name", "John");
@@ -576,25 +569,25 @@ public class DMNRuntimeTypesTest extends BaseVariantTest {
         context.set("MyPerson", myPersonCapital);
 
         final DMNResult dmnResult = evaluateModel(runtime, dmnModel, context);
-        assertThat(dmnResult.hasErrors(), is(false));
-        assertThat(dmnResult.getContext().get("myDecision"), is("myDecision is John"));
-        assertThat(dmnResult.getContext().get("MyDecision"), is("MyDecision is Paul"));
+        assertThat(dmnResult.hasErrors()).isFalse();
+        assertThat(dmnResult.getContext().get("myDecision")).isEqualTo("myDecision is John");
+        assertThat(dmnResult.getContext().get("MyDecision")).isEqualTo("MyDecision is Paul");
 
         if (isTypeSafe()) {
             FEELPropertyAccessible outputSet = ((DMNContextFPAImpl)dmnResult.getContext()).getFpa();
             Map<String, Object> allProperties = outputSet.allFEELProperties();
             FEELPropertyAccessible myPersonOut = (FEELPropertyAccessible) allProperties.get("myPerson");
-            assertThat(myPersonOut.getClass().getSimpleName(), is("TPerson"));
-            assertThat(myPersonOut.getFEELProperty("name").toOptional().get(), is("John"));
-            assertThat(EvalHelper.coerceNumber(myPersonOut.getFEELProperty("age").toOptional().get()), is(EvalHelper.coerceNumber(28)));
+            assertThat(myPersonOut.getClass().getSimpleName()).isEqualTo("TPerson");
+            assertThat(myPersonOut.getFEELProperty("name").toOptional().get()).isEqualTo("John");
+            assertThat(EvalHelper.coerceNumber(myPersonOut.getFEELProperty("age").toOptional().get())).isEqualTo(EvalHelper.coerceNumber(28));
             FEELPropertyAccessible myPersonCapitalOut = (FEELPropertyAccessible) allProperties.get("MyPerson");
-            assertThat(myPersonCapitalOut.getClass().getSimpleName(), is("TPerson"));
-            assertThat(myPersonCapitalOut.getFEELProperty("name").toOptional().get(), is("Paul"));
-            assertThat(EvalHelper.coerceNumber(myPersonCapitalOut.getFEELProperty("age").toOptional().get()), is(EvalHelper.coerceNumber(26)));
+            assertThat(myPersonCapitalOut.getClass().getSimpleName()).isEqualTo("TPerson");
+            assertThat(myPersonCapitalOut.getFEELProperty("name").toOptional().get()).isEqualTo("Paul");
+            assertThat(EvalHelper.coerceNumber(myPersonCapitalOut.getFEELProperty("age").toOptional().get())).isEqualTo(EvalHelper.coerceNumber(26));
             Object myDecision = (String) allProperties.get("myDecision");
-            assertThat(myDecision, is("myDecision is John"));
+            assertThat(myDecision).isEqualTo("myDecision is John");
             Object myDecisionCapital = (String) allProperties.get("MyDecision");
-            assertThat(myDecisionCapital, is("MyDecision is Paul"));
+            assertThat(myDecisionCapital).isEqualTo("MyDecision is Paul");
         }
     }
 
@@ -602,8 +595,8 @@ public class DMNRuntimeTypesTest extends BaseVariantTest {
     public void testCapitalLetterConflictWithInputAndDecision() {
         final DMNRuntime runtime = createRuntime("capitalLetterConflictWithInputAndDecision.dmn", this.getClass());
         final DMNModel dmnModel = runtime.getModel("https://kiegroup.org/dmn/_EE9DAFC0-D50D-4D23-8676-FF8A40E02919", "capitalLetterConflictWithInputAndDecision");
-        assertThat(dmnModel, notNullValue());
-        assertThat(DMNRuntimeUtil.formatMessages(dmnModel.getMessages()), dmnModel.hasErrors(), is(false));
+        assertThat(dmnModel).isNotNull();
+        assertThat(dmnModel.hasErrors()).as(DMNRuntimeUtil.formatMessages(dmnModel.getMessages())).isFalse();
 
         final Map<String, Object> person = new HashMap<>();
         person.put("name", "John");
@@ -613,18 +606,18 @@ public class DMNRuntimeTypesTest extends BaseVariantTest {
         context.set("myNode", person);
 
         final DMNResult dmnResult = evaluateModel(runtime, dmnModel, context);
-        assertThat(dmnResult.hasErrors(), is(false));
-        assertThat(dmnResult.getContext().get("MyNode"), is("MyNode is John"));
+        assertThat(dmnResult.hasErrors()).isFalse();
+        assertThat(dmnResult.getContext().get("MyNode")).isEqualTo("MyNode is John");
 
         if (isTypeSafe()) {
             FEELPropertyAccessible outputSet = ((DMNContextFPAImpl)dmnResult.getContext()).getFpa();
             Map<String, Object> allProperties = outputSet.allFEELProperties();
             FEELPropertyAccessible myPersonOut = (FEELPropertyAccessible) allProperties.get("myNode");
-            assertThat(myPersonOut.getClass().getSimpleName(), is("TPerson"));
-            assertThat(myPersonOut.getFEELProperty("name").toOptional().get(), is("John"));
-            assertThat(EvalHelper.coerceNumber(myPersonOut.getFEELProperty("age").toOptional().get()), is(EvalHelper.coerceNumber(28)));
+            assertThat(myPersonOut.getClass().getSimpleName()).isEqualTo("TPerson");
+            assertThat(myPersonOut.getFEELProperty("name").toOptional().get()).isEqualTo("John");
+            assertThat(EvalHelper.coerceNumber(myPersonOut.getFEELProperty("age").toOptional().get())).isEqualTo(EvalHelper.coerceNumber(28));
             Object myDecision = (String) allProperties.get("MyNode");
-            assertThat(myDecision, is("MyNode is John"));
+            assertThat(myDecision).isEqualTo("MyNode is John");
         }
     }
 
@@ -632,8 +625,8 @@ public class DMNRuntimeTypesTest extends BaseVariantTest {
     public void testCapitalLetterConflictItemDef() {
         final DMNRuntime runtime = createRuntime("capitalLetterConflictItemDef.dmn", this.getClass());
         final DMNModel dmnModel = runtime.getModel("https://kiegroup.org/dmn/_DA986720-823F-4334-8AB5-5CBA76FD1B9E", "capitalLetterConflictItemDef");
-        assertThat(dmnModel, notNullValue());
-        assertThat(DMNRuntimeUtil.formatMessages(dmnModel.getMessages()), dmnModel.hasErrors(), is(false));
+        assertThat(dmnModel).isNotNull();
+        assertThat(dmnModel.hasErrors()).as(DMNRuntimeUtil.formatMessages(dmnModel.getMessages())).isFalse();
 
         final Map<String, Object> person = new HashMap<>();
         person.put("name", "john");
@@ -643,19 +636,19 @@ public class DMNRuntimeTypesTest extends BaseVariantTest {
         context.set("InputData-1", person);
 
         final DMNResult dmnResult = evaluateModel(runtime, dmnModel, context);
-        assertThat(dmnResult.hasErrors(), is(false));
+        assertThat(dmnResult.hasErrors()).isFalse();
 
         if (isTypeSafe()) {
             FEELPropertyAccessible outputSet = ((DMNContextFPAImpl)dmnResult.getContext()).getFpa();
             Map<String, Object> allProperties = outputSet.allFEELProperties();
             FEELPropertyAccessible myPersonOut = (FEELPropertyAccessible) allProperties.get("Decision-1");
-            assertThat(myPersonOut.getClass().getSimpleName(), is("TPerson"));
-            assertThat(myPersonOut.getFEELProperty("name").toOptional().get(), is("paul"));
-            assertThat(myPersonOut.getFEELProperty("Name").toOptional().get(), is("Paul"));
+            assertThat(myPersonOut.getClass().getSimpleName()).isEqualTo("TPerson");
+            assertThat(myPersonOut.getFEELProperty("name").toOptional().get()).isEqualTo("paul");
+            assertThat(myPersonOut.getFEELProperty("Name").toOptional().get()).isEqualTo("Paul");
         } else {
             Map<String, Object> outPerson = (Map<String, Object>)dmnResult.getContext().get("Decision-1");
-            assertThat(outPerson.get("name"), is("paul"));
-            assertThat(outPerson.get("Name"), is("Paul"));
+            assertThat(outPerson.get("name")).isEqualTo("paul");
+            assertThat(outPerson.get("Name")).isEqualTo("Paul");
         }
     }
 
@@ -663,8 +656,8 @@ public class DMNRuntimeTypesTest extends BaseVariantTest {
     public void testShareTypeForInputAndOutput() {
         final DMNRuntime runtime = createRuntime("shareTypeForInputAndOutput.dmn", this.getClass());
         final DMNModel dmnModel = runtime.getModel("https://kiegroup.org/dmn/_DBEFBA7B-C568-4631-A89E-AA31F7C6564B", "shareTypeForInputAndOutput");
-        assertThat(dmnModel, notNullValue());
-        assertThat(DMNRuntimeUtil.formatMessages(dmnModel.getMessages()), dmnModel.hasErrors(), is(false));
+        assertThat(dmnModel).isNotNull();
+        assertThat(dmnModel.hasErrors()).as(DMNRuntimeUtil.formatMessages(dmnModel.getMessages())).isFalse();
 
         final Map<String, Object> person = new HashMap<>();
         person.put("name", "John");
@@ -675,21 +668,21 @@ public class DMNRuntimeTypesTest extends BaseVariantTest {
         context.set("inputPerson", person);
 
         final DMNResult dmnResult = evaluateModel(runtime, dmnModel, context);
-        assertThat(dmnResult.hasErrors(), is(false));
+        assertThat(dmnResult.hasErrors()).isFalse();
 
         if (isTypeSafe()) {
             FEELPropertyAccessible outputSet = ((DMNContextFPAImpl)dmnResult.getContext()).getFpa();
             Map<String, Object> allProperties = outputSet.allFEELProperties();
             FEELPropertyAccessible myPersonOut = (FEELPropertyAccessible) allProperties.get("outputPerson");
-            assertThat(myPersonOut.getClass().getSimpleName(), is("TPerson"));
-            assertThat(myPersonOut.getFEELProperty("name").toOptional().get(), is("Paul"));
-            assertThat(myPersonOut.getFEELProperty("age").toOptional().get(), is(new BigDecimal(20)));
-            assertThat(myPersonOut.getFEELProperty("employmentPeriod").toOptional().get(), is(ComparablePeriod.of(1, 3, 1)));
+            assertThat(myPersonOut.getClass().getSimpleName()).isEqualTo("TPerson");
+            assertThat(myPersonOut.getFEELProperty("name").toOptional().get()).isEqualTo("Paul");
+            assertThat(myPersonOut.getFEELProperty("age").toOptional().get()).isEqualTo(new BigDecimal(20));
+            assertThat(myPersonOut.getFEELProperty("employmentPeriod").toOptional().get()).isEqualTo(ComparablePeriod.of(1, 3, 1));
         } else {
             Map<String, Object> outputPerson = (Map<String, Object>) dmnResult.getContext().get("outputPerson");
-            assertThat(outputPerson.get("name"), is("Paul"));
-            assertThat(outputPerson.get("age"), is(new BigDecimal(20)));
-            assertThat(outputPerson.get("employmentPeriod"), is(ComparablePeriod.of(1, 3, 1)));
+            assertThat(outputPerson.get("name")).isEqualTo("Paul");
+            assertThat(outputPerson.get("age")).isEqualTo(new BigDecimal(20));
+            assertThat(outputPerson.get("employmentPeriod")).isEqualTo(ComparablePeriod.of(1, 3, 1));
         }
     }
 
@@ -698,8 +691,8 @@ public class DMNRuntimeTypesTest extends BaseVariantTest {
         final DMNRuntime runtime = createRuntime("PersonListHelloBKM2.dmn", DMNRuntimeTest.class);
         final DMNModel dmnModel = runtime.getModel(
                 "http://www.trisotech.com/definitions/_7e41a76e-2df6-4899-bf81-ae098757a3b6", "PersonListHelloBKM2");
-        assertThat(dmnModel, notNullValue());
-        assertThat(DMNRuntimeUtil.formatMessages(dmnModel.getMessages()), dmnModel.hasErrors(), is(false));
+        assertThat(dmnModel).isNotNull();
+        assertThat(dmnModel.hasErrors()).as(DMNRuntimeUtil.formatMessages(dmnModel.getMessages())).isFalse();
 
         final DMNContext context = DMNFactory.newContext();
 
@@ -709,7 +702,7 @@ public class DMNRuntimeTypesTest extends BaseVariantTest {
         context.set("My Input Data", Arrays.asList(p1, p2));
 
         final DMNResult dmnResult = evaluateModel(runtime, dmnModel, context);
-        assertThat(dmnResult.hasErrors(), is(false));
+        assertThat(dmnResult.hasErrors()).isFalse();
 
         if (isTypeSafe()) {
             FEELPropertyAccessible outputSet = ((DMNContextFPAImpl)dmnResult.getContext()).getFpa();
@@ -717,14 +710,14 @@ public class DMNRuntimeTypesTest extends BaseVariantTest {
             List<FEELPropertyAccessible> personList = (List<FEELPropertyAccessible>) allProperties.get("My Decision");
             FEELPropertyAccessible person1 = personList.get(0);
             FEELPropertyAccessible person2 = personList.get(1);
-            assertThat(person1.getFEELProperty("Full Name").toOptional().get(), anyOf(is("Prof. John Doe"),is("Prof. 47")));
-            assertThat(person1.getFEELProperty("Age").toOptional().get(), anyOf(is(EvalHelper.coerceNumber(33)), is(EvalHelper.coerceNumber(47))));
-            assertThat(person2.getFEELProperty("Full Name").toOptional().get(), anyOf(is("Prof. John Doe"),is("Prof. 47")));
-            assertThat(person2.getFEELProperty("Age").toOptional().get(), anyOf(is(EvalHelper.coerceNumber(33)), is(EvalHelper.coerceNumber(47))));
+            assertThat(person1.getFEELProperty("Full Name").toOptional().get()).isIn("Prof. John Doe", "Prof. 47");
+            assertThat(person1.getFEELProperty("Age").toOptional().get()).isIn(EvalHelper.coerceNumber(33), EvalHelper.coerceNumber(47));
+            assertThat(person2.getFEELProperty("Full Name").toOptional().get()).isIn("Prof. John Doe", "Prof. 47");
+            assertThat(person2.getFEELProperty("Age").toOptional().get()).isIn(EvalHelper.coerceNumber(33), EvalHelper.coerceNumber(47));
         } else {
-            assertThat((List<?>) dmnResult.getContext().get("My Decision"),
+            assertThat((List<?>) dmnResult.getContext().get("My Decision")).asList().
             contains(prototype(entry("Full Name", "Prof. John Doe"), entry("Age", EvalHelper.coerceNumber(33))),
-                     prototype(entry("Full Name", "Prof. 47"), entry("Age", EvalHelper.coerceNumber(47)))));
+                     prototype(entry("Full Name", "Prof. 47"), entry("Age", EvalHelper.coerceNumber(47))));
         }
     }
 
@@ -733,8 +726,8 @@ public class DMNRuntimeTypesTest extends BaseVariantTest {
         final DMNRuntime runtime = createRuntime("topLevelCompositeCollection.dmn", this.getClass());
         final DMNModel dmnModel = runtime.getModel(
                 "https://kiegroup.org/dmn/_3ED2F714-24F0-4764-88FA-04217901C05A", "topLevelCompositeCollection");
-        assertThat(dmnModel, notNullValue());
-        assertThat(DMNRuntimeUtil.formatMessages(dmnModel.getMessages()), dmnModel.hasErrors(), is(false));
+        assertThat(dmnModel).isNotNull();
+        assertThat(dmnModel.hasErrors()).as(DMNRuntimeUtil.formatMessages(dmnModel.getMessages())).isFalse();
 
         final DMNContext context = DMNFactory.newContext();
 
@@ -745,7 +738,7 @@ public class DMNRuntimeTypesTest extends BaseVariantTest {
         context.set("InputData-1", pairs);
 
         final DMNResult dmnResult = evaluateModel(runtime, dmnModel, context);
-        assertThat(dmnResult.hasErrors(), is(false));
+        assertThat(dmnResult.hasErrors()).isFalse();
 
         if (isTypeSafe()) {
             FEELPropertyAccessible outputSet = ((DMNContextFPAImpl)dmnResult.getContext()).getFpa();
@@ -753,14 +746,14 @@ public class DMNRuntimeTypesTest extends BaseVariantTest {
             List<FEELPropertyAccessible> pairList = (List<FEELPropertyAccessible>) allProperties.get("Decision-1");
             FEELPropertyAccessible pair1 = pairList.get(0);
             FEELPropertyAccessible pair2 = pairList.get(1);
-            assertThat(pair1.getFEELProperty("letter").toOptional().get(), anyOf(is("ABC"),is("DEF")));
-            assertThat(pair1.getFEELProperty("num").toOptional().get(), anyOf(is(EvalHelper.coerceNumber(123)), is(EvalHelper.coerceNumber(456))));
-            assertThat(pair2.getFEELProperty("letter").toOptional().get(), anyOf(is("ABC"),is("DEF")));
-            assertThat(pair2.getFEELProperty("num").toOptional().get(), anyOf(is(EvalHelper.coerceNumber(123)), is(EvalHelper.coerceNumber(456))));
+            assertThat(pair1.getFEELProperty("letter").toOptional().get()).isIn("ABC", "DEF");
+            assertThat(pair1.getFEELProperty("num").toOptional().get()).isIn(EvalHelper.coerceNumber(123), EvalHelper.coerceNumber(456));
+            assertThat(pair2.getFEELProperty("letter").toOptional().get()).isIn("ABC", "DEF");
+            assertThat(pair2.getFEELProperty("num").toOptional().get()).isIn(EvalHelper.coerceNumber(123), EvalHelper.coerceNumber(456));
         } else {
-            assertThat((List<?>) dmnResult.getContext().get("Decision-1"),
+            assertThat((List<?>) dmnResult.getContext().get("Decision-1")).asList().
             contains(mapOf(entry("letter", "ABC"), entry("num", EvalHelper.coerceNumber(123))),
-                     mapOf(entry("letter", "DEF"), entry("num", EvalHelper.coerceNumber(456)))));
+                     mapOf(entry("letter", "DEF"), entry("num", EvalHelper.coerceNumber(456))));
         }
     }
 
@@ -768,8 +761,8 @@ public class DMNRuntimeTypesTest extends BaseVariantTest {
     public void testComponentCollection() {
         final DMNRuntime runtime = createRuntime("collections.dmn", this.getClass());
         final DMNModel dmnModel = runtime.getModel("https://kiegroup.org/dmn/_2A93F258-EF3B-4150-A202-1D02A893DF2B", "collections");
-        assertThat(dmnModel, notNullValue());
-        assertThat(DMNRuntimeUtil.formatMessages(dmnModel.getMessages()), dmnModel.hasErrors(), is(false));
+        assertThat(dmnModel).isNotNull();
+        assertThat(dmnModel.hasErrors()).as(DMNRuntimeUtil.formatMessages(dmnModel.getMessages())).isFalse();
 
         final DMNContext context = DMNFactory.newContext();
 
@@ -781,32 +774,32 @@ public class DMNRuntimeTypesTest extends BaseVariantTest {
         context.set("inputPerson", person);
 
         final DMNResult dmnResult = evaluateModel(runtime, dmnModel, context);
-        assertThat(dmnResult.hasErrors(), is(false));
+        assertThat(dmnResult.hasErrors()).isFalse();
 
         if (isTypeSafe()) {
             FEELPropertyAccessible outputSet = ((DMNContextFPAImpl)dmnResult.getContext()).getFpa();
             Map<String, Object> allProperties = outputSet.allFEELProperties();
             FEELPropertyAccessible typedOutputPerson = (FEELPropertyAccessible) allProperties.get("outputPerson");
-            assertThat(typedOutputPerson.getClass().getSimpleName(), is("TPerson"));
-            assertThat(typedOutputPerson.getFEELProperty("name").toOptional().get(), is("Paul"));
+            assertThat(typedOutputPerson.getClass().getSimpleName()).isEqualTo("TPerson");
+            assertThat(typedOutputPerson.getFEELProperty("name").toOptional().get()).isEqualTo("Paul");
             List<FEELPropertyAccessible> addressList = (List<FEELPropertyAccessible>)typedOutputPerson.getFEELProperty("addressList").toOptional().get();
             FEELPropertyAccessible typedOutputAddr1 = addressList.get(0);
             FEELPropertyAccessible typedOutputAddr2 = addressList.get(1);
-            assertThat(typedOutputAddr1.getFEELProperty("city").toOptional().get(), anyOf(is("cityA"), is("cityB")));
-            assertThat(typedOutputAddr1.getFEELProperty("street").toOptional().get(), anyOf(is("streetA"), is("streetB")));
-            assertThat(typedOutputAddr2.getFEELProperty("city").toOptional().get(), anyOf(is("cityA"), is("cityB")));
-            assertThat(typedOutputAddr2.getFEELProperty("street").toOptional().get(), anyOf(is("streetA"), is("streetB")));
+            assertThat(typedOutputAddr1.getFEELProperty("city").toOptional().get()).isIn("cityA", "cityB");
+            assertThat(typedOutputAddr1.getFEELProperty("street").toOptional().get()).isIn("streetA", "streetB");
+            assertThat(typedOutputAddr2.getFEELProperty("city").toOptional().get()).isIn("cityA", "cityB");
+            assertThat(typedOutputAddr2.getFEELProperty("street").toOptional().get()).isIn("streetA", "streetB");
         } else {
             Map<String, Object> outputPerson = (Map<String, Object>)dmnResult.getContext().get("outputPerson");
 
-            assertThat(outputPerson.get("name"), is("Paul"));
+            assertThat(outputPerson.get("name")).isEqualTo("Paul");
             Map<String, Object> outputAddr1 = (Map<String, Object>)((List)outputPerson.get("addressList")).get(0);
             Map<String, Object> outputAddr2 = (Map<String, Object>)((List)outputPerson.get("addressList")).get(1);
 
-            assertThat(outputAddr1.get("city"), anyOf(is("cityA"), is("cityB")));
-            assertThat(outputAddr1.get("street"), anyOf(is("streetA"), is("streetB")));
-            assertThat(outputAddr2.get("city"), anyOf(is("cityA"), is("cityB")));
-            assertThat(outputAddr2.get("street"), anyOf(is("streetA"), is("streetB")));
+            assertThat(outputAddr1.get("city")).isIn("cityA", "cityB");
+            assertThat(outputAddr1.get("street")).isIn("streetA", "streetB");
+            assertThat(outputAddr2.get("city")).isIn("cityA", "cityB");
+            assertThat(outputAddr2.get("street")).isIn("streetA", "streetB");
         }
     }
 
@@ -814,8 +807,8 @@ public class DMNRuntimeTypesTest extends BaseVariantTest {
     public void testComponentCollectionPassTypedObject() {
         final DMNRuntime runtime = createRuntime("collectionsPassTypedObject.dmn", this.getClass());
         final DMNModel dmnModel = runtime.getModel("https://kiegroup.org/dmn/_10C4DB2B-1DCA-4B4F-A994-FA046AE5C7B0", "collectionsPassTypedObject");
-        assertThat(dmnModel, notNullValue());
-        assertThat(DMNRuntimeUtil.formatMessages(dmnModel.getMessages()), dmnModel.hasErrors(), is(false));
+        assertThat(dmnModel).isNotNull();
+        assertThat(dmnModel.hasErrors()).as(DMNRuntimeUtil.formatMessages(dmnModel.getMessages())).isFalse();
 
         final DMNContext context = DMNFactory.newContext();
 
@@ -827,33 +820,33 @@ public class DMNRuntimeTypesTest extends BaseVariantTest {
         context.set("inputPerson", person);
 
         final DMNResult dmnResult = evaluateModel(runtime, dmnModel, context);
-        assertThat(dmnResult.hasErrors(), is(false));
+        assertThat(dmnResult.hasErrors()).isFalse();
 
         if (isTypeSafe()) {
             FEELPropertyAccessible outputSet = ((DMNContextFPAImpl)dmnResult.getContext()).getFpa();
             Map<String, Object> allProperties = outputSet.allFEELProperties();
             FEELPropertyAccessible typedOutputPerson = (FEELPropertyAccessible) allProperties.get("outputPerson");
-            assertThat(typedOutputPerson.getClass().getSimpleName(), is("TPerson"));
-            assertThat(typedOutputPerson.getFEELProperty("name").toOptional().get(), is("Paul"));
+            assertThat(typedOutputPerson.getClass().getSimpleName()).isEqualTo("TPerson");
+            assertThat(typedOutputPerson.getFEELProperty("name").toOptional().get()).isEqualTo("Paul");
             List<FEELPropertyAccessible> addressList = (List<FEELPropertyAccessible>) typedOutputPerson.getFEELProperty("addressList").toOptional().get();
             FEELPropertyAccessible typedOutputAddr1 = addressList.get(0);
             FEELPropertyAccessible typedOutputAddr2 = addressList.get(1);
-            assertThat(typedOutputAddr1.getFEELProperty("city").toOptional().get(), anyOf(is("city1"), is("city2")));
-            assertThat(typedOutputAddr1.getFEELProperty("street").toOptional().get(), anyOf(is("street1"), is("street2")));
-            assertThat(typedOutputAddr2.getFEELProperty("city").toOptional().get(), anyOf(is("city1"), is("city2")));
-            assertThat(typedOutputAddr2.getFEELProperty("street").toOptional().get(), anyOf(is("street1"), is("street2")));
+            assertThat(typedOutputAddr1.getFEELProperty("city").toOptional().get()).isIn("city1", "city2");
+            assertThat(typedOutputAddr1.getFEELProperty("street").toOptional().get()).isIn("street1", "street2");
+            assertThat(typedOutputAddr2.getFEELProperty("city").toOptional().get()).isIn("city1", "city2");
+            assertThat(typedOutputAddr2.getFEELProperty("street").toOptional().get()).isIn("street1", "street2");
         } else {
             Map<String, Object> outputPerson = (Map<String, Object>) dmnResult.getContext().get("outputPerson");
 
-            assertThat(outputPerson.get("name"), is("Paul"));
+            assertThat(outputPerson.get("name")).isEqualTo("Paul");
 
             Map<String, Object> outputAddr1 = (Map<String, Object>) ((List) outputPerson.get("addressList")).get(0);
             Map<String, Object> outputAddr2 = (Map<String, Object>) ((List) outputPerson.get("addressList")).get(1);
 
-            assertThat(outputAddr1.get("city"), anyOf(is("city1"), is("city2")));
-            assertThat(outputAddr1.get("street"), anyOf(is("street1"), is("street2")));
-            assertThat(outputAddr2.get("city"), anyOf(is("city1"), is("city2")));
-            assertThat(outputAddr2.get("street"), anyOf(is("street1"), is("street2")));
+            assertThat(outputAddr1.get("city")).isIn("city1", "city2");
+            assertThat(outputAddr1.get("street")).isIn("street1", "street2");
+            assertThat(outputAddr2.get("city")).isIn("city1", "city2");
+            assertThat(outputAddr2.get("street")).isIn("street1", "street2");
         }
     }
 
@@ -861,60 +854,60 @@ public class DMNRuntimeTypesTest extends BaseVariantTest {
     public void testEvaluateByIdAndName() {
         final DMNRuntime runtime = createRuntimeWithAdditionalResources("2decisions.dmn", this.getClass());
         final DMNModel dmnModel = runtime.getModel("https://kiegroup.org/dmn/_6453A539-85B5-4A4E-800E-6721C50B6B55", "2decisions");
-        assertThat(dmnModel, notNullValue());
-        assertThat(DMNRuntimeUtil.formatMessages(dmnModel.getMessages()), dmnModel.hasErrors(), is(false));
+        assertThat(dmnModel).isNotNull();
+        assertThat(dmnModel.hasErrors()).as(DMNRuntimeUtil.formatMessages(dmnModel.getMessages())).isFalse();
 
         final DMNContext context = DMNFactory.newContext();
         context.set("InputData-1", mapOf(entry("name", "John"), entry("age", 30)));
 
         final DMNResult dmnResult1 = evaluateById(runtime, dmnModel, context, "_0BD595AB-B8C6-4FBF-B2DD-BEB49420EDFE");
 
-        assertThat(DMNRuntimeUtil.formatMessages(dmnResult1.getMessages()), dmnResult1.hasErrors(), is(false));
+        assertThat(dmnResult1.hasErrors()).as(DMNRuntimeUtil.formatMessages(dmnResult1.getMessages())).isFalse();
 
         if (isTypeSafe()) {
             FEELPropertyAccessible outputSet = ((DMNContextFPAImpl)dmnResult1.getContext()).getFpa();
             Map<String, Object> allProperties = outputSet.allFEELProperties();
             FEELPropertyAccessible person = (FEELPropertyAccessible)allProperties.get("Decision-1");
-            assertThat(person.getClass().getSimpleName(), is("TPerson"));
-            assertThat(person.getFEELProperty("name").toOptional().get(), is("Paul"));
-            assertThat(person.getFEELProperty("age").toOptional().get(), is(EvalHelper.coerceNumber(28)));
+            assertThat(person.getClass().getSimpleName()).isEqualTo("TPerson");
+            assertThat(person.getFEELProperty("name").toOptional().get()).isEqualTo("Paul");
+            assertThat(person.getFEELProperty("age").toOptional().get()).isEqualTo(EvalHelper.coerceNumber(28));
 
-            assertThat(allProperties.get("Decision-2"), nullValue());
+            assertThat(allProperties.get("Decision-2")).isNull();
         } else {
             Map<String, Object> person = (Map<String, Object>)dmnResult1.getContext().get("Decision-1");
-            assertThat(person.get("name"), is("Paul"));
-            assertThat(person.get("age"), is(EvalHelper.coerceNumber(28)));
+            assertThat(person.get("name")).isEqualTo("Paul");
+            assertThat(person.get("age")).isEqualTo(EvalHelper.coerceNumber(28));
 
-            assertThat(dmnResult1.getContext().get("Decision-2"), nullValue());
+            assertThat(dmnResult1.getContext().get("Decision-2")).isNull();
         }
 
         final DMNResult dmnResult2 = evaluateByName(runtime, dmnModel, context, "Decision-2");
 
-        assertThat(DMNRuntimeUtil.formatMessages(dmnResult2.getMessages()), dmnResult2.hasErrors(), is(false));
+        assertThat(dmnResult2.hasErrors()).as(DMNRuntimeUtil.formatMessages(dmnResult2.getMessages())).isFalse();
 
         if (isTypeSafe()) {
             FEELPropertyAccessible outputSet = ((DMNContextFPAImpl)dmnResult2.getContext()).getFpa();
             Map<String, Object> allProperties = outputSet.allFEELProperties();
             FEELPropertyAccessible person = (FEELPropertyAccessible)allProperties.get("Decision-2");
-            assertThat(person.getClass().getSimpleName(), is("TPerson"));
-            assertThat(person.getFEELProperty("name").toOptional().get(), is("George"));
-            assertThat(person.getFEELProperty("age").toOptional().get(), is(EvalHelper.coerceNumber(27)));
+            assertThat(person.getClass().getSimpleName()).isEqualTo("TPerson");
+            assertThat(person.getFEELProperty("name").toOptional().get()).isEqualTo("George");
+            assertThat(person.getFEELProperty("age").toOptional().get()).isEqualTo(EvalHelper.coerceNumber(27));
 
-            assertThat(allProperties.get("Decision-1"), nullValue());
+            assertThat(allProperties.get("Decision-1")).isNull();
         } else {
             Map<String, Object> person = (Map<String, Object>)dmnResult2.getContext().get("Decision-2");
-            assertThat(person.get("name"), is("George"));
-            assertThat(person.get("age"), is(EvalHelper.coerceNumber(27)));
+            assertThat(person.get("name")).isEqualTo("George");
+            assertThat(person.get("age")).isEqualTo(EvalHelper.coerceNumber(27));
 
-            assertThat(dmnResult2.getContext().get("Decision-1"), nullValue());
+            assertThat(dmnResult2.getContext().get("Decision-1")).isNull();
         }
     }
 
     public void testCollectionOfCollection() {
         final DMNRuntime runtime = createRuntime("topLevelColOfCol.dmn", this.getClass());
         final DMNModel dmnModel = runtime.getModel("https://kiegroup.org/dmn/_74636626-ACB0-4A1F-9AD3-D4E0AFA1A24A", "topLevelColOfCol");
-        assertThat(dmnModel, notNullValue());
-        assertThat(DMNRuntimeUtil.formatMessages(dmnModel.getMessages()), dmnModel.hasErrors(), is(false));
+        assertThat(dmnModel).isNotNull();
+        assertThat(dmnModel.hasErrors()).as(DMNRuntimeUtil.formatMessages(dmnModel.getMessages())).isFalse();
 
         final DMNContext context = DMNFactory.newContext();
         // create ColB -> ColA -> Person data
@@ -930,7 +923,7 @@ public class DMNRuntimeTypesTest extends BaseVariantTest {
         context.set("InputData-1", colB);
 
         final DMNResult dmnResult = evaluateModel(runtime, dmnModel, context);
-        assertThat(dmnResult.hasErrors(), is(false));
+        assertThat(dmnResult.hasErrors()).isFalse();
 
         if (isTypeSafe()) {
             FEELPropertyAccessible outputSet = ((DMNContextFPAImpl)dmnResult.getContext()).getFpa();
@@ -954,21 +947,21 @@ public class DMNRuntimeTypesTest extends BaseVariantTest {
     }
 
     private void assertPersonInCol(FEELPropertyAccessible person) {
-        assertThat(person.getFEELProperty("name").toOptional().get(), anyOf(is("John0X"), is("John1X"), is("John2X"), is("John3X")));
-        assertThat(person.getFEELProperty("age").toOptional().get(), anyOf(is(coerceNumber(21)), is(coerceNumber(22)), is(coerceNumber(23)), is(coerceNumber(24))));
+        assertThat(person.getFEELProperty("name").toOptional().get()).isIn("John0X", "John1X", "John2X", "John3X");
+        assertThat(person.getFEELProperty("age").toOptional().get()).isIn(coerceNumber(21), coerceNumber(22), coerceNumber(23), coerceNumber(24));
     }
 
     private void assertPersonMapInCol(Map<String, Object> personMap) {
-        assertThat(personMap.get("name"), anyOf(is("John0X"), is("John1X"), is("John2X"), is("John3X")));
-        assertThat(personMap.get("age"), anyOf(is(coerceNumber(21)), is(coerceNumber(22)), is(coerceNumber(23)), is(coerceNumber(24))));
+        assertThat(personMap.get("name")).isIn("John0X", "John1X", "John2X", "John3X");
+        assertThat(personMap.get("age")).isIn(coerceNumber(21), coerceNumber(22), coerceNumber(23), coerceNumber(24));
     }
 
     @Test
     public void testCollectionOfCollectionOfCollection() {
         final DMNRuntime runtime = createRuntime("topLevelColOfColOfCol.dmn", this.getClass());
         final DMNModel dmnModel = runtime.getModel("https://kiegroup.org/dmn/_74636626-ACB0-4A1F-9AD3-D4E0AFA1A24A", "topLevelColOfColOfCol");
-        assertThat(dmnModel, notNullValue());
-        assertThat(DMNRuntimeUtil.formatMessages(dmnModel.getMessages()), dmnModel.hasErrors(), is(false));
+        assertThat(dmnModel).isNotNull();
+        assertThat(dmnModel.hasErrors()).as(DMNRuntimeUtil.formatMessages(dmnModel.getMessages())).isFalse();
 
         final DMNContext context = DMNFactory.newContext();
 
@@ -990,7 +983,7 @@ public class DMNRuntimeTypesTest extends BaseVariantTest {
         context.set("InputData-1", colC);
 
         final DMNResult dmnResult = evaluateModel(runtime, dmnModel, context);
-        assertThat(dmnResult.hasErrors(), is(false));
+        assertThat(dmnResult.hasErrors()).isFalse();
 
         if (isTypeSafe()) {
             FEELPropertyAccessible outputSet = ((DMNContextFPAImpl)dmnResult.getContext()).getFpa();
@@ -1006,20 +999,20 @@ public class DMNRuntimeTypesTest extends BaseVariantTest {
     }
 
     private void assertPersonInDeepCol(FEELPropertyAccessible person) {
-        assertThat(person.getFEELProperty("name").toOptional().get(),
-                   anyOf(is("John0X"), is("John1X"), is("John2X"), is("John3X"),
-                         is("John4X"), is("John5X"), is("John6X"), is("John7X")));
-        assertThat(person.getFEELProperty("age").toOptional().get(),
-                   anyOf(is(coerceNumber(21)), is(coerceNumber(22)), is(coerceNumber(23)), is(coerceNumber(24)),
-                         is(coerceNumber(25)), is(coerceNumber(26)), is(coerceNumber(27)), is(coerceNumber(28))));
+        assertThat(person.getFEELProperty("name").toOptional().get()).isIn(
+                   "John0X", "John1X", "John2X", "John3X",
+                   "John4X", "John5X", "John6X", "John7X");
+        assertThat(person.getFEELProperty("age").toOptional().get()).isIn(
+                   coerceNumber(21), coerceNumber(22), coerceNumber(23), coerceNumber(24), 
+                   coerceNumber(25), coerceNumber(26), coerceNumber(27), coerceNumber(28));
     }
 
     private void assertPersonMapInDeepCol(Map<String, Object> personMap) {
-        assertThat(personMap.get("name"),
-                   anyOf(is("John0X"), is("John1X"), is("John2X"), is("John3X"),
-                         is("John4X"), is("John5X"), is("John6X"), is("John7X")));
-        assertThat(personMap.get("age"),
-                   anyOf(is(coerceNumber(21)), is(coerceNumber(22)), is(coerceNumber(23)), is(coerceNumber(24)),
-                         is(coerceNumber(25)), is(coerceNumber(26)), is(coerceNumber(27)), is(coerceNumber(28))));
+        assertThat(personMap.get("name")).isIn(
+                "John0X", "John1X", "John2X", "John3X",
+                "John4X", "John5X", "John6X", "John7X");
+        assertThat(personMap.get("age")).isIn(
+                coerceNumber(21), coerceNumber(22), coerceNumber(23), coerceNumber(24), 
+                coerceNumber(25), coerceNumber(26), coerceNumber(27), coerceNumber(28));
     }
 }

--- a/kie-dmn/kie-dmn-core/src/test/java/org/kie/dmn/core/stronglytyped/DMNTypeSafeTest.java
+++ b/kie-dmn/kie-dmn-core/src/test/java/org/kie/dmn/core/stronglytyped/DMNTypeSafeTest.java
@@ -39,12 +39,9 @@ import org.kie.memorycompiler.KieMemoryCompiler;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static java.util.Arrays.asList;
-import static org.hamcrest.CoreMatchers.equalTo;
-import static org.hamcrest.CoreMatchers.is;
-import static org.hamcrest.CoreMatchers.notNullValue;
 import static org.junit.Assert.assertEquals;
-import static org.hamcrest.MatcherAssert.assertThat;
 import static org.kie.dmn.core.BaseVariantTest.VariantTestConf.KIE_API_TYPECHECK_TYPESAFE;
 import static org.kie.dmn.core.util.DynamicTypeUtils.entry;
 import static org.kie.dmn.core.util.DynamicTypeUtils.mapOf;
@@ -105,14 +102,14 @@ public class DMNTypeSafeTest extends BaseVariantTest {
         DMNContext result = evaluateAll.getContext();
 
         Map<String, Object> d = (Map<String, Object>) result.get("d");
-        assertThat(d.get("Hello"), is("Hello Mr. x"));
+        assertThat(d.get("Hello")).isEqualTo("Hello Mr. x");
 
         FEELPropertyAccessible outputSet = ((DMNContextFPAImpl)result).getFpa();
 
-        assertThat(outputSet.getFEELProperty("p").toOptional().get(), equalTo(tPersonInstance));
+        assertThat(outputSet.getFEELProperty("p").toOptional().get()).isEqualTo(tPersonInstance);
         Map<String, Object> dContext = (Map<String, Object>)outputSet.getFEELProperty("d").toOptional().get();
-        assertThat(dContext.get("Hello"), is("Hello Mr. x"));
-        assertThat(dContext.get("the person"), equalTo(tPersonInstance));
+        assertThat(dContext.get("Hello")).isEqualTo("Hello Mr. x");
+        assertThat(dContext.get("the person")).isEqualTo(tPersonInstance);
     }
 
     private FEELPropertyAccessible tAddress(Map<String, Class<?>> compile, String streetName, int streetNumber) throws Exception {
@@ -166,14 +163,14 @@ public class DMNTypeSafeTest extends BaseVariantTest {
         DMNContext result = evaluateAll.getContext();
 
         Map<String, Object> d = (Map<String, Object>) result.get("d");
-        assertThat(d.get("Hello"), is("Hello Mr. x"));
+        assertThat(d.get("Hello")).isEqualTo("Hello Mr. x");
 
         FEELPropertyAccessible outputSet = ((DMNContextFPAImpl)result).getFpa();
 
-        assertThat(outputSet.getFEELProperty("p").toOptional().get(), equalTo(context.getFEELProperty("p").toOptional().get()));
+        assertThat(outputSet.getFEELProperty("p").toOptional().get()).isEqualTo(context.getFEELProperty("p").toOptional().get());
         Map<String, Object> dContext = (Map<String, Object>)outputSet.getFEELProperty("d").toOptional().get();
-        assertThat(dContext.get("Hello"), is("Hello Mr. x"));
-        assertThat(dContext.get("the person"), equalTo(context.getFEELProperty("p").toOptional().get()));
+        assertThat(dContext.get("Hello")).isEqualTo("Hello Mr. x");
+        assertThat(dContext.get("the person")).isEqualTo(context.getFEELProperty("p").toOptional().get());
     }
 
     @Test
@@ -194,8 +191,8 @@ public class DMNTypeSafeTest extends BaseVariantTest {
     }
 
     private void assertValidDmnModel(DMNModel dmnModel){
-        assertThat(dmnModel, notNullValue());
-        assertThat(DMNRuntimeUtil.formatMessages(dmnModel.getMessages()), dmnModel.hasErrors(), is(false));
+        assertThat(dmnModel).isNotNull();
+        assertThat(dmnModel.hasErrors()).as(DMNRuntimeUtil.formatMessages(dmnModel.getMessages())).isFalse();
     }
 
     private static DMNResult evaluateTyped(FEELPropertyAccessible context, DMNRuntime runtime, DMNModel dmnModel) {

--- a/kie-dmn/kie-dmn-core/src/test/java/org/kie/dmn/core/stronglytyped/JavadocTest.java
+++ b/kie-dmn/kie-dmn-core/src/test/java/org/kie/dmn/core/stronglytyped/JavadocTest.java
@@ -35,10 +35,7 @@ import org.kie.dmn.core.util.DMNRuntimeUtil;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import static org.hamcrest.CoreMatchers.is;
-import static org.hamcrest.CoreMatchers.notNullValue;
-import static org.hamcrest.Matchers.containsString;
-import static org.hamcrest.MatcherAssert.assertThat;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.Assert.assertTrue;
 import static org.kie.dmn.core.BaseVariantTest.VariantTestConf.BUILDER_DEFAULT_NOCL_TYPECHECK_TYPESAFE;
 import static org.kie.dmn.core.BaseVariantTest.VariantTestConf.KIE_API_TYPECHECK_TYPESAFE;
@@ -62,8 +59,8 @@ public class JavadocTest extends BaseVariantTest {
         runtime.addListener(DMNRuntimeUtil.createListener());
 
         final DMNModel dmnModel = runtime.getModel("http://www.trisotech.com/definitions/_69430b3e-17b8-430d-b760-c505bf6469f9", "dateTime Table 58");
-        assertThat(dmnModel, notNullValue());
-        assertThat(DMNRuntimeUtil.formatMessages(dmnModel.getMessages()), dmnModel.hasErrors(), is(false));
+        assertThat(dmnModel).isNotNull();
+        assertThat(dmnModel.hasErrors()).as(DMNRuntimeUtil.formatMessages(dmnModel.getMessages())).isFalse();
 
         // Typesafe only test
         Map<String, String> sourceMap = new HashMap<>();
@@ -140,6 +137,6 @@ public class JavadocTest extends BaseVariantTest {
         assertTrue(opt.isPresent());
         Optional<JavadocComment> actual = opt.get().getJavadocComment();
         assertTrue(actual.isPresent());
-        assertThat(actual.get().getContent(), containsString(expectedJavadocComment));
+        assertThat(actual.get().getContent()).contains(expectedJavadocComment);
     }
 }

--- a/kie-dmn/kie-dmn-core/src/test/java/org/kie/dmn/core/util/DMNRuntimeUtil.java
+++ b/kie-dmn/kie-dmn-core/src/test/java/org/kie/dmn/core/util/DMNRuntimeUtil.java
@@ -50,8 +50,7 @@ import org.kie.internal.builder.InternalKieBuilder;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import static org.hamcrest.CoreMatchers.is;
-import static org.hamcrest.MatcherAssert.assertThat;
+import static org.assertj.core.api.Assertions.assertThat;
 
 /**
  * A type-check safe runtime creation helper.
@@ -92,7 +91,7 @@ public final class DMNRuntimeUtil {
                                                    .filter(DMNMessage.class::isInstance)
                                                    .map(DMNMessage.class::cast)
                                                    .collect(Collectors.toList());
-        assertThat(dmnMessages.isEmpty(), is(false));
+        assertThat(dmnMessages).isNotEmpty();;
         return dmnMessages;
     }
 

--- a/kie-dmn/kie-dmn-core/src/test/java/org/kie/dmn/core/util/DMNTestUtil.java
+++ b/kie-dmn/kie-dmn-core/src/test/java/org/kie/dmn/core/util/DMNTestUtil.java
@@ -19,9 +19,7 @@ package org.kie.dmn.core.util;
 import org.kie.dmn.api.core.DMNModel;
 import org.kie.dmn.api.core.DMNRuntime;
 
-import static org.hamcrest.CoreMatchers.is;
-import static org.hamcrest.CoreMatchers.notNullValue;
-import static org.hamcrest.MatcherAssert.assertThat;
+import static org.assertj.core.api.Assertions.assertThat;
 
 public class DMNTestUtil {
 
@@ -31,8 +29,8 @@ public class DMNTestUtil {
 
     public static DMNModel getAndAssertModelNoErrors(final DMNRuntime runtime, final String namespace, final String modelName) {
         DMNModel dmnModel = runtime.getModel(namespace, modelName);
-        assertThat(dmnModel, notNullValue());
-        assertThat(DMNRuntimeUtil.formatMessages(dmnModel.getMessages()), dmnModel.hasErrors(), is(false));
+        assertThat(dmnModel).isNotNull();
+        assertThat(dmnModel.hasErrors()).as(DMNRuntimeUtil.formatMessages(dmnModel.getMessages())).isFalse();
         return dmnModel;
     }
 }

--- a/kie-dmn/kie-dmn-core/src/test/java/org/kie/dmn/core/v1_2/DMN12specificTest.java
+++ b/kie-dmn/kie-dmn-core/src/test/java/org/kie/dmn/core/v1_2/DMN12specificTest.java
@@ -19,7 +19,6 @@ package org.kie.dmn.core.v1_2;
 import java.math.BigDecimal;
 import java.time.LocalDateTime;
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -35,9 +34,7 @@ import org.kie.dmn.core.util.DMNRuntimeUtil;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import static org.hamcrest.CoreMatchers.is;
-import static org.hamcrest.CoreMatchers.notNullValue;
-import static org.hamcrest.MatcherAssert.assertThat;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.kie.dmn.core.util.DynamicTypeUtils.entry;
 import static org.kie.dmn.core.util.DynamicTypeUtils.mapOf;
 
@@ -54,26 +51,26 @@ public class DMN12specificTest extends BaseInterpretedVsCompiledTest {
         // DROOLS-
         final DMNRuntime runtime = DMNRuntimeUtil.createRuntime("typeAliases.dmn", this.getClass());
         final DMNModel dmnModel = runtime.getModel("http://www.trisotech.com/dmn/definitions/_9f6be450-17c0-49d9-a67f-960ad04b046f", "Drawing 1");
-        assertThat(dmnModel, notNullValue());
-        assertThat(DMNRuntimeUtil.formatMessages(dmnModel.getMessages()), dmnModel.hasErrors(), is(false));
+        assertThat(dmnModel).isNotNull();
+        assertThat(dmnModel.hasErrors()).as(DMNRuntimeUtil.formatMessages(dmnModel.getMessages())).isFalse();
 
         final DMNContext context = DMNFactory.newContext();
         context.set("a date and time", LocalDateTime.of(2018, 9, 28, 16, 7));
 
         final DMNResult dmnResult = runtime.evaluateAll(dmnModel, context);
         LOG.debug("{}", dmnResult);
-        assertThat(DMNRuntimeUtil.formatMessages(dmnResult.getMessages()), dmnResult.hasErrors(), is(false));
+        assertThat(dmnResult.hasErrors()).as(DMNRuntimeUtil.formatMessages(dmnResult.getMessages())).isFalse();
 
         final DMNContext result = dmnResult.getContext();
-        assertThat(result.get("a decision"), is(LocalDateTime.of(2018, 9, 28, 16, 7).plusDays(1)));
+        assertThat(result.get("a decision")).isEqualTo(LocalDateTime.of(2018, 9, 28, 16, 7).plusDays(1));
     }
 
     @Test
     public void testItemDefCollection() {
         final DMNRuntime runtime = DMNRuntimeUtil.createRuntime("0001-filter.dmn", getClass());
         final DMNModel dmnModel = runtime.getModel("http://www.trisotech.com/definitions/_f52ca843-504b-4c3b-a6bc-4d377bffef7a", "filter01");
-        assertThat(dmnModel, notNullValue());
-        assertThat(dmnModel.getMessages().toString(), dmnModel.hasErrors(), is(false));
+        assertThat(dmnModel).isNotNull();
+        assertThat(dmnModel.hasErrors()).as(DMNRuntimeUtil.formatMessages(dmnModel.getMessages())).isFalse();
 
         final Object[][] data = new Object[][]{{7792, 10, "Clark"},
                                                {7934, 10, "Miller"},
@@ -93,8 +90,8 @@ public class DMN12specificTest extends BaseInterpretedVsCompiledTest {
 
         final DMNResult dmnResult = runtime.evaluateAll(dmnModel, context);
         LOG.debug("{}", dmnResult);
-        assertThat(dmnResult.hasErrors(), is(false));
-        assertThat(dmnResult.getContext().get("filter01"), is(Arrays.asList("Adams", "Ford")));
+        assertThat(dmnResult.hasErrors()).isFalse();
+        assertThat(dmnResult.getContext().get("filter01")).asList().containsExactly("Adams", "Ford");
     }
 
     @Test
@@ -112,20 +109,20 @@ public class DMN12specificTest extends BaseInterpretedVsCompiledTest {
     private void check_testDMN12typeRefInformationItem(String filename) {
         final DMNRuntime runtime = DMNRuntimeUtil.createRuntime(filename, this.getClass());
         final DMNModel dmnModel = runtime.getModel("http://www.trisotech.com/definitions/_fe2fd9ea-5928-4a35-b218-036de5798776", "Drawing 1");
-        assertThat(dmnModel, notNullValue());
-        assertThat(DMNRuntimeUtil.formatMessages(dmnModel.getMessages()), dmnModel.hasErrors(), is(false));
+        assertThat(dmnModel).isNotNull();
+        assertThat(dmnModel.hasErrors()).as(DMNRuntimeUtil.formatMessages(dmnModel.getMessages())).isFalse();
 
         final DMNContext emptyContext = DMNFactory.newContext();
 
         final DMNResult dmnResult = runtime.evaluateAll(dmnModel, emptyContext);
         LOG.debug("{}", dmnResult);
-        assertThat(DMNRuntimeUtil.formatMessages(dmnResult.getMessages()), dmnResult.hasErrors(), is(false));
+        assertThat(dmnResult.hasErrors()).as(DMNRuntimeUtil.formatMessages(dmnResult.getMessages())).isFalse();
 
         final DMNContext result = dmnResult.getContext();
-        assertThat(result.get("invoke the a function"), is("Hello World"));
-        assertThat(result.get("the list of vowels"), is(Arrays.asList("a", "e", "i", "o", "u")));
-        assertThat(result.get("a Person"), is(mapOf(entry("name", "John"),
+        assertThat(result.get("invoke the a function")).isEqualTo("Hello World");
+        assertThat(result.get("the list of vowels")).asList().containsExactly("a", "e", "i", "o", "u");
+        assertThat(result.get("a Person")).isEqualTo(mapOf(entry("name", "John"),
                                                     entry("surname", "Doe"),
-                                                    entry("age", BigDecimal.valueOf(47)))));
+                                                    entry("age", BigDecimal.valueOf(47))));
     }
 }

--- a/kie-dmn/kie-dmn-core/src/test/java/org/kie/dmn/core/v1_2/DMNDecisionServicesTest.java
+++ b/kie-dmn/kie-dmn-core/src/test/java/org/kie/dmn/core/v1_2/DMNDecisionServicesTest.java
@@ -24,9 +24,7 @@ import org.kie.dmn.core.util.DMNRuntimeUtil;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import static org.hamcrest.CoreMatchers.is;
-import static org.hamcrest.CoreMatchers.notNullValue;
-import static org.hamcrest.MatcherAssert.assertThat;
+import static org.assertj.core.api.Assertions.assertThat;
 
 public class DMNDecisionServicesTest extends BaseInterpretedVsCompiledTest {
 
@@ -41,8 +39,8 @@ public class DMNDecisionServicesTest extends BaseInterpretedVsCompiledTest {
         // DROOLS-2943 DMN DecisionServiceCompiler not correctly wired for DMNv1.2 format
         final DMNRuntime runtime = DMNRuntimeUtil.createRuntime("DecisionServiceABC_DMN12.dmn", this.getClass());
         final DMNModel dmnModel = runtime.getModel("http://www.trisotech.com/dmn/definitions/_2443d3f5-f178-47c6-a0c9-b1fd1c933f60", "Drawing 1");
-        assertThat(dmnModel, notNullValue());
-        assertThat(DMNRuntimeUtil.formatMessages(dmnModel.getMessages()), dmnModel.hasErrors(), is(false));
+        assertThat(dmnModel).isNotNull();
+        assertThat(dmnModel.hasErrors()).as(DMNRuntimeUtil.formatMessages(dmnModel.getMessages())).isFalse();
 
         org.kie.dmn.core.decisionservices.DMNDecisionServicesTest.testDecisionServiceCompiler20180830_testEvaluateDS(runtime, dmnModel);
         org.kie.dmn.core.decisionservices.DMNDecisionServicesTest.testDecisionServiceCompiler20180830_testEvaluateAll(runtime, dmnModel);

--- a/kie-dmn/kie-dmn-core/src/test/java/org/kie/dmn/core/v1_3/DMN13specificTest.java
+++ b/kie-dmn/kie-dmn-core/src/test/java/org/kie/dmn/core/v1_3/DMN13specificTest.java
@@ -33,9 +33,7 @@ import org.kie.dmn.core.util.DMNRuntimeUtil;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import static org.hamcrest.CoreMatchers.is;
-import static org.hamcrest.CoreMatchers.notNullValue;
-import static org.hamcrest.MatcherAssert.assertThat;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.kie.dmn.core.util.DynamicTypeUtils.entry;
 import static org.kie.dmn.core.util.DynamicTypeUtils.mapOf;
 
@@ -51,23 +49,23 @@ public class DMN13specificTest extends BaseVariantTest {
     public void testDMNv1_3_simple() {
         final DMNRuntime runtime = createRuntime("simple.dmn", this.getClass());
         final DMNModel dmnModel = runtime.getModel("http://www.trisotech.com/definitions/_9d01a0c4-f529-4ad8-ad8e-ec5fb5d96ad4", "Chapter 11 Example");
-        assertThat(dmnModel, notNullValue());
-        assertThat(DMNRuntimeUtil.formatMessages(dmnModel.getMessages()), dmnModel.hasErrors(), is(false));
+        assertThat(dmnModel).isNotNull();
+        assertThat(dmnModel.hasErrors()).as(DMNRuntimeUtil.formatMessages(dmnModel.getMessages())).isFalse();
 
         final DMNContext context = DMNFactory.newContext();
         context.set("name", "John");
 
         final DMNResult dmnResult = evaluateModel(runtime, dmnModel, context);
         LOG.debug("{}", dmnResult);
-        assertThat(DMNRuntimeUtil.formatMessages(dmnResult.getMessages()), dmnResult.hasErrors(), is(false));
+        assertThat(dmnResult.hasErrors()).as(DMNRuntimeUtil.formatMessages(dmnResult.getMessages())).isFalse();
 
         final DMNContext result = dmnResult.getContext();
-        assertThat(result.get("salutation"), is("Hello, John"));
+        assertThat(result.get("salutation")).isEqualTo("Hello, John");
 
         if (isTypeSafe()) {
             FEELPropertyAccessible outputSet = ((DMNContextFPAImpl)dmnResult.getContext()).getFpa();
             Map<String, Object> allProperties = outputSet.allFEELProperties();
-            assertThat(allProperties.get("salutation"), is("Hello, John"));
+            assertThat(allProperties.get("salutation")).isEqualTo("Hello, John");
         }
     }
 
@@ -77,8 +75,8 @@ public class DMN13specificTest extends BaseVariantTest {
 
         final DMNRuntime runtime = createRuntimeWithAdditionalResources("Chapter 11 Example.dmn", this.getClass(), "Financial.dmn");
         final DMNModel dmnModel = runtime.getModel("http://www.trisotech.com/definitions/_9d01a0c4-f529-4ad8-ad8e-ec5fb5d96ad4", "Chapter 11 Example");
-        assertThat(dmnModel, notNullValue());
-        assertThat(DMNRuntimeUtil.formatMessages(dmnModel.getMessages()), dmnModel.hasErrors(), is(false));
+        assertThat(dmnModel).isNotNull();
+        assertThat(dmnModel.hasErrors()).as(DMNRuntimeUtil.formatMessages(dmnModel.getMessages())).isFalse();
 
         final DMNContext context = DMNFactory.newContext();
         context.set("Applicant data", mapOf(entry("Age", new BigDecimal(51)),
@@ -97,17 +95,17 @@ public class DMN13specificTest extends BaseVariantTest {
         context.set("Supporting documents", null);
         final DMNResult dmnResult = evaluateModel(runtime, dmnModel, context);
         LOG.debug("{}", dmnResult);
-        assertThat(DMNRuntimeUtil.formatMessages(dmnResult.getMessages()), dmnResult.hasErrors(), is(false));
+        assertThat(dmnResult.hasErrors()).as(DMNRuntimeUtil.formatMessages(dmnResult.getMessages())).isFalse();
 
         final DMNContext result = dmnResult.getContext();
-        assertThat(result.get("Strategy"), is("THROUGH"));
-        assertThat(result.get("Routing"), is("ACCEPT"));
+        assertThat(result.get("Strategy")).isEqualTo("THROUGH");
+        assertThat(result.get("Routing")).isEqualTo("ACCEPT");
 
         if (isTypeSafe()) {
             FEELPropertyAccessible outputSet = ((DMNContextFPAImpl)dmnResult.getContext()).getFpa();
             Map<String, Object> allProperties = outputSet.allFEELProperties();
-            assertThat(allProperties.get("Strategy"), is("THROUGH"));
-            assertThat(allProperties.get("Routing"), is("ACCEPT"));
+            assertThat(allProperties.get("Strategy")).isEqualTo("THROUGH");
+            assertThat(allProperties.get("Routing")).isEqualTo("ACCEPT");
         }
     }
 
@@ -116,8 +114,8 @@ public class DMN13specificTest extends BaseVariantTest {
         testName = "testDMNv1_3_ch11_asSpecInputDataValues";
         final DMNRuntime runtime = createRuntimeWithAdditionalResources("Chapter 11 Example.dmn", this.getClass(), "Financial.dmn");
         final DMNModel dmnModel = runtime.getModel("http://www.trisotech.com/definitions/_9d01a0c4-f529-4ad8-ad8e-ec5fb5d96ad4", "Chapter 11 Example");
-        assertThat(dmnModel, notNullValue());
-        assertThat(DMNRuntimeUtil.formatMessages(dmnModel.getMessages()), dmnModel.hasErrors(), is(false));
+        assertThat(dmnModel).isNotNull();
+        assertThat(dmnModel.hasErrors()).as(DMNRuntimeUtil.formatMessages(dmnModel.getMessages())).isFalse();
 
         final DMNContext context = DMNFactory.newContext();
         context.set("Applicant data", mapOf(entry("Age", new BigDecimal(51)),
@@ -136,17 +134,17 @@ public class DMN13specificTest extends BaseVariantTest {
         context.set("Supporting documents", null);
         final DMNResult dmnResult = evaluateModel(runtime, dmnModel, context);
         LOG.debug("{}", dmnResult);
-        assertThat(DMNRuntimeUtil.formatMessages(dmnResult.getMessages()), dmnResult.hasErrors(), is(false));
+        assertThat(dmnResult.hasErrors()).as(DMNRuntimeUtil.formatMessages(dmnResult.getMessages())).isFalse();
 
         final DMNContext result = dmnResult.getContext();
-        assertThat(result.get("Strategy"), is("THROUGH"));
-        assertThat(result.get("Routing"), is("ACCEPT"));
+        assertThat(result.get("Strategy")).isEqualTo("THROUGH");
+        assertThat(result.get("Routing")).isEqualTo("ACCEPT");
 
         if (isTypeSafe()) {
             FEELPropertyAccessible outputSet = ((DMNContextFPAImpl)dmnResult.getContext()).getFpa();
             Map<String, Object> allProperties = outputSet.allFEELProperties();
-            assertThat(allProperties.get("Strategy"), is("THROUGH"));
-            assertThat(allProperties.get("Routing"), is("ACCEPT"));
+            assertThat(allProperties.get("Strategy")).isEqualTo("THROUGH");
+            assertThat(allProperties.get("Routing")).isEqualTo("ACCEPT");
         }
     }
 
@@ -154,22 +152,22 @@ public class DMN13specificTest extends BaseVariantTest {
     public void testBKMencapsulatedlogictyperef() {
         final DMNRuntime runtime = createRuntime("bkmELTyperef.dmn", this.getClass());
         final DMNModel dmnModel = runtime.getModel("http://www.trisotech.com/definitions/_a49df6fc-c936-467a-9762-9aa3c9a93c06", "Drawing 1");
-        assertThat(dmnModel, notNullValue());
-        assertThat(DMNRuntimeUtil.formatMessages(dmnModel.getMessages()), dmnModel.hasErrors(), is(false));
+        assertThat(dmnModel).isNotNull();
+        assertThat(dmnModel.hasErrors()).as(DMNRuntimeUtil.formatMessages(dmnModel.getMessages())).isFalse();
 
         final DMNContext context = DMNFactory.newContext();
 
         final DMNResult dmnResult = evaluateModel(runtime, dmnModel, context);
         LOG.debug("{}", dmnResult);
-        assertThat(DMNRuntimeUtil.formatMessages(dmnResult.getMessages()), dmnResult.hasErrors(), is(false));
+        assertThat(dmnResult.hasErrors()).as(DMNRuntimeUtil.formatMessages(dmnResult.getMessages())).isFalse();
 
         final DMNContext result = dmnResult.getContext();
-        assertThat(result.get("Decision1"), is(new BigDecimal("3")));
+        assertThat(result.get("Decision1")).isEqualTo(new BigDecimal("3"));
 
         if (isTypeSafe()) {
             FEELPropertyAccessible outputSet = ((DMNContextFPAImpl) dmnResult.getContext()).getFpa();
             Map<String, Object> allProperties = outputSet.allFEELProperties();
-            assertThat(allProperties.get("Decision1"), is(new BigDecimal("3")));
+            assertThat(allProperties.get("Decision1")).isEqualTo(new BigDecimal("3"));
         }
     }
     
@@ -177,53 +175,53 @@ public class DMN13specificTest extends BaseVariantTest {
     public void testBKMFnTypeVirtuous() {
         final DMNRuntime runtime = createRuntime("bkmFnTypeVirtuous.dmn", this.getClass());
         final DMNModel dmnModel = runtime.getModel("http://www.trisotech.com/definitions/_563323ba-325e-4a3f-938f-369854010eaf", "Drawing 1");
-        assertThat(dmnModel, notNullValue());
-        assertThat(DMNRuntimeUtil.formatMessages(dmnModel.getMessages()), dmnModel.hasErrors(), is(false));
+        assertThat(dmnModel).isNotNull();
+        assertThat(dmnModel.hasErrors()).as(DMNRuntimeUtil.formatMessages(dmnModel.getMessages())).isFalse();
 
         final DMNContext context = DMNFactory.newContext();
         context.set("name", "John");
 
         final DMNResult dmnResult = evaluateModel(runtime, dmnModel, context);
         LOG.debug("{}", dmnResult);
-        assertThat(DMNRuntimeUtil.formatMessages(dmnResult.getMessages()), dmnResult.hasErrors(), is(false));
+        assertThat(dmnResult.hasErrors()).as(DMNRuntimeUtil.formatMessages(dmnResult.getMessages())).isFalse();
 
         final DMNContext result = dmnResult.getContext();
-        assertThat(result.get("do greet the name"), is("Hello, John"));
+        assertThat(result.get("do greet the name")).isEqualTo("Hello, John");
     }
     
     @Test
     public void testBKMFnTypeWrongEL() {
         final DMNRuntime runtime = createRuntime("bkmFnTypeWrongEL.dmn", this.getClass());
         final DMNModel dmnModel = runtime.getModel("http://www.trisotech.com/definitions/_563323ba-325e-4a3f-938f-369854010eaf", "Drawing 1");
-        assertThat(dmnModel, notNullValue());
-        assertThat("Expected WARNs of mismatches type in "+DMNRuntimeUtil.formatMessages(dmnModel.getMessages()), dmnModel.getMessages(Severity.WARN).isEmpty(), is(false));
+        assertThat(dmnModel).isNotNull();
+        assertThat(dmnModel.getMessages(Severity.WARN)).as("Expected WARNs of mismatches type in "+DMNRuntimeUtil.formatMessages(dmnModel.getMessages())).isNotEmpty();
 
         final DMNContext context = DMNFactory.newContext();
         context.set("name", "John");
 
         final DMNResult dmnResult = evaluateModel(runtime, dmnModel, context);
         LOG.debug("{}", dmnResult);
-        assertThat(DMNRuntimeUtil.formatMessages(dmnResult.getMessages()), dmnResult.hasErrors(), is(false));
+        assertThat(dmnResult.hasErrors()).as(DMNRuntimeUtil.formatMessages(dmnResult.getMessages())).isFalse();
 
         final DMNContext result = dmnResult.getContext();
-        assertThat(result.get("do greet the name"), is("Hello, John"));
+        assertThat(result.get("do greet the name")).isEqualTo("Hello, John");
     }
     
     @Test
     public void testBKMWrongELExpr() {
         final DMNRuntime runtime = createRuntime("bkmWrongELExprType.dmn", this.getClass());
         final DMNModel dmnModel = runtime.getModel("http://www.trisotech.com/definitions/_563323ba-325e-4a3f-938f-369854010eaf", "Drawing 1");
-        assertThat(dmnModel, notNullValue());
-        assertThat("Expected WARNs of mismatches type in "+DMNRuntimeUtil.formatMessages(dmnModel.getMessages()), dmnModel.getMessages(Severity.WARN).isEmpty(), is(false));
+        assertThat(dmnModel).isNotNull();
+        assertThat(dmnModel.getMessages(Severity.WARN)).as("Expected WARNs of mismatches type in "+DMNRuntimeUtil.formatMessages(dmnModel.getMessages())).isNotEmpty();
 
         final DMNContext context = DMNFactory.newContext();
         context.set("name", "John");
 
         final DMNResult dmnResult = evaluateModel(runtime, dmnModel, context);
         LOG.debug("{}", dmnResult);
-        assertThat(DMNRuntimeUtil.formatMessages(dmnResult.getMessages()), dmnResult.hasErrors(), is(false));
+        assertThat(dmnResult.hasErrors()).as(DMNRuntimeUtil.formatMessages(dmnResult.getMessages())).isFalse();
 
         final DMNContext result = dmnResult.getContext();
-        assertThat(result.get("do greet the name"), is("Hello, John"));
+        assertThat(result.get("do greet the name")).isEqualTo("Hello, John");
     }
 }

--- a/kie-dmn/kie-dmn-core/src/test/java/org/kie/dmn/core/v1_3/DMN13specificTestNonTypesafe.java
+++ b/kie-dmn/kie-dmn-core/src/test/java/org/kie/dmn/core/v1_3/DMN13specificTestNonTypesafe.java
@@ -30,9 +30,7 @@ import org.kie.dmn.core.util.DMNRuntimeUtil;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import static org.hamcrest.CoreMatchers.is;
-import static org.hamcrest.CoreMatchers.notNullValue;
-import static org.hamcrest.MatcherAssert.assertThat;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.kie.dmn.core.util.DynamicTypeUtils.entry;
 import static org.kie.dmn.core.util.DynamicTypeUtils.mapOf;
 
@@ -50,8 +48,8 @@ public class DMN13specificTestNonTypesafe extends BaseVariantNonTypeSafeTest {
 
         final DMNRuntime runtime = createRuntimeWithAdditionalResources("Recommended Loan Products.dmn", this.getClass(), "Loan info.dmn");
         final DMNModel dmnModel = runtime.getModel("http://www.trisotech.com/definitions/_736fa164-03d8-429f-8318-4913a548c3a6", "Recommended Loan Products");
-        assertThat(dmnModel, notNullValue());
-        assertThat(DMNRuntimeUtil.formatMessages(dmnModel.getMessages()), dmnModel.hasErrors(), is(false));
+        assertThat(dmnModel).isNotNull();
+        assertThat(dmnModel.hasErrors()).as(DMNRuntimeUtil.formatMessages(dmnModel.getMessages())).isFalse();
 
         final DMNContext context = DMNFactory.newContext();
         context.set("Credit Score", new BigDecimal(735));
@@ -111,10 +109,10 @@ public class DMN13specificTestNonTypesafe extends BaseVariantNonTypeSafeTest {
 
         final DMNResult dmnResult = evaluateModel(runtime, dmnModel, context);
         LOG.debug("{}", dmnResult);
-        assertThat(DMNRuntimeUtil.formatMessages(dmnResult.getMessages()), dmnResult.hasErrors(), is(false));
+        assertThat(dmnResult.hasErrors()).as(DMNRuntimeUtil.formatMessages(dmnResult.getMessages())).isFalse();
 
         final DMNContext result = dmnResult.getContext();
-        assertThat(result.get("Recommended Loan Products"), is(Arrays.asList(mapOf(entry("Product", "Lender B - ARM5/1-Standard"),
+        assertThat(result.get("Recommended Loan Products")).asList().containsExactly(mapOf(entry("Product", "Lender B - ARM5/1-Standard"),
                                                                                    entry("Note Amount", "$273,775.90"),
                                                                                    entry("Interest Rate Pct", " 3.75"),
                                                                                    entry("Monthly Payment", "$1,267.90"),
@@ -155,6 +153,6 @@ public class DMN13specificTestNonTypesafe extends BaseVariantNonTypeSafeTest {
                                                                                    entry("Monthly Payment", "$1,969.43"),
                                                                                    entry("Cash to Close", "$75,416.32"),
                                                                                    entry("Required Credit Score", new BigDecimal(720)),
-                                                                                   entry("Recommendation", "Best")))));
+                                                                                   entry("Recommendation", "Best")));
     }
 }

--- a/kie-dmn/kie-dmn-core/src/test/java/org/kie/dmn/core/v1_4/DMN14specificTest.java
+++ b/kie-dmn/kie-dmn-core/src/test/java/org/kie/dmn/core/v1_4/DMN14specificTest.java
@@ -18,7 +18,6 @@ package org.kie.dmn.core.v1_4;
 
 import java.math.BigDecimal;
 import java.util.Arrays;
-import java.util.Map;
 
 import org.junit.Test;
 import org.junit.runners.Parameterized;
@@ -26,10 +25,8 @@ import org.kie.dmn.api.core.DMNContext;
 import org.kie.dmn.api.core.DMNModel;
 import org.kie.dmn.api.core.DMNResult;
 import org.kie.dmn.api.core.DMNRuntime;
-import org.kie.dmn.api.core.FEELPropertyAccessible;
 import org.kie.dmn.core.BaseVariantTest;
 import org.kie.dmn.core.api.DMNFactory;
-import org.kie.dmn.core.impl.DMNContextFPAImpl;
 import org.kie.dmn.core.model.Person;
 import org.kie.dmn.core.util.DMNRuntimeUtil;
 import org.kie.dmn.feel.model.SupportRequest;
@@ -37,9 +34,6 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.hamcrest.CoreMatchers.is;
-import static org.hamcrest.CoreMatchers.notNullValue;
-import static org.hamcrest.MatcherAssert.assertThat;
 import static org.kie.dmn.core.BaseVariantTest.VariantTestConf.BUILDER_DEFAULT_NOCL_TYPECHECK;
 import static org.kie.dmn.core.BaseVariantTest.VariantTestConf.KIE_API_TYPECHECK;
 import static org.kie.dmn.core.util.DMNRuntimeUtil.formatMessages;
@@ -100,26 +94,26 @@ public class DMN14specificTest extends BaseVariantTest {
     public void test_simple() {
         final DMNRuntime runtime = createRuntime("simple.dmn", this.getClass());
         final DMNModel dmnModel = runtime.getModel("http://www.trisotech.com/definitions/_d9232146-7aaa-49a9-8668-261a01844ace", "Drawing 1");
-        assertThat(dmnModel, notNullValue());
-        assertThat(DMNRuntimeUtil.formatMessages(dmnModel.getMessages()), dmnModel.hasErrors(), is(false));
+        assertThat(dmnModel).isNotNull();
+        assertThat(dmnModel.hasErrors()).as(DMNRuntimeUtil.formatMessages(dmnModel.getMessages())).isFalse();
 
         final DMNContext context = DMNFactory.newContext();
         context.set("name", "John");
 
         final DMNResult dmnResult = evaluateModel(runtime, dmnModel, context);
         LOG.debug("{}", dmnResult);
-        assertThat(DMNRuntimeUtil.formatMessages(dmnResult.getMessages()), dmnResult.hasErrors(), is(false));
+        assertThat(dmnResult.hasErrors()).as(DMNRuntimeUtil.formatMessages(dmnResult.getMessages())).isFalse();
 
         final DMNContext result = dmnResult.getContext();
-        assertThat(result.get("greet"), is("Hello, John"));
+        assertThat(result.get("greet")).isEqualTo("Hello, John");
     }
     
     @Test
     public void testDMNv1_4_ch11() {
         final DMNRuntime runtime = createRuntimeWithAdditionalResources("Chapter 11 Example.dmn", this.getClass(), "Financial.dmn");
         final DMNModel dmnModel = runtime.getModel("http://www.trisotech.com/definitions/_9d01a0c4-f529-4ad8-ad8e-ec5fb5d96ad4", "Chapter 11 Example");
-        assertThat(dmnModel, notNullValue());
-        assertThat(DMNRuntimeUtil.formatMessages(dmnModel.getMessages()), dmnModel.hasErrors(), is(false));
+        assertThat(dmnModel).isNotNull();
+        assertThat(dmnModel.hasErrors()).as(DMNRuntimeUtil.formatMessages(dmnModel.getMessages())).isFalse();
 
         final DMNContext context = DMNFactory.newContext();
         context.set("Applicant data", mapOf(entry("Age", new BigDecimal(51)),
@@ -138,19 +132,19 @@ public class DMN14specificTest extends BaseVariantTest {
         context.set("Supporting documents", null);
         final DMNResult dmnResult = evaluateModel(runtime, dmnModel, context);
         LOG.debug("{}", dmnResult);
-        assertThat(DMNRuntimeUtil.formatMessages(dmnResult.getMessages()), dmnResult.hasErrors(), is(false));
+        assertThat(dmnResult.hasErrors()).as(DMNRuntimeUtil.formatMessages(dmnResult.getMessages())).isFalse();
 
         final DMNContext result = dmnResult.getContext();
-        assertThat(result.get("Strategy"), is("THROUGH"));
-        assertThat(result.get("Routing"), is("ACCEPT"));
+        assertThat(result.get("Strategy")).isEqualTo("THROUGH");
+        assertThat(result.get("Routing")).isEqualTo("ACCEPT");
     }
     
     @Test
     public void testDMNv1_4_ch11_Example2() {
         final DMNRuntime runtime = createRuntimeWithAdditionalResources("Recommended Loan Products.dmn", this.getClass(), "Loan info.dmn");
         final DMNModel dmnModel = runtime.getModel("http://www.trisotech.com/definitions/_736fa164-03d8-429f-8318-4913a548c3a6", "Recommended Loan Products");
-        assertThat(dmnModel, notNullValue());
-        assertThat(DMNRuntimeUtil.formatMessages(dmnModel.getMessages()), dmnModel.hasErrors(), is(false));
+        assertThat(dmnModel).isNotNull();
+        assertThat(dmnModel.hasErrors()).as(DMNRuntimeUtil.formatMessages(dmnModel.getMessages())).isFalse();
 
         final DMNContext context = DMNFactory.newContext();
         context.set("Credit Score", new BigDecimal(735));
@@ -210,10 +204,10 @@ public class DMN14specificTest extends BaseVariantTest {
 
         final DMNResult dmnResult = evaluateModel(runtime, dmnModel, context);
         LOG.debug("{}", dmnResult);
-        assertThat(DMNRuntimeUtil.formatMessages(dmnResult.getMessages()), dmnResult.hasErrors(), is(false));
+        assertThat(dmnResult.hasErrors()).as(DMNRuntimeUtil.formatMessages(dmnResult.getMessages())).isFalse();
 
         final DMNContext result = dmnResult.getContext();
-        assertThat(result.get("Recommended Loan Products"), is(Arrays.asList(mapOf(entry("Product", "Lender B - ARM5/1-Standard"),
+        assertThat(result.get("Recommended Loan Products")).asList().containsExactly(mapOf(entry("Product", "Lender B - ARM5/1-Standard"),
                                                                                    entry("Note Amount", "$273,775.90"),
                                                                                    entry("Interest Rate Pct", " 3.75"),
                                                                                    entry("Monthly Payment", "$1,267.90"),
@@ -254,71 +248,71 @@ public class DMN14specificTest extends BaseVariantTest {
                                                                                    entry("Monthly Payment", "$1,969.43"),
                                                                                    entry("Cash to Close", "$75,416.32"),
                                                                                    entry("Required Credit Score", new BigDecimal(720)),
-                                                                                   entry("Recommendation", "Best")))));
+                                                                                   entry("Recommendation", "Best")));
     }
 
     @Test
     public void test_sampleFor() {
         final DMNRuntime runtime = createRuntime("sampleFor.dmn", this.getClass());
         final DMNModel dmnModel = runtime.getModel("http://www.trisotech.com/definitions/_5d7731f1-525d-4e75-a24a-39066f52ccdf", "Drawing 1");
-        assertThat(dmnModel, notNullValue());
-        assertThat(DMNRuntimeUtil.formatMessages(dmnModel.getMessages()), dmnModel.hasErrors(), is(false));
+        assertThat(dmnModel).isNotNull();
+        assertThat(dmnModel.hasErrors()).as(DMNRuntimeUtil.formatMessages(dmnModel.getMessages())).isFalse();
 
         final DMNContext emptyContext = DMNFactory.newContext();
         final DMNResult dmnResult = evaluateModel(runtime, dmnModel, emptyContext);
         LOG.debug("{}", dmnResult);
-        assertThat(DMNRuntimeUtil.formatMessages(dmnResult.getMessages()), dmnResult.hasErrors(), is(false));
+        assertThat(dmnResult.hasErrors()).as(DMNRuntimeUtil.formatMessages(dmnResult.getMessages())).isFalse();
 
         final DMNContext result = dmnResult.getContext();
-        assertThat(result.get("sampleFor"), is(Arrays.asList(new BigDecimal(2), new BigDecimal(3), new BigDecimal(4))));
+        assertThat(result.get("sampleFor")).asList().containsExactly(new BigDecimal(2), new BigDecimal(3), new BigDecimal(4));
     }
     
     @Test
     public void test_sampleQuantified() {
         final DMNRuntime runtime = createRuntime("sampleQuantified.dmn", this.getClass());
         final DMNModel dmnModel = runtime.getModel("http://www.trisotech.com/definitions/_480411d5-e8b4-422f-9a76-1e8929930ead", "Drawing 1");
-        assertThat(dmnModel, notNullValue());
-        assertThat(DMNRuntimeUtil.formatMessages(dmnModel.getMessages()), dmnModel.hasErrors(), is(false));
+        assertThat(dmnModel).isNotNull();
+        assertThat(dmnModel.hasErrors()).as(DMNRuntimeUtil.formatMessages(dmnModel.getMessages())).isFalse();
 
         final DMNContext emptyContext = DMNFactory.newContext();
         final DMNResult dmnResult = evaluateModel(runtime, dmnModel, emptyContext);
         LOG.debug("{}", dmnResult);
-        assertThat(DMNRuntimeUtil.formatMessages(dmnResult.getMessages()), dmnResult.hasErrors(), is(false));
+        assertThat(dmnResult.hasErrors()).as(DMNRuntimeUtil.formatMessages(dmnResult.getMessages())).isFalse();
 
         final DMNContext result = dmnResult.getContext();
-        assertThat(result.get("sampleEvery"), is(Boolean.TRUE));
-        assertThat(result.get("sampleSome"), is(Boolean.TRUE));
+        assertThat(result.get("sampleEvery")).isEqualTo(Boolean.TRUE);
+        assertThat(result.get("sampleSome")).isEqualTo(Boolean.TRUE);
     }
     
     @Test
     public void test_sampleConditional() {
         final DMNRuntime runtime = createRuntime("sampleConditional.dmn", this.getClass());
         final DMNModel dmnModel = runtime.getModel("http://www.trisotech.com/definitions/_da2ac43a-133b-483d-9c08-958d10024584", "Drawing 1");
-        assertThat(dmnModel, notNullValue());
-        assertThat(DMNRuntimeUtil.formatMessages(dmnModel.getMessages()), dmnModel.hasErrors(), is(false));
+        assertThat(dmnModel).isNotNull();
+        assertThat(dmnModel.hasErrors()).as(DMNRuntimeUtil.formatMessages(dmnModel.getMessages())).isFalse();
 
         final DMNContext emptyContext = DMNFactory.newContext();
         final DMNResult dmnResult = evaluateModel(runtime, dmnModel, emptyContext);
         LOG.debug("{}", dmnResult);
-        assertThat(DMNRuntimeUtil.formatMessages(dmnResult.getMessages()), dmnResult.hasErrors(), is(false));
+        assertThat(dmnResult.hasErrors()).as(DMNRuntimeUtil.formatMessages(dmnResult.getMessages())).isFalse();
 
         final DMNContext result = dmnResult.getContext();
-        assertThat(result.get("sampleConditional"), is("Hello World"));
+        assertThat(result.get("sampleConditional")).isEqualTo("Hello World");
     }
     
     @Test
     public void test_sampleFilter() {
         final DMNRuntime runtime = createRuntime("sampleFilter.dmn", this.getClass());
         final DMNModel dmnModel = runtime.getModel("http://www.trisotech.com/definitions/_e1291f4e-e828-4a47-86e8-474899d50185", "Drawing 1");
-        assertThat(dmnModel, notNullValue());
-        assertThat(DMNRuntimeUtil.formatMessages(dmnModel.getMessages()), dmnModel.hasErrors(), is(false));
+        assertThat(dmnModel).isNotNull();
+        assertThat(dmnModel.hasErrors()).as(DMNRuntimeUtil.formatMessages(dmnModel.getMessages())).isFalse();
 
         final DMNContext emptyContext = DMNFactory.newContext();
         final DMNResult dmnResult = evaluateModel(runtime, dmnModel, emptyContext);
         LOG.debug("{}", dmnResult);
-        assertThat(DMNRuntimeUtil.formatMessages(dmnResult.getMessages()), dmnResult.hasErrors(), is(false));
+        assertThat(dmnResult.hasErrors()).as(DMNRuntimeUtil.formatMessages(dmnResult.getMessages())).isFalse();
 
         final DMNContext result = dmnResult.getContext();
-        assertThat(result.get("sampleFilter"),  is(Arrays.asList(new BigDecimal(3), new BigDecimal(4))));
+        assertThat(result.get("sampleFilter")).asList().containsExactly(new BigDecimal(3), new BigDecimal(4));
     }
 }

--- a/kie-dmn/kie-dmn-feel/pom.xml
+++ b/kie-dmn/kie-dmn-feel/pom.xml
@@ -88,11 +88,6 @@
       <scope>test</scope>
     </dependency>
     <dependency>
-      <groupId>org.hamcrest</groupId>
-      <artifactId>hamcrest-library</artifactId>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
       <groupId>org.assertj</groupId>
       <artifactId>assertj-core</artifactId>
       <scope>test</scope>

--- a/kie-dmn/kie-dmn-feel/src/test/java/org/kie/dmn/feel/codegen/feel11/DirectCompilerTest.java
+++ b/kie-dmn/kie-dmn-feel/src/test/java/org/kie/dmn/feel/codegen/feel11/DirectCompilerTest.java
@@ -18,10 +18,8 @@ package org.kie.dmn.feel.codegen.feel11;
 
 import java.math.BigDecimal;
 import java.time.LocalDate;
-import java.util.Arrays;
 import java.util.Collections;
 import java.util.Map;
-import java.util.stream.Collectors;
 
 import com.github.javaparser.ast.expr.Expression;
 import org.antlr.v4.runtime.tree.ParseTree;
@@ -42,10 +40,7 @@ import org.kie.dmn.feel.runtime.FEELTernaryLogicTest;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import static org.hamcrest.CoreMatchers.instanceOf;
-import static org.hamcrest.CoreMatchers.is;
-import static org.hamcrest.CoreMatchers.nullValue;
-import static org.hamcrest.MatcherAssert.assertThat;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.kie.dmn.feel.util.DynamicTypeUtils.entry;
 import static org.kie.dmn.feel.util.DynamicTypeUtils.mapOf;
 
@@ -65,47 +60,47 @@ public class DirectCompilerTest {
 
     @Test
     public void test_FEEL_number() {
-        assertThat(parseCompileEvaluate("10"), is( BigDecimal.valueOf(10) ));
+        assertThat(parseCompileEvaluate("10")).isEqualTo(BigDecimal.valueOf(10));
     }
     
     @Test
     public void test_FEEL_negative_number() {
-        assertThat(parseCompileEvaluate("-10"), is( BigDecimal.valueOf(-10) ));
+        assertThat(parseCompileEvaluate("-10")).isEqualTo(BigDecimal.valueOf(-10));
     }
     
     @Test
     public void test_FEEL_DROOLS_2143() {
         // DROOLS-2143: Allow ''--1' expression as per FEEL grammar rule 26 
-        assertThat(parseCompileEvaluate("--10"), is(BigDecimal.valueOf(10)));
-        assertThat(parseCompileEvaluate("---10"), is(BigDecimal.valueOf(-10)));
-        assertThat(parseCompileEvaluate("+10"), is(BigDecimal.valueOf(10)));
+        assertThat(parseCompileEvaluate("--10")).isEqualTo(BigDecimal.valueOf(10));
+        assertThat(parseCompileEvaluate("---10")).isEqualTo(BigDecimal.valueOf(-10));
+        assertThat(parseCompileEvaluate("+10")).isEqualTo(BigDecimal.valueOf(10));
     }
 
     @Test
     public void test_FEEL_boolean() {
-        assertThat(parseCompileEvaluate("false"), is( false ));
-        assertThat(parseCompileEvaluate("true"), is( true ));
-        assertThat(parseCompileEvaluate("null"), nullValue());
+        assertThat(parseCompileEvaluate("false")).isEqualTo(Boolean.FALSE);
+        assertThat(parseCompileEvaluate("true")).isEqualTo(Boolean.TRUE);
+        assertThat(parseCompileEvaluate("null")).isNull();
     }
     
     @Test
     public void test_FEEL_null() {
-        assertThat(parseCompileEvaluate("null"), nullValue());
+        assertThat(parseCompileEvaluate("null")).isNull();
     }
     
     @Test
     public void test_FEEL_string() {
-        assertThat(parseCompileEvaluate("\"some string\""), is( "some string" ));
+        assertThat(parseCompileEvaluate("\"some string\"")).isEqualTo("some string" );
     }
     
     @Test
     public void test_primary_parens() {
-        assertThat(parseCompileEvaluate("(\"some string\")"), is( "some string" ));
-        assertThat(parseCompileEvaluate("(123)"), is( BigDecimal.valueOf(123) ));
-        assertThat(parseCompileEvaluate("(-123)"), is( BigDecimal.valueOf(-123) ));
-        assertThat(parseCompileEvaluate("-(123)"), is( BigDecimal.valueOf(-123) ));
-        assertThat(parseCompileEvaluate("(false)"), is( false ));
-        assertThat(parseCompileEvaluate("(true)"), is( true ));
+        assertThat(parseCompileEvaluate("(\"some string\")")).isEqualTo("some string" );
+        assertThat(parseCompileEvaluate("(123)")).isEqualTo(BigDecimal.valueOf(123));
+        assertThat(parseCompileEvaluate("(-123)")).isEqualTo(BigDecimal.valueOf(-123));
+        assertThat(parseCompileEvaluate("-(123)")).isEqualTo(BigDecimal.valueOf(-123));
+        assertThat(parseCompileEvaluate("(false)")).isEqualTo(Boolean.FALSE);
+        assertThat(parseCompileEvaluate("(true)")).isEqualTo(Boolean.TRUE);
     }
     
     /**
@@ -113,29 +108,29 @@ public class DirectCompilerTest {
      */
     @Test
     public void test_ternary_logic() {
-        assertThat(parseCompileEvaluate( "true and true"), is( Boolean.TRUE ));
-        assertThat(parseCompileEvaluate( "true and false"), is( Boolean.FALSE ));
-        assertThat(parseCompileEvaluate( "true and null"), nullValue());
-        assertThat(parseCompileEvaluate( "false and true"), is( Boolean.FALSE ));
-        assertThat(parseCompileEvaluate( "false and false"), is( Boolean.FALSE ));
-        assertThat(parseCompileEvaluate( "false and null"), is( Boolean.FALSE ));
-        assertThat(parseCompileEvaluate( "null and true"), nullValue());
-        assertThat(parseCompileEvaluate( "null and false"), is( Boolean.FALSE ));
-        assertThat(parseCompileEvaluate( "null and null"), nullValue());
-        assertThat(parseCompileEvaluate( "true or true"), is( Boolean.TRUE ));
-        assertThat(parseCompileEvaluate( "true or false"), is( Boolean.TRUE ));
-        assertThat(parseCompileEvaluate( "true or null"), is(  Boolean.TRUE ));
-        assertThat(parseCompileEvaluate( "false or true"), is( Boolean.TRUE ));
-        assertThat(parseCompileEvaluate( "false or false"), is( Boolean.FALSE ));
-        assertThat(parseCompileEvaluate( "false or null"), nullValue());
-        assertThat(parseCompileEvaluate( "null or true"), is( Boolean.TRUE ));
-        assertThat(parseCompileEvaluate( "null or false"), nullValue());
-        assertThat(parseCompileEvaluate( "null or null"), nullValue());
+        assertThat(parseCompileEvaluate( "true and true")).isEqualTo(Boolean.TRUE);
+        assertThat(parseCompileEvaluate( "true and false")).isEqualTo(Boolean.FALSE);
+        assertThat(parseCompileEvaluate( "true and null")).isNull();
+        assertThat(parseCompileEvaluate( "false and true")).isEqualTo(Boolean.FALSE);
+        assertThat(parseCompileEvaluate( "false and false")).isEqualTo(Boolean.FALSE);
+        assertThat(parseCompileEvaluate( "false and null")).isEqualTo(Boolean.FALSE);
+        assertThat(parseCompileEvaluate( "null and true")).isNull();
+        assertThat(parseCompileEvaluate( "null and false")).isEqualTo(Boolean.FALSE);
+        assertThat(parseCompileEvaluate( "null and null")).isNull();
+        assertThat(parseCompileEvaluate( "true or true")).isEqualTo(Boolean.TRUE);
+        assertThat(parseCompileEvaluate( "true or false")).isEqualTo(Boolean.TRUE);
+        assertThat(parseCompileEvaluate( "true or null")).isEqualTo(Boolean.TRUE);
+        assertThat(parseCompileEvaluate( "false or true")).isEqualTo(Boolean.TRUE);
+        assertThat(parseCompileEvaluate( "false or false")).isEqualTo(Boolean.FALSE);
+        assertThat(parseCompileEvaluate( "false or null")).isNull();
+        assertThat(parseCompileEvaluate( "null or true")).isEqualTo(Boolean.TRUE);
+        assertThat(parseCompileEvaluate( "null or false")).isNull();
+        assertThat(parseCompileEvaluate( "null or null")).isNull();
         // logical operator priority
-        assertThat(parseCompileEvaluate( "false and false or true"), is( Boolean.TRUE ));
-        assertThat(parseCompileEvaluate( "false and (false or true)"), is( Boolean.FALSE ));
-        assertThat(parseCompileEvaluate( "true or false and false"), is( Boolean.TRUE ));
-        assertThat(parseCompileEvaluate( "(true or false) and false"), is( Boolean.FALSE  ));
+        assertThat(parseCompileEvaluate( "false and false or true")).isEqualTo(Boolean.TRUE);
+        assertThat(parseCompileEvaluate( "false and (false or true)")).isEqualTo(Boolean.FALSE);
+        assertThat(parseCompileEvaluate( "true or false and false")).isEqualTo(Boolean.TRUE);
+        assertThat(parseCompileEvaluate( "(true or false) and false")).isEqualTo(Boolean.FALSE);
     }
     
     /**
@@ -143,95 +138,95 @@ public class DirectCompilerTest {
      */
     @Test
     public void test_if() {
-        assertThat(parseCompileEvaluate( "if true then 15 else 5"), is(BigDecimal.valueOf( 15 )));
-        assertThat(parseCompileEvaluate( "if false then 15 else 5"), is(BigDecimal.valueOf( 5 )));
-        assertThat(parseCompileEvaluate("if null then 15 else 5"), is(BigDecimal.valueOf(5)));
-        assertThat(parseCompileEvaluate("if \"hello\" then 15 else 5"), is(BigDecimal.valueOf(5)));
+        assertThat(parseCompileEvaluate( "if true then 15 else 5")).isEqualTo(BigDecimal.valueOf( 15 ));
+        assertThat(parseCompileEvaluate( "if false then 15 else 5")).isEqualTo(BigDecimal.valueOf( 5 ));
+        assertThat(parseCompileEvaluate("if null then 15 else 5")).isEqualTo(BigDecimal.valueOf(5));
+        assertThat(parseCompileEvaluate("if \"hello\" then 15 else 5")).isEqualTo(BigDecimal.valueOf(5));
     }
     
     @Test
     public void test_additiveExpression() {
-        assertThat(parseCompileEvaluate( "1 + 2"), is(BigDecimal.valueOf( 3 )));
-        assertThat(parseCompileEvaluate( "1 + null"), nullValue());
-        assertThat(parseCompileEvaluate( "1 - 2"), is(BigDecimal.valueOf( -1 )));
-        assertThat(parseCompileEvaluate( "1 - null"), nullValue());
-        assertThat(parseCompileEvaluate( "\"Hello, \" + \"World\""), is("Hello, World"));
+        assertThat(parseCompileEvaluate( "1 + 2")).isEqualTo(BigDecimal.valueOf( 3 ));
+        assertThat(parseCompileEvaluate( "1 + null")).isNull();
+        assertThat(parseCompileEvaluate( "1 - 2")).isEqualTo(BigDecimal.valueOf( -1 ));
+        assertThat(parseCompileEvaluate( "1 - null")).isNull();
+        assertThat(parseCompileEvaluate( "\"Hello, \" + \"World\"")).isEqualTo("Hello, World");
     }
     
     @Test
     public void test_multiplicativeExpression() {
-        assertThat(parseCompileEvaluate("3 * 5"), is(BigDecimal.valueOf(15)));
-        assertThat(parseCompileEvaluate("3 * null"), nullValue());
-        assertThat(parseCompileEvaluate("10 / 2"), is(BigDecimal.valueOf(5)));
-        assertThat(parseCompileEvaluate("10 / null"), nullValue());
+        assertThat(parseCompileEvaluate("3 * 5")).isEqualTo(BigDecimal.valueOf(15));
+        assertThat(parseCompileEvaluate("3 * null")).isNull();
+        assertThat(parseCompileEvaluate("10 / 2")).isEqualTo(BigDecimal.valueOf(5));
+        assertThat(parseCompileEvaluate("10 / null")).isNull();
     }
 
     @Test
     public void test_exponentiationExpression() {
-        assertThat(parseCompileEvaluate("3 ** 3"), is(BigDecimal.valueOf(27)));
-        assertThat(parseCompileEvaluate("3 ** null"), nullValue());
+        assertThat(parseCompileEvaluate("3 ** 3")).isEqualTo(BigDecimal.valueOf(27));
+        assertThat(parseCompileEvaluate("3 ** null")).isNull();
     }
 
     @Test
     public void test_logicalNegationExpression() {
         // this is all invalid syntax
-        assertThat(parseCompileEvaluate("not true"), nullValue());
-        assertThat(parseCompileEvaluate("not false"), nullValue());
-        assertThat(parseCompileEvaluate("not null"), nullValue());
-        assertThat(parseCompileEvaluate("not 3"), nullValue());
+        assertThat(parseCompileEvaluate("not true")).isNull();
+        assertThat(parseCompileEvaluate("not false")).isNull();
+        assertThat(parseCompileEvaluate("not null")).isNull();
+        assertThat(parseCompileEvaluate("not 3")).isNull();
     }
 
     @Test
     public void test_listExpression() {
-        assertThat(parseCompileEvaluate("[]"), is(Collections.emptyList()));
-        assertThat(parseCompileEvaluate("[ ]"), is(Collections.emptyList()));
-        assertThat(parseCompileEvaluate("[1]"), is(Arrays.asList(BigDecimal.valueOf(1))));
-        assertThat(parseCompileEvaluate("[1, 2,3]"), is(Arrays.asList(BigDecimal.valueOf(1), BigDecimal.valueOf(2), BigDecimal.valueOf(3))));
+        assertThat(parseCompileEvaluate("[]")).asList().isEmpty();
+        assertThat(parseCompileEvaluate("[ ]")).asList().isEmpty();
+        assertThat(parseCompileEvaluate("[1]")).asList().containsExactly(BigDecimal.valueOf(1));
+        assertThat(parseCompileEvaluate("[1, 2,3]")).asList().containsExactly(BigDecimal.valueOf(1), BigDecimal.valueOf(2), BigDecimal.valueOf(3));
     }
 
     @Test
     public void test_instanceOfExpression() {
-        assertThat(parseCompileEvaluate("123 instance of number"), is(true));
-        assertThat(parseCompileEvaluate("\"ciao\" instance of number"), is(false));
-        assertThat(parseCompileEvaluate("123 instance of string"), is(false));
-        assertThat(parseCompileEvaluate("\"ciao\" instance of string"), is(true));
+        assertThat(parseCompileEvaluate("123 instance of number")).isEqualTo(Boolean.TRUE);
+        assertThat(parseCompileEvaluate("\"ciao\" instance of number")).isEqualTo(Boolean.FALSE);
+        assertThat(parseCompileEvaluate("123 instance of string")).isEqualTo(Boolean.FALSE);
+        assertThat(parseCompileEvaluate("\"ciao\" instance of string")).isEqualTo(Boolean.TRUE);
     }
 
     @Test
     public void test_between() {
-        assertThat(parseCompileEvaluate("10 between 5 and 12"), is(true));
-        assertThat(parseCompileEvaluate("10 between 20 and 30"), is(false));
-        assertThat(parseCompileEvaluate("10 between 5 and \"foo\""), nullValue());
-        assertThat(parseCompileEvaluate("\"foo\" between 5 and 12"), nullValue());
-        assertThat(parseCompileEvaluate("\"foo\" between \"bar\" and \"zap\""), is(true));
-        assertThat(parseCompileEvaluate("\"foo\" between null and \"zap\""), nullValue());
+        assertThat(parseCompileEvaluate("10 between 5 and 12")).isEqualTo(Boolean.TRUE);
+        assertThat(parseCompileEvaluate("10 between 20 and 30")).isEqualTo(Boolean.FALSE);
+        assertThat(parseCompileEvaluate("10 between 5 and \"foo\"")).isNull();
+        assertThat(parseCompileEvaluate("\"foo\" between 5 and 12")).isNull();
+        assertThat(parseCompileEvaluate("\"foo\" between \"bar\" and \"zap\"")).isEqualTo(Boolean.TRUE);
+        assertThat(parseCompileEvaluate("\"foo\" between null and \"zap\"")).isNull();
     }
 
     @Test
     public void test_filterPath() {
         // Filtering by index
-        assertThat(parseCompileEvaluate("[\"a\", \"b\", \"c\"][1]"), is("a"));
-        assertThat(parseCompileEvaluate("[\"a\", \"b\", \"c\"][2]"), is("b"));
-        assertThat(parseCompileEvaluate("[\"a\", \"b\", \"c\"][3]"), is("c"));
-        assertThat(parseCompileEvaluate("[\"a\", \"b\", \"c\"][-1]"), is("c"));
-        assertThat(parseCompileEvaluate("[\"a\", \"b\", \"c\"][-2]"), is("b"));
-        assertThat(parseCompileEvaluate("[\"a\", \"b\", \"c\"][-3]"), is("a"));
-        assertThat(parseCompileEvaluate("[\"a\", \"b\", \"c\"][4]"), nullValue());
-        assertThat(parseCompileEvaluate("[\"a\", \"b\", \"c\"][984]"), nullValue());
-        assertThat(parseCompileEvaluate("[\"a\", \"b\", \"c\"][-4]"), nullValue());
-        assertThat(parseCompileEvaluate("[\"a\", \"b\", \"c\"][-984]"), nullValue());
-        assertThat(parseCompileEvaluate("\"a\"[1]"), is("a"));
-        assertThat(parseCompileEvaluate("\"a\"[2]"), nullValue());
-        assertThat(parseCompileEvaluate("\"a\"[-1]"), is("a"));
-        assertThat(parseCompileEvaluate("\"a\"[-2]"), nullValue());
+        assertThat(parseCompileEvaluate("[\"a\", \"b\", \"c\"][1]")).isEqualTo("a");
+        assertThat(parseCompileEvaluate("[\"a\", \"b\", \"c\"][2]")).isEqualTo("b");
+        assertThat(parseCompileEvaluate("[\"a\", \"b\", \"c\"][3]")).isEqualTo("c");
+        assertThat(parseCompileEvaluate("[\"a\", \"b\", \"c\"][-1]")).isEqualTo("c");
+        assertThat(parseCompileEvaluate("[\"a\", \"b\", \"c\"][-2]")).isEqualTo("b");
+        assertThat(parseCompileEvaluate("[\"a\", \"b\", \"c\"][-3]")).isEqualTo("a");
+        assertThat(parseCompileEvaluate("[\"a\", \"b\", \"c\"][4]")).isNull();
+        assertThat(parseCompileEvaluate("[\"a\", \"b\", \"c\"][984]")).isNull();
+        assertThat(parseCompileEvaluate("[\"a\", \"b\", \"c\"][-4]")).isNull();
+        assertThat(parseCompileEvaluate("[\"a\", \"b\", \"c\"][-984]")).isNull();
+        assertThat(parseCompileEvaluate("\"a\"[1]")).isEqualTo("a");
+        assertThat(parseCompileEvaluate("\"a\"[2]")).isNull();
+        assertThat(parseCompileEvaluate("\"a\"[-1]")).isEqualTo("a");
+        assertThat(parseCompileEvaluate("\"a\"[-2]")).isNull();
 
         // Filtering by boolean expression
-        assertThat(parseCompileEvaluate("[1, 2, 3, 4][item = 4]"), is(Arrays.asList(BigDecimal.valueOf(4))));
-        assertThat(parseCompileEvaluate("[1, 2, 3, 4][item > 2]"), is(Arrays.asList(BigDecimal.valueOf(3), BigDecimal.valueOf(4))));
-        assertThat(parseCompileEvaluate("[1, 2, 3, 4][item > 5]"), is(Collections.emptyList()));
-        assertThat(parseCompileEvaluate("[ {x:1, y:2}, {x:2, y:3} ][x = 1]"), is(Arrays.asList(mapOf(entry("x", new BigDecimal(1)), entry("y", new BigDecimal(2))))));
-        assertThat(parseCompileEvaluate("[ {x:1, y:2}, {x:2, y:3} ][x > 1]"), is(Arrays.asList(mapOf(entry("x", new BigDecimal(2)), entry("y", new BigDecimal(3))))));
-        assertThat(parseCompileEvaluate("[ {x:1, y:2}, {x:2, y:3} ][x = 0]"), is(Collections.emptyList()));
+        assertThat(parseCompileEvaluate("[1, 2, 3, 4][item = 4]")).asList().containsExactly(BigDecimal.valueOf(4));
+        assertThat(parseCompileEvaluate("[1, 2, 3, 4][item > 2]")).asList().containsExactly(BigDecimal.valueOf(3), BigDecimal.valueOf(4));
+        assertThat(parseCompileEvaluate("[1, 2, 3, 4][item > 5]")).asList().isEmpty();
+        assertThat(parseCompileEvaluate("[ {x:1, y:2}, {x:2, y:3} ][x = 1]")).asList().containsExactly(mapOf(entry("x", new BigDecimal(1)), entry("y", new BigDecimal(2))));
+        assertThat(parseCompileEvaluate("[ {x:1, y:2}, {x:2, y:3} ][x > 1]")).asList().containsExactly(mapOf(entry("x", new BigDecimal(2)), entry("y", new BigDecimal(3))));
+        assertThat(parseCompileEvaluate("[ {x:1, y:2}, {x:2, y:3} ][x = 0]")).asList().isEmpty();
     }
 
     @Test
@@ -244,7 +239,7 @@ public class DirectCompilerTest {
         Object result = nameRef.apply(context);
         LOG.debug("{}", result);
         
-        assertThat(result, is(mapOf(entry("x", new BigDecimal(2)), entry("y", new BigDecimal(3)))));
+        assertThat(result).isEqualTo(mapOf(entry("x", new BigDecimal(2)), entry("y", new BigDecimal(3))));
     }
 
     @Test
@@ -257,26 +252,27 @@ public class DirectCompilerTest {
         Object result = nameRef.apply(context);
         LOG.debug("{}", result);
 
-        assertThat(result, is(Collections.emptyList()));
+        assertThat(result).asList().isEmpty();
     }
 
     @Test
     public void test_filterPathSelection() {
         // Selection
-        assertThat(parseCompileEvaluate("[ {x:1, y:2}, {x:2, y:3} ].y"), is(Arrays.asList(BigDecimal.valueOf(2), BigDecimal.valueOf(3))));
-        assertThat(parseCompileEvaluate("[ {x:1, y:2}, {x:2} ].y"), is(Arrays.asList(BigDecimal.valueOf(2))));
-        assertThat(parseCompileEvaluate("[ {x:1, y:2}, {x:2, y:3} ].z"), is(Collections.emptyList()));
+        assertThat(parseCompileEvaluate("[ {x:1, y:2}, {x:2, y:3} ].y")).asList().containsExactly(BigDecimal.valueOf(2), BigDecimal.valueOf(3));
+        assertThat(parseCompileEvaluate("[ {x:1, y:2}, {x:2} ].y")).asList().containsExactly(BigDecimal.valueOf(2));
+        assertThat(parseCompileEvaluate("[ {x:1, y:2}, {x:2, y:3} ].z")).asList().isEmpty();
     }
 
     @Test
     public void test_for() {
         // for
-        assertThat(parseCompileEvaluate("for x in [ 10, 20, 30 ], y in [ 1, 2, 3 ] return x * y"),
-                   is(Arrays.asList(10, 20, 30, 20, 40, 60, 30, 60, 90).stream().map(x -> BigDecimal.valueOf(x)).collect(Collectors.toList())));
+        Object parseCompileEvaluate = parseCompileEvaluate("for x in [ 10, 20, 30 ], y in [ 1, 2, 3 ] return x * y");
+		assertThat(parseCompileEvaluate).asList().
+		containsExactly(BigDecimal.valueOf(10), BigDecimal.valueOf(20), BigDecimal.valueOf(30), BigDecimal.valueOf(20), BigDecimal.valueOf(40), BigDecimal.valueOf(60), BigDecimal.valueOf(30), BigDecimal.valueOf(60), BigDecimal.valueOf(90));
 
         // normal:
-        assertThat(parseCompileEvaluate("for x in [1, 2, 3] return x+1"),
-                   is(Arrays.asList(1, 2, 3).stream().map(x -> BigDecimal.valueOf(x + 1)).collect(Collectors.toList())));
+        assertThat(parseCompileEvaluate("for x in [1, 2, 3] return x+1")).asList().
+            	containsExactly(BigDecimal.valueOf(2), BigDecimal.valueOf(3), BigDecimal.valueOf(4));
         
         // TODO in order to parse correctly the enhanced for loop it is required to configure the FEEL Profiles
     }
@@ -284,63 +280,63 @@ public class DirectCompilerTest {
     @Test
     public void test_quantifiedExpressions() {
         // quantified expressions
-        assertThat(parseCompileEvaluate("some price in [ 80, 11, 110 ] satisfies price > 100"), is(Boolean.TRUE));
-        assertThat(parseCompileEvaluate("some price in [ 80, 11, 90 ] satisfies price > 100"), is(Boolean.FALSE));
-        assertThat(parseCompileEvaluate("some x in [ 5, 6, 7 ], y in [ 10, 11, 6 ] satisfies x > y"), is(Boolean.TRUE));
-        assertThat(parseCompileEvaluate("every price in [ 80, 11, 90 ] satisfies price > 10"), is(Boolean.TRUE));
-        assertThat(parseCompileEvaluate("every price in [ 80, 11, 90 ] satisfies price > 70"), is(Boolean.FALSE));
-        assertThat(parseCompileEvaluate("some x in [ 5, 6, 7 ], y in [ 10, 11, 12 ] satisfies x < y"), is(Boolean.TRUE));
-        assertThat(parseCompileEvaluate("some price in [ 80, 11, 110 ] satisfies price > max(100, 50, 10)"), is(Boolean.TRUE));
+        assertThat(parseCompileEvaluate("some price in [ 80, 11, 110 ] satisfies price > 100")).isEqualTo(Boolean.TRUE);
+        assertThat(parseCompileEvaluate("some price in [ 80, 11, 90 ] satisfies price > 100")).isEqualTo(Boolean.FALSE);
+        assertThat(parseCompileEvaluate("some x in [ 5, 6, 7 ], y in [ 10, 11, 6 ] satisfies x > y")).isEqualTo(Boolean.TRUE);
+        assertThat(parseCompileEvaluate("every price in [ 80, 11, 90 ] satisfies price > 10")).isEqualTo(Boolean.TRUE);
+        assertThat(parseCompileEvaluate("every price in [ 80, 11, 90 ] satisfies price > 70")).isEqualTo(Boolean.FALSE);
+        assertThat(parseCompileEvaluate("some x in [ 5, 6, 7 ], y in [ 10, 11, 12 ] satisfies x < y")).isEqualTo(Boolean.TRUE);
+        assertThat(parseCompileEvaluate("some price in [ 80, 11, 110 ] satisfies price > max(100, 50, 10)")).isEqualTo(Boolean.TRUE);
     }
 
     @Test
     public void test_basicFunctionInvocation() {
-        assertThat(parseCompileEvaluate("max(1, 2, 3)"), is(new BigDecimal(3)));
+        assertThat(parseCompileEvaluate("max(1, 2, 3)")).isEqualTo(new BigDecimal(3));
     }
 
     @Test
     public void test_basicFunctionDefinition() {
-        assertThat(parseCompileEvaluate("function (a, b) a + b"), is(instanceOf(CompiledCustomFEELFunction.class)));
-        assertThat(parseCompileEvaluate("{ s : function (a, b) a + b, x : 1, y : 2, r : s(x,y) }.r"), is(new BigDecimal(3)));
+        assertThat(parseCompileEvaluate("function (a, b) a + b")).isInstanceOf(CompiledCustomFEELFunction.class);
+        assertThat(parseCompileEvaluate("{ s : function (a, b) a + b, x : 1, y : 2, r : s(x,y) }.r")).isEqualTo(new BigDecimal(3));
     }
 
     @Test
     public void test_namedFunctionInvocation() {
-        assertThat(parseCompileEvaluate("substring(start position: 2, string: \"FOOBAR\")"), is("OOBAR"));
-        assertThat(parseCompileEvaluate("ceiling( n : 1.5 )"), is(new BigDecimal("2")));
+        assertThat(parseCompileEvaluate("substring(start position: 2, string: \"FOOBAR\")")).isEqualTo("OOBAR");
+        assertThat(parseCompileEvaluate("ceiling( n : 1.5 )")).isEqualTo(new BigDecimal("2"));
     }
 
     @Test
     public void test_Misc_fromOriginalFEELInterpretedTestSuite() {
-        assertThat(parseCompileEvaluate("if null then \"foo\" else \"bar\""), is("bar"));
-        assertThat(parseCompileEvaluate("{ hello world : function() \"Hello World!\", message : hello world() }.message"), is("Hello World!"));
-        assertThat(parseCompileEvaluate("1 + if true then 1 else 2"), is(new BigDecimal("2")));
-        assertThat(parseCompileEvaluate("\"string with \\\"quotes\\\"\""), is("string with \"quotes\""));
-        assertThat(parseCompileEvaluate("date( -0105, 8, 2 )"), is(LocalDate.of(-105, 8, 2)));
-        assertThat(parseCompileEvaluate("string(null)"), is(nullValue()));
-        assertThat(parseCompileEvaluate("[ null ]"), is(Arrays.asList(new Object[]{null})));
-        assertThat(parseCompileEvaluate("[ null, null ]"), is(Arrays.asList(new Object[]{null, null})));
-        assertThat(parseCompileEvaluate("[ null, 47, null ]"), is(Arrays.asList(new Object[]{null, BigDecimal.valueOf(47), null})));
+        assertThat(parseCompileEvaluate("if null then \"foo\" else \"bar\"")).isEqualTo("bar");
+        assertThat(parseCompileEvaluate("{ hello world : function() \"Hello World!\", message : hello world() }.message")).isEqualTo("Hello World!");
+        assertThat(parseCompileEvaluate("1 + if true then 1 else 2")).isEqualTo(new BigDecimal("2"));
+        assertThat(parseCompileEvaluate("\"string with \\\"quotes\\\"\"")).isEqualTo("string with \"quotes\"");
+        assertThat(parseCompileEvaluate("date( -0105, 8, 2 )")).isEqualTo(LocalDate.of(-105, 8, 2));
+        assertThat(parseCompileEvaluate("string(null)")).isNull();
+        assertThat(parseCompileEvaluate("[ null ]")).asList().containsExactly(new Object[]{null});
+        assertThat(parseCompileEvaluate("[ null, null ]")).asList().containsExactly(new Object[]{null, null});
+        assertThat(parseCompileEvaluate("[ null, 47, null ]")).asList().containsExactly(new Object[]{null, BigDecimal.valueOf(47), null});
     }
 
     @Test
     public void test_Benchmark_feelExpressions() {
-        assertThat(parseCompileEvaluate("{ full name: { first name: \"John\", last name: \"Doe\" } }.full name.last name"), is("Doe"));
-        assertThat(parseCompileEvaluate("some price in [ 80, 11, 110 ] satisfies price > 100"), is(Boolean.TRUE));
-        assertThat(parseCompileEvaluate("every price in [ 80, 11, 90 ] satisfies price > 10"), is(Boolean.TRUE));
+        assertThat(parseCompileEvaluate("{ full name: { first name: \"John\", last name: \"Doe\" } }.full name.last name")).isEqualTo("Doe");
+        assertThat(parseCompileEvaluate("some price in [ 80, 11, 110 ] satisfies price > 100")).isEqualTo(Boolean.TRUE);
+        assertThat(parseCompileEvaluate("every price in [ 80, 11, 90 ] satisfies price > 10")).isEqualTo(Boolean.TRUE);
     }
 
     @Test
     public void test_contextExpression() {
-        assertThat(parseCompileEvaluate("{}"), is(Collections.emptyMap()));
-        assertThat(parseCompileEvaluate("{ }"), is(Collections.emptyMap()));
-        assertThat(parseCompileEvaluate("{ a : 1 }"), is(mapOf(entry("a", new BigDecimal(1)))));
-        assertThat(parseCompileEvaluate("{ \"a\" : 1 }"), is(mapOf(entry("a", new BigDecimal(1)))));
-        assertThat(parseCompileEvaluate("{ \" a\" : 1 }"), is(mapOf(entry(" a", new BigDecimal(1))))); // Demonstrating a bad practice.
-        assertThat(parseCompileEvaluate("{ a : 1, b : 2, c : 3 }"), is(mapOf(entry("a", new BigDecimal(1)), entry("b", new BigDecimal(2)), entry("c", new BigDecimal(3)))));
-        assertThat(parseCompileEvaluate("{ a : 1, a name : \"John Doe\" }"), is(mapOf(entry("a", new BigDecimal(1)), entry("a name", "John Doe"))));
+        assertThat(parseCompileEvaluate("{}")).isEqualTo(Collections.emptyMap());
+        assertThat(parseCompileEvaluate("{ }")).isEqualTo(Collections.emptyMap());
+        assertThat(parseCompileEvaluate("{ a : 1 }")).isEqualTo(mapOf(entry("a", new BigDecimal(1))));
+        assertThat(parseCompileEvaluate("{ \"a\" : 1 }")).isEqualTo(mapOf(entry("a", new BigDecimal(1))));
+        assertThat(parseCompileEvaluate("{ \" a\" : 1 }")).isEqualTo(mapOf(entry(" a", new BigDecimal(1)))); // Demonstrating a bad practice.
+        assertThat(parseCompileEvaluate("{ a : 1, b : 2, c : 3 }")).isEqualTo(mapOf(entry("a", new BigDecimal(1)), entry("b", new BigDecimal(2)), entry("c", new BigDecimal(3))));
+        assertThat(parseCompileEvaluate("{ a : 1, a name : \"John Doe\" }")).isEqualTo(mapOf(entry("a", new BigDecimal(1)), entry("a name", "John Doe")));
 
-        assertThat(parseCompileEvaluate("{ a : 1, b : a }"), is(mapOf(entry("a", new BigDecimal(1)), entry("b", new BigDecimal(1)))));
+        assertThat(parseCompileEvaluate("{ a : 1, b : a }")).isEqualTo(mapOf(entry("a", new BigDecimal(1)), entry("b", new BigDecimal(1))));
     }
     
     /**
@@ -351,7 +347,7 @@ public class DirectCompilerTest {
         String inputExpression = "{ \"a string key\" : 10," + "\n"
                                + " a non-string key : 11," + "\n"
                                + " a key.with + /' odd chars : 12 }";
-        assertThat(parseCompileEvaluate(inputExpression), is(mapOf(entry("a string key", new BigDecimal(10)), entry("a non-string key", new BigDecimal(11)), entry("a key.with + /' odd chars", new BigDecimal(12)))));
+        assertThat(parseCompileEvaluate(inputExpression)).isEqualTo(mapOf(entry("a string key", new BigDecimal(10)), entry("a non-string key", new BigDecimal(11)), entry("a key.with + /' odd chars", new BigDecimal(12))));
     }
     
     /**
@@ -371,13 +367,13 @@ public class DirectCompilerTest {
                        + "    xxx: last + name" + "\n"
                        + " } " + "\n"
                        + "}";
-        assertThat(parseCompileEvaluate(inputExpression), is(mapOf(entry("a value", new BigDecimal(10)), 
+        assertThat(parseCompileEvaluate(inputExpression)).isEqualTo(mapOf(entry("a value", new BigDecimal(10)), 
                                                                    entry("an applicant", mapOf(entry("first name", "Edson"),
                                                                                                entry("last + name", "Tirelli"),
                                                                                                entry("full name", "EdsonTirelli"),
                                                                                                entry("address", mapOf(entry("street", "55 broadway st"),
                                                                                                                       entry("city", "New York"))),
-                                                                                               entry("xxx", "Tirelli"))))));
+                                                                                               entry("xxx", "Tirelli")))));
     }
 
     /**
@@ -393,9 +389,9 @@ public class DirectCompilerTest {
                                 "   },                                             \n" +
                                 "   street : an applicant.home address.street name \n" +
                                 "}                                                 ";
-        assertThat(parseCompileEvaluate(complexContext), is(mapOf(entry("an applicant", mapOf(entry("home address", mapOf(entry("street name", "broadway st"),
+        assertThat(parseCompileEvaluate(complexContext)).isEqualTo(mapOf(entry("an applicant", mapOf(entry("home address", mapOf(entry("street name", "broadway st"),
                                                                                                                           entry("city", "New York"))))),
-                                                                  entry("street", "broadway st"))));
+                                                                  entry("street", "broadway st")));
     }
 
     @Test
@@ -409,7 +405,7 @@ public class DirectCompilerTest {
         Object result = nameRef.apply(context);
         LOG.debug("{}", result);
         
-        assertThat(result, is( BigDecimal.valueOf(123) ));
+        assertThat(result).isEqualTo(BigDecimal.valueOf(123));
     }
     
     @Test
@@ -424,7 +420,7 @@ public class DirectCompilerTest {
         Object result = qualRef.apply(context);
         LOG.debug("{}", result);
         
-        assertThat(result, is( "John Doe" ));
+        assertThat(result).isEqualTo("John Doe" );
 
         // check number coercion for qualified name
         CompiledFEELExpression personAgeExpression = parse("My Person.Age", mapOf(entry("My Person", personType)));
@@ -433,7 +429,7 @@ public class DirectCompilerTest {
         Object resultPersonAge = personAgeExpression.apply(context); // Please notice input variable in context is a Map containing and entry value for int 47.
         LOG.debug("{}", resultPersonAge);
 
-        assertThat(resultPersonAge, is(BigDecimal.valueOf(47)));
+        assertThat(resultPersonAge).isEqualTo(BigDecimal.valueOf(47));
     }
     
     public static class MyPerson {
@@ -454,7 +450,7 @@ public class DirectCompilerTest {
         Object result = qualRef.apply(context);
         LOG.debug("{}", result);
         
-        assertThat(result, is( "John Doe" ));
+        assertThat(result).isEqualTo("John Doe" );
     }
 
     @Test
@@ -469,7 +465,7 @@ public class DirectCompilerTest {
         Object result = qualRef.apply(context);
         LOG.debug("{}", result);
         
-        assertThat(result, is(BigDecimal.valueOf(2016)));
+        assertThat(result).isEqualTo(BigDecimal.valueOf(2016));
     }
 
     private CompiledFEELExpression parse(String input) {

--- a/kie-dmn/kie-dmn-feel/src/test/java/org/kie/dmn/feel/codegen/feel11/DirectCompilerUnaryTestsTest.java
+++ b/kie-dmn/kie-dmn-feel/src/test/java/org/kie/dmn/feel/codegen/feel11/DirectCompilerUnaryTestsTest.java
@@ -16,7 +16,6 @@
 
 package org.kie.dmn.feel.codegen.feel11;
 
-import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
@@ -36,8 +35,7 @@ import org.kie.dmn.feel.util.EvalHelper;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import static org.hamcrest.CoreMatchers.is;
-import static org.hamcrest.MatcherAssert.assertThat;
+import static org.assertj.core.api.Assertions.assertThat;
 
 public class DirectCompilerUnaryTestsTest {
 
@@ -65,48 +63,48 @@ public class DirectCompilerUnaryTestsTest {
 
     @Test
     public void test_Dash() {
-        assertThat(parseCompileEvaluate("-", 1), is(Arrays.asList(true)));
-        assertThat(parseCompileEvaluate("-, -", 1), is(Collections.emptyList()));
+        assertThat(parseCompileEvaluate("-", 1)).containsExactly(Boolean.TRUE);
+        assertThat(parseCompileEvaluate("-, -", 1)).isEmpty();
     }
     
     @Test
     public void test_positiveUnaryTestIneq() {
-        assertThat(parseCompileEvaluate("<47", 1), is(Arrays.asList(true)));
-        assertThat(parseCompileEvaluate("<47, <100", 1), is(Arrays.asList(true, true)));
-        assertThat(parseCompileEvaluate("<47, <100, <-47", 1), is(Arrays.asList(true, true, false)));
-        assertThat(parseCompileEvaluate(">=1, >2, <3, <=4", 0), is(Arrays.asList(false, false, true, true)));
-        assertThat(parseCompileEvaluate(">=1, >2, <3, <=4", 1), is(Arrays.asList(true, false, true, true)));
-        assertThat(parseCompileEvaluate(">=1, >2, <3, <=4", 2), is(Arrays.asList(true, false, true, true)));
-        assertThat(parseCompileEvaluate(">=1, >2, <3, <=4", 3), is(Arrays.asList(true, true, false, true)));
-        assertThat(parseCompileEvaluate(">=1, >2, <3, <=4", 4), is(Arrays.asList(true, true, false, true)));
-        assertThat(parseCompileEvaluate(">=1, >2, <3, <=4", 5), is(Arrays.asList(true, true, false, false)));
-        assertThat(parseCompileEvaluate("!=1, !=42", 1), is(Arrays.asList(false, true)));
+        assertThat(parseCompileEvaluate("<47", 1)).containsExactly(Boolean.TRUE);
+        assertThat(parseCompileEvaluate("<47, <100", 1)).containsExactly(Boolean.TRUE, Boolean.TRUE);
+        assertThat(parseCompileEvaluate("<47, <100, <-47", 1)).containsExactly(Boolean.TRUE, Boolean.TRUE, Boolean.FALSE);
+        assertThat(parseCompileEvaluate(">=1, >2, <3, <=4", 0)).containsExactly(Boolean.FALSE, Boolean.FALSE, Boolean.TRUE, Boolean.TRUE);
+        assertThat(parseCompileEvaluate(">=1, >2, <3, <=4", 1)).containsExactly(Boolean.TRUE, Boolean.FALSE, Boolean.TRUE, Boolean.TRUE);
+        assertThat(parseCompileEvaluate(">=1, >2, <3, <=4", 2)).containsExactly(Boolean.TRUE, Boolean.FALSE, Boolean.TRUE, Boolean.TRUE);
+        assertThat(parseCompileEvaluate(">=1, >2, <3, <=4", 3)).containsExactly(Boolean.TRUE, Boolean.TRUE, Boolean.FALSE, Boolean.TRUE);
+        assertThat(parseCompileEvaluate(">=1, >2, <3, <=4", 4)).containsExactly(Boolean.TRUE, Boolean.TRUE, Boolean.FALSE, Boolean.TRUE);
+        assertThat(parseCompileEvaluate(">=1, >2, <3, <=4", 5)).containsExactly(Boolean.TRUE, Boolean.TRUE, Boolean.FALSE, Boolean.FALSE);
+        assertThat(parseCompileEvaluate("!=1, !=42", 1)).containsExactly(Boolean.FALSE, Boolean.TRUE);
     }
     
     @Test
     public void test_positiveUnaryTestIneq_forEQ() {
-        assertThat(parseCompileEvaluate("<47, =1", 1), is(Arrays.asList(true, true)));
-        assertThat(parseCompileEvaluate("<47, =47", 1), is(Arrays.asList(true, false)));
-        assertThat(parseCompileEvaluate("<47, 1", 1), is(Arrays.asList(true, true)));
-        assertThat(parseCompileEvaluate("<47, 47", 1), is(Arrays.asList(true, false)));
+        assertThat(parseCompileEvaluate("<47, =1", 1)).containsExactly(Boolean.TRUE, Boolean.TRUE);
+        assertThat(parseCompileEvaluate("<47, =47", 1)).containsExactly(Boolean.TRUE, Boolean.FALSE);
+        assertThat(parseCompileEvaluate("<47, 1", 1)).containsExactly(Boolean.TRUE, Boolean.TRUE);
+        assertThat(parseCompileEvaluate("<47, 47", 1)).containsExactly(Boolean.TRUE, Boolean.FALSE);
     }
 
     @Test
     public void test_not() {
-        assertThat(parseCompileEvaluate("not(=47), not(<1), not(!=1)", 1), is(Collections.emptyList()));
+        assertThat(parseCompileEvaluate("not(=47), not(<1), not(!=1)", 1)).isEmpty();
     }
 
     @Test
     public void test_simpleUnaryTest_forRANGE() {
-        assertThat(parseCompileEvaluate("[1..2]", 1), is(Collections.singletonList(true)));
-        assertThat(parseCompileEvaluate("[1..2], [2..3]", 1), is(Arrays.asList(true, false)));
-        assertThat(parseCompileEvaluate("(1..2], [2..3]", 1), is(Arrays.asList(false, false)));
-        assertThat(parseCompileEvaluate("(1..2], [2..3]", 2), is(Arrays.asList(true, true)));
+        assertThat(parseCompileEvaluate("[1..2]", 1)).containsExactly(Boolean.TRUE);
+        assertThat(parseCompileEvaluate("[1..2], [2..3]", 1)).containsExactly(Boolean.TRUE, Boolean.FALSE);
+        assertThat(parseCompileEvaluate("(1..2], [2..3]", 1)).containsExactly(Boolean.FALSE, Boolean.FALSE);
+        assertThat(parseCompileEvaluate("(1..2], [2..3]", 2)).containsExactly(Boolean.TRUE, Boolean.TRUE);
     }
 
     @Test
     public void t2() {
-        assertThat(parseCompileEvaluate("\"asd\"", "asd"), is(Collections.singletonList(true)));
+        assertThat(parseCompileEvaluate("\"asd\"", "asd")).containsExactly(Boolean.TRUE);
     }
 
     private CompiledFEELUnaryTests parse(String input, FEELEventListenersManager mgr, CompiledFEELSupport.SyntaxErrorListener listener) {

--- a/kie-dmn/kie-dmn-feel/src/test/java/org/kie/dmn/feel/codegen/feel11/ManualBasicFunctionInvocationTest.java
+++ b/kie-dmn/kie-dmn-feel/src/test/java/org/kie/dmn/feel/codegen/feel11/ManualBasicFunctionInvocationTest.java
@@ -24,8 +24,7 @@ import org.kie.dmn.feel.lang.EvaluationContext;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import static org.hamcrest.CoreMatchers.is;
-import static org.hamcrest.MatcherAssert.assertThat;
+import static org.assertj.core.api.Assertions.assertThat;
 
 public class ManualBasicFunctionInvocationTest {
 
@@ -56,7 +55,7 @@ public class ManualBasicFunctionInvocationTest {
         Object result = compiledExpression.apply(emptyContext);
         LOG.debug("{}", result);
 
-        assertThat(result, is(BigDecimal.valueOf(3)));
+        assertThat(result).isEqualTo(BigDecimal.valueOf(3));
     }
 
 }

--- a/kie-dmn/kie-dmn-feel/src/test/java/org/kie/dmn/feel/codegen/feel11/ManualContextTest.java
+++ b/kie-dmn/kie-dmn-feel/src/test/java/org/kie/dmn/feel/codegen/feel11/ManualContextTest.java
@@ -23,9 +23,7 @@ import org.kie.dmn.feel.lang.EvaluationContext;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import static org.hamcrest.CoreMatchers.instanceOf;
-import static org.hamcrest.CoreMatchers.is;
-import static org.hamcrest.MatcherAssert.assertThat;
+import static org.assertj.core.api.Assertions.assertThat;
 
 public class ManualContextTest {
 
@@ -64,8 +62,8 @@ public class ManualContextTest {
         Object result = compiledExpression.apply(emptyContext);
         LOG.debug("{}", result);
 
-        assertThat(result, is(instanceOf(Map.class)));
-        assertThat(((Map) result).get("street"), is("broadway st"));
+        assertThat(result).isInstanceOf(Map.class);
+        assertThat(((Map<String, String>) result)).containsEntry("street", "broadway st");
     }
 
 }

--- a/kie-dmn/kie-dmn-feel/src/test/java/org/kie/dmn/feel/codegen/feel11/ManualFilterTest.java
+++ b/kie-dmn/kie-dmn-feel/src/test/java/org/kie/dmn/feel/codegen/feel11/ManualFilterTest.java
@@ -17,15 +17,13 @@
 package org.kie.dmn.feel.codegen.feel11;
 
 import java.math.BigDecimal;
-import java.util.Arrays;
 
 import org.junit.Test;
 import org.kie.dmn.feel.lang.EvaluationContext;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import static org.hamcrest.CoreMatchers.is;
-import static org.hamcrest.MatcherAssert.assertThat;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.kie.dmn.feel.codegen.feel11.CompiledFEELSemanticMappings.gt;
 
 public class ManualFilterTest {
@@ -65,7 +63,7 @@ public class ManualFilterTest {
         Object result = compiledExpression.apply(emptyContext);
         LOG.debug("{}", result);
 
-        assertThat(result, is(Arrays.asList(BigDecimal.valueOf(3), BigDecimal.valueOf(4))));
+        assertThat(result).asList().containsExactly(BigDecimal.valueOf(3), BigDecimal.valueOf(4));
     }
 
 }

--- a/kie-dmn/kie-dmn-feel/src/test/java/org/kie/dmn/feel/codegen/feel11/ManualForTest.java
+++ b/kie-dmn/kie-dmn-feel/src/test/java/org/kie/dmn/feel/codegen/feel11/ManualForTest.java
@@ -24,8 +24,7 @@ import org.kie.dmn.feel.lang.EvaluationContext;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import static org.hamcrest.CoreMatchers.is;
-import static org.hamcrest.MatcherAssert.assertThat;
+import static org.assertj.core.api.Assertions.assertThat;
 
 public class ManualForTest {
     
@@ -65,9 +64,9 @@ public class ManualForTest {
         Object result = compiledExpression.apply(emptyContext);
         LOG.debug("{}", result);
 
-        assertThat(result, is(Arrays.asList(BigDecimal.valueOf(10), BigDecimal.valueOf(20), BigDecimal.valueOf(30),
+        assertThat(result).asList().containsExactly(BigDecimal.valueOf(10), BigDecimal.valueOf(20), BigDecimal.valueOf(30),
                                             BigDecimal.valueOf(20), BigDecimal.valueOf(40), BigDecimal.valueOf(60),
-                                            BigDecimal.valueOf(30), BigDecimal.valueOf(60), BigDecimal.valueOf(90))));
+                                            BigDecimal.valueOf(30), BigDecimal.valueOf(60), BigDecimal.valueOf(90));
     }
 
 }

--- a/kie-dmn/kie-dmn-feel/src/test/java/org/kie/dmn/feel/codegen/feel11/ManualNamedFunctionInvocationTest.java
+++ b/kie-dmn/kie-dmn-feel/src/test/java/org/kie/dmn/feel/codegen/feel11/ManualNamedFunctionInvocationTest.java
@@ -24,8 +24,7 @@ import org.kie.dmn.feel.lang.impl.NamedParameter;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import static org.hamcrest.CoreMatchers.is;
-import static org.hamcrest.MatcherAssert.assertThat;
+import static org.assertj.core.api.Assertions.assertThat;
 
 public class ManualNamedFunctionInvocationTest {
     
@@ -56,7 +55,7 @@ public class ManualNamedFunctionInvocationTest {
         Object result = compiledExpression.apply(emptyContext);
         LOG.debug("{}", result);
 
-        assertThat(result, is("OOBAR"));
+        assertThat(result).isEqualTo("OOBAR");
     }
 
 }

--- a/kie-dmn/kie-dmn-feel/src/test/java/org/kie/dmn/feel/codegen/feel11/ManualQuantTest.java
+++ b/kie-dmn/kie-dmn-feel/src/test/java/org/kie/dmn/feel/codegen/feel11/ManualQuantTest.java
@@ -24,8 +24,7 @@ import org.kie.dmn.feel.lang.ast.QuantifiedExpressionNode.Quantifier;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import static org.hamcrest.CoreMatchers.is;
-import static org.hamcrest.MatcherAssert.assertThat;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.kie.dmn.feel.codegen.feel11.CompiledFEELSemanticMappings.gt;
 
 public class ManualQuantTest {
@@ -61,7 +60,7 @@ public class ManualQuantTest {
         Object result = compiledExpression.apply(emptyContext);
         LOG.debug("{}", result);
 
-        assertThat(result, is(true));
+        assertThat(result).isEqualTo(Boolean.TRUE);
     }
 
 }

--- a/kie-dmn/kie-dmn-feel/src/test/java/org/kie/dmn/feel/codegen/feel11/ManualUnaryTestsTest.java
+++ b/kie-dmn/kie-dmn-feel/src/test/java/org/kie/dmn/feel/codegen/feel11/ManualUnaryTestsTest.java
@@ -29,8 +29,7 @@ import org.kie.dmn.feel.util.EvalHelper;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import static org.hamcrest.CoreMatchers.is;
-import static org.hamcrest.MatcherAssert.assertThat;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.kie.dmn.feel.codegen.feel11.CompiledFEELSemanticMappings.lt;
 
 public class ManualUnaryTestsTest {
@@ -61,7 +60,7 @@ public class ManualUnaryTestsTest {
         List<Boolean> result = compiledUnaryTests.getUnaryTests().stream().map(ut -> ut.apply(emptyContext, left)).collect(Collectors.toList());
         LOG.debug("{}", result);
 
-        assertThat(result, is(Arrays.asList(true, false)));
+        assertThat(result).asList().containsExactly(true, false);
     }
 
 }

--- a/kie-dmn/kie-dmn-feel/src/test/java/org/kie/dmn/feel/lang/examples/CompileEvaluateTest.java
+++ b/kie-dmn/kie-dmn-feel/src/test/java/org/kie/dmn/feel/lang/examples/CompileEvaluateTest.java
@@ -38,11 +38,6 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.hasSize;
-import static org.hamcrest.Matchers.instanceOf;
-import static org.hamcrest.Matchers.is;
-import static org.hamcrest.Matchers.nullValue;
 import static org.junit.Assert.assertTrue;
 import static org.kie.dmn.feel.util.DynamicTypeUtils.entry;
 import static org.kie.dmn.feel.util.DynamicTypeUtils.prototype;
@@ -90,7 +85,7 @@ public class CompileEvaluateTest {
         
         CompiledExpression compiledExpression = feel.compile( "Person List[My Variable 1 = \"A\"]", ctx );
         
-        assertThat(errors.toString(), errors.size(), is(0) );
+        assertThat(errors).as(errors.toString()).hasSize(0);
 
         Map<String, Object> inputs = new HashMap<>();
         List<Map<String, ?>> pList = new ArrayList<>();
@@ -104,9 +99,9 @@ public class CompileEvaluateTest {
         
         Object result = feel.evaluate(compiledExpression, inputs);
         
-        assertThat( result, instanceOf( List.class ) );
-        assertThat( (List<?>) result, hasSize(1) );
-        assertThat( ((Map<?, ?>) ((List<?>) result).get(0)).get("Full Name"), is("Edson Tirelli") );
+        assertThat(result).isInstanceOf(List.class);
+        assertThat((List<?>) result).hasSize(1);
+        assertThat(((Map<?, ?>) ((List<?>) result).get(0)).get("Full Name")).isEqualTo("Edson Tirelli");
     }        
     
     @Test
@@ -116,14 +111,14 @@ public class CompileEvaluateTest {
         
         CompiledExpression compiledExpression = feel.compile( "MyPerson.fullName", ctx );
         
-        assertThat(errors.toString(), errors.size(), is(1) );
+        assertThat(errors).as(errors.toString()).hasSize(1);
         
         Map<String, Object> inputs = new HashMap<>();
         inputs.put( "MyPerson", prototype(entry("FullName", "John Doe")) );
         
         Object result = feel.evaluate(compiledExpression, inputs);
         
-        assertThat(result, nullValue());
+        assertThat(result).isNull();
     }
 
     @Test
@@ -138,7 +133,7 @@ public class CompileEvaluateTest {
         
         Object result = feel.evaluate(compiledExpression, inputs);
         
-        assertThat(result, is("John Doe"));
+        assertThat(result).isEqualTo("John Doe");
     }
     
     @Test
@@ -151,7 +146,7 @@ public class CompileEvaluateTest {
         Map<String, Object> inputs = new HashMap<>();
         inputs.put( "input", prototype(entry("Primary-Key", "k987")) );
         Object result = feel.evaluate(compiledExpression, inputs);
-        assertThat(result, is("k987"));
+        assertThat(result).isEqualTo("k987");
         assertTrue(errors.isEmpty());
     }
     
@@ -166,7 +161,7 @@ public class CompileEvaluateTest {
         Map<String, Object> inputs = new HashMap<>();
         inputs.put( "input", Arrays.asList(prototype(entry("Primary-Key", "k987"))) );
         Object result = feel.evaluate(compiledExpression, inputs);
-        assertThat(result, is(Arrays.asList("k987")));
+        assertThat(result).asList().containsExactly("k987");
         assertTrue(errors.isEmpty());
     }
     
@@ -181,7 +176,7 @@ public class CompileEvaluateTest {
         Map<String, Object> inputs = new HashMap<>();
         inputs.put( "my input", Arrays.asList(prototype(entry("Primary-Key", "k987"))) );
         Object result = feel.evaluate(compiledExpression, inputs);
-        assertThat(result, is("k987"));
+        assertThat(result).isEqualTo("k987");
         assertTrue(errors.isEmpty());
     }
     

--- a/kie-dmn/kie-dmn-feel/src/test/java/org/kie/dmn/feel/lang/examples/ExamplesTest.java
+++ b/kie-dmn/kie-dmn-feel/src/test/java/org/kie/dmn/feel/lang/examples/ExamplesTest.java
@@ -25,8 +25,7 @@ import org.slf4j.LoggerFactory;
 import java.math.BigDecimal;
 import java.util.Map;
 
-import static org.hamcrest.CoreMatchers.is;
-import static org.hamcrest.MatcherAssert.assertThat;
+import static org.assertj.core.api.Assertions.assertThat;
 
 public class ExamplesTest
         extends ExamplesBaseTest {
@@ -49,13 +48,13 @@ public class ExamplesTest
         Map applicant = (Map) feel.evaluate( expression );
         System.out.println( printContext( applicant ) );
 
-        assertThat( applicant.size(), is( 5 ) );
+        assertThat(applicant).hasSize(5);
     }
 
     @Test
     public void testLoadExample_10_6_1() {
         System.out.println( printContext( context ) );
-        assertThat( context.size(), is( 6 ) );
+        assertThat(context).hasSize(6);
     }
 
     @Test
@@ -64,7 +63,7 @@ public class ExamplesTest
 
         System.out.println( "Yearly income = " + yearlyIncome );
 
-        assertThat( yearlyIncome, is( new BigDecimal( "120000.00" ) ) );
+        assertThat(yearlyIncome).isEqualTo(new BigDecimal( "120000.00" ) );
     }
 
     @Test
@@ -75,7 +74,7 @@ public class ExamplesTest
 
         System.out.println( "Marital status = " + maritalStatus );
 
-        assertThat( maritalStatus, is( "valid" ) );
+        assertThat(maritalStatus).isEqualTo("valid" );
     }
 
     @Test
@@ -84,7 +83,7 @@ public class ExamplesTest
 
         System.out.println( "Monthly total expenses = " + totalExpenses );
 
-        assertThat( totalExpenses, is( new BigDecimal( "5500.00" ) ) );
+        assertThat(totalExpenses).isEqualTo(new BigDecimal( "5500.00" ) );
     }
 
     @Test
@@ -95,7 +94,7 @@ public class ExamplesTest
 
         System.out.println( "PMT = " + pmt );
 
-        assertThat( pmt, is( new BigDecimal( "3975.982590125552338278440100112431" ) ) );
+        assertThat(pmt).isEqualTo(new BigDecimal( "3975.982590125552338278440100112431" ) );
     }
 
     @Test
@@ -106,7 +105,7 @@ public class ExamplesTest
 
         System.out.println( "Weight = " + total );
 
-        assertThat( total, is( new BigDecimal( "150" ) ) );
+        assertThat(total).isEqualTo(new BigDecimal( "150" ) );
     }
 
     @Test
@@ -117,7 +116,7 @@ public class ExamplesTest
 
         System.out.println( "Is there bankrupcy event? " + bankrupcy );
 
-        assertThat( bankrupcy, is( Boolean.FALSE ) );
+        assertThat(bankrupcy).isFalse();
     }
 
     @Test

--- a/kie-dmn/kie-dmn-feel/src/test/java/org/kie/dmn/feel/lang/impl/FEELProfileTest.java
+++ b/kie-dmn/kie-dmn-feel/src/test/java/org/kie/dmn/feel/lang/impl/FEELProfileTest.java
@@ -12,8 +12,7 @@ import org.kie.dmn.feel.runtime.FEELFunction;
 import org.kie.dmn.feel.runtime.functions.BaseFEELFunction;
 import org.kie.dmn.feel.runtime.functions.FEELFnResult;
 
-import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.equalTo;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.kie.dmn.feel.util.DynamicTypeUtils.entry;
 import static org.kie.dmn.feel.util.DynamicTypeUtils.mapOf;
 
@@ -25,9 +24,9 @@ public class FEELProfileTest {
         // Instantiate a new FEEL with the profile to try the method that uses the data cache
         FEEL feel = FEEL.newInstance(Arrays.asList(new TestFEELProfile()));
 
-        assertThat(feel.evaluate("use cache(\"val 1\")"), equalTo("1"));
-        assertThat(feel.evaluate("use cache(\"val 3\")"), equalTo("3"));
-        assertThat(feel.evaluate("use cache(\"val 5\")"), equalTo(null));
+        assertThat(feel.evaluate("use cache(\"val 1\")")).isEqualTo("1");
+        assertThat(feel.evaluate("use cache(\"val 3\")")).isEqualTo("3");
+        assertThat(feel.evaluate("use cache(\"val 5\")")).isNull();
     }
 
     /**

--- a/kie-dmn/kie-dmn-feel/src/test/java/org/kie/dmn/feel/lang/impl/JavaBackedTypeTest.java
+++ b/kie-dmn/kie-dmn-feel/src/test/java/org/kie/dmn/feel/lang/impl/JavaBackedTypeTest.java
@@ -1,16 +1,13 @@
 package org.kie.dmn.feel.lang.impl;
 
-import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.hasItem;
-import static org.hamcrest.Matchers.not;
-
 import java.util.Set;
 
 import org.junit.Test;
 import org.kie.dmn.feel.lang.CompositeType;
 import org.kie.dmn.feel.lang.FEELType;
-
 import org.kie.dmn.feel.model.Person;
+
+import static org.assertj.core.api.Assertions.assertThat;
 
 public class JavaBackedTypeTest {
 
@@ -19,11 +16,11 @@ public class JavaBackedTypeTest {
         CompositeType personType = (CompositeType) JavaBackedType.of( Person.class );
         Set<String> personProperties = personType.getFields().keySet();
         
-        assertThat( personProperties,  hasItem("home address") );
-        assertThat( personProperties,  hasItem("address") );
+        assertThat(personProperties).contains("home address");
+        assertThat(personProperties).contains("address");
         
         // for consistency and to fix possible hierarchy resolution problem, we add the property also as per standard JavaBean specs.
-        assertThat( personProperties,  hasItem("homeAddress") );
+        assertThat(personProperties).contains("homeAddress");
     }
     
     @FEELType
@@ -63,14 +60,14 @@ public class JavaBackedTypeTest {
         CompositeType personType = (CompositeType) JavaBackedType.of( MyPojoNoMethodAnn.class );
         Set<String> personProperties = personType.getFields().keySet();
         
-        assertThat( personProperties,  hasItem("a") );
-        assertThat( personProperties,  hasItem("b") );
+        assertThat(personProperties).contains("a");
+        assertThat(personProperties).contains("b");
         
         // should not include private methods
-        assertThat( personProperties,  not( hasItem("bPrivate") ) );
+        assertThat(personProperties).doesNotContain("bPrivate");
         
         // should not include methods which are actually Object methods.
-        assertThat( personProperties,  not( hasItem("equals") ) );
-        assertThat( personProperties,  not( hasItem("wait") ) );
+        assertThat(personProperties).doesNotContain("equals");
+        assertThat(personProperties).doesNotContain("wait");
     }
 }

--- a/kie-dmn/kie-dmn-feel/src/test/java/org/kie/dmn/feel/marshaller/FEELCodeMarshallerTest.java
+++ b/kie-dmn/kie-dmn-feel/src/test/java/org/kie/dmn/feel/marshaller/FEELCodeMarshallerTest.java
@@ -13,9 +13,7 @@ import java.util.Arrays;
 import java.util.Collection;
 import java.util.LinkedHashMap;
 
-import static org.hamcrest.Matchers.is;
-import static org.hamcrest.Matchers.nullValue;
-import static org.hamcrest.MatcherAssert.assertThat;
+import static org.assertj.core.api.Assertions.assertThat;
 
 @RunWith(Parameterized.class)
 public class FEELCodeMarshallerTest {
@@ -100,9 +98,9 @@ public class FEELCodeMarshallerTest {
 
     protected void assertResult( Object value, String result ) {
         if( result == null ) {
-            assertThat( "Marshalling: '" + value + "'", FEELCodeMarshaller.INSTANCE.marshall( value ), is( nullValue() ) );
+            assertThat(FEELCodeMarshaller.INSTANCE.marshall( value )).as("Marshalling: '" + value + "'").isNull();
         } else {
-            assertThat( "Marshalling: '"+value+"'", FEELCodeMarshaller.INSTANCE.marshall( value ), is( result ) );
+            assertThat(FEELCodeMarshaller.INSTANCE.marshall( value )).as("Marshalling: '" + value + "'").isEqualTo(result);
         }
     }
 }

--- a/kie-dmn/kie-dmn-feel/src/test/java/org/kie/dmn/feel/marshaller/FEELCodeMarshallerUnmarshallTest.java
+++ b/kie-dmn/kie-dmn-feel/src/test/java/org/kie/dmn/feel/marshaller/FEELCodeMarshallerUnmarshallTest.java
@@ -21,9 +21,7 @@ import org.kie.dmn.feel.lang.types.impl.ComparablePeriod;
 import org.kie.dmn.feel.runtime.Range;
 import org.kie.dmn.feel.runtime.impl.RangeImpl;
 
-import static org.hamcrest.Matchers.is;
-import static org.hamcrest.Matchers.nullValue;
-import static org.hamcrest.MatcherAssert.assertThat;
+import static org.assertj.core.api.Assertions.assertThat;
 
 @RunWith(Parameterized.class)
 public class FEELCodeMarshallerUnmarshallTest {
@@ -105,9 +103,9 @@ public class FEELCodeMarshallerUnmarshallTest {
 
     protected void assertResult(Type feelType, String value, Object result ) {
         if( result == null ) {
-            assertThat( "Unmarshalling: '" + value + "'", FEELCodeMarshaller.INSTANCE.unmarshall( feelType, value ), is( nullValue() ) );
+        	assertThat(FEELCodeMarshaller.INSTANCE.unmarshall( feelType, value )).as("Unmarshalling: '" + value + "'").isNull();
         } else {
-            assertThat( "Unmarshalling: '"+value+"'", FEELCodeMarshaller.INSTANCE.unmarshall( feelType, value ), is( result ) );
+        	assertThat(FEELCodeMarshaller.INSTANCE.unmarshall( feelType, value )).as("Unmarshalling: '" + value + "'").isEqualTo(result);
         }
     }
 }

--- a/kie-dmn/kie-dmn-feel/src/test/java/org/kie/dmn/feel/marshaller/FEELStringMarshallerTest.java
+++ b/kie-dmn/kie-dmn-feel/src/test/java/org/kie/dmn/feel/marshaller/FEELStringMarshallerTest.java
@@ -13,9 +13,7 @@ import java.util.Arrays;
 import java.util.Collection;
 import java.util.LinkedHashMap;
 
-import static org.hamcrest.Matchers.is;
-import static org.hamcrest.Matchers.nullValue;
-import static org.hamcrest.MatcherAssert.assertThat;
+import static org.assertj.core.api.Assertions.assertThat;
 
 @RunWith(Parameterized.class)
 public class FEELStringMarshallerTest {
@@ -101,9 +99,9 @@ public class FEELStringMarshallerTest {
 
     protected void assertResult( Object value, String result ) {
         if( result == null ) {
-            assertThat( "Marshalling: '" + value + "'", FEELStringMarshaller.INSTANCE.marshall( value ), is( nullValue() ) );
+        	assertThat(FEELStringMarshaller.INSTANCE.marshall(value)).as("Marshalling: '" + value + "'").isNull();
         } else {
-            assertThat( "Marshalling: '"+value+"'", FEELStringMarshaller.INSTANCE.marshall( value ), is( result ) );
+        	assertThat(FEELStringMarshaller.INSTANCE.marshall(value)).as("Marshalling: '" + value + "'").isEqualTo(result);
         }
     }
 }

--- a/kie-dmn/kie-dmn-feel/src/test/java/org/kie/dmn/feel/marshaller/FEELStringMarshallerUnmarshallTest.java
+++ b/kie-dmn/kie-dmn-feel/src/test/java/org/kie/dmn/feel/marshaller/FEELStringMarshallerUnmarshallTest.java
@@ -18,9 +18,7 @@ import org.kie.dmn.feel.lang.Type;
 import org.kie.dmn.feel.lang.types.BuiltInType;
 import org.kie.dmn.feel.lang.types.impl.ComparablePeriod;
 
-import static org.hamcrest.Matchers.is;
-import static org.hamcrest.Matchers.nullValue;
-import static org.hamcrest.MatcherAssert.assertThat;
+import static org.assertj.core.api.Assertions.assertThat;
 
 @RunWith(Parameterized.class)
 public class FEELStringMarshallerUnmarshallTest {
@@ -94,9 +92,9 @@ public class FEELStringMarshallerUnmarshallTest {
 
     protected void assertResult(Type feelType, String value, Object result ) {
         if( result == null ) {
-            assertThat( "Unmarshalling: '" + value + "'", FEELStringMarshaller.INSTANCE.unmarshall( feelType, value ), is( nullValue() ) );
+        	assertThat(FEELStringMarshaller.INSTANCE.unmarshall( feelType, value )).as("Unmarshalling: '" + value + "'").isNull();
         } else {
-            assertThat( "Unmarshalling: '"+value+"'", FEELStringMarshaller.INSTANCE.unmarshall( feelType, value ), is( result ) );
+        	assertThat(FEELStringMarshaller.INSTANCE.unmarshall( feelType, value )).as("Unmarshalling: '" + value + "'").isEqualTo(result);
         }
     }
 }

--- a/kie-dmn/kie-dmn-feel/src/test/java/org/kie/dmn/feel/parser/feel11/FEELParserSeverityTest.java
+++ b/kie-dmn/kie-dmn-feel/src/test/java/org/kie/dmn/feel/parser/feel11/FEELParserSeverityTest.java
@@ -35,9 +35,7 @@ import org.mockito.ArgumentCaptor;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import static org.hamcrest.CoreMatchers.instanceOf;
-import static org.hamcrest.CoreMatchers.is;
-import static org.hamcrest.MatcherAssert.assertThat;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.kie.dmn.feel.parser.feel11.FEELParserTest.assertLocation;
 import static org.mockito.Mockito.atLeastOnce;
 import static org.mockito.Mockito.mock;
@@ -54,8 +52,8 @@ public class FEELParserSeverityTest {
         String inputExpression = "1 >> 2";
         ASTNode number = parseSeverity(inputExpression, FEELEvent.Severity.WARN);
 
-        assertThat(number, is(instanceOf(InfixOpNode.class)));
-        assertThat(number.getResultType(), is(BuiltInType.BOOLEAN));
+        assertThat(number).isInstanceOf(InfixOpNode.class);
+        assertThat(number.getResultType()).isEqualTo(BuiltInType.BOOLEAN);
         assertLocation(inputExpression, number);
     }
 
@@ -65,8 +63,8 @@ public class FEELParserSeverityTest {
         String inputExpression = "1 >>> 2";
         ASTNode number = parseSeverity(inputExpression, FEELEvent.Severity.WARN);
 
-        assertThat(number, is(instanceOf(InfixOpNode.class)));
-        assertThat(number.getResultType(), is(BuiltInType.BOOLEAN));
+        assertThat(number).isInstanceOf(InfixOpNode.class);
+        assertThat(number.getResultType()).isEqualTo(BuiltInType.BOOLEAN);
         assertLocation(inputExpression, number);
     }
 
@@ -76,8 +74,8 @@ public class FEELParserSeverityTest {
         String inputExpression = "1 == 2";
         ASTNode number = parseSeverity(inputExpression, FEELEvent.Severity.WARN);
 
-        assertThat(number, is(instanceOf(InfixOpNode.class)));
-        assertThat(number.getResultType(), is(BuiltInType.BOOLEAN));
+        assertThat(number).isInstanceOf(InfixOpNode.class);
+        assertThat(number.getResultType()).isEqualTo(BuiltInType.BOOLEAN);
         assertLocation(inputExpression, number);
     }
 
@@ -87,8 +85,8 @@ public class FEELParserSeverityTest {
         String inputExpression = "{ m: <<18 }.m(16)";
         ASTNode number = parseSeverity(inputExpression, FEELEvent.Severity.WARN);
 
-        assertThat(number, is(instanceOf(FunctionInvocationNode.class)));
-        assertThat(number.getResultType(), is(instanceOf(Type.class)));
+        assertThat(number).isInstanceOf(FunctionInvocationNode.class);
+        assertThat(number.getResultType()).isInstanceOf(Type.class);
         assertLocation(inputExpression, number);
     }
 
@@ -103,7 +101,7 @@ public class FEELParserSeverityTest {
 
         final ArgumentCaptor<FEELEvent> captor = ArgumentCaptor.forClass(FEELEvent.class);
         verify(listener, atLeastOnce()).onEvent(captor.capture());
-        assertThat(captor.getValue().getSeverity(), is(severity));
+        assertThat(captor.getValue().getSeverity()).isEqualTo(severity);
 
         return processedExpression.getInterpreted().getASTNode();
     }

--- a/kie-dmn/kie-dmn-feel/src/test/java/org/kie/dmn/feel/parser/feel11/FEELParserTest.java
+++ b/kie-dmn/kie-dmn-feel/src/test/java/org/kie/dmn/feel/parser/feel11/FEELParserTest.java
@@ -57,11 +57,7 @@ import org.kie.dmn.feel.lang.impl.MapBackedType;
 import org.kie.dmn.feel.lang.types.BuiltInType;
 import org.kie.dmn.feel.util.Msg;
 
-import static org.hamcrest.CoreMatchers.instanceOf;
-import static org.hamcrest.CoreMatchers.is;
-import static org.hamcrest.CoreMatchers.notNullValue;
-import static org.hamcrest.Matchers.empty;
-import static org.hamcrest.MatcherAssert.assertThat;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.kie.dmn.feel.util.DynamicTypeUtils.entry;
 import static org.kie.dmn.feel.util.DynamicTypeUtils.mapOf;
 
@@ -72,8 +68,8 @@ public class FEELParserTest {
         String inputExpression = "10";
         BaseNode number = parse( inputExpression );
 
-        assertThat( number, is( instanceOf( NumberNode.class ) ) );
-        assertThat( number.getResultType(), is( BuiltInType.NUMBER ) );
+        assertThat( number).isInstanceOf(NumberNode.class);
+        assertThat( number.getResultType()).isEqualTo(BuiltInType.NUMBER);
         assertLocation( inputExpression, number );
     }
 
@@ -82,14 +78,14 @@ public class FEELParserTest {
         String inputExpression = "-10";
         BaseNode number = parse( inputExpression );
 
-        assertThat( number, is( instanceOf( SignedUnaryNode.class ) ) );
-        assertThat( number.getResultType(), is( BuiltInType.NUMBER ) );
+        assertThat( number).isInstanceOf(SignedUnaryNode.class);
+        assertThat( number.getResultType()).isEqualTo(BuiltInType.NUMBER);
         assertLocation( inputExpression, number );
 
         SignedUnaryNode sun = (SignedUnaryNode) number;
-        assertThat( sun.getSign(), is( SignedUnaryNode.Sign.NEGATIVE ) );
-        assertThat( sun.getExpression(), is( instanceOf( NumberNode.class ) ) );
-        assertThat( sun.getExpression().getText(), is( "10" ) );
+        assertThat( sun.getSign()).isEqualTo(SignedUnaryNode.Sign.NEGATIVE);
+        assertThat( sun.getExpression()).isInstanceOf(NumberNode.class);
+        assertThat( sun.getExpression().getText()).isEqualTo("10");
     }
 
     @Test
@@ -97,14 +93,14 @@ public class FEELParserTest {
         String inputExpression = "+10";
         BaseNode number = parse( inputExpression );
 
-        assertThat( number, is( instanceOf( SignedUnaryNode.class ) ) );
-        assertThat( number.getResultType(), is( BuiltInType.NUMBER ) );
+        assertThat( number).isInstanceOf(SignedUnaryNode.class);
+        assertThat( number.getResultType()).isEqualTo(BuiltInType.NUMBER);
         assertLocation( inputExpression, number );
 
         SignedUnaryNode sun = (SignedUnaryNode) number;
-        assertThat( sun.getSign(), is( SignedUnaryNode.Sign.POSITIVE ) );
-        assertThat( sun.getExpression(), is( instanceOf( NumberNode.class ) ) );
-        assertThat( sun.getExpression().getText(), is( "10" ) );
+        assertThat( sun.getSign()).isEqualTo(SignedUnaryNode.Sign.POSITIVE);
+        assertThat( sun.getExpression()).isInstanceOf(NumberNode.class);
+        assertThat( sun.getExpression().getText()).isEqualTo("10");
     }
 
     @Test
@@ -112,8 +108,8 @@ public class FEELParserTest {
         String inputExpression = "10.5";
         BaseNode number = parse( inputExpression );
 
-        assertThat( number, is( instanceOf( NumberNode.class ) ) );
-        assertThat( number.getResultType(), is( BuiltInType.NUMBER ) );
+        assertThat( number).isInstanceOf(NumberNode.class);
+        assertThat( number.getResultType()).isEqualTo(BuiltInType.NUMBER);
         assertLocation( inputExpression, number );
     }
 
@@ -122,14 +118,14 @@ public class FEELParserTest {
         String inputExpression = "-10.5";
         BaseNode number = parse( inputExpression );
 
-        assertThat( number, is( instanceOf( SignedUnaryNode.class ) ) );
-        assertThat( number.getResultType(), is( BuiltInType.NUMBER ) );
+        assertThat( number).isInstanceOf(SignedUnaryNode.class);
+        assertThat( number.getResultType()).isEqualTo(BuiltInType.NUMBER);
         assertLocation( inputExpression, number );
 
         SignedUnaryNode sun = (SignedUnaryNode) number;
-        assertThat( sun.getSign(), is( SignedUnaryNode.Sign.NEGATIVE ) );
-        assertThat( sun.getExpression(), is( instanceOf( NumberNode.class ) ) );
-        assertThat( sun.getExpression().getText(), is( "10.5" ) );
+        assertThat( sun.getSign()).isEqualTo(SignedUnaryNode.Sign.NEGATIVE);
+        assertThat( sun.getExpression()).isInstanceOf(NumberNode.class);
+        assertThat( sun.getExpression().getText()).isEqualTo("10.5");
     }
 
     @Test
@@ -137,14 +133,14 @@ public class FEELParserTest {
         String inputExpression = "+10.5";
         BaseNode number = parse( inputExpression );
 
-        assertThat( number, is( instanceOf( SignedUnaryNode.class ) ) );
-        assertThat( number.getResultType(), is( BuiltInType.NUMBER ) );
+        assertThat( number).isInstanceOf(SignedUnaryNode.class);
+        assertThat( number.getResultType()).isEqualTo(BuiltInType.NUMBER);
         assertLocation( inputExpression, number );
 
         SignedUnaryNode sun = (SignedUnaryNode) number;
-        assertThat( sun.getSign(), is( SignedUnaryNode.Sign.POSITIVE ) );
-        assertThat( sun.getExpression(), is( instanceOf( NumberNode.class ) ) );
-        assertThat( sun.getExpression().getText(), is( "10.5" ) );
+        assertThat( sun.getSign()).isEqualTo(SignedUnaryNode.Sign.POSITIVE);
+        assertThat( sun.getExpression()).isInstanceOf(NumberNode.class);
+        assertThat( sun.getExpression().getText()).isEqualTo("10.5");
     }
 
     @Test
@@ -152,8 +148,8 @@ public class FEELParserTest {
         String inputExpression = "true";
         BaseNode bool = parse( inputExpression );
 
-        assertThat( bool, is( instanceOf( BooleanNode.class ) ) );
-        assertThat( bool.getResultType(), is( BuiltInType.BOOLEAN ) );
+        assertThat( bool).isInstanceOf(BooleanNode.class);
+        assertThat( bool.getResultType()).isEqualTo(BuiltInType.BOOLEAN);
         assertLocation( inputExpression, bool );
     }
 
@@ -162,8 +158,8 @@ public class FEELParserTest {
         String inputExpression = "false";
         BaseNode bool = parse( inputExpression );
 
-        assertThat( bool, is( instanceOf( BooleanNode.class ) ) );
-        assertThat( bool.getResultType(), is( BuiltInType.BOOLEAN ) );
+        assertThat( bool).isInstanceOf(BooleanNode.class);
+        assertThat( bool.getResultType()).isEqualTo(BuiltInType.BOOLEAN);
         assertLocation( inputExpression, bool );
     }
 
@@ -172,8 +168,8 @@ public class FEELParserTest {
         String inputExpression = "@\"2016-07-29\"";
         BaseNode bool = parse(inputExpression);
 
-        assertThat(bool, is(instanceOf(AtLiteralNode.class)));
-        assertThat(bool.getResultType(), is(BuiltInType.DATE));
+        assertThat(bool).isInstanceOf(AtLiteralNode.class);
+        assertThat(bool.getResultType()).isEqualTo(BuiltInType.DATE);
         assertLocation(inputExpression, bool);
     }
 
@@ -182,8 +178,8 @@ public class FEELParserTest {
         String inputExpression = "@\"23:59:00\"";
         BaseNode bool = parse(inputExpression);
 
-        assertThat(bool, is(instanceOf(AtLiteralNode.class)));
-        assertThat(bool.getResultType(), is(BuiltInType.TIME));
+        assertThat(bool).isInstanceOf(AtLiteralNode.class);
+        assertThat(bool.getResultType()).isEqualTo(BuiltInType.TIME);
         assertLocation(inputExpression, bool);
     }
 
@@ -192,8 +188,8 @@ public class FEELParserTest {
         String inputExpression = "@\"2016-07-29T05:48:23\"";
         BaseNode bool = parse(inputExpression);
 
-        assertThat(bool, is(instanceOf(AtLiteralNode.class)));
-        assertThat(bool.getResultType(), is(BuiltInType.DATE_TIME));
+        assertThat(bool).isInstanceOf(AtLiteralNode.class);
+        assertThat(bool.getResultType()).isEqualTo(BuiltInType.DATE_TIME);
         assertLocation(inputExpression, bool);
     }
 
@@ -202,8 +198,8 @@ public class FEELParserTest {
         String inputExpression = "@\"P2Y2M\"";
         BaseNode bool = parse(inputExpression);
 
-        assertThat(bool, is(instanceOf(AtLiteralNode.class)));
-        assertThat(bool.getResultType(), is(BuiltInType.DURATION));
+        assertThat(bool).isInstanceOf(AtLiteralNode.class);
+        assertThat(bool.getResultType()).isEqualTo(BuiltInType.DURATION);
         assertLocation(inputExpression, bool);
     }
 
@@ -212,8 +208,8 @@ public class FEELParserTest {
         String inputExpression = "null";
         BaseNode nullLit = parse( inputExpression );
 
-        assertThat( nullLit, is( instanceOf( NullNode.class ) ) );
-        assertThat( nullLit.getResultType(), is( BuiltInType.UNKNOWN ) );
+        assertThat( nullLit).isInstanceOf(NullNode.class);
+        assertThat( nullLit.getResultType()).isEqualTo(BuiltInType.UNKNOWN);
         assertLocation( inputExpression, nullLit );
     }
 
@@ -222,38 +218,38 @@ public class FEELParserTest {
         String inputExpression = "\"some string\"";
         BaseNode stringLit = parse( inputExpression );
 
-        assertThat( stringLit, is( instanceOf( StringNode.class ) ) );
-        assertThat( stringLit.getResultType(), is( BuiltInType.STRING ) );
+        assertThat( stringLit).isInstanceOf(StringNode.class);
+        assertThat( stringLit.getResultType()).isEqualTo(BuiltInType.STRING);
         assertLocation( inputExpression, stringLit );
-        assertThat(stringLit.getText(), is(inputExpression));
+        assertThat(stringLit.getText()).isEqualTo(inputExpression);
     }
 
     @Test
     public void testNameReference() {
         String inputExpression = "someSimpleName";
-        BaseNode nameRef = parse( inputExpression, mapOf( entry("someSimpleName", BuiltInType.STRING) ) );
+        BaseNode nameRef = parse( inputExpression, mapOf( entry("someSimpleName", BuiltInType.STRING)));
 
-        assertThat( nameRef, is( instanceOf( NameRefNode.class ) ) );
-        assertThat( nameRef.getResultType(), is( BuiltInType.STRING ) );
+        assertThat( nameRef).isInstanceOf(NameRefNode.class);
+        assertThat( nameRef.getResultType()).isEqualTo(BuiltInType.STRING);
         assertLocation( inputExpression, nameRef );
     }
 
     @Test
     public void testQualifiedName() {
         String inputExpression = "My Person.Full Name";
-        MapBackedType personType = new MapBackedType("Person", mapOf( entry("Full Name", BuiltInType.STRING), entry("Age", BuiltInType.NUMBER) ) );
-        BaseNode qualRef = parse( inputExpression, mapOf( entry("My Person", personType) ) );
+        MapBackedType personType = new MapBackedType("Person", mapOf( entry("Full Name", BuiltInType.STRING), entry("Age", BuiltInType.NUMBER)));
+        BaseNode qualRef = parse( inputExpression, mapOf( entry("My Person", personType)));
 
-        assertThat( qualRef, is( instanceOf( QualifiedNameNode.class ) ) );
-        assertThat( qualRef.getResultType(), is( BuiltInType.STRING ) );
+        assertThat( qualRef).isInstanceOf(QualifiedNameNode.class);
+        assertThat( qualRef.getResultType()).isEqualTo(BuiltInType.STRING);
 
         List<NameRefNode> parts = ((QualifiedNameNode) qualRef).getParts();
         // `My Person` ...
-        assertThat( parts.get(0), is( instanceOf( NameRefNode.class ) ) );
-        assertThat( parts.get(0).getResultType(), is( personType ) );
+        assertThat( parts.get(0)).isInstanceOf(NameRefNode.class);
+        assertThat( parts.get(0).getResultType()).isEqualTo(personType);
         // ... `.Full Name`
-        assertThat( parts.get(1), is( instanceOf( NameRefNode.class ) ) );
-        assertThat( parts.get(1).getResultType(), is( BuiltInType.STRING ) );
+        assertThat( parts.get(1)).isInstanceOf(NameRefNode.class);
+        assertThat( parts.get(1).getResultType()).isEqualTo(BuiltInType.STRING);
 
         assertLocation( inputExpression, qualRef );
     }
@@ -263,9 +259,9 @@ public class FEELParserTest {
         String inputExpression = "(10.5 )";
         BaseNode number = parse( inputExpression );
 
-        assertThat( number, is( instanceOf( NumberNode.class ) ) );
-        assertThat( number.getResultType(), is( BuiltInType.NUMBER ) );
-        assertThat( number.getText(), is( "10.5" ) );
+        assertThat( number).isInstanceOf(NumberNode.class);
+        assertThat( number.getResultType()).isEqualTo(BuiltInType.NUMBER);
+        assertThat( number.getText()).isEqualTo("10.5");
     }
 
     @Test
@@ -273,14 +269,14 @@ public class FEELParserTest {
         String inputExpression = "not ( true )";
         BaseNode neg = parse( inputExpression );
 
-        assertThat( neg, is( instanceOf( FunctionInvocationNode.class ) ) );
-        assertThat( neg.getResultType(), is( BuiltInType.UNKNOWN ) );
-        assertThat( neg.getText(), is( "not ( true )" ) );
+        assertThat( neg).isInstanceOf(FunctionInvocationNode.class);
+        assertThat( neg.getResultType()).isEqualTo(BuiltInType.UNKNOWN);
+        assertThat( neg.getText()).isEqualTo( "not ( true )");
 
         FunctionInvocationNode not = (FunctionInvocationNode) neg;
-        assertThat( not.getParams().getElements().get( 0 ), is( instanceOf( BooleanNode.class ) ) );
-        assertThat( not.getParams().getElements().get( 0 ).getResultType(), is( BuiltInType.BOOLEAN ) );
-        assertThat( not.getParams().getElements().get( 0 ).getText(), is( "true" ) );
+        assertThat( not.getParams().getElements().get( 0 )).isInstanceOf(BooleanNode.class);
+        assertThat( not.getParams().getElements().get( 0 ).getResultType()).isEqualTo(BuiltInType.BOOLEAN);
+        assertThat( not.getParams().getElements().get( 0 ).getText()).isEqualTo("true");
     }
 
     @Test
@@ -288,18 +284,18 @@ public class FEELParserTest {
         String inputExpression = "10 * x";
         BaseNode infix = parse( inputExpression, mapOf(entry("x", BuiltInType.NUMBER)) );
 
-        assertThat( infix, is( instanceOf( InfixOpNode.class ) ) );
-        assertThat( infix.getResultType(), is( BuiltInType.NUMBER ) );
-        assertThat( infix.getText(), is( inputExpression ) );
+        assertThat( infix).isInstanceOf(InfixOpNode.class);
+        assertThat( infix.getResultType()).isEqualTo(BuiltInType.NUMBER);
+        assertThat( infix.getText()).isEqualTo(inputExpression);
 
         InfixOpNode mult = (InfixOpNode) infix;
-        assertThat( mult.getLeft(), is( instanceOf( NumberNode.class ) ) );
-        assertThat( mult.getLeft().getText(), is( "10" ) );
+        assertThat( mult.getLeft()).isInstanceOf(NumberNode.class);
+        assertThat( mult.getLeft().getText()).isEqualTo("10");
 
-        assertThat( mult.getOperator(), is( InfixOpNode.InfixOperator.MULT ) );
+        assertThat( mult.getOperator()).isEqualTo(InfixOpNode.InfixOperator.MULT);
 
-        assertThat( mult.getRight(), is( instanceOf( NameRefNode.class ) ) );
-        assertThat( mult.getRight().getText(), is( "x" ) );
+        assertThat( mult.getRight()).isInstanceOf(NameRefNode.class);
+        assertThat( mult.getRight().getText()).isEqualTo("x");
     }
 
     @Test
@@ -307,27 +303,27 @@ public class FEELParserTest {
         String inputExpression = "y / 5 * ( x )";
         BaseNode infix = parse( inputExpression, mapOf(entry("x", BuiltInType.NUMBER), entry("y", BuiltInType.NUMBER)) );
 
-        assertThat( infix, is( instanceOf( InfixOpNode.class ) ) );
-        assertThat( infix.getResultType(), is( BuiltInType.NUMBER ) );
-        assertThat( infix.getText(), is( inputExpression ) );
+        assertThat( infix).isInstanceOf(InfixOpNode.class);
+        assertThat( infix.getResultType()).isEqualTo(BuiltInType.NUMBER);
+        assertThat( infix.getText()).isEqualTo(inputExpression);
 
         InfixOpNode mult = (InfixOpNode) infix;
-        assertThat( mult.getLeft(), is( instanceOf( InfixOpNode.class ) ) );
-        assertThat( mult.getLeft().getText(), is( "y / 5" ) );
+        assertThat( mult.getLeft()).isInstanceOf(InfixOpNode.class);
+        assertThat( mult.getLeft().getText()).isEqualTo( "y / 5");
 
         InfixOpNode div = (InfixOpNode) mult.getLeft();
-        assertThat( div.getLeft(), is( instanceOf( NameRefNode.class ) ) );
-        assertThat( div.getLeft().getText(), is( "y" ) );
+        assertThat( div.getLeft()).isInstanceOf(NameRefNode.class);
+        assertThat( div.getLeft().getText()).isEqualTo("y");
 
-        assertThat( div.getOperator(), is( InfixOpNode.InfixOperator.DIV ) );
+        assertThat( div.getOperator()).isEqualTo(InfixOpNode.InfixOperator.DIV);
 
-        assertThat( div.getRight(), is( instanceOf( NumberNode.class ) ) );
-        assertThat( div.getRight().getText(), is( "5" ) );
+        assertThat( div.getRight()).isInstanceOf(NumberNode.class);
+        assertThat( div.getRight().getText()).isEqualTo("5");
 
-        assertThat( mult.getOperator(), is( InfixOpNode.InfixOperator.MULT ) );
+        assertThat( mult.getOperator()).isEqualTo(InfixOpNode.InfixOperator.MULT);
 
-        assertThat( mult.getRight(), is( instanceOf( NameRefNode.class ) ) );
-        assertThat( mult.getRight().getText(), is( "x" ) );
+        assertThat( mult.getRight()).isInstanceOf(NameRefNode.class);
+        assertThat( mult.getRight().getText()).isEqualTo("x");
     }
 
     @Test
@@ -335,27 +331,27 @@ public class FEELParserTest {
         String inputExpression = "y * 5 ** 3";
         BaseNode infix = parse( inputExpression, mapOf(entry("y", BuiltInType.NUMBER)) );
 
-        assertThat( infix, is( instanceOf( InfixOpNode.class ) ) );
-        assertThat( infix.getResultType(), is( BuiltInType.NUMBER ) );
-        assertThat( infix.getText(), is( inputExpression ) );
+        assertThat( infix).isInstanceOf(InfixOpNode.class);
+        assertThat( infix.getResultType()).isEqualTo(BuiltInType.NUMBER);
+        assertThat( infix.getText()).isEqualTo(inputExpression);
 
         InfixOpNode mult = (InfixOpNode) infix;
-        assertThat( mult.getLeft(), is( instanceOf( NameRefNode.class ) ) );
-        assertThat( mult.getLeft().getText(), is( "y" ) );
+        assertThat( mult.getLeft()).isInstanceOf(NameRefNode.class);
+        assertThat( mult.getLeft().getText()).isEqualTo("y");
 
-        assertThat( mult.getOperator(), is( InfixOpNode.InfixOperator.MULT ) );
+        assertThat( mult.getOperator()).isEqualTo(InfixOpNode.InfixOperator.MULT);
 
-        assertThat( mult.getRight(), is( instanceOf( InfixOpNode.class ) ) );
-        assertThat( mult.getRight().getText(), is( "5 ** 3" ) );
+        assertThat( mult.getRight()).isInstanceOf(InfixOpNode.class);
+        assertThat( mult.getRight().getText()).isEqualTo( "5 ** 3");
 
         InfixOpNode exp = (InfixOpNode) mult.getRight();
-        assertThat( exp.getLeft(), is( instanceOf( NumberNode.class ) ) );
-        assertThat( exp.getLeft().getText(), is( "5" ) );
+        assertThat( exp.getLeft()).isInstanceOf(NumberNode.class);
+        assertThat( exp.getLeft().getText()).isEqualTo("5");
 
-        assertThat( exp.getOperator(), is( InfixOpNode.InfixOperator.POW ) );
+        assertThat( exp.getOperator()).isEqualTo(InfixOpNode.InfixOperator.POW);
 
-        assertThat( exp.getRight(), is( instanceOf( NumberNode.class ) ) );
-        assertThat( exp.getRight().getText(), is( "3" ) );
+        assertThat( exp.getRight()).isInstanceOf(NumberNode.class);
+        assertThat( exp.getRight().getText()).isEqualTo("3");
     }
 
     @Test
@@ -363,27 +359,27 @@ public class FEELParserTest {
         String inputExpression = "(y * 5) ** 3";
         BaseNode infix = parse( inputExpression, mapOf(entry("y", BuiltInType.NUMBER)) );
 
-        assertThat( infix, is( instanceOf( InfixOpNode.class ) ) );
-        assertThat( infix.getResultType(), is( BuiltInType.NUMBER ) );
-        assertThat( infix.getText(), is( inputExpression ) );
+        assertThat( infix).isInstanceOf(InfixOpNode.class);
+        assertThat( infix.getResultType()).isEqualTo(BuiltInType.NUMBER);
+        assertThat( infix.getText()).isEqualTo(inputExpression);
 
         InfixOpNode exp = (InfixOpNode) infix;
-        assertThat( exp.getLeft(), is( instanceOf( InfixOpNode.class ) ) );
-        assertThat( exp.getLeft().getText(), is( "y * 5" ) );
+        assertThat( exp.getLeft()).isInstanceOf(InfixOpNode.class);
+        assertThat( exp.getLeft().getText()).isEqualTo( "y * 5");
 
-        assertThat( exp.getOperator(), is( InfixOpNode.InfixOperator.POW ) );
+        assertThat( exp.getOperator()).isEqualTo(InfixOpNode.InfixOperator.POW);
 
-        assertThat( exp.getRight(), is( instanceOf( NumberNode.class ) ) );
-        assertThat( exp.getRight().getText(), is( "3" ) );
+        assertThat( exp.getRight()).isInstanceOf(NumberNode.class);
+        assertThat( exp.getRight().getText()).isEqualTo("3");
 
         InfixOpNode mult = (InfixOpNode) exp.getLeft();
-        assertThat( mult.getLeft(), is( instanceOf( NameRefNode.class ) ) );
-        assertThat( mult.getLeft().getText(), is( "y" ) );
+        assertThat( mult.getLeft()).isInstanceOf(NameRefNode.class);
+        assertThat( mult.getLeft().getText()).isEqualTo("y");
 
-        assertThat( mult.getOperator(), is( InfixOpNode.InfixOperator.MULT ) );
+        assertThat( mult.getOperator()).isEqualTo(InfixOpNode.InfixOperator.MULT);
 
-        assertThat( mult.getRight(), is( instanceOf( NumberNode.class ) ) );
-        assertThat( mult.getRight().getText(), is( "5" ) );
+        assertThat( mult.getRight()).isInstanceOf(NumberNode.class);
+        assertThat( mult.getRight().getText()).isEqualTo("5");
     }
 
     @Test
@@ -391,27 +387,27 @@ public class FEELParserTest {
         String inputExpression = "y ** 5 * 3";
         BaseNode infix = parse( inputExpression, mapOf(entry("y", BuiltInType.NUMBER)) );
 
-        assertThat( infix, is( instanceOf( InfixOpNode.class ) ) );
-        assertThat( infix.getResultType(), is( BuiltInType.NUMBER ) );
-        assertThat( infix.getText(), is( inputExpression ) );
+        assertThat( infix).isInstanceOf(InfixOpNode.class);
+        assertThat( infix.getResultType()).isEqualTo(BuiltInType.NUMBER);
+        assertThat( infix.getText()).isEqualTo(inputExpression);
 
         InfixOpNode mult = (InfixOpNode) infix;
-        assertThat( mult.getLeft(), is( instanceOf( InfixOpNode.class ) ) );
-        assertThat( mult.getLeft().getText(), is( "y ** 5" ) );
+        assertThat( mult.getLeft()).isInstanceOf(InfixOpNode.class);
+        assertThat( mult.getLeft().getText()).isEqualTo( "y ** 5");
 
-        assertThat( mult.getOperator(), is( InfixOpNode.InfixOperator.MULT ) );
+        assertThat( mult.getOperator()).isEqualTo(InfixOpNode.InfixOperator.MULT);
 
-        assertThat( mult.getRight(), is( instanceOf( NumberNode.class ) ) );
-        assertThat( mult.getRight().getText(), is( "3" ) );
+        assertThat( mult.getRight()).isInstanceOf(NumberNode.class);
+        assertThat( mult.getRight().getText()).isEqualTo("3");
 
         InfixOpNode exp = (InfixOpNode) mult.getLeft();
-        assertThat( exp.getLeft(), is( instanceOf( NameRefNode.class ) ) );
-        assertThat( exp.getLeft().getText(), is( "y" ) );
+        assertThat( exp.getLeft()).isInstanceOf(NameRefNode.class);
+        assertThat( exp.getLeft().getText()).isEqualTo("y");
 
-        assertThat( exp.getOperator(), is( InfixOpNode.InfixOperator.POW ) );
+        assertThat( exp.getOperator()).isEqualTo(InfixOpNode.InfixOperator.POW);
 
-        assertThat( exp.getRight(), is( instanceOf( NumberNode.class ) ) );
-        assertThat( exp.getRight().getText(), is( "5" ) );
+        assertThat( exp.getRight()).isInstanceOf(NumberNode.class);
+        assertThat( exp.getRight().getText()).isEqualTo("5");
     }
 
     @Test
@@ -419,27 +415,27 @@ public class FEELParserTest {
         String inputExpression = "y ** ( 5 * 3 )";
         BaseNode infix = parse( inputExpression, mapOf(entry("y", BuiltInType.NUMBER)) );
 
-        assertThat( infix, is( instanceOf( InfixOpNode.class ) ) );
-        assertThat( infix.getResultType(), is( BuiltInType.NUMBER ) );
-        assertThat( infix.getText(), is( inputExpression ) );
+        assertThat( infix).isInstanceOf(InfixOpNode.class);
+        assertThat( infix.getResultType()).isEqualTo(BuiltInType.NUMBER);
+        assertThat( infix.getText()).isEqualTo(inputExpression);
 
         InfixOpNode exp = (InfixOpNode) infix;
-        assertThat( exp.getLeft(), is( instanceOf( NameRefNode.class ) ) );
-        assertThat( exp.getLeft().getText(), is( "y" ) );
+        assertThat( exp.getLeft()).isInstanceOf(NameRefNode.class);
+        assertThat( exp.getLeft().getText()).isEqualTo("y");
 
-        assertThat( exp.getOperator(), is( InfixOpNode.InfixOperator.POW ) );
+        assertThat( exp.getOperator()).isEqualTo(InfixOpNode.InfixOperator.POW);
 
-        assertThat( exp.getRight(), is( instanceOf( InfixOpNode.class ) ) );
-        assertThat( exp.getRight().getText(), is( "5 * 3" ) );
+        assertThat( exp.getRight()).isInstanceOf(InfixOpNode.class);
+        assertThat( exp.getRight().getText()).isEqualTo( "5 * 3");
 
         InfixOpNode mult = (InfixOpNode) exp.getRight();
-        assertThat( mult.getLeft(), is( instanceOf( NumberNode.class ) ) );
-        assertThat( mult.getLeft().getText(), is( "5" ) );
+        assertThat( mult.getLeft()).isInstanceOf(NumberNode.class);
+        assertThat( mult.getLeft().getText()).isEqualTo("5");
 
-        assertThat( mult.getOperator(), is( InfixOpNode.InfixOperator.MULT ) );
+        assertThat( mult.getOperator()).isEqualTo(InfixOpNode.InfixOperator.MULT);
 
-        assertThat( mult.getRight(), is( instanceOf( NumberNode.class ) ) );
-        assertThat( mult.getRight().getText(), is( "3" ) );
+        assertThat( mult.getRight()).isInstanceOf(NumberNode.class);
+        assertThat( mult.getRight().getText()).isEqualTo("3");
     }
 
     @Test
@@ -447,27 +443,27 @@ public class FEELParserTest {
         String inputExpression = "y + 5 * 3";
         BaseNode infix = parse( inputExpression, mapOf(entry("y", BuiltInType.NUMBER)) );
 
-        assertThat( infix, is( instanceOf( InfixOpNode.class ) ) );
-        assertThat( infix.getResultType(), is( BuiltInType.NUMBER ) );
-        assertThat( infix.getText(), is( inputExpression ) );
+        assertThat( infix).isInstanceOf(InfixOpNode.class);
+        assertThat( infix.getResultType()).isEqualTo(BuiltInType.NUMBER);
+        assertThat( infix.getText()).isEqualTo(inputExpression);
 
         InfixOpNode add = (InfixOpNode) infix;
-        assertThat( add.getLeft(), is( instanceOf( NameRefNode.class ) ) );
-        assertThat( add.getLeft().getText(), is( "y" ) );
+        assertThat( add.getLeft()).isInstanceOf(NameRefNode.class);
+        assertThat( add.getLeft().getText()).isEqualTo("y");
 
-        assertThat( add.getOperator(), is( InfixOpNode.InfixOperator.ADD ) );
+        assertThat( add.getOperator()).isEqualTo(InfixOpNode.InfixOperator.ADD);
 
-        assertThat( add.getRight(), is( instanceOf( InfixOpNode.class ) ) );
-        assertThat( add.getRight().getText(), is( "5 * 3" ) );
+        assertThat( add.getRight()).isInstanceOf(InfixOpNode.class);
+        assertThat( add.getRight().getText()).isEqualTo( "5 * 3");
 
         InfixOpNode mult = (InfixOpNode) add.getRight();
-        assertThat( mult.getLeft(), is( instanceOf( NumberNode.class ) ) );
-        assertThat( mult.getLeft().getText(), is( "5" ) );
+        assertThat( mult.getLeft()).isInstanceOf(NumberNode.class);
+        assertThat( mult.getLeft().getText()).isEqualTo("5");
 
-        assertThat( mult.getOperator(), is( InfixOpNode.InfixOperator.MULT ) );
+        assertThat( mult.getOperator()).isEqualTo(InfixOpNode.InfixOperator.MULT);
 
-        assertThat( mult.getRight(), is( instanceOf( NumberNode.class ) ) );
-        assertThat( mult.getRight().getText(), is( "3" ) );
+        assertThat( mult.getRight()).isInstanceOf(NumberNode.class);
+        assertThat( mult.getRight().getText()).isEqualTo("3");
     }
 
     @Test
@@ -475,27 +471,27 @@ public class FEELParserTest {
         String inputExpression = "(y - 5) ** 3";
         BaseNode infix = parse( inputExpression, mapOf(entry("y", BuiltInType.NUMBER)) );
 
-        assertThat( infix, is( instanceOf( InfixOpNode.class ) ) );
-        assertThat( infix.getResultType(), is( BuiltInType.NUMBER ) );
-        assertThat( infix.getText(), is( inputExpression ) );
+        assertThat( infix).isInstanceOf(InfixOpNode.class);
+        assertThat( infix.getResultType()).isEqualTo(BuiltInType.NUMBER);
+        assertThat( infix.getText()).isEqualTo(inputExpression);
 
         InfixOpNode sub = (InfixOpNode) infix;
-        assertThat( sub.getLeft(), is( instanceOf( InfixOpNode.class ) ) );
-        assertThat( sub.getLeft().getText(), is( "y - 5" ) );
+        assertThat( sub.getLeft()).isInstanceOf(InfixOpNode.class);
+        assertThat( sub.getLeft().getText()).isEqualTo( "y - 5");
 
-        assertThat( sub.getOperator(), is( InfixOpNode.InfixOperator.POW ) );
+        assertThat( sub.getOperator()).isEqualTo(InfixOpNode.InfixOperator.POW);
 
-        assertThat( sub.getRight(), is( instanceOf( NumberNode.class ) ) );
-        assertThat( sub.getRight().getText(), is( "3" ) );
+        assertThat( sub.getRight()).isInstanceOf(NumberNode.class);
+        assertThat( sub.getRight().getText()).isEqualTo("3");
 
         InfixOpNode mult = (InfixOpNode) sub.getLeft();
-        assertThat( mult.getLeft(), is( instanceOf( NameRefNode.class ) ) );
-        assertThat( mult.getLeft().getText(), is( "y" ) );
+        assertThat( mult.getLeft()).isInstanceOf(NameRefNode.class);
+        assertThat( mult.getLeft().getText()).isEqualTo("y");
 
-        assertThat( mult.getOperator(), is( InfixOpNode.InfixOperator.SUB ) );
+        assertThat( mult.getOperator()).isEqualTo(InfixOpNode.InfixOperator.SUB);
 
-        assertThat( mult.getRight(), is( instanceOf( NumberNode.class ) ) );
-        assertThat( mult.getRight().getText(), is( "5" ) );
+        assertThat( mult.getRight()).isInstanceOf(NumberNode.class);
+        assertThat( mult.getRight().getText()).isEqualTo("5");
     }
 
     @Test
@@ -503,19 +499,19 @@ public class FEELParserTest {
         String inputExpression = "x between 10+y and 3**z";
         BaseNode between = parse( inputExpression );
 
-        assertThat( between, is( instanceOf( BetweenNode.class ) ) );
-        assertThat( between.getResultType(), is( BuiltInType.BOOLEAN ) );
-        assertThat( between.getText(), is( inputExpression ) );
+        assertThat( between).isInstanceOf(BetweenNode.class);
+        assertThat( between.getResultType()).isEqualTo(BuiltInType.BOOLEAN);
+        assertThat( between.getText()).isEqualTo(inputExpression);
 
         BetweenNode btw = (BetweenNode) between;
-        assertThat( btw.getValue(), is( instanceOf( NameRefNode.class ) ) );
-        assertThat( btw.getValue().getText(), is( "x" ) );
+        assertThat( btw.getValue()).isInstanceOf(NameRefNode.class);
+        assertThat( btw.getValue().getText()).isEqualTo("x");
 
-        assertThat( btw.getStart(), is( instanceOf( InfixOpNode.class ) ) );
-        assertThat( btw.getStart().getText(), is( "10+y" ) );
+        assertThat( btw.getStart()).isInstanceOf(InfixOpNode.class);
+        assertThat( btw.getStart().getText()).isEqualTo( "10+y");
 
-        assertThat( btw.getEnd(), is( instanceOf( InfixOpNode.class ) ) );
-        assertThat( btw.getEnd().getText(), is( "3**z" ) );
+        assertThat( btw.getEnd()).isInstanceOf(InfixOpNode.class);
+        assertThat( btw.getEnd().getText()).isEqualTo( "3**z");
     }
 
     @Test
@@ -524,22 +520,22 @@ public class FEELParserTest {
         String inputExpression = "x / 4 in ( 10+y, true, 80, someVar )";
         BaseNode inNode = parse( inputExpression );
 
-        assertThat( inNode, is( instanceOf( InNode.class ) ) );
-        assertThat( inNode.getResultType(), is( BuiltInType.BOOLEAN ) );
-        assertThat( inNode.getText(), is( inputExpression ) );
+        assertThat( inNode).isInstanceOf(InNode.class);
+        assertThat( inNode.getResultType()).isEqualTo(BuiltInType.BOOLEAN);
+        assertThat( inNode.getText()).isEqualTo(inputExpression);
 
         InNode in = (InNode) inNode;
-        assertThat( in.getValue(), is( instanceOf( InfixOpNode.class ) ) );
-        assertThat( in.getValue().getText(), is( "x / 4" ) );
+        assertThat( in.getValue()).isInstanceOf(InfixOpNode.class);
+        assertThat( in.getValue().getText()).isEqualTo( "x / 4");
 
-        assertThat( in.getExprs(), is( instanceOf( ListNode.class ) ) );
-        assertThat( in.getExprs().getText(), is( "10+y, true, 80, someVar" ) );
+        assertThat( in.getExprs()).isInstanceOf(ListNode.class);
+        assertThat( in.getExprs().getText()).isEqualTo( "10+y, true, 80, someVar");
 
         ListNode list = (ListNode) in.getExprs();
-        assertThat( list.getElements().get( 0 ), is( instanceOf( InfixOpNode.class ) ) );
-        assertThat( list.getElements().get( 1 ), is( instanceOf( BooleanNode.class ) ) );
-        assertThat( list.getElements().get( 2 ), is( instanceOf( NumberNode.class ) ) );
-        assertThat( list.getElements().get( 3 ), is( instanceOf( NameRefNode.class ) ) );
+        assertThat( list.getElements().get( 0 )).isInstanceOf(InfixOpNode.class);
+        assertThat( list.getElements().get( 1 )).isInstanceOf(BooleanNode.class);
+        assertThat( list.getElements().get( 2 )).isInstanceOf(NumberNode.class);
+        assertThat( list.getElements().get( 3 )).isInstanceOf(NameRefNode.class);
     }
 
     @Test
@@ -547,50 +543,50 @@ public class FEELParserTest {
         String inputExpression = "x ** y in ( <=1000, >t, null, (2000..z[, ]z..2000], [(10+5)..(a*b)) )";
         BaseNode inNode = parse( inputExpression );
 
-        assertThat( inNode, is( instanceOf( InNode.class ) ) );
-        assertThat( inNode.getResultType(), is( BuiltInType.BOOLEAN ) );
-        assertThat( inNode.getText(), is( inputExpression ) );
+        assertThat( inNode).isInstanceOf(InNode.class);
+        assertThat( inNode.getResultType()).isEqualTo(BuiltInType.BOOLEAN);
+        assertThat( inNode.getText()).isEqualTo(inputExpression);
 
         InNode in = (InNode) inNode;
-        assertThat( in.getValue(), is( instanceOf( InfixOpNode.class ) ) );
-        assertThat( in.getValue().getText(), is( "x ** y" ) );
+        assertThat( in.getValue()).isInstanceOf(InfixOpNode.class);
+        assertThat( in.getValue().getText()).isEqualTo( "x ** y");
 
-        assertThat( in.getExprs(), is( instanceOf( ListNode.class ) ) );
-        assertThat( in.getExprs().getText(), is( "<=1000, >t, null, (2000..z[, ]z..2000], [(10+5)..(a*b))" ) );
+        assertThat( in.getExprs()).isInstanceOf(ListNode.class);
+        assertThat( in.getExprs().getText()).isEqualTo( "<=1000, >t, null, (2000..z[, ]z..2000], [(10+5)..(a*b))");
 
         ListNode list = (ListNode) in.getExprs();
-        assertThat( list.getElements().get( 0 ), is( instanceOf( RangeNode.class ) ) );
-        assertThat( list.getElements().get( 0 ).getText(), is( "<=1000" ) );
+        assertThat( list.getElements().get( 0 )).isInstanceOf(RangeNode.class);
+        assertThat( list.getElements().get( 0 ).getText()).isEqualTo( "<=1000");
 
-        assertThat( list.getElements().get( 1 ), is( instanceOf( RangeNode.class ) ) );
-        assertThat( list.getElements().get( 1 ).getText(), is( ">t" ) );
+        assertThat( list.getElements().get( 1 )).isInstanceOf(RangeNode.class);
+        assertThat( list.getElements().get( 1 ).getText()).isEqualTo( ">t");
 
-        assertThat( list.getElements().get( 2 ), is( instanceOf( NullNode.class ) ) );
-        assertThat( list.getElements().get( 2 ).getText(), is( "null" ) );
+        assertThat( list.getElements().get( 2 )).isInstanceOf(NullNode.class);
+        assertThat( list.getElements().get( 2 ).getText()).isEqualTo("null");
 
-        assertThat( list.getElements().get( 3 ), is( instanceOf( RangeNode.class ) ) );
+        assertThat( list.getElements().get( 3 )).isInstanceOf(RangeNode.class);
         RangeNode interval = (RangeNode) list.getElements().get( 3 );
-        assertThat( interval.getText(), is( "(2000..z[") );
-        assertThat( interval.getLowerBound(), is( RangeNode.IntervalBoundary.OPEN ) );
-        assertThat( interval.getUpperBound(), is( RangeNode.IntervalBoundary.OPEN ) );
-        assertThat( interval.getStart(), is( instanceOf( NumberNode.class ) ) );
-        assertThat( interval.getEnd(), is( instanceOf( NameRefNode.class ) ) );
+        assertThat( interval.getText()).isEqualTo( "(2000..z[");
+        assertThat( interval.getLowerBound()).isEqualTo(RangeNode.IntervalBoundary.OPEN);
+        assertThat( interval.getUpperBound()).isEqualTo(RangeNode.IntervalBoundary.OPEN);
+        assertThat( interval.getStart()).isInstanceOf(NumberNode.class);
+        assertThat( interval.getEnd()).isInstanceOf(NameRefNode.class);
 
-        assertThat( list.getElements().get( 4 ), is( instanceOf( RangeNode.class ) ) );
+        assertThat( list.getElements().get( 4 )).isInstanceOf(RangeNode.class);
         interval = (RangeNode) list.getElements().get( 4 );
-        assertThat( interval.getText(), is( "]z..2000]") );
-        assertThat( interval.getLowerBound(), is( RangeNode.IntervalBoundary.OPEN ) );
-        assertThat( interval.getUpperBound(), is( RangeNode.IntervalBoundary.CLOSED ) );
-        assertThat( interval.getStart(), is( instanceOf( NameRefNode.class ) ) );
-        assertThat( interval.getEnd(), is( instanceOf( NumberNode.class ) ) );
+        assertThat( interval.getText()).isEqualTo( "]z..2000]");
+        assertThat( interval.getLowerBound()).isEqualTo(RangeNode.IntervalBoundary.OPEN);
+        assertThat( interval.getUpperBound()).isEqualTo(RangeNode.IntervalBoundary.CLOSED);
+        assertThat( interval.getStart()).isInstanceOf(NameRefNode.class);
+        assertThat( interval.getEnd()).isInstanceOf(NumberNode.class);
 
-        assertThat( list.getElements().get( 5 ), is( instanceOf( RangeNode.class ) ) );
+        assertThat( list.getElements().get( 5 )).isInstanceOf(RangeNode.class);
         interval = (RangeNode) list.getElements().get( 5 );
-        assertThat( interval.getText(), is( "[(10+5)..(a*b))") );
-        assertThat( interval.getLowerBound(), is( RangeNode.IntervalBoundary.CLOSED ) );
-        assertThat( interval.getUpperBound(), is( RangeNode.IntervalBoundary.OPEN ) );
-        assertThat( interval.getStart(), is( instanceOf( InfixOpNode.class ) ) );
-        assertThat( interval.getEnd(), is( instanceOf( InfixOpNode.class ) ) );
+        assertThat( interval.getText()).isEqualTo( "[(10+5)..(a*b))");
+        assertThat( interval.getLowerBound()).isEqualTo(RangeNode.IntervalBoundary.CLOSED);
+        assertThat( interval.getUpperBound()).isEqualTo(RangeNode.IntervalBoundary.OPEN);
+        assertThat( interval.getStart()).isInstanceOf(InfixOpNode.class);
+        assertThat( interval.getEnd()).isInstanceOf(InfixOpNode.class);
 
     }
 
@@ -599,16 +595,16 @@ public class FEELParserTest {
         String inputExpression = "x - y in [(10+5)..(a*b))";
         BaseNode inNode = parse( inputExpression );
 
-        assertThat( inNode, is( instanceOf( InNode.class ) ) );
-        assertThat( inNode.getResultType(), is( BuiltInType.BOOLEAN ) );
-        assertThat( inNode.getText(), is( inputExpression ) );
+        assertThat( inNode).isInstanceOf(InNode.class);
+        assertThat( inNode.getResultType()).isEqualTo(BuiltInType.BOOLEAN);
+        assertThat( inNode.getText()).isEqualTo(inputExpression);
 
         InNode in = (InNode) inNode;
-        assertThat( in.getValue(), is( instanceOf( InfixOpNode.class ) ) );
-        assertThat( in.getValue().getText(), is( "x - y" ) );
+        assertThat( in.getValue()).isInstanceOf(InfixOpNode.class);
+        assertThat( in.getValue().getText()).isEqualTo( "x - y");
 
-        assertThat( in.getExprs(), is( instanceOf( RangeNode.class ) ) );
-        assertThat( in.getExprs().getText(), is( "[(10+5)..(a*b))" ) );
+        assertThat( in.getExprs()).isInstanceOf(RangeNode.class);
+        assertThat( in.getExprs().getText()).isEqualTo( "[(10+5)..(a*b))");
     }
 
     @Test
@@ -616,15 +612,15 @@ public class FEELParserTest {
         final String inputExpression = "name in [\"A\"..\"Z...\")";
         final BaseNode inNode = parse( inputExpression );
 
-        assertThat( inNode, is( instanceOf( InNode.class ) ) );
-        assertThat( inNode.getResultType(), is( BuiltInType.BOOLEAN ) );
-        assertThat( inNode.getText(), is( inputExpression ) );
+        assertThat( inNode).isInstanceOf(InNode.class);
+        assertThat( inNode.getResultType()).isEqualTo(BuiltInType.BOOLEAN);
+        assertThat( inNode.getText()).isEqualTo(inputExpression);
 
         final InNode in = (InNode) inNode;
-        assertThat( in.getExprs(), is( instanceOf( RangeNode.class ) ) );
+        assertThat( in.getExprs()).isInstanceOf(RangeNode.class);
         final RangeNode range = (RangeNode) in.getExprs();
-        assertThat( range.getStart().getText(), is( "\"A\"" ) );
-        assertThat( range.getEnd().getText(), is( "\"Z...\"" ) );
+        assertThat( range.getStart().getText()).isEqualTo( "\"A\"");
+        assertThat( range.getEnd().getText()).isEqualTo( "\"Z...\"");
     }
 
     @Test
@@ -632,16 +628,16 @@ public class FEELParserTest {
         String inputExpression = "foo >= bar * 10";
         BaseNode infix = parse( inputExpression );
 
-        assertThat( infix, is( instanceOf( InfixOpNode.class ) ) );
-        assertThat( infix.getResultType(), is( BuiltInType.BOOLEAN ) );
-        assertThat( infix.getText(), is( inputExpression ) );
+        assertThat( infix).isInstanceOf(InfixOpNode.class);
+        assertThat( infix.getResultType()).isEqualTo(BuiltInType.BOOLEAN);
+        assertThat( infix.getText()).isEqualTo(inputExpression);
 
         InfixOpNode in = (InfixOpNode) infix;
-        assertThat( in.getLeft(), is( instanceOf( NameRefNode.class ) ) );
-        assertThat( in.getLeft().getText(), is( "foo" ) );
+        assertThat( in.getLeft()).isInstanceOf(NameRefNode.class);
+        assertThat( in.getLeft().getText()).isEqualTo("foo");
 
-        assertThat( in.getRight(), is( instanceOf( InfixOpNode.class ) ) );
-        assertThat( in.getRight().getText(), is( "bar * 10" ) );
+        assertThat( in.getRight()).isInstanceOf(InfixOpNode.class);
+        assertThat( in.getRight().getText()).isEqualTo( "bar * 10");
     }
 
     @Test
@@ -649,27 +645,27 @@ public class FEELParserTest {
         String inputExpression = "foo < 10 and bar = \"x\" or baz";
         BaseNode infix = parse( inputExpression );
 
-        assertThat( infix, is( instanceOf( InfixOpNode.class ) ) );
-        assertThat( infix.getResultType(), is( BuiltInType.BOOLEAN ) );
-        assertThat( infix.getText(), is( inputExpression ) );
+        assertThat( infix).isInstanceOf(InfixOpNode.class);
+        assertThat( infix.getResultType()).isEqualTo(BuiltInType.BOOLEAN);
+        assertThat( infix.getText()).isEqualTo(inputExpression);
 
         InfixOpNode or = (InfixOpNode) infix;
-        assertThat( or.getLeft(), is( instanceOf( InfixOpNode.class ) ) );
-        assertThat( or.getLeft().getText(), is( "foo < 10 and bar = \"x\"" ) );
+        assertThat( or.getLeft()).isInstanceOf(InfixOpNode.class);
+        assertThat( or.getLeft().getText()).isEqualTo( "foo < 10 and bar = \"x\"");
 
-        assertThat( or.getOperator(), is( InfixOpNode.InfixOperator.OR ) );
+        assertThat( or.getOperator()).isEqualTo(InfixOpNode.InfixOperator.OR);
 
-        assertThat( or.getRight(), is( instanceOf( NameRefNode.class ) ) );
-        assertThat( or.getRight().getText(), is( "baz" ) );
+        assertThat( or.getRight()).isInstanceOf(NameRefNode.class);
+        assertThat( or.getRight().getText()).isEqualTo("baz");
 
         InfixOpNode and = (InfixOpNode) or.getLeft();
-        assertThat( and.getLeft(), is( instanceOf( InfixOpNode.class ) ) );
-        assertThat( and.getLeft().getText(), is( "foo < 10" ) );
+        assertThat( and.getLeft()).isInstanceOf(InfixOpNode.class);
+        assertThat( and.getLeft().getText()).isEqualTo( "foo < 10");
 
-        assertThat( and.getOperator(), is( InfixOpNode.InfixOperator.AND ) );
+        assertThat( and.getOperator()).isEqualTo(InfixOpNode.InfixOperator.AND);
 
-        assertThat( and.getRight(), is( instanceOf( InfixOpNode.class ) ) );
-        assertThat( and.getRight().getText(), is( "bar = \"x\"" ) );
+        assertThat( and.getRight()).isInstanceOf(InfixOpNode.class);
+        assertThat( and.getRight().getText()).isEqualTo( "bar = \"x\"");
     }
 
     @Test
@@ -677,12 +673,12 @@ public class FEELParserTest {
         String inputExpression = "[]";
         BaseNode list = parse( inputExpression );
 
-        assertThat( list, is( instanceOf( ListNode.class ) ) );
-        assertThat( list.getResultType(), is( BuiltInType.LIST ) );
-        assertThat( list.getText(), is( inputExpression ) );
+        assertThat( list).isInstanceOf(ListNode.class);
+        assertThat( list.getResultType()).isEqualTo(BuiltInType.LIST);
+        assertThat( list.getText()).isEqualTo(inputExpression);
 
         ListNode ln = (ListNode) list;
-        assertThat( ln.getElements(), is( empty() ));
+        assertThat( ln.getElements()).isEmpty();
     }
 
     @Test
@@ -691,15 +687,15 @@ public class FEELParserTest {
         String inputExpression = "[ 10, foo * bar, true ]";
         BaseNode list = parse( inputExpression );
 
-        assertThat( list, is( instanceOf( ListNode.class ) ) );
-        assertThat( list.getResultType(), is( BuiltInType.LIST ) );
-        assertThat( list.getText(), is( "10, foo * bar, true" ) );
+        assertThat( list).isInstanceOf(ListNode.class);
+        assertThat( list.getResultType()).isEqualTo(BuiltInType.LIST);
+        assertThat( list.getText()).isEqualTo( "10, foo * bar, true");
 
         ListNode ln = (ListNode) list;
-        assertThat( ln.getElements().size(), is( 3 ) );
-        assertThat( ln.getElements().get( 0 ), is( instanceOf( NumberNode.class ) ) );
-        assertThat( ln.getElements().get( 1 ), is( instanceOf( InfixOpNode.class ) ) );
-        assertThat( ln.getElements().get( 2 ), is( instanceOf( BooleanNode.class ) ) );
+        assertThat( ln.getElements().size()).isEqualTo(3);
+        assertThat( ln.getElements().get( 0 )).isInstanceOf(NumberNode.class);
+        assertThat( ln.getElements().get( 1 )).isInstanceOf(InfixOpNode.class);
+        assertThat( ln.getElements().get( 2 )).isInstanceOf(BooleanNode.class);
     }
 
     @Test
@@ -707,11 +703,11 @@ public class FEELParserTest {
         String inputExpression = "{}";
         BaseNode context = parse( inputExpression );
 
-        assertThat( context, is( instanceOf( ContextNode.class ) ) );
-        assertThat( context.getText(), is( inputExpression ) );
+        assertThat( context).isInstanceOf(ContextNode.class);
+        assertThat( context.getText()).isEqualTo(inputExpression);
 
         ContextNode ctx = (ContextNode) context;
-        assertThat( ctx.getEntries(), is( empty() ));
+        assertThat( ctx.getEntries()).isEmpty();
     }
 
     @Test
@@ -719,42 +715,42 @@ public class FEELParserTest {
         String inputExpression = "{ \"a string key\" : 10,"
                        + " a non-string key : foo+bar,"
                        + " a key.with + /' odd chars : [10..50] }";
-        BaseNode ctxbase = parse( inputExpression, mapOf(entry("foo", BuiltInType.NUMBER), entry("bar", BuiltInType.NUMBER)) );
+        BaseNode ctxbase = parse( inputExpression, mapOf(entry("foo", BuiltInType.NUMBER), entry("bar", BuiltInType.NUMBER)));
 
-        assertThat( ctxbase, is( instanceOf( ContextNode.class ) ) );
-        assertThat( ctxbase.getText(), is( inputExpression ) );
+        assertThat( ctxbase).isInstanceOf(ContextNode.class);
+        assertThat( ctxbase.getText()).isEqualTo(inputExpression);
 
         ContextNode ctx = (ContextNode) ctxbase;
-        assertThat( ctx.getEntries().size(), is( 3 ) );
+        assertThat( ctx.getEntries().size()).isEqualTo(3);
 
         ContextEntryNode entry = ctx.getEntries().get( 0 );
-        assertThat(entry.getName(), is(instanceOf(StringNode.class)));
+        assertThat(entry.getName()).isInstanceOf(StringNode.class);
         StringNode nameNode = (StringNode) entry.getName();
-        assertThat(nameNode.getText(), is(notNullValue()));
-        assertThat(nameNode.getText(), is("\"a string key\"")); // Reference String literal test, BaseNode#getText() return the FEEL equivalent expression, in this case quoted.
-        assertThat( entry.getValue(), is( instanceOf( NumberNode.class ) ) );
-        assertThat( entry.getResultType(), is( BuiltInType.NUMBER ) );
-        assertThat( entry.getValue().getText(), is("10") );
+        assertThat(nameNode.getText()).isNotNull();
+        assertThat(nameNode.getText()).isEqualTo("\"a string key\""); // Reference String literal test, BaseNode#getText() return the FEEL equivalent expression, in this case quoted.
+        assertThat( entry.getValue()).isInstanceOf(NumberNode.class);
+        assertThat( entry.getResultType()).isEqualTo(BuiltInType.NUMBER);
+        assertThat( entry.getValue().getText()).isEqualTo("10");
 
         entry = ctx.getEntries().get( 1 );
-        assertThat( entry.getName(), is( instanceOf( NameDefNode.class ) ) );
+        assertThat( entry.getName()).isInstanceOf(NameDefNode.class);
         NameDefNode name = (NameDefNode) entry.getName();
-        assertThat( name.getParts(), is( notNullValue() ) );
-        assertThat( name.getParts().size(), is( 5 ) );
-        assertThat( entry.getName().getText(), is("a non-string key") );
-        assertThat( entry.getValue(), is( instanceOf( InfixOpNode.class ) ) );
-        assertThat( entry.getResultType(), is( BuiltInType.NUMBER ) );
-        assertThat( entry.getValue().getText(), is( "foo+bar" ) );
+        assertThat( name.getParts()).isNotNull();
+        assertThat( name.getParts().size()).isEqualTo(5);
+        assertThat( entry.getName().getText()).isEqualTo("a non-string key");
+        assertThat( entry.getValue()).isInstanceOf(InfixOpNode.class);
+        assertThat( entry.getResultType()).isEqualTo(BuiltInType.NUMBER);
+        assertThat( entry.getValue().getText()).isEqualTo( "foo+bar");
 
         entry = ctx.getEntries().get( 2 );
-        assertThat( entry.getName(), is( instanceOf( NameDefNode.class ) ) );
+        assertThat( entry.getName()).isInstanceOf(NameDefNode.class);
         name = (NameDefNode) entry.getName();
-        assertThat( name.getParts(), is( notNullValue() ) );
-        assertThat( name.getParts().size(), is( 9 ) );
-        assertThat( entry.getName().getText(), is("a key.with + /' odd chars") );
-        assertThat( entry.getValue(), is( instanceOf( RangeNode.class ) ) );
-        assertThat( entry.getResultType(), is( BuiltInType.RANGE ) );
-        assertThat( entry.getValue().getText(), is( "[10..50]" ) );
+        assertThat( name.getParts()).isNotNull();
+        assertThat( name.getParts().size()).isEqualTo(9);
+        assertThat( entry.getName().getText()).isEqualTo("a key.with + /' odd chars");
+        assertThat( entry.getValue()).isInstanceOf(RangeNode.class);
+        assertThat( entry.getResultType()).isEqualTo(BuiltInType.RANGE);
+        assertThat( entry.getValue().getText()).isEqualTo( "[10..50]");
     }
 
     @Test
@@ -764,41 +760,41 @@ public class FEELParserTest {
                 + " another in variable : an external in variable / 2 }";
         BaseNode ctxbase = parse( inputExpression, mapOf(entry("an external in variable", BuiltInType.NUMBER)) );
 
-        assertThat( ctxbase, is( instanceOf( ContextNode.class ) ) );
-        assertThat( ctxbase.getText(), is( inputExpression ) );
+        assertThat( ctxbase).isInstanceOf(ContextNode.class);
+        assertThat( ctxbase.getText()).isEqualTo(inputExpression);
 
         ContextNode ctx = (ContextNode) ctxbase;
-        assertThat( ctx.getEntries().size(), is( 3 ) );
+        assertThat( ctx.getEntries().size()).isEqualTo(3);
 
         ContextEntryNode entry = ctx.getEntries().get( 0 );
-        assertThat( entry.getName(), is( instanceOf( NameDefNode.class ) ) );
+        assertThat( entry.getName()).isInstanceOf(NameDefNode.class);
         NameDefNode name = (NameDefNode) entry.getName();
-        assertThat( name.getParts(), is( notNullValue() ) );
-        assertThat( name.getParts().size(), is( 5 ) );
-        assertThat( entry.getName().getText(), is("a variable with in keyword") );
-        assertThat( entry.getValue(), is( instanceOf( NumberNode.class ) ) );
-        assertThat( entry.getResultType(), is( BuiltInType.NUMBER ) );
-        assertThat( entry.getValue().getText(), is("10") );
+        assertThat( name.getParts()).isNotNull();
+        assertThat( name.getParts().size()).isEqualTo(5);
+        assertThat( entry.getName().getText()).isEqualTo("a variable with in keyword");
+        assertThat( entry.getValue()).isInstanceOf(NumberNode.class);
+        assertThat( entry.getResultType()).isEqualTo(BuiltInType.NUMBER);
+        assertThat( entry.getValue().getText()).isEqualTo("10");
 
         entry = ctx.getEntries().get( 1 );
-        assertThat( entry.getName(), is( instanceOf( NameDefNode.class ) ) );
+        assertThat( entry.getName()).isInstanceOf(NameDefNode.class);
         name = (NameDefNode) entry.getName();
-        assertThat( name.getParts(), is( notNullValue() ) );
-        assertThat( name.getParts().size(), is( 2 ) );
-        assertThat( entry.getName().getText(), is("another variable") );
-        assertThat( entry.getValue(), is( instanceOf( InfixOpNode.class ) ) );
-        assertThat( entry.getResultType(), is( BuiltInType.NUMBER ) );
-        assertThat( entry.getValue().getText(), is( "a variable with in keyword + 20" ) );
+        assertThat( name.getParts()).isNotNull();
+        assertThat( name.getParts().size()).isEqualTo(2);
+        assertThat( entry.getName().getText()).isEqualTo("another variable");
+        assertThat( entry.getValue()).isInstanceOf(InfixOpNode.class);
+        assertThat( entry.getResultType()).isEqualTo(BuiltInType.NUMBER);
+        assertThat( entry.getValue().getText()).isEqualTo( "a variable with in keyword + 20");
 
         entry = ctx.getEntries().get( 2 );
-        assertThat( entry.getName(), is( instanceOf( NameDefNode.class ) ) );
+        assertThat( entry.getName()).isInstanceOf(NameDefNode.class);
         name = (NameDefNode) entry.getName();
-        assertThat( name.getParts(), is( notNullValue() ) );
-        assertThat( name.getParts().size(), is( 3 ) );
-        assertThat( entry.getName().getText(), is("another in variable") );
-        assertThat( entry.getValue(), is( instanceOf( InfixOpNode.class ) ) );
-        assertThat( entry.getResultType(), is( BuiltInType.NUMBER ) );
-        assertThat( entry.getValue().getText(), is( "an external in variable / 2" ) );
+        assertThat( name.getParts()).isNotNull();
+        assertThat( name.getParts().size()).isEqualTo(3);
+        assertThat( entry.getName().getText()).isEqualTo("another in variable");
+        assertThat( entry.getValue()).isInstanceOf(InfixOpNode.class);
+        assertThat( entry.getResultType()).isEqualTo(BuiltInType.NUMBER);
+        assertThat( entry.getValue().getText()).isEqualTo( "an external in variable / 2");
     }
 
     @Test
@@ -817,43 +813,43 @@ public class FEELParserTest {
                        + "}";
         BaseNode ctxbase = parse( inputExpression );
 
-        assertThat( ctxbase, is( instanceOf( ContextNode.class ) ) );
-        assertThat( ctxbase.getText(), is( inputExpression ) );
+        assertThat( ctxbase).isInstanceOf(ContextNode.class);
+        assertThat( ctxbase.getText()).isEqualTo(inputExpression);
 
         ContextNode ctx = (ContextNode) ctxbase;
-        assertThat( ctx.getEntries().size(), is( 2 ) );
+        assertThat( ctx.getEntries().size()).isEqualTo(2);
 
         ContextEntryNode entry = ctx.getEntries().get( 0 );
-        assertThat( entry.getName(), is( instanceOf( NameDefNode.class ) ) );
+        assertThat( entry.getName()).isInstanceOf(NameDefNode.class);
         NameDefNode name = (NameDefNode) entry.getName();
-        assertThat( name.getText(), is("a value") );
-        assertThat( entry.getValue(), is( instanceOf( NumberNode.class ) ) );
-        assertThat( entry.getResultType(), is( BuiltInType.NUMBER ) );
-        assertThat( entry.getValue().getText(), is("10") );
+        assertThat( name.getText()).isEqualTo("a value");
+        assertThat( entry.getValue()).isInstanceOf(NumberNode.class);
+        assertThat( entry.getResultType()).isEqualTo(BuiltInType.NUMBER);
+        assertThat( entry.getValue().getText()).isEqualTo("10");
 
         entry = ctx.getEntries().get( 1 );
-        assertThat( entry.getName(), is( instanceOf( NameDefNode.class ) ) );
+        assertThat( entry.getName()).isInstanceOf(NameDefNode.class);
         name = (NameDefNode) entry.getName();
-        assertThat( name.getText(), is( "an applicant" ) );
-        assertThat( entry.getValue(), is( instanceOf( ContextNode.class ) ) );
+        assertThat( name.getText()).isEqualTo( "an applicant");
+        assertThat( entry.getValue()).isInstanceOf(ContextNode.class);
 
         ContextNode applicant = (ContextNode) entry.getValue();
-        assertThat( applicant.getEntries().size(), is( 5 ) );
-        assertThat( applicant.getEntries().get( 0 ).getName().getText(), is("first name") );
-        assertThat( applicant.getEntries().get( 0 ).getResultType(), is( BuiltInType.STRING ) );
-        assertThat( applicant.getEntries().get( 1 ).getName().getText(), is("last + name") );
-        assertThat( applicant.getEntries().get( 1 ).getResultType(), is( BuiltInType.STRING ) );
-        assertThat( applicant.getEntries().get( 2 ).getName().getText(), is("full name") );
-        assertThat( applicant.getEntries().get( 2 ).getResultType(), is( BuiltInType.STRING ) );
-        assertThat( applicant.getEntries().get( 3 ).getName().getText(), is("address") );
-        assertThat( applicant.getEntries().get( 3 ).getValue(), is( instanceOf( ContextNode.class ) ) );
+        assertThat( applicant.getEntries().size()).isEqualTo(5);
+        assertThat( applicant.getEntries().get( 0 ).getName().getText()).isEqualTo("first name");
+        assertThat( applicant.getEntries().get( 0 ).getResultType()).isEqualTo(BuiltInType.STRING);
+        assertThat( applicant.getEntries().get( 1 ).getName().getText()).isEqualTo("last + name");
+        assertThat( applicant.getEntries().get( 1 ).getResultType()).isEqualTo(BuiltInType.STRING);
+        assertThat( applicant.getEntries().get( 2 ).getName().getText()).isEqualTo("full name");
+        assertThat( applicant.getEntries().get( 2 ).getResultType()).isEqualTo(BuiltInType.STRING);
+        assertThat( applicant.getEntries().get( 3 ).getName().getText()).isEqualTo("address");
+        assertThat( applicant.getEntries().get( 3 ).getValue()).isInstanceOf(ContextNode.class);
 
         ContextNode address = (ContextNode) applicant.getEntries().get( 3 ).getValue();
-        assertThat( address.getEntries().size(), is( 2 ) );
-        assertThat( address.getEntries().get( 0 ).getName().getText(), is("street") );
-        assertThat( address.getEntries().get( 0 ).getResultType(), is( BuiltInType.STRING ) );
-        assertThat( address.getEntries().get( 1 ).getName().getText(), is("city") );
-        assertThat( address.getEntries().get( 0 ).getResultType(), is( BuiltInType.STRING ) );
+        assertThat( address.getEntries().size()).isEqualTo(2);
+        assertThat( address.getEntries().get( 0 ).getName().getText()).isEqualTo("street");
+        assertThat( address.getEntries().get( 0 ).getResultType()).isEqualTo(BuiltInType.STRING);
+        assertThat( address.getEntries().get( 1 ).getName().getText()).isEqualTo("city");
+        assertThat( address.getEntries().get( 0 ).getResultType()).isEqualTo(BuiltInType.STRING);
     }
 
     @Test
@@ -868,22 +864,22 @@ public class FEELParserTest {
                                  + "}";
         BaseNode ctxbase = parse( inputExpression );
 
-        assertThat( ctxbase, is( instanceOf( ContextNode.class ) ) );
-        assertThat( ctxbase.getText(), is( inputExpression ) );
+        assertThat( ctxbase).isInstanceOf(ContextNode.class);
+        assertThat( ctxbase.getText()).isEqualTo(inputExpression);
 
         ContextNode ctx = (ContextNode) ctxbase;
-        assertThat( ctx.getEntries().size(), is( 2 ) );
+        assertThat( ctx.getEntries().size()).isEqualTo(2);
 
         ContextEntryNode entry = ctx.getEntries().get( 1 );
-        assertThat( entry.getName(), is( instanceOf( NameDefNode.class ) ) );
-        assertThat( entry.getResultType(), is( BuiltInType.STRING ) );
+        assertThat( entry.getName()).isInstanceOf(NameDefNode.class);
+        assertThat( entry.getResultType()).isEqualTo(BuiltInType.STRING);
         NameDefNode name = (NameDefNode) entry.getName();
-        assertThat( name.getText(), is("street") );
-        assertThat( entry.getValue(), is( instanceOf( QualifiedNameNode.class ) ) );
+        assertThat( name.getText()).isEqualTo("street");
+        assertThat( entry.getValue()).isInstanceOf(QualifiedNameNode.class);
         QualifiedNameNode qnn = (QualifiedNameNode) entry.getValue();
-        assertThat( qnn.getParts().get( 0 ).getText(), is("an applicant") );
-        assertThat( qnn.getParts().get( 1 ).getText(), is("home address") );
-        assertThat( qnn.getParts().get( 2 ).getText(), is("street name") );
+        assertThat( qnn.getParts().get( 0 ).getText()).isEqualTo("an applicant");
+        assertThat( qnn.getParts().get( 1 ).getText()).isEqualTo("home address");
+        assertThat( qnn.getParts().get( 2 ).getText()).isEqualTo("street name");
     }
 
     @Test
@@ -891,24 +887,24 @@ public class FEELParserTest {
         String inputExpression = "{ is minor : function( person's age ) person's age < 21 }";
         BaseNode ctxbase = parse( inputExpression );
 
-        assertThat( ctxbase, is( instanceOf( ContextNode.class ) ) );
-        assertThat( ctxbase.getText(), is( inputExpression ) );
+        assertThat( ctxbase).isInstanceOf(ContextNode.class);
+        assertThat( ctxbase.getText()).isEqualTo(inputExpression);
 
         ContextNode ctx = (ContextNode) ctxbase;
-        assertThat( ctx.getEntries().size(), is( 1 ) );
+        assertThat( ctx.getEntries().size()).isEqualTo(1);
 
         ContextEntryNode entry = ctx.getEntries().get( 0 );
-        assertThat( entry.getName(), is( instanceOf( NameDefNode.class ) ) );
+        assertThat( entry.getName()).isInstanceOf(NameDefNode.class);
         NameDefNode name = (NameDefNode) entry.getName();
-        assertThat( name.getText(), is("is minor") );
-        assertThat( entry.getValue(), is( instanceOf( FunctionDefNode.class ) ) );
-        assertThat( entry.getValue().getText(), is("function( person's age ) person's age < 21") );
+        assertThat( name.getText()).isEqualTo("is minor");
+        assertThat( entry.getValue()).isInstanceOf(FunctionDefNode.class);
+        assertThat( entry.getValue().getText()).isEqualTo("function( person's age ) person's age < 21");
 
         FunctionDefNode isMinorFunc = (FunctionDefNode) entry.getValue();
-        assertThat( isMinorFunc.getFormalParameters().size(), is( 1 ) );
-        assertThat( isMinorFunc.getFormalParameters().get( 0 ).getText(), is( "person's age" ) );
-        assertThat( isMinorFunc.isExternal(), is( false ) );
-        assertThat( isMinorFunc.getBody(), is( instanceOf( InfixOpNode.class ) ) );
+        assertThat( isMinorFunc.getFormalParameters().size()).isEqualTo(1);
+        assertThat( isMinorFunc.getFormalParameters().get( 0 ).getText()).isEqualTo( "person's age");
+        assertThat( isMinorFunc.isExternal()).isEqualTo(false);
+        assertThat( isMinorFunc.getBody()).isInstanceOf(InfixOpNode.class);
     }
 
     @Test
@@ -921,44 +917,44 @@ public class FEELParserTest {
                        + "}}";
         BaseNode ctxbase = parse( inputExpression );
 
-        assertThat( ctxbase, is( instanceOf( ContextNode.class ) ) );
-        assertThat( ctxbase.getText(), is( inputExpression ) );
+        assertThat( ctxbase).isInstanceOf(ContextNode.class);
+        assertThat( ctxbase.getText()).isEqualTo(inputExpression);
 
         ContextNode ctx = (ContextNode) ctxbase;
-        assertThat( ctx.getEntries().size(), is( 1 ) );
+        assertThat( ctx.getEntries().size()).isEqualTo(1);
 
         ContextEntryNode entry = ctx.getEntries().get( 0 );
-        assertThat( entry.getName(), is( instanceOf( NameDefNode.class ) ) );
+        assertThat( entry.getName()).isInstanceOf(NameDefNode.class);
         NameDefNode name = (NameDefNode) entry.getName();
-        assertThat( name.getText(), is("trigonometric cosine") );
-        assertThat( entry.getValue(), is( instanceOf( FunctionDefNode.class ) ) );
-        assertThat( entry.getValue().getText(), is("function( angle ) external {"
+        assertThat( name.getText()).isEqualTo("trigonometric cosine");
+        assertThat( entry.getValue()).isInstanceOf(FunctionDefNode.class);
+        assertThat( entry.getValue().getText()).isEqualTo("function( angle ) external {"
                                                  + "    java : {"
                                                  + "        class : \"java.lang.Math\","
                                                  + "        method signature : \"cos(double)\""
                                                  + "    }"
-                                                 + "}" ) );
+                                                 + "}");
 
         FunctionDefNode cos = (FunctionDefNode) entry.getValue();
-        assertThat( cos.getFormalParameters().size(), is( 1 ) );
-        assertThat( cos.getFormalParameters().get( 0 ).getText(), is( "angle" ) );
-        assertThat( cos.isExternal(), is( true ) );
-        assertThat( cos.getBody(), is( instanceOf( ContextNode.class ) ) );
+        assertThat( cos.getFormalParameters().size()).isEqualTo(1);
+        assertThat( cos.getFormalParameters().get( 0 ).getText()).isEqualTo("angle");
+        assertThat( cos.isExternal()).isEqualTo(true);
+        assertThat( cos.getBody()).isInstanceOf(ContextNode.class);
 
         ContextNode body = (ContextNode) cos.getBody();
-        assertThat( body.getEntries().size(), is( 1 ) );
+        assertThat( body.getEntries().size()).isEqualTo(1);
         ContextEntryNode java = body.getEntries().get( 0 );
-        assertThat( java.getName().getText(), is( "java" ) );
-        assertThat( java.getValue(), is( instanceOf( ContextNode.class ) ) );
+        assertThat( java.getName().getText()).isEqualTo("java");
+        assertThat( java.getValue()).isInstanceOf(ContextNode.class);
 
         ContextNode def = (ContextNode) java.getValue();
-        assertThat( def.getEntries().size(), is( 2 ) );
-        assertThat( def.getEntries().get( 0 ).getName().getText(), is( "class" ) );
-        assertThat( def.getEntries().get( 0 ).getValue(), is( instanceOf( StringNode.class ) ) );
-        assertThat( def.getEntries().get( 0 ).getValue().getText(), is( "\"java.lang.Math\"" ) );
-        assertThat( def.getEntries().get( 1 ).getName().getText(), is( "method signature" ) );
-        assertThat( def.getEntries().get( 1 ).getValue(), is( instanceOf( StringNode.class ) ) );
-        assertThat( def.getEntries().get( 1 ).getValue().getText(), is( "\"cos(double)\"" ) );
+        assertThat( def.getEntries().size()).isEqualTo(2);
+        assertThat( def.getEntries().get( 0 ).getName().getText()).isEqualTo("class");
+        assertThat( def.getEntries().get( 0 ).getValue()).isInstanceOf(StringNode.class);
+        assertThat( def.getEntries().get( 0 ).getValue().getText()).isEqualTo( "\"java.lang.Math\"");
+        assertThat( def.getEntries().get( 1 ).getName().getText()).isEqualTo( "method signature");
+        assertThat( def.getEntries().get( 1 ).getValue()).isInstanceOf(StringNode.class);
+        assertThat( def.getEntries().get( 1 ).getValue().getText()).isEqualTo( "\"cos(double)\"");
     }
 
     @Test
@@ -966,19 +962,19 @@ public class FEELParserTest {
         String inputExpression = "for item in order.items return item.price * item.quantity";
         BaseNode forbase = parse( inputExpression );
 
-        assertThat( forbase, is( instanceOf( ForExpressionNode.class ) ) );
-        assertThat( forbase.getText(), is( inputExpression ) );
-        assertThat( forbase.getResultType(), is( BuiltInType.LIST ) );
+        assertThat( forbase).isInstanceOf(ForExpressionNode.class);
+        assertThat( forbase.getText()).isEqualTo(inputExpression);
+        assertThat( forbase.getResultType()).isEqualTo(BuiltInType.LIST);
 
         ForExpressionNode forExpr = (ForExpressionNode) forbase;
-        assertThat( forExpr.getIterationContexts().size(), is( 1 ) );
-        assertThat( forExpr.getExpression(), is( instanceOf( InfixOpNode.class ) ) );
-        assertThat( forExpr.getExpression().getText(), is( "item.price * item.quantity" ) );
+        assertThat( forExpr.getIterationContexts().size()).isEqualTo(1);
+        assertThat( forExpr.getExpression()).isInstanceOf(InfixOpNode.class);
+        assertThat( forExpr.getExpression().getText()).isEqualTo( "item.price * item.quantity");
 
         IterationContextNode ic = forExpr.getIterationContexts().get( 0 );
-        assertThat( ic.getName().getText(), is("item") );
-        assertThat( ic.getExpression(), is( instanceOf( QualifiedNameNode.class ) ) );
-        assertThat( ic.getExpression().getText(), is("order.items") );
+        assertThat( ic.getName().getText()).isEqualTo("item");
+        assertThat( ic.getExpression()).isInstanceOf(QualifiedNameNode.class);
+        assertThat( ic.getExpression().getText()).isEqualTo("order.items");
     }
 
     @Test
@@ -986,14 +982,14 @@ public class FEELParserTest {
         String inputExpression = "if applicant.age < 18 then \"declined\" else \"accepted\"";
         BaseNode ifBase = parse( inputExpression );
 
-        assertThat( ifBase, is( instanceOf( IfExpressionNode.class ) ) );
-        assertThat( ifBase.getText(), is( inputExpression ) );
-        assertThat( ifBase.getResultType(), is( BuiltInType.STRING ) );
+        assertThat( ifBase).isInstanceOf(IfExpressionNode.class);
+        assertThat( ifBase.getText()).isEqualTo(inputExpression);
+        assertThat( ifBase.getResultType()).isEqualTo(BuiltInType.STRING);
 
         IfExpressionNode ifExpr = (IfExpressionNode) ifBase;
-        assertThat( ifExpr.getCondition().getText(), is( "applicant.age < 18" ) );
-        assertThat( ifExpr.getThenExpression().getText(), is( "\"declined\"" ) );
-        assertThat( ifExpr.getElseExpression().getText(), is( "\"accepted\"" ) );
+        assertThat( ifExpr.getCondition().getText()).isEqualTo( "applicant.age < 18");
+        assertThat( ifExpr.getThenExpression().getText()).isEqualTo( "\"declined\"");
+        assertThat( ifExpr.getElseExpression().getText()).isEqualTo( "\"accepted\"");
     }
 
     @Test
@@ -1001,15 +997,15 @@ public class FEELParserTest {
         String inputExpression = "some item in order.items satisfies item.price > 100";
         BaseNode someBase = parse( inputExpression );
 
-        assertThat( someBase, is( instanceOf( QuantifiedExpressionNode.class ) ) );
-        assertThat( someBase.getText(), is( inputExpression ) );
-        assertThat( someBase.getResultType(), is( BuiltInType.BOOLEAN ) );
+        assertThat( someBase).isInstanceOf(QuantifiedExpressionNode.class);
+        assertThat( someBase.getText()).isEqualTo(inputExpression);
+        assertThat( someBase.getResultType()).isEqualTo(BuiltInType.BOOLEAN);
 
         QuantifiedExpressionNode someExpr = (QuantifiedExpressionNode) someBase;
-        assertThat( someExpr.getQuantifier(), is( QuantifiedExpressionNode.Quantifier.SOME ) );
-        assertThat( someExpr.getIterationContexts().size(), is( 1 ) );
-        assertThat( someExpr.getIterationContexts().get( 0 ).getText(), is( "item in order.items" ) );
-        assertThat( someExpr.getExpression().getText(), is( "item.price > 100" ) );
+        assertThat( someExpr.getQuantifier()).isEqualTo(QuantifiedExpressionNode.Quantifier.SOME);
+        assertThat( someExpr.getIterationContexts().size()).isEqualTo(1);
+        assertThat( someExpr.getIterationContexts().get( 0 ).getText()).isEqualTo( "item in order.items");
+        assertThat( someExpr.getExpression().getText()).isEqualTo( "item.price > 100");
     }
 
     @Test
@@ -1017,15 +1013,15 @@ public class FEELParserTest {
         String inputExpression = "every item in order.items satisfies item.price > 100";
         BaseNode everyBase = parse( inputExpression );
 
-        assertThat( everyBase, is( instanceOf( QuantifiedExpressionNode.class ) ) );
-        assertThat( everyBase.getText(), is( inputExpression ) );
-        assertThat( everyBase.getResultType(), is( BuiltInType.BOOLEAN ) );
+        assertThat( everyBase).isInstanceOf(QuantifiedExpressionNode.class);
+        assertThat( everyBase.getText()).isEqualTo(inputExpression);
+        assertThat( everyBase.getResultType()).isEqualTo(BuiltInType.BOOLEAN);
 
         QuantifiedExpressionNode everyExpr = (QuantifiedExpressionNode) everyBase;
-        assertThat( everyExpr.getQuantifier(), is( QuantifiedExpressionNode.Quantifier.EVERY ) );
-        assertThat( everyExpr.getIterationContexts().size(), is( 1 ) );
-        assertThat( everyExpr.getIterationContexts().get( 0 ).getText(), is( "item in order.items" ) );
-        assertThat( everyExpr.getExpression().getText(), is( "item.price > 100" ) );
+        assertThat( everyExpr.getQuantifier()).isEqualTo(QuantifiedExpressionNode.Quantifier.EVERY);
+        assertThat( everyExpr.getIterationContexts().size()).isEqualTo(1);
+        assertThat( everyExpr.getIterationContexts().get( 0 ).getText()).isEqualTo( "item in order.items");
+        assertThat( everyExpr.getExpression().getText()).isEqualTo( "item.price > 100");
     }
 
     @Test
@@ -1033,15 +1029,15 @@ public class FEELParserTest {
         String inputExpression = "\"foo\" instance of string";
         BaseNode instanceOfBase = parse( inputExpression );
 
-        assertThat( instanceOfBase, is( instanceOf( InstanceOfNode.class ) ) );
-        assertThat( instanceOfBase.getText(), is( inputExpression ) );
-        assertThat( instanceOfBase.getResultType(), is( BuiltInType.BOOLEAN ) );
+        assertThat( instanceOfBase).isInstanceOf(InstanceOfNode.class);
+        assertThat( instanceOfBase.getText()).isEqualTo(inputExpression);
+        assertThat( instanceOfBase.getResultType()).isEqualTo(BuiltInType.BOOLEAN);
 
         InstanceOfNode ioExpr = (InstanceOfNode) instanceOfBase;
-        assertThat( ioExpr.getExpression(), is( instanceOf( StringNode.class ) ) );
-        assertThat( ioExpr.getExpression().getText(), is( "\"foo\"" ) );
-        assertThat( ioExpr.getType(), is( instanceOf( TypeNode.class ) ) );
-        assertThat( ioExpr.getType().getText(), is( "string" ) );
+        assertThat( ioExpr.getExpression()).isInstanceOf(StringNode.class);
+        assertThat( ioExpr.getExpression().getText()).isEqualTo( "\"foo\"");
+        assertThat( ioExpr.getType()).isInstanceOf(TypeNode.class);
+        assertThat( ioExpr.getType().getText()).isEqualTo("string");
     }
 
     @Test
@@ -1049,30 +1045,30 @@ public class FEELParserTest {
         String inputExpression = "\"foo\" instance of string and 10 instance of number";
         BaseNode andExpr = parse( inputExpression );
 
-        assertThat( andExpr, is( instanceOf( InfixOpNode.class ) ) );
-        assertThat( andExpr.getText(), is( inputExpression ) );
-        assertThat( andExpr.getResultType(), is( BuiltInType.BOOLEAN ) );
+        assertThat( andExpr).isInstanceOf(InfixOpNode.class);
+        assertThat( andExpr.getText()).isEqualTo(inputExpression);
+        assertThat( andExpr.getResultType()).isEqualTo(BuiltInType.BOOLEAN);
 
         InfixOpNode and = (InfixOpNode) andExpr;
-        assertThat( and.getOperator(), is( InfixOpNode.InfixOperator.AND ) );
-        assertThat( and.getLeft(), is( instanceOf( InstanceOfNode.class ) ) );
-        assertThat( and.getRight(), is( instanceOf( InstanceOfNode.class ) ) );
-        assertThat( and.getLeft().getText(), is( "\"foo\" instance of string" ) );
-        assertThat( and.getRight().getText(), is( "10 instance of number" ) );
-        assertThat( and.getLeft().getResultType(), is( BuiltInType.BOOLEAN ) );
-        assertThat( and.getRight().getResultType(), is( BuiltInType.BOOLEAN ) );
+        assertThat( and.getOperator()).isEqualTo(InfixOpNode.InfixOperator.AND);
+        assertThat( and.getLeft()).isInstanceOf(InstanceOfNode.class);
+        assertThat( and.getRight()).isInstanceOf(InstanceOfNode.class);
+        assertThat( and.getLeft().getText()).isEqualTo( "\"foo\" instance of string");
+        assertThat( and.getRight().getText()).isEqualTo( "10 instance of number");
+        assertThat( and.getLeft().getResultType()).isEqualTo(BuiltInType.BOOLEAN);
+        assertThat( and.getRight().getResultType()).isEqualTo(BuiltInType.BOOLEAN);
 
         InstanceOfNode ioExpr = (InstanceOfNode) and.getLeft();
-        assertThat( ioExpr.getExpression(), is( instanceOf( StringNode.class ) ) );
-        assertThat( ioExpr.getExpression().getText(), is( "\"foo\"" ) );
-        assertThat( ioExpr.getType(), is( instanceOf( TypeNode.class ) ) );
-        assertThat( ioExpr.getType().getText(), is( "string" ) );
+        assertThat( ioExpr.getExpression()).isInstanceOf(StringNode.class);
+        assertThat( ioExpr.getExpression().getText()).isEqualTo( "\"foo\"");
+        assertThat( ioExpr.getType()).isInstanceOf(TypeNode.class);
+        assertThat( ioExpr.getType().getText()).isEqualTo("string");
 
         ioExpr = (InstanceOfNode) and.getRight();
-        assertThat( ioExpr.getExpression(), is( instanceOf( NumberNode.class ) ) );
-        assertThat( ioExpr.getExpression().getText(), is( "10" ) );
-        assertThat( ioExpr.getType(), is( instanceOf( TypeNode.class ) ) );
-        assertThat( ioExpr.getType().getText(), is( "number" ) );
+        assertThat( ioExpr.getExpression()).isInstanceOf(NumberNode.class);
+        assertThat( ioExpr.getExpression().getText()).isEqualTo("10");
+        assertThat( ioExpr.getType()).isInstanceOf(TypeNode.class);
+        assertThat( ioExpr.getType().getText()).isEqualTo("number");
     }
 
     @Test
@@ -1080,15 +1076,15 @@ public class FEELParserTest {
         String inputExpression = "duration instance of function";
         BaseNode instanceOfBase = parse( inputExpression );
 
-        assertThat( instanceOfBase, is( instanceOf( InstanceOfNode.class ) ) );
-        assertThat( instanceOfBase.getText(), is( inputExpression ) );
-        assertThat( instanceOfBase.getResultType(), is( BuiltInType.BOOLEAN ) );
+        assertThat( instanceOfBase).isInstanceOf(InstanceOfNode.class);
+        assertThat( instanceOfBase.getText()).isEqualTo(inputExpression);
+        assertThat( instanceOfBase.getResultType()).isEqualTo(BuiltInType.BOOLEAN);
 
         InstanceOfNode ioExpr = (InstanceOfNode) instanceOfBase;
-        assertThat( ioExpr.getExpression(), is( instanceOf( NameRefNode.class ) ) );
-        assertThat( ioExpr.getExpression().getText(), is( "duration" ) );
-        assertThat( ioExpr.getType(), is( instanceOf( TypeNode.class ) ) );
-        assertThat( ioExpr.getType().getText(), is( "function" ) );
+        assertThat( ioExpr.getExpression()).isInstanceOf(NameRefNode.class);
+        assertThat( ioExpr.getExpression().getText()).isEqualTo("duration");
+        assertThat( ioExpr.getType()).isInstanceOf(TypeNode.class);
+        assertThat( ioExpr.getType().getText()).isEqualTo("function");
     }
 
     @Test
@@ -1096,14 +1092,14 @@ public class FEELParserTest {
         String inputExpression = "[ 10, 15 ].size";
         BaseNode pathBase = parse( inputExpression );
 
-        assertThat( pathBase, is( instanceOf( PathExpressionNode.class ) ) );
-        assertThat( pathBase.getText(), is( inputExpression ) );
+        assertThat( pathBase).isInstanceOf(PathExpressionNode.class);
+        assertThat( pathBase.getText()).isEqualTo(inputExpression);
 
         PathExpressionNode pathExpr = (PathExpressionNode) pathBase;
-        assertThat( pathExpr.getExpression(), is( instanceOf( ListNode.class ) ) );
-        assertThat( pathExpr.getExpression().getText(), is( "10, 15" ) );
-        assertThat( pathExpr.getName(), is( instanceOf( NameRefNode.class ) ) );
-        assertThat( pathExpr.getName().getText(), is( "size" ) );
+        assertThat( pathExpr.getExpression()).isInstanceOf(ListNode.class);
+        assertThat( pathExpr.getExpression().getText()).isEqualTo( "10, 15");
+        assertThat( pathExpr.getName()).isInstanceOf(NameRefNode.class);
+        assertThat( pathExpr.getName().getText()).isEqualTo("size");
     }
 
     @Test
@@ -1111,14 +1107,14 @@ public class FEELParserTest {
         String inputExpression = "[ {x:1, y:2}, {x:2, y:3} ][ x=1 ]";
         BaseNode filterBase = parse( inputExpression );
 
-        assertThat( filterBase, is( instanceOf( FilterExpressionNode.class ) ) );
-        assertThat( filterBase.getText(), is( inputExpression ) );
+        assertThat( filterBase).isInstanceOf(FilterExpressionNode.class);
+        assertThat( filterBase.getText()).isEqualTo(inputExpression);
 
         FilterExpressionNode filter = (FilterExpressionNode) filterBase;
-        assertThat( filter.getExpression(), is( instanceOf( ListNode.class ) ) );
-        assertThat( filter.getExpression().getText(), is( "{x:1, y:2}, {x:2, y:3}" ) );
-        assertThat( filter.getFilter(), is( instanceOf( InfixOpNode.class ) ) );
-        assertThat( filter.getFilter().getText(), is( "x=1" ) );
+        assertThat( filter.getExpression()).isInstanceOf(ListNode.class);
+        assertThat( filter.getExpression().getText()).isEqualTo( "{x:1, y:2}, {x:2, y:3}");
+        assertThat( filter.getFilter()).isInstanceOf(InfixOpNode.class);
+        assertThat( filter.getFilter().getText()).isEqualTo( "x=1");
     }
 
     @Test
@@ -1126,28 +1122,28 @@ public class FEELParserTest {
         String inputExpression = "my.test.Function( named parameter 1 : x+10, named parameter 2 : \"foo\" )";
         BaseNode functionBase = parse( inputExpression );
 
-        assertThat( functionBase, is( instanceOf( FunctionInvocationNode.class ) ) );
-        assertThat( functionBase.getText(), is( inputExpression ) );
+        assertThat( functionBase).isInstanceOf(FunctionInvocationNode.class);
+        assertThat( functionBase.getText()).isEqualTo(inputExpression);
 
         FunctionInvocationNode function = (FunctionInvocationNode) functionBase;
-        assertThat( function.getName(), is( instanceOf( QualifiedNameNode.class ) ) );
-        assertThat( function.getName().getText(), is( "my.test.Function" ) );
-        assertThat( function.getParams(), is( instanceOf( ListNode.class ) ) );
-        assertThat( function.getParams().getElements().size(), is( 2 ) );
-        assertThat( function.getParams().getElements().get( 0 ), is( instanceOf( NamedParameterNode.class ) ) );
-        assertThat( function.getParams().getElements().get( 1 ), is( instanceOf( NamedParameterNode.class ) ) );
+        assertThat( function.getName()).isInstanceOf(QualifiedNameNode.class);
+        assertThat( function.getName().getText()).isEqualTo("my.test.Function");
+        assertThat( function.getParams()).isInstanceOf(ListNode.class);
+        assertThat( function.getParams().getElements().size()).isEqualTo(2);
+        assertThat( function.getParams().getElements().get( 0 )).isInstanceOf(NamedParameterNode.class);
+        assertThat( function.getParams().getElements().get( 1 )).isInstanceOf(NamedParameterNode.class);
 
         NamedParameterNode named = (NamedParameterNode) function.getParams().getElements().get( 0 );
-        assertThat( named.getText(), is( "named parameter 1 : x+10" ) );
-        assertThat( named.getName().getText(), is( "named parameter 1" ) );
-        assertThat( named.getExpression(), is( instanceOf( InfixOpNode.class ) ) );
-        assertThat( named.getExpression().getText(), is( "x+10" ) );
+        assertThat( named.getText()).isEqualTo( "named parameter 1 : x+10");
+        assertThat( named.getName().getText()).isEqualTo( "named parameter 1");
+        assertThat( named.getExpression()).isInstanceOf(InfixOpNode.class);
+        assertThat( named.getExpression().getText()).isEqualTo( "x+10");
 
         named = (NamedParameterNode) function.getParams().getElements().get( 1 );
-        assertThat( named.getText(), is( "named parameter 2 : \"foo\"" ) );
-        assertThat( named.getName().getText(), is( "named parameter 2" ) );
-        assertThat( named.getExpression(), is( instanceOf( StringNode.class ) ) );
-        assertThat( named.getExpression().getText(), is( "\"foo\"" ) );
+        assertThat( named.getText()).isEqualTo( "named parameter 2 : \"foo\"");
+        assertThat( named.getName().getText()).isEqualTo( "named parameter 2");
+        assertThat( named.getExpression()).isInstanceOf(StringNode.class);
+        assertThat( named.getExpression().getText()).isEqualTo( "\"foo\"");
     }
 
     @Test
@@ -1155,16 +1151,16 @@ public class FEELParserTest {
         String inputExpression = "my.test.Function( x+10, \"foo\" )";
         BaseNode functionBase = parse( inputExpression );
 
-        assertThat( functionBase, is( instanceOf( FunctionInvocationNode.class ) ) );
-        assertThat( functionBase.getText(), is( inputExpression ) );
+        assertThat( functionBase).isInstanceOf(FunctionInvocationNode.class);
+        assertThat( functionBase.getText()).isEqualTo(inputExpression);
 
         FunctionInvocationNode function = (FunctionInvocationNode) functionBase;
-        assertThat( function.getName(), is( instanceOf( QualifiedNameNode.class ) ) );
-        assertThat( function.getName().getText(), is( "my.test.Function" ) );
-        assertThat( function.getParams(), is( instanceOf( ListNode.class ) ) );
-        assertThat( function.getParams().getElements().size(), is( 2 ) );
-        assertThat( function.getParams().getElements().get( 0 ), is( instanceOf( InfixOpNode.class ) ) );
-        assertThat( function.getParams().getElements().get( 1 ), is( instanceOf( StringNode.class ) ) );
+        assertThat( function.getName()).isInstanceOf(QualifiedNameNode.class);
+        assertThat( function.getName().getText()).isEqualTo("my.test.Function");
+        assertThat( function.getParams()).isInstanceOf(ListNode.class);
+        assertThat( function.getParams().getElements().size()).isEqualTo(2);
+        assertThat( function.getParams().getElements().get( 0 )).isInstanceOf(InfixOpNode.class);
+        assertThat( function.getParams().getElements().get( 1 )).isInstanceOf(StringNode.class);
     }
 
     @Test
@@ -1172,15 +1168,15 @@ public class FEELParserTest {
         String inputExpression = "date and time( \"2016-07-29T19:47:53\" )";
         BaseNode functionBase = parse( inputExpression );
 
-        assertThat( functionBase, is( instanceOf( FunctionInvocationNode.class ) ) );
-        assertThat( functionBase.getText(), is( inputExpression ) );
+        assertThat( functionBase).isInstanceOf(FunctionInvocationNode.class);
+        assertThat( functionBase.getText()).isEqualTo(inputExpression);
 
         FunctionInvocationNode function = (FunctionInvocationNode) functionBase;
-        assertThat( function.getName(), is( instanceOf( NameRefNode.class ) ) );
-        assertThat( function.getName().getText(), is( "date and time" ) );
-        assertThat( function.getParams(), is( instanceOf( ListNode.class ) ) );
-        assertThat( function.getParams().getElements().size(), is( 1 ) );
-        assertThat( function.getParams().getElements().get( 0 ), is( instanceOf( StringNode.class ) ) );
+        assertThat( function.getName()).isInstanceOf(NameRefNode.class);
+        assertThat( function.getName().getText()).isEqualTo( "date and time");
+        assertThat( function.getParams()).isInstanceOf(ListNode.class);
+        assertThat( function.getParams().getElements().size()).isEqualTo(1);
+        assertThat( function.getParams().getElements().get( 0 )).isInstanceOf(StringNode.class);
     }
 
     @Test
@@ -1188,16 +1184,16 @@ public class FEELParserTest {
         String inputExpression = "date and time( date(\"2016-07-29\"), time(\"19:47:53\") )";
         BaseNode functionBase = parse( inputExpression );
 
-        assertThat( functionBase, is( instanceOf( FunctionInvocationNode.class ) ) );
-        assertThat( functionBase.getText(), is( inputExpression ) );
+        assertThat( functionBase).isInstanceOf(FunctionInvocationNode.class);
+        assertThat( functionBase.getText()).isEqualTo(inputExpression);
 
         FunctionInvocationNode function = (FunctionInvocationNode) functionBase;
-        assertThat( function.getName(), is( instanceOf( NameRefNode.class ) ) );
-        assertThat( function.getName().getText(), is( "date and time" ) );
-        assertThat( function.getParams(), is( instanceOf( ListNode.class ) ) );
-        assertThat( function.getParams().getElements().size(), is( 2 ) );
-        assertThat( function.getParams().getElements().get( 0 ), is( instanceOf( FunctionInvocationNode.class ) ) );
-        assertThat( function.getParams().getElements().get( 1 ), is( instanceOf( FunctionInvocationNode.class ) ) );
+        assertThat( function.getName()).isInstanceOf(NameRefNode.class);
+        assertThat( function.getName().getText()).isEqualTo( "date and time");
+        assertThat( function.getParams()).isInstanceOf(ListNode.class);
+        assertThat( function.getParams().getElements().size()).isEqualTo(2);
+        assertThat( function.getParams().getElements().get( 0 )).isInstanceOf(FunctionInvocationNode.class);
+        assertThat( function.getParams().getElements().get( 1 )).isInstanceOf(FunctionInvocationNode.class);
     }
 
     @Test
@@ -1205,14 +1201,14 @@ public class FEELParserTest {
         String inputExpression = "my.test.Function()";
         BaseNode functionBase = parse( inputExpression );
 
-        assertThat( functionBase, is( instanceOf( FunctionInvocationNode.class ) ) );
-        assertThat( functionBase.getText(), is( inputExpression ) );
+        assertThat( functionBase).isInstanceOf(FunctionInvocationNode.class);
+        assertThat( functionBase.getText()).isEqualTo(inputExpression);
 
         FunctionInvocationNode function = (FunctionInvocationNode) functionBase;
-        assertThat( function.getName(), is( instanceOf( QualifiedNameNode.class ) ) );
-        assertThat( function.getName().getText(), is( "my.test.Function" ) );
-        assertThat( function.getParams(), is( instanceOf( ListNode.class ) ) );
-        assertThat( function.getParams().getElements(), is( empty() ) );
+        assertThat( function.getName()).isInstanceOf(QualifiedNameNode.class);
+        assertThat( function.getName().getText()).isEqualTo("my.test.Function");
+        assertThat( function.getParams()).isInstanceOf(ListNode.class);
+        assertThat( function.getParams().getElements()).isEmpty();
     }
 
     @Ignore("dropped since DMNv1.2")
@@ -1231,57 +1227,57 @@ public class FEELParserTest {
         // need to call parse passing in the input variables
         BaseNode functionBase = parse( inputExpression );
 
-        assertThat( functionBase, is( instanceOf( FunctionInvocationNode.class ) ) );
-        assertThat( functionBase.getText(), is( inputExpression ) );
+        assertThat( functionBase).isInstanceOf(FunctionInvocationNode.class);
+        assertThat( functionBase.getText()).isEqualTo(inputExpression);
 
         FunctionInvocationNode function = (FunctionInvocationNode) functionBase;
-        assertThat( function.getName(), is( instanceOf( NameRefNode.class ) ) );
-        assertThat( function.getName().getText(), is( "decision table" ) );
-        assertThat( function.getParams(), is( instanceOf( ListNode.class ) ) );
-        assertThat( function.getParams().getElements().size(), is( 4 ) );
-        assertThat( function.getParams().getElements().get( 0 ), is( instanceOf( NamedParameterNode.class ) ) );
-        assertThat( function.getParams().getElements().get( 1 ), is( instanceOf( NamedParameterNode.class ) ) );
-        assertThat( function.getParams().getElements().get( 2 ), is( instanceOf( NamedParameterNode.class ) ) );
-        assertThat( function.getParams().getElements().get( 3 ), is( instanceOf( NamedParameterNode.class ) ) );
+        assertThat( function.getName()).isInstanceOf(NameRefNode.class);
+        assertThat( function.getName().getText()).isEqualTo( "decision table");
+        assertThat( function.getParams()).isInstanceOf(ListNode.class);
+        assertThat( function.getParams().getElements().size()).isEqualTo(4);
+        assertThat( function.getParams().getElements().get( 0 )).isInstanceOf(NamedParameterNode.class);
+        assertThat( function.getParams().getElements().get( 1 )).isInstanceOf(NamedParameterNode.class);
+        assertThat( function.getParams().getElements().get( 2 )).isInstanceOf(NamedParameterNode.class);
+        assertThat( function.getParams().getElements().get( 3 )).isInstanceOf(NamedParameterNode.class);
 
         NamedParameterNode named = (NamedParameterNode) function.getParams().getElements().get( 0 );
-        assertThat( named.getText(), is( "outputs: \"Applicant Risk Rating\"" ) );
-        assertThat( named.getName().getText(), is( "outputs" ) );
-        assertThat( named.getExpression(), is( instanceOf( StringNode.class ) ) );
-        assertThat( named.getExpression().getText(), is( "\"Applicant Risk Rating\"" ) );
+        assertThat( named.getText()).isEqualTo( "outputs: \"Applicant Risk Rating\"");
+        assertThat( named.getName().getText()).isEqualTo("outputs");
+        assertThat( named.getExpression()).isInstanceOf(StringNode.class);
+        assertThat( named.getExpression().getText()).isEqualTo( "\"Applicant Risk Rating\"");
 
         named = (NamedParameterNode) function.getParams().getElements().get( 1 );
-        assertThat( named.getName().getText(), is( "input expression list" ) );
-        assertThat( named.getExpression(), is( instanceOf( ListNode.class ) ) );
+        assertThat( named.getName().getText()).isEqualTo( "input expression list");
+        assertThat( named.getExpression()).isInstanceOf(ListNode.class);
 
         ListNode list = (ListNode) named.getExpression();
-        assertThat( list.getElements().size(), is( 2 ) );
-        assertThat( list.getElements().get( 0 ), is( instanceOf( StringNode.class ) ) );
-        assertThat( list.getElements().get( 0 ).getText(), is( "\"Applicant Age\"" ) );
-        assertThat( list.getElements().get( 1 ), is( instanceOf( StringNode.class ) ) );
-        assertThat( list.getElements().get( 1 ).getText(), is( "\"Medical History\"" ) );
+        assertThat( list.getElements().size()).isEqualTo(2);
+        assertThat( list.getElements().get( 0 )).isInstanceOf(StringNode.class);
+        assertThat( list.getElements().get( 0 ).getText()).isEqualTo( "\"Applicant Age\"");
+        assertThat( list.getElements().get( 1 )).isInstanceOf(StringNode.class);
+        assertThat( list.getElements().get( 1 ).getText()).isEqualTo( "\"Medical History\"");
 
         named = (NamedParameterNode) function.getParams().getElements().get( 2 );
-        assertThat( named.getName().getText(), is( "rule list" ) );
-        assertThat( named.getExpression(), is( instanceOf( ListNode.class ) ) );
+        assertThat( named.getName().getText()).isEqualTo( "rule list");
+        assertThat( named.getExpression()).isInstanceOf(ListNode.class);
 
         list = (ListNode) named.getExpression();
-        assertThat(list.getElements().size(), is(5)); // this assert on the 5 rows but third row contains the - operation which is not allowed in expression.
-        assertThat( list.getElements().get( 0 ), is( instanceOf( ListNode.class ) ) );
+        assertThat(list.getElements().size()).isEqualTo(5); // this assert on the 5 rows but third row contains the - operation which is not allowed in expression.
+        assertThat( list.getElements().get( 0 )).isInstanceOf(ListNode.class);
 
         ListNode rule = (ListNode) list.getElements().get( 0 );
-        assertThat( rule.getElements().size(), is( 3 ) );
-        assertThat( rule.getElements().get( 0 ), is( instanceOf( RangeNode.class ) ) );
-        assertThat( rule.getElements().get( 0 ).getText(), is( ">60" ) );
-        assertThat( rule.getElements().get( 1 ), is( instanceOf( StringNode.class ) ) );
-        assertThat( rule.getElements().get( 1 ).getText(), is( "\"good\"" ) );
-        assertThat( rule.getElements().get( 2 ), is( instanceOf( StringNode.class ) ) );
-        assertThat( rule.getElements().get( 2 ).getText(), is( "\"Medium\"" ) );
+        assertThat( rule.getElements().size()).isEqualTo(3);
+        assertThat( rule.getElements().get( 0 )).isInstanceOf(RangeNode.class);
+        assertThat( rule.getElements().get( 0 ).getText()).isEqualTo( ">60");
+        assertThat( rule.getElements().get( 1 )).isInstanceOf(StringNode.class);
+        assertThat( rule.getElements().get( 1 ).getText()).isEqualTo( "\"good\"");
+        assertThat( rule.getElements().get( 2 )).isInstanceOf(StringNode.class);
+        assertThat( rule.getElements().get( 2 ).getText()).isEqualTo( "\"Medium\"");
 
         named = (NamedParameterNode) function.getParams().getElements().get( 3 );
-        assertThat( named.getName().getText(), is( "hit policy" ) );
-        assertThat( named.getExpression(), is( instanceOf( StringNode.class ) ) );
-        assertThat( named.getExpression().getText(), is( "\"Unique\"" ) );
+        assertThat( named.getName().getText()).isEqualTo( "hit policy");
+        assertThat( named.getExpression()).isInstanceOf(StringNode.class);
+        assertThat( named.getExpression().getText()).isEqualTo( "\"Unique\"");
     }
 
     @Test
@@ -1289,15 +1285,15 @@ public class FEELParserTest {
         String inputExpression = "{ x : \"foo\" }.x";
         BaseNode pathBase = parse( inputExpression );
 
-        assertThat( pathBase, is( instanceOf( PathExpressionNode.class ) ) );
-        assertThat( pathBase.getText(), is( inputExpression ) );
-        assertThat( pathBase.getResultType(), is( BuiltInType.STRING ) );
+        assertThat( pathBase).isInstanceOf(PathExpressionNode.class);
+        assertThat( pathBase.getText()).isEqualTo(inputExpression);
+        assertThat( pathBase.getResultType()).isEqualTo(BuiltInType.STRING);
 
         PathExpressionNode pathExpr = (PathExpressionNode) pathBase;
-        assertThat( pathExpr.getExpression(), is( instanceOf( ContextNode.class ) ) );
-        assertThat( pathExpr.getExpression().getText(), is( "{ x : \"foo\" }" ) );
-        assertThat( pathExpr.getName(), is( instanceOf( NameRefNode.class ) ) );
-        assertThat( pathExpr.getName().getText(), is( "x" ) );
+        assertThat( pathExpr.getExpression()).isInstanceOf(ContextNode.class);
+        assertThat( pathExpr.getExpression().getText()).isEqualTo( "{ x : \"foo\" }");
+        assertThat( pathExpr.getName()).isInstanceOf(NameRefNode.class);
+        assertThat( pathExpr.getName().getText()).isEqualTo("x");
     }
 
     @Test
@@ -1305,15 +1301,15 @@ public class FEELParserTest {
         String inputExpression = "{ x : { y : \"foo\" } }.x.y";
         BaseNode pathBase = parse( inputExpression );
 
-        assertThat( pathBase, is( instanceOf( PathExpressionNode.class ) ) );
-        assertThat( pathBase.getText(), is( inputExpression ) );
-        assertThat( pathBase.getResultType(), is( BuiltInType.STRING ) );
+        assertThat( pathBase).isInstanceOf(PathExpressionNode.class);
+        assertThat( pathBase.getText()).isEqualTo(inputExpression);
+        assertThat( pathBase.getResultType()).isEqualTo(BuiltInType.STRING);
 
         PathExpressionNode pathExpr = (PathExpressionNode) pathBase;
-        assertThat( pathExpr.getExpression(), is( instanceOf( ContextNode.class ) ) );
-        assertThat( pathExpr.getExpression().getText(), is( "{ x : { y : \"foo\" } }" ) );
-        assertThat( pathExpr.getName(), is( instanceOf( QualifiedNameNode.class ) ) );
-        assertThat( pathExpr.getName().getText(), is( "x.y" ) );
+        assertThat( pathExpr.getExpression()).isInstanceOf(ContextNode.class);
+        assertThat( pathExpr.getExpression().getText()).isEqualTo( "{ x : { y : \"foo\" } }");
+        assertThat( pathExpr.getName()).isInstanceOf(QualifiedNameNode.class);
+        assertThat( pathExpr.getName().getText()).isEqualTo("x.y");
     }
 
     @Test
@@ -1321,78 +1317,78 @@ public class FEELParserTest {
         String inputExpression = "{ first name : \"bob\" }.first name";
         BaseNode pathBase = parse( inputExpression );
 
-        assertThat( pathBase, is( instanceOf( PathExpressionNode.class ) ) );
-        assertThat( pathBase.getText(), is( inputExpression ) );
-        assertThat( pathBase.getResultType(), is( BuiltInType.STRING ) );
+        assertThat( pathBase).isInstanceOf(PathExpressionNode.class);
+        assertThat( pathBase.getText()).isEqualTo(inputExpression);
+        assertThat( pathBase.getResultType()).isEqualTo(BuiltInType.STRING);
 
         PathExpressionNode pathExpr = (PathExpressionNode) pathBase;
-        assertThat( pathExpr.getExpression(), is( instanceOf( ContextNode.class ) ) );
-        assertThat( pathExpr.getExpression().getText(), is( "{ first name : \"bob\" }" ) );
-        assertThat( pathExpr.getName(), is( instanceOf( NameRefNode.class ) ) );
-        assertThat( pathExpr.getName().getText(), is( "first name" ) );
+        assertThat( pathExpr.getExpression()).isInstanceOf(ContextNode.class);
+        assertThat( pathExpr.getExpression().getText()).isEqualTo( "{ first name : \"bob\" }");
+        assertThat( pathExpr.getName()).isInstanceOf(NameRefNode.class);
+        assertThat( pathExpr.getName().getText()).isEqualTo( "first name");
     }
 
     @Test
     public void testVariableName() {
         String var = "valid variable name";
-        assertThat( FEELParser.isVariableNameValid( var ), is( true ) );
+        assertThat( FEELParser.isVariableNameValid( var )).isEqualTo(true);
     }
 
     @Test
     public void testVariableNameWithValidCharacters() {
         String var = "?_873./-'+*valid";
-        assertThat( FEELParser.isVariableNameValid( var ), is( true ) );
+        assertThat( FEELParser.isVariableNameValid( var )).isEqualTo(true);
     }
 
     @Test
     public void testVariableNameWithValidCharactersHorseEmoji() {
         String var = "🐎";
-        assertThat(FEELParser.isVariableNameValid(var), is(true));
+        assertThat(FEELParser.isVariableNameValid(var)).isEqualTo(true);
     }
 
     @Test
     public void testVariableNameWithInvalidCharacterPercentSimplified() {
         String var = "banana%mango";
-        assertThat(FEELParser.isVariableNameValid(var), is(false));
-        assertThat(FEELParser.checkVariableName(var).get(0).getMessage(), is(Msg.createMessage(Msg.INVALID_VARIABLE_NAME, "character", "%")));
+        assertThat(FEELParser.isVariableNameValid(var)).isEqualTo(false);
+        assertThat(FEELParser.checkVariableName(var).get(0).getMessage()).isEqualTo(Msg.createMessage(Msg.INVALID_VARIABLE_NAME, "character", "%"));
     }
 
     @Test
     public void testVariableNameWithInvalidCharacterPercent() {
         String var = "?_873./-'%+*valid";
-        assertThat( FEELParser.isVariableNameValid( var ), is( false ) );
-        assertThat( FEELParser.checkVariableName( var ).get( 0 ).getMessage(), is( Msg.createMessage(Msg.INVALID_VARIABLE_NAME, "character", "%") ) );
+        assertThat( FEELParser.isVariableNameValid( var )).isEqualTo(false);
+        assertThat( FEELParser.checkVariableName( var ).get( 0 ).getMessage()).isEqualTo( Msg.createMessage(Msg.INVALID_VARIABLE_NAME, "character", "%"));
     }
 
     @Test
     public void testVariableNameWithInvalidCharacterAt() {
         String var = "?_873./-'@+*valid";
-        assertThat(FEELParser.isVariableNameValid(var), is(false));
-        assertThat(FEELParser.checkVariableName(var).get(0).getMessage(), is(Msg.createMessage(Msg.INVALID_VARIABLE_NAME, "character", "@")));
+        assertThat(FEELParser.isVariableNameValid(var)).isEqualTo(false);
+        assertThat(FEELParser.checkVariableName(var).get(0).getMessage()).isEqualTo(Msg.createMessage(Msg.INVALID_VARIABLE_NAME, "character", "@"));
     }
 
     @Test
     public void testVariableNameInvalidStartCharacter() {
         String var = "5variable can't start with a number";
-        assertThat( FEELParser.isVariableNameValid( var ), is( false ) );
-        assertThat( FEELParser.checkVariableName( var ).get( 0 ).getMessage(), is( Msg.createMessage(Msg.INVALID_VARIABLE_NAME_START, "character", "5") ) );
+        assertThat( FEELParser.isVariableNameValid( var )).isEqualTo(false);
+        assertThat( FEELParser.checkVariableName( var ).get( 0 ).getMessage()).isEqualTo( Msg.createMessage(Msg.INVALID_VARIABLE_NAME_START, "character", "5"));
     }
 
     @Test
     public void testVariableNameCantStartWithKeyword() {
         String var = "for keyword is an invalid start for a variable name";
-        assertThat( FEELParser.isVariableNameValid( var ), is( false ) );
-        assertThat( FEELParser.checkVariableName( var ).get( 0 ).getMessage(), is( Msg.createMessage(Msg.INVALID_VARIABLE_NAME_START, "keyword", "for") ) );
+        assertThat( FEELParser.isVariableNameValid( var )).isEqualTo(false);
+        assertThat( FEELParser.checkVariableName( var ).get( 0 ).getMessage()).isEqualTo( Msg.createMessage(Msg.INVALID_VARIABLE_NAME_START, "keyword", "for"));
     }
 
     public static void assertLocation(String inputExpression, ASTNode number) {
-        assertThat( number.getText(), is( inputExpression ) );
-        assertThat( number.getStartChar(), is( 0 ) );
-        assertThat( number.getStartLine(), is( 1 ) );
-        assertThat( number.getStartColumn(), is( 0 ) );
-        assertThat( number.getEndChar(), is( inputExpression.length() - 1 ) );
-        assertThat( number.getEndLine(), is( 1 ) );
-        assertThat( number.getEndColumn(), is( inputExpression.length() ) );
+        assertThat( number.getText()).isEqualTo(inputExpression);
+        assertThat( number.getStartChar()).isEqualTo(0);
+        assertThat( number.getStartLine()).isEqualTo(1);
+        assertThat( number.getStartColumn()).isEqualTo(0);
+        assertThat( number.getEndChar()).isEqualTo( inputExpression.length() - 1 );
+        assertThat( number.getEndLine()).isEqualTo(1);
+        assertThat( number.getEndColumn()).isEqualTo( inputExpression.length() );
     }
 
     private BaseNode parse(String input) {

--- a/kie-dmn/kie-dmn-feel/src/test/java/org/kie/dmn/feel/runtime/BaseFEELCompilerTest.java
+++ b/kie-dmn/kie-dmn-feel/src/test/java/org/kie/dmn/feel/runtime/BaseFEELCompilerTest.java
@@ -31,10 +31,7 @@ import org.kie.dmn.feel.lang.Type;
 import org.kie.dmn.feel.parser.feel11.profiles.DoCompileFEELProfile;
 import org.kie.dmn.feel.runtime.BaseFEELTest.FEEL_TARGET;
 
-import static org.hamcrest.Matchers.instanceOf;
-import static org.hamcrest.Matchers.is;
-import static org.hamcrest.Matchers.nullValue;
-import static org.hamcrest.MatcherAssert.assertThat;
+import static org.assertj.core.api.Assertions.assertThat;
 
 @RunWith(Parameterized.class)
 public abstract class BaseFEELCompilerTest {
@@ -68,11 +65,11 @@ public abstract class BaseFEELCompilerTest {
         final CompiledExpression compiledExpression = feel.compile(expression, ctx );
 
         if( result == null ) {
-            assertThat( "Evaluating: '" + expression + "'", feel.evaluate( compiledExpression, inputValues ), is( nullValue() ) );
+        	assertThat(feel.evaluate( compiledExpression, inputValues)).as("Evaluating: '" + expression + "'").isNull();
         } else if( result instanceof Class<?> ) {
-            assertThat( "Evaluating: '" + expression + "'", feel.evaluate( compiledExpression, inputValues ), is( instanceOf( (Class<?>) result ) ) );
+        	assertThat(feel.evaluate( compiledExpression, inputValues)).as("Evaluating: '" + expression + "'").isInstanceOf((Class<?>) result);
         } else {
-            assertThat( "Evaluating: '"+expression+"'", feel.evaluate( compiledExpression, inputValues ), is( result ) );
+        	assertThat(feel.evaluate( compiledExpression, inputValues)).as("Evaluating: '" + expression + "'").isEqualTo(result);
         }
     }
 

--- a/kie-dmn/kie-dmn-feel/src/test/java/org/kie/dmn/feel/runtime/BaseFEELTest.java
+++ b/kie-dmn/kie-dmn-feel/src/test/java/org/kie/dmn/feel/runtime/BaseFEELTest.java
@@ -30,10 +30,7 @@ import org.kie.dmn.feel.parser.feel11.profiles.DoCompileFEELProfile;
 import org.kie.dmn.feel.parser.feel11.profiles.KieExtendedFEELProfile;
 import org.mockito.ArgumentCaptor;
 
-import static org.hamcrest.Matchers.instanceOf;
-import static org.hamcrest.Matchers.is;
-import static org.hamcrest.Matchers.nullValue;
-import static org.hamcrest.MatcherAssert.assertThat;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.atLeastOnce;
 import static org.mockito.Mockito.mock;
@@ -77,7 +74,7 @@ public abstract class BaseFEELTest {
         if( severity != null ) {
             final ArgumentCaptor<FEELEvent> captor = ArgumentCaptor.forClass(FEELEvent.class );
             verify( listener , atLeastOnce()).onEvent( captor.capture() );
-            assertThat( captor.getValue().getSeverity(), is( severity ) );
+            assertThat(captor.getValue().getSeverity()).isEqualTo(severity);
         } else {
             verify( listener, never() ).onEvent( any(FEELEvent.class) );
         }
@@ -85,11 +82,11 @@ public abstract class BaseFEELTest {
 
     protected void assertResult(final String expression, final Object result ) {
         if( result == null ) {
-            assertThat( "Evaluating: '" + expression + "'", feel.evaluate( expression ), is( nullValue() ) );
+        	assertThat(feel.evaluate( expression )).as("Evaluating: '" + expression + "'").isNull();
         } else if( result instanceof Class<?> ) {
-            assertThat( "Evaluating: '" + expression + "'", feel.evaluate( expression ), is( instanceOf( (Class<?>) result ) ) );
+        	assertThat(feel.evaluate( expression )).as("Evaluating: '" + expression + "'").isInstanceOf((Class<?>) result);
         } else {
-            assertThat( "Evaluating: '"+expression+"'", feel.evaluate( expression ), is( result ) );
+        	assertThat(feel.evaluate( expression )).as("Evaluating: '" + expression + "'").isEqualTo(result);
         }
     }
 

--- a/kie-dmn/kie-dmn-feel/src/test/java/org/kie/dmn/feel/runtime/FEELNumberCoercionTest.java
+++ b/kie-dmn/kie-dmn-feel/src/test/java/org/kie/dmn/feel/runtime/FEELNumberCoercionTest.java
@@ -24,9 +24,7 @@ import org.junit.Test;
 import org.kie.dmn.feel.FEEL;
 import org.kie.dmn.feel.lang.ast.InfixOpNode.InfixOperator;
 
-import static org.hamcrest.CoreMatchers.is;
-import static org.hamcrest.CoreMatchers.nullValue;
-import static org.hamcrest.MatcherAssert.assertThat;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.kie.dmn.feel.util.EvalHelper.getBigDecimalOrNull;
 
 public class FEELNumberCoercionTest {
@@ -43,14 +41,14 @@ public class FEELNumberCoercionTest {
     
     @Test
     public void test() {
-        assertThat( evaluateInfix( 1  , InfixOperator.LT  , 2d  ), is( true  )  );
-        assertThat( evaluateInfix( 2d , InfixOperator.LT  ,  1  ), is( false )  );
-        assertThat( evaluateInfix( 1  , InfixOperator.LTE , 2d  ), is( true  )  );
-        assertThat( evaluateInfix( 2d , InfixOperator.LTE ,  1  ), is( false )  );
-        assertThat( evaluateInfix( 1  , InfixOperator.GT  , 2d  ), is( false )  );
-        assertThat( evaluateInfix( 2d , InfixOperator.GT  ,  1  ), is( true  )  );
-        assertThat( evaluateInfix( 1  , InfixOperator.GTE , 2d  ), is( false )  );
-        assertThat( evaluateInfix( 2d , InfixOperator.GTE ,  1  ), is( true  )  );
+        assertThat( evaluateInfix( 1  , InfixOperator.LT  , 2d  )).isEqualTo(Boolean.TRUE);
+        assertThat( evaluateInfix( 2d , InfixOperator.LT  ,  1  )).isEqualTo(Boolean.FALSE);
+        assertThat( evaluateInfix( 1  , InfixOperator.LTE , 2d  )).isEqualTo(Boolean.TRUE);
+        assertThat( evaluateInfix( 2d , InfixOperator.LTE ,  1  )).isEqualTo(Boolean.FALSE);
+        assertThat( evaluateInfix( 1  , InfixOperator.GT  , 2d  )).isEqualTo(Boolean.FALSE);
+        assertThat( evaluateInfix( 2d , InfixOperator.GT  ,  1  )).isEqualTo(Boolean.TRUE);
+        assertThat( evaluateInfix( 1  , InfixOperator.GTE , 2d  )).isEqualTo(Boolean.FALSE);
+        assertThat( evaluateInfix( 2d , InfixOperator.GTE ,  1  )).isEqualTo(Boolean.TRUE);
     }
     
     @SafeVarargs
@@ -68,30 +66,30 @@ public class FEELNumberCoercionTest {
     
     @Test
     public void testOthers() {
-        assertThat( evaluate("ceiling( 1.01 )") , is( getBigDecimalOrNull( 2d ) ) );
-        assertThat( evaluate("ceiling( x )", var("x", 1.01d )) , is( getBigDecimalOrNull( 2d ) ) );
-        assertThat( ((Map) evaluate("{ myf : function( v1, v2 ) ceiling(v1), invoked: myf(v2: false, v1: x) }", var("x", 1.01d) )).get("invoked"), is( getBigDecimalOrNull( 2d ) ) );
-        assertThat( ((Map) evaluate("{ myf : function( v1, v2 ) v1, invoked: myf(v2: false, v1: x) }", var("x", 1.01d) )).get("invoked"), is( getBigDecimalOrNull( 1.01d ) ) );
+        assertThat( evaluate("ceiling( 1.01 )") ).isEqualTo(getBigDecimalOrNull( 2d ) );
+        assertThat( evaluate("ceiling( x )", var("x", 1.01d )) ).isEqualTo(getBigDecimalOrNull( 2d ) );
+        assertThat( ((Map) evaluate("{ myf : function( v1, v2 ) ceiling(v1), invoked: myf(v2: false, v1: x) }", var("x", 1.01d) )).get("invoked")).isEqualTo(getBigDecimalOrNull( 2d ) );
+        assertThat( ((Map) evaluate("{ myf : function( v1, v2 ) v1, invoked: myf(v2: false, v1: x) }", var("x", 1.01d) )).get("invoked")).isEqualTo(getBigDecimalOrNull( 1.01d ) );
 
-        assertThat( evaluate(" x.y ", var("x", new HashMap<String, Object>(){{ put("y", 1.01d); }} )), is( getBigDecimalOrNull( 1.01d ) ) );
-        assertThat( evaluate("ceiling( x.y )", var("x", new HashMap<String, Object>(){{ put("y", 1.01d); }} )), is( getBigDecimalOrNull( 2d ) ) );
+        assertThat( evaluate(" x.y ", var("x", new HashMap<String, Object>(){{ put("y", 1.01d); }} ))).isEqualTo(getBigDecimalOrNull( 1.01d ) );
+        assertThat( evaluate("ceiling( x.y )", var("x", new HashMap<String, Object>(){{ put("y", 1.01d); }} ))).isEqualTo(getBigDecimalOrNull( 2d ) );
     }
 
     @Test
     public void testMethodGetBigDecimalOrNull() {
-        assertThat( getBigDecimalOrNull((short) 1), is(BigDecimal.ONE) );
-        assertThat( getBigDecimalOrNull((byte) 1), is(BigDecimal.ONE) );
-        assertThat( getBigDecimalOrNull(1), is(BigDecimal.ONE) );
-        assertThat( getBigDecimalOrNull(1L), is(BigDecimal.ONE) );
-        assertThat( getBigDecimalOrNull(1f), is(BigDecimal.ONE) );
-        assertThat( getBigDecimalOrNull(1.1f), is(BigDecimal.valueOf(1.1)) );
-        assertThat( getBigDecimalOrNull(1d), is(BigDecimal.ONE) );
-        assertThat( getBigDecimalOrNull(1.1d), is(BigDecimal.valueOf(1.1)) );
-        assertThat( getBigDecimalOrNull("1"), is(BigDecimal.ONE) );
-        assertThat( getBigDecimalOrNull("1.1"), is(BigDecimal.valueOf(1.1)) );
-        assertThat( getBigDecimalOrNull("1.1000000"), is(BigDecimal.valueOf(1.1).setScale(7, BigDecimal.ROUND_HALF_EVEN)) );
-        assertThat( getBigDecimalOrNull(Double.POSITIVE_INFINITY), is(nullValue()) );
-        assertThat( getBigDecimalOrNull(Double.NEGATIVE_INFINITY), is(nullValue()) );
-        assertThat( getBigDecimalOrNull(Double.NaN), is(nullValue()) );
+        assertThat( getBigDecimalOrNull((short) 1)).isEqualTo(BigDecimal.ONE);
+        assertThat( getBigDecimalOrNull((byte) 1)).isEqualTo(BigDecimal.ONE);
+        assertThat( getBigDecimalOrNull(1)).isEqualTo(BigDecimal.ONE);
+        assertThat( getBigDecimalOrNull(1L)).isEqualTo(BigDecimal.ONE);
+        assertThat( getBigDecimalOrNull(1f)).isEqualTo(BigDecimal.ONE);
+        assertThat( getBigDecimalOrNull(1.1f)).isEqualTo(BigDecimal.valueOf(1.1));
+        assertThat( getBigDecimalOrNull(1d)).isEqualTo(BigDecimal.ONE);
+        assertThat( getBigDecimalOrNull(1.1d)).isEqualTo(BigDecimal.valueOf(1.1));
+        assertThat( getBigDecimalOrNull("1")).isEqualTo(BigDecimal.ONE);
+        assertThat( getBigDecimalOrNull("1.1")).isEqualTo(BigDecimal.valueOf(1.1));
+        assertThat( getBigDecimalOrNull("1.1000000")).isEqualTo(BigDecimal.valueOf(1.1).setScale(7, BigDecimal.ROUND_HALF_EVEN));
+        assertThat( getBigDecimalOrNull(Double.POSITIVE_INFINITY)).isNull();
+        assertThat( getBigDecimalOrNull(Double.NEGATIVE_INFINITY)).isNull();
+        assertThat( getBigDecimalOrNull(Double.NaN)).isNull();
     }
 }

--- a/kie-dmn/kie-dmn-feel/src/test/java/org/kie/dmn/feel/runtime/functions/NowFunctionTest.java
+++ b/kie-dmn/kie-dmn-feel/src/test/java/org/kie/dmn/feel/runtime/functions/NowFunctionTest.java
@@ -19,8 +19,6 @@ package org.kie.dmn.feel.runtime.functions;
 import java.time.ZonedDateTime;
 import java.time.temporal.TemporalAccessor;
 
-import org.hamcrest.Matchers;
-import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
 import org.kie.dmn.feel.runtime.functions.extended.NowFunction;

--- a/kie-dmn/kie-dmn-legacy-tests/pom.xml
+++ b/kie-dmn/kie-dmn-legacy-tests/pom.xml
@@ -63,11 +63,6 @@
       <artifactId>slf4j-api</artifactId>
     </dependency>
     <dependency>
-      <groupId>org.hamcrest</groupId>
-      <artifactId>hamcrest-library</artifactId>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
       <groupId>junit</groupId>
       <artifactId>junit</artifactId>
       <scope>test</scope>

--- a/kie-dmn/kie-dmn-legacy-tests/src/test/java/org/kie/dmn/legacy/tests/core/v1_1/DMNCompilerTest.java
+++ b/kie-dmn/kie-dmn-legacy-tests/src/test/java/org/kie/dmn/legacy/tests/core/v1_1/DMNCompilerTest.java
@@ -16,7 +16,6 @@
 
 package org.kie.dmn.legacy.tests.core.v1_1;
 
-import org.hamcrest.Matchers;
 import org.junit.Test;
 import org.kie.dmn.api.core.DMNContext;
 import org.kie.dmn.api.core.DMNMessage;
@@ -36,12 +35,8 @@ import org.kie.dmn.feel.util.ClassLoaderUtil;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import static org.hamcrest.CoreMatchers.instanceOf;
-import static org.hamcrest.CoreMatchers.is;
-import static org.hamcrest.CoreMatchers.notNullValue;
-import static org.hamcrest.CoreMatchers.nullValue;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.Assert.assertFalse;
-import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.Assert.fail;
 import static org.kie.dmn.core.util.DynamicTypeUtils.entry;
 import static org.kie.dmn.core.util.DynamicTypeUtils.mapOf;
@@ -58,67 +53,67 @@ public class DMNCompilerTest extends BaseDMN1_1VariantTest {
     public void testItemDefAllowedValuesString() {
         final DMNRuntime runtime = createRuntime("0003-input-data-string-allowed-values.dmn", this.getClass());
         final DMNModel dmnModel = runtime.getModel("https://github.com/kiegroup/kie-dmn", "0003-input-data-string-allowed-values" );
-        assertThat( dmnModel, notNullValue() );
+        assertThat(dmnModel).isNotNull();
 
         final ItemDefNode itemDef = dmnModel.getItemDefinitionByName("tEmploymentStatus" );
 
-        assertThat( itemDef.getName(), is( "tEmploymentStatus" ) );
-        assertThat( itemDef.getId(), is( nullValue() ) );
+        assertThat(itemDef.getName()).isEqualTo("tEmploymentStatus");
+        assertThat(itemDef.getId()).isNull();
 
         final DMNType type = itemDef.getType();
 
-        assertThat( type, is( notNullValue() ) );
-        assertThat( type.getName(), is( "tEmploymentStatus" ) );
-        assertThat( type.getId(), is( nullValue() ) );
-        assertThat( type, is( instanceOf( SimpleTypeImpl.class ) ) );
+        assertThat(type).isNotNull();
+        assertThat(type.getName()).isEqualTo("tEmploymentStatus");
+        assertThat(type.getId()).isNull();
+        assertThat(type).isInstanceOf(SimpleTypeImpl.class);
 
         final SimpleTypeImpl feelType = (SimpleTypeImpl) type;
 
         final EvaluationContext ctx = new EvaluationContextImpl(ClassLoaderUtil.findDefaultClassLoader(), null);
-        assertThat( feelType.getFeelType(), is(instanceOf(AliasFEELType.class)));
-        assertThat( feelType.getFeelType().getName(), is("tEmploymentStatus"));
-        assertThat( feelType.getAllowedValuesFEEL().size(), is( 4 ) );
-        assertThat( feelType.getAllowedValuesFEEL().get( 0 ).apply( ctx, "UNEMPLOYED" ), is( true ) );
-        assertThat( feelType.getAllowedValuesFEEL().get( 1 ).apply( ctx, "EMPLOYED" ), is( true )   );
-        assertThat( feelType.getAllowedValuesFEEL().get( 2 ).apply( ctx, "SELF-EMPLOYED" ), is( true )  );
-        assertThat( feelType.getAllowedValuesFEEL().get( 3 ).apply( ctx, "STUDENT" ), is( true )  );
+        assertThat(feelType.getFeelType()).isInstanceOf(AliasFEELType.class);
+        assertThat(feelType.getFeelType().getName()).isEqualTo("tEmploymentStatus");
+        assertThat(feelType.getAllowedValuesFEEL()).hasSize(4);
+        assertThat(feelType.getAllowedValuesFEEL().get( 0 ).apply( ctx, "UNEMPLOYED" )).isEqualTo(true);
+        assertThat(feelType.getAllowedValuesFEEL().get( 1 ).apply( ctx, "EMPLOYED" )).isEqualTo(true);
+        assertThat(feelType.getAllowedValuesFEEL().get( 2 ).apply( ctx, "SELF-EMPLOYED" )).isEqualTo(true);
+        assertThat(feelType.getAllowedValuesFEEL().get( 3 ).apply( ctx, "STUDENT" )).isEqualTo(true);
     }
 
     @Test
     public void testCompositeItemDefinition() {
         final DMNRuntime runtime = createRuntime("0008-LX-arithmetic.dmn", this.getClass());
         final DMNModel dmnModel = runtime.getModel("https://github.com/kiegroup/kie-dmn", "0008-LX-arithmetic" );
-        assertThat( dmnModel, notNullValue() );
+        assertThat(dmnModel).isNotNull();
 
         final ItemDefNode itemDef = dmnModel.getItemDefinitionByName("tLoan" );
 
-        assertThat( itemDef.getName(), is( "tLoan" ) );
-        assertThat( itemDef.getId(), is( "tLoan" ) );
+        assertThat(itemDef.getName()).isEqualTo("tLoan");
+        assertThat(itemDef.getId()).isEqualTo("tLoan");
 
         final DMNType type = itemDef.getType();
 
-        assertThat( type, is( notNullValue() ) );
-        assertThat( type.getName(), is( "tLoan" ) );
-        assertThat( type.getId(), is( "tLoan" ) );
-        assertThat( type, is( instanceOf( CompositeTypeImpl.class ) ) );
+        assertThat(type).isNotNull();
+        assertThat(type.getName()).isEqualTo("tLoan");
+        assertThat(type.getId()).isEqualTo("tLoan");
+        assertThat(type).isInstanceOf(CompositeTypeImpl.class);
 
         final CompositeTypeImpl compType = (CompositeTypeImpl) type;
 
-        assertThat( compType.getFields().size(), is( 3 ) );
+        assertThat(compType.getFields()).hasSize(3);
         final DMNType principal = compType.getFields().get("principal" );
-        assertThat( principal, is( notNullValue() ) );
-        assertThat( principal.getName(), is( "number" ) );
-        assertThat( ((SimpleTypeImpl)principal).getFeelType(), is( BuiltInType.NUMBER ) );
+        assertThat(principal).isNotNull();
+        assertThat(principal.getName()).isEqualTo("number");
+        assertThat(((SimpleTypeImpl)principal).getFeelType()).isEqualTo(BuiltInType.NUMBER);
 
         final DMNType rate = compType.getFields().get("rate" );
-        assertThat( rate, is( notNullValue() ) );
-        assertThat( rate.getName(), is( "number" ) );
-        assertThat( ((SimpleTypeImpl)rate).getFeelType(), is( BuiltInType.NUMBER ) );
+        assertThat(rate).isNotNull();
+        assertThat(rate.getName()).isEqualTo("number");
+        assertThat(((SimpleTypeImpl)rate).getFeelType()).isEqualTo(BuiltInType.NUMBER);
 
         final DMNType termMonths = compType.getFields().get("termMonths" );
-        assertThat( termMonths, is( notNullValue() ) );
-        assertThat( termMonths.getName(), is( "number" ) );
-        assertThat( ((SimpleTypeImpl)termMonths).getFeelType(), is( BuiltInType.NUMBER ) );
+        assertThat(termMonths).isNotNull();
+        assertThat(termMonths.getName()).isEqualTo("number");
+        assertThat(((SimpleTypeImpl)termMonths).getFeelType()).isEqualTo(BuiltInType.NUMBER);
     }
 
     @Test
@@ -127,7 +122,7 @@ public class DMNCompilerTest extends BaseDMN1_1VariantTest {
             createRuntime("compilationThrowsNPE.dmn", this.getClass());
             fail("shouldn't have reached here.");
         } catch (final Exception ex) {
-            assertThat(ex.getMessage(), Matchers.containsString("Unable to compile DMN model for the resource"));
+            assertThat(ex.getMessage()).containsSequence("Unable to compile DMN model for the resource");
         }
     }
 
@@ -136,7 +131,7 @@ public class DMNCompilerTest extends BaseDMN1_1VariantTest {
         // DROOLS-2161
         final DMNRuntime runtime = createRuntime("Recursive.dmn", this.getClass());
         final DMNModel dmnModel = runtime.getModel("https://github.com/kiegroup/kie-dmn", "Recursive" );
-        assertThat( dmnModel, notNullValue() );
+        assertThat(dmnModel).isNotNull();
         assertFalse( evaluateModel(runtime, dmnModel, DMNFactory.newContext() ).hasErrors() );
     }
 
@@ -148,14 +143,14 @@ public class DMNCompilerTest extends BaseDMN1_1VariantTest {
 
         final DMNModel importedModel = runtime.getModel("http://www.trisotech.com/dmn/definitions/_f27bb64b-6fc7-4e1f-9848-11ba35e0df36",
                                                         "Imported Model");
-        assertThat(importedModel, notNullValue());
+        assertThat(importedModel).isNotNull();
         for (final DMNMessage message : importedModel.getMessages()) {
             LOG.debug("{}", message);
         }
 
         final DMNModel dmnModel = runtime.getModel("http://www.trisotech.com/dmn/definitions/_f79aa7a4-f9a3-410a-ac95-bea496edab52",
                                                    "Importing Model");
-        assertThat(dmnModel, notNullValue());
+        assertThat(dmnModel).isNotNull();
         for (final DMNMessage message : dmnModel.getMessages()) {
             LOG.debug("{}", message);
         }
@@ -168,7 +163,7 @@ public class DMNCompilerTest extends BaseDMN1_1VariantTest {
             LOG.debug("{}", message);
         }
         LOG.debug("{}", evaluateAll);
-        assertThat(evaluateAll.getDecisionResultByName("Greeting").getResult(), is("Hello John!"));
+        assertThat(evaluateAll.getDecisionResultByName("Greeting").getResult()).isEqualTo("Hello John!");
     }
 
 }

--- a/kie-dmn/kie-dmn-legacy-tests/src/test/java/org/kie/dmn/legacy/tests/core/v1_1/DMNDecisionTableHitPolicyTest.java
+++ b/kie-dmn/kie-dmn-legacy-tests/src/test/java/org/kie/dmn/legacy/tests/core/v1_1/DMNDecisionTableHitPolicyTest.java
@@ -33,14 +33,7 @@ import org.kie.dmn.feel.runtime.events.HitPolicyViolationEvent;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import static org.hamcrest.CoreMatchers.is;
-import static org.hamcrest.CoreMatchers.notNullValue;
-import static org.hamcrest.CoreMatchers.nullValue;
-import static org.hamcrest.Matchers.contains;
-import static org.hamcrest.Matchers.hasEntry;
-import static org.hamcrest.Matchers.hasSize;
-import static org.hamcrest.Matchers.isEmptyOrNullString;
-import static org.hamcrest.MatcherAssert.assertThat;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.Assert.assertTrue;
 
 public class DMNDecisionTableHitPolicyTest extends BaseDMN1_1VariantTest {
@@ -55,24 +48,24 @@ public class DMNDecisionTableHitPolicyTest extends BaseDMN1_1VariantTest {
     public void testSimpleDecisionTableHitPolicyUnique() {
         final DMNRuntime runtime = DMNRuntimeUtil.createRuntime("0004-simpletable-U.dmn", this.getClass());
         final DMNModel dmnModel = runtime.getModel("https://github.com/kiegroup/kie-dmn", "0004-simpletable-U");
-        assertThat(dmnModel, notNullValue());
+        assertThat(dmnModel).isNotNull();
 
         final DMNContext context = getSimpleTableContext(BigDecimal.valueOf(18), "Medium", true);
         final DMNContext result = evaluateSimpleTableWithContext(dmnModel, runtime, context);
-        assertThat(result.get("Approval Status"), is("Approved"));
+        assertThat(result.get("Approval Status")).isEqualTo("Approved");
     }
 
     @Test
     public void testSimpleDecisionTableHitPolicyUniqueSatisfies() {
         final DMNRuntime runtime = DMNRuntimeUtil.createRuntime("0004-simpletable-U.dmn", this.getClass());
         final DMNModel dmnModel = runtime.getModel("https://github.com/kiegroup/kie-dmn", "0004-simpletable-U");
-        assertThat(dmnModel, notNullValue());
+        assertThat(dmnModel).isNotNull();
 
         final DMNContext context = getSimpleTableContext(BigDecimal.valueOf(18), "ASD", false);
         final DMNResult dmnResult = runtime.evaluateAll(dmnModel, context);
         final DMNContext result = dmnResult.getContext();
 
-        assertThat(result.get("Approval Status"), nullValue());
+        assertThat(result.get("Approval Status")).isNull();
         assertTrue(dmnResult.getMessages().size() > 0);
     }
 
@@ -80,7 +73,7 @@ public class DMNDecisionTableHitPolicyTest extends BaseDMN1_1VariantTest {
     public void testSimpleDecisionTableHitPolicyUniqueNullWarn() {
         final DMNRuntime runtime = DMNRuntimeUtil.createRuntime("0004-simpletable-U-noinputvalues.dmn", this.getClass());
         final DMNModel dmnModel = runtime.getModel("https://github.com/kiegroup/kie-dmn", "0004-simpletable-U-noinputvalues");
-        assertThat(dmnModel, notNullValue());
+        assertThat(dmnModel).isNotNull();
 
         check_testSimpleDecisionTableHitPolicyUniqueNullWarn(runtime, dmnModel);
     }
@@ -90,7 +83,7 @@ public class DMNDecisionTableHitPolicyTest extends BaseDMN1_1VariantTest {
         final DMNResult dmnResult = runtime.evaluateAll(dmnModel, context);
         final DMNContext result = dmnResult.getContext();
 
-        assertThat(result.get("Approval Status"), nullValue());
+        assertThat(result.get("Approval Status")).isNull();
         assertTrue(dmnResult.getMessages().size() > 0);
         assertTrue(dmnResult.getMessages().stream().anyMatch(dm -> dm.getSeverity().equals(DMNMessage.Severity.WARN) && dm.getFeelEvent() instanceof HitPolicyViolationEvent && dm.getFeelEvent().getSeverity().equals(FEELEvent.Severity.WARN)));
     }
@@ -99,7 +92,7 @@ public class DMNDecisionTableHitPolicyTest extends BaseDMN1_1VariantTest {
     public void testSimpleDecisionTableHitPolicyUniqueNullWarn_ctxe() {
         final DMNRuntime runtime = DMNRuntimeUtil.createRuntime("0004-simpletable-U-noinputvalues-ctxe.dmn", this.getClass());
         final DMNModel dmnModel = runtime.getModel("https://github.com/kiegroup/kie-dmn", "0004-simpletable-U-noinputvalues");
-        assertThat(dmnModel, notNullValue());
+        assertThat(dmnModel).isNotNull();
 
         check_testSimpleDecisionTableHitPolicyUniqueNullWarn(runtime, dmnModel);
     }
@@ -108,7 +101,7 @@ public class DMNDecisionTableHitPolicyTest extends BaseDMN1_1VariantTest {
     public void testSimpleDecisionTableHitPolicyUniqueNullWarn_ctxr() {
         final DMNRuntime runtime = DMNRuntimeUtil.createRuntime("0004-simpletable-U-noinputvalues-ctxr.dmn", this.getClass());
         final DMNModel dmnModel = runtime.getModel("https://github.com/kiegroup/kie-dmn", "0004-simpletable-U-noinputvalues");
-        assertThat(dmnModel, notNullValue());
+        assertThat(dmnModel).isNotNull();
 
         check_testSimpleDecisionTableHitPolicyUniqueNullWarn(runtime, dmnModel);
     }
@@ -117,31 +110,31 @@ public class DMNDecisionTableHitPolicyTest extends BaseDMN1_1VariantTest {
     public void testDecisionTableHitPolicyUnique() {
         final DMNRuntime runtime = DMNRuntimeUtil.createRuntime("BranchDistribution.dmn", this.getClass());
         final DMNModel dmnModel = runtime.getModel("http://www.trisotech.com/dmn/definitions/_cdf29af2-959b-4004-8271-82a9f5a62147", "Dessin 1");
-        assertThat(dmnModel, notNullValue());
+        assertThat(dmnModel).isNotNull();
 
         final DMNContext context = DMNFactory.newContext();
         context.set("Branches dispersion", "Province");
         context.set("Number of Branches", BigDecimal.valueOf(10));
 
         final DMNResult dmnResult = runtime.evaluateAll(dmnModel, context);
-        assertThat(dmnResult.hasErrors(), is(false));
+        assertThat(dmnResult.hasErrors()).isFalse();
 
         final DMNContext result = dmnResult.getContext();
-        assertThat(result.get("Branches distribution"), is("Medium"));
+        assertThat(result.get("Branches distribution")).isEqualTo("Medium");
     }
 
     @Test
     public void testSimpleDecisionTableHitPolicyFirst() {
         final DMNRuntime runtime = DMNRuntimeUtil.createRuntime("0004-simpletable-F.dmn", this.getClass());
         final DMNModel dmnModel = runtime.getModel("https://github.com/kiegroup/kie-dmn", "0004-simpletable-F");
-        assertThat(dmnModel, notNullValue());
+        assertThat(dmnModel).isNotNull();
 
         final DMNContext context = getSimpleTableContext(BigDecimal.valueOf(18), "Medium", true);
         final DMNContext result = evaluateSimpleTableWithContext(dmnModel, runtime, context);
         final Map<String, Object> decisionResult = (Map<String, Object>) result.get("Decision Result");
-        assertThat(decisionResult.values(), hasSize(2));
-        assertThat(decisionResult, hasEntry(is("Approval Status"), is("Approved")));
-        assertThat(decisionResult, hasEntry(is("Decision Review"), is("Decision final")));
+        assertThat(decisionResult.values()).hasSize(2);
+        assertThat(decisionResult).containsEntry("Approval Status", "Approved");
+        assertThat(decisionResult).containsEntry("Decision Review", "Decision final");
     }
 
     @Test
@@ -157,16 +150,16 @@ public class DMNDecisionTableHitPolicyTest extends BaseDMN1_1VariantTest {
     private void testSimpleDecisionTableHitPolicyAny(final String resurceName, final String modelName, final boolean equalRules) {
         final DMNRuntime runtime = DMNRuntimeUtil.createRuntime(resurceName, this.getClass());
         final DMNModel dmnModel = runtime.getModel("https://github.com/kiegroup/kie-dmn", modelName);
-        assertThat(dmnModel, notNullValue());
+        assertThat(dmnModel).isNotNull();
 
         final DMNContext context = getSimpleTableContext(BigDecimal.valueOf(18), "Medium", true);
         final DMNResult dmnResult = runtime.evaluateAll(dmnModel, context);
         final DMNContext result = dmnResult.getContext();
         if (equalRules) {
-            assertThat(result.get("Approval Status"), is("Approved"));
+            assertThat(result.get("Approval Status")).isEqualTo("Approved");
         } else {
-            assertThat(dmnResult.hasErrors(), is(true));
-            assertThat((String) result.get("Approval Status"), isEmptyOrNullString());
+            assertThat(dmnResult.hasErrors()).isTrue();
+            assertThat((String) result.get("Approval Status")).isNullOrEmpty();
         }
     }
 
@@ -174,50 +167,50 @@ public class DMNDecisionTableHitPolicyTest extends BaseDMN1_1VariantTest {
     public void testSimpleDecisionTableHitPolicyPriority() {
         final DMNRuntime runtime = DMNRuntimeUtil.createRuntime("0004-simpletable-P.dmn", this.getClass());
         final DMNModel dmnModel = runtime.getModel("https://github.com/kiegroup/kie-dmn", "0004-simpletable-P");
-        assertThat(dmnModel, notNullValue());
+        assertThat(dmnModel).isNotNull();
 
         final DMNContext context = getSimpleTableContext(BigDecimal.valueOf(70), "Medium", true);
         final DMNContext result = evaluateSimpleTableWithContext(dmnModel, runtime, context);
-        assertThat(result.get("Approval Status"), is("Declined"));
+        assertThat(result.get("Approval Status")).isEqualTo("Declined");
     }
 
     @Test
     public void testSimpleDecisionTableHitPolicyPriorityMultipleOutputs() {
         final DMNRuntime runtime = DMNRuntimeUtil.createRuntime("0004-simpletable-P-multiple-outputs.dmn", this.getClass());
         final DMNModel dmnModel = runtime.getModel("https://github.com/kiegroup/kie-dmn", "0004-simpletable-P-multiple-outputs");
-        assertThat(dmnModel, notNullValue());
+        assertThat(dmnModel).isNotNull();
 
         final DMNContext context = getSimpleTableContext(BigDecimal.valueOf(18), "Medium", true);
         final DMNContext result = evaluateSimpleTableWithContext(dmnModel, runtime, context);
         final Map<String, Object> decisionResult = (Map<String, Object>) result.get("Decision Result");
-        assertThat(decisionResult.values(), hasSize(2));
-        assertThat(decisionResult, hasEntry(is("Approval Status"), is("Declined")));
-        assertThat(decisionResult, hasEntry(is("Decision Review"), is("Needs verification")));
+        assertThat(decisionResult.values()).hasSize(2);
+        assertThat(decisionResult).containsEntry("Approval Status", "Declined");
+        assertThat(decisionResult).containsEntry("Decision Review", "Needs verification");
     }
 
     @Test
     public void testSimpleDecisionTableHitPolicyOutputOrder() {
         final DMNRuntime runtime = DMNRuntimeUtil.createRuntime("0004-simpletable-O.dmn", this.getClass());
         final DMNModel dmnModel = runtime.getModel("https://github.com/kiegroup/kie-dmn", "0004-simpletable-O");
-        assertThat(dmnModel, notNullValue());
+        assertThat(dmnModel).isNotNull();
 
         final DMNContext context = getSimpleTableContext(BigDecimal.valueOf(70), "Medium", true);
         final DMNContext result = evaluateSimpleTableWithContext(dmnModel, runtime, context);
         final List<String> decisionResults = (List<String>) result.get("Approval Status");
-        assertThat(decisionResults, hasSize(3));
-        assertThat(decisionResults, contains("Declined", "Declined", "Approved"));
+        assertThat(decisionResults).hasSize(3);
+        assertThat(decisionResults).contains("Declined", "Declined", "Approved");
     }
 
     @Test
     public void testSimpleDecisionTableHitPolicyOutputOrderMultipleOutputs() {
         final DMNRuntime runtime = DMNRuntimeUtil.createRuntime("0004-simpletable-O-multiple-outputs.dmn", this.getClass());
         final DMNModel dmnModel = runtime.getModel("https://github.com/kiegroup/kie-dmn", "0004-simpletable-O-multiple-outputs");
-        assertThat(dmnModel, notNullValue());
+        assertThat(dmnModel).isNotNull();
 
         final DMNContext context = getSimpleTableContext(BigDecimal.valueOf(18), "Medium", true);
         final DMNContext result = evaluateSimpleTableWithContext(dmnModel, runtime, context);
         final List<Map<String, String>> decisionResult = (List<Map<String, String>>) result.get("Decision Result");
-        assertThat(decisionResult, hasSize(4));
+        assertThat(decisionResult).hasSize(4);
         // Must be ordered, so we can read from the list by index
         checkMultipleOutputResult(decisionResult.get(0), "Declined", "Needs verification");
         checkMultipleOutputResult(decisionResult.get(1), "Declined", "Decision final");
@@ -227,40 +220,40 @@ public class DMNDecisionTableHitPolicyTest extends BaseDMN1_1VariantTest {
 
     private void checkMultipleOutputResult(final Map<String, String> outputResult,
             final String expectedApprovalStatus, final String expectedDecisionReview) {
-        assertThat(outputResult, hasEntry(is("Approval Status"), is(expectedApprovalStatus)));
-        assertThat(outputResult, hasEntry(is("Decision Review"), is(expectedDecisionReview)));
+        assertThat(outputResult).containsEntry("Approval Status", expectedApprovalStatus);
+        assertThat(outputResult).containsEntry("Decision Review", expectedDecisionReview);
     }
 
     @Test
     public void testSimpleDecisionTableHitPolicyRuleOrder() {
         final DMNRuntime runtime = DMNRuntimeUtil.createRuntime("0004-simpletable-R.dmn", this.getClass());
         final DMNModel dmnModel = runtime.getModel("https://github.com/kiegroup/kie-dmn", "0004-simpletable-R");
-        assertThat(dmnModel, notNullValue());
+        assertThat(dmnModel).isNotNull();
 
         final DMNContext context = getSimpleTableContext(BigDecimal.valueOf(70), "Medium", true);
         final DMNContext result = evaluateSimpleTableWithContext(dmnModel, runtime, context);
         final List<String> decisionResults = (List<String>) result.get("Approval Status");
-        assertThat(decisionResults, hasSize(3));
-        assertThat(decisionResults, contains("Approved", "Needs review", "Declined"));
+        assertThat(decisionResults).hasSize(3);
+        assertThat(decisionResults).contains("Approved", "Needs review", "Declined");
     }
 
     @Test
     public void testSimpleDecisionTableHitPolicyCollect() {
         final List<BigDecimal> decisionResults = executeTestDecisionTableHitPolicyCollect(getSimpleTableContext(BigDecimal.valueOf(70 ), "Medium", true));
-        assertThat(decisionResults, hasSize(3));
-        assertThat(decisionResults, contains(BigDecimal.valueOf(10), BigDecimal.valueOf(25), BigDecimal.valueOf(13)));
+        assertThat(decisionResults).hasSize(3);
+        assertThat(decisionResults).contains(BigDecimal.valueOf(10), BigDecimal.valueOf(25), BigDecimal.valueOf(13));
     }
 
     @Test
     public void testSimpleDecisionTableHitPolicyCollectNoHits() {
         final List<BigDecimal> decisionResults = executeTestDecisionTableHitPolicyCollect(getSimpleTableContext(BigDecimal.valueOf(5 ), "Medium", true));
-        assertThat(decisionResults, hasSize(0));
+        assertThat(decisionResults).hasSize(0);
     }
 
     private List<BigDecimal> executeTestDecisionTableHitPolicyCollect(final DMNContext context) {
         final DMNRuntime runtime = DMNRuntimeUtil.createRuntime( "0004-simpletable-C.dmn", this.getClass());
         final DMNModel dmnModel = runtime.getModel( "https://github.com/kiegroup/kie-dmn", "0004-simpletable-C");
-        assertThat(dmnModel, notNullValue());
+        assertThat(dmnModel).isNotNull();
 
         final DMNContext result = evaluateSimpleTableWithContext(dmnModel, runtime, context);
 
@@ -279,16 +272,16 @@ public class DMNDecisionTableHitPolicyTest extends BaseDMN1_1VariantTest {
         final DMNRuntime runtime = DMNRuntimeUtil.createRuntime("0004-simpletable-C-sum-multiple-outputs.dmn", this.getClass());
         final DMNModel dmnModel =
                 runtime.getModel("https://github.com/kiegroup/kie-dmn", "0004-simpletable-C-sum-multiple-outputs");
-        assertThat(dmnModel, notNullValue());
+        assertThat(dmnModel).isNotNull();
 
         final DMNContext context = getSimpleTableContext(BigDecimal.valueOf(70), "Medium", true);
         final DMNResult dmnResult = runtime.evaluateAll(dmnModel, context);
 
         final DMNContext result = dmnResult.getContext();
         final Map<String, Object> decisionResult = (Map<String, Object>) result.get("Decision Result");
-        assertThat(decisionResult.values(), hasSize(2));
-        assertThat(decisionResult, hasEntry( "Value1", BigDecimal.valueOf( 25 ) ));
-        assertThat(decisionResult, hasEntry( "Value2", BigDecimal.valueOf( 32 ) ));
+        assertThat(decisionResult.values()).hasSize(2);
+        assertThat(decisionResult).containsEntry("Value1", BigDecimal.valueOf(25));
+        assertThat(decisionResult).containsEntry("Value2", BigDecimal.valueOf(32));
     }
 
     @Test
@@ -323,10 +316,10 @@ public class DMNDecisionTableHitPolicyTest extends BaseDMN1_1VariantTest {
             final String resourceName, final String modelName, final BigDecimal expectedResult, final DMNContext context) {
         final DMNRuntime runtime = DMNRuntimeUtil.createRuntime(resourceName, this.getClass());
         final DMNModel dmnModel = runtime.getModel("https://github.com/kiegroup/kie-dmn", modelName);
-        assertThat(dmnModel, notNullValue());
+        assertThat(dmnModel).isNotNull();
 
         final DMNContext result = evaluateSimpleTableWithContext(dmnModel, runtime, context);
-        assertThat(result.get("Status number"), is(expectedResult));
+        assertThat(result.get("Status number")).isEqualTo(expectedResult);
     }
 
     private DMNContext evaluateSimpleTableWithContext(final DMNModel model, final DMNRuntime runtime, final DMNContext context) {
@@ -346,16 +339,16 @@ public class DMNDecisionTableHitPolicyTest extends BaseDMN1_1VariantTest {
     public void testDecisionTableHitPolicyCollect() {
         final DMNRuntime runtime = DMNRuntimeUtil.createRuntime("Collect_Hit_Policy.dmn", this.getClass());
         final DMNModel dmnModel = runtime.getModel("http://www.trisotech.com/definitions/_da1a4dcb-01bf-4dee-9be8-f498bc68178c", "Collect Hit Policy");
-        assertThat(dmnModel, notNullValue());
+        assertThat(dmnModel).isNotNull();
 
         final DMNContext context = DMNFactory.newContext();
         context.set("Input", 20);
 
         final DMNResult dmnResult = runtime.evaluateAll(dmnModel, context);
-        assertThat(dmnResult.hasErrors(), is(false));
+        assertThat(dmnResult.hasErrors()).isFalse();
 
         final DMNContext result = dmnResult.getContext();
-        assertThat(result.get("Collect"), is(BigDecimal.valueOf(50)));
+        assertThat(result.get("Collect")).isEqualTo(BigDecimal.valueOf(50));
     }
 
 }

--- a/kie-dmn/kie-dmn-legacy-tests/src/test/java/org/kie/dmn/legacy/tests/core/v1_1/DMNDecisionTableRuntimeTest.java
+++ b/kie-dmn/kie-dmn-legacy-tests/src/test/java/org/kie/dmn/legacy/tests/core/v1_1/DMNDecisionTableRuntimeTest.java
@@ -19,7 +19,6 @@ package org.kie.dmn.legacy.tests.core.v1_1;
 import java.math.BigDecimal;
 import java.math.RoundingMode;
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
@@ -44,13 +43,8 @@ import org.mockito.Mockito;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import static org.hamcrest.CoreMatchers.instanceOf;
-import static org.hamcrest.CoreMatchers.is;
-import static org.hamcrest.CoreMatchers.notNullValue;
-import static org.hamcrest.Matchers.empty;
-import static org.hamcrest.Matchers.hasEntry;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.Assert.assertNull;
-import static org.hamcrest.MatcherAssert.assertThat;
 import static org.mockito.Mockito.verify;
 import static org.mockito.internal.verification.VerificationModeFactory.times;
 
@@ -70,7 +64,7 @@ public class DMNDecisionTableRuntimeTest extends BaseDMN1_1VariantTest {
 
     private void checkDecisionTableWithCalculatedResult(final DMNRuntime runtime) {
         final DMNModel dmnModel = runtime.getModel( "http://www.trisotech.com/definitions/_77ae284e-ce52-4579-a50f-f3cc584d7f4b", "Calculation1" );
-        assertThat( dmnModel, notNullValue() );
+        assertThat(dmnModel).isNotNull();
 
         final DMNContext context = DMNFactory.newContext();
         context.set( "MonthlyDeptPmt", BigDecimal.valueOf( 200 ) );
@@ -78,10 +72,10 @@ public class DMNDecisionTableRuntimeTest extends BaseDMN1_1VariantTest {
         context.set( "MonthlyIncome", BigDecimal.valueOf( 600 ) );
 
         final DMNResult dmnResult = runtime.evaluateAll( dmnModel, context );
-        assertThat( dmnResult.hasErrors(), is( false ) );
+        assertThat(dmnResult.hasErrors()).isFalse();
 
         final DMNContext result = dmnResult.getContext();
-        assertThat( ((BigDecimal) result.get( "Logique de décision 1" )).setScale( 1, RoundingMode.CEILING ), is( BigDecimal.valueOf( 0.5 ) ) );
+        assertThat( ((BigDecimal) result.get( "Logique de décision 1" )).setScale( 1, RoundingMode.CEILING )).isEqualTo(BigDecimal.valueOf( 0.5 ) );
     }
     
     @Test(timeout = 30_000L)
@@ -109,7 +103,7 @@ public class DMNDecisionTableRuntimeTest extends BaseDMN1_1VariantTest {
         runtime.addListener( listener );
 
         final DMNModel dmnModel = runtime.getModel( "http://www.trisotech.com/definitions/_820611e9-c21c-47cd-8e52-5cba2be9f9cc", "Car Damage Responsibility" );
-        assertThat( dmnModel, notNullValue() );
+        assertThat(dmnModel).isNotNull();
 
         final DMNContext context = DMNFactory.newContext();
         context.set( "Membership Level", "Silver" );
@@ -117,30 +111,30 @@ public class DMNDecisionTableRuntimeTest extends BaseDMN1_1VariantTest {
         context.set( "Responsible", "Driver" );
 
         final DMNResult dmnResult = runtime.evaluateAll( dmnModel, context );
-        assertThat( dmnResult.hasErrors(), is( false ) );
+        assertThat(dmnResult.hasErrors()).isFalse();
 
         final DMNContext result = dmnResult.getContext();
-        assertThat( (Map<String, Object>) result.get( "Car Damage Responsibility" ), hasEntry( is( "EU Rent" ), is( BigDecimal.valueOf( 40 ) ) ) );
-        assertThat( (Map<String, Object>) result.get( "Car Damage Responsibility" ), hasEntry( is( "Renter" ), is( BigDecimal.valueOf( 60 ) ) ) );
-        assertThat( result.get( "Payment method" ), is( "Check" ) );
+        assertThat( (Map<String, Object>) result.get( "Car Damage Responsibility" )).containsEntry("EU Rent", BigDecimal.valueOf(40));
+        assertThat( (Map<String, Object>) result.get( "Car Damage Responsibility" )).containsEntry("Renter", BigDecimal.valueOf(60));
+        assertThat( result.get( "Payment method" )).isEqualTo("Check" );
 
         final ArgumentCaptor<AfterEvaluateDecisionTableEvent> captor = ArgumentCaptor.forClass( AfterEvaluateDecisionTableEvent.class );
         verify( listener, times( 2 ) ).afterEvaluateDecisionTable( captor.capture() );
 
         final AfterEvaluateDecisionTableEvent first = captor.getAllValues().get( 0 );
-        assertThat( first.getMatches(), is( Collections.singletonList( 5 ) ) );
-        assertThat( first.getSelected(), is( Collections.singletonList( 5 ) ) );
+        assertThat( first.getMatches()).containsExactly(5);
+        assertThat( first.getSelected()).containsExactly(5);
 
         final AfterEvaluateDecisionTableEvent second = captor.getAllValues().get( 1 );
-        assertThat( second.getMatches(), is( Collections.singletonList( 3 ) ) );
-        assertThat( second.getSelected(), is( Collections.singletonList( 3 ) ) );
+        assertThat( second.getMatches()).containsExactly(3);
+        assertThat( second.getSelected()).containsExactly(3);
     }
 
     @Test
     public void testSimpleDecisionTableMultipleOutputWrongOutputType() {
         final DMNRuntime runtime = DMNRuntimeUtil.createRuntime( "0004-simpletable-P-multiple-outputs-wrong-output.dmn", this.getClass() );
         final DMNModel dmnModel = runtime.getModel( "https://github.com/kiegroup/kie-dmn", "0004-simpletable-P-multiple-outputs-wrong-output" );
-        assertThat( dmnModel, notNullValue() );
+        assertThat(dmnModel).isNotNull();
 
         final DMNContext context = DMNFactory.newContext();
         context.set( "Age", BigDecimal.valueOf( 18 ) );
@@ -148,9 +142,9 @@ public class DMNDecisionTableRuntimeTest extends BaseDMN1_1VariantTest {
         context.set( "isAffordable", true );
 
         final DMNResult dmnResult = runtime.evaluateAll( dmnModel, context );
-        assertThat( dmnResult.hasErrors(), is( true ) );
+        assertThat( dmnResult.hasErrors()).isTrue();
         assertThat( dmnResult.getMessages().stream().filter(
-                message -> message.getFeelEvent().getSourceException() instanceof NullPointerException ).count(), is( 0L ) );
+                message -> message.getFeelEvent().getSourceException() instanceof NullPointerException ).count()).isEqualTo(0L );
     }
 
     @Test
@@ -183,13 +177,13 @@ public class DMNDecisionTableRuntimeTest extends BaseDMN1_1VariantTest {
     private void testDecisionTableInvalidInput(final DMNContext inputContext) {
         final DMNRuntime runtime = DMNRuntimeUtil.createRuntime( "InvalidInput.dmn", this.getClass() );
         final DMNModel dmnModel = runtime.getModel( "http://www.trisotech.com/dmn/definitions/_cdf29af2-959b-4004-8271-82a9f5a62147", "Dessin 1" );
-        assertThat( dmnModel, notNullValue() );
+        assertThat(dmnModel).isNotNull();
 
         final DMNResult dmnResult = runtime.evaluateAll( dmnModel, inputContext );
-        assertThat( dmnResult.hasErrors(), is( true ) );
+        assertThat( dmnResult.hasErrors()).isTrue();
 
         final DMNContext result = dmnResult.getContext();
-        assertThat( result.isDefined( "Branches distribution" ), is( false ) );
+        assertThat(result.isDefined( "Branches distribution")).isEqualTo(Boolean.FALSE);
     }
 
     @Test
@@ -199,8 +193,8 @@ public class DMNDecisionTableRuntimeTest extends BaseDMN1_1VariantTest {
         runtime.addListener( listener );
 
         final DMNModel dmnModel = runtime.getModel( "https://github.com/kiegroup/kie-dmn", "decisiontable-default-value" );
-        assertThat( dmnModel, notNullValue() );
-        assertThat( dmnModel.getMessages().toString(), dmnModel.hasErrors(), is( false ) );
+        assertThat(dmnModel).isNotNull();
+        assertThat(dmnModel.hasErrors()).as(DMNRuntimeUtil.formatMessages(dmnModel.getMessages())).isFalse();
 
         final DMNContext context = DMNFactory.newContext();
         context.set( "Age", new BigDecimal( 16 ) );
@@ -208,16 +202,16 @@ public class DMNDecisionTableRuntimeTest extends BaseDMN1_1VariantTest {
         context.set( "isAffordable", true );
 
         final DMNResult dmnResult = runtime.evaluateAll( dmnModel, context );
-        assertThat( dmnResult.getMessages().toString(), dmnResult.hasErrors(), is( false ) );
+        assertThat(dmnResult.hasErrors()).as(DMNRuntimeUtil.formatMessages(dmnResult.getMessages())).isFalse();
 
         final DMNContext result = dmnResult.getContext();
-        assertThat( result.get( "Approval Status" ), is( "Declined" ) );
+        assertThat( result.get( "Approval Status" )).isEqualTo("Declined" );
 
         final ArgumentCaptor<AfterEvaluateDecisionTableEvent> captor = ArgumentCaptor.forClass( AfterEvaluateDecisionTableEvent.class );
         verify( listener ).afterEvaluateDecisionTable( captor.capture() );
 
-        assertThat( captor.getValue().getMatches(), is( empty() ) );
-        assertThat( captor.getValue().getSelected(), is( empty() ) );
+        assertThat( captor.getValue().getMatches()).isEmpty();
+        assertThat( captor.getValue().getSelected()).isEmpty();
     }
 
     @Test
@@ -227,24 +221,24 @@ public class DMNDecisionTableRuntimeTest extends BaseDMN1_1VariantTest {
         runtime.addListener( listener );
 
         final DMNModel dmnModel = runtime.getModel( "http://www.trisotech.com/definitions/_bbb692e7-3d95-407a-bf39-353085bf57f0", "Invocation with two decision table as parameters" );
-        assertThat( dmnModel, notNullValue() );
-        assertThat( dmnModel.getMessages().toString(), dmnModel.hasErrors(), is( false ) );
+        assertThat(dmnModel).isNotNull();
+        assertThat(dmnModel.hasErrors()).as(DMNRuntimeUtil.formatMessages(dmnModel.getMessages())).isFalse();
 
         final DMNContext context = DMNFactory.newContext();
         context.set( "Number", 50 );
 
         final DMNResult dmnResult = runtime.evaluateAll( dmnModel, context );
-        assertThat( dmnResult.getMessages().toString(), dmnResult.hasErrors(), is( false ) );
+        assertThat(dmnResult.hasErrors()).as(DMNRuntimeUtil.formatMessages(dmnResult.getMessages())).isFalse();
 
         final DMNContext result = dmnResult.getContext();
-        assertThat( (Map<String, Object>) result.get( "Decision Logic 2" ), hasEntry( "the 5 analysis", "A number greater than 5" ) );
-        assertThat( (Map<String, Object>) result.get( "Decision Logic 2" ), hasEntry( "the 100 analysis", "A number smaller than 100" ) );
+        assertThat( (Map<String, Object>) result.get( "Decision Logic 2" )).containsEntry("the 5 analysis", "A number greater than 5");
+        assertThat( (Map<String, Object>) result.get( "Decision Logic 2" )).containsEntry("the 100 analysis", "A number smaller than 100");
 
         final ArgumentCaptor<AfterEvaluateDecisionTableEvent> captor = ArgumentCaptor.forClass( AfterEvaluateDecisionTableEvent.class );
         verify( listener, times( 2 ) ).afterEvaluateDecisionTable( captor.capture() );
 
-        assertThat( captor.getAllValues().get( 0 ).getDecisionTableName(), is( "a" ) );
-        assertThat( captor.getAllValues().get( 1 ).getDecisionTableName(), is( "b" ) );
+        assertThat( captor.getAllValues().get( 0 ).getDecisionTableName()).isEqualTo("a" );
+        assertThat( captor.getAllValues().get( 1 ).getDecisionTableName()).isEqualTo("b" );
     }
 
     @Test
@@ -253,41 +247,41 @@ public class DMNDecisionTableRuntimeTest extends BaseDMN1_1VariantTest {
         final DMNModel dmnModel = runtime.getModel(
                 "https://www.drools.org/kie-dmn/definitions",
                 "definitions" );
-        assertThat( dmnModel, notNullValue() );
-        assertThat( DMNRuntimeUtil.formatMessages( dmnModel.getMessages() ), dmnModel.hasErrors(), is( false ) );
+        assertThat(dmnModel).isNotNull();
+        assertThat(dmnModel.hasErrors()).as(DMNRuntimeUtil.formatMessages(dmnModel.getMessages())).isFalse();
 
         final DMNContext context = runtime.newContext();
         context.set( "MyInput", "a" );
 
         final DMNResult dmnResult = runtime.evaluateAll(dmnModel, context );
 
-        assertThat( DMNRuntimeUtil.formatMessages( dmnResult.getMessages() ), dmnResult.hasErrors(), is( false ) );
+        assertThat(dmnResult.hasErrors()).as(DMNRuntimeUtil.formatMessages(dmnResult.getMessages())).isFalse();
         final DMNContext result = dmnResult.getContext();
-        assertThat( result.get( "MyDecision" ), is( "Decision taken" ) );
+        assertThat( result.get( "MyDecision" )).isEqualTo("Decision taken" );
     }
 
     @Test
     public void testDTInContext() {
         final DMNRuntime runtime = DMNRuntimeUtil.createRuntime("DT_in_context.dmn", this.getClass() );
         final DMNModel dmnModel = runtime.getModel("http://www.trisotech.com/dmn/definitions/_4acdcb25-b298-435e-abd5-efd00ed686a5", "Drawing 1" );
-        assertThat( dmnModel, notNullValue() );
+        assertThat(dmnModel).isNotNull();
 
         final DMNContext context = DMNFactory.newContext();
         final DMNResult dmnResult = runtime.evaluateAll(dmnModel, context );
 
-        assertThat( dmnResult.getDecisionResults().size(), is( 1 ) );
-        assertThat( dmnResult.getDecisionResultByName( "D1" ).getResult(), is( instanceOf( Map.class ) ) );
+        assertThat( dmnResult.getDecisionResults()).hasSize(1);
+        assertThat( dmnResult.getDecisionResultByName( "D1" ).getResult()).isInstanceOf(Map.class);
 
         final DMNContext result = dmnResult.getContext();
-        assertThat( ((Map) result.get( "D1" )).get( "Text color" ), is( "red" ) );
+        assertThat( ((Map) result.get( "D1" )).get( "Text color" )).isEqualTo("red" );
     }
 
     @Test
     public void testDTUsingEqualsUnaryTestWithVariable1() {
         final DMNRuntime runtime = DMNRuntimeUtil.createRuntime("DT_using_variables.dmn", this.getClass() );
         final DMNModel dmnModel = runtime.getModel("http://www.trisotech.com/definitions/_ed1ec15b-40aa-424d-b1d0-4936df80b135", "DT Using variables" );
-        assertThat( dmnModel, notNullValue() );
-        assertThat( DMNRuntimeUtil.formatMessages( dmnModel.getMessages() ), dmnModel.hasErrors(), is( false ) );
+        assertThat(dmnModel).isNotNull();
+        assertThat(dmnModel.hasErrors()).as(DMNRuntimeUtil.formatMessages(dmnModel.getMessages())).isFalse();
 
         final Map<String, Object> complex = new HashMap<>();
         complex.put( "aBoolean", true );
@@ -302,17 +296,17 @@ public class DMNDecisionTableRuntimeTest extends BaseDMN1_1VariantTest {
         final DMNResult dmnResult = runtime.evaluateAll(dmnModel, context );
 
         final DMNContext result = dmnResult.getContext();
-        assertThat( result.get( "Compare Boolean" ), is( "Same boolean" ) );
-        assertThat( result.get( "Compare Number" ), is( "Equals" ) );
-        assertThat( result.get( "Compare String" ), is( "Same String" ) );
+        assertThat( result.get( "Compare Boolean" )).isEqualTo("Same boolean" );
+        assertThat( result.get( "Compare Number" )).isEqualTo("Equals" );
+        assertThat( result.get( "Compare String" )).isEqualTo("Same String" );
     }
 
     @Test
     public void testDTUsingEqualsUnaryTestWithVariable2() {
         final DMNRuntime runtime = DMNRuntimeUtil.createRuntime("DT_using_variables.dmn", this.getClass() );
         final DMNModel dmnModel = runtime.getModel("http://www.trisotech.com/definitions/_ed1ec15b-40aa-424d-b1d0-4936df80b135", "DT Using variables" );
-        assertThat( dmnModel, notNullValue() );
-        assertThat( dmnModel.hasErrors(), is( false ) );
+        assertThat(dmnModel).isNotNull();
+        assertThat( dmnModel.hasErrors()).isFalse();
 
         final Map<String, Object> complex = new HashMap<>();
         complex.put( "aBoolean", true );
@@ -327,23 +321,23 @@ public class DMNDecisionTableRuntimeTest extends BaseDMN1_1VariantTest {
         final DMNResult dmnResult = runtime.evaluateAll(dmnModel, context );
 
         final DMNContext result = dmnResult.getContext();
-        assertThat( result.get( "Compare Boolean" ), is( "Not same boolean" ) );
-        assertThat( result.get( "Compare Number" ), is( "Bigger" ) );
-        assertThat( result.get( "Compare String" ), is( "Different String" ) );
+        assertThat( result.get( "Compare Boolean" )).isEqualTo("Not same boolean" );
+        assertThat( result.get( "Compare Number" )).isEqualTo("Bigger" );
+        assertThat( result.get( "Compare String" )).isEqualTo("Different String" );
     }
 
     @Test
     public void testEmptyOutputCell() {
         final DMNRuntime runtime = DMNRuntimeUtil.createRuntime( "DT_empty_output_cell.dmn", this.getClass() );
         final DMNModel dmnModel = runtime.getModel( "http://www.trisotech.com/definitions/_77ae284e-ce52-4579-a50f-f3cc584d7f4b", "Calculation1" );
-        assertThat( dmnModel, notNullValue() );
+        assertThat(dmnModel).isNotNull();
         final DMNContext context = DMNFactory.newContext();
         context.set( "MonthlyDeptPmt", BigDecimal.valueOf( 1 ) );
         context.set( "MonthlyPmt", BigDecimal.valueOf( 1 ) );
         context.set( "MonthlyIncome", BigDecimal.valueOf( 1 ) );
         final DMNResult dmnResult = runtime.evaluateAll( dmnModel, context );
         LOG.debug("{}", dmnResult);
-        assertThat( dmnResult.hasErrors(), is( false ) );
+        assertThat(dmnResult.hasErrors()).isFalse();
         assertNull( dmnResult.getContext().get("Logique de décision 1") );
     }
 
@@ -351,12 +345,12 @@ public class DMNDecisionTableRuntimeTest extends BaseDMN1_1VariantTest {
     public void testNullRelation() {
         final DMNRuntime runtime = DMNRuntimeUtil.createRuntime("nullrelation.dmn", getClass());
         final DMNModel model = runtime.getModel("http://www.trisotech.com/definitions/_946a2145-89ae-4197-88b4-40e6f88c8101", "Null in relations");
-        assertThat(model, notNullValue());
-        assertThat(DMNRuntimeUtil.formatMessages(model.getMessages()), model.hasErrors(), is(false));
+        assertThat(model).isNotNull();
+        assertThat(model.hasErrors()).as(DMNRuntimeUtil.formatMessages(model.getMessages())).isFalse();
         final DMNContext context = DMNFactory.newContext();
         context.set("Value", "a3");
         final DMNResult result = runtime.evaluateByName(model, context, "Mapping");
-        assertThat(DMNRuntimeUtil.formatMessages(result.getMessages()), result.hasErrors(), is(false));
+        assertThat(result.hasErrors()).as(DMNRuntimeUtil.formatMessages(result.getMessages())).isFalse();
     }
 
     @Test
@@ -364,17 +358,17 @@ public class DMNDecisionTableRuntimeTest extends BaseDMN1_1VariantTest {
         // DROOLS-2359
         final DMNRuntime runtime = DMNRuntimeUtil.createRuntime("DecisionTableOutputDMNTypeCollection.dmn", this.getClass());
         final DMNModel dmnModel = runtime.getModel("http://www.trisotech.com/dmn/definitions/_ae5d2033-c6d0-411f-a394-da33a70e5638", "Drawing 1");
-        assertThat(dmnModel, notNullValue());
-        assertThat(DMNRuntimeUtil.formatMessages(dmnModel.getMessages()), dmnModel.hasErrors(), is(false));
+        assertThat(dmnModel).isNotNull();
+        assertThat(dmnModel.hasErrors()).as(DMNRuntimeUtil.formatMessages(dmnModel.getMessages())).isFalse();
 
         final DMNContext context = DMNFactory.newContext();
         context.set("selector", "asd");
 
         final DMNResult dmnResult = runtime.evaluateAll(dmnModel, context);
-        assertThat(DMNRuntimeUtil.formatMessages(dmnResult.getMessages()), dmnResult.hasErrors(), is(false));
+        assertThat(dmnResult.hasErrors()).as(DMNRuntimeUtil.formatMessages(dmnResult.getMessages())).isFalse();
 
         final DMNContext result = dmnResult.getContext();
-        assertThat(result.get("a decision"), is(Arrays.asList("abc", "xyz")));
+        assertThat(result.get("a decision")).asList().containsExactly("abc", "xyz");
     }
 
     @Test
@@ -386,17 +380,17 @@ public class DMNDecisionTableRuntimeTest extends BaseDMN1_1VariantTest {
                                                                     ks.getResources().newClassPathResource("DecisionTableOutputDMNTypeCollection.dmn", this.getClass()));
         final DMNRuntime runtime = kieContainer.newKieSession().getKieRuntime(DMNRuntime.class);
         final DMNModel dmnModel = runtime.getModel("http://www.trisotech.com/dmn/definitions/_ae5d2033-c6d0-411f-a394-da33a70e5638", "Drawing 1");
-        assertThat(dmnModel, notNullValue());
-        assertThat(DMNRuntimeUtil.formatMessages(dmnModel.getMessages()), dmnModel.hasErrors(), is(false));
+        assertThat(dmnModel).isNotNull();
+        assertThat(dmnModel.hasErrors()).as(DMNRuntimeUtil.formatMessages(dmnModel.getMessages())).isFalse();
 
         final DMNContext context = DMNFactory.newContext();
         context.set("selector", "asd");
 
         final DMNResult dmnResult = runtime.evaluateAll(dmnModel, context);
-        assertThat(DMNRuntimeUtil.formatMessages(dmnResult.getMessages()), dmnResult.hasErrors(), is(false));
+        assertThat(dmnResult.hasErrors()).as(DMNRuntimeUtil.formatMessages(dmnResult.getMessages())).isFalse();
 
         final DMNContext result = dmnResult.getContext();
-        assertThat(result.get("a decision"), is(Arrays.asList("abc", "xyz")));
+        assertThat(result.get("a decision")).asList().containsExactly("abc", "xyz");
     }
 
     @Test
@@ -404,17 +398,17 @@ public class DMNDecisionTableRuntimeTest extends BaseDMN1_1VariantTest {
         // DROOLS-2359
         final DMNRuntime runtime = DMNRuntimeUtil.createRuntime("DecisionTableOutputDMNTypeCollectionWithLOV.dmn", this.getClass());
         final DMNModel dmnModel = runtime.getModel("http://www.trisotech.com/dmn/definitions/_ae5d2033-c6d0-411f-a394-da33a70e5638", "List of Words in DT");
-        assertThat(dmnModel, notNullValue());
-        assertThat(DMNRuntimeUtil.formatMessages(dmnModel.getMessages()), dmnModel.hasErrors(), is(false));
+        assertThat(dmnModel).isNotNull();
+        assertThat(dmnModel.hasErrors()).as(DMNRuntimeUtil.formatMessages(dmnModel.getMessages())).isFalse();
 
         final DMNContext context = DMNFactory.newContext();
         context.set("selector", "asd");
 
         final DMNResult dmnResult = runtime.evaluateAll(dmnModel, context);
-        assertThat(DMNRuntimeUtil.formatMessages(dmnResult.getMessages()), dmnResult.hasErrors(), is(false));
+        assertThat(dmnResult.hasErrors()).as(DMNRuntimeUtil.formatMessages(dmnResult.getMessages())).isFalse();
 
         final DMNContext result = dmnResult.getContext();
-        assertThat(result.get("a decision"), is(Arrays.asList("abc", "a")));
+        assertThat(result.get("a decision")).asList().containsExactly("abc", "a");
     }
 
     @Test
@@ -426,17 +420,17 @@ public class DMNDecisionTableRuntimeTest extends BaseDMN1_1VariantTest {
                                                                     ks.getResources().newClassPathResource("DecisionTableOutputDMNTypeCollectionWithLOV.dmn", this.getClass()));
         final DMNRuntime runtime = kieContainer.newKieSession().getKieRuntime(DMNRuntime.class);
         final DMNModel dmnModel = runtime.getModel("http://www.trisotech.com/dmn/definitions/_ae5d2033-c6d0-411f-a394-da33a70e5638", "List of Words in DT");
-        assertThat(dmnModel, notNullValue());
-        assertThat(DMNRuntimeUtil.formatMessages(dmnModel.getMessages()), dmnModel.hasErrors(), is(false));
+        assertThat(dmnModel).isNotNull();
+        assertThat(dmnModel.hasErrors()).as(DMNRuntimeUtil.formatMessages(dmnModel.getMessages())).isFalse();
 
         final DMNContext context = DMNFactory.newContext();
         context.set("selector", "asd");
 
         final DMNResult dmnResult = runtime.evaluateAll(dmnModel, context);
-        assertThat(DMNRuntimeUtil.formatMessages(dmnResult.getMessages()), dmnResult.hasErrors(), is(false));
+        assertThat(dmnResult.hasErrors()).as(DMNRuntimeUtil.formatMessages(dmnResult.getMessages())).isFalse();
 
         final DMNContext result = dmnResult.getContext();
-        assertThat(result.get("a decision"), is(Arrays.asList("abc", "a")));
+        assertThat(result.get("a decision")).asList().containsExactly("abc", "a");
     }
 
 }

--- a/kie-dmn/kie-dmn-legacy-tests/src/test/java/org/kie/dmn/legacy/tests/core/v1_1/DMNDecisionTableWithSymbolsTest.java
+++ b/kie-dmn/kie-dmn-legacy-tests/src/test/java/org/kie/dmn/legacy/tests/core/v1_1/DMNDecisionTableWithSymbolsTest.java
@@ -24,9 +24,7 @@ import org.kie.dmn.api.core.DMNRuntime;
 import org.kie.dmn.core.api.DMNFactory;
 import org.kie.dmn.core.util.DMNRuntimeUtil;
 
-import static org.hamcrest.Matchers.is;
-import static org.hamcrest.core.IsNull.notNullValue;
-import static org.hamcrest.MatcherAssert.assertThat;
+import static org.assertj.core.api.Assertions.assertThat;
 
 public class DMNDecisionTableWithSymbolsTest extends BaseDMN1_1VariantTest {
 
@@ -38,7 +36,7 @@ public class DMNDecisionTableWithSymbolsTest extends BaseDMN1_1VariantTest {
     public void testDecisionWithArgumentsOnOutput() {
         final DMNRuntime runtime = DMNRuntimeUtil.createRuntime("Decide with symbols.dmn", this.getClass());
         final DMNModel dmnModel = runtime.getModel("http://www.trisotech.com/dmn/definitions/_79b16a68-013b-484c-98f5-49ff77808800", "Decide with symbols");
-        assertThat(dmnModel, notNullValue());
+        assertThat(dmnModel).isNotNull();
 
         final DMNContext context = DMNFactory.newContext();
         context.set("Person age", 44);
@@ -46,6 +44,6 @@ public class DMNDecisionTableWithSymbolsTest extends BaseDMN1_1VariantTest {
 
         final DMNResult dmnResult = runtime.evaluateAll(dmnModel, context);
         final DMNContext result = dmnResult.getContext();
-        assertThat(result.get("Decide with symbol"), is("Hello, Mario"));
+        assertThat(result.get("Decide with symbol")).isEqualTo("Hello, Mario");
     }
 }

--- a/kie-dmn/kie-dmn-legacy-tests/src/test/java/org/kie/dmn/legacy/tests/core/v1_1/DMNInputRuntimeTest.java
+++ b/kie-dmn/kie-dmn-legacy-tests/src/test/java/org/kie/dmn/legacy/tests/core/v1_1/DMNInputRuntimeTest.java
@@ -34,10 +34,7 @@ import org.kie.dmn.api.core.ast.InputDataNode;
 import org.kie.dmn.core.api.DMNFactory;
 import org.kie.dmn.core.util.DMNRuntimeUtil;
 
-import static org.hamcrest.CoreMatchers.is;
-import static org.hamcrest.CoreMatchers.notNullValue;
-import static org.hamcrest.CoreMatchers.nullValue;
-import static org.hamcrest.MatcherAssert.assertThat;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.kie.dmn.core.util.DynamicTypeUtils.entry;
 import static org.kie.dmn.core.util.DynamicTypeUtils.prototype;
 
@@ -51,88 +48,88 @@ public class DMNInputRuntimeTest extends BaseDMN1_1VariantTest {
     public void testInputStringEvaluateAll() {
         final DMNRuntime runtime = DMNRuntimeUtil.createRuntime( "0001-input-data-string.dmn", this.getClass() );
         final DMNModel dmnModel = runtime.getModel( "https://github.com/kiegroup/drools/kie-dmn", "_0001-input-data-string" );
-        assertThat( dmnModel, notNullValue() );
+        assertThat(dmnModel).isNotNull();
 
         final DMNContext context = DMNFactory.newContext();
         context.set( "Full Name", "John Doe" );
 
         final DMNResult dmnResult = runtime.evaluateAll( dmnModel, context );
 
-        assertThat( dmnResult.getDecisionResults().size(), is(1) );
-        assertThat( dmnResult.getDecisionResultByName( "Greeting Message" ).getResult(), is( "Hello John Doe" ) );
+        assertThat(dmnResult.getDecisionResults()).hasSize(1);
+        assertThat(dmnResult.getDecisionResultByName("Greeting Message").getResult()).isEqualTo("Hello John Doe");
 
         final DMNContext result = dmnResult.getContext();
 
-        assertThat( result.get( "Greeting Message" ), is( "Hello John Doe" ) );
+        assertThat(result.get("Greeting Message")).isEqualTo("Hello John Doe");
     }
 
     @Test
     public void testInputStringEvaluateDecisionByName() {
         final DMNRuntime runtime = DMNRuntimeUtil.createRuntime( "0001-input-data-string.dmn", this.getClass() );
         final DMNModel dmnModel = runtime.getModel( "https://github.com/kiegroup/drools/kie-dmn", "_0001-input-data-string" );
-        assertThat( dmnModel, notNullValue() );
+        assertThat(dmnModel).isNotNull();
 
         final DMNContext context = DMNFactory.newContext();
         context.set( "Full Name", "John Doe" );
 
         DMNResult dmnResult = runtime.evaluateByName( dmnModel, context, "Greeting Message");
 
-        assertThat( dmnResult.getDecisionResults().size(), is(1) );
-        assertThat( dmnResult.getDecisionResultByName( "Greeting Message" ).getResult(), is( "Hello John Doe" ) );
+        assertThat(dmnResult.getDecisionResults()).hasSize(1);
+        assertThat(dmnResult.getDecisionResultByName( "Greeting Message" ).getResult()).isEqualTo( "Hello John Doe");
 
         final DMNContext result = dmnResult.getContext();
 
-        assertThat( result.get( "Greeting Message" ), is( "Hello John Doe" ) );
+        assertThat(result.get( "Greeting Message" )).isEqualTo("Hello John Doe" );
 
         dmnResult = runtime.evaluateByName( dmnModel, context, "nonExistantName");
-        assertThat( dmnResult.getDecisionResults().size(), is(1) );
-        assertThat( dmnResult.getDecisionResultByName( "Greeting Message" ).getEvaluationStatus(), is( DMNDecisionResult.DecisionEvaluationStatus.NOT_EVALUATED ) );
+        assertThat(dmnResult.getDecisionResults()).hasSize(1);
+        assertThat(dmnResult.getDecisionResultByName( "Greeting Message" ).getEvaluationStatus()).isEqualTo(DMNDecisionResult.DecisionEvaluationStatus.NOT_EVALUATED);
 
         dmnResult = runtime.evaluateByName( dmnModel, context, "" );
-        assertThat( dmnResult.getDecisionResults().size(), is(1) );
-        assertThat( dmnResult.getDecisionResultByName( "Greeting Message" ).getEvaluationStatus(), is( DMNDecisionResult.DecisionEvaluationStatus.NOT_EVALUATED ) );
+        assertThat(dmnResult.getDecisionResults()).hasSize(1);
+        assertThat(dmnResult.getDecisionResultByName( "Greeting Message" ).getEvaluationStatus()).isEqualTo(DMNDecisionResult.DecisionEvaluationStatus.NOT_EVALUATED);
 
         dmnResult = runtime.evaluateByName( dmnModel, context, (String) null);
-        assertThat( dmnResult.getDecisionResults().size(), is(1) );
-        assertThat( dmnResult.getDecisionResultByName( "Greeting Message" ).getEvaluationStatus(), is( DMNDecisionResult.DecisionEvaluationStatus.NOT_EVALUATED ) );
+        assertThat(dmnResult.getDecisionResults()).hasSize(1);
+        assertThat(dmnResult.getDecisionResultByName( "Greeting Message" ).getEvaluationStatus()).isEqualTo(DMNDecisionResult.DecisionEvaluationStatus.NOT_EVALUATED);
     }
 
     @Test
     public void testInputStringEvaluateDecisionById() {
         final DMNRuntime runtime = DMNRuntimeUtil.createRuntime( "0001-input-data-string.dmn", this.getClass() );
         final DMNModel dmnModel = runtime.getModel( "https://github.com/kiegroup/drools/kie-dmn", "_0001-input-data-string" );
-        assertThat( dmnModel, notNullValue() );
+        assertThat(dmnModel).isNotNull();
 
         final DMNContext context = DMNFactory.newContext();
         context.set( "Full Name", "John Doe" );
 
         DMNResult dmnResult = runtime.evaluateById( dmnModel, context, "d_GreetingMessage" );
 
-        assertThat( dmnResult.getDecisionResults().size(), is(1) );
-        assertThat( dmnResult.getDecisionResultById( "d_GreetingMessage" ).getResult(), is( "Hello John Doe" ) );
+        assertThat(dmnResult.getDecisionResults()).hasSize(1);
+        assertThat(dmnResult.getDecisionResultById( "d_GreetingMessage" ).getResult()).isEqualTo( "Hello John Doe");
 
         final DMNContext result = dmnResult.getContext();
 
-        assertThat( result.get( "Greeting Message" ), is( "Hello John Doe" ) );
+        assertThat(result.get( "Greeting Message" )).isEqualTo("Hello John Doe" );
 
         dmnResult = runtime.evaluateById( dmnModel, context, "nonExistantId" );
-        assertThat( dmnResult.getDecisionResults().size(), is(1) );
-        assertThat( dmnResult.getDecisionResultByName( "Greeting Message" ).getEvaluationStatus(), is( DMNDecisionResult.DecisionEvaluationStatus.NOT_EVALUATED ) );
+        assertThat(dmnResult.getDecisionResults()).hasSize(1);
+        assertThat(dmnResult.getDecisionResultByName( "Greeting Message" ).getEvaluationStatus()).isEqualTo(DMNDecisionResult.DecisionEvaluationStatus.NOT_EVALUATED);
 
         dmnResult = runtime.evaluateById( dmnModel, context, "" );
-        assertThat( dmnResult.getDecisionResults().size(), is(1) );
-        assertThat( dmnResult.getDecisionResultByName( "Greeting Message" ).getEvaluationStatus(), is( DMNDecisionResult.DecisionEvaluationStatus.NOT_EVALUATED ) );
+        assertThat(dmnResult.getDecisionResults()).hasSize(1);
+        assertThat(dmnResult.getDecisionResultByName( "Greeting Message" ).getEvaluationStatus()).isEqualTo(DMNDecisionResult.DecisionEvaluationStatus.NOT_EVALUATED);
 
         dmnResult = runtime.evaluateById( dmnModel, context, (String) null);
-        assertThat( dmnResult.getDecisionResults().size(), is(1) );
-        assertThat( dmnResult.getDecisionResultByName( "Greeting Message" ).getEvaluationStatus(), is( DMNDecisionResult.DecisionEvaluationStatus.NOT_EVALUATED ) );
+        assertThat(dmnResult.getDecisionResults()).hasSize(1);
+        assertThat(dmnResult.getDecisionResultByName( "Greeting Message" ).getEvaluationStatus()).isEqualTo(DMNDecisionResult.DecisionEvaluationStatus.NOT_EVALUATED);
     }
 
     @Test
     public void testInputStringAllowedValuesEvaluateAll() {
         final DMNRuntime runtime = DMNRuntimeUtil.createRuntime( "0003-input-data-string-allowed-values.dmn", this.getClass() );
         final DMNModel dmnModel = runtime.getModel( "https://github.com/kiegroup/kie-dmn", "0003-input-data-string-allowed-values" );
-        assertThat( dmnModel, notNullValue() );
+        assertThat(dmnModel).isNotNull();
 
         final DMNContext context = DMNFactory.newContext();
         context.set( "Employment Status", "SELF-EMPLOYED" );
@@ -141,7 +138,7 @@ public class DMNInputRuntimeTest extends BaseDMN1_1VariantTest {
 
         final DMNContext result = dmnResult.getContext();
 
-        assertThat( result.get( "Employment Status Statement" ), is( "You are SELF-EMPLOYED" ) );
+        assertThat(result.get( "Employment Status Statement" )).isEqualTo("You are SELF-EMPLOYED");
     }
 
     @Test
@@ -157,26 +154,26 @@ public class DMNInputRuntimeTest extends BaseDMN1_1VariantTest {
     private void testInputStringNotAllowedValuesEvaluateAll(final Object inputValue) {
         final DMNRuntime runtime = DMNRuntimeUtil.createRuntime( "0003-input-data-string-allowed-values.dmn", this.getClass() );
         final DMNModel dmnModel = runtime.getModel( "https://github.com/kiegroup/kie-dmn", "0003-input-data-string-allowed-values" );
-        assertThat( dmnModel, notNullValue() );
+        assertThat(dmnModel).isNotNull();
 
         final DMNContext context = DMNFactory.newContext();
         context.set( "Employment Status", inputValue );
 
         final DMNResult dmnResult = runtime.evaluateAll( dmnModel, context );
 
-        assertThat( dmnResult.getDecisionResults().size(), is(1) );
-        assertThat( dmnResult.getDecisionResultByName( "Employment Status Statement" ).getResult(), is((String) null) );
-        assertThat( dmnResult.getMessages().size(), is(1) );
-        assertThat( dmnResult.getMessages().get(0).getSeverity(), is(DMNMessage.Severity.ERROR) );
-        assertThat( dmnResult.getDecisionResults().get(0).getMessages().size(), is(1) );
-        assertThat( dmnResult.getDecisionResults().get(0).getMessages().get(0).getSeverity(), is(DMNMessage.Severity.ERROR) );
+        assertThat(dmnResult.getDecisionResults()).hasSize(1);
+        assertThat(dmnResult.getDecisionResultByName( "Employment Status Statement" ).getResult()).isEqualTo((String) null);
+        assertThat(dmnResult.getMessages()).hasSize(1);
+        assertThat(dmnResult.getMessages().get(0).getSeverity()).isEqualTo(DMNMessage.Severity.ERROR);
+        assertThat(dmnResult.getDecisionResults().get(0).getMessages()).hasSize(1);
+        assertThat(dmnResult.getDecisionResults().get(0).getMessages().get(0).getSeverity()).isEqualTo(DMNMessage.Severity.ERROR);
     }
 
     @Test
     public void testInputNumberEvaluateAll() {
         final DMNRuntime runtime = DMNRuntimeUtil.createRuntime( "0002-input-data-number.dmn", this.getClass() );
         final DMNModel dmnModel = runtime.getModel( "https://github.com/kiegroup/kie-dmn", "0002-input-data-number" );
-        assertThat( dmnModel, notNullValue() );
+        assertThat(dmnModel).isNotNull();
 
         final DMNContext context = DMNFactory.newContext();
         context.set( "Monthly Salary", new BigDecimal( 1000 ) );
@@ -185,56 +182,56 @@ public class DMNInputRuntimeTest extends BaseDMN1_1VariantTest {
 
         final DMNContext result = dmnResult.getContext();
 
-        assertThat( result.get( "Yearly Salary" ), is( new BigDecimal( 12000 ) ) );
+        assertThat(result.get( "Yearly Salary" )).isEqualTo( new BigDecimal(12000));
     }
 
     @Test
     public void testGetRequiredInputsByName() {
         final DMNRuntime runtime = DMNRuntimeUtil.createRuntime( "0001-input-data-string.dmn", this.getClass() );
         final DMNModel dmnModel = runtime.getModel( "https://github.com/kiegroup/drools/kie-dmn", "_0001-input-data-string" );
-        assertThat( dmnModel, notNullValue() );
+        assertThat(dmnModel).isNotNull();
 
         Set<InputDataNode> inputs = dmnModel.getRequiredInputsForDecisionName( "Greeting Message" );
 
-        assertThat( inputs.size(), is(1) );
-        assertThat( inputs.iterator().next().getName(), is("Full Name") );
+        assertThat(inputs).hasSize(1);
+        assertThat(inputs.iterator().next().getName()).isEqualTo("Full Name");
 
         inputs = dmnModel.getRequiredInputsForDecisionName("nonExistantDecisionName");
-        assertThat( inputs.size(), is(0) );
+        assertThat(inputs).hasSize(0);
     }
 
     @Test
     public void testGetRequiredInputsById() {
         final DMNRuntime runtime = DMNRuntimeUtil.createRuntime( "0001-input-data-string.dmn", this.getClass() );
         final DMNModel dmnModel = runtime.getModel( "https://github.com/kiegroup/drools/kie-dmn", "_0001-input-data-string" );
-        assertThat( dmnModel, notNullValue() );
+        assertThat(dmnModel).isNotNull();
 
         Set<InputDataNode> inputs = dmnModel.getRequiredInputsForDecisionId( "d_GreetingMessage" );
 
-        assertThat( inputs.size(), is(1) );
-        assertThat( inputs.iterator().next().getName(), is("Full Name") );
+        assertThat(inputs).hasSize(1);
+        assertThat(inputs.iterator().next().getName()).isEqualTo("Full Name");
 
         inputs = dmnModel.getRequiredInputsForDecisionId( "nonExistantId" );
-        assertThat( inputs.size(), is(0) );
+        assertThat(inputs).hasSize(0);
     }
 
     @Test
     public void testNonexistantInputNodeName() {
         final DMNRuntime runtime = DMNRuntimeUtil.createRuntime( "0001-input-data-string.dmn", this.getClass() );
         final DMNModel dmnModel = runtime.getModel( "https://github.com/kiegroup/drools/kie-dmn", "_0001-input-data-string" );
-        assertThat( dmnModel, notNullValue() );
+        assertThat(dmnModel).isNotNull();
 
         final DMNContext context = DMNFactory.newContext();
         context.set( "Nonexistant Input", "John Doe" );
 
         final DMNResult dmnResult = runtime.evaluateAll( dmnModel, context );
 
-        assertThat( dmnResult.getDecisionResults().size(), is(1) );
-        assertThat( dmnResult.getDecisionResultByName( "Greeting Message" ).getResult(), is((String) null) );
-        assertThat( dmnResult.getMessages().size(), is(1) );
-        assertThat( dmnResult.getMessages().get(0).getSeverity(), is(DMNMessage.Severity.ERROR) );
-        assertThat( dmnResult.getDecisionResults().get(0).getMessages().size(), is(1) );
-        assertThat( dmnResult.getDecisionResults().get(0).getMessages().get(0).getSeverity(), is(DMNMessage.Severity.ERROR) );
+        assertThat(dmnResult.getDecisionResults()).hasSize(1);
+        assertThat(dmnResult.getDecisionResultByName("Greeting Message").getResult()).isEqualTo((String) null);
+        assertThat(dmnResult.getMessages()).hasSize(1);
+        assertThat(dmnResult.getMessages().get(0).getSeverity()).isEqualTo(DMNMessage.Severity.ERROR);
+        assertThat(dmnResult.getDecisionResults().get(0).getMessages()).hasSize(1);
+        assertThat(dmnResult.getDecisionResults().get(0).getMessages().get(0).getSeverity()).isEqualTo(DMNMessage.Severity.ERROR);
     }
 
     @Test
@@ -243,32 +240,32 @@ public class DMNInputRuntimeTest extends BaseDMN1_1VariantTest {
         final DMNModel dmnModel = runtime.getModel(
                 "http://www.trisotech.com/definitions/_238bd96d-47cd-4746-831b-504f3e77b442",
                 "AllowedValuesChecks" );
-        assertThat( dmnModel, notNullValue() );
-        assertThat( DMNRuntimeUtil.formatMessages( dmnModel.getMessages() ), dmnModel.hasErrors(), is( false ) );
+        assertThat(dmnModel).isNotNull();
+        assertThat(dmnModel.hasErrors()).as(DMNRuntimeUtil.formatMessages(dmnModel.getMessages())).isFalse();
 
         final DMNContext ctx1 = runtime.newContext();
         ctx1.set("p1", prototype(entry("Name", "P1"), entry("Interests", Collections.singletonList("Golf"))));
         final DMNResult dmnResult1 = runtime.evaluateAll( dmnModel, ctx1 );
-        assertThat( DMNRuntimeUtil.formatMessages( dmnResult1.getMessages() ), dmnResult1.hasErrors(), is( false ) );
-        assertThat( dmnResult1.getContext().get( "MyDecision" ), is( "The Person P1 likes 1 thing(s)." ) );
+        assertThat(dmnResult1.hasErrors()).as(DMNRuntimeUtil.formatMessages(dmnResult1.getMessages())).isFalse();
+        assertThat(dmnResult1.getContext().get( "MyDecision" )).isEqualTo( "The Person P1 likes 1 thing(s).");
 
         final DMNContext ctx2 = runtime.newContext();
         ctx2.set("p1", prototype(entry("Name", "P2"), entry("Interests", Collections.singletonList("x"))));
         final DMNResult dmnResult2 = runtime.evaluateAll( dmnModel, ctx2 );
-        assertThat( DMNRuntimeUtil.formatMessages( dmnResult2.getMessages() ), dmnResult2.hasErrors(), is( true ) );
-        assertThat( dmnResult2.getMessages().stream().anyMatch( m -> m.getMessageType().equals( DMNMessageType.ERROR_EVAL_NODE ) ), is( true ) );
+        assertThat(dmnResult2.hasErrors()).as(DMNRuntimeUtil.formatMessages(dmnResult2.getMessages())).isTrue();
+        assertThat(dmnResult2.getMessages().stream().anyMatch( m -> m.getMessageType().equals( DMNMessageType.ERROR_EVAL_NODE))).isTrue();
 
         final DMNContext ctx3 = runtime.newContext();
         ctx3.set("p1", prototype(entry("Name", "P3"), entry("Interests", Arrays.asList("Golf", "Computer"))));
         final DMNResult dmnResult3 = runtime.evaluateAll( dmnModel, ctx3 );
-        assertThat( DMNRuntimeUtil.formatMessages( dmnResult3.getMessages() ), dmnResult3.hasErrors(), is( false ) );
-        assertThat( dmnResult3.getContext().get( "MyDecision" ), is( "The Person P3 likes 2 thing(s)." ) );
+        assertThat(dmnResult3.hasErrors()).as(DMNRuntimeUtil.formatMessages(dmnResult3.getMessages())).isFalse();
+        assertThat(dmnResult3.getContext().get("MyDecision")).isEqualTo("The Person P3 likes 2 thing(s).");
 
         final DMNContext ctx4 = runtime.newContext();
         ctx4.set("p1", prototype(entry("Name", "P4"), entry("Interests", Arrays.asList("Golf", "x"))));
         final DMNResult dmnResult4 = runtime.evaluateAll( dmnModel, ctx4 );
-        assertThat( DMNRuntimeUtil.formatMessages( dmnResult4.getMessages() ), dmnResult4.hasErrors(), is( true ) );
-        assertThat( dmnResult4.getMessages().stream().anyMatch( m -> m.getMessageType().equals( DMNMessageType.ERROR_EVAL_NODE ) ), is( true ) );
+        assertThat(dmnResult4.hasErrors()).as(DMNRuntimeUtil.formatMessages(dmnResult4.getMessages())).isTrue();
+        assertThat(dmnResult4.getMessages().stream().anyMatch(m -> m.getMessageType().equals(DMNMessageType.ERROR_EVAL_NODE))).isTrue();
     }
 
     @Test
@@ -278,76 +275,76 @@ public class DMNInputRuntimeTest extends BaseDMN1_1VariantTest {
         final String MODEL_NAMESPACE = "http://www.trisotech.com/definitions/_17396034-163a-48aa-9a7f-c6eb17f9cc6c";
         final String FEEL_NAMESPACE = "http://www.omg.org/spec/FEEL/20140401";
         final DMNModel dmnModel = runtime.getModel(MODEL_NAMESPACE, "DMNInputDataNodeTypeTest");
-        assertThat(dmnModel, notNullValue());
-        assertThat(DMNRuntimeUtil.formatMessages(dmnModel.getMessages()), dmnModel.hasErrors(), is(false));
+        assertThat(dmnModel).isNotNull();
+        assertThat(dmnModel.hasErrors()).as(DMNRuntimeUtil.formatMessages(dmnModel.getMessages())).isFalse();
 
         final InputDataNode idnMembership = dmnModel.getInputs().stream().filter(idn -> idn.getName().equals("Membership Level")).findFirst().get();
-        assertThat(idnMembership.getType().getBaseType().getNamespace(), is(FEEL_NAMESPACE));
-        assertThat(idnMembership.getType().getBaseType().getName(), is("string"));
-        assertThat(idnMembership.getType().isCollection(), is(false));
-        assertThat(idnMembership.getType().isComposite(), is(false));
-        assertThat(idnMembership.getType().getAllowedValues().size(), is(3));
-        assertThat(idnMembership.getType().getAllowedValues().get(0).toString(), is("\"Gold\""));
-        assertThat(idnMembership.getType().getAllowedValues().get(1).toString(), is("\"Silver\""));
-        assertThat(idnMembership.getType().getAllowedValues().get(2).toString(), is("\"None\""));
+        assertThat(idnMembership.getType().getBaseType().getNamespace()).isEqualTo(FEEL_NAMESPACE);
+        assertThat(idnMembership.getType().getBaseType().getName()).isEqualTo("string");
+        assertThat(idnMembership.getType().isCollection()).isFalse();
+        assertThat(idnMembership.getType().isComposite()).isFalse();
+        assertThat(idnMembership.getType().getAllowedValues()).hasSize(3);
+        assertThat(idnMembership.getType().getAllowedValues().get(0).toString()).isEqualTo("\"Gold\"");
+        assertThat(idnMembership.getType().getAllowedValues().get(1).toString()).isEqualTo("\"Silver\"");
+        assertThat(idnMembership.getType().getAllowedValues().get(2).toString()).isEqualTo("\"None\"");
 
         final InputDataNode idnMembershipLevels = dmnModel.getInputs().stream().filter(idn -> idn.getName().equals("Membership Levels")).findFirst().get();
-        assertThat(idnMembershipLevels.getType().getBaseType().getNamespace(), is(MODEL_NAMESPACE));
-        assertThat(idnMembershipLevels.getType().getBaseType().getName(), is("tMembershipLevel"));
-        assertThat(idnMembershipLevels.getType().isCollection(), is(true));
-        assertThat(idnMembershipLevels.getType().isComposite(), is(false));
-        assertThat(idnMembershipLevels.getType().getAllowedValues().isEmpty(), is(true));
+        assertThat(idnMembershipLevels.getType().getBaseType().getNamespace()).isEqualTo(MODEL_NAMESPACE);
+        assertThat(idnMembershipLevels.getType().getBaseType().getName()).isEqualTo("tMembershipLevel");
+        assertThat(idnMembershipLevels.getType().isCollection()).isTrue();
+        assertThat(idnMembershipLevels.getType().isComposite()).isFalse();
+        assertThat(idnMembershipLevels.getType().getAllowedValues().isEmpty()).isTrue();
 
         final InputDataNode idnPercent = dmnModel.getInputs().stream().filter(idn -> idn.getName().equals("Percent")).findFirst().get();
-        assertThat(idnPercent.getType().getBaseType().getNamespace(), is(FEEL_NAMESPACE));
-        assertThat(idnPercent.getType().getBaseType().getName(), is("number"));
-        assertThat(idnPercent.getType().isCollection(), is(false));
-        assertThat(idnPercent.getType().isComposite(), is(false));
-        assertThat(idnPercent.getType().getAllowedValues().size(), is(1));
-        assertThat(idnPercent.getType().getAllowedValues().get(0).toString(), is("[0..100]"));
+        assertThat(idnPercent.getType().getBaseType().getNamespace()).isEqualTo(FEEL_NAMESPACE);
+        assertThat(idnPercent.getType().getBaseType().getName()).isEqualTo("number");
+        assertThat(idnPercent.getType().isCollection()).isFalse();
+        assertThat(idnPercent.getType().isComposite()).isFalse();
+        assertThat(idnPercent.getType().getAllowedValues()).hasSize(1);
+        assertThat(idnPercent.getType().getAllowedValues().get(0).toString()).isEqualTo("[0..100]");
 
         final InputDataNode idnCarDamageResponsibility = dmnModel.getInputs().stream().filter(idn -> idn.getName().equals("Car Damage Responsibility")).findFirst().get();
-        assertThat(idnCarDamageResponsibility.getType().getBaseType(), is(nullValue()));
-        assertThat(idnCarDamageResponsibility.getType().isCollection(), is(false));
-        assertThat(idnCarDamageResponsibility.getType().isComposite(), is(true));
+        assertThat(idnCarDamageResponsibility.getType().getBaseType()).isNull();
+        assertThat(idnCarDamageResponsibility.getType().isCollection()).isFalse();
+        assertThat(idnCarDamageResponsibility.getType().isComposite()).isTrue();
     }
 
     @Test
     public void testInputClauseTypeRefWithAllowedValues() {
         final DMNRuntime runtime = DMNRuntimeUtil.createRuntime("actualInputMatchInputValues-forTypeRef.dmn", this.getClass());
         final DMNModel dmnModel = runtime.getModel("https://www.drools.org/kie-dmn/definitions", "definitions");
-        assertThat(dmnModel, notNullValue());
-        assertThat(DMNRuntimeUtil.formatMessages(dmnModel.getMessages()), dmnModel.hasErrors(), is(false));
+        assertThat(dmnModel).isNotNull();
+        assertThat(dmnModel.hasErrors()).as(DMNRuntimeUtil.formatMessages(dmnModel.getMessages())).isFalse();
 
         final DMNContext context = runtime.newContext();
         context.set("MyInput", "a");
 
         final DMNResult dmnResult = runtime.evaluateAll(dmnModel, context);
 
-        assertThat(DMNRuntimeUtil.formatMessages(dmnResult.getMessages()), dmnResult.hasErrors(), is(false));
+        assertThat(dmnResult.hasErrors()).as(DMNRuntimeUtil.formatMessages(dmnResult.getMessages())).isFalse();
         final DMNContext result = dmnResult.getContext();
-        assertThat(result.get("MyDecision"), is("Decision taken"));
+        assertThat(result.get("MyDecision")).isEqualTo("Decision taken");
     }
 
     @Test
     public void testInputDataTypeRefWithAllowedValues() {
         final DMNRuntime runtime = DMNRuntimeUtil.createRuntime("actualInputMatchInputValues-forTypeRef.dmn", this.getClass());
         final DMNModel dmnModel = runtime.getModel("https://www.drools.org/kie-dmn/definitions", "definitions");
-        assertThat(dmnModel, notNullValue());
-        assertThat(DMNRuntimeUtil.formatMessages(dmnModel.getMessages()), dmnModel.hasErrors(), is(false));
+        assertThat(dmnModel).isNotNull();
+        assertThat(dmnModel.hasErrors()).as(DMNRuntimeUtil.formatMessages(dmnModel.getMessages())).isFalse();
 
         final DMNContext context = runtime.newContext();
         context.set("MyInput", "zzz");              // <<< `zzz` is NOT in the list of allowed value as declared by the typeRef for this inputdata
 
         final DMNResult dmnResult = runtime.evaluateAll(dmnModel, context);
-        assertThat(DMNRuntimeUtil.formatMessages(dmnResult.getMessages()), dmnResult.hasErrors(), is(true));
-        assertThat(dmnResult.getMessages().size(), is(1));
-        assertThat(dmnResult.getMessages().get(0).getSourceId(), is("_3d560678-a126-4654-a686-bc6d941fe40b"));
+        assertThat(dmnResult.hasErrors()).as(DMNRuntimeUtil.formatMessages(dmnResult.getMessages())).isTrue();
+        assertThat(dmnResult.getMessages()).hasSize(1);
+        assertThat(dmnResult.getMessages().get(0).getSourceId()).isEqualTo("_3d560678-a126-4654-a686-bc6d941fe40b");
     }
 
     @Test
     public void testMissingInputData() {
         final List<DMNMessage> messages = DMNRuntimeUtil.createExpectingDMNMessages("missing_input_data.dmn", getClass());
-        assertThat(messages.get(0).getMessageType(), is(DMNMessageType.ERR_COMPILING_FEEL));
+        assertThat(messages.get(0).getMessageType()).isEqualTo(DMNMessageType.ERR_COMPILING_FEEL);
     }
 }

--- a/kie-dmn/kie-dmn-legacy-tests/src/test/java/org/kie/dmn/legacy/tests/core/v1_1/DMNRuntimeTest.java
+++ b/kie-dmn/kie-dmn-legacy-tests/src/test/java/org/kie/dmn/legacy/tests/core/v1_1/DMNRuntimeTest.java
@@ -73,18 +73,9 @@ import org.mockito.ArgumentCaptor;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import static org.hamcrest.CoreMatchers.containsString;
-import static org.hamcrest.CoreMatchers.instanceOf;
-import static org.hamcrest.CoreMatchers.is;
-import static org.hamcrest.CoreMatchers.not;
-import static org.hamcrest.CoreMatchers.notNullValue;
-import static org.hamcrest.CoreMatchers.nullValue;
-import static org.hamcrest.Matchers.contains;
-import static org.hamcrest.Matchers.hasEntry;
-import static org.hamcrest.Matchers.hasSize;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
-import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.Assert.assertTrue;
 import static org.kie.dmn.core.util.DMNTestUtil.getAndAssertModelNoErrors;
 import static org.kie.dmn.core.util.DynamicTypeUtils.entry;
@@ -107,25 +98,25 @@ public class DMNRuntimeTest extends BaseDMN1_1VariantTest {
     public void testSimpleItemDefinition() {
         final DMNRuntime runtime = DMNRuntimeUtil.createRuntime("simple-item-def.dmn", this.getClass() );
         final DMNModel dmnModel = runtime.getModel("https://github.com/kiegroup/kie-dmn/itemdef", "simple-item-def" );
-        assertThat( dmnModel, notNullValue() );
-        assertThat( DMNRuntimeUtil.formatMessages( dmnModel.getMessages() ), dmnModel.hasErrors(), is( false ) );
+        assertThat(dmnModel).isNotNull();
+        assertThat(dmnModel.hasErrors()).as(DMNRuntimeUtil.formatMessages(dmnModel.getMessages())).isFalse();
 
         final DMNContext context = DMNFactory.newContext();
         context.set( "Monthly Salary", 1000 );
 
         final DMNResult dmnResult = runtime.evaluateAll(dmnModel, context );
-        assertThat(DMNRuntimeUtil.formatMessages(dmnResult.getMessages()), dmnResult.hasErrors(), is(false));
+        assertThat(dmnResult.hasErrors()).as(DMNRuntimeUtil.formatMessages(dmnResult.getMessages())).isFalse();
 
         final DMNContext result = dmnResult.getContext();
 
-        assertThat( result.get( "Yearly Salary" ), is( new BigDecimal( "12000" ) ) );
+        assertThat( result.get( "Yearly Salary" )).isEqualTo(new BigDecimal( "12000" ) );
     }
 
     @Test
     public void testCompositeItemDefinition() {
         final DMNRuntime runtime = DMNRuntimeUtil.createRuntime("0008-LX-arithmetic.dmn", this.getClass() );
         final DMNModel dmnModel = runtime.getModel("https://github.com/kiegroup/kie-dmn", "0008-LX-arithmetic" );
-        assertThat( dmnModel, notNullValue() );
+        assertThat(dmnModel).isNotNull();
 
         final DMNContext context = DMNFactory.newContext();
         final Map<String, Object> loan = new HashMap<>();
@@ -138,15 +129,15 @@ public class DMNRuntimeTest extends BaseDMN1_1VariantTest {
 
         final DMNContext result = dmnResult.getContext();
 
-        assertThat( result.get( "payment" ), is( new BigDecimal( "2778.693549432766768088520383236299" ) ) );
+        assertThat( result.get( "payment" )).isEqualTo(new BigDecimal( "2778.693549432766768088520383236299" ) );
     }
 
     @Test
     public void testTrisotechNamespace() {
         final DMNRuntime runtime = DMNRuntimeUtil.createRuntime("trisotech_namespace.dmn", this.getClass() );
         final DMNModel dmnModel = runtime.getModel("http://www.trisotech.com/dmn/definitions/_b8feec86-dadf-4051-9feb-8e6093bbb530", "Solution 3" );
-        assertThat( dmnModel, notNullValue() );
-        assertThat( DMNRuntimeUtil.formatMessages( dmnModel.getMessages() ), dmnModel.hasErrors(), is( false ) );
+        assertThat(dmnModel).isNotNull();
+        assertThat(dmnModel.hasErrors()).as(DMNRuntimeUtil.formatMessages(dmnModel.getMessages())).isFalse();
         
         final DMNContext context = DMNFactory.newContext();
         context.set( "IsDoubleHulled", true );
@@ -154,17 +145,17 @@ public class DMNRuntimeTest extends BaseDMN1_1VariantTest {
         context.set( "Ship Size", new BigDecimal( 50 ) );
         
         final DMNResult dmnResult = runtime.evaluateAll(dmnModel, context );
-        assertThat( DMNRuntimeUtil.formatMessages( dmnResult.getMessages() ), dmnResult.hasErrors(), is( false ) );
+        assertThat(dmnResult.hasErrors()).as(DMNRuntimeUtil.formatMessages(dmnResult.getMessages())).isFalse();
         
         final DMNContext result = dmnResult.getContext();
-        assertThat( result.get( "Ship can enter a Dutch port" ), is( true ) );
+        assertThat( result.get( "Ship can enter a Dutch port" )).isEqualTo(Boolean.TRUE);
     }
 
     @Test
     public void testEmptyDecision1() {
         final DMNRuntime runtime = DMNRuntimeUtil.createRuntime("empty_decision.dmn", this.getClass() );
         final DMNModel dmnModel = runtime.getModel("http://www.trisotech.com/dmn/definitions/_ba9fc4b1-5ced-4d00-9b61-290de4bf3213", "Solution 3" );
-        assertThat( dmnModel, notNullValue() );
+        assertThat(dmnModel).isNotNull();
 
         final DMNContext context = DMNFactory.newContext();
         final Map<String, Object> shipInfo = new HashMap<>();
@@ -177,15 +168,15 @@ public class DMNRuntimeTest extends BaseDMN1_1VariantTest {
         // the other decisions in the model are still evaluated
         final DMNResult dmnResult = runtime.evaluateAll(dmnModel, context );
         final DMNContext result = dmnResult.getContext();
-        assertThat( dmnResult.hasErrors(), is( true ) );
-        assertThat( result.get( "Ship Can Enter v2" ), is( true ) );
+        assertThat( dmnResult.hasErrors()).isTrue();
+        assertThat( result.get( "Ship Can Enter v2" )).isEqualTo(Boolean.TRUE);
     }
-
+        
     @Test
     public void testEmptyDecision2() {
         final DMNRuntime runtime = DMNRuntimeUtil.createRuntime("empty_decision.dmn", this.getClass() );
         final DMNModel dmnModel = runtime.getModel("http://www.trisotech.com/dmn/definitions/_ba9fc4b1-5ced-4d00-9b61-290de4bf3213", "Solution 3" );
-        assertThat( dmnModel, notNullValue() );
+        assertThat(dmnModel).isNotNull();
 
         final DMNContext context = DMNFactory.newContext();
         final Map<String, Object> shipInfo = new HashMap<>();
@@ -202,12 +193,12 @@ public class DMNRuntimeTest extends BaseDMN1_1VariantTest {
         final DMNResult dmnResult = runtime.evaluateAll(dmnModel, context );
 
         final List<DMNMessage> messages = dmnResult.getMessages(DMNMessage.Severity.WARN );
-        assertThat( messages.size(), is( 1 ) );
-        assertThat( messages.get( 0 ).getSeverity(), is( DMNMessage.Severity.WARN ) );
-        assertThat( messages.get( 0 ).getSourceId(), is( "_42806504-8ed5-488f-b274-de98c1bc67b9" ) );
+        assertThat( messages).hasSize(1);
+        assertThat( messages.get( 0 ).getSeverity()).isEqualTo(DMNMessage.Severity.WARN );
+        assertThat( messages.get( 0 ).getSourceId()).isEqualTo("_42806504-8ed5-488f-b274-de98c1bc67b9" );
 
         final DMNContext result = dmnResult.getContext();
-        assertThat( result.get( "Ship Can Enter v2" ), is( true ) );
+        assertThat( result.get( "Ship Can Enter v2" )).isEqualTo(Boolean.TRUE);
     }
 
     @Test
@@ -219,7 +210,7 @@ public class DMNRuntimeTest extends BaseDMN1_1VariantTest {
         runtime.addListener( DMNRuntimeUtil.createListener() );
 
         final DMNModel dmnModel = runtime.getModel("http://www.trisotech.com/definitions/_820611e9-c21c-47cd-8e52-5cba2be9f9cc", "Car Damage Responsibility" );
-        assertThat( dmnModel, notNullValue() );
+        assertThat(dmnModel).isNotNull();
 
         final DMNContext context = DMNFactory.newContext();
         context.set( "Membership Level", "Silver" );
@@ -239,19 +230,19 @@ public class DMNRuntimeTest extends BaseDMN1_1VariantTest {
                 .afterEvaluateDecisionTable( argument.capture() );
 
         AfterEvaluateDecisionTableEvent dte = argument.getAllValues().get( 0 );
-        assertThat( dte.getDecisionTableName(), is( "Car Damage Responsibility" ) );
-        assertThat( dte.getMatches(), is(Collections.singletonList(5)) ); // rows are 1-based
+        assertThat( dte.getDecisionTableName()).isEqualTo("Car Damage Responsibility" );
+        assertThat( dte.getMatches()).containsExactly(5); // rows are 1-based
 
         dte = argument.getAllValues().get( 1 );
-        assertThat( dte.getDecisionTableName(), is( "Payment method" ) );
-        assertThat( dte.getMatches(), is(Collections.singletonList(3)) ); // rows are 1-based
+        assertThat( dte.getDecisionTableName()).isEqualTo("Payment method" );
+        assertThat( dte.getMatches()).containsExactly(3); // rows are 1-based
 
-        assertThat( dmnResult.hasErrors(), is( false ) );
+        assertThat(dmnResult.hasErrors()).isFalse();
 
         final DMNContext result = dmnResult.getContext();
-        assertThat( (Map<String, Object>) result.get( "Car Damage Responsibility" ), hasEntry( is( "EU Rent" ), is( BigDecimal.valueOf( 40 ) ) ) );
-        assertThat( (Map<String, Object>) result.get( "Car Damage Responsibility" ), hasEntry( is( "Renter" ), is( BigDecimal.valueOf( 60 ) ) ) );
-        assertThat( result.get( "Payment method" ), is( "Check" ) );
+        assertThat( (Map<String, Object>) result.get( "Car Damage Responsibility" )).containsEntry("EU Rent", BigDecimal.valueOf(40));
+        assertThat( (Map<String, Object>) result.get( "Car Damage Responsibility" )).containsEntry("Renter", BigDecimal.valueOf(60));
+        assertThat( result.get( "Payment method" )).isEqualTo("Check" );
     }
 
     @Test
@@ -263,7 +254,7 @@ public class DMNRuntimeTest extends BaseDMN1_1VariantTest {
         runtime.addListener( DMNRuntimeUtil.createListener() );
 
         final DMNModel dmnModel = runtime.getModel("http://www.trisotech.com/dmn/definitions/_73481d02-76fb-4927-ac11-5d936882e16c", "context listener" );
-        assertThat( dmnModel, notNullValue() );
+        assertThat(dmnModel).isNotNull();
 
         final DMNContext context = DMNFactory.newContext();
 
@@ -280,108 +271,108 @@ public class DMNRuntimeTest extends BaseDMN1_1VariantTest {
                 .afterEvaluateContextEntry( argument.capture() );
 
         AfterEvaluateContextEntryEvent aece = argument.getAllValues().get( 0 );
-        assertThat( aece.getNodeName(), is( "d1" ) );
-        assertThat( aece.getVariableName(), is( "a1" ) );
-        assertThat( aece.getVariableId(), is( "_b199c7b1-cb87-4a92-b045-a2954ccc9d01" ) );
-        assertThat( aece.getExpressionId(), is( "_898c24f8-93da-4fe2-827c-924c30956833" ) );
-        assertThat( aece.getExpressionResult(), is( BigDecimal.valueOf( 10 ) ) );
+        assertThat( aece.getNodeName()).isEqualTo("d1" );
+        assertThat( aece.getVariableName()).isEqualTo("a1" );
+        assertThat( aece.getVariableId()).isEqualTo("_b199c7b1-cb87-4a92-b045-a2954ccc9d01" );
+        assertThat( aece.getExpressionId()).isEqualTo("_898c24f8-93da-4fe2-827c-924c30956833" );
+        assertThat( aece.getExpressionResult()).isEqualTo(BigDecimal.valueOf( 10 ) );
 
         aece = argument.getAllValues().get( 1 );
-        assertThat( aece.getNodeName(), is( "d1" ) );
-        assertThat( aece.getVariableName(), is( "c1" ) );
-        assertThat( aece.getVariableId(), is( "_38a88aef-8b3c-424d-b60c-a139ffb610e1" ) );
-        assertThat( aece.getExpressionId(), is( "_879c4ac6-8b25-4cd1-9b8e-c18d0b0b281c" ) );
-        assertThat( aece.getExpressionResult(), is( "a" ) );
+        assertThat( aece.getNodeName()).isEqualTo("d1" );
+        assertThat( aece.getVariableName()).isEqualTo("c1" );
+        assertThat( aece.getVariableId()).isEqualTo("_38a88aef-8b3c-424d-b60c-a139ffb610e1" );
+        assertThat( aece.getExpressionId()).isEqualTo("_879c4ac6-8b25-4cd1-9b8e-c18d0b0b281c" );
+        assertThat( aece.getExpressionResult()).isEqualTo("a" );
 
         aece = argument.getAllValues().get( 2 );
-        assertThat( aece.getNodeName(), is( "d1" ) );
-        assertThat( aece.getVariableName(), is( "c2" ) );
-        assertThat( aece.getVariableId(), is( "_3aad82f0-74b9-4921-8b2f-d6c277c840db" ) );
-        assertThat( aece.getExpressionId(), is( "_9acf4baf-6c49-4d47-88ab-2e511e598e04" ) );
-        assertThat( aece.getExpressionResult(), is( "b" ) );
+        assertThat( aece.getNodeName()).isEqualTo("d1" );
+        assertThat( aece.getVariableName()).isEqualTo("c2" );
+        assertThat( aece.getVariableId()).isEqualTo("_3aad82f0-74b9-4921-8b2f-d6c277c840db" );
+        assertThat( aece.getExpressionId()).isEqualTo("_9acf4baf-6c49-4d47-88ab-2e511e598e04" );
+        assertThat( aece.getExpressionResult()).isEqualTo("b" );
 
         aece = argument.getAllValues().get( 3 );
-        assertThat( aece.getNodeName(), is( "d1" ) );
-        assertThat( aece.getVariableName(), is( "b1" ) );
-        assertThat( aece.getVariableId(), is( "_f4a6c2ba-e6e9-4dbd-b776-edef2c1a1343" ) );
-        assertThat( aece.getExpressionId(), is( "_c450d947-1874-41fe-9c0a-da5f1cca7fde" ) );
-        assertThat( (Map<String, Object>) aece.getExpressionResult(), hasEntry( is( "c1" ), is( "a" ) ) );
-        assertThat( (Map<String, Object>) aece.getExpressionResult(), hasEntry( is( "c2" ), is( "b" ) ) );
+        assertThat( aece.getNodeName()).isEqualTo("d1" );
+        assertThat( aece.getVariableName()).isEqualTo("b1" );
+        assertThat( aece.getVariableId()).isEqualTo("_f4a6c2ba-e6e9-4dbd-b776-edef2c1a1343" );
+        assertThat( aece.getExpressionId()).isEqualTo("_c450d947-1874-41fe-9c0a-da5f1cca7fde" );
+        assertThat( (Map<String, Object>) aece.getExpressionResult()).containsEntry("c1", "a");
+        assertThat( (Map<String, Object>) aece.getExpressionResult()).containsEntry("c2", "b");
 
         aece = argument.getAllValues().get( 4 );
-        assertThat( aece.getNodeName(), is( "d1" ) );
-        assertThat( aece.getVariableName(), is( DMNContextEvaluator.RESULT_ENTRY ) );
-        assertThat( aece.getVariableId(), nullValue() );
-        assertThat( aece.getExpressionId(), is( "_4264b25c-d676-4516-ab8a-a4ff34e7a95c" ) );
-        assertThat( aece.getExpressionResult(), is( "a" ) );
+        assertThat( aece.getNodeName()).isEqualTo("d1" );
+        assertThat( aece.getVariableName()).isEqualTo(DMNContextEvaluator.RESULT_ENTRY );
+        assertThat(aece.getVariableId()).isNull();
+        assertThat( aece.getExpressionId()).isEqualTo("_4264b25c-d676-4516-ab8a-a4ff34e7a95c" );
+        assertThat( aece.getExpressionResult()).isEqualTo("a" );
 
-        assertThat( dmnResult.hasErrors(), is( false ) );
+        assertThat(dmnResult.hasErrors()).isFalse();
 
         final DMNContext result = dmnResult.getContext();
-        assertThat( result.get( "d1" ), is( "a" ) );
+        assertThat( result.get( "d1" )).isEqualTo("a" );
     }
 
     @Test
     public void testErrorMessages() {
         final List<DMNMessage> messages = DMNRuntimeUtil.createExpectingDMNMessages("car_damage_responsibility2.dmn", this.getClass());
-        assertThat(messages.isEmpty(), is(false));
+        assertThat(messages).isNotEmpty();
     }
 
     @Test
     public void testOutputReuse() {
         final DMNRuntime runtime = DMNRuntimeUtil.createRuntime("Input_reuse_in_output.dmn", this.getClass() );
         final DMNModel dmnModel = runtime.getModel("http://www.trisotech.com/dmn/definitions/_098bb607-eff7-4772-83ac-6ded8b371fa7", "Input reuse in output" );
-        assertThat( dmnModel, notNullValue() );
+        assertThat(dmnModel).isNotNull();
 
         final DMNContext context = DMNFactory.newContext();
         context.set( "Age", 40 );
         context.set( "Requested Product", "Fixed30" );
 
         final DMNResult dmnResult = runtime.evaluateAll(dmnModel, context );
-        assertThat( dmnResult.hasErrors(), is( false ) );
+        assertThat(dmnResult.hasErrors()).isFalse();
 
         final DMNContext result = dmnResult.getContext();
-        assertThat( result.get( "My Decision" ), is( "Fixed30" ) );
+        assertThat( result.get( "My Decision" )).isEqualTo("Fixed30" );
     }
 
     @Test
     public void testSimpleNot() {
         final DMNRuntime runtime = DMNRuntimeUtil.createRuntime("Simple_Not.dmn", this.getClass() );
         final DMNModel dmnModel = runtime.getModel("http://www.trisotech.com/definitions/_98436ebb-7c42-48c0-8d11-d693e2a817c9", "Simple Not" );
-        assertThat( dmnModel, notNullValue() );
+        assertThat(dmnModel).isNotNull();
 
         final DMNContext context = DMNFactory.newContext();
         context.set( "Occupation", "Student" );
 
         final DMNResult dmnResult = runtime.evaluateAll(dmnModel, context );
-        assertThat( dmnResult.hasErrors(), is( false ) );
+        assertThat(dmnResult.hasErrors()).isFalse();
 
         final DMNContext result = dmnResult.getContext();
-        assertThat( result.get( "a" ), is( "Is Student" ) );
+        assertThat( result.get( "a" )).isEqualTo("Is Student" );
     }
 
     @Test
     public void testSimpleNot2() {
         final DMNRuntime runtime = DMNRuntimeUtil.createRuntime("Simple_Not.dmn", this.getClass() );
         final DMNModel dmnModel = runtime.getModel("http://www.trisotech.com/definitions/_98436ebb-7c42-48c0-8d11-d693e2a817c9", "Simple Not" );
-        assertThat( dmnModel, notNullValue() );
+        assertThat(dmnModel).isNotNull();
 
         final DMNContext context = DMNFactory.newContext();
         context.set( "Occupation", "Engineer" );
 
         final DMNResult dmnResult = runtime.evaluateAll(dmnModel, context );
-        assertThat( dmnResult.hasErrors(), is( false ) );
+        assertThat(dmnResult.hasErrors()).isFalse();
 
         final DMNContext result = dmnResult.getContext();
-        assertThat( result.get( "a" ), is( "Is not a Student" ) );
+        assertThat( result.get( "a" )).isEqualTo("Is not a Student" );
     }
 
     @Test
     public void testDinner() {
         final DMNRuntime runtime = DMNRuntimeUtil.createRuntime("Dinner.dmn", this.getClass() );
         final DMNModel dmnModel = runtime.getModel("http://www.trisotech.com/definitions/_0c45df24-0d57-4acc-b296-b4cba8b71a36", "Dinner" );
-        assertThat( dmnModel, notNullValue() );
-        assertThat( dmnModel.hasErrors(), is( false ) );
+        assertThat(dmnModel).isNotNull();
+        assertThat( dmnModel.hasErrors()).isFalse();
 
         final DMNContext context = DMNFactory.newContext();
         context.set( "Guests with children", true );
@@ -391,17 +382,17 @@ public class DMNRuntimeTest extends BaseDMN1_1VariantTest {
         context.set( "Rain Probability", 30 );
 
         final DMNResult dmnResult = runtime.evaluateAll(dmnModel, context );
-        assertThat( dmnResult.hasErrors(), is( false ) );
-        assertThat( dmnResult.getContext().get( "Where to eat" ), is( "Outside" ) );
-        assertThat( dmnResult.getContext().get( "Dish" ), is( "Spareribs" ) );
-        assertThat( dmnResult.getContext().get( "Drinks" ), is( Arrays.asList( "Apero", "Ale", "Juice Boxes" ) ) );
+        assertThat(dmnResult.hasErrors()).isFalse();
+        assertThat( dmnResult.getContext().get( "Where to eat" )).isEqualTo("Outside" );
+        assertThat( dmnResult.getContext().get( "Dish" )).isEqualTo("Spareribs" );
+        assertThat( dmnResult.getContext().get( "Drinks" )).asList().containsExactly( "Apero", "Ale", "Juice Boxes");
     }
 
     @Test
     public void testNotificationsApproved2() {
         final DMNRuntime runtime = DMNRuntimeUtil.createRuntime("NotificationsTest2.dmn", this.getClass() );
         final DMNModel dmnModel = runtime.getModel("https://github.com/kiegroup/kie-dmn", "building-structure-rules" );
-        assertThat( dmnModel, notNullValue() );
+        assertThat(dmnModel).isNotNull();
 
         final DMNContext context = DMNFactory.newContext();
         context.set( "existingActivityApplicability", true );
@@ -410,49 +401,49 @@ public class DMNRuntimeTest extends BaseDMN1_1VariantTest {
 
         final DMNResult dmnResult = runtime.evaluateAll(dmnModel, context );
         final DMNContext result = dmnResult.getContext();
-        assertThat( result.get( "Notification Status" ), is( "Notification to Province Approved" ) );
-        assertThat( result.get( "Permit Status" ), is( "Building Activity Province Permit Required" ) );
+        assertThat( result.get( "Notification Status" )).isEqualTo("Notification to Province Approved" );
+        assertThat( result.get( "Permit Status" )).isEqualTo("Building Activity Province Permit Required" );
     }
 
     @Test
     public void testBoxedContext() {
         final DMNRuntime runtime = DMNRuntimeUtil.createRuntime("BoxedContext.dmn", this.getClass() );
         final DMNModel dmnModel = runtime.getModel("http://www.trisotech.com/dmn/definitions/_0de36357-fec0-4b4e-b7f1-382d381e06e9", "Dessin 1" );
-        assertThat( dmnModel, notNullValue() );
-        assertThat( DMNRuntimeUtil.formatMessages( dmnModel.getMessages() ) , dmnModel.hasErrors(), is( false ) );
+        assertThat(dmnModel).isNotNull();
+        assertThat(dmnModel.hasErrors()).as(DMNRuntimeUtil.formatMessages(dmnModel.getMessages())).isFalse();
 
         final DMNContext context = DMNFactory.newContext();
         context.set( "a", 10 );
         context.set( "b", 5 );
 
         final DMNResult dmnResult = runtime.evaluateAll(dmnModel, context );
-        assertThat( DMNRuntimeUtil.formatMessages( dmnResult.getMessages() ), dmnResult.hasErrors(), is( false ) );
-        assertThat( (Map<String, Object>) dmnResult.getContext().get( "Math" ), hasEntry( "Sum", BigDecimal.valueOf( 15 ) ) );
-        assertThat( (Map<String, Object>) dmnResult.getContext().get( "Math" ), hasEntry( "Product", BigDecimal.valueOf( 50 ) ) );
+        assertThat(dmnResult.hasErrors()).as(DMNRuntimeUtil.formatMessages(dmnResult.getMessages())).isFalse();
+        assertThat( (Map<String, Object>) dmnResult.getContext().get( "Math" )).containsEntry("Sum", BigDecimal.valueOf(15));
+        assertThat( (Map<String, Object>) dmnResult.getContext().get( "Math" )).containsEntry("Product", BigDecimal.valueOf(50));
     }
 
     @Test
     public void testFunctionDefAndInvocation() {
         final DMNRuntime runtime = DMNRuntimeUtil.createRuntime("FunctionDefinition.dmn", this.getClass() );
         final DMNModel dmnModel = runtime.getModel("http://www.trisotech.com/dmn/definitions/_0de36357-fec0-4b4e-b7f1-382d381e06e9", "Dessin 1" );
-        assertThat( dmnModel, notNullValue() );
-        assertThat( dmnModel.getMessages().toString(), dmnModel.hasErrors(), is( false ) );
+        assertThat(dmnModel).isNotNull();
+        assertThat(dmnModel.hasErrors()).as(DMNRuntimeUtil.formatMessages(dmnModel.getMessages())).isFalse();
 
         final DMNContext context = DMNFactory.newContext();
         context.set( "a", 10 );
         context.set( "b", 5 );
 
         final DMNResult dmnResult = runtime.evaluateAll(dmnModel, context );
-        assertThat( dmnResult.hasErrors(), is( false ) );
-        assertThat( (Map<String, Object>) dmnResult.getContext().get( "Math" ), hasEntry( "Sum", BigDecimal.valueOf( 15 ) ) );
+        assertThat(dmnResult.hasErrors()).isFalse();
+        assertThat((Map<String, Object>) dmnResult.getContext().get("Math")).containsEntry("Sum", BigDecimal.valueOf(15));
     }
 
     @Test
     public void testBuiltInFunctionInvocation() {
         final DMNRuntime runtime = DMNRuntimeUtil.createRuntime("BuiltInFunctionInvocation.dmn", this.getClass() );
         final DMNModel dmnModel = runtime.getModel("http://www.trisotech.com/definitions/_b77219ee-ec28-48e3-b240-8e0dbbabefeb", "built in function invocation" );
-        assertThat( dmnModel, notNullValue() );
-        assertThat( dmnModel.getMessages().toString(), dmnModel.hasErrors(), is( false ) );
+        assertThat(dmnModel).isNotNull();
+        assertThat(dmnModel.hasErrors()).as(DMNRuntimeUtil.formatMessages(dmnModel.getMessages())).isFalse();
 
         final DMNContext context = DMNFactory.newContext();
         context.set( "a", 10 );
@@ -460,10 +451,10 @@ public class DMNRuntimeTest extends BaseDMN1_1VariantTest {
         context.set( "x", "Hello, World!" );
 
         final DMNResult dmnResult = runtime.evaluateAll(dmnModel, context );
-        assertThat( dmnResult.hasErrors(), is( false ) );
-        assertThat( dmnResult.getContext().get( "calc min" ), is( BigDecimal.valueOf( 5 ) ) );
-        assertThat( dmnResult.getContext().get( "fixed params" ), is( "World!" ) );
-        assertThat( dmnResult.getContext().get( "out of order" ), is( BigDecimal.valueOf( 5 ) ) );
+        assertThat(dmnResult.hasErrors()).isFalse();
+        assertThat( dmnResult.getContext().get( "calc min" )).isEqualTo(BigDecimal.valueOf( 5 ) );
+        assertThat( dmnResult.getContext().get( "fixed params" )).isEqualTo("World!");
+        assertThat( dmnResult.getContext().get( "out of order" )).isEqualTo(BigDecimal.valueOf( 5 ) );
     }
 
     @Test
@@ -472,8 +463,8 @@ public class DMNRuntimeTest extends BaseDMN1_1VariantTest {
 //        runtime.addListener( DMNRuntimeUtil.createListener() );
 
         final DMNModel dmnModel = runtime.getModel("http://www.trisotech.com/definitions/_cb28c255-91cd-4c01-ac7b-1a9cb1ecdb11", "literal invocation1" );
-        assertThat( dmnModel, notNullValue() );
-        assertThat( dmnModel.getMessages().toString(), dmnModel.hasErrors(), is( false ) );
+        assertThat(dmnModel).isNotNull();
+        assertThat(dmnModel.hasErrors()).as(DMNRuntimeUtil.formatMessages(dmnModel.getMessages())).isFalse();
 
         final Map<String, Object> loan = new HashMap<>();
         loan.put( "amount", BigDecimal.valueOf( 600000 ) );
@@ -484,10 +475,10 @@ public class DMNRuntimeTest extends BaseDMN1_1VariantTest {
         context.set( "Loan", loan );
 
         final DMNResult dmnResult = runtime.evaluateAll(dmnModel, context );
-        assertThat( dmnResult.hasErrors(), is( false ) );
+        assertThat(dmnResult.hasErrors()).isFalse();
         assertThat(
-                ((BigDecimal) dmnResult.getContext().get( "MonthlyPayment" )).setScale( 8, BigDecimal.ROUND_DOWN ),
-                is( new BigDecimal( "2878.69354943277" ).setScale( 8, BigDecimal.ROUND_DOWN ) ) );
+                ((BigDecimal) dmnResult.getContext().get("MonthlyPayment")).setScale(8, BigDecimal.ROUND_DOWN)).
+                isEqualTo(new BigDecimal("2878.69354943277").setScale(8, BigDecimal.ROUND_DOWN));
     }
 
     @Test
@@ -496,8 +487,8 @@ public class DMNRuntimeTest extends BaseDMN1_1VariantTest {
 //        runtime.addListener( DMNRuntimeUtil.createListener() );
 
         final DMNModel dmnModel = runtime.getModel("http://www.trisotech.com/definitions/_f52ca843-504b-4c3b-a6bc-4d377bffef7a", "filter01" );
-        assertThat( dmnModel, notNullValue() );
-        assertThat( dmnModel.getMessages().toString(), dmnModel.hasErrors(), is( false ) );
+        assertThat(dmnModel).isNotNull();
+        assertThat(dmnModel.hasErrors()).as(DMNRuntimeUtil.formatMessages(dmnModel.getMessages())).isFalse();
 
         final Object[][] data = new Object[][]{
                 {1, "Finances", "John"},
@@ -516,8 +507,8 @@ public class DMNRuntimeTest extends BaseDMN1_1VariantTest {
         context.set( "Employee", employees );
 
         final DMNResult dmnResult = runtime.evaluateAll(dmnModel, context );
-        assertThat( dmnResult.hasErrors(), is( false ) );
-        assertThat( dmnResult.getContext().get( "filter01" ), is(Collections.singletonList("Mary")) );
+        assertThat(dmnResult.hasErrors()).isFalse();
+        assertThat( dmnResult.getContext().get("filter01")).asList().containsExactly("Mary");
     }
 
     @Test
@@ -526,13 +517,13 @@ public class DMNRuntimeTest extends BaseDMN1_1VariantTest {
 //        runtime.addListener( DMNRuntimeUtil.createListener() );
 
         final DMNModel dmnModel = runtime.getModel("https://github.com/kiegroup/kie-dmn", "list-expression" );
-        assertThat( dmnModel, notNullValue() );
-        assertThat( dmnModel.getMessages().toString(), dmnModel.hasErrors(), is( false ) );
+        assertThat(dmnModel).isNotNull();
+        assertThat(dmnModel.hasErrors()).as(DMNRuntimeUtil.formatMessages(dmnModel.getMessages())).isFalse();
 
         final DMNContext context = DMNFactory.newContext();
         final DMNResult dmnResult = runtime.evaluateAll(dmnModel, context );
-        assertThat( dmnResult.hasErrors(), is( false ) );
-        assertThat( dmnResult.getContext().get( "Name list" ), is( Arrays.asList( "John", "Mary" ) ) );
+        assertThat(dmnResult.hasErrors()).isFalse();
+        assertThat(dmnResult.getContext().get("Name list")).asList().containsExactly("John", "Mary");
     }
 
     @Test
@@ -541,24 +532,24 @@ public class DMNRuntimeTest extends BaseDMN1_1VariantTest {
 //        runtime.addListener( DMNRuntimeUtil.createListener() );
 
         final DMNModel dmnModel = runtime.getModel("https://github.com/kiegroup/kie-dmn", "relation-expression" );
-        assertThat( dmnModel, notNullValue() );
-        assertThat( dmnModel.getMessages().toString(), dmnModel.hasErrors(), is( false ) );
+        assertThat(dmnModel).isNotNull();
+        assertThat(dmnModel.hasErrors()).as(DMNRuntimeUtil.formatMessages(dmnModel.getMessages())).isFalse();
 
         final DMNContext context = DMNFactory.newContext();
         final DMNResult dmnResult = runtime.evaluateAll(dmnModel, context );
-        assertThat( dmnResult.hasErrors(), is( false ) );
-        assertThat( dmnResult.getContext().get( "Employee Relation" ), is( instanceOf( List.class ) ) );
+        assertThat(dmnResult.hasErrors()).isFalse();
+        assertThat(dmnResult.getContext().get( "Employee Relation")).isInstanceOf(List.class);
 
         final List<Map<String, Object>> employees = (List<Map<String, Object>>) dmnResult.getContext().get("Employee Relation" );
         Map<String, Object> e = employees.get( 0 );
-        assertThat( e.get( "Name" ), is( "John" ) );
-        assertThat( e.get( "Dept" ), is( "Sales" ) );
-        assertThat( e.get( "Salary" ), is( BigDecimal.valueOf( 100000 ) ) );
+        assertThat( e.get( "Name" )).isEqualTo("John" );
+        assertThat( e.get( "Dept" )).isEqualTo("Sales" );
+        assertThat( e.get( "Salary" )).isEqualTo(BigDecimal.valueOf( 100000 ) );
 
         e = employees.get( 1 );
-        assertThat( e.get( "Name" ), is( "Mary" ) );
-        assertThat( e.get( "Dept" ), is( "Finances" ) );
-        assertThat( e.get( "Salary" ), is( BigDecimal.valueOf( 120000 ) ) );
+        assertThat( e.get( "Name" )).isEqualTo("Mary" );
+        assertThat( e.get( "Dept" )).isEqualTo("Finances" );
+        assertThat( e.get( "Salary" )).isEqualTo(BigDecimal.valueOf( 120000 ) );
     }
 
     @Test
@@ -567,8 +558,8 @@ public class DMNRuntimeTest extends BaseDMN1_1VariantTest {
 //        runtime.addListener( DMNRuntimeUtil.createListener() );
 
         final DMNModel dmnModel = runtime.getModel("http://www.trisotech.com/definitions/_4e0f0b70-d31c-471c-bd52-5ca709ed362b", "Lending1" );
-        assertThat( dmnModel, notNullValue() );
-        assertThat( DMNRuntimeUtil.formatMessages( dmnModel.getMessages() ), dmnModel.hasErrors(), is( false ) );
+        assertThat(dmnModel).isNotNull();
+        assertThat(dmnModel.hasErrors()).as(DMNRuntimeUtil.formatMessages(dmnModel.getMessages())).isFalse();
 
         final DMNContext context = DMNFactory.newContext();
         final Map<String, Object> applicant = new HashMap<>();
@@ -598,17 +589,17 @@ public class DMNRuntimeTest extends BaseDMN1_1VariantTest {
         LOG.debug("{}", dmnResult);
         final DMNContext ctx = dmnResult.getContext();
 
-        assertThat( ctx.get( "ApplicationRiskScore" ), is( BigDecimal.valueOf( 130 ) ) );
-        assertThat( ctx.get( "Pre-bureauRiskCategory" ), is( "LOW" ) );
-        assertThat( ctx.get( "BureauCallType" ), is( "MINI" ) );
-        assertThat( ctx.get( "Post-bureauRiskCategory" ), is( "LOW" ) );
-        assertThat( ((BigDecimal)ctx.get( "RequiredMonthlyInstallment" )).setScale( 5, BigDecimal.ROUND_DOWN ),
-                    is( new BigDecimal( "1680.880325608555" ).setScale( 5, BigDecimal.ROUND_DOWN ) ) );
-        assertThat( ctx.get( "Pre-bureauAffordability" ), is( true ) );
-        assertThat( ctx.get( "Eligibility" ), is( "ELIGIBLE" ) );
-        assertThat( ctx.get( "Strategy" ), is( "BUREAU" ) );
-        assertThat( ctx.get( "Post-bureauAffordability" ), is( true ) );
-        assertThat( ctx.get( "Routing" ), is( "ACCEPT" ) );
+        assertThat( ctx.get( "ApplicationRiskScore" )).isEqualTo(BigDecimal.valueOf( 130 ) );
+        assertThat( ctx.get( "Pre-bureauRiskCategory" )).isEqualTo("LOW" );
+        assertThat( ctx.get( "BureauCallType" )).isEqualTo("MINI" );
+        assertThat( ctx.get( "Post-bureauRiskCategory" )).isEqualTo("LOW" );
+        assertThat( ((BigDecimal)ctx.get( "RequiredMonthlyInstallment" )).setScale(5, BigDecimal.ROUND_DOWN )).
+                    isEqualTo(new BigDecimal("1680.880325608555").setScale( 5, BigDecimal.ROUND_DOWN));
+        assertThat( ctx.get( "Pre-bureauAffordability" )).isEqualTo(Boolean.TRUE);
+        assertThat( ctx.get( "Eligibility" )).isEqualTo("ELIGIBLE" );
+        assertThat( ctx.get( "Strategy" )).isEqualTo("BUREAU" );
+        assertThat( ctx.get( "Post-bureauAffordability" )).isEqualTo(Boolean.TRUE);
+        assertThat( ctx.get( "Routing" )).isEqualTo("ACCEPT" );
     }
 
     @Test
@@ -617,8 +608,8 @@ public class DMNRuntimeTest extends BaseDMN1_1VariantTest {
         runtime.addListener( DMNRuntimeUtil.createListener() );
 
         final DMNModel dmnModel = runtime.getModel("http://www.trisotech.com/definitions/_69430b3e-17b8-430d-b760-c505bf6469f9", "dateTime Table 58" );
-        assertThat( dmnModel, notNullValue() );
-        assertThat( DMNRuntimeUtil.formatMessages( dmnModel.getMessages() ), dmnModel.hasErrors(), is( false ) );
+        assertThat(dmnModel).isNotNull();
+        assertThat(dmnModel.hasErrors()).as(DMNRuntimeUtil.formatMessages(dmnModel.getMessages())).isFalse();
 
         final DMNContext context = DMNFactory.newContext();
         context.set( "dateString", "2015-12-24" );
@@ -636,31 +627,31 @@ public class DMNRuntimeTest extends BaseDMN1_1VariantTest {
         final DMNResult dmnResult = runtime.evaluateAll(dmnModel, context );
         final DMNContext ctx = dmnResult.getContext();
 
-        assertThat( DMNRuntimeUtil.formatMessages( dmnResult.getMessages() ), dmnResult.hasErrors(), is( false ) );
-        assertThat( ctx.get("Date-Time"), is( ZonedDateTime.of( 2016, 12, 24, 23, 59, 0, 0, ZoneOffset.ofHours( -5 ) ) ) );
-        assertThat( ctx.get("Date"), is( new HashMap<String, Object>(  ) {{
+        assertThat(dmnResult.hasErrors()).as(DMNRuntimeUtil.formatMessages(dmnResult.getMessages())).isFalse();
+        assertThat( ctx.get("Date-Time")).isEqualTo(ZonedDateTime.of( 2016, 12, 24, 23, 59, 0, 0, ZoneOffset.ofHours( -5 ) ) );
+        assertThat( ctx.get("Date")).isEqualTo( new HashMap<String, Object>(  ) {{
             put( "fromString", LocalDate.of( 2015, 12, 24 ) );
             put( "fromDateTime", LocalDate.of( 2016, 12, 24 ) );
             put( "fromYearMonthDay", LocalDate.of( 1999, 11, 22 ) );
-        }} ) );
-        assertThat( ctx.get("Time"), is( OffsetTime.of(0, 0, 1, 0, ZoneOffset.ofHours(-1 ) ) ) );
-        assertThat( ctx.get("Date-Time2"), is( ZonedDateTime.of(2015, 12, 24, 0, 0, 1, 0, ZoneOffset.ofHours(-1 ) ) ) );
-        assertThat( ctx.get("Time2"), is( OffsetTime.of(0, 0, 1, 0, ZoneOffset.ofHours(-1 ) ) ) );
-        assertThat( ctx.get("Time3"), is( OffsetTime.of( 12, 59, 1, 300000000, ZoneOffset.ofHours( -1 ) )) );
-        assertThat( ctx.get("dtDuration1"), is( Duration.parse( "P13DT2H14S" ) ) );
-        assertThat( ctx.get("dtDuration2"), is( Duration.parse( "P367DT3H58M59S" ) ) );
-        assertThat( ctx.get("hoursInDuration"), is( new BigDecimal( "3" ) ) );
-        assertThat( ctx.get("sumDurations"), is( Duration.parse( "PT9125H59M13S" ) ) );
-        assertThat( ctx.get("ymDuration2"), is( ComparablePeriod.parse( "P1Y" ) ) );
-        assertThat( ctx.get("cDay"), is( BigDecimal.valueOf( 24 ) ) );
-        assertThat( ctx.get("cYear"), is( BigDecimal.valueOf( 2015 ) ) );
-        assertThat( ctx.get("cMonth"), is( BigDecimal.valueOf( 12 ) ) );
-        assertThat( ctx.get("cHour"), is( BigDecimal.valueOf( 0 ) ) );
-        assertThat( ctx.get("cMinute"), is( BigDecimal.valueOf( 0 ) ) );
-        assertThat( ctx.get("cSecond"), is( BigDecimal.valueOf( 1 ) ) );
-        assertThat( ctx.get("cTimezone"), is( "GMT-01:00" ) );
-        assertThat( ctx.get("years"), is( BigDecimal.valueOf( 1 ) ) );
-        assertThat( ctx.get("d1seconds"), is( BigDecimal.valueOf( 14 ) ) );
+        }});
+        assertThat( ctx.get("Time")).isEqualTo(OffsetTime.of(0, 0, 1, 0, ZoneOffset.ofHours(-1 ) ) );
+        assertThat( ctx.get("Date-Time2")).isEqualTo(ZonedDateTime.of(2015, 12, 24, 0, 0, 1, 0, ZoneOffset.ofHours(-1 ) ) );
+        assertThat( ctx.get("Time2")).isEqualTo(OffsetTime.of(0, 0, 1, 0, ZoneOffset.ofHours(-1 ) ) );
+        assertThat( ctx.get("Time3")).isEqualTo(OffsetTime.of( 12, 59, 1, 300000000, ZoneOffset.ofHours( -1 ) ));
+        assertThat( ctx.get("dtDuration1")).isEqualTo(Duration.parse( "P13DT2H14S" ) );
+        assertThat( ctx.get("dtDuration2")).isEqualTo(Duration.parse( "P367DT3H58M59S" ) );
+        assertThat( ctx.get("hoursInDuration")).isEqualTo(new BigDecimal( "3" ) );
+        assertThat( ctx.get("sumDurations")).isEqualTo(Duration.parse( "PT9125H59M13S" ) );
+        assertThat( ctx.get("ymDuration2")).isEqualTo(ComparablePeriod.parse( "P1Y" ) );
+        assertThat( ctx.get("cDay")).isEqualTo(BigDecimal.valueOf( 24 ) );
+        assertThat( ctx.get("cYear")).isEqualTo(BigDecimal.valueOf( 2015 ) );
+        assertThat( ctx.get("cMonth")).isEqualTo(BigDecimal.valueOf( 12 ) );
+        assertThat( ctx.get("cHour")).isEqualTo(BigDecimal.valueOf( 0 ) );
+        assertThat( ctx.get("cMinute")).isEqualTo(BigDecimal.valueOf( 0 ) );
+        assertThat( ctx.get("cSecond")).isEqualTo(BigDecimal.valueOf( 1 ) );
+        assertThat( ctx.get("cTimezone")).isEqualTo( "GMT-01:00");
+        assertThat( ctx.get("years")).isEqualTo(BigDecimal.valueOf( 1 ) );
+        assertThat( ctx.get("d1seconds")).isEqualTo(BigDecimal.valueOf( 14 ) );
 
     }
 
@@ -670,13 +661,13 @@ public class DMNRuntimeTest extends BaseDMN1_1VariantTest {
         runtime.addListener( DMNRuntimeUtil.createListener() );
 
         final DMNModel dmnModel = runtime.getModel("http://www.trisotech.com/definitions/_e215ed7a-701b-4c53-b8df-4b4d23d5fe32", "Person filtering by age" );
-        assertThat( dmnModel, notNullValue() );
-        assertThat( DMNRuntimeUtil.formatMessages( dmnModel.getMessages() ), dmnModel.hasErrors(), is( false ) );
+        assertThat(dmnModel).isNotNull();
+        assertThat(dmnModel.hasErrors()).as(DMNRuntimeUtil.formatMessages(dmnModel.getMessages())).isFalse();
 
         final DMNContext context = DMNFactory.newContext();
         context.set( "Min Age", 50 );
         final DMNResult dmnResult = runtime.evaluateAll(dmnModel, context );
-        assertThat( DMNRuntimeUtil.formatMessages( dmnResult.getMessages() ), ((List)dmnResult.getContext().get("Filtering")).size(), is( 2 ) );
+        assertThat(((List)dmnResult.getContext().get("Filtering"))).as(DMNRuntimeUtil.formatMessages( dmnResult.getMessages())).hasSize(2);
     }
 
     @Test
@@ -685,13 +676,13 @@ public class DMNRuntimeTest extends BaseDMN1_1VariantTest {
         runtime.addListener( DMNRuntimeUtil.createListener() );
 
         final DMNModel dmnModel = runtime.getModel("http://www.trisotech.com/dmn/definitions/_4ad80959-5fd8-46b7-8c9a-ab2fa58cb5b4", "When is it" );
-        assertThat( dmnModel, notNullValue() );
-        assertThat( DMNRuntimeUtil.formatMessages( dmnModel.getMessages() ), dmnModel.hasErrors(), is( false ) );
+        assertThat(dmnModel).isNotNull();
+        assertThat(dmnModel.hasErrors()).as(DMNRuntimeUtil.formatMessages(dmnModel.getMessages())).isFalse();
 
         final DMNContext context = DMNFactory.newContext();
         context.set( "The date", LocalDate.of(2017, 1, 12 ) );
         final DMNResult dmnResult = runtime.evaluateAll(dmnModel, context );
-        assertThat( DMNRuntimeUtil.formatMessages( dmnResult.getMessages() ), dmnResult.getContext().get("When is it"), is( "It is in the past" ) );
+        assertThat(dmnResult.getContext().get("When is it")).as(DMNRuntimeUtil.formatMessages( dmnResult.getMessages())).isEqualTo( "It is in the past" );
     }
 
     @Test
@@ -700,54 +691,54 @@ public class DMNRuntimeTest extends BaseDMN1_1VariantTest {
         runtime.addListener( DMNRuntimeUtil.createListener() );
 
         final DMNModel dmnModel = runtime.getModel("http://www.trisotech.com/dmn/definitions/_ecf4ea54-2abc-4e2f-a101-4fe14e356a46", "Dessin 1" );
-        assertThat( dmnModel, notNullValue() );
-        assertThat( DMNRuntimeUtil.formatMessages( dmnModel.getMessages() ), dmnModel.hasErrors(), is( false ) );
+        assertThat(dmnModel).isNotNull();
+        assertThat(dmnModel.hasErrors()).as(DMNRuntimeUtil.formatMessages(dmnModel.getMessages())).isFalse();
 
         final DMNContext context = DMNFactory.newContext();
         context.set( "datetimestring", "2016-07-29T05:48:23" );
         final DMNResult dmnResult = runtime.evaluateAll(dmnModel, context );
-        assertThat( DMNRuntimeUtil.formatMessages( dmnResult.getMessages() ), dmnResult.getContext().get("time"), is( LocalTime.of( 5, 48, 23 ) ) );
+        assertThat(dmnResult.getContext().get("time")).as(DMNRuntimeUtil.formatMessages( dmnResult.getMessages() )).isEqualTo(LocalTime.of(5, 48, 23)); 
     }
 
     @Test
     public void testAlternativeNSDecl() {
         final DMNRuntime runtime = DMNRuntimeUtil.createRuntime("alternative_feel_ns_declaration.dmn", this.getClass() );
         final DMNModel dmnModel = runtime.getModel("https://github.com/kiegroup/kie-dmn", "0001-input-data-string" );
-        assertThat( dmnModel, notNullValue() );
+        assertThat(dmnModel).isNotNull();
 
         final DMNContext context = DMNFactory.newContext();
         context.set( "Full Name", "John Doe" );
 
         final DMNResult dmnResult = runtime.evaluateAll(dmnModel, context );
 
-        assertThat( dmnResult.getDecisionResults().size(), is( 1 ) );
-        assertThat( dmnResult.getDecisionResultByName( "Greeting Message" ).getResult(), is( "Hello John Doe" ) );
+        assertThat( dmnResult.getDecisionResults()).hasSize(1);
+        assertThat( dmnResult.getDecisionResultByName( "Greeting Message" ).getResult()).isEqualTo("Hello John Doe" );
 
         final DMNContext result = dmnResult.getContext();
 
-        assertThat( result.get( "Greeting Message" ), is( "Hello John Doe" ) );
+        assertThat( result.get( "Greeting Message" )).isEqualTo("Hello John Doe" );
     }
 
     @Test
     public void testLoanComparison() {
         final DMNRuntime runtime = DMNRuntimeUtil.createRuntime("loanComparison.dmn", this.getClass() );
         final DMNModel dmnModel = runtime.getModel("http://www.trisotech.com/definitions/_3a1fd8f4-ea04-4453-aa30-ff14140e3441", "loanComparison" );
-        assertThat( dmnModel, notNullValue() );
-        assertThat( DMNRuntimeUtil.formatMessages( dmnModel.getMessages() ), dmnModel.hasErrors(), is( false ) );
+        assertThat(dmnModel).isNotNull();
+        assertThat(dmnModel.hasErrors()).as(DMNRuntimeUtil.formatMessages(dmnModel.getMessages())).isFalse();
 
         final DMNContext context = DMNFactory.newContext();
         context.set( "RequestedAmt", 500000 );
 
         final DMNResult dmnResult = runtime.evaluateAll(dmnModel, context );
-        assertThat( DMNRuntimeUtil.formatMessages( dmnResult.getMessages() ), dmnResult.hasErrors(), is( false ) );
+        assertThat(dmnResult.hasErrors()).as(DMNRuntimeUtil.formatMessages(dmnResult.getMessages())).isFalse();
     }
 
     @Test
     public void testGetViableLoanProducts() {
         final DMNRuntime runtime = DMNRuntimeUtil.createRuntime("Get_Viable_Loan_Products.dmn", this.getClass() );
         final DMNModel dmnModel = runtime.getModel("http://www.trisotech.com/definitions/_3e1a628d-36bc-45f1-8464-b201735e5ce0", "Get Viable Loan Products" );
-        assertThat( dmnModel, notNullValue() );
-        assertThat( DMNRuntimeUtil.formatMessages( dmnModel.getMessages() ), dmnModel.hasErrors(), is( false ) );
+        assertThat(dmnModel).isNotNull();
+        assertThat(dmnModel.hasErrors()).as(DMNRuntimeUtil.formatMessages(dmnModel.getMessages())).isFalse();
 
         final Map<String, Object> requested = new HashMap<>(  );
         requested.put( "PropertyZIP", "91001" );
@@ -759,19 +750,19 @@ public class DMNRuntimeTest extends BaseDMN1_1VariantTest {
         context.set( "Requested", requested );
 
         final DMNResult dmnResult = runtime.evaluateAll(dmnModel, context );
-        assertThat( dmnResult.hasErrors(), is( false ) );
+        assertThat(dmnResult.hasErrors()).isFalse();
 
         final DMNContext result = dmnResult.getContext();
-        assertThat( result.get( "isConforming" ), is( true ) );
-        assertThat( (Collection<Object>) result.get( "LoanTypes" ), hasSize( 3 ) );
+        assertThat( result.get( "isConforming" )).isEqualTo(Boolean.TRUE);
+        assertThat((Collection<Object>) result.get("LoanTypes")).hasSize(3);
     }
 
     @Test
     public void testYearsAndMonthsDuration() {
         final DMNRuntime runtime = DMNRuntimeUtil.createRuntime("yearMonthDuration.dmn", this.getClass() );
         final DMNModel dmnModel = runtime.getModel("http://www.trisotech.com/dmn/definitions/_6eda1490-21ca-441e-8a26-ab3ca800e43c", "Drawing 1" );
-        assertThat( dmnModel, notNullValue() );
-        assertThat( DMNRuntimeUtil.formatMessages( dmnModel.getMessages() ), dmnModel.hasErrors(), is( false ) );
+        assertThat(dmnModel).isNotNull();
+        assertThat(dmnModel.hasErrors()).as(DMNRuntimeUtil.formatMessages(dmnModel.getMessages())).isFalse();
 
         final BuiltInType feelType = (BuiltInType) BuiltInType.determineTypeFromName("yearMonthDuration" );
         final ChronoPeriod period = (ChronoPeriod) feelType.fromString("P2Y1M");
@@ -780,82 +771,82 @@ public class DMNRuntimeTest extends BaseDMN1_1VariantTest {
         context.set( "iDuration", period );
 
         final DMNResult dmnResult = runtime.evaluateAll(dmnModel, context );
-        assertThat( DMNRuntimeUtil.formatMessages( dmnResult.getMessages() ), dmnResult.hasErrors(), is( false ) );
+        assertThat(dmnResult.hasErrors()).as(DMNRuntimeUtil.formatMessages(dmnResult.getMessages())).isFalse();
 
         final DMNContext result = dmnResult.getContext();
-        assertThat( result.get( "How long" ), is( "Longer than a year" ) );
+        assertThat( result.get( "How long" )).isEqualTo("Longer than a year" );
     }
 
     @Test
     public void testInvalidVariableNames() {
         final List<DMNMessage> messages = DMNRuntimeUtil.createExpectingDMNMessages("invalid-variable-names.dmn", this.getClass());
-        assertThat(messages.isEmpty(), is(false));
+        assertThat(messages).isNotEmpty();
     }
 
     @Test
     public void testNull() {
         final DMNRuntime runtime = DMNRuntimeUtil.createRuntime("null_values.dmn", this.getClass() );
         final DMNModel dmnModel = runtime.getModel("https://github.com/kiegroup/kie-dmn", "Null values model" );
-        assertThat( dmnModel, notNullValue() );
-        assertThat( DMNRuntimeUtil.formatMessages( dmnModel.getMessages() ), dmnModel.hasErrors(), is( false ) );
+        assertThat(dmnModel).isNotNull();
+        assertThat(dmnModel.hasErrors()).as(DMNRuntimeUtil.formatMessages(dmnModel.getMessages())).isFalse();
 
         DMNContext context = runtime.newContext();
         context.set( "Null Input", null );
 
         DMNResult dmnResult = runtime.evaluateAll( dmnModel, context );
-        assertThat( DMNRuntimeUtil.formatMessages( dmnResult.getMessages() ), dmnResult.hasErrors(), is( false ) );
+        assertThat(dmnResult.hasErrors()).as(DMNRuntimeUtil.formatMessages(dmnResult.getMessages())).isFalse();
         DMNContext result = dmnResult.getContext();
-        assertThat( result.get( "Null value" ), is( "Input is null" ) );
+        assertThat( result.get( "Null value" )).isEqualTo("Input is null" );
 
         context = runtime.newContext();
         context.set( "Null Input", "foo" );
 
         dmnResult = runtime.evaluateAll( dmnModel, context );
-        assertThat( DMNRuntimeUtil.formatMessages( dmnResult.getMessages() ), dmnResult.hasErrors(), is( false ) );
+        assertThat(dmnResult.hasErrors()).as(DMNRuntimeUtil.formatMessages(dmnResult.getMessages())).isFalse();
         result = dmnResult.getContext();
-        assertThat( result.get( "Null value" ), is( "Input is not null" ) );
+        assertThat( result.get( "Null value" )).isEqualTo("Input is not null" );
 
     }
 
     @Test
     public void testInvalidModel() {
         final List<DMNMessage> messages = DMNRuntimeUtil.createExpectingDMNMessages("Loan_Prequalification_Condensed_Invalid.dmn", this.getClass());
-        assertThat(messages.size(), is(2));
-        assertThat(messages.get(0).getSourceId(), is("_8b5cac9e-c8ca-4817-b05a-c70fa79a8d48"));
-        assertThat(messages.get(1).getSourceId(), is("_ef09d90e-e1a4-4ec9-885b-482d1f4a1cee"));
+        assertThat(messages).hasSize(2);
+        assertThat(messages.get(0).getSourceId()).isEqualTo("_8b5cac9e-c8ca-4817-b05a-c70fa79a8d48");
+        assertThat(messages.get(1).getSourceId()).isEqualTo("_ef09d90e-e1a4-4ec9-885b-482d1f4a1cee");
     }
 
     @Test
     public void testNullOnNumber() {
         final DMNRuntime runtime = DMNRuntimeUtil.createRuntime("Number_and_null_entry.dmn", this.getClass() );
         final DMNModel dmnModel = runtime.getModel("http://www.trisotech.com/definitions/_a293b9f9-c912-41ee-8147-eae59ba86ac5", "Number and null entry" );
-        assertThat( dmnModel, notNullValue() );
-        assertThat( DMNRuntimeUtil.formatMessages( dmnModel.getMessages() ), dmnModel.hasErrors(), is( false ) );
+        assertThat(dmnModel).isNotNull();
+        assertThat(dmnModel.hasErrors()).as(DMNRuntimeUtil.formatMessages(dmnModel.getMessages())).isFalse();
 
         DMNContext context = runtime.newContext();
 
         context.set( "num", null );
 
         DMNResult dmnResult = runtime.evaluateAll( dmnModel, context );
-        assertThat( DMNRuntimeUtil.formatMessages( dmnResult.getMessages() ), dmnResult.hasErrors(), is( false ) );
+        assertThat(dmnResult.hasErrors()).as(DMNRuntimeUtil.formatMessages(dmnResult.getMessages())).isFalse();
         DMNContext result = dmnResult.getContext();
-        assertThat( result.get( "Decision Logic 1" ), is( "Null" ) );
+        assertThat( result.get( "Decision Logic 1" )).isEqualTo("Null" );
 
         context = runtime.newContext();
         context.set( "num", 4 );
 
         dmnResult = runtime.evaluateAll( dmnModel, context );
-        assertThat( DMNRuntimeUtil.formatMessages( dmnResult.getMessages() ), dmnResult.hasErrors(), is( false ) );
+        assertThat(dmnResult.hasErrors()).as(DMNRuntimeUtil.formatMessages(dmnResult.getMessages())).isFalse();
         result = dmnResult.getContext();
-        assertThat( result.get( "Decision Logic 1" ), is( "Positive number" ) );
+        assertThat( result.get( "Decision Logic 1" )).isEqualTo("Positive number" );
     }
 
     @Test
     public void testLoan_Recommendation2() {
         final DMNRuntime runtime = DMNRuntimeUtil.createRuntime("Loan_Recommendation2.dmn", this.getClass() );
         final DMNModel dmnModel = runtime.getModel("http://www.trisotech.com/definitions/_35c7339b-b868-43da-8f06-eb481708c73c", "Loan Recommendation2" );
-        assertThat( dmnModel, notNullValue() );
-        assertThat( DMNRuntimeUtil.formatMessages( dmnModel.getMessages() ), dmnModel.hasErrors(), is( false ) );
+        assertThat(dmnModel).isNotNull();
+        assertThat(dmnModel.hasErrors()).as(DMNRuntimeUtil.formatMessages(dmnModel.getMessages())).isFalse();
 
         final Map<String,Object> loan = new HashMap<>(  );
         loan.put( "Amount", 100000);
@@ -878,9 +869,9 @@ public class DMNRuntimeTest extends BaseDMN1_1VariantTest {
         context.set( "Borrower", borrower );
 
         final DMNResult dmnResult = runtime.evaluateAll(dmnModel, context );
-        assertThat( DMNRuntimeUtil.formatMessages( dmnResult.getMessages() ), dmnResult.hasErrors(), is( false ) );
+        assertThat(dmnResult.hasErrors()).as(DMNRuntimeUtil.formatMessages(dmnResult.getMessages())).isFalse();
         final DMNContext result = dmnResult.getContext();
-        assertThat( result.get( "Loan Recommendation" ), is( "Decline" ) );
+        assertThat( result.get( "Loan Recommendation" )).isEqualTo("Decline" );
     }
     
     @Test
@@ -889,8 +880,8 @@ public class DMNRuntimeTest extends BaseDMN1_1VariantTest {
         final DMNModel dmnModel = runtime.getModel(
                 "http://www.trisotech.com/definitions/_ff54a44d-b8f5-48fc-b2b7-43db767e8a1c",
                 "not quite all or nothing P" );
-        assertThat( dmnModel, notNullValue() );
-        assertThat( DMNRuntimeUtil.formatMessages( dmnModel.getMessages() ), dmnModel.hasErrors(), is( false ) );
+        assertThat(dmnModel).isNotNull();
+        assertThat(dmnModel.hasErrors()).as(DMNRuntimeUtil.formatMessages(dmnModel.getMessages())).isFalse();
         
         final DMNContext context = runtime.newContext();
         context.set("isAffordable", false);
@@ -898,7 +889,7 @@ public class DMNRuntimeTest extends BaseDMN1_1VariantTest {
         
         final DMNResult dmnResult = runtime.evaluateAll(dmnModel, context );
         final DMNContext result = dmnResult.getContext();
-        assertThat( result.get( "Approval Status" ), is( "Declined" ) );
+        assertThat( result.get( "Approval Status" )).isEqualTo("Declined" );
     }
     
     @Test
@@ -907,8 +898,8 @@ public class DMNRuntimeTest extends BaseDMN1_1VariantTest {
         final DMNModel dmnModel = runtime.getModel(
                 "http://www.trisotech.com/definitions/_ff54a44d-b8f5-48fc-b2b7-43db767e8a1c",
                 "not quite all or nothing P" );
-        assertThat( dmnModel, notNullValue() );
-        assertThat( DMNRuntimeUtil.formatMessages( dmnModel.getMessages() ), dmnModel.hasErrors(), is( false ) );
+        assertThat(dmnModel).isNotNull();
+        assertThat(dmnModel.hasErrors()).as(DMNRuntimeUtil.formatMessages(dmnModel.getMessages())).isFalse();
         
         final DMNContext context = runtime.newContext();
         context.set("isAffordable", false);
@@ -916,13 +907,13 @@ public class DMNRuntimeTest extends BaseDMN1_1VariantTest {
         
         final DMNResult dmnResult = runtime.evaluateAll(dmnModel, context );
         final DMNContext result = dmnResult.getContext();
-        assertThat( result.get( "Approval Status" ), is( "Declined" ) );
+        assertThat( result.get( "Approval Status" )).isEqualTo("Declined" );
     }
     
     @Test
     public void testPriority_table_missing_output_values() {
         final List<DMNMessage> messages = DMNRuntimeUtil.createExpectingDMNMessages("DTABLE_PRIORITY_MISSING_OUTVALS.dmn", this.getClass());
-        assertThat(messages.size(), is(1));
+        assertThat(messages).hasSize(1);
     }
 
     @Test
@@ -931,8 +922,8 @@ public class DMNRuntimeTest extends BaseDMN1_1VariantTest {
         final DMNModel dmnModel = runtime.getModel(
         "https://github.com/kiegroup/kie-dmn",
         "DTABLE_NON_PRIORITY_MISSING_OUTVALS" );
-        assertThat( dmnModel, notNullValue() );
-        assertThat( DMNRuntimeUtil.formatMessages( dmnModel.getMessages() ), dmnModel.hasErrors(), is( false ) );
+        assertThat(dmnModel).isNotNull();
+        assertThat(dmnModel.hasErrors()).as(DMNRuntimeUtil.formatMessages(dmnModel.getMessages())).isFalse();
     }
 
     @Test
@@ -941,8 +932,8 @@ public class DMNRuntimeTest extends BaseDMN1_1VariantTest {
         final DMNModel dmnModel = runtime.getModel(
         "https://github.com/kiegroup/kie-dmn",
         "DTABLE_PRIORITY_ONE_OUTVAL" );
-        assertThat( dmnModel, notNullValue() );
-        assertThat( DMNRuntimeUtil.formatMessages( dmnModel.getMessages() ), dmnModel.hasErrors(), is( false ) );
+        assertThat(dmnModel).isNotNull();
+        assertThat(dmnModel.hasErrors()).as(DMNRuntimeUtil.formatMessages(dmnModel.getMessages())).isFalse();
     }
     
     @Test
@@ -951,32 +942,32 @@ public class DMNRuntimeTest extends BaseDMN1_1VariantTest {
         final DMNModel dmnModel = runtime.getModel(
                 "https://www.drools.org/kie-dmn/definitions",
                 "definitions" );
-        assertThat( dmnModel, notNullValue() );
-        assertThat( DMNRuntimeUtil.formatMessages( dmnModel.getMessages() ), dmnModel.hasErrors(), is( false ) );
+        assertThat(dmnModel).isNotNull();
+        assertThat(dmnModel.hasErrors()).as(DMNRuntimeUtil.formatMessages(dmnModel.getMessages())).isFalse();
         
         final DMNContext context = runtime.newContext();
         context.set("MyInput", "a");
 
         final DMNResult dmnResult = runtime.evaluateAll(dmnModel, context );
         
-        assertThat( DMNRuntimeUtil.formatMessages( dmnResult.getMessages() ), dmnResult.hasErrors(), is( false ) );
+        assertThat(dmnResult.hasErrors()).as(DMNRuntimeUtil.formatMessages(dmnResult.getMessages())).isFalse();
         final DMNContext result = dmnResult.getContext();
-        assertThat( result.get( "MyDecision" ), is( "Decision taken" ) );
+        assertThat( result.get( "MyDecision" )).isEqualTo("Decision taken" );
     }
     
     @Test
     public void testWrongConstraintsInItemDefinition() {
         // DROOLS-1503
         final List<DMNMessage> messages = DMNRuntimeUtil.createExpectingDMNMessages("WrongConstraintsInItemDefinition.dmn", this.getClass());
-        assertThat(DMNRuntimeUtil.formatMessages(messages), messages.size(), is(3));
-        assertThat(messages.get(0).getSourceReference(), is(instanceOf(ItemDefinition.class)));
-        assertThat(messages.get(0).getMessageType(), is(DMNMessageType.ERR_COMPILING_FEEL));
-        assertThat(messages.get(1).getSourceId(), is("_e794c655-4fdf-45d1-b7b7-d990df513f92"));
-        assertThat(messages.get(1).getMessageType(), is(DMNMessageType.ERR_COMPILING_FEEL));
+        assertThat(messages).as(DMNRuntimeUtil.formatMessages(messages)).hasSize(3);
+        assertThat(messages.get(0).getSourceReference()).isInstanceOf(ItemDefinition.class);
+        assertThat(messages.get(0).getMessageType()).isEqualTo(DMNMessageType.ERR_COMPILING_FEEL);
+        assertThat(messages.get(1).getSourceId()).isEqualTo("_e794c655-4fdf-45d1-b7b7-d990df513f92");
+        assertThat(messages.get(1).getMessageType()).isEqualTo(DMNMessageType.ERR_COMPILING_FEEL);
         
         // The DecisionTable does not define typeRef for the single OutputClause, but neither the enclosing Decision define typeRef for its variable
-        assertThat(messages.get(2).getSourceId(), is("_31911de7-e184-411c-99d1-f33977971270"));
-        assertThat(messages.get(2).getMessageType(), is(DMNMessageType.MISSING_TYPE_REF));
+        assertThat(messages.get(2).getSourceId()).isEqualTo("_31911de7-e184-411c-99d1-f33977971270");
+        assertThat(messages.get(2).getMessageType()).isEqualTo(DMNMessageType.MISSING_TYPE_REF);
     }
     
     @Test
@@ -986,8 +977,8 @@ public class DMNRuntimeTest extends BaseDMN1_1VariantTest {
         final DMNModel dmnModel = runtime.getModel(
                 "https://www.drools.org/kie-dmn/definitions",
                 "definitions" );
-        assertThat( dmnModel, notNullValue() );
-        assertThat( DMNRuntimeUtil.formatMessages( dmnModel.getMessages() ), dmnModel.hasErrors(), is( false ) );
+        assertThat(dmnModel).isNotNull();
+        assertThat(dmnModel.hasErrors()).as(DMNRuntimeUtil.formatMessages(dmnModel.getMessages())).isFalse();
         
         final DMNContext context = runtime.newContext();
         final Map<String, String> person = new HashMap<>();
@@ -997,9 +988,9 @@ public class DMNRuntimeTest extends BaseDMN1_1VariantTest {
 
         final DMNResult dmnResult = runtime.evaluateAll(dmnModel, context );
         
-        assertThat( DMNRuntimeUtil.formatMessages( dmnResult.getMessages() ), dmnResult.hasErrors(), is( false ) );
+        assertThat(dmnResult.hasErrors()).as(DMNRuntimeUtil.formatMessages(dmnResult.getMessages())).isFalse();
         final DMNContext result = dmnResult.getContext();
-        assertThat( result.get( "Further Decision" ), is( "The person was greeted with: 'Ciao John Doe'" ) );
+        assertThat(result.get("Further Decision")).isEqualTo("The person was greeted with: 'Ciao John Doe'");
     }
 
     @Test
@@ -1008,8 +999,9 @@ public class DMNRuntimeTest extends BaseDMN1_1VariantTest {
         final DMNModel dmnModel = runtime.getModel(
                 "https://github.com/kiegroup/kie-dmn",
                 "out-of-order" );
-        assertThat( dmnModel, notNullValue() );
-        assertThat( DMNRuntimeUtil.formatMessages( dmnModel.getMessages() ), dmnModel.getMessages().stream().anyMatch( m -> m.getMessageType().equals( DMNMessageType.FAILED_VALIDATOR ) ), is( false ) );
+        assertThat(dmnModel).isNotNull();
+        assertThat(dmnModel.getMessages().stream().anyMatch( m -> m.getMessageType().equals( DMNMessageType.FAILED_VALIDATOR ) ))
+        .as(DMNRuntimeUtil.formatMessages( dmnModel.getMessages() )).isFalse();
     }
   
     @Test
@@ -1019,8 +1011,8 @@ public class DMNRuntimeTest extends BaseDMN1_1VariantTest {
         final DMNModel dmnModel = runtime.getModel(
                 "http://www.trisotech.com/definitions/_2374ee6d-75ed-4e9d-95d3-a88c135e1c43",
                 "Drawing 1a" );
-        assertThat( dmnModel, notNullValue() );
-        assertThat( DMNRuntimeUtil.formatMessages( dmnModel.getMessages() ), dmnModel.hasErrors(), is( false ) );
+        assertThat(dmnModel).isNotNull();
+        assertThat(dmnModel.hasErrors()).as(DMNRuntimeUtil.formatMessages(dmnModel.getMessages())).isFalse();
 
         final DMNContext context = runtime.newContext();
         final Map<String, String> person = new HashMap<>();
@@ -1030,9 +1022,9 @@ public class DMNRuntimeTest extends BaseDMN1_1VariantTest {
 
         final DMNResult dmnResult = runtime.evaluateAll(dmnModel, context );
 
-        assertThat( DMNRuntimeUtil.formatMessages( dmnResult.getMessages() ), dmnResult.hasErrors(), is( false ) );
+        assertThat(dmnResult.hasErrors()).as(DMNRuntimeUtil.formatMessages(dmnResult.getMessages())).isFalse();
         final DMNContext result = dmnResult.getContext();
-        assertThat( result.get( "My Decision" ), is( "The person John Doe is located at 100 East Davie Street" ) );
+        assertThat( result.get( "My Decision" )).isEqualTo("The person John Doe is located at 100 East Davie Street" );
     }
     
     @Test
@@ -1042,9 +1034,9 @@ public class DMNRuntimeTest extends BaseDMN1_1VariantTest {
         final DMNModel dmnModel = runtime.getModel(
                 "http://www.trisotech.com/dmn/definitions/_591d49d0-26e1-4a1c-9f72-b65bec09964a",
                 "Loan Recommendation Multi-step" );
-        assertThat( dmnModel, notNullValue() );
+        assertThat(dmnModel).isNotNull();
         System.out.println(DMNRuntimeUtil.formatMessages( dmnModel.getMessages() ));
-        assertThat( DMNRuntimeUtil.formatMessages( dmnModel.getMessages() ), dmnModel.hasErrors(), is( false ) );
+        assertThat(dmnModel.hasErrors()).as(DMNRuntimeUtil.formatMessages(dmnModel.getMessages())).isFalse();
         
         final DMNContext context = runtime.newContext();
         final Map<String, Number> loan = new HashMap<>();
@@ -1054,10 +1046,10 @@ public class DMNRuntimeTest extends BaseDMN1_1VariantTest {
         context.set("Loan", loan);
 
         final DMNResult dmnResult = runtime.evaluateByName(dmnModel, context, "Loan Payment");
-        assertThat( DMNRuntimeUtil.formatMessages( dmnResult.getMessages() ), dmnResult.hasErrors(), is( true ) );
-        assertThat( dmnResult.getMessages().size(), is( 1 ) );
-        assertThat( dmnResult.getMessages().get( 0 ).getSourceId(), is("_93062144-ebc7-4ef7-a156-c342aeffac49") );
-        assertThat( dmnResult.getMessages().get( 0 ).getMessageType(), is( DMNMessageType.ERROR_EVAL_NODE ) );
+        assertThat(dmnResult.hasErrors()).as(DMNRuntimeUtil.formatMessages(dmnResult.getMessages())).isTrue();
+        assertThat( dmnResult.getMessages()).hasSize(1);
+        assertThat( dmnResult.getMessages().get( 0 ).getSourceId()).isEqualTo("_93062144-ebc7-4ef7-a156-c342aeffac49");
+        assertThat( dmnResult.getMessages().get( 0 ).getMessageType()).isEqualTo(DMNMessageType.ERROR_EVAL_NODE );
     }
 
     @Test
@@ -1067,14 +1059,14 @@ public class DMNRuntimeTest extends BaseDMN1_1VariantTest {
         final DMNModel dmnModel = runtime.getModel(
                 "http://www.trisotech.com/dmn/definitions/_95b7ee22-1964-4be5-b7db-7db66692c707",
                 "Dessin 1" );
-        assertThat( dmnModel, notNullValue() );
-        assertThat( DMNRuntimeUtil.formatMessages( dmnModel.getMessages() ), dmnModel.hasErrors(), is( false ) );
+        assertThat(dmnModel).isNotNull();
+        assertThat(dmnModel.hasErrors()).as(DMNRuntimeUtil.formatMessages(dmnModel.getMessages())).isFalse();
 
         final DMNContext context = runtime.newContext();
         final DMNResult dmnResult = runtime.evaluateAll(dmnModel, context );
 
-        assertThat( DMNRuntimeUtil.formatMessages( dmnResult.getMessages() ), dmnResult.hasErrors(), is( true ) );
-        assertThat( dmnResult.getMessages().stream().anyMatch( m -> m.getMessageType().equals( DMNMessageType.REQ_NOT_FOUND ) ), is( true ) );
+        assertThat(dmnResult.hasErrors()).as(DMNRuntimeUtil.formatMessages(dmnResult.getMessages())).isTrue();
+        assertThat( dmnResult.getMessages().stream().anyMatch( m -> m.getMessageType().equals( DMNMessageType.REQ_NOT_FOUND ) )).isEqualTo(Boolean.TRUE);
     }
     
     @Test
@@ -1083,22 +1075,22 @@ public class DMNRuntimeTest extends BaseDMN1_1VariantTest {
         final DMNModel dmnModel = runtime.getModel(
                 "http://www.trisotech.com/definitions/_76362694-41e8-400c-8dea-e5f033d4f405",
                 "Union of letters" );
-        assertThat( dmnModel, notNullValue() );
-        assertThat( DMNRuntimeUtil.formatMessages( dmnModel.getMessages() ), dmnModel.hasErrors(), is( false ) );
+        assertThat(dmnModel).isNotNull();
+        assertThat(dmnModel.hasErrors()).as(DMNRuntimeUtil.formatMessages(dmnModel.getMessages())).isFalse();
 
         final DMNContext ctx1 = runtime.newContext();
         ctx1.set("A1", Arrays.asList("a", "b"));
         ctx1.set("A2", Arrays.asList("b", "c"));
         final DMNResult dmnResult1 = runtime.evaluateAll(dmnModel, ctx1 );
-        assertThat( DMNRuntimeUtil.formatMessages( dmnResult1.getMessages() ), dmnResult1.hasErrors(), is( false ) );
-        assertThat( (List<?>) dmnResult1.getContext().get( "D1" ), contains( "a", "b", "c" ) );
+        assertThat(dmnResult1.hasErrors()).as(DMNRuntimeUtil.formatMessages(dmnResult1.getMessages())).isFalse();
+        assertThat((List<?>) dmnResult1.getContext().get("D1")).asList().contains("a", "b", "c");
         
         final DMNContext ctx2 = runtime.newContext();
         ctx2.set("A1", Arrays.asList("a", "b"));
         ctx2.set("A2", Arrays.asList("b", "x"));
         final DMNResult dmnResult2 = runtime.evaluateAll(dmnModel, ctx2 );
-        assertThat( DMNRuntimeUtil.formatMessages( dmnResult2.getMessages() ), dmnResult2.hasErrors(), is( true ) );
-        assertThat( dmnResult2.getMessages().stream().anyMatch( m -> m.getMessageType().equals( DMNMessageType.ERROR_EVAL_NODE ) ), is( true ) );
+        assertThat(dmnResult2.hasErrors()).as(DMNRuntimeUtil.formatMessages(dmnResult2.getMessages())).isTrue();
+        assertThat( dmnResult2.getMessages().stream().anyMatch( m -> m.getMessageType().equals( DMNMessageType.ERROR_EVAL_NODE ) )).isTrue();
     }
 
     @Test
@@ -1112,8 +1104,8 @@ public class DMNRuntimeTest extends BaseDMN1_1VariantTest {
     @Test
     public void testUnknownVariable2() {
         final List<DMNMessage> messages = DMNRuntimeUtil.createExpectingDMNMessages("unknown_variable2.dmn", this.getClass());
-        assertThat(messages.get(0).getMessageType(), is(DMNMessageType.ERR_COMPILING_FEEL));
-        assertThat(messages.get(0).getMessage(), containsString("Unknown variable 'Borrower.liquidAssetsAmt'"));
+        assertThat(messages.get(0).getMessageType()).isEqualTo(DMNMessageType.ERR_COMPILING_FEEL);
+        assertThat(messages.get(0).getMessage()).containsSequence("Unknown variable 'Borrower.liquidAssetsAmt'");
     }
 
     @Test
@@ -1122,15 +1114,15 @@ public class DMNRuntimeTest extends BaseDMN1_1VariantTest {
         final DMNModel dmnModel = runtime.getModel(
                 "http://www.trisotech.com/definitions/_71af58db-e1df-4b0f-aee2-48e0e8d89672",
                 "SingleDecisionWithContext" );
-        assertThat( dmnModel, notNullValue() );
-        assertThat( DMNRuntimeUtil.formatMessages( dmnModel.getMessages() ), dmnModel.hasErrors(), is( false ) );
+        assertThat(dmnModel).isNotNull();
+        assertThat(dmnModel.hasErrors()).as(DMNRuntimeUtil.formatMessages(dmnModel.getMessages())).isFalse();
         
         final DMNContext emptyContext = runtime.newContext();
         final DMNResult dmnResult = runtime.evaluateAll(dmnModel, emptyContext );
        
-        assertThat( DMNRuntimeUtil.formatMessages( dmnResult.getMessages() ), dmnResult.hasErrors(), is( false ) );
+        assertThat(dmnResult.hasErrors()).as(DMNRuntimeUtil.formatMessages(dmnResult.getMessages())).isFalse();
         final DMNContext result = dmnResult.getContext();
-        assertThat( result.get( "MyDecision" ), is( "Hello John Doe" ) );
+        assertThat( result.get( "MyDecision" )).isEqualTo("Hello John Doe" );
     }
 
     @Test
@@ -1139,8 +1131,8 @@ public class DMNRuntimeTest extends BaseDMN1_1VariantTest {
         final DMNModel dmnModel = runtime.getModel(
                 "http://www.trisotech.com/definitions/_5f1269c8-1e6f-4748-9eca-26aa1b1278ef",
                 "Ex 6-1" );
-        assertThat( dmnModel, notNullValue() );
-        assertThat( DMNRuntimeUtil.formatMessages( dmnModel.getMessages() ), dmnModel.hasErrors(), is( false ) );
+        assertThat(dmnModel).isNotNull();
+        assertThat(dmnModel.hasErrors()).as(DMNRuntimeUtil.formatMessages(dmnModel.getMessages())).isFalse();
         
         final DMNContext ctx = runtime.newContext();
         final Map<String, Object> t1 = new HashMap<>();
@@ -1158,15 +1150,15 @@ public class DMNRuntimeTest extends BaseDMN1_1VariantTest {
         ctx.set("NBA Pacific", Arrays.asList(t1, t2));
         final DMNResult dmnResult = runtime.evaluateAll(dmnModel, ctx );
        
-        assertThat( DMNRuntimeUtil.formatMessages( dmnResult.getMessages() ), dmnResult.hasErrors(), is( false ) );
+        assertThat(dmnResult.hasErrors()).as(DMNRuntimeUtil.formatMessages(dmnResult.getMessages())).isFalse();
         final DMNContext result = dmnResult.getContext();
-        assertThat( result.get( "Number of distinct cities" ), is( new BigDecimal(2) ) );
-        assertThat( result.get( "Second place losses" ), is( new BigDecimal(0) ) );
-        assertThat( result.get( "Max wins" ), is( new BigDecimal(1) ) );
-        assertThat( result.get( "Mean wins" ), is( new BigDecimal(0.5) ) );
-        assertThat( (List<?>) result.get( "Positions of Los Angeles teams" ), contains( new BigDecimal(1) ) );
-        assertThat( result.get( "Number of teams" ), is( new BigDecimal(2) ) );
-        assertThat( result.get( "Sum of bonus points" ), is( new BigDecimal(47) ) );
+        assertThat( result.get( "Number of distinct cities" )).isEqualTo(new BigDecimal(2) );
+        assertThat( result.get( "Second place losses" )).isEqualTo(new BigDecimal(0) );
+        assertThat( result.get( "Max wins" )).isEqualTo(new BigDecimal(1) );
+        assertThat( result.get( "Mean wins" )).isEqualTo(new BigDecimal(0.5) );
+        assertThat( (List<?>) result.get( "Positions of Los Angeles teams" )).asList().contains(new BigDecimal(1));
+        assertThat( result.get( "Number of teams" )).isEqualTo(new BigDecimal(2) );
+        assertThat( result.get( "Sum of bonus points" )).isEqualTo(new BigDecimal(47) );
     }
     
     @Test
@@ -1175,26 +1167,26 @@ public class DMNRuntimeTest extends BaseDMN1_1VariantTest {
         final DMNModel dmnModel = runtime.getModel(
                 "http://www.trisotech.com/definitions/_0768879b-5ee1-410f-92f0-7732573b069d",
                 "expression function subst [a] with a" );
-        assertThat( dmnModel, notNullValue() );
-        assertThat( DMNRuntimeUtil.formatMessages( dmnModel.getMessages() ), dmnModel.hasErrors(), is( false ) );
+        assertThat(dmnModel).isNotNull();
+        assertThat(dmnModel.hasErrors()).as(DMNRuntimeUtil.formatMessages(dmnModel.getMessages())).isFalse();
         
         final DMNContext ctx = runtime.newContext();
         ctx.set("InputLineItem", prototype(entry("Line", "0015"), entry("Description", "additional Battery")));
         final DMNResult dmnResult = runtime.evaluateAll(dmnModel, ctx );
        
-        assertThat( DMNRuntimeUtil.formatMessages( dmnResult.getMessages() ), dmnResult.hasErrors(), is( false ) );
+        assertThat(dmnResult.hasErrors()).as(DMNRuntimeUtil.formatMessages(dmnResult.getMessages())).isFalse();
         final DMNContext result = dmnResult.getContext();
-        assertThat( result.get("The Battery"), is( prototype(entry("Line", "0010"), entry("Description", "Battery")) ) );
-        assertThat( (List<?>)result.get("Remove Battery"), contains( prototype(entry("Line", "0020"), entry("Description", "Case")),
+        assertThat( result.get("The Battery")).isEqualTo( prototype(entry("Line", "0010"), entry("Description", "Battery")));
+        assertThat( (List<?>)result.get("Remove Battery")).asList().contains( prototype(entry("Line", "0020"), entry("Description", "Case")),
                                                                      prototype(entry("Line", "0030"), entry("Description", "Power Supply"))
-                                                                     ) );
-        assertThat( (List<?>)result.get("Remove Battery"), not( contains( prototype(entry("Line", "0010"), entry("Description", "Battery")) ) ) );
+                                                                     );
+        assertThat( (List<?>)result.get("Remove Battery")).asList().doesNotContain(prototype(entry("Line", "0010"), entry("Description", "Battery")));
         
-        assertThat( (List<?>)result.get("Insert before Line 0020"), contains( prototype(entry("Line", "0010"), entry("Description", "Battery")), 
+        assertThat( (List<?>)result.get("Insert before Line 0020")).asList().contains(prototype(entry("Line", "0010"), entry("Description", "Battery")), 
                                                                               prototype(entry("Line", "0015"), entry("Description", "additional Battery")), 
                                                                               prototype(entry("Line", "0020"), entry("Description", "Case")),
                                                                               prototype(entry("Line", "0030"), entry("Description", "Power Supply"))
-                                                                              ) );
+                                                                              );
     }
 
     @Test
@@ -1203,24 +1195,24 @@ public class DMNRuntimeTest extends BaseDMN1_1VariantTest {
         final DMNModel dmnModel = runtime.getModel(
                 "http://www.trisotech.com/dmn/definitions/_b42317c4-4f0c-474e-a0bf-2895b0b3c314",
                 "Dessin 1" );
-        assertThat( dmnModel, notNullValue() );
-        assertThat( DMNRuntimeUtil.formatMessages( dmnModel.getMessages() ), dmnModel.hasErrors(), is( false ) );
+        assertThat(dmnModel).isNotNull();
+        assertThat(dmnModel.hasErrors()).as(DMNRuntimeUtil.formatMessages(dmnModel.getMessages())).isFalse();
 
         final DMNContext ctx = runtime.newContext();
         ctx.set( "Input", 3.14 );
         final DMNResult dmnResult = runtime.evaluateAll(dmnModel, ctx );
 
-        assertThat( DMNRuntimeUtil.formatMessages( dmnResult.getMessages() ), dmnResult.hasErrors(), is( false ) );
+        assertThat(dmnResult.hasErrors()).as(DMNRuntimeUtil.formatMessages(dmnResult.getMessages())).isFalse();
         final DMNContext result = dmnResult.getContext();
-        assertThat( ((BigDecimal) result.get( "D1" )).setScale( 4, BigDecimal.ROUND_HALF_UP ), is( new BigDecimal( "-1.0000" ) ) );
-        assertThat( ((BigDecimal) result.get( "D2" )).setScale( 4, BigDecimal.ROUND_HALF_UP ), is( new BigDecimal( "-1.0000" ) ) );
+        assertThat( ((BigDecimal) result.get( "D1" )).setScale( 4, BigDecimal.ROUND_HALF_UP )).isEqualTo(new BigDecimal( "-1.0000" ) );
+        assertThat( ((BigDecimal) result.get( "D2" )).setScale( 4, BigDecimal.ROUND_HALF_UP )).isEqualTo(new BigDecimal( "-1.0000" ) );
     }
     
     @Test
     public void testJavaFunctionContext_withErrors() {
         // DROOLS-1568
         final List<DMNMessage> messages = DMNRuntimeUtil.createExpectingDMNMessages("java_function_context_with_errors.dmn", this.getClass());
-        assertThat(messages.size(), is(1));
+        assertThat(messages).hasSize(1);
 
         final List<String> sourceIDs = messages.stream().map(DMNMessage::getSourceId).collect(Collectors.toList());
         // FEEL FuncDefNode not checked at compile time: assertTrue( sourceIDs.contains( "_a72a7aff-48c3-4806-83ca-fc1f1fe34320") );
@@ -1234,8 +1226,8 @@ public class DMNRuntimeTest extends BaseDMN1_1VariantTest {
         final DMNModel dmnModel = runtime.getModel(
                 "http://www.trisotech.com/definitions/_1a7d184c-2e38-4462-ae28-15591ef6d534",
                 "countCSATradeRatings" );
-        assertThat( dmnModel, notNullValue() );
-        assertThat( DMNRuntimeUtil.formatMessages( dmnModel.getMessages() ), dmnModel.hasErrors(), is( false ) );
+        assertThat(dmnModel).isNotNull();
+        assertThat(dmnModel.hasErrors()).as(DMNRuntimeUtil.formatMessages(dmnModel.getMessages())).isFalse();
         
         final DMNContext ctx = runtime.newContext();
         final List<Map<?, ?>> ratings = new ArrayList<>();
@@ -1244,22 +1236,22 @@ public class DMNRuntimeTest extends BaseDMN1_1VariantTest {
         ctx.set("CSA Trade Ratings", ratings);
         final DMNResult dmnResult = runtime.evaluateAll(dmnModel, ctx );
        
-        assertThat( DMNRuntimeUtil.formatMessages( dmnResult.getMessages() ), dmnResult.hasErrors(), is( false ) );
+        assertThat(dmnResult.hasErrors()).as(DMNRuntimeUtil.formatMessages(dmnResult.getMessages())).isFalse();
         final DMNContext result = dmnResult.getContext();
-        assertThat( result.get("Trade Ratings"), is( new BigDecimal(2) ) );
+        assertThat( result.get("Trade Ratings")).isEqualTo(new BigDecimal(2) );
         
         
         final DMNContext ctx2 = runtime.newContext();
         ctx2.set("CSA Trade Ratings", null);
         final DMNResult dmnResult2 = runtime.evaluateAll(dmnModel, ctx2 );
-        assertThat(DMNRuntimeUtil.formatMessages(dmnResult2.getMessages()), dmnResult2.hasErrors(), is(true));
-        assertThat(dmnResult2.getMessages().stream().anyMatch(m -> m.getMessageType().equals(DMNMessageType.FEEL_EVALUATION_ERROR)), is(true));
-        assertThat(dmnResult2.getDecisionResultByName("Trade Ratings").getEvaluationStatus(), is(DecisionEvaluationStatus.FAILED));
+        assertThat(dmnResult2.hasErrors()).as(DMNRuntimeUtil.formatMessages(dmnResult2.getMessages())).isTrue();
+        assertThat(dmnResult2.getMessages().stream().anyMatch(m -> m.getMessageType().equals(DMNMessageType.FEEL_EVALUATION_ERROR))).isTrue();
+        assertThat(dmnResult2.getDecisionResultByName("Trade Ratings").getEvaluationStatus()).isEqualTo(DecisionEvaluationStatus.FAILED);
         
                 
         final DMNResult dmnResult3 = runtime.evaluateAll(dmnModel, runtime.newContext() );
-        assertThat( DMNRuntimeUtil.formatMessages( dmnResult3.getMessages() ), dmnResult3.hasErrors(), is( true ) );
-        assertThat( dmnResult3.getMessages().stream().anyMatch( m -> m.getMessageType().equals( DMNMessageType.REQ_NOT_FOUND ) ), is( true ) );
+        assertThat(dmnResult3.hasErrors()).as(DMNRuntimeUtil.formatMessages(dmnResult3.getMessages())).isTrue();
+        assertThat(dmnResult3.getMessages().stream().anyMatch( m -> m.getMessageType().equals( DMNMessageType.REQ_NOT_FOUND ))).isTrue();
     }
     
     @Test
@@ -1269,8 +1261,8 @@ public class DMNRuntimeTest extends BaseDMN1_1VariantTest {
         final DMNModel dmnModel = runtime.getModel(
                 "http://www.trisotech.com/definitions/_ec5a78c7-a317-4c39-8310-db59be60f1c8",
                 "PersonListHelloBKM" );
-        assertThat( dmnModel, notNullValue() );
-        assertThat( DMNRuntimeUtil.formatMessages( dmnModel.getMessages() ), dmnModel.hasErrors(), is( false ) );
+        assertThat(dmnModel).isNotNull();
+        assertThat(dmnModel.hasErrors()).as(DMNRuntimeUtil.formatMessages(dmnModel.getMessages())).isFalse();
         
         final DMNContext context = runtime.newContext();
         
@@ -1281,9 +1273,9 @@ public class DMNRuntimeTest extends BaseDMN1_1VariantTest {
         final DMNResult dmnResult = runtime.evaluateAll(dmnModel, context );
         final DMNContext result = dmnResult.getContext();
 
-        assertThat( DMNRuntimeUtil.formatMessages( dmnResult.getMessages() ), dmnResult.hasErrors(), is( false ) );
-        assertThat( (List<?>)result.get("My Decision"), contains( "The person named John Doe is 33 years old.",
-                                                                  "The person named 47 is 47 years old.") );
+        assertThat(dmnResult.hasErrors()).as(DMNRuntimeUtil.formatMessages(dmnResult.getMessages())).isFalse();
+        assertThat( (List<?>)result.get("My Decision")).asList().contains( "The person named John Doe is 33 years old.",
+                                                                  "The person named 47 is 47 years old.");
     }
     
     @Test
@@ -1293,8 +1285,8 @@ public class DMNRuntimeTest extends BaseDMN1_1VariantTest {
         final DMNModel dmnModel = runtime.getModel(
                 "http://www.trisotech.com/definitions/_7e41a76e-2df6-4899-bf81-ae098757a3b6",
                 "PersonListHelloBKM2" );
-        assertThat( dmnModel, notNullValue() );
-        assertThat( DMNRuntimeUtil.formatMessages( dmnModel.getMessages() ), dmnModel.hasErrors(), is( false ) );
+        assertThat(dmnModel).isNotNull();
+        assertThat(dmnModel.hasErrors()).as(DMNRuntimeUtil.formatMessages(dmnModel.getMessages())).isFalse();
         
         final DMNContext context = runtime.newContext();
         
@@ -1305,10 +1297,10 @@ public class DMNRuntimeTest extends BaseDMN1_1VariantTest {
         final DMNResult dmnResult = runtime.evaluateAll(dmnModel, context );
         final DMNContext result = dmnResult.getContext();
 
-        assertThat( DMNRuntimeUtil.formatMessages( dmnResult.getMessages() ), dmnResult.hasErrors(), is( false ) );
-        assertThat( (List<?>)result.get("My Decision"), contains( prototype( entry("Full Name", "Prof. John Doe"), entry("Age", EvalHelper.coerceNumber(33)) ),
+        assertThat(dmnResult.hasErrors()).as(DMNRuntimeUtil.formatMessages(dmnResult.getMessages())).isFalse();
+        assertThat( (List<?>)result.get("My Decision")).asList().contains( prototype( entry("Full Name", "Prof. John Doe"), entry("Age", EvalHelper.coerceNumber(33)) ),
                                                                   prototype( entry("Full Name", "Prof. 47"), entry("Age", EvalHelper.coerceNumber(47)) ) 
-                                                                  ) );
+                                                                  );
     }
 
     @Test
@@ -1318,20 +1310,20 @@ public class DMNRuntimeTest extends BaseDMN1_1VariantTest {
         final DMNModel dmnModel = runtime.getModel(
                 "http://www.trisotech.com/definitions/_09a13244-114d-43fb-9e00-cda89a2000dd",
                 "same every type check" );
-        assertThat( dmnModel, notNullValue() );
-        assertThat( DMNRuntimeUtil.formatMessages( dmnModel.getMessages() ), dmnModel.hasErrors(), is( false ) );
+        assertThat(dmnModel).isNotNull();
+        assertThat(dmnModel.hasErrors()).as(DMNRuntimeUtil.formatMessages(dmnModel.getMessages())).isFalse();
         
         final DMNContext emptyContext = runtime.newContext();
         final DMNResult dmnResult = runtime.evaluateAll(dmnModel, emptyContext );
         final DMNContext result = dmnResult.getContext();
         
-        assertThat( DMNRuntimeUtil.formatMessages( dmnResult.getMessages() ), dmnResult.hasErrors(), is( false ) );
-        assertThat( result.get("Some are even"), is( true ) );
-        assertThat( result.get("Every are even"), is( false ) );
-        assertThat( result.get("Some are positive"), is( true ) );
-        assertThat( result.get("Every are positive"), is( true ) );
-        assertThat( result.get("Some are negative"), is( false ) );
-        assertThat( result.get("Every are negative"), is( false ) );
+        assertThat(dmnResult.hasErrors()).as(DMNRuntimeUtil.formatMessages(dmnResult.getMessages())).isFalse();
+        assertThat( result.get("Some are even")).isEqualTo(Boolean.TRUE);
+        assertThat( result.get("Every are even")).isEqualTo(Boolean.FALSE);
+        assertThat( result.get("Some are positive")).isEqualTo(Boolean.TRUE);
+        assertThat( result.get("Every are positive")).isEqualTo(Boolean.TRUE);
+        assertThat( result.get("Some are negative")).isEqualTo(Boolean.FALSE);
+        assertThat( result.get("Every are negative")).isEqualTo(Boolean.FALSE);
     }
 
     @Test
@@ -1340,8 +1332,8 @@ public class DMNRuntimeTest extends BaseDMN1_1VariantTest {
         final DMNModel dmnModel = runtime.getModel(
                 "http://www.trisotech.com/definitions/_fbf002a3-615b-4f02-98e4-c28d4676225a",
                 "Error with constraints verification" );
-        assertThat( dmnModel, notNullValue() );
-        assertThat( DMNRuntimeUtil.formatMessages( dmnModel.getMessages() ), dmnModel.hasErrors(), is( false ) );
+        assertThat(dmnModel).isNotNull();
+        assertThat(dmnModel.hasErrors()).as(DMNRuntimeUtil.formatMessages(dmnModel.getMessages())).isFalse();
 
         final DMNContext ctx = runtime.newContext();
         final Object duration = BuiltInType.DURATION.fromString("P20Y" );
@@ -1351,35 +1343,35 @@ public class DMNRuntimeTest extends BaseDMN1_1VariantTest {
         final DMNResult dmnResult = runtime.evaluateAll(dmnModel, ctx );
         final DMNContext result = dmnResult.getContext();
 
-        assertThat( DMNRuntimeUtil.formatMessages( dmnResult.getMessages() ), dmnResult.hasErrors(), is( false ) );
-        assertThat( (Map<String,Object>) result.get( "Decision Logic 1" ), hasEntry( "years and months", duration ) );
-        assertThat( (Map<String,Object>) result.get( "Decision Logic 1" ), hasEntry( "Date Time", dateTime ) );
+        assertThat(dmnResult.hasErrors()).as(DMNRuntimeUtil.formatMessages(dmnResult.getMessages())).isFalse();
+        assertThat( (Map<String,Object>) result.get( "Decision Logic 1" )).containsEntry("years and months", duration);
+        assertThat( (Map<String,Object>) result.get( "Decision Logic 1" )).containsEntry("Date Time", dateTime);
     }
     
     @Test
     public void testArtificialAttributes() {
         final DMNRuntime runtime = DMNRuntimeUtil.createRuntime("0001-input-data-string-artificial-attributes.dmn", this.getClass() );
         final DMNModel dmnModel = runtime.getModel("https://github.com/kiegroup/drools", "0001-input-data-string" );
-        assertThat( dmnModel, notNullValue() );
+        assertThat(dmnModel).isNotNull();
 
         final DMNContext context = DMNFactory.newContext();
         context.set( "Full Name", "John Doe" );
 
         final DMNResult dmnResult = runtime.evaluateAll(dmnModel, context );
 
-        assertThat( dmnResult.getDecisionResults().size(), is( 1 ) );
-        assertThat( dmnResult.getDecisionResultByName( "Greeting Message" ).getResult(), is( "Hello John Doe" ) );
+        assertThat( dmnResult.getDecisionResults()).hasSize(1);
+        assertThat( dmnResult.getDecisionResultByName( "Greeting Message" ).getResult()).isEqualTo("Hello John Doe" );
 
         final DMNContext result = dmnResult.getContext();
 
-        assertThat( result.get( "Greeting Message" ), is( "Hello John Doe" ) );
+        assertThat( result.get( "Greeting Message" )).isEqualTo("Hello John Doe" );
     }
     
     @Test
     public void testInvokeFunctionSuccess() {
         final DMNRuntime runtime = DMNRuntimeUtil.createRuntimeWithAdditionalResources("Caller.dmn", this.getClass(), "Calling.dmn" );
         final DMNModel dmnModel = runtime.getModel("http://www.trisotech.com/definitions/_b0a696d6-3d57-4e97-b5d4-b44a63909d67", "Caller" );
-        assertThat( dmnModel, notNullValue() );
+        assertThat(dmnModel).isNotNull();
 
         final DMNContext context = DMNFactory.newContext();
         context.set( "My Name", "John Doe" );
@@ -1389,17 +1381,17 @@ public class DMNRuntimeTest extends BaseDMN1_1VariantTest {
         context.set( "Invoke decision", "Final Result" );
 
         final DMNResult dmnResult = runtime.evaluateAll(dmnModel, context );
-        assertThat( DMNRuntimeUtil.formatMessages( dmnResult.getMessages() ), dmnResult.hasErrors(), is( false ) );
+        assertThat(dmnResult.hasErrors()).as(DMNRuntimeUtil.formatMessages(dmnResult.getMessages())).isFalse();
             
         final DMNContext result = dmnResult.getContext();
-        assertThat( result.get( "Final decision" ), is( "The final decision is: Hello, John Doe your number once double is equal to: 6" ) );
+        assertThat( result.get("Final decision")).isEqualTo("The final decision is: Hello, John Doe your number once double is equal to: 6");
     }
 
     @Test
     public void testInvokeFunctionWrongNamespace() {
         final DMNRuntime runtime = DMNRuntimeUtil.createRuntimeWithAdditionalResources("Caller.dmn", this.getClass(), "Calling.dmn" );
         final DMNModel dmnModel = runtime.getModel("http://www.trisotech.com/definitions/_b0a696d6-3d57-4e97-b5d4-b44a63909d67", "Caller" );
-        assertThat( dmnModel, notNullValue() );
+        assertThat(dmnModel).isNotNull();
 
         final DMNContext wrongContext = DMNFactory.newContext();
         wrongContext.set( "My Name", "John Doe" );
@@ -1409,16 +1401,16 @@ public class DMNRuntimeTest extends BaseDMN1_1VariantTest {
         wrongContext.set( "Invoke decision", "Final Result" );
 
         final DMNResult dmnResult = runtime.evaluateAll(dmnModel, wrongContext );
-        assertThat( DMNRuntimeUtil.formatMessages( dmnResult.getMessages() ), dmnResult.hasErrors(), is( true ) );
+        assertThat(dmnResult.hasErrors()).as(DMNRuntimeUtil.formatMessages(dmnResult.getMessages())).isTrue();
         // total of: 2. x1 error in calling external decision, and x1 error in making final decision as it depends on the former.
-        assertThat( DMNRuntimeUtil.formatMessages( dmnResult.getMessages() ), dmnResult.getMessages().size(), is( 2 ) );
+        assertThat(dmnResult.getMessages()).as(DMNRuntimeUtil.formatMessages(dmnResult.getMessages())).hasSize(2);
     }
 
     @Test
     public void testInvokeFunctionWrongDecisionName() {
         final DMNRuntime runtime = DMNRuntimeUtil.createRuntimeWithAdditionalResources("Caller.dmn", this.getClass(), "Calling.dmn" );
         final DMNModel dmnModel = runtime.getModel("http://www.trisotech.com/definitions/_b0a696d6-3d57-4e97-b5d4-b44a63909d67", "Caller" );
-        assertThat( dmnModel, notNullValue() );
+        assertThat(dmnModel).isNotNull();
 
         final DMNContext wrongContext = DMNFactory.newContext();
         wrongContext.set( "My Name", "John Doe" );
@@ -1428,10 +1420,9 @@ public class DMNRuntimeTest extends BaseDMN1_1VariantTest {
         wrongContext.set("Invoke decision", "<unexistent decision>");
 
         final DMNResult dmnResult = runtime.evaluateAll(dmnModel, wrongContext );
-        assertThat( DMNRuntimeUtil.formatMessages( dmnResult.getMessages() ), dmnResult.hasErrors(), is( true ) );
+        assertThat(dmnResult.hasErrors()).as(DMNRuntimeUtil.formatMessages(dmnResult.getMessages())).isTrue();
         // total of: 2. x1 error in calling external decision, and x1 error in making final decision as it depends on the former.
-        assertThat( DMNRuntimeUtil.formatMessages( dmnResult.getMessages() ), dmnResult.getMessages().size(), is( 2 ) );
-
+        assertThat(dmnResult.getMessages()).as(DMNRuntimeUtil.formatMessages(dmnResult.getMessages())).hasSize(2);
     }
 
     @Test
@@ -1439,7 +1430,7 @@ public class DMNRuntimeTest extends BaseDMN1_1VariantTest {
 
         final DMNRuntime runtime = DMNRuntimeUtil.createRuntimeWithAdditionalResources("Caller.dmn", this.getClass(), "Calling.dmn" );
         final DMNModel dmnModel = runtime.getModel("http://www.trisotech.com/definitions/_b0a696d6-3d57-4e97-b5d4-b44a63909d67", "Caller" );
-        assertThat( dmnModel, notNullValue() );
+        assertThat(dmnModel).isNotNull();
 
         final DMNContext wrongContext = DMNFactory.newContext();
         wrongContext.set( "My Name", "John Doe" );
@@ -1449,17 +1440,17 @@ public class DMNRuntimeTest extends BaseDMN1_1VariantTest {
         wrongContext.set( "Invoke decision", "Final Result" );
 
         final DMNResult dmnResult = runtime.evaluateAll(dmnModel, wrongContext );
-        assertThat( DMNRuntimeUtil.formatMessages( dmnResult.getMessages() ), dmnResult.hasErrors(), is( true ) );
+        assertThat(dmnResult.hasErrors()).as(DMNRuntimeUtil.formatMessages(dmnResult.getMessages())).isTrue();
         // total of: 2. x1 error in calling external decision, and x1 error in making final decision as it depends on the former.
         // please notice it will print 4 lines in the log, 2x are the "external invocation" and then 2x are the one by the caller, checked herebelow:
-        assertThat( DMNRuntimeUtil.formatMessages( dmnResult.getMessages() ), dmnResult.getMessages().size(), is( 2 ) );
+        assertThat(dmnResult.getMessages()).as(DMNRuntimeUtil.formatMessages(dmnResult.getMessages())).hasSize(2);
     }
 
     @Test
     public void testInvalidFunction() {
         final DMNRuntime runtime = DMNRuntimeUtil.createRuntimeWithAdditionalResources( "InvalidFunction.dmn", this.getClass() );
         final DMNModel model = runtime.getModel( "http://www.trisotech.com/definitions/_84453b71-5d23-479f-9481-5196d92bacae", "0003-iteration-augmented" );
-        assertThat( model, notNullValue() );
+        assertThat(model).isNotNull();
         final DMNContext context = DMNFactory.newContext();
         context.set( "Loans", new HashMap<>() );
         final DMNResult result = runtime.evaluateAll(model, context);
@@ -1557,19 +1548,19 @@ public class DMNRuntimeTest extends BaseDMN1_1VariantTest {
     public void testEx_4_3simplified() {
         final DMNRuntime runtime = DMNRuntimeUtil.createRuntime("Ex_4_3simplified.dmn", this.getClass());
         final DMNModel dmnModel = runtime.getModel("http://www.trisotech.com/definitions/_5c5a9c72-627e-4666-ae85-31356fed3658", "Ex_4_3simplified");
-        assertThat(dmnModel, notNullValue());
-        assertThat(DMNRuntimeUtil.formatMessages(dmnModel.getMessages()), dmnModel.hasErrors(), is(false));
+        assertThat(dmnModel).isNotNull();
+        assertThat(dmnModel.hasErrors()).as(DMNRuntimeUtil.formatMessages(dmnModel.getMessages())).isFalse();
 
         final DMNContext context = DMNFactory.newContext();
         context.set("number", 123.123456d);
 
         final DMNResult dmnResult = runtime.evaluateAll(dmnModel, context);
         System.out.println(dmnResult);
-        assertThat(DMNRuntimeUtil.formatMessages(dmnResult.getMessages()), dmnResult.hasErrors(), is(false));
+        assertThat(dmnResult.hasErrors()).as(DMNRuntimeUtil.formatMessages(dmnResult.getMessages())).isFalse();
 
         final DMNContext result = dmnResult.getContext();
 
-        assertThat(result.get("Formatted Monthly Payment"), is("€123.12"));
+        assertThat(result.get("Formatted Monthly Payment")).isEqualTo("€123.12");
     }
 
     @Test
@@ -1577,20 +1568,20 @@ public class DMNRuntimeTest extends BaseDMN1_1VariantTest {
         // DROOLS-2117 improve Msg.ERROR_EVAL_NODE_DEP_WRONG_TYPE
         final DMNRuntime runtime = DMNRuntimeUtil.createRuntime("Ex_4_3simplified.dmn", this.getClass());
         final DMNModel dmnModel = runtime.getModel("http://www.trisotech.com/definitions/_5c5a9c72-627e-4666-ae85-31356fed3658", "Ex_4_3simplified");
-        assertThat(dmnModel, notNullValue());
-        assertThat(DMNRuntimeUtil.formatMessages(dmnModel.getMessages()), dmnModel.hasErrors(), is(false));
+        assertThat(dmnModel).isNotNull();
+        assertThat(dmnModel.hasErrors()).as(DMNRuntimeUtil.formatMessages(dmnModel.getMessages())).isFalse();
 
         final DMNContext context = DMNFactory.newContext();
         context.set("number", "ciao");
 
         final DMNResult dmnResult = runtime.evaluateAll(dmnModel, context);
         System.out.println(dmnResult);
-        assertThat(DMNRuntimeUtil.formatMessages(dmnResult.getMessages()), dmnResult.hasErrors(), is(true));
+        assertThat(dmnResult.hasErrors()).as(DMNRuntimeUtil.formatMessages(dmnResult.getMessages())).isTrue();
 
         // we want the error message to include not only which value was incompatible, but the type which was expected.
         // in this case the value is `ciao` for a String
         // but should have been a FEEL:number.
-        assertThat(dmnResult.getMessages().stream().filter(m -> m.getMessageType() == DMNMessageType.ERROR_EVAL_NODE).anyMatch(m -> m.getMessage().endsWith("is not allowed by the declared type (DMNType{ http://www.omg.org/spec/FEEL/20140401 : number })")), is(true));
+        assertThat(dmnResult.getMessages().stream().filter(m -> m.getMessageType() == DMNMessageType.ERROR_EVAL_NODE).anyMatch(m -> m.getMessage().endsWith("is not allowed by the declared type (DMNType{ http://www.omg.org/spec/FEEL/20140401 : number })"))).isTrue();
     }
 
     @Test
@@ -1598,22 +1589,22 @@ public class DMNRuntimeTest extends BaseDMN1_1VariantTest {
         // DROOLS-2125
         final DMNRuntime runtime = DMNRuntimeUtil.createRuntime("drools2125.dmn", this.getClass());
         final DMNModel dmnModel = runtime.getModel("http://www.trisotech.com/definitions/_9f976b29-4cdd-42e9-8737-0ccbc2ad9498", "drools2125");
-        assertThat(dmnModel, notNullValue());
-        assertThat(DMNRuntimeUtil.formatMessages(dmnModel.getMessages()), dmnModel.hasErrors(), is(false));
+        assertThat(dmnModel).isNotNull();
+        assertThat(dmnModel.hasErrors()).as(DMNRuntimeUtil.formatMessages(dmnModel.getMessages())).isFalse();
 
         final DMNContext context = DMNFactory.newContext();
         context.set("person", "Bob");
         context.set("list of persons", Arrays.asList("Bob", "John"));
 
         final DMNResult dmnResult = runtime.evaluateAll(dmnModel, context);
-        assertThat(DMNRuntimeUtil.formatMessages(dmnResult.getMessages()), dmnResult.hasErrors(), is(false));
+        assertThat(dmnResult.hasErrors()).as(DMNRuntimeUtil.formatMessages(dmnResult.getMessages())).isFalse();
 
         final DMNContext result = dmnResult.getContext();
-        assertThat(result.get("person is Bob"), is("yes"));
-        assertThat(result.get("persons complies with UT list"), is("yes"));
-        assertThat(result.get("person on the list of persons"), is("yes"));
-        assertThat(result.get("persons complies with hardcoded list"), is("yes"));
-        assertThat(result.get("person is person"), is("yes"));
+        assertThat(result.get("person is Bob")).isEqualTo("yes");
+        assertThat(result.get("persons complies with UT list")).isEqualTo("yes");
+        assertThat(result.get("person on the list of persons")).isEqualTo("yes");
+        assertThat(result.get("persons complies with hardcoded list")).isEqualTo("yes");
+        assertThat(result.get("person is person")).isEqualTo("yes");
     }
 
     @Test
@@ -1621,13 +1612,13 @@ public class DMNRuntimeTest extends BaseDMN1_1VariantTest {
         // DROOLS-2147
         final DMNRuntime runtime = DMNRuntimeUtil.createRuntime("DROOLS-2147.dmn", this.getClass());
         final DMNModel dmnModel = runtime.getModel("http://www.trisotech.com/dmn/definitions/_cbdacb7b-f72d-457d-b4f4-54020a06db24", "Drawing 1");
-        assertThat(dmnModel, notNullValue());
-        assertThat(DMNRuntimeUtil.formatMessages(dmnModel.getMessages()), dmnModel.hasErrors(), is(false));
+        assertThat(dmnModel).isNotNull();
+        assertThat(dmnModel.hasErrors()).as(DMNRuntimeUtil.formatMessages(dmnModel.getMessages())).isFalse();
 
         final DMNContext context = DMNFactory.newContext();
 
         final DMNResult dmnResult = runtime.evaluateAll(dmnModel, context);
-        assertThat(DMNRuntimeUtil.formatMessages(dmnResult.getMessages()), dmnResult.hasErrors(), is(false));
+        assertThat(dmnResult.hasErrors()).as(DMNRuntimeUtil.formatMessages(dmnResult.getMessages())).isFalse();
 
         final DMNContext resultContext = dmnResult.getContext();
         final List people = (List) resultContext.get("People");
@@ -1646,8 +1637,8 @@ public class DMNRuntimeTest extends BaseDMN1_1VariantTest {
         // DROOLS-2147 truncate message length
         final DMNRuntime runtime = DMNRuntimeUtil.createRuntime("Ex_4_3simplified.dmn", this.getClass());
         final DMNModel dmnModel = runtime.getModel("http://www.trisotech.com/definitions/_5c5a9c72-627e-4666-ae85-31356fed3658", "Ex_4_3simplified");
-        assertThat(dmnModel, notNullValue());
-        assertThat(DMNRuntimeUtil.formatMessages(dmnModel.getMessages()), dmnModel.hasErrors(), is(false));
+        assertThat(dmnModel).isNotNull();
+        assertThat(dmnModel.hasErrors()).as(DMNRuntimeUtil.formatMessages(dmnModel.getMessages())).isFalse();
 
         final DMNContext context = DMNFactory.newContext();
         final StringBuilder sb = new StringBuilder("abcdefghijklmnopqrstuvwxyz");
@@ -1658,9 +1649,9 @@ public class DMNRuntimeTest extends BaseDMN1_1VariantTest {
 
         final DMNResult dmnResult = runtime.evaluateAll(dmnModel, context);
         System.out.println(dmnResult);
-        assertThat(DMNRuntimeUtil.formatMessages(dmnResult.getMessages()), dmnResult.hasErrors(), is(true));
+        assertThat(dmnResult.hasErrors()).as(DMNRuntimeUtil.formatMessages(dmnResult.getMessages())).isTrue();
 
-        assertThat(dmnResult.getMessages().stream().filter(m -> m.getMessageType() == DMNMessageType.ERROR_EVAL_NODE).anyMatch(m -> m.getMessage().contains("... [string clipped after 50 chars, total length is")), is(true));
+        assertThat(dmnResult.getMessages().stream().filter(m -> m.getMessageType() == DMNMessageType.ERROR_EVAL_NODE).anyMatch(m -> m.getMessage().contains("... [string clipped after 50 chars, total length is"))).isTrue();
     }
 
     @Test
@@ -1668,16 +1659,16 @@ public class DMNRuntimeTest extends BaseDMN1_1VariantTest {
         // DROOLS-2192
         final DMNRuntime runtime = DMNRuntimeUtil.createRuntime("hardcoded_function_definition.dmn", this.getClass());
         final DMNModel dmnModel = runtime.getModel("http://www.trisotech.com/definitions/_99854980-65c8-4e9b-b365-bd30ded69f40", "hardcoded_function_definition");
-        assertThat(dmnModel, notNullValue());
-        assertThat(DMNRuntimeUtil.formatMessages(dmnModel.getMessages()), dmnModel.hasErrors(), is(false));
+        assertThat(dmnModel).isNotNull();
+        assertThat(dmnModel.hasErrors()).as(DMNRuntimeUtil.formatMessages(dmnModel.getMessages())).isFalse();
 
         final DMNContext emptyContext = DMNFactory.newContext();
 
         final DMNResult dmnResult = runtime.evaluateAll(dmnModel, emptyContext);
-        assertThat(DMNRuntimeUtil.formatMessages(dmnResult.getMessages()), dmnResult.hasErrors(), is(false));
+        assertThat(dmnResult.hasErrors()).as(DMNRuntimeUtil.formatMessages(dmnResult.getMessages())).isFalse();
 
         final DMNContext resultContext = dmnResult.getContext();
-        assertThat(((BigDecimal) resultContext.get("hardcoded decision")).intValue(), is(47));
+        assertThat(((BigDecimal) resultContext.get("hardcoded decision")).intValue()).isEqualTo(47);
     }
 
     @Test
@@ -1685,18 +1676,18 @@ public class DMNRuntimeTest extends BaseDMN1_1VariantTest {
         // DROOLS-2200
         final DMNRuntime runtime = DMNRuntimeUtil.createRuntime("will_be_null_if_negative.dmn", this.getClass());
         final DMNModel dmnModel = runtime.getModel("http://www.trisotech.com/definitions/_c5889555-7ae5-4a67-a872-3a9492caf6e7", "will be null if negative");
-        assertThat(dmnModel, notNullValue());
-        assertThat(DMNRuntimeUtil.formatMessages(dmnModel.getMessages()), dmnModel.hasErrors(), is(false));
+        assertThat(dmnModel).isNotNull();
+        assertThat(dmnModel.hasErrors()).as(DMNRuntimeUtil.formatMessages(dmnModel.getMessages())).isFalse();
 
         final DMNContext context = DMNFactory.newContext();
         context.set("a number", -1);
 
         final DMNResult dmnResult = runtime.evaluateAll(dmnModel, context);
-        assertThat(DMNRuntimeUtil.formatMessages(dmnResult.getMessages()), dmnResult.hasErrors(), is(false));
+        assertThat(dmnResult.hasErrors()).as(DMNRuntimeUtil.formatMessages(dmnResult.getMessages())).isFalse();
 
         final DMNContext resultContext = dmnResult.getContext();
-        assertThat(((Map) resultContext.get("will be null if negative")).get("s1"), nullValue());
-        assertThat(((Map) resultContext.get("will be null if negative")).get("s2"), is("negative"));
+        assertThat(((Map) resultContext.get("will be null if negative")).get("s1")).isNull();
+        assertThat(((Map) resultContext.get("will be null if negative")).get("s2")).isEqualTo("negative");
     }
 
     @Test
@@ -1709,17 +1700,17 @@ public class DMNRuntimeTest extends BaseDMN1_1VariantTest {
         final DMNRuntime runtime = kieContainer.newKieSession().getKieRuntime(DMNRuntime.class);
 
         final DMNModel dmnModel = runtime.getModel("http://www.trisotech.com/definitions/_42bf043d-df86-48bd-9045-dfc08aa8ba0d", "typecheck in context result");
-        assertThat(dmnModel, notNullValue());
-        assertThat(DMNRuntimeUtil.formatMessages(dmnModel.getMessages()), dmnModel.hasErrors(), is(false));
+        assertThat(dmnModel).isNotNull();
+        assertThat(dmnModel.hasErrors()).as(DMNRuntimeUtil.formatMessages(dmnModel.getMessages())).isFalse();
 
         final DMNContext emptyContext = DMNFactory.newContext();
 
         final DMNResult dmnResult = runtime.evaluateAll(dmnModel, emptyContext);
-        assertThat(DMNRuntimeUtil.formatMessages(dmnResult.getMessages()), dmnResult.hasErrors(), is(false));
+        assertThat(dmnResult.hasErrors()).as(DMNRuntimeUtil.formatMessages(dmnResult.getMessages())).isFalse();
 
         final DMNContext resultContext = dmnResult.getContext();
-        assertThat(((Map<String, Object>) resultContext.get("an hardcoded person")).keySet(), contains("name", "age"));
-        assertThat(((Map<String, Object>) resultContext.get("an hardcoded person with no name")).keySet(), contains("age"));
+        assertThat(((Map<String, Object>) resultContext.get("an hardcoded person"))).containsKeys("name", "age");
+        assertThat(((Map<String, Object>) resultContext.get("an hardcoded person with no name"))).containsKeys("age");
     }
 
     @Test
@@ -1732,17 +1723,17 @@ public class DMNRuntimeTest extends BaseDMN1_1VariantTest {
         final DMNRuntime runtime = kieContainer.newKieSession().getKieRuntime(DMNRuntime.class);
 
         final DMNModel dmnModel = runtime.getModel("http://www.trisotech.com/definitions/_99ccd4df-41ac-43c3-a563-d58f43149829", "typecheck in DT");
-        assertThat(dmnModel, notNullValue());
-        assertThat(DMNRuntimeUtil.formatMessages(dmnModel.getMessages()), dmnModel.hasErrors(), is(false));
+        assertThat(dmnModel).isNotNull();
+        assertThat(dmnModel.hasErrors()).as(DMNRuntimeUtil.formatMessages(dmnModel.getMessages())).isFalse();
 
         final DMNContext context = DMNFactory.newContext();
         context.set("a number", 0);
 
         final DMNResult dmnResult = runtime.evaluateAll(dmnModel, context);
-        assertThat(DMNRuntimeUtil.formatMessages(dmnResult.getMessages()), dmnResult.hasErrors(), is(false));
+        assertThat(dmnResult.hasErrors()).as(DMNRuntimeUtil.formatMessages(dmnResult.getMessages())).isFalse();
 
         final DMNContext resultContext = dmnResult.getContext();
-        assertThat(((BigDecimal) resultContext.get("an odd decision")).intValue(), is(47));
+        assertThat(((BigDecimal) resultContext.get("an odd decision")).intValue()).isEqualTo(47);
     }
 
     public static class DROOLS2286 {
@@ -1813,15 +1804,15 @@ public class DMNRuntimeTest extends BaseDMN1_1VariantTest {
         // DROOLS-2322
         final DMNRuntime runtime = DMNRuntimeUtil.createRuntime("just_now.dmn", this.getClass());
         final DMNModel dmnModel = runtime.getModel("http://www.trisotech.com/definitions/_56fd6445-ff6a-4c28-8206-71fce7f80436", "just now");
-        assertThat(dmnModel, notNullValue());
-        assertThat(DMNRuntimeUtil.formatMessages(dmnModel.getMessages()), dmnModel.hasErrors(), is(false));
+        assertThat(dmnModel).isNotNull();
+        assertThat(dmnModel.hasErrors()).as(DMNRuntimeUtil.formatMessages(dmnModel.getMessages())).isFalse();
 
         final DMNContext emptyContext = DMNFactory.newContext();
 
         final DMNResult dmnResult = runtime.evaluateAll(dmnModel, emptyContext);
-        assertThat(DMNRuntimeUtil.formatMessages(dmnResult.getMessages()), dmnResult.hasErrors(), is(false));
+        assertThat(dmnResult.hasErrors()).as(DMNRuntimeUtil.formatMessages(dmnResult.getMessages())).isFalse();
 
-        assertThat(dmnResult.getDecisionResultByName("a decision just now").getResult(), notNullValue());
+        assertThat(dmnResult.getDecisionResultByName("a decision just now").getResult()).isNotNull();
     }
 
     @Test
@@ -1829,15 +1820,15 @@ public class DMNRuntimeTest extends BaseDMN1_1VariantTest {
         // DROOLS-2322
         final DMNRuntime runtime = DMNRuntimeUtil.createRuntime("just_today.dmn", this.getClass());
         final DMNModel dmnModel = runtime.getModel("http://www.trisotech.com/definitions/_56fd6445-ff6a-4c28-8206-71fce7f80436", "just today");
-        assertThat(dmnModel, notNullValue());
-        assertThat(DMNRuntimeUtil.formatMessages(dmnModel.getMessages()), dmnModel.hasErrors(), is(false));
+        assertThat(dmnModel).isNotNull();
+        assertThat(dmnModel.hasErrors()).as(DMNRuntimeUtil.formatMessages(dmnModel.getMessages())).isFalse();
 
         final DMNContext emptyContext = DMNFactory.newContext();
 
         final DMNResult dmnResult = runtime.evaluateAll(dmnModel, emptyContext);
-        assertThat(DMNRuntimeUtil.formatMessages(dmnResult.getMessages()), dmnResult.hasErrors(), is(false));
+        assertThat(dmnResult.hasErrors()).as(DMNRuntimeUtil.formatMessages(dmnResult.getMessages())).isFalse();
 
-        assertThat(dmnResult.getDecisionResultByName("a decision just today").getResult(), notNullValue());
+        assertThat(dmnResult.getDecisionResultByName("a decision just today").getResult()).isNotNull();
     }
 
     @Test
@@ -1845,16 +1836,16 @@ public class DMNRuntimeTest extends BaseDMN1_1VariantTest {
         // DROOLS-2307
         final DMNRuntime runtime = DMNRuntimeUtil.createRuntime("drools2307.dmn", this.getClass());
         final DMNModel dmnModel = runtime.getModel("http://www.trisotech.com/dmn/definitions/_03d9481e-dcfc-4a59-9bdd-4f021cb2f0d8", "Drawing 1");
-        assertThat(dmnModel, notNullValue());
-        assertThat(DMNRuntimeUtil.formatMessages(dmnModel.getMessages()), dmnModel.hasErrors(), is(false));
+        assertThat(dmnModel).isNotNull();
+        assertThat(dmnModel.hasErrors()).as(DMNRuntimeUtil.formatMessages(dmnModel.getMessages())).isFalse();
 
         final DMNContext emptyContext = DMNFactory.newContext();
 
         final DMNResult dmnResult = runtime.evaluateAll(dmnModel, emptyContext);
-        assertThat(DMNRuntimeUtil.formatMessages(dmnResult.getMessages()), dmnResult.hasErrors(), is(false));
+        assertThat(dmnResult.hasErrors()).as(DMNRuntimeUtil.formatMessages(dmnResult.getMessages())).isFalse();
 
         final DMNContext result = dmnResult.getContext();
-        assertThat(result.get("an hardcoded forloop"), is(Arrays.asList(new BigDecimal(2), new BigDecimal(3), new BigDecimal(4))));
+        assertThat(result.get("an hardcoded forloop")).asList().containsExactly(new BigDecimal(2), new BigDecimal(3), new BigDecimal(4));
     }
 
     @Test
@@ -1862,29 +1853,28 @@ public class DMNRuntimeTest extends BaseDMN1_1VariantTest {
         // DROOLS-2357
         final DMNRuntime runtime = DMNRuntimeUtil.createRuntime("List_of_Vowels.dmn", this.getClass());
         final DMNModel dmnModel = runtime.getModel("http://www.trisotech.com/dmn/definitions/_c5f007ce-4d45-4aac-8729-991d4abc7826", "List of Vowels");
-        assertThat(dmnModel, notNullValue());
-        assertThat(DMNRuntimeUtil.formatMessages(dmnModel.getMessages()), dmnModel.hasErrors(), is(false));
+        assertThat(dmnModel).isNotNull();
+        assertThat(dmnModel.hasErrors()).as(DMNRuntimeUtil.formatMessages(dmnModel.getMessages())).isFalse();
 
         final DMNContext emptyContext = DMNFactory.newContext();
 
         final DMNResult dmnResult = runtime.evaluateAll(dmnModel, emptyContext);
-        assertThat(DMNRuntimeUtil.formatMessages(dmnResult.getMessages()), dmnResult.hasErrors(), is(true));
+        assertThat(dmnResult.hasErrors()).as(DMNRuntimeUtil.formatMessages(dmnResult.getMessages())).isTrue();
         assertThat(dmnResult.getMessages().stream()
                             .filter(m -> m.getMessageType() == DMNMessageType.ERROR_EVAL_NODE)
-                            .anyMatch(m -> m.getSourceId().equals("_b2205027-d06c-41b5-8419-e14b501e14a6")),
-                   is(true));
+                            .anyMatch(m -> m.getSourceId().equals("_b2205027-d06c-41b5-8419-e14b501e14a6"))).isTrue();
 
         final DMNContext result = dmnResult.getContext();
-        assertThat(result.get("Decide Vowel a"), is("a"));
-        assertThat(result.get("Decide BAD"), nullValue());
+        assertThat(result.get("Decide Vowel a")).isEqualTo("a");
+        assertThat(result.get("Decide BAD")).isNull();
     }
 
     @Test
     public void testEnhancedForLoop2() {
         final DMNRuntime runtime = DMNRuntimeUtil.createRuntime("MACD-enhanced_iteration.dmn", this.getClass());
         final DMNModel dmnModel = runtime.getModel("http://www.trisotech.com/definitions/_6cfe7d88-6741-45d1-968c-b61a597d0964", "MACD-enhanced iteration");
-        assertThat(dmnModel, notNullValue());
-        assertThat(DMNRuntimeUtil.formatMessages(dmnModel.getMessages()), dmnModel.hasErrors(), is(false));
+        assertThat(dmnModel).isNotNull();
+        assertThat(dmnModel.hasErrors()).as(DMNRuntimeUtil.formatMessages(dmnModel.getMessages())).isFalse();
 
         final DMNContext context = DMNFactory.newContext();
         final Map<String, Object> d1 = prototype(entry("aDate", LocalDate.of(2018, 3, 5)), entry("Close", 1010));
@@ -1893,13 +1883,13 @@ public class DMNRuntimeTest extends BaseDMN1_1VariantTest {
         context.set("DailyTable", Arrays.asList(d1, d2, d3));
 
         final DMNResult dmnResult = runtime.evaluateAll(dmnModel, context);
-        assertThat(DMNRuntimeUtil.formatMessages(dmnResult.getMessages()), dmnResult.hasErrors(), is(false));
+        assertThat(dmnResult.hasErrors()).as(DMNRuntimeUtil.formatMessages(dmnResult.getMessages())).isFalse();
         LOG.debug("{}", dmnResult);
 
         final DMNContext resultContext = dmnResult.getContext();
-        assertThat(((Map<String, Object>) ((List) resultContext.get("MACDTable")).get(0)).get("aDate"), is(LocalDate.of(2018, 3, 5)));
-        assertThat(((Map<String, Object>) ((List) resultContext.get("MACDTable")).get(1)).get("aDate"), is(LocalDate.of(2018, 3, 6)));
-        assertThat(((Map<String, Object>) ((List) resultContext.get("MACDTable")).get(2)).get("aDate"), is(LocalDate.of(2018, 3, 7)));
+        assertThat(((Map<String, Object>) ((List) resultContext.get("MACDTable")).get(0)).get("aDate")).isEqualTo(LocalDate.of(2018, 3, 5));
+        assertThat(((Map<String, Object>) ((List) resultContext.get("MACDTable")).get(1)).get("aDate")).isEqualTo(LocalDate.of(2018, 3, 6));
+        assertThat(((Map<String, Object>) ((List) resultContext.get("MACDTable")).get(2)).get("aDate")).isEqualTo(LocalDate.of(2018, 3, 7));
     }
 
     @Test
@@ -1907,17 +1897,17 @@ public class DMNRuntimeTest extends BaseDMN1_1VariantTest {
         // DROOLS-2416
         final DMNRuntime runtime = DMNRuntimeUtil.createRuntime("anot.dmn", this.getClass());
         final DMNModel dmnModel = runtime.getModel("http://www.trisotech.com/dmn/definitions/_292c1c7b-6b38-415d-938f-e9ca51d30b2b", "anot");
-        assertThat(dmnModel, notNullValue());
-        assertThat(DMNRuntimeUtil.formatMessages(dmnModel.getMessages()), dmnModel.hasErrors(), is(false));
+        assertThat(dmnModel).isNotNull();
+        assertThat(dmnModel.hasErrors()).as(DMNRuntimeUtil.formatMessages(dmnModel.getMessages())).isFalse();
 
         final DMNContext context = DMNFactory.newContext();
         context.set("a letter", "a");
 
         final DMNResult dmnResult = runtime.evaluateAll(dmnModel, context);
-        assertThat(DMNRuntimeUtil.formatMessages(dmnResult.getMessages()), dmnResult.hasErrors(), is(false));
+        assertThat(dmnResult.hasErrors()).as(DMNRuntimeUtil.formatMessages(dmnResult.getMessages())).isFalse();
 
         final DMNContext result = dmnResult.getContext();
-        assertThat(result.get("what letter decision"), is("vowel"));
+        assertThat(result.get("what letter decision")).isEqualTo("vowel");
     }
 
     @Test
@@ -1925,17 +1915,17 @@ public class DMNRuntimeTest extends BaseDMN1_1VariantTest {
         // DROOLS-2416
         final DMNRuntime runtime = DMNRuntimeUtil.createRuntime("list_containment_DT.dmn", this.getClass());
         final DMNModel dmnModel = runtime.getModel("http://www.trisotech.com/definitions/_6ab2bd6d-adaa-45c4-a141-a84382a201eb", "list containment DT");
-        assertThat(dmnModel, notNullValue());
-        assertThat(DMNRuntimeUtil.formatMessages(dmnModel.getMessages()), dmnModel.hasErrors(), is(false));
+        assertThat(dmnModel).isNotNull();
+        assertThat(dmnModel.hasErrors()).as(DMNRuntimeUtil.formatMessages(dmnModel.getMessages())).isFalse();
 
         final DMNContext context = DMNFactory.newContext();
         context.set("Passenger", prototype(entry("name", "Osama bin Laden")));
 
         final DMNResult dmnResult = runtime.evaluateAll(dmnModel, context);
-        assertThat(DMNRuntimeUtil.formatMessages(dmnResult.getMessages()), dmnResult.hasErrors(), is(false));
+        assertThat(dmnResult.hasErrors()).as(DMNRuntimeUtil.formatMessages(dmnResult.getMessages())).isFalse();
 
         final DMNContext result = dmnResult.getContext();
-        assertThat(result.get("Boarding Status"), is("Denied"));
+        assertThat(result.get("Boarding Status")).isEqualTo("Denied");
     }
 
     @Test
@@ -1943,20 +1933,20 @@ public class DMNRuntimeTest extends BaseDMN1_1VariantTest {
         // DROOLS-2439
         final DMNRuntime runtime = DMNRuntimeUtil.createRuntime("relation_with_empty_cell.dmn", this.getClass());
         final DMNModel dmnModel = runtime.getModel("http://www.trisotech.com/dmn/definitions/_99a00903-2943-47df-bab1-a32f276617ea", "Relation with empty cell");
-        assertThat(dmnModel, notNullValue());
-        assertThat(DMNRuntimeUtil.formatMessages(dmnModel.getMessages()), dmnModel.hasErrors(), is(false));
+        assertThat(dmnModel).isNotNull();
+        assertThat(dmnModel.hasErrors()).as(DMNRuntimeUtil.formatMessages(dmnModel.getMessages())).isFalse();
 
         final DMNContext context = DMNFactory.newContext();
 
         final DMNResult dmnResult = runtime.evaluateAll(dmnModel, context);
         System.out.println(dmnResult);
-        assertThat(DMNRuntimeUtil.formatMessages(dmnResult.getMessages()), dmnResult.hasErrors(), is(false));
+        assertThat(dmnResult.hasErrors()).as(DMNRuntimeUtil.formatMessages(dmnResult.getMessages())).isFalse();
 
         final DMNContext result = dmnResult.getContext();
-        assertThat(result.get("Decision A"), is(Arrays.asList(prototype(entry("name", null), entry("age", null)),
+        assertThat(result.get("Decision A")).asList().containsExactly(prototype(entry("name", null), entry("age", null)),
                                                               prototype(entry("name", "John"), entry("age", new BigDecimal(1))),
                                                               prototype(entry("name", null), entry("age", null)),
-                                                              prototype(entry("name", "Matteo"), entry("age", null)))));
+                                                              prototype(entry("name", "Matteo"), entry("age", null)));
     }
 
     @Test
@@ -1964,8 +1954,8 @@ public class DMNRuntimeTest extends BaseDMN1_1VariantTest {
         // DROOLS-2317
         final DMNRuntime runtime = DMNRuntimeUtil.createRuntime("Dynamic composition.dmn", this.getClass());
         final DMNModel dmnModel = runtime.getModel("http://www.trisotech.com/definitions/_c2d86765-c3c7-4e1d-b1fa-b830fa5bc529", "Dynamic composition");
-        assertThat(dmnModel, notNullValue());
-        assertThat(DMNRuntimeUtil.formatMessages(dmnModel.getMessages()), dmnModel.hasErrors(), is(false));
+        assertThat(dmnModel).isNotNull();
+        assertThat(dmnModel.hasErrors()).as(DMNRuntimeUtil.formatMessages(dmnModel.getMessages())).isFalse();
     }
 
     @Test
@@ -1973,24 +1963,24 @@ public class DMNRuntimeTest extends BaseDMN1_1VariantTest {
         // DROOLS-2317 FEEL Syntax error on function(bkm) containing `for` keyword
         final DMNRuntime runtime = DMNRuntimeUtil.createRuntime("say_for_hello.dmn", this.getClass());
         final DMNModel dmnModel = runtime.getModel("http://www.trisotech.com/dmn/definitions/_b6f2a9ca-a246-4f27-896a-e8ef04ea439c", "say for hello");
-        assertThat(dmnModel, notNullValue());
-        assertThat(DMNRuntimeUtil.formatMessages(dmnModel.getMessages()), dmnModel.hasErrors(), is(false));
+        assertThat(dmnModel).isNotNull();
+        assertThat(dmnModel.hasErrors()).as(DMNRuntimeUtil.formatMessages(dmnModel.getMessages())).isFalse();
 
         final DMNContext emptyContext = DMNFactory.newContext();
 
         final DMNResult dmnResult = runtime.evaluateAll(dmnModel, emptyContext);
-        assertThat(DMNRuntimeUtil.formatMessages(dmnResult.getMessages()), dmnResult.hasErrors(), is(false));
+        assertThat(dmnResult.hasErrors()).as(DMNRuntimeUtil.formatMessages(dmnResult.getMessages())).isFalse();
 
         final DMNContext result = dmnResult.getContext();
-        assertThat(result.get("just say"), is(Arrays.asList("Hello", "Hello", "Hello")));
+        assertThat(result.get("just say")).asList().containsExactly("Hello", "Hello", "Hello");
     }
 
     @Test
     public void testProductFunction() {
         final DMNRuntime runtime = DMNRuntimeUtil.createRuntime("product.dmn", this.getClass() );
         final DMNModel model = runtime.getModel("http://www.trisotech.com/dmn/definitions/_40fdbc2c-a631-4ba4-8435-17571b5d1942", "Drawing 1" );
-        assertThat( model, notNullValue() );
-        assertThat( DMNRuntimeUtil.formatMessages( model.getMessages() ), model.hasErrors(), is( false ) );
+        assertThat(model).isNotNull();
+        assertThat(model.hasErrors()).as(DMNRuntimeUtil.formatMessages(model.getMessages())).isFalse();
         final DMNContext context = DMNFactory.newContext();
         context.set("product", new HashMap<String, Object>(){{
             put("name", "Product1");
@@ -2006,22 +1996,22 @@ public class DMNRuntimeTest extends BaseDMN1_1VariantTest {
         // DROOLS-2605
         final DMNRuntime runtime = DMNRuntimeUtil.createRuntime("test20180601.dmn", this.getClass());
         final DMNModel dmnModel = runtime.getModel("http://www.trisotech.com/dmn/definitions/_9b8f2642-2597-4a99-9fcd-f9302692d3dc", "Drawing 1");
-        assertThat(dmnModel, notNullValue());
-        assertThat(DMNRuntimeUtil.formatMessages(dmnModel.getMessages()), dmnModel.hasErrors(), is(false));
+        assertThat(dmnModel).isNotNull();
+        assertThat(dmnModel.hasErrors()).as(DMNRuntimeUtil.formatMessages(dmnModel.getMessages())).isFalse();
 
         final DMNContext context3 = DMNFactory.newContext();
         context3.set("my num", new BigDecimal(3));
 
         final DMNResult dmnResult3 = runtime.evaluateAll(dmnModel, context3);
-        assertThat(DMNRuntimeUtil.formatMessages(dmnResult3.getMessages()), dmnResult3.hasErrors(), is(false));
-        assertThat(dmnResult3.getDecisionResultByName("my decision").getResult(), is(false));
+        assertThat(dmnResult3.hasErrors()).as(DMNRuntimeUtil.formatMessages(dmnResult3.getMessages())).isFalse();
+        assertThat(dmnResult3.getDecisionResultByName("my decision").getResult()).isEqualTo(Boolean.FALSE);
 
         final DMNContext context10 = DMNFactory.newContext();
         context10.set("my num", new BigDecimal(10));
 
         final DMNResult dmnResult10 = runtime.evaluateAll(dmnModel, context10);
-        assertThat(DMNRuntimeUtil.formatMessages(dmnResult10.getMessages()), dmnResult10.hasErrors(), is(false));
-        assertThat(dmnResult10.getDecisionResultByName("my decision").getResult(), is(true));
+        assertThat(dmnResult10.hasErrors()).as(DMNRuntimeUtil.formatMessages(dmnResult10.getMessages())).isFalse();
+        assertThat(dmnResult10.getDecisionResultByName("my decision").getResult()).isEqualTo(Boolean.TRUE);
     }
 
     @Test
@@ -2029,8 +2019,8 @@ public class DMNRuntimeTest extends BaseDMN1_1VariantTest {
         // DROOLS-2605
         final DMNRuntime runtime = DMNRuntimeUtil.createRuntime("BruceTask20180601.dmn", this.getClass());
         final DMNModel dmnModel = runtime.getModel("http://www.trisotech.com/definitions/_3802fcb2-5b93-4502-aff4-0f5c61244eab", "Bruce Task");
-        assertThat(dmnModel, notNullValue());
-        assertThat(DMNRuntimeUtil.formatMessages(dmnModel.getMessages()), dmnModel.hasErrors(), is(false));
+        assertThat(dmnModel).isNotNull();
+        assertThat(dmnModel.hasErrors()).as(DMNRuntimeUtil.formatMessages(dmnModel.getMessages())).isFalse();
 
         final DMNContext context = DMNFactory.newContext();
         context.set("TheBook", Arrays.asList(prototype(entry("Title", "55"), entry("Price", new BigDecimal(5)), entry("Quantity", new BigDecimal(5))),
@@ -2040,10 +2030,10 @@ public class DMNRuntimeTest extends BaseDMN1_1VariantTest {
                                              prototype(entry("Title", "66"), entry("Price", new BigDecimal(6)), entry("Quantity", new BigDecimal(6)))));
 
         final DMNResult dmnResult = runtime.evaluateAll(dmnModel, context);
-        assertThat(DMNRuntimeUtil.formatMessages(dmnResult.getMessages()), dmnResult.hasErrors(), is(false));
+        assertThat(dmnResult.hasErrors()).as(DMNRuntimeUtil.formatMessages(dmnResult.getMessages())).isFalse();
 
         final DMNContext result = dmnResult.getContext();
-        assertThat(result.get("Bruce"), is(instanceOf(Map.class)));
+        assertThat(result.get("Bruce")).isInstanceOf(Map.class);
         final Map<String, Object> bruce = (Map<String, Object>) result.get("Bruce");
 
         assertEquals(2, ((List) bruce.get("one")).size());
@@ -2075,8 +2065,8 @@ public class DMNRuntimeTest extends BaseDMN1_1VariantTest {
     public void testModelById() {
         final DMNRuntime runtime = DMNRuntimeUtil.createRuntime("simple-item-def.dmn", this.getClass() );
         final DMNModel dmnModel = runtime.getModelById("https://github.com/kiegroup/kie-dmn/itemdef", "_simple-item-def" );
-        assertThat( dmnModel, notNullValue() );
-        assertThat( DMNRuntimeUtil.formatMessages( dmnModel.getMessages() ), dmnModel.hasErrors(), is( false ) );
+        assertThat(dmnModel).isNotNull();
+        assertThat(dmnModel.hasErrors()).as(DMNRuntimeUtil.formatMessages(dmnModel.getMessages())).isFalse();
 
     }
 
@@ -2085,8 +2075,8 @@ public class DMNRuntimeTest extends BaseDMN1_1VariantTest {
         // DROOLS-2648 DMN v1.2 weekday on 'date', 'date and time'
         final DMNRuntime runtime = DMNRuntimeUtil.createRuntime("weekday-on-date.dmn", this.getClass());
         final DMNModel dmnModel = runtime.getModel("http://www.trisotech.com/definitions/_55a2dafd-ab4d-4154-bace-826d426da251", "weekday on date");
-        assertThat(dmnModel, notNullValue());
-        assertThat(DMNRuntimeUtil.formatMessages(dmnModel.getMessages()), dmnModel.hasErrors(), is(false));
+        assertThat(dmnModel).isNotNull();
+        assertThat(dmnModel.hasErrors()).as(DMNRuntimeUtil.formatMessages(dmnModel.getMessages())).isFalse();
 
         for (int i = 0; i < 7; i++) {
             final DMNContext context = DMNFactory.newContext();
@@ -2094,10 +2084,10 @@ public class DMNRuntimeTest extends BaseDMN1_1VariantTest {
 
             final DMNResult dmnResult = runtime.evaluateAll(dmnModel, context);
             LOG.debug("{}", dmnResult);
-            assertThat(DMNRuntimeUtil.formatMessages(dmnResult.getMessages()), dmnResult.hasErrors(), is(false));
+            assertThat(dmnResult.hasErrors()).as(DMNRuntimeUtil.formatMessages(dmnResult.getMessages())).isFalse();
 
             final DMNContext result = dmnResult.getContext();
-            assertThat(result.get("Weekday"), is(new BigDecimal(i + 1)));
+            assertThat(result.get("Weekday")).isEqualTo(new BigDecimal(i + 1));
         }
     }
 
@@ -2106,8 +2096,8 @@ public class DMNRuntimeTest extends BaseDMN1_1VariantTest {
         // DROOLS-2665
         final DMNRuntime runtime = DMNRuntimeUtil.createRuntime("Instance_of.dmn", this.getClass());
         final DMNModel dmnModel = runtime.getModel("http://www.trisotech.com/definitions/_b5c4d644-5a15-4528-8028-86537cb1c836", "Instance of");
-        assertThat(dmnModel, notNullValue());
-        assertThat(DMNRuntimeUtil.formatMessages(dmnModel.getMessages()), dmnModel.hasErrors(), is(false));
+        assertThat(dmnModel).isNotNull();
+        assertThat(dmnModel.hasErrors()).as(DMNRuntimeUtil.formatMessages(dmnModel.getMessages())).isFalse();
 
         final DMNContext context = DMNFactory.newContext();
         context.set("input year month duration", Duration.parse("P12D"));
@@ -2117,13 +2107,13 @@ public class DMNRuntimeTest extends BaseDMN1_1VariantTest {
 
         final DMNResult dmnResult = runtime.evaluateAll(dmnModel, context);
         LOG.debug("{}", dmnResult);
-        assertThat(DMNRuntimeUtil.formatMessages(dmnResult.getMessages()), dmnResult.hasErrors(), is(false));
+        assertThat(dmnResult.hasErrors()).as(DMNRuntimeUtil.formatMessages(dmnResult.getMessages())).isFalse();
 
         final DMNContext result = dmnResult.getContext();
-        assertThat(result.get("Decision Logic 1"), is(true));
-        assertThat(result.get("Decision Logic 2"), is(true));
-        assertThat(result.get("Decision Logic 3"), is(true));
-        assertThat(result.get("Decision Logic 4"), is(true));
+        assertThat(result.get("Decision Logic 1")).isEqualTo(Boolean.TRUE);
+        assertThat(result.get("Decision Logic 2")).isEqualTo(Boolean.TRUE);
+        assertThat(result.get("Decision Logic 3")).isEqualTo(Boolean.TRUE);
+        assertThat(result.get("Decision Logic 4")).isEqualTo(Boolean.TRUE);
     }
 
     @Test
@@ -2131,17 +2121,17 @@ public class DMNRuntimeTest extends BaseDMN1_1VariantTest {
         // DROOLS-2732 FEEL invoking a function on a literal context
         final DMNRuntime runtime = DMNRuntimeUtil.createRuntime("invokingAFunctionOnALiteralContext.dmn", this.getClass());
         final DMNModel dmnModel = runtime.getModel("http://www.trisotech.com/dmn/definitions/_781968dd-64dc-4231-9cd0-2ce590881f2c", "Drawing 1");
-        assertThat(dmnModel, notNullValue());
-        assertThat(DMNRuntimeUtil.formatMessages(dmnModel.getMessages()), dmnModel.hasErrors(), is(false));
+        assertThat(dmnModel).isNotNull();
+        assertThat(dmnModel.hasErrors()).as(DMNRuntimeUtil.formatMessages(dmnModel.getMessages())).isFalse();
 
         final DMNContext emptyContext = DMNFactory.newContext();
 
         final DMNResult dmnResult = runtime.evaluateAll(dmnModel, emptyContext);
         LOG.debug("{}", dmnResult);
-        assertThat(DMNRuntimeUtil.formatMessages(dmnResult.getMessages()), dmnResult.hasErrors(), is(false));
+        assertThat(dmnResult.hasErrors()).as(DMNRuntimeUtil.formatMessages(dmnResult.getMessages())).isFalse();
 
         final DMNContext result = dmnResult.getContext();
-        assertThat(result.get("invoking a function on a literal context"), is(new BigDecimal(3)));
+        assertThat(result.get("invoking a function on a literal context")).isEqualTo(new BigDecimal(3));
     }
 
     @Test
@@ -2157,25 +2147,25 @@ public class DMNRuntimeTest extends BaseDMN1_1VariantTest {
         // DROOLS-2822 FEEL augment not() heuristic for function invocation
         final DMNRuntime runtime = DMNRuntimeUtil.createRuntime("Not-heuristic-for-function-invocation-drools-2822.dmn", this.getClass());
         final DMNModel dmnModel = runtime.getModel("http://www.trisotech.com/dmn/definitions/_82f7e67e-0a8c-492d-aa78-94851c10eee6", "Drawing 1");
-        assertThat(dmnModel, notNullValue());
-        assertThat(DMNRuntimeUtil.formatMessages(dmnModel.getMessages()), dmnModel.hasErrors(), is(false));
+        assertThat(dmnModel).isNotNull();
+        assertThat(dmnModel.hasErrors()).as(DMNRuntimeUtil.formatMessages(dmnModel.getMessages())).isFalse();
 
         final DMNContext emptyContext = DMNFactory.newContext();
 
         final DMNResult dmnResult = runtime.evaluateAll(dmnModel, emptyContext);
         LOG.debug("{}", dmnResult);
-        assertThat(DMNRuntimeUtil.formatMessages(dmnResult.getMessages()), dmnResult.hasErrors(), is(false));
+        assertThat(dmnResult.hasErrors()).as(DMNRuntimeUtil.formatMessages(dmnResult.getMessages())).isFalse();
 
         final DMNContext result = dmnResult.getContext();
-        assertThat(result.get("Not working"), is(false));
+        assertThat(result.get("Not working")).isEqualTo(Boolean.FALSE);
     }
     
     @Test(timeout = 30_000L)
     public void testAccessorCache() {
         final DMNRuntime runtime = DMNRuntimeUtil.createRuntime("20180731-pr1997.dmn", this.getClass());
         final DMNModel dmnModel = runtime.getModel("http://www.trisotech.com/dmn/definitions/_7a39d775-bce9-45e3-aa3b-147d6f0028c7", "20180731-pr1997");
-        assertThat(dmnModel, notNullValue());
-        assertThat(DMNRuntimeUtil.formatMessages(dmnModel.getMessages()), dmnModel.hasErrors(), is(false));
+        assertThat(dmnModel).isNotNull();
+        assertThat(dmnModel.hasErrors()).as(DMNRuntimeUtil.formatMessages(dmnModel.getMessages())).isFalse();
 
         for (int i = 0; i < 10_000; i++) {
             final DMNContext context = DMNFactory.newContext();
@@ -2183,10 +2173,10 @@ public class DMNRuntimeTest extends BaseDMN1_1VariantTest {
 
             final DMNResult dmnResult = runtime.evaluateAll(dmnModel, context);
             LOG.debug("{}", dmnResult);
-            assertThat(DMNRuntimeUtil.formatMessages(dmnResult.getMessages()), dmnResult.hasErrors(), is(false));
+            assertThat(dmnResult.hasErrors()).as(DMNRuntimeUtil.formatMessages(dmnResult.getMessages())).isFalse();
 
             final DMNContext result = dmnResult.getContext();
-            assertThat(result.get("Say hello and age"), is("Hello John Doe, your age is: " + i));
+            assertThat(result.get("Say hello and age")).isEqualTo("Hello John Doe, your age is: " + i);
         }
     }
 
@@ -2195,10 +2185,10 @@ public class DMNRuntimeTest extends BaseDMN1_1VariantTest {
         // DROOLS-2917 DMN resolveTypeRef returning null in BKM causes NPE during KieContainer compilation
         final List<DMNMessage> messages = DMNRuntimeUtil.createExpectingDMNMessages("WrongTypeRefForDRGElement.dmn", this.getClass());
         DMNRuntimeUtil.formatMessages(messages);
-        assertThat(messages.isEmpty(), is(false));
-        assertThat(messages.stream().anyMatch(m -> m.getMessageType().equals(DMNMessageType.TYPE_DEF_NOT_FOUND)), is(true));
-        assertThat(messages.stream().anyMatch(m -> m.getSourceId().equals("_561d31ba-a34b-4cf3-b9a4-537e21ce1013")), is(true));
-        assertThat(messages.stream().anyMatch(m -> m.getSourceId().equals("_45fa8674-f4f0-4c06-b2fd-52bbd17d8550")), is(true));
+        assertThat(messages).isNotEmpty();
+        assertThat(messages.stream().anyMatch(m -> m.getMessageType().equals(DMNMessageType.TYPE_DEF_NOT_FOUND))).isTrue();
+        assertThat(messages.stream().anyMatch(m -> m.getSourceId().equals("_561d31ba-a34b-4cf3-b9a4-537e21ce1013"))).isTrue();
+        assertThat(messages.stream().anyMatch(m -> m.getSourceId().equals("_45fa8674-f4f0-4c06-b2fd-52bbd17d8550"))).isTrue();
     }
 
     @Test
@@ -2208,8 +2198,8 @@ public class DMNRuntimeTest extends BaseDMN1_1VariantTest {
                                                                                        this.getClass(),
                                                                                        "imports/Importing_Person_DT_with_Person.dmn");
         final DMNModel dmnModel = runtime.getModel("http://www.trisotech.com/dmn/definitions/_3d586cb1-3ed0-4bc4-a1a7-070b70ece398", "Importing Person DT with Person");
-        assertThat(dmnModel, notNullValue());
-        assertThat(DMNRuntimeUtil.formatMessages(dmnModel.getMessages()), dmnModel.hasErrors(), is(false));
+        assertThat(dmnModel).isNotNull();
+        assertThat(dmnModel.hasErrors()).as(DMNRuntimeUtil.formatMessages(dmnModel.getMessages())).isFalse();
 
         final DMNContext context = DMNFactory.newContext();
         context.set("A Person here", mapOf(entry("age", new BigDecimal(17)),
@@ -2217,10 +2207,10 @@ public class DMNRuntimeTest extends BaseDMN1_1VariantTest {
 
         final DMNResult dmnResult = runtime.evaluateAll(dmnModel, context);
         LOG.debug("{}", dmnResult);
-        assertThat(DMNRuntimeUtil.formatMessages(dmnResult.getMessages()), dmnResult.hasErrors(), is(false));
+        assertThat(dmnResult.hasErrors()).as(DMNRuntimeUtil.formatMessages(dmnResult.getMessages())).isFalse();
 
         final DMNContext result = dmnResult.getContext();
-        assertThat(result.get("A Decision Table"), is("NOT Allowed"));
+        assertThat(result.get("A Decision Table")).isEqualTo("NOT Allowed");
     }
 
     @Test
@@ -2228,17 +2218,17 @@ public class DMNRuntimeTest extends BaseDMN1_1VariantTest {
         // DROOLS-3132 DMN assign null to ItemDefinition with allowedValues
         final DMNRuntime runtime = DMNRuntimeUtil.createRuntime("assignNullToAllowedValues.dmn", this.getClass());
         final DMNModel dmnModel = runtime.getModel("http://www.trisotech.com/dmn/definitions/_700a46e0-01ed-4361-9034-4afdb2537ea4", "Drawing 1");
-        assertThat(dmnModel, notNullValue());
-        assertThat(DMNRuntimeUtil.formatMessages(dmnModel.getMessages()), dmnModel.hasErrors(), is(false));
+        assertThat(dmnModel).isNotNull();
+        assertThat(dmnModel.hasErrors()).as(DMNRuntimeUtil.formatMessages(dmnModel.getMessages())).isFalse();
 
         final DMNContext context = DMNFactory.newContext();
         context.set("an input letter", null);
         final DMNResult dmnResult = runtime.evaluateAll(dmnModel, context);
         LOG.debug("{}", dmnResult);
         DMNRuntimeUtil.formatMessages(dmnResult.getMessages());
-        assertThat(dmnResult.hasErrors(), is(true));
-        assertThat(dmnResult.getMessages().stream().anyMatch(m -> m.getSourceId().equals("_24e8b31b-9505-4f52-93af-6dd9ef39c72a")), is(true));
-        assertThat(dmnResult.getMessages().stream().anyMatch(m -> m.getSourceId().equals("_09945fda-2b89-4148-8758-0bcb91a66e4a")), is(true));
+        assertThat(dmnResult.hasErrors()).isTrue();
+        assertThat(dmnResult.getMessages().stream().anyMatch(m -> m.getSourceId().equals("_24e8b31b-9505-4f52-93af-6dd9ef39c72a"))).isTrue();
+        assertThat(dmnResult.getMessages().stream().anyMatch(m -> m.getSourceId().equals("_09945fda-2b89-4148-8758-0bcb91a66e4a"))).isTrue();
     }
 
     @Test
@@ -2246,18 +2236,18 @@ public class DMNRuntimeTest extends BaseDMN1_1VariantTest {
         // DROOLS-3132 DMN assign null to ItemDefinition with allowedValues
         final DMNRuntime runtime = DMNRuntimeUtil.createRuntime("assignNullToAllowedValuesExplicitingNull.dmn", this.getClass());
         final DMNModel dmnModel = runtime.getModel("http://www.trisotech.com/dmn/definitions/_700a46e0-01ed-4361-9034-4afdb2537ea4", "Drawing 1");
-        assertThat(dmnModel, notNullValue());
-        assertThat(DMNRuntimeUtil.formatMessages(dmnModel.getMessages()), dmnModel.hasErrors(), is(false));
+        assertThat(dmnModel).isNotNull();
+        assertThat(dmnModel.hasErrors()).as(DMNRuntimeUtil.formatMessages(dmnModel.getMessages())).isFalse();
 
         final DMNContext context = DMNFactory.newContext();
         context.set("an input letter", null);
         final DMNResult dmnResult = runtime.evaluateAll(dmnModel, context);
         LOG.debug("{}", dmnResult);
-        assertThat(DMNRuntimeUtil.formatMessages(dmnResult.getMessages()), dmnResult.hasErrors(), is(false));
-        assertThat(dmnResult.getDecisionResultByName("hardcoded letter").getEvaluationStatus(), is(DecisionEvaluationStatus.SUCCEEDED));
-        assertThat(dmnResult.getDecisionResultByName("hardcoded letter").getResult(), nullValue());
-        assertThat(dmnResult.getDecisionResultByName("decision over the input letter").getEvaluationStatus(), is(DecisionEvaluationStatus.SUCCEEDED));
-        assertThat(dmnResult.getDecisionResultByName("decision over the input letter").getResult(), nullValue());
+        assertThat(dmnResult.hasErrors()).as(DMNRuntimeUtil.formatMessages(dmnResult.getMessages())).isFalse();
+        assertThat(dmnResult.getDecisionResultByName("hardcoded letter").getEvaluationStatus()).isEqualTo(DecisionEvaluationStatus.SUCCEEDED);
+        assertThat(dmnResult.getDecisionResultByName("hardcoded letter").getResult()).isNull();
+        assertThat(dmnResult.getDecisionResultByName("decision over the input letter").getEvaluationStatus()).isEqualTo(DecisionEvaluationStatus.SUCCEEDED);
+        assertThat(dmnResult.getDecisionResultByName("decision over the input letter").getResult()).isNull();
     }
 
     @Test
@@ -2269,9 +2259,9 @@ public class DMNRuntimeTest extends BaseDMN1_1VariantTest {
         final DMNContext emptyContext = DMNFactory.newContext();
         final DMNResult dmnResult = runtime.evaluateAll(dmnModel, emptyContext);
         LOG.debug("{}", dmnResult);
-        assertThat(DMNRuntimeUtil.formatMessages(dmnResult.getMessages()), dmnResult.hasErrors(), is(false));
-        assertThat(dmnResult.getDecisionResultByName("using get entries").getEvaluationStatus(), is(DecisionEvaluationStatus.SUCCEEDED));
-        assertThat(dmnResult.getDecisionResultByName("using get entries").getResult(), is(Arrays.asList("value2")));
+        assertThat(dmnResult.hasErrors()).as(DMNRuntimeUtil.formatMessages(dmnResult.getMessages())).isFalse();
+        assertThat(dmnResult.getDecisionResultByName("using get entries").getEvaluationStatus()).isEqualTo(DecisionEvaluationStatus.SUCCEEDED);
+        assertThat(dmnResult.getDecisionResultByName("using get entries").getResult()).asList().containsExactly("value2");
     }
 
     @Test
@@ -2283,9 +2273,9 @@ public class DMNRuntimeTest extends BaseDMN1_1VariantTest {
         final DMNContext emptyContext = DMNFactory.newContext();
         final DMNResult dmnResult = runtime.evaluateAll(dmnModel, emptyContext);
         LOG.debug("{}", dmnResult);
-        assertThat(DMNRuntimeUtil.formatMessages(dmnResult.getMessages()), dmnResult.hasErrors(), is(false));
-        assertThat(dmnResult.getDecisionResultByName("using get value").getEvaluationStatus(), is(DecisionEvaluationStatus.SUCCEEDED));
-        assertThat(dmnResult.getDecisionResultByName("using get value").getResult(), is("value2"));
+        assertThat(dmnResult.hasErrors()).as(DMNRuntimeUtil.formatMessages(dmnResult.getMessages())).isFalse();
+        assertThat(dmnResult.getDecisionResultByName("using get value").getEvaluationStatus()).isEqualTo(DecisionEvaluationStatus.SUCCEEDED);
+        assertThat(dmnResult.getDecisionResultByName("using get value").getResult()).isEqualTo("value2");
     }
 
     @Test
@@ -2303,26 +2293,26 @@ public class DMNRuntimeTest extends BaseDMN1_1VariantTest {
     private void testDTinputExprCollectionWithAllowedValues(final DMNRuntime runtime) {
         // DROOLS-4379 DMN decision table input expr collection with allowedValues
         final DMNModel dmnModel = runtime.getModel("http://www.trisotech.com/definitions/_95436b7a-7268-4713-bf84-58bff10407b4", "Dessin 1");
-        assertThat(dmnModel, notNullValue());
-        assertThat(DMNRuntimeUtil.formatMessages(dmnModel.getMessages()), dmnModel.hasErrors(), is(false));
+        assertThat(dmnModel).isNotNull();
+        assertThat(dmnModel.hasErrors()).as(DMNRuntimeUtil.formatMessages(dmnModel.getMessages())).isFalse();
 
         final DMNContext context = DMNFactory.newContext();
         context.set("test", Arrays.asList("r2", "r1"));
         final DMNResult dmnResult = runtime.evaluateAll(dmnModel, context);
         LOG.debug("{}", dmnResult);
-        assertThat(DMNRuntimeUtil.formatMessages(dmnResult.getMessages()), dmnResult.hasErrors(), is(false));
+        assertThat(dmnResult.hasErrors()).as(DMNRuntimeUtil.formatMessages(dmnResult.getMessages())).isFalse();
 
         final DMNContext result = dmnResult.getContext();
-        assertThat(result.get("D4"), is("Contains r1"));
-        assertThat((List<?>) result.get("D5"), contains(is("r1"), is("r2")));
+        assertThat(result.get("D4")).isEqualTo("Contains r1");
+        assertThat((List<?>) result.get("D5")).asList().contains("r1", "r2");
     }
 
     @Test(expected = IllegalArgumentException.class)
     public void testEvaluateByNameWithEmptyParam() {
         final DMNRuntime runtime = DMNRuntimeUtil.createRuntime("simple-item-def.dmn", this.getClass());
         final DMNModel dmnModel = runtime.getModel("https://github.com/kiegroup/kie-dmn/itemdef", "simple-item-def");
-        assertThat(dmnModel, notNullValue());
-        assertThat(DMNRuntimeUtil.formatMessages(dmnModel.getMessages()), dmnModel.hasErrors(), is(false));
+        assertThat(dmnModel).isNotNull();
+        assertThat(dmnModel.hasErrors()).as(DMNRuntimeUtil.formatMessages(dmnModel.getMessages())).isFalse();
 
         final DMNContext context = DMNFactory.newContext();
         context.set("Monthly Salary", 1000);
@@ -2335,8 +2325,8 @@ public class DMNRuntimeTest extends BaseDMN1_1VariantTest {
     public void testEvaluateByIdWithEmptyParam() {
         final DMNRuntime runtime = DMNRuntimeUtil.createRuntime("simple-item-def.dmn", this.getClass());
         final DMNModel dmnModel = runtime.getModel("https://github.com/kiegroup/kie-dmn/itemdef", "simple-item-def");
-        assertThat(dmnModel, notNullValue());
-        assertThat(DMNRuntimeUtil.formatMessages(dmnModel.getMessages()), dmnModel.hasErrors(), is(false));
+        assertThat(dmnModel).isNotNull();
+        assertThat(dmnModel.hasErrors()).as(DMNRuntimeUtil.formatMessages(dmnModel.getMessages())).isFalse();
 
         final DMNContext context = DMNFactory.newContext();
         context.set("Monthly Salary", 1000);
@@ -2349,8 +2339,8 @@ public class DMNRuntimeTest extends BaseDMN1_1VariantTest {
     public void testUniqueMissingMatchDefaultEmpty() {
         final DMNRuntime runtime = DMNRuntimeUtil.createRuntime("uniqueNoMatch.dmn", this.getClass());
         final DMNModel dmnModel = runtime.getModel("http://activiti.org/schema/1.0/dmn", "decisionmulti");
-        assertThat(dmnModel, notNullValue());
-        assertThat(DMNRuntimeUtil.formatMessages(dmnModel.getMessages()), dmnModel.hasErrors(), is(false));
+        assertThat(dmnModel).isNotNull();
+        assertThat(dmnModel.hasErrors()).as(DMNRuntimeUtil.formatMessages(dmnModel.getMessages())).isFalse();
 
         checkUniqueMissingMatchDefaultEmpty(runtime, dmnModel, 11, true);
         checkUniqueMissingMatchDefaultEmpty(runtime, dmnModel, 12, null);
@@ -2362,8 +2352,8 @@ public class DMNRuntimeTest extends BaseDMN1_1VariantTest {
 
         final DMNResult dmnResult = runtime.evaluateAll(dmnModel, context);
         LOG.debug("{}", dmnResult);
-        assertThat(DMNRuntimeUtil.formatMessages(dmnResult.getMessages()), dmnResult.hasErrors(), is(false));
-        assertThat(dmnResult.getDecisionResultByName("Decision_decisionboolean").getResult(), is(output));
+        assertThat(dmnResult.hasErrors()).as(DMNRuntimeUtil.formatMessages(dmnResult.getMessages())).isFalse();
+        assertThat(dmnResult.getDecisionResultByName("Decision_decisionboolean").getResult()).isEqualTo(output);
     }
 }
 

--- a/kie-dmn/kie-dmn-legacy-tests/src/test/java/org/kie/dmn/legacy/tests/core/v1_1/FlightRebookingTest.java
+++ b/kie-dmn/kie-dmn-legacy-tests/src/test/java/org/kie/dmn/legacy/tests/core/v1_1/FlightRebookingTest.java
@@ -32,9 +32,7 @@ import org.kie.dmn.api.core.DMNRuntime;
 import org.kie.dmn.core.api.DMNFactory;
 import org.kie.dmn.core.util.DMNRuntimeUtil;
 
-import static org.hamcrest.CoreMatchers.is;
-import static org.hamcrest.CoreMatchers.notNullValue;
-import static org.hamcrest.MatcherAssert.assertThat;
+import static org.assertj.core.api.Assertions.assertThat;
 
 public class FlightRebookingTest extends BaseDMN1_1VariantTest {
 
@@ -46,8 +44,8 @@ public class FlightRebookingTest extends BaseDMN1_1VariantTest {
     public void testSolution1() {
         final DMNRuntime runtime = DMNRuntimeUtil.createRuntime("0019-flight-rebooking.dmn", this.getClass() );
         final DMNModel dmnModel = runtime.getModel("https://www.drools.org/kie-dmn", "0019-flight-rebooking" );
-        assertThat( dmnModel, notNullValue() );
-        assertThat( DMNRuntimeUtil.formatMessages( dmnModel.getMessages() ), dmnModel.hasErrors(), is(false) ); // need proper type support to enable this
+        assertThat(dmnModel).isNotNull();
+        assertThat(dmnModel.hasErrors()).as(DMNRuntimeUtil.formatMessages(dmnModel.getMessages())).isFalse();// need proper type support to enable this
 
         final DMNContext context = DMNFactory.newContext();
 
@@ -61,15 +59,15 @@ public class FlightRebookingTest extends BaseDMN1_1VariantTest {
 
         final DMNContext result = dmnResult.getContext();
 
-        assertThat( result.get( "Rebooked Passengers" ), is( loadExpectedResult() ) );
+        assertThat(result.get("Rebooked Passengers")).isEqualTo(loadExpectedResult());
     }
 
     @Test
     public void testSolutionAlternate() {
         final DMNRuntime runtime = DMNRuntimeUtil.createRuntime("0019-flight-rebooking-alternative.dmn", this.getClass() );
         final DMNModel dmnModel = runtime.getModel("https://www.drools.org/kie-dmn", "0019-flight-rebooking" );
-        assertThat( dmnModel, notNullValue() );
-        assertThat( DMNRuntimeUtil.formatMessages( dmnModel.getMessages() ), dmnModel.hasErrors(), is(false) );
+        assertThat(dmnModel).isNotNull();
+        assertThat(dmnModel.hasErrors()).as(DMNRuntimeUtil.formatMessages(dmnModel.getMessages())).isFalse();
 
         final DMNContext context = DMNFactory.newContext();
 
@@ -83,15 +81,15 @@ public class FlightRebookingTest extends BaseDMN1_1VariantTest {
 
         final DMNContext result = dmnResult.getContext();
 
-        assertThat( result.get( "Rebooked Passengers" ), is( loadExpectedResult() ) );
+        assertThat(result.get("Rebooked Passengers")).isEqualTo(loadExpectedResult());
     }
 
     @Test
     public void testSolutionSingletonLists() {
         final DMNRuntime runtime = DMNRuntimeUtil.createRuntime("0019-flight-rebooking-singleton-lists.dmn", this.getClass() );
         final DMNModel dmnModel = runtime.getModel("https://www.drools.org/kie-dmn", "0019-flight-rebooking" );
-        assertThat( dmnModel, notNullValue() );
-        assertThat( DMNRuntimeUtil.formatMessages( dmnModel.getMessages() ), dmnModel.hasErrors(), is(false) );
+        assertThat(dmnModel).isNotNull();
+        assertThat(dmnModel.hasErrors()).as(DMNRuntimeUtil.formatMessages(dmnModel.getMessages())).isFalse();
         
         final DMNContext context = DMNFactory.newContext();
 
@@ -105,15 +103,15 @@ public class FlightRebookingTest extends BaseDMN1_1VariantTest {
 
         final DMNContext result = dmnResult.getContext();
 
-        assertThat( result.get( "Rebooked Passengers" ), is( loadExpectedResult() ) );
+        assertThat(result.get("Rebooked Passengers")).isEqualTo(loadExpectedResult());
     }
 
     @Test
     public void testSolutionBadExample() {
         final DMNRuntime runtime = DMNRuntimeUtil.createRuntime("0019-flight-rebooking-bad-example.dmn", this.getClass() );
         final DMNModel dmnModel = runtime.getModel("https://www.drools.org/kie-dmn", "0019-flight-rebooking" );
-        assertThat( dmnModel, notNullValue() );
-        assertThat( DMNRuntimeUtil.formatMessages( dmnModel.getMessages() ), dmnModel.hasErrors(), is(false) );
+        assertThat(dmnModel).isNotNull();
+        assertThat(dmnModel.hasErrors()).as(DMNRuntimeUtil.formatMessages(dmnModel.getMessages())).isFalse();
 
         final DMNContext context = DMNFactory.newContext();
 
@@ -127,7 +125,7 @@ public class FlightRebookingTest extends BaseDMN1_1VariantTest {
 
         final DMNContext result = dmnResult.getContext();
 
-        assertThat( result.get( "Rebooked Passengers" ), is( loadExpectedResult() ) );
+        assertThat(result.get("Rebooked Passengers")).isEqualTo(loadExpectedResult());
     }
 
     @Test
@@ -135,8 +133,8 @@ public class FlightRebookingTest extends BaseDMN1_1VariantTest {
         final DMNRuntime runtime = DMNRuntimeUtil.createRuntime("0019-flight-rebooking-uninterpreted.dmn", this.getClass() );
         final DMNModel dmnModel = runtime.getModel("http://www.trisotech.com/dmn/definitions/_188d6caf-a355-49b5-a692-bd6ce713da08", "0019-flight-rebooking" );
         runtime.addListener( DMNRuntimeUtil.createListener() );
-        assertThat( dmnModel, notNullValue() );
-        assertThat( DMNRuntimeUtil.formatMessages( dmnModel.getMessages() ), dmnModel.hasErrors(), is(false) );
+        assertThat(dmnModel).isNotNull();
+        assertThat(dmnModel.hasErrors()).as(DMNRuntimeUtil.formatMessages(dmnModel.getMessages())).isFalse();
 
         final DMNContext context = DMNFactory.newContext();
 
@@ -148,7 +146,7 @@ public class FlightRebookingTest extends BaseDMN1_1VariantTest {
 
         final DMNResult dmnResult = runtime.evaluateAll(dmnModel, context );
 
-        assertThat( dmnResult.getDecisionResultByName( "Rebooked Passengers" ).getEvaluationStatus(), is( DMNDecisionResult.DecisionEvaluationStatus.SKIPPED ) );
+        assertThat(dmnResult.getDecisionResultByName("Rebooked Passengers").getEvaluationStatus()).isEqualTo(DMNDecisionResult.DecisionEvaluationStatus.SKIPPED);
     }
 
     private List loadPassengerList() {

--- a/kie-dmn/kie-dmn-legacy-tests/src/test/java/org/kie/dmn/legacy/tests/core/v1_1/VacationDaysTest.java
+++ b/kie-dmn/kie-dmn-legacy-tests/src/test/java/org/kie/dmn/legacy/tests/core/v1_1/VacationDaysTest.java
@@ -26,9 +26,7 @@ import org.kie.dmn.api.core.DMNRuntime;
 import org.kie.dmn.core.api.DMNFactory;
 import org.kie.dmn.core.util.DMNRuntimeUtil;
 
-import static org.hamcrest.CoreMatchers.is;
-import static org.hamcrest.CoreMatchers.notNullValue;
-import static org.hamcrest.MatcherAssert.assertThat;
+import static org.assertj.core.api.Assertions.assertThat;
 
 public class VacationDaysTest extends BaseDMN1_1VariantTest {
 
@@ -74,7 +72,7 @@ public class VacationDaysTest extends BaseDMN1_1VariantTest {
     private void executeTest(final int age, final int yearsService, final int expectedVacationDays ) {
         final DMNRuntime runtime = DMNRuntimeUtil.createRuntime("0020-vacation-days.dmn", this.getClass() );
         final DMNModel dmnModel = runtime.getModel("https://www.drools.org/kie-dmn", "0020-vacation-days" );
-        assertThat( dmnModel, notNullValue() );
+        assertThat(dmnModel).isNotNull();
 
         final DMNContext context = DMNFactory.newContext();
 
@@ -85,7 +83,7 @@ public class VacationDaysTest extends BaseDMN1_1VariantTest {
 
         final DMNContext result = dmnResult.getContext();
 
-        assertThat( result.get( "Total Vacation Days" ), is( BigDecimal.valueOf( expectedVacationDays ) ) );
+        assertThat(result.get("Total Vacation Days")).isEqualTo(BigDecimal.valueOf(expectedVacationDays));
     }
 }
 

--- a/kie-dmn/kie-dmn-legacy-tests/src/test/java/org/kie/dmn/legacy/tests/core/v1_1/decisionservices/DMNDecisionServicesTest.java
+++ b/kie-dmn/kie-dmn-legacy-tests/src/test/java/org/kie/dmn/legacy/tests/core/v1_1/decisionservices/DMNDecisionServicesTest.java
@@ -32,14 +32,8 @@ import org.kie.dmn.legacy.tests.core.v1_1.BaseDMN1_1VariantTest;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import static org.hamcrest.CoreMatchers.is;
-import static org.hamcrest.CoreMatchers.notNullValue;
-import static org.hamcrest.CoreMatchers.nullValue;
-import static org.hamcrest.Matchers.anything;
-import static org.hamcrest.Matchers.hasEntry;
-import static org.hamcrest.Matchers.not;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.Assert.assertNull;
-import static org.hamcrest.MatcherAssert.assertThat;
 
 public class DMNDecisionServicesTest extends BaseDMN1_1VariantTest {
 
@@ -53,8 +47,8 @@ public class DMNDecisionServicesTest extends BaseDMN1_1VariantTest {
     public void testBasic() {
         final DMNRuntime runtime = DMNRuntimeUtil.createRuntime("0004-decision-services.dmn", this.getClass());
         final DMNModel dmnModel = runtime.getModel("http://www.trisotech.com/definitions/_686f58d4-4ec3-4c65-8c06-0e4fd8983def", "Decision Services");
-        assertThat(dmnModel, notNullValue());
-        assertThat(DMNRuntimeUtil.formatMessages(dmnModel.getMessages()), dmnModel.hasErrors(), is(false));
+        assertThat(dmnModel).isNotNull();
+        assertThat(dmnModel.hasErrors()).as(DMNRuntimeUtil.formatMessages(dmnModel.getMessages())).isFalse();
 
         checkDSwithInputData(runtime, dmnModel);
 
@@ -70,10 +64,10 @@ public class DMNDecisionServicesTest extends BaseDMN1_1VariantTest {
         final DMNResult dmnResult = runtime.evaluateDecisionService(dmnModel, context, "A only as output knowing D and E");
         LOG.debug("{}", dmnResult);
         dmnResult.getDecisionResults().forEach(x -> LOG.debug("{}", x));
-        assertThat(DMNRuntimeUtil.formatMessages(dmnResult.getMessages()), dmnResult.hasErrors(), is(false));
+        assertThat(dmnResult.hasErrors()).as(DMNRuntimeUtil.formatMessages(dmnResult.getMessages())).isFalse();
 
         final DMNContext result = dmnResult.getContext();
-        assertThat(result.get("A"), is("de"));
+        assertThat(result.get("A")).isEqualTo("de");
     }
 
     private void checkDSwithInputDecision(final DMNRuntime runtime, final DMNModel dmnModel) {
@@ -84,10 +78,11 @@ public class DMNDecisionServicesTest extends BaseDMN1_1VariantTest {
         final DMNResult dmnResult = runtime.evaluateDecisionService(dmnModel, context, "A Only Knowing B and C");
         LOG.debug("{}", dmnResult);
         dmnResult.getDecisionResults().forEach(x -> LOG.debug("{}", x));
-        assertThat(DMNRuntimeUtil.formatMessages(dmnResult.getMessages()), dmnResult.hasErrors(), is(false));
+        
+        assertThat(dmnResult.hasErrors()).as(DMNRuntimeUtil.formatMessages(dmnResult.getMessages())).isFalse();
 
         final DMNContext result = dmnResult.getContext();
-        assertThat(result.get("A"), nullValue()); // because B and C are not defined in input.
+        assertThat(result.get("A")).isNull(); // because B and C are not defined in input.
     }
 
     private void checkDSwithInputDecision2(final DMNRuntime runtime, final DMNModel dmnModel) {
@@ -100,18 +95,18 @@ public class DMNDecisionServicesTest extends BaseDMN1_1VariantTest {
         final DMNResult dmnResult = runtime.evaluateDecisionService(dmnModel, context, "A Only Knowing B and C");
         LOG.debug("{}", dmnResult);
         dmnResult.getDecisionResults().forEach(x -> LOG.debug("{}", x));
-        assertThat(DMNRuntimeUtil.formatMessages(dmnResult.getMessages()), dmnResult.hasErrors(), is(false));
+        assertThat(dmnResult.hasErrors()).as(DMNRuntimeUtil.formatMessages(dmnResult.getMessages())).isFalse();
 
         final DMNContext result = dmnResult.getContext();
-        assertThat(result.get("A"), is("inBinC"));
+        assertThat(result.get("A")).isEqualTo("inBinC");
     }
 
     @Test
     public void testDSInLiteralExpression() {
         final DMNRuntime runtime = DMNRuntimeUtil.createRuntime("DecisionServicesInLiteralExpression.dmn", this.getClass());
         final DMNModel dmnModel = runtime.getModel("http://www.trisotech.com/definitions/_686f58d4-4ec3-4c65-8c06-0e4fd8983def", "Decision Services");
-        assertThat(dmnModel, notNullValue());
-        assertThat(DMNRuntimeUtil.formatMessages(dmnModel.getMessages()), dmnModel.hasErrors(), is(false));
+        assertThat(dmnModel).isNotNull();
+        assertThat(dmnModel.hasErrors()).as(DMNRuntimeUtil.formatMessages(dmnModel.getMessages())).isFalse();
 
         final DMNContext context = DMNFactory.newContext();
         context.set("D", "d");
@@ -120,18 +115,18 @@ public class DMNDecisionServicesTest extends BaseDMN1_1VariantTest {
         final DMNResult dmnResult = runtime.evaluateAll(dmnModel, context);
         LOG.debug("{}", dmnResult);
         dmnResult.getDecisionResults().forEach(x -> LOG.debug("{}", x));
-        assertThat(DMNRuntimeUtil.formatMessages(dmnResult.getMessages()), dmnResult.hasErrors(), is(false));
+        assertThat(dmnResult.hasErrors()).as(DMNRuntimeUtil.formatMessages(dmnResult.getMessages())).isFalse();
 
         final DMNContext result = dmnResult.getContext();
-        assertThat(result.get("Decide based on A and DS"), is("xyde"));
+        assertThat(result.get("Decide based on A and DS")).isEqualTo("xyde");
     }
 
     @Test
     public void testDSInLiteralExpressionWithBKM() {
         final DMNRuntime runtime = DMNRuntimeUtil.createRuntime("DecisionServicesInLiteralExpressionWithBKM.dmn", this.getClass());
         final DMNModel dmnModel = runtime.getModel("http://www.trisotech.com/definitions/_686f58d4-4ec3-4c65-8c06-0e4fd8983def", "Decision Services");
-        assertThat(dmnModel, notNullValue());
-        assertThat(DMNRuntimeUtil.formatMessages(dmnModel.getMessages()), dmnModel.hasErrors(), is(false));
+        assertThat(dmnModel).isNotNull();
+        assertThat(dmnModel.hasErrors()).as(DMNRuntimeUtil.formatMessages(dmnModel.getMessages())).isFalse();
 
         final DMNContext context = DMNFactory.newContext();
         context.set("D", "d");
@@ -140,18 +135,18 @@ public class DMNDecisionServicesTest extends BaseDMN1_1VariantTest {
         final DMNResult dmnResult = runtime.evaluateAll(dmnModel, context);
         LOG.debug("{}", dmnResult);
         dmnResult.getDecisionResults().forEach(x -> LOG.debug("{}", x));
-        assertThat(DMNRuntimeUtil.formatMessages(dmnResult.getMessages()), dmnResult.hasErrors(), is(false));
+        assertThat(dmnResult.hasErrors()).as(DMNRuntimeUtil.formatMessages(dmnResult.getMessages())).isFalse();
 
         final DMNContext result = dmnResult.getContext();
-        assertThat(result.get("Decide based on A and DS"), is("xydemn"));
+        assertThat(result.get("Decide based on A and DS")).isEqualTo("xydemn");
     }
 
     @Test
     public void testDSInLiteralExpressionWithBKMUsingInvocation() {
         final DMNRuntime runtime = DMNRuntimeUtil.createRuntime("DecisionServicesInLiteralExpressionWithBKMUsingInvocation.dmn", this.getClass());
         final DMNModel dmnModel = runtime.getModel("http://www.trisotech.com/definitions/_686f58d4-4ec3-4c65-8c06-0e4fd8983def", "Decision Services");
-        assertThat(dmnModel, notNullValue());
-        assertThat(DMNRuntimeUtil.formatMessages(dmnModel.getMessages()), dmnModel.hasErrors(), is(false));
+        assertThat(dmnModel).isNotNull();
+        assertThat(dmnModel.hasErrors()).as(DMNRuntimeUtil.formatMessages(dmnModel.getMessages())).isFalse();
 
         final DMNContext context = DMNFactory.newContext();
         context.set("D", "d");
@@ -160,18 +155,18 @@ public class DMNDecisionServicesTest extends BaseDMN1_1VariantTest {
         final DMNResult dmnResult = runtime.evaluateAll(dmnModel, context);
         LOG.debug("{}", dmnResult);
         dmnResult.getDecisionResults().forEach(x -> LOG.debug("{}", x));
-        assertThat(DMNRuntimeUtil.formatMessages(dmnResult.getMessages()), dmnResult.hasErrors(), is(false));
+        assertThat(dmnResult.hasErrors()).as(DMNRuntimeUtil.formatMessages(dmnResult.getMessages())).isFalse();
 
         final DMNContext result = dmnResult.getContext();
-        assertThat(result.get("Decide based on A and DS"), is("xydemn"));
+        assertThat(result.get("Decide based on A and DS")).isEqualTo("xydemn");
     }
 
     @Test
     public void testDSInLiteralExpressionOnlyfromBKMUsingInvocation() {
         final DMNRuntime runtime = DMNRuntimeUtil.createRuntime("DecisionServicesInLiteralExpressionOnlyFromBKMUsingInvocation.dmn", this.getClass());
         final DMNModel dmnModel = runtime.getModel("http://www.trisotech.com/definitions/_686f58d4-4ec3-4c65-8c06-0e4fd8983def", "Decision Services");
-        assertThat(dmnModel, notNullValue());
-        assertThat(DMNRuntimeUtil.formatMessages(dmnModel.getMessages()), dmnModel.hasErrors(), is(false));
+        assertThat(dmnModel).isNotNull();
+        assertThat(dmnModel.hasErrors()).as(DMNRuntimeUtil.formatMessages(dmnModel.getMessages())).isFalse();
 
         final DMNContext context = DMNFactory.newContext();
         context.set("D", "d");
@@ -180,18 +175,18 @@ public class DMNDecisionServicesTest extends BaseDMN1_1VariantTest {
         final DMNResult dmnResult = runtime.evaluateAll(dmnModel, context);
         LOG.debug("{}", dmnResult);
         dmnResult.getDecisionResults().forEach(x -> LOG.debug("{}", x));
-        assertThat(DMNRuntimeUtil.formatMessages(dmnResult.getMessages()), dmnResult.hasErrors(), is(false));
+        assertThat(dmnResult.hasErrors()).as(DMNRuntimeUtil.formatMessages(dmnResult.getMessages())).isFalse();
 
         final DMNContext result = dmnResult.getContext();
-        assertThat(result.get("Decide based on A and DS"), is("demn"));
+        assertThat(result.get("Decide based on A and DS")).isEqualTo("demn");
     }
 
     @Test
     public void testMixtypeDS() {
         final DMNRuntime runtime = DMNRuntimeUtil.createRuntime("mixtype-DS.dmn", this.getClass());
         final DMNModel dmnModel = runtime.getModel("http://www.trisotech.com/dmn/definitions/_c9885563-aa54-4c7b-ae8a-738cfd29b544", "mixtype DS");
-        assertThat(dmnModel, notNullValue());
-        assertThat(DMNRuntimeUtil.formatMessages(dmnModel.getMessages()), dmnModel.hasErrors(), is(false));
+        assertThat(dmnModel).isNotNull();
+        assertThat(dmnModel.hasErrors()).as(DMNRuntimeUtil.formatMessages(dmnModel.getMessages())).isFalse();
 
         final DMNContext context = DMNFactory.newContext();
         context.set("Person name", "John");
@@ -200,27 +195,27 @@ public class DMNDecisionServicesTest extends BaseDMN1_1VariantTest {
         final DMNResult dmnResult = runtime.evaluateAll(dmnModel, context);
         LOG.debug("{}", dmnResult);
         dmnResult.getDecisionResults().forEach(x -> LOG.debug("{}", x));
-        assertThat(DMNRuntimeUtil.formatMessages(dmnResult.getMessages()), dmnResult.hasErrors(), is(false));
+        assertThat(dmnResult.hasErrors()).as(DMNRuntimeUtil.formatMessages(dmnResult.getMessages())).isFalse();
 
         final DMNContext result = dmnResult.getContext();
-        assertThat(result.get("Greet the Person"), is("Hello, John"));
-        assertThat(result.get("Person age"), is(BigDecimal.valueOf(38)));
-        assertThat(result.get("is Person an adult"), is(true));
+        assertThat(result.get("Greet the Person")).isEqualTo("Hello, John");
+        assertThat(result.get("Person age")).isEqualTo(BigDecimal.valueOf(38));
+        assertThat(result.get("is Person an adult")).isEqualTo(Boolean.TRUE);
 
-        assertThat((Map<String, Object>) result.get("eval DS all"), hasEntry(is("Greet the Person"), is("Hello, ds all")));
-        assertThat((Map<String, Object>) result.get("eval DS all"), hasEntry(is("Person age"), is(BigDecimal.valueOf(18))));
-        assertThat((Map<String, Object>) result.get("eval DS all"), hasEntry(is("is Person an adult"), is(true)));
-        assertThat((Map<String, Object>) result.get("eval DS all"), not(hasEntry(is("hardcoded now"), anything())));
+        assertThat((Map<String, Object>) result.get("eval DS all")).containsEntry("Greet the Person", "Hello, ds all");
+        assertThat((Map<String, Object>) result.get("eval DS all")).containsEntry("Person age", BigDecimal.valueOf(18));
+        assertThat((Map<String, Object>) result.get("eval DS all")).containsEntry("is Person an adult", true);
+        assertThat((Map<String, Object>) result.get("eval DS all")).doesNotContainKey("hardcoded now");
 
-        assertThat((Map<String, Object>) result.get("eval DS encapsulate"), hasEntry(is("Greet the Person"), is("Hello, DS encapsulate")));
-        assertThat((Map<String, Object>) result.get("eval DS encapsulate"), not(hasEntry(is("Person age"), anything())));
-        assertThat((Map<String, Object>) result.get("eval DS encapsulate"), hasEntry(is("is Person an adult"), is(true)));
-        assertThat((Map<String, Object>) result.get("eval DS encapsulate"), not(hasEntry(is("hardcoded now"), anything())));
+        assertThat((Map<String, Object>) result.get("eval DS encapsulate")).containsEntry("Greet the Person", "Hello, DS encapsulate");
+        assertThat((Map<String, Object>) result.get("eval DS encapsulate")).doesNotContainKey("Person age");
+        assertThat((Map<String, Object>) result.get("eval DS encapsulate")).containsEntry("is Person an adult", true);
+        assertThat((Map<String, Object>) result.get("eval DS encapsulate")).doesNotContainKey("hardcoded now");
 
-        assertThat((Map<String, Object>) result.get("eval DS greet adult"), hasEntry(is("Greet the Person"), is("Hello, DS greet adult")));
-        assertThat((Map<String, Object>) result.get("eval DS greet adult"), not(hasEntry(is("Person age"), anything())));
-        assertThat((Map<String, Object>) result.get("eval DS greet adult"), hasEntry(is("is Person an adult"), is(true)));
-        assertThat((Map<String, Object>) result.get("eval DS greet adult"), not(hasEntry(is("hardcoded now"), anything())));
+        assertThat((Map<String, Object>) result.get("eval DS greet adult")).containsEntry("Greet the Person", "Hello, DS greet adult");
+        assertThat((Map<String, Object>) result.get("eval DS greet adult")).doesNotContainKey("Person age");
+        assertThat((Map<String, Object>) result.get("eval DS greet adult")).containsEntry("is Person an adult", true);
+        assertThat((Map<String, Object>) result.get("eval DS greet adult")).doesNotContainKey("hardcoded now");
 
         // additionally check DS one-by-one
         testMixtypeDS_checkDSall(runtime, dmnModel);
@@ -236,13 +231,13 @@ public class DMNDecisionServicesTest extends BaseDMN1_1VariantTest {
         final DMNResult dmnResult = runtime.evaluateDecisionService(dmnModel, context, "DS all");
         LOG.debug("{}", dmnResult);
         dmnResult.getDecisionResults().forEach(x -> LOG.debug("{}", x));
-        assertThat(DMNRuntimeUtil.formatMessages(dmnResult.getMessages()), dmnResult.hasErrors(), is(false));
+        assertThat(dmnResult.hasErrors()).as(DMNRuntimeUtil.formatMessages(dmnResult.getMessages())).isFalse();
 
         final DMNContext result = dmnResult.getContext();
-        assertThat(result.getAll(), hasEntry(is("Greet the Person"), is("Hello, John")));
-        assertThat(result.getAll(), hasEntry(is("Person age"), is(BigDecimal.valueOf(10))));
-        assertThat(result.getAll(), hasEntry(is("is Person an adult"), is(false)));
-        assertThat(result.getAll(), not(hasEntry(is("hardcoded now"), anything())));
+        assertThat(result.getAll()).containsEntry("Greet the Person", "Hello, John");
+        assertThat(result.getAll()).containsEntry("Person age", BigDecimal.valueOf(10));
+        assertThat(result.getAll()).containsEntry("is Person an adult", false);
+        assertThat(result.getAll()).doesNotContainKey("hardcoded now");
     }
 
     private void testMixtypeDS_checkDSencapsulate(final DMNRuntime runtime, final DMNModel dmnModel) {
@@ -253,13 +248,13 @@ public class DMNDecisionServicesTest extends BaseDMN1_1VariantTest {
         final DMNResult dmnResult = runtime.evaluateDecisionService(dmnModel, context, "DS encapsulate");
         LOG.debug("{}", dmnResult);
         dmnResult.getDecisionResults().forEach(x -> LOG.debug("{}", x));
-        assertThat(DMNRuntimeUtil.formatMessages(dmnResult.getMessages()), dmnResult.hasErrors(), is(false));
+        assertThat(dmnResult.hasErrors()).as(DMNRuntimeUtil.formatMessages(dmnResult.getMessages())).isFalse();
 
         final DMNContext result = dmnResult.getContext();
-        assertThat(result.getAll(), hasEntry(is("Greet the Person"), is("Hello, John")));
-        assertThat(result.getAll(), not(hasEntry(is("Person age"), anything())));
-        assertThat(result.getAll(), hasEntry(is("is Person an adult"), is(false)));
-        assertThat(result.getAll(), not(hasEntry(is("hardcoded now"), anything())));
+        assertThat(result.getAll()).containsEntry("Greet the Person", "Hello, John");
+        assertThat(result.getAll()).doesNotContainKey("Person age");
+        assertThat(result.getAll()).containsEntry("is Person an adult", false);
+        assertThat(result.getAll()).doesNotContainKey("hardcoded now");
     }
 
     private void testMixtypeDS_checkDSgreetadult(final DMNRuntime runtime, final DMNModel dmnModel) {
@@ -270,21 +265,21 @@ public class DMNDecisionServicesTest extends BaseDMN1_1VariantTest {
         final DMNResult dmnResult = runtime.evaluateDecisionService(dmnModel, context, "DS greet adult");
         LOG.debug("{}", dmnResult);
         dmnResult.getDecisionResults().forEach(x -> LOG.debug("{}", x));
-        assertThat(DMNRuntimeUtil.formatMessages(dmnResult.getMessages()), dmnResult.hasErrors(), is(false));
+        assertThat(dmnResult.hasErrors()).as(DMNRuntimeUtil.formatMessages(dmnResult.getMessages())).isFalse();
 
         final DMNContext result = dmnResult.getContext();
-        assertThat(result.getAll(), hasEntry(is("Greet the Person"), is("Hello, John")));
-        assertThat(dmnResult.getDecisionResultByName("Person age"), nullValue());
-        assertThat(result.getAll(), hasEntry(is("is Person an adult"), is(false)));
-        assertThat(result.getAll(), not(hasEntry(is("hardcoded now"), anything())));
+        assertThat(result.getAll()).containsEntry("Greet the Person", "Hello, John");
+        assertThat(dmnResult.getDecisionResultByName("Person age")).isNull();
+        assertThat(result.getAll()).containsEntry("is Person an adult", false);
+        assertThat(result.getAll()).doesNotContainKey("hardcoded now");
     }
 
     @Test
     public void testDSForTypeCheck() {
         final DMNRuntime runtime = DMNRuntimeUtil.createRuntime("DecisionService20180718.dmn", this.getClass());
         final DMNModel dmnModel = runtime.getModel("http://www.trisotech.com/dmn/definitions/_6eef3a7c-bb0d-40bb-858d-f9067789c18a", "Decision Service 20180718");
-        assertThat(dmnModel, notNullValue());
-        assertThat(DMNRuntimeUtil.formatMessages(dmnModel.getMessages()), dmnModel.hasErrors(), is(false));
+        assertThat(dmnModel).isNotNull();
+        assertThat(dmnModel.hasErrors()).as(DMNRuntimeUtil.formatMessages(dmnModel.getMessages())).isFalse();
 
         testDSForTypeCheck_runNormal(runtime, dmnModel);
         testDSForTypeCheck_runAllDecisionsWithWrongTypes(runtime, dmnModel);
@@ -300,12 +295,12 @@ public class DMNDecisionServicesTest extends BaseDMN1_1VariantTest {
         final DMNResult dmnResult = runtime.evaluateAll(dmnModel, context);
         LOG.debug("{}", dmnResult);
         dmnResult.getDecisionResults().forEach(x -> LOG.debug("{}", x));
-        assertThat(DMNRuntimeUtil.formatMessages(dmnResult.getMessages()), dmnResult.hasErrors(), is(false));
+        assertThat(dmnResult.hasErrors()).as(DMNRuntimeUtil.formatMessages(dmnResult.getMessages())).isFalse();
 
         final DMNContext result = dmnResult.getContext();
-        assertThat(result.get("Greet the person"), is("Hello, John"));
-        assertThat(result.get("is Person at age allowed"), is(true));
-        assertThat(result.get("Final Decision"), is("Hello, John; you are allowed"));
+        assertThat(result.get("Greet the person")).isEqualTo("Hello, John");
+        assertThat(result.get("is Person at age allowed")).isEqualTo(Boolean.TRUE);
+        assertThat(result.get("Final Decision")).isEqualTo("Hello, John; you are allowed");
     }
 
     private void testDSForTypeCheck_runAllDecisionsWithWrongTypes(final DMNRuntime runtime, final DMNModel dmnModel) {
@@ -316,7 +311,7 @@ public class DMNDecisionServicesTest extends BaseDMN1_1VariantTest {
         final DMNResult dmnResult = runtime.evaluateAll(dmnModel, context);
         LOG.debug("{}", dmnResult);
         dmnResult.getDecisionResults().forEach(x -> LOG.debug("{}", x));
-        assertThat(DMNRuntimeUtil.formatMessages(dmnResult.getMessages()), dmnResult.hasErrors(), is(true));
+        assertThat(dmnResult.hasErrors()).as(DMNRuntimeUtil.formatMessages(dmnResult.getMessages())).isTrue();
     }
 
     private void testDSForTypeCheck_runDecisionService_Normal(final DMNRuntime runtime, final DMNModel dmnModel) {
@@ -327,12 +322,12 @@ public class DMNDecisionServicesTest extends BaseDMN1_1VariantTest {
         final DMNResult dmnResult = runtime.evaluateDecisionService(dmnModel, context, "DS given inputdata");
         LOG.debug("{}", dmnResult);
         dmnResult.getDecisionResults().forEach(x -> LOG.debug("{}", x));
-        assertThat(DMNRuntimeUtil.formatMessages(dmnResult.getMessages()), dmnResult.hasErrors(), is(false));
+        assertThat(dmnResult.hasErrors()).as(DMNRuntimeUtil.formatMessages(dmnResult.getMessages())).isFalse();
 
         final DMNContext result = dmnResult.getContext();
-        assertThat(result.getAll(), not(hasEntry(is("Greet the person"), anything()))); // Decision Service will encapsulate this decision
-        assertThat(result.getAll(), not(hasEntry(is("is Person at age allowed"), anything()))); // Decision Service will encapsulate this decision
-        assertThat(result.get("Final Decision"), is("Hello, John; you are allowed"));
+        assertThat(result.getAll()).doesNotContainKey("Greet the person"); // Decision Service will encapsulate this decision
+        assertThat(result.getAll()).doesNotContainKey("is Person at age allowed"); // Decision Service will encapsulate this decision
+        assertThat(result.get("Final Decision")).isEqualTo("Hello, John; you are allowed");
     }
 
     private void testDSForTypeCheck_runDecisionService_WithWrongTypes(final DMNRuntime runtime, final DMNModel dmnModel) {
@@ -343,48 +338,47 @@ public class DMNDecisionServicesTest extends BaseDMN1_1VariantTest {
         final DMNResult dmnResult = runtime.evaluateDecisionService(dmnModel, context, "DS given inputdata");
         LOG.debug("{}", dmnResult);
         dmnResult.getDecisionResults().forEach(x -> LOG.debug("{}", x));
-        assertThat(DMNRuntimeUtil.formatMessages(dmnResult.getMessages()),
-                   dmnResult.getMessages().stream().anyMatch(m -> m.getSourceId().equals("_cf49add9-84a4-40ac-8306-1eea599ff43c") && m.getLevel() == Level.WARNING),
-                   is(true));
+        assertThat(dmnResult.getMessages().stream().anyMatch(m -> m.getSourceId().equals("_cf49add9-84a4-40ac-8306-1eea599ff43c") && m.getLevel() == Level.WARNING))
+        	.as(DMNRuntimeUtil.formatMessages(dmnResult.getMessages())).isTrue();
     }
 
     @Test
     public void testDSSingletonOrMultipleOutputDecisions() {
         final DMNRuntime runtime = DMNRuntimeUtil.createRuntime("Decision-Services-singleton-or-multiple-output-decisions.dmn", this.getClass());
         final DMNModel dmnModel = runtime.getModel("http://www.trisotech.com/dmn/definitions/_b4ebfbf2-8608-4297-9662-be70bab01974", "Decision Services singleton or multiple output decisions");
-        assertThat(dmnModel, notNullValue());
-        assertThat(DMNRuntimeUtil.formatMessages(dmnModel.getMessages()), dmnModel.hasErrors(), is(false));
+        assertThat(dmnModel).isNotNull();
+        assertThat(dmnModel.hasErrors()).as(DMNRuntimeUtil.formatMessages(dmnModel.getMessages())).isFalse();
 
         final DMNContext emptyContext = DMNFactory.newContext();
 
         final DMNResult dmnResult = runtime.evaluateAll(dmnModel, emptyContext);
         LOG.debug("{}", dmnResult);
         dmnResult.getDecisionResults().forEach(x -> LOG.debug("{}", x));
-        assertThat(DMNRuntimeUtil.formatMessages(dmnResult.getMessages()), dmnResult.hasErrors(), is(false));
+        assertThat(dmnResult.hasErrors()).as(DMNRuntimeUtil.formatMessages(dmnResult.getMessages())).isFalse();
 
         final DMNContext result = dmnResult.getContext();
-        assertThat(result.get("a Value"), is("a string Value"));
-        assertThat(result.get("a String Value"), is("a String Value"));
-        assertThat(result.get("a Number Value"), is(BigDecimal.valueOf(47)));
-        assertThat(result.get("eval DS with singleton value"), is("a string Value"));
-        assertThat((Map<String, Object>) result.get("eval DS with multiple output decisions"), hasEntry(is("a String Value"), is("a String Value")));
-        assertThat((Map<String, Object>) result.get("eval DS with multiple output decisions"), hasEntry(is("a Number Value"), is(BigDecimal.valueOf(47))));
+        assertThat(result.get("a Value")).isEqualTo("a string Value");
+        assertThat(result.get("a String Value")).isEqualTo("a String Value");
+        assertThat(result.get("a Number Value")).isEqualTo(BigDecimal.valueOf(47));
+        assertThat(result.get("eval DS with singleton value")).isEqualTo("a string Value");
+        assertThat((Map<String, Object>) result.get("eval DS with multiple output decisions")).containsEntry("a String Value", "a String Value");
+        assertThat((Map<String, Object>) result.get("eval DS with multiple output decisions")).containsEntry("a Number Value", BigDecimal.valueOf(47));
 
         final DMNResult dmnResultDSSingleton = runtime.evaluateDecisionService(dmnModel, emptyContext, "DS with singleton value");
         LOG.debug("{}", dmnResultDSSingleton);
         dmnResultDSSingleton.getDecisionResults().forEach(x -> LOG.debug("{}", x));
-        assertThat(DMNRuntimeUtil.formatMessages(dmnResultDSSingleton.getMessages()), dmnResultDSSingleton.hasErrors(), is(false));
-        assertThat(dmnResultDSSingleton.getContext().get("a Value"), is("a string Value"));
-        assertThat(dmnResultDSSingleton.getContext().getAll(), not(hasEntry(is("a String Value"), anything()))); // Decision Service will not expose (nor encapsulate hence not execute) this decision.
-        assertThat(dmnResultDSSingleton.getContext().getAll(), not(hasEntry(is("a Number Value"), anything()))); // Decision Service will not expose (nor encapsulate hence not execute) this decision.
+        assertThat(dmnResultDSSingleton.hasErrors()).as(DMNRuntimeUtil.formatMessages(dmnResultDSSingleton.getMessages())).isFalse();
+        assertThat(dmnResultDSSingleton.getContext().get("a Value")).isEqualTo("a string Value");
+        assertThat(dmnResultDSSingleton.getContext().getAll()).doesNotContainKey("a String Value"); // Decision Service will not expose (nor encapsulate hence not execute) this decision.
+        assertThat(dmnResultDSSingleton.getContext().getAll()).doesNotContainKey("a Number Value"); // Decision Service will not expose (nor encapsulate hence not execute) this decision.
 
         final DMNResult dmnResultMultiple = runtime.evaluateDecisionService(dmnModel, emptyContext, "DS with multiple output decisions");
         LOG.debug("{}", dmnResultMultiple);
         dmnResultMultiple.getDecisionResults().forEach(x -> LOG.debug("{}", x));
-        assertThat(DMNRuntimeUtil.formatMessages(dmnResultMultiple.getMessages()), dmnResultMultiple.hasErrors(), is(false));
-        assertThat(dmnResultMultiple.getContext().get("a String Value"), is("a String Value"));
-        assertThat(dmnResultMultiple.getContext().get("a Number Value"), is(BigDecimal.valueOf(47)));
-        assertThat(dmnResultMultiple.getContext().getAll(), not(hasEntry(is("a Value"), anything()))); // Decision Service will not expose (nor encapsulate hence not execute) this decision.
+        assertThat(dmnResultMultiple.hasErrors()).as(DMNRuntimeUtil.formatMessages(dmnResultMultiple.getMessages())).isFalse();
+        assertThat(dmnResultMultiple.getContext().get("a String Value")).isEqualTo("a String Value");
+        assertThat(dmnResultMultiple.getContext().get("a Number Value")).isEqualTo(BigDecimal.valueOf(47));
+        assertThat(dmnResultMultiple.getContext().getAll()).doesNotContainKey("a Value"); // Decision Service will not expose (nor encapsulate hence not execute) this decision.
     }
 
     @Test
@@ -393,39 +387,39 @@ public class DMNDecisionServicesTest extends BaseDMN1_1VariantTest {
             System.setProperty(CoerceDecisionServiceSingletonOutputOption.PROPERTY_NAME, "false");
             final DMNRuntime runtime = DMNRuntimeUtil.createRuntime("Decision-Services-singleton-or-multiple-output-decisions.dmn", this.getClass());
             final DMNModel dmnModel = runtime.getModel("http://www.trisotech.com/dmn/definitions/_b4ebfbf2-8608-4297-9662-be70bab01974", "Decision Services singleton or multiple output decisions");
-            assertThat(dmnModel, notNullValue());
-            assertThat(DMNRuntimeUtil.formatMessages(dmnModel.getMessages()), dmnModel.hasErrors(), is(false));
+            assertThat(dmnModel).isNotNull();
+            assertThat(dmnModel.hasErrors()).as(DMNRuntimeUtil.formatMessages(dmnModel.getMessages())).isFalse();
 
             final DMNContext emptyContext = DMNFactory.newContext();
 
             final DMNResult dmnResult = runtime.evaluateAll(dmnModel, emptyContext);
             LOG.debug("{}", dmnResult);
             dmnResult.getDecisionResults().forEach(x -> LOG.debug("{}", x));
-            assertThat(DMNRuntimeUtil.formatMessages(dmnResult.getMessages()), dmnResult.hasErrors(), is(false));
+            assertThat(dmnResult.hasErrors()).as(DMNRuntimeUtil.formatMessages(dmnResult.getMessages())).isFalse();
 
             final DMNContext result = dmnResult.getContext();
-            assertThat(result.get("a Value"), is("a string Value"));
-            assertThat(result.get("a String Value"), is("a String Value"));
-            assertThat(result.get("a Number Value"), is(BigDecimal.valueOf(47)));
-            assertThat((Map<String, Object>) result.get("eval DS with singleton value"), hasEntry(is("a Value"), is("a string Value"))); // DIFFERENCE with base test
-            assertThat((Map<String, Object>) result.get("eval DS with multiple output decisions"), hasEntry(is("a String Value"), is("a String Value")));
-            assertThat((Map<String, Object>) result.get("eval DS with multiple output decisions"), hasEntry(is("a Number Value"), is(BigDecimal.valueOf(47))));
+            assertThat(result.get("a Value")).isEqualTo("a string Value");
+            assertThat(result.get("a String Value")).isEqualTo("a String Value");
+            assertThat(result.get("a Number Value")).isEqualTo(BigDecimal.valueOf(47));
+            assertThat((Map<String, Object>) result.get("eval DS with singleton value")).containsEntry("a Value", "a string Value"); // DIFFERENCE with base test
+            assertThat((Map<String, Object>) result.get("eval DS with multiple output decisions")).containsEntry("a String Value", "a String Value");
+            assertThat((Map<String, Object>) result.get("eval DS with multiple output decisions")).containsEntry("a Number Value", BigDecimal.valueOf(47));
 
             final DMNResult dmnResultDSSingleton = runtime.evaluateDecisionService(dmnModel, emptyContext, "DS with singleton value");
             LOG.debug("{}", dmnResultDSSingleton);
             dmnResultDSSingleton.getDecisionResults().forEach(x -> LOG.debug("{}", x));
-            assertThat(DMNRuntimeUtil.formatMessages(dmnResultDSSingleton.getMessages()), dmnResultDSSingleton.hasErrors(), is(false));
-            assertThat(dmnResultDSSingleton.getContext().get("a Value"), is("a string Value"));
-            assertThat(dmnResultDSSingleton.getContext().getAll(), not(hasEntry(is("a String Value"), anything()))); // Decision Service will not expose (nor encapsulate hence not execute) this decision.
-            assertThat(dmnResultDSSingleton.getContext().getAll(), not(hasEntry(is("a Number Value"), anything()))); // Decision Service will not expose (nor encapsulate hence not execute) this decision.
+            assertThat(dmnResultDSSingleton.hasErrors()).as(DMNRuntimeUtil.formatMessages(dmnResultDSSingleton.getMessages())).isFalse();
+            assertThat(dmnResultDSSingleton.getContext().get("a Value")).isEqualTo("a string Value");
+            assertThat(dmnResultDSSingleton.getContext().getAll()).doesNotContainKey("a String Value"); // Decision Service will not expose (nor encapsulate hence not execute) this decision.
+            assertThat(dmnResultDSSingleton.getContext().getAll()).doesNotContainKey("a Number Value"); // Decision Service will not expose (nor encapsulate hence not execute) this decision.
 
             final DMNResult dmnResultMultiple = runtime.evaluateDecisionService(dmnModel, emptyContext, "DS with multiple output decisions");
             LOG.debug("{}", dmnResultMultiple);
             dmnResultMultiple.getDecisionResults().forEach(x -> LOG.debug("{}", x));
-            assertThat(DMNRuntimeUtil.formatMessages(dmnResultMultiple.getMessages()), dmnResultMultiple.hasErrors(), is(false));
-            assertThat(dmnResultMultiple.getContext().get("a String Value"), is("a String Value"));
-            assertThat(dmnResultMultiple.getContext().get("a Number Value"), is(BigDecimal.valueOf(47)));
-            assertThat(dmnResultMultiple.getContext().getAll(), not(hasEntry(is("a Value"), anything()))); // Decision Service will not expose (nor encapsulate hence not execute) this decision.
+            assertThat(dmnResultMultiple.hasErrors()).as(DMNRuntimeUtil.formatMessages(dmnResultMultiple.getMessages())).isFalse();
+            assertThat(dmnResultMultiple.getContext().get("a String Value")).isEqualTo("a String Value");
+            assertThat(dmnResultMultiple.getContext().get("a Number Value")).isEqualTo(BigDecimal.valueOf(47));
+            assertThat(dmnResultMultiple.getContext().getAll()).doesNotContainKey("a Value"); // Decision Service will not expose (nor encapsulate hence not execute) this decision.
         } catch (final Exception e) {
             LOG.error("{}", e.getLocalizedMessage(), e);
             throw e;
@@ -440,8 +434,8 @@ public class DMNDecisionServicesTest extends BaseDMN1_1VariantTest {
         // DROOLS-2768 DMN Decision Service encapsulate Decision which imports a Decision Service
         final DMNRuntime runtime = DMNRuntimeUtil.createRuntimeWithAdditionalResources("DecisionService20180718.dmn", this.getClass(), "ImportDecisionService20180718.dmn");
         final DMNModel dmnModel = runtime.getModel("http://www.trisotech.com/dmn/definitions/_0ff3708a-c861-4a96-b85c-7b882f18b7a1", "Import Decision Service 20180718");
-        assertThat(dmnModel, notNullValue());
-        assertThat(DMNRuntimeUtil.formatMessages(dmnModel.getMessages()), dmnModel.hasErrors(), is(false));
+        assertThat(dmnModel).isNotNull();
+        assertThat(dmnModel.hasErrors()).as(DMNRuntimeUtil.formatMessages(dmnModel.getMessages())).isFalse();
 
         testImportDS_testEvaluateAll(runtime, dmnModel);
         testImportDS_testEvaluateDS(runtime, dmnModel);
@@ -454,12 +448,12 @@ public class DMNDecisionServicesTest extends BaseDMN1_1VariantTest {
         final DMNResult dmnResult = runtime.evaluateAll(dmnModel, context);
         LOG.debug("{}", dmnResult);
         dmnResult.getDecisionResults().forEach(x -> LOG.debug("{}", x));
-        assertThat(DMNRuntimeUtil.formatMessages(dmnResult.getMessages()), dmnResult.hasErrors(), is(false));
+        assertThat(dmnResult.hasErrors()).as(DMNRuntimeUtil.formatMessages(dmnResult.getMessages())).isFalse();
 
         final DMNContext result = dmnResult.getContext();
-        assertThat(result.get("invoke imported DS"), is("Hello, L1 Import John; you are allowed"));
-        assertThat(result.get("Prefixing"), is("Hello, L1 Import John"));
-        assertThat(result.get("final Import L1 decision"), is("Hello, L1 Import John the result of invoking the imported DS is: Hello, L1 Import John; you are allowed"));
+        assertThat(result.get("invoke imported DS")).isEqualTo("Hello, L1 Import John; you are allowed");
+        assertThat(result.get("Prefixing")).isEqualTo("Hello, L1 Import John");
+        assertThat(result.get("final Import L1 decision")).isEqualTo("Hello, L1 Import John the result of invoking the imported DS is: Hello, L1 Import John; you are allowed");
     }
 
     private void testImportDS_testEvaluateDS(final DMNRuntime runtime, final DMNModel dmnModel) {
@@ -469,12 +463,12 @@ public class DMNDecisionServicesTest extends BaseDMN1_1VariantTest {
         final DMNResult dmnResult = runtime.evaluateDecisionService(dmnModel, context, "Import L1 DS");
         LOG.debug("{}", dmnResult);
         dmnResult.getDecisionResults().forEach(x -> LOG.debug("{}", x));
-        assertThat(DMNRuntimeUtil.formatMessages(dmnResult.getMessages()), dmnResult.hasErrors(), is(false));
+        assertThat(dmnResult.hasErrors()).as(DMNRuntimeUtil.formatMessages(dmnResult.getMessages())).isFalse();
 
         final DMNContext result = dmnResult.getContext();
-        assertThat(result.getAll(), not(hasEntry(is("invoke imported DS"), anything()))); // Decision Service will encapsulate this decision
-        assertThat(result.getAll(), not(hasEntry(is("Prefixing"), anything()))); // Decision Service will encapsulate this decision
-        assertThat(result.get("final Import L1 decision"), is("Hello, L1 Import Evaluate DS NAME the result of invoking the imported DS is: Hello, L1 Import Evaluate DS NAME; you are allowed"));
+        assertThat(result.getAll()).doesNotContainKey("invoke imported DS"); // Decision Service will encapsulate this decision
+        assertThat(result.getAll()).doesNotContainKey("Prefixing"); // Decision Service will encapsulate this decision
+        assertThat(result.get("final Import L1 decision")).isEqualTo("Hello, L1 Import Evaluate DS NAME the result of invoking the imported DS is: Hello, L1 Import Evaluate DS NAME; you are allowed");
     }
 
     @Test
@@ -484,8 +478,8 @@ public class DMNDecisionServicesTest extends BaseDMN1_1VariantTest {
                                                                                        "ImportDecisionService20180718.dmn",
                                                                                        "ImportofImportDecisionService20180718.dmn");
         final DMNModel dmnModel = runtime.getModel("http://www.trisotech.com/dmn/definitions/_6698dc07-cc43-47ec-8187-8faa7d8c35ba", "Import of Import Decision Service 20180718");
-        assertThat(dmnModel, notNullValue());
-        assertThat(DMNRuntimeUtil.formatMessages(dmnModel.getMessages()), dmnModel.hasErrors(), is(false));
+        assertThat(dmnModel).isNotNull();
+        assertThat(dmnModel.hasErrors()).as(DMNRuntimeUtil.formatMessages(dmnModel.getMessages())).isFalse();
 
         testTransitiveImportDS_testEvaluateAll(runtime, dmnModel);
         testTransitiveImportDS_testEvaluateDS(runtime, dmnModel);
@@ -498,11 +492,11 @@ public class DMNDecisionServicesTest extends BaseDMN1_1VariantTest {
         final DMNResult dmnResult = runtime.evaluateAll(dmnModel, context);
         LOG.debug("{}", dmnResult);
         dmnResult.getDecisionResults().forEach(x -> LOG.debug("{}", x));
-        assertThat(DMNRuntimeUtil.formatMessages(dmnResult.getMessages()), dmnResult.hasErrors(), is(false));
+        assertThat(dmnResult.hasErrors()).as(DMNRuntimeUtil.formatMessages(dmnResult.getMessages())).isFalse();
 
         final DMNContext result = dmnResult.getContext();
-        assertThat(result.get("L2 Invoking the L1 import"), is("Hello, L2 Bob the result of invoking the imported DS is: Hello, L2 Bob; you are allowed"));
-        assertThat(result.get("Final L2 Decision"), is("The result of invoking the L1 DS was: Hello, L2 Bob the result of invoking the imported DS is: Hello, L2 Bob; you are allowed"));
+        assertThat(result.get("L2 Invoking the L1 import")).isEqualTo("Hello, L2 Bob the result of invoking the imported DS is: Hello, L2 Bob; you are allowed");
+        assertThat(result.get("Final L2 Decision")).isEqualTo("The result of invoking the L1 DS was: Hello, L2 Bob the result of invoking the imported DS is: Hello, L2 Bob; you are allowed");
     }
 
     private void testTransitiveImportDS_testEvaluateDS(final DMNRuntime runtime, final DMNModel dmnModel) {
@@ -512,11 +506,11 @@ public class DMNDecisionServicesTest extends BaseDMN1_1VariantTest {
         final DMNResult dmnResult = runtime.evaluateDecisionService(dmnModel, context, "L2 DS");
         LOG.debug("{}", dmnResult);
         dmnResult.getDecisionResults().forEach(x -> LOG.debug("{}", x));
-        assertThat(DMNRuntimeUtil.formatMessages(dmnResult.getMessages()), dmnResult.hasErrors(), is(false));
+        assertThat(dmnResult.hasErrors()).as(DMNRuntimeUtil.formatMessages(dmnResult.getMessages())).isFalse();
 
         final DMNContext result = dmnResult.getContext();
-        assertThat(result.getAll(), not(hasEntry(is("L2 Invoking the L1 import"), anything()))); // Decision Service will encapsulate this decision
-        assertThat(result.get("Final L2 Decision"), is("The result of invoking the L1 DS was: Hello, L2 Bob DS the result of invoking the imported DS is: Hello, L2 Bob DS; you are allowed"));
+        assertThat(result.getAll()).doesNotContainKey("L2 Invoking the L1 import"); // Decision Service will encapsulate this decision
+        assertThat(result.get("Final L2 Decision")).isEqualTo("The result of invoking the L1 DS was: Hello, L2 Bob DS the result of invoking the imported DS is: Hello, L2 Bob DS; you are allowed");
     }
 
     @Test
@@ -524,8 +518,8 @@ public class DMNDecisionServicesTest extends BaseDMN1_1VariantTest {
         // DROOLS-2943 DMN DecisionServiceCompiler not correctly wired for DMNv1.2 format
         final DMNRuntime runtime = DMNRuntimeUtil.createRuntime("DecisionServiceABC.dmn", this.getClass());
         final DMNModel dmnModel = runtime.getModel("http://www.trisotech.com/dmn/definitions/_2443d3f5-f178-47c6-a0c9-b1fd1c933f60", "Drawing 1");
-        assertThat(dmnModel, notNullValue());
-        assertThat(DMNRuntimeUtil.formatMessages(dmnModel.getMessages()), dmnModel.hasErrors(), is(false));
+        assertThat(dmnModel).isNotNull();
+        assertThat(dmnModel.hasErrors()).as(DMNRuntimeUtil.formatMessages(dmnModel.getMessages())).isFalse();
 
         testDecisionServiceCompiler20180830_testEvaluateDS(runtime, dmnModel);
         testDecisionServiceCompiler20180830_testEvaluateAll(runtime, dmnModel);
@@ -537,11 +531,11 @@ public class DMNDecisionServicesTest extends BaseDMN1_1VariantTest {
         final DMNResult dmnResult = runtime.evaluateAll(dmnModel, context);
         LOG.debug("{}", dmnResult);
         dmnResult.getDecisionResults().forEach(x -> LOG.debug("{}", x));
-        assertThat(DMNRuntimeUtil.formatMessages(dmnResult.getMessages()), dmnResult.hasErrors(), is(false));
+        assertThat(dmnResult.hasErrors()).as(DMNRuntimeUtil.formatMessages(dmnResult.getMessages())).isFalse();
 
         final DMNContext result = dmnResult.getContext();
-        assertThat(result.get("ABC"), is("abc"));
-        assertThat(result.get("Invoking Decision"), is("abc"));
+        assertThat(result.get("ABC")).isEqualTo("abc");
+        assertThat(result.get("Invoking Decision")).isEqualTo("abc");
     }
 
     public static void testDecisionServiceCompiler20180830_testEvaluateDS(final DMNRuntime runtime, final DMNModel dmnModel) {
@@ -550,11 +544,11 @@ public class DMNDecisionServicesTest extends BaseDMN1_1VariantTest {
         final DMNResult dmnResult = runtime.evaluateDecisionService(dmnModel, context, "Decision Service ABC");
         LOG.debug("{}", dmnResult);
         dmnResult.getDecisionResults().forEach(x -> LOG.debug("{}", x));
-        assertThat(DMNRuntimeUtil.formatMessages(dmnResult.getMessages()), dmnResult.hasErrors(), is(false));
+        assertThat(dmnResult.hasErrors()).as(DMNRuntimeUtil.formatMessages(dmnResult.getMessages())).isFalse();
 
         final DMNContext result = dmnResult.getContext();
         // NOTE: Decision Service "Decision Service ABC" does NOT encapsulate any decision. 
-        assertThat(result.getAll(), not(hasEntry(is("Invoking Decision"), anything()))); // we invoked only the Decision Service, not this other Decision in the model.
-        assertThat(result.get("ABC"), is("abc"));
+        assertThat(result.getAll()).doesNotContainKey("Invoking Decision"); // we invoked only the Decision Service, not this other Decision in the model.
+        assertThat(result.get("ABC")).isEqualTo("abc");
     }
 }

--- a/kie-dmn/kie-dmn-legacy-tests/src/test/java/org/kie/dmn/legacy/tests/core/v1_1/imports/ImportsTest.java
+++ b/kie-dmn/kie-dmn-legacy-tests/src/test/java/org/kie/dmn/legacy/tests/core/v1_1/imports/ImportsTest.java
@@ -31,14 +31,7 @@ import org.kie.dmn.legacy.tests.core.v1_1.BaseDMN1_1VariantTest;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import static org.hamcrest.CoreMatchers.is;
-import static org.hamcrest.CoreMatchers.notNullValue;
-import static org.hamcrest.CoreMatchers.nullValue;
-import static org.hamcrest.Matchers.contains;
-import static org.hamcrest.Matchers.containsInAnyOrder;
-import static org.hamcrest.Matchers.hasEntry;
-import static org.hamcrest.Matchers.hasSize;
-import static org.hamcrest.MatcherAssert.assertThat;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.kie.dmn.core.util.DMNTestUtil.getAndAssertModelNoErrors;
 import static org.kie.dmn.core.util.DynamicTypeUtils.entry;
 import static org.kie.dmn.core.util.DynamicTypeUtils.mapOf;
@@ -59,22 +52,22 @@ public class ImportsTest extends BaseDMN1_1VariantTest {
 
         final DMNModel importedModel = runtime.getModel("http://www.trisotech.com/definitions/_f27bb64b-6fc7-4e1f-9848-11ba35e0df36",
                                                         "Imported Model");
-        assertThat(importedModel, notNullValue());
-        assertThat(DMNRuntimeUtil.formatMessages(importedModel.getMessages()), importedModel.hasErrors(), is(false));
+        assertThat(importedModel).isNotNull();
+        assertThat(importedModel.hasErrors()).as(DMNRuntimeUtil.formatMessages(importedModel.getMessages())).isFalse();
 
         final DMNModel dmnModel = runtime.getModel("http://www.trisotech.com/definitions/_c3e08836-7973-4e4d-af2b-d46b23725c13",
                                                    "Import BKM and have a Decision Ctx with DT");
-        assertThat(dmnModel, notNullValue());
-        assertThat(DMNRuntimeUtil.formatMessages(dmnModel.getMessages()), dmnModel.hasErrors(), is(false));
+        assertThat(dmnModel).isNotNull();
+        assertThat(dmnModel.hasErrors()).as(DMNRuntimeUtil.formatMessages(dmnModel.getMessages())).isFalse();
 
         final DMNContext context = runtime.newContext();
         context.set("A Person", mapOf(entry("name", "John"), entry("age", 47)));
 
         final DMNResult evaluateAll = runtime.evaluateAll(dmnModel, context);
-        assertThat(DMNRuntimeUtil.formatMessages(evaluateAll.getMessages()), evaluateAll.hasErrors(), is(false));
+        assertThat(evaluateAll.hasErrors()).as(DMNRuntimeUtil.formatMessages(evaluateAll.getMessages())).isFalse();
 
         LOG.debug("{}", evaluateAll);
-        assertThat(evaluateAll.getDecisionResultByName("A Decision Ctx with DT").getResult(), is("Respectfully, Hello John!"));
+        assertThat(evaluateAll.getDecisionResultByName("A Decision Ctx with DT").getResult()).isEqualTo("Respectfully, Hello John!");
     }
     
     @Test
@@ -85,23 +78,24 @@ public class ImportsTest extends BaseDMN1_1VariantTest {
 
         final DMNModel importedModel = runtime.getModel("http://www.trisotech.com/dmn/definitions/_16a48e7a-0687-4c2d-b402-42925084fa1a",
                                                         "Saying hello 2 bkms");
-        assertThat(importedModel, notNullValue());
-        assertThat(DMNRuntimeUtil.formatMessages(importedModel.getMessages()), importedModel.hasErrors(), is(false));
+        assertThat(importedModel).isNotNull();
+        assertThat(importedModel.hasErrors()).as(DMNRuntimeUtil.formatMessages(importedModel.getMessages())).isFalse();
 
         final DMNModel dmnModel = runtime.getModel("http://www.trisotech.com/dmn/definitions/_01a65215-7e0d-47ac-845a-a768f6abf7fe",
                                                    "Do say hello with 2 bkms");
-        assertThat(dmnModel, notNullValue());
-        assertThat(DMNRuntimeUtil.formatMessages(dmnModel.getMessages()), dmnModel.hasErrors(), is(false));
+        assertThat(dmnModel).isNotNull();
+        assertThat(dmnModel.hasErrors()).as(DMNRuntimeUtil.formatMessages(dmnModel.getMessages())).isFalse();
 
         final DMNContext context = runtime.newContext();
         context.set("Person name", "John");
 
         final DMNResult evaluateAll = runtime.evaluateAll(dmnModel, context);
-        assertThat(DMNRuntimeUtil.formatMessages(evaluateAll.getMessages()), evaluateAll.hasErrors(), is(false));
+        
+        assertThat(evaluateAll.hasErrors()).as(DMNRuntimeUtil.formatMessages(evaluateAll.getMessages())).isFalse();
 
         LOG.debug("{}", evaluateAll);
-        assertThat(evaluateAll.getDecisionResultByName("Say hello decision").getResult(), is("Hello, John"));
-        assertThat(evaluateAll.getDecisionResultByName("what about hello").getResult(), is("Hello"));
+        assertThat(evaluateAll.getDecisionResultByName("Say hello decision").getResult()).isEqualTo("Hello, John");
+        assertThat(evaluateAll.getDecisionResultByName("what about hello").getResult()).isEqualTo("Hello");
     }
 
     @Test
@@ -112,21 +106,21 @@ public class ImportsTest extends BaseDMN1_1VariantTest {
 
         final DMNModel importedModel = runtime.getModel("http://www.trisotech.com/dmn/definitions/_16a48e7a-0687-4c2d-b402-42925084fa1a",
                                                         "Saying hello 2 bkms");
-        assertThat(importedModel, notNullValue());
-        assertThat(DMNRuntimeUtil.formatMessages(importedModel.getMessages()), importedModel.hasErrors(), is(false));
+        assertThat(importedModel).isNotNull();
+        assertThat(importedModel.hasErrors()).as(DMNRuntimeUtil.formatMessages(importedModel.getMessages())).isFalse();
 
         final DMNModel dmnModel = runtime.getModel("http://www.trisotech.com/definitions/_eedf6ecc-f113-4333-ace0-79b783e313e5",
                                                    "Do invoke hello with 2 bkms");
-        assertThat(dmnModel, notNullValue());
-        assertThat(DMNRuntimeUtil.formatMessages(dmnModel.getMessages()), dmnModel.hasErrors(), is(false));
+        assertThat(dmnModel).isNotNull();
+        assertThat(dmnModel.hasErrors()).as(DMNRuntimeUtil.formatMessages(dmnModel.getMessages())).isFalse();
 
         final DMNContext emptyContext = runtime.newContext();
 
         final DMNResult evaluateAll = runtime.evaluateAll(dmnModel, emptyContext);
-        assertThat(DMNRuntimeUtil.formatMessages(evaluateAll.getMessages()), evaluateAll.hasErrors(), is(false));
+        assertThat(evaluateAll.hasErrors()).as(DMNRuntimeUtil.formatMessages(evaluateAll.getMessages())).isFalse();
 
         LOG.debug("{}", evaluateAll);
-        assertThat(evaluateAll.getDecisionResultByName("invocation of hello").getResult(), is("Hello, John"));
+        assertThat(evaluateAll.getDecisionResultByName("invocation of hello").getResult()).isEqualTo("Hello, John");
     }
 
     @Test
@@ -138,22 +132,23 @@ public class ImportsTest extends BaseDMN1_1VariantTest {
 
         final DMNModel importedModel = runtime.getModel("http://www.trisotech.com/dmn/definitions/_16a48e7a-0687-4c2d-b402-42925084fa1a",
                                                         "Saying hello 2 bkms");
-        assertThat(importedModel, notNullValue());
-        assertThat(DMNRuntimeUtil.formatMessages(importedModel.getMessages()), importedModel.hasErrors(), is(false));
+        assertThat(importedModel).isNotNull();
+        
+        assertThat(importedModel.hasErrors()).as(DMNRuntimeUtil.formatMessages(importedModel.getMessages())).isFalse();
 
         final DMNModel dmnModel = runtime.getModel("http://www.trisotech.com/definitions/_eedf6ecc-f113-4333-ace0-79b783e313e5",
                                                    "Do invoke hello with 2 bkms");
-        assertThat(dmnModel, notNullValue());
-        assertThat(DMNRuntimeUtil.formatMessages(dmnModel.getMessages()), dmnModel.hasErrors(), is(false));
+        assertThat(dmnModel).isNotNull();
+        assertThat(dmnModel.hasErrors()).as(DMNRuntimeUtil.formatMessages(dmnModel.getMessages())).isFalse();
 
         final DMNContext context = runtime.newContext();
         context.set("Person name", "Bob");
 
         final DMNResult evaluateAll = runtime.evaluateAll(dmnModel, context);
-        assertThat(DMNRuntimeUtil.formatMessages(evaluateAll.getMessages()), evaluateAll.hasErrors(), is(false));
+        assertThat(evaluateAll.hasErrors()).as(DMNRuntimeUtil.formatMessages(evaluateAll.getMessages())).isFalse();
 
         LOG.debug("{}", evaluateAll);
-        assertThat(evaluateAll.getDecisionResultByName("what about hello").getResult(), is("Hello, Bob"));
+        assertThat(evaluateAll.getDecisionResultByName("what about hello").getResult()).isEqualTo("Hello, Bob");
     }
 
     @Test
@@ -169,30 +164,30 @@ public class ImportsTest extends BaseDMN1_1VariantTest {
 
         final DMNModel importedModel = runtime.getModel("http://www.trisotech.com/dmn/definitions/_16a48e7a-0687-4c2d-b402-42925084fa1a",
                                                         "Saying hello 2 bkms");
-        assertThat(importedModel, notNullValue());
-        assertThat(DMNRuntimeUtil.formatMessages(importedModel.getMessages()), importedModel.hasErrors(), is(false));
+        assertThat(importedModel).isNotNull();
+        assertThat(importedModel.hasErrors()).as(DMNRuntimeUtil.formatMessages(importedModel.getMessages())).isFalse();
 
         final DMNModel dmnModel = runtime.getModel("http://www.trisotech.com/dmn/definitions/_01a65215-7e0d-47ac-845a-a768f6abf7fe",
                                                    "Do say hello with 2 bkms");
-        assertThat(dmnModel, notNullValue());
-        assertThat(DMNRuntimeUtil.formatMessages(dmnModel.getMessages()), dmnModel.hasErrors(), is(false));
+        assertThat(dmnModel).isNotNull();
+        assertThat(dmnModel.hasErrors()).as(DMNRuntimeUtil.formatMessages(dmnModel.getMessages())).isFalse();
 
         final DMNModel dmnModelL3 = runtime.getModel("http://www.trisotech.com/dmn/definitions/_820c548c-377d-463e-a62b-bb95ddc4758c",
                                                      "L3 Do say hello");
-        assertThat(dmnModelL3, notNullValue());
-        assertThat(DMNRuntimeUtil.formatMessages(dmnModelL3.getMessages()), dmnModelL3.hasErrors(), is(false));
+        assertThat(dmnModelL3).isNotNull();
+        assertThat(dmnModelL3.hasErrors()).as(DMNRuntimeUtil.formatMessages(dmnModelL3.getMessages())).isFalse();
 
         final DMNContext context = runtime.newContext();
         context.set("Another Name", "Bob");
         context.set("L2import", mapOf(entry("Person name", "John")));
 
         final DMNResult evaluateAll = runtime.evaluateAll(dmnModelL3, context);
-        assertThat(DMNRuntimeUtil.formatMessages(evaluateAll.getMessages()), evaluateAll.hasErrors(), is(false));
+        assertThat(evaluateAll.hasErrors()).as(DMNRuntimeUtil.formatMessages(evaluateAll.getMessages())).isFalse();
 
         LOG.debug("{}", evaluateAll);
-        assertThat(evaluateAll.getDecisionResultByName("L3 decision").getResult(), is("Hello, Bob"));
-        assertThat(evaluateAll.getDecisionResultByName("L3 view on M2").getResult(), is("Hello, John"));
-        assertThat(evaluateAll.getDecisionResultByName("L3 what about hello").getResult(), is("Hello"));
+        assertThat(evaluateAll.getDecisionResultByName("L3 decision").getResult()).isEqualTo("Hello, Bob");
+        assertThat(evaluateAll.getDecisionResultByName("L3 view on M2").getResult()).isEqualTo("Hello, John");
+        assertThat(evaluateAll.getDecisionResultByName("L3 what about hello").getResult()).isEqualTo("Hello");
     }
 
     @Test
@@ -203,22 +198,22 @@ public class ImportsTest extends BaseDMN1_1VariantTest {
 
         final DMNModel importedModel = runtime.getModel("http://www.trisotech.com/dmn/definitions/_88f4fc88-1eb2-4188-a721-5720cf5565ce",
                                                         "Spell Greeting");
-        assertThat(importedModel, notNullValue());
-        assertThat(DMNRuntimeUtil.formatMessages(importedModel.getMessages()), importedModel.hasErrors(), is(false));
+        assertThat(importedModel).isNotNull();
+        assertThat(importedModel.hasErrors()).as(DMNRuntimeUtil.formatMessages(importedModel.getMessages())).isFalse();
 
         final DMNModel dmnModel = runtime.getModel("http://www.trisotech.com/dmn/definitions/_d67f19e9-7835-4cad-9c80-16b8423cc392",
                                                    "Import Spell Greeting");
-        assertThat(dmnModel, notNullValue());
-        assertThat(DMNRuntimeUtil.formatMessages(dmnModel.getMessages()), dmnModel.hasErrors(), is(false));
+        assertThat(dmnModel).isNotNull();
+        assertThat(dmnModel.hasErrors()).as(DMNRuntimeUtil.formatMessages(dmnModel.getMessages())).isFalse();
 
         final DMNContext context = runtime.newContext();
         context.set("Person Name", "John");
 
         final DMNResult evaluateAll = runtime.evaluateAll(dmnModel, context);
-        assertThat(DMNRuntimeUtil.formatMessages(evaluateAll.getMessages()), evaluateAll.hasErrors(), is(false));
+        assertThat(evaluateAll.hasErrors()).as(DMNRuntimeUtil.formatMessages(evaluateAll.getMessages())).isFalse();
 
         LOG.debug("{}", evaluateAll);
-        assertThat(evaluateAll.getDecisionResultByName("Say the Greeting to Person").getResult(), is("Hello, John"));
+        assertThat(evaluateAll.getDecisionResultByName("Say the Greeting to Person").getResult()).isEqualTo("Hello, John");
     }
 
     @Test
@@ -245,9 +240,9 @@ public class ImportsTest extends BaseDMN1_1VariantTest {
 
         final DMNResult evaluateAll = runtime.evaluateAll(dmnModel, context);
         LOG.debug("{}", evaluateAll);
-        assertThat(DMNRuntimeUtil.formatMessages(evaluateAll.getMessages()), evaluateAll.hasErrors(), is(false));
+        assertThat(evaluateAll.hasErrors()).as(DMNRuntimeUtil.formatMessages(evaluateAll.getMessages())).isFalse();
 
-        assertThat(evaluateAll.getDecisionResultByName("Evaluating Say Hello").getResult(), is("Evaluating Say Hello to: Hello, John"));
+        assertThat(evaluateAll.getDecisionResultByName("Evaluating Say Hello").getResult()).isEqualTo("Evaluating Say Hello to: Hello, John");
     }
 
     @Test
@@ -265,9 +260,9 @@ public class ImportsTest extends BaseDMN1_1VariantTest {
 
         final DMNResult evaluateAll = runtime.evaluateAll(dmnModel, context);
         LOG.debug("{}", evaluateAll);
-        assertThat(DMNRuntimeUtil.formatMessages(evaluateAll.getMessages()), evaluateAll.hasErrors(), is(false));
+        assertThat(evaluateAll.hasErrors()).as(DMNRuntimeUtil.formatMessages(evaluateAll.getMessages())).isFalse();
 
-        assertThat(evaluateAll.getDecisionResultByName("Model C Decision based on Bs").getResult(), is("B: Evaluating Say Hello to: Hello, B.A.John; B2:Evaluating Say Hello to: Hello, B2.A.John2"));
+        assertThat(evaluateAll.getDecisionResultByName("Model C Decision based on Bs").getResult()).isEqualTo("B: Evaluating Say Hello to: Hello, B.A.John; B2:Evaluating Say Hello to: Hello, B2.A.John2");
     }
 
     @Test
@@ -283,9 +278,9 @@ public class ImportsTest extends BaseDMN1_1VariantTest {
 
         final DMNResult evaluateAll = runtime.evaluateAll(dmnModel, context);
         LOG.debug("{}", evaluateAll);
-        assertThat(DMNRuntimeUtil.formatMessages(evaluateAll.getMessages()), evaluateAll.hasErrors(), is(false));
+        assertThat(evaluateAll.hasErrors()).as(DMNRuntimeUtil.formatMessages(evaluateAll.getMessages())).isFalse();
 
-        assertThat(evaluateAll.getDecisionResultByName("Hello decision using imported InputData").getResult(), is("Hello, DROOLS-2944"));
+        assertThat(evaluateAll.getDecisionResultByName("Hello decision using imported InputData").getResult()).isEqualTo("Hello, DROOLS-2944");
     }
 
     @Test
@@ -315,10 +310,10 @@ public class ImportsTest extends BaseDMN1_1VariantTest {
         final DMNResult evaluateAll = fn.apply(context);
         LOG.debug("{}", evaluateAll);
         LOG.debug("{}", evaluateAll.getDecisionResults());
-        assertThat(DMNRuntimeUtil.formatMessages(evaluateAll.getMessages()), evaluateAll.hasErrors(), is(false));
+        assertThat(evaluateAll.hasErrors()).as(DMNRuntimeUtil.formatMessages(evaluateAll.getMessages())).isFalse();
 
-        assertThat(evaluateAll.getDecisionResultByName("Evaluating Say Hello").getResult(), is("Evaluating Say Hello to: Hello, John"));
-        assertThat(evaluateAll.getDecisionResultByName("modelA.Greet the Person").getResult(), is("Hello, John"));
+        assertThat(evaluateAll.getDecisionResultByName("Evaluating Say Hello").getResult()).isEqualTo("Evaluating Say Hello to: Hello, John");
+        assertThat(evaluateAll.getDecisionResultByName("modelA.Greet the Person").getResult()).isEqualTo("Hello, John");
     }
 
     @Test
@@ -329,19 +324,19 @@ public class ImportsTest extends BaseDMN1_1VariantTest {
                                                                                        "ModelB.dmn");
         final DMNModel dmnModel = getAndAssertModelNoErrors(runtime, "http://www.trisotech.com/dmn/definitions/_2a1d771a-a899-4fef-abd6-fc894332337c", "Model B");
 
-        assertThat(dmnModel.getDecisionById("_96df766e-23e1-4aa6-9d5d-545fbe2f1e23").getName(), is("Evaluating Say Hello"));
-        assertThat(dmnModel.getDecisionById("http://www.trisotech.com/dmn/definitions/_ae5b3c17-1ac3-4e1d-b4f9-2cf861aec6d9#_f7fdaec4-d669-4797-b3b4-12b860de2eb5").getName(), is("Greet the Person")); // this is an imported Decision
-        assertThat(dmnModel.getDecisionById("_f7fdaec4-d669-4797-b3b4-12b860de2eb5"), nullValue()); // this is an imported Decision
+        assertThat(dmnModel.getDecisionById("_96df766e-23e1-4aa6-9d5d-545fbe2f1e23").getName()).isEqualTo("Evaluating Say Hello");
+        assertThat(dmnModel.getDecisionById("http://www.trisotech.com/dmn/definitions/_ae5b3c17-1ac3-4e1d-b4f9-2cf861aec6d9#_f7fdaec4-d669-4797-b3b4-12b860de2eb5").getName()).isEqualTo("Greet the Person"); // this is an imported Decision
+        assertThat(dmnModel.getDecisionById("_f7fdaec4-d669-4797-b3b4-12b860de2eb5")).isNull(); // this is an imported Decision
 
-        assertThat(dmnModel.getDecisionByName("Evaluating Say Hello").getId(), is("_96df766e-23e1-4aa6-9d5d-545fbe2f1e23"));
-        assertThat(dmnModel.getDecisionByName("Greet the Person"), nullValue()); // this is an imported Decision
-        assertThat(dmnModel.getDecisionByName("modelA.Greet the Person").getId(), is("_f7fdaec4-d669-4797-b3b4-12b860de2eb5")); // this is an imported Decision
+        assertThat(dmnModel.getDecisionByName("Evaluating Say Hello").getId()).isEqualTo("_96df766e-23e1-4aa6-9d5d-545fbe2f1e23");
+        assertThat(dmnModel.getDecisionByName("Greet the Person")).isNull(); // this is an imported Decision
+        assertThat(dmnModel.getDecisionByName("modelA.Greet the Person").getId()).isEqualTo("_f7fdaec4-d669-4797-b3b4-12b860de2eb5"); // this is an imported Decision
 
-        assertThat(dmnModel.getInputById("http://www.trisotech.com/dmn/definitions/_ae5b3c17-1ac3-4e1d-b4f9-2cf861aec6d9#_4f6c136c-8512-4d71-8bbf-7c9eb6e74063").getName(), is("Person name")); // this is an imported InputData node.
-        assertThat(dmnModel.getInputById("_4f6c136c-8512-4d71-8bbf-7c9eb6e74063"), nullValue()); // this is an imported InputData node.
+        assertThat(dmnModel.getInputById("http://www.trisotech.com/dmn/definitions/_ae5b3c17-1ac3-4e1d-b4f9-2cf861aec6d9#_4f6c136c-8512-4d71-8bbf-7c9eb6e74063").getName()).isEqualTo("Person name"); // this is an imported InputData node.
+        assertThat(dmnModel.getInputById("_4f6c136c-8512-4d71-8bbf-7c9eb6e74063")).isNull(); // this is an imported InputData node.
 
-        assertThat(dmnModel.getInputByName("Person name"), nullValue()); // this is an imported InputData node.
-        assertThat(dmnModel.getInputByName("modelA.Person name").getId(), is("_4f6c136c-8512-4d71-8bbf-7c9eb6e74063")); // this is an imported InputData node.
+        assertThat(dmnModel.getInputByName("Person name")).isNull(); // this is an imported InputData node.
+        assertThat(dmnModel.getInputByName("modelA.Person name").getId()).isEqualTo("_4f6c136c-8512-4d71-8bbf-7c9eb6e74063"); // this is an imported InputData node.
     }
 
     @Test
@@ -354,22 +349,25 @@ public class ImportsTest extends BaseDMN1_1VariantTest {
                                                                                        "ModelC.dmn");
 
         final DMNModelImpl modelA = (DMNModelImpl) getAndAssertModelNoErrors(runtime, "http://www.trisotech.com/dmn/definitions/_ae5b3c17-1ac3-4e1d-b4f9-2cf861aec6d9", "Say hello 1ID1D");
-        assertThat(modelA.getImportChainAliases().entrySet(), hasSize(0));
+        assertThat(modelA.getImportChainAliases()).hasSize(0);
 
         final DMNModelImpl modelB = (DMNModelImpl) getAndAssertModelNoErrors(runtime, "http://www.trisotech.com/dmn/definitions/_2a1d771a-a899-4fef-abd6-fc894332337c", "Model B");
-        assertThat(modelB.getImportChainAliases().entrySet(), hasSize(1));
-        assertThat(modelB.getImportChainAliases(), hasEntry(is("http://www.trisotech.com/dmn/definitions/_ae5b3c17-1ac3-4e1d-b4f9-2cf861aec6d9"),
-                                                            contains(Collections.singletonList("modelA"))));
+        assertThat(modelB.getImportChainAliases()).hasSize(1);
+        assertThat(modelB.getImportChainAliases()).containsKey("http://www.trisotech.com/dmn/definitions/_ae5b3c17-1ac3-4e1d-b4f9-2cf861aec6d9");
+        assertThat(modelB.getImportChainAliases().get("http://www.trisotech.com/dmn/definitions/_ae5b3c17-1ac3-4e1d-b4f9-2cf861aec6d9")).contains(Collections.singletonList("modelA"));
 
         final DMNModelImpl modelC = (DMNModelImpl) getAndAssertModelNoErrors(runtime, "http://www.trisotech.com/dmn/definitions/_10435dcd-8774-4575-a338-49dd554a0928", "Model C");
-        assertThat(modelC.getImportChainAliases().entrySet(), hasSize(3));
-        assertThat(modelC.getImportChainAliases(), hasEntry(is("http://www.trisotech.com/dmn/definitions/_2a1d771a-a899-4fef-abd6-fc894332337c"),
-                                                            contains(Collections.singletonList("Model B"))));
-        assertThat(modelC.getImportChainAliases(), hasEntry(is("http://www.trisotech.com/definitions/_9d46ece4-a96c-4cb0-abc0-0ca121ac3768"),
-                                                            contains(Collections.singletonList("Model B2"))));
-        assertThat(modelC.getImportChainAliases(), hasEntry(is("http://www.trisotech.com/dmn/definitions/_ae5b3c17-1ac3-4e1d-b4f9-2cf861aec6d9"),
-                                                            containsInAnyOrder(Arrays.asList("Model B2", "modelA"),
-                                                                               Arrays.asList("Model B", "modelA"))));
+        assertThat(modelC.getImportChainAliases()).hasSize(3);
+        
+        assertThat(modelC.getImportChainAliases()).containsKey("http://www.trisotech.com/dmn/definitions/_2a1d771a-a899-4fef-abd6-fc894332337c");
+        assertThat(modelC.getImportChainAliases().get("http://www.trisotech.com/dmn/definitions/_2a1d771a-a899-4fef-abd6-fc894332337c")).contains(Collections.singletonList("Model B"));
+        
+        assertThat(modelC.getImportChainAliases()).containsKey("http://www.trisotech.com/definitions/_9d46ece4-a96c-4cb0-abc0-0ca121ac3768");
+        assertThat(modelC.getImportChainAliases().get("http://www.trisotech.com/definitions/_9d46ece4-a96c-4cb0-abc0-0ca121ac3768")).contains(Collections.singletonList("Model B2"));
+
+        assertThat(modelC.getImportChainAliases()).containsKey("http://www.trisotech.com/dmn/definitions/_ae5b3c17-1ac3-4e1d-b4f9-2cf861aec6d9");
+        assertThat(modelC.getImportChainAliases().get("http://www.trisotech.com/dmn/definitions/_ae5b3c17-1ac3-4e1d-b4f9-2cf861aec6d9")).contains(Arrays.asList("Model B2", "modelA"),
+                                                                               Arrays.asList("Model B", "modelA"));
     }
 
 }

--- a/kie-dmn/kie-dmn-legacy-tests/src/test/java/org/kie/dmn/legacy/tests/validation/v1_1/ValidatorArtifactTest.java
+++ b/kie-dmn/kie-dmn-legacy-tests/src/test/java/org/kie/dmn/legacy/tests/validation/v1_1/ValidatorArtifactTest.java
@@ -26,8 +26,7 @@ import org.kie.dmn.api.core.DMNMessageType;
 import org.kie.dmn.validation.AbstractValidatorTest;
 import org.kie.dmn.validation.ValidatorUtil;
 
-import static org.hamcrest.CoreMatchers.is;
-import static org.hamcrest.MatcherAssert.assertThat;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.Assert.assertTrue;
 import static org.kie.dmn.validation.DMNValidator.Validation.VALIDATE_COMPILATION;
 import static org.kie.dmn.validation.DMNValidator.Validation.VALIDATE_MODEL;
@@ -41,7 +40,7 @@ public class ValidatorArtifactTest extends AbstractValidatorTest {
             final List<DMNMessage> validate = validator.validate(
                     reader,
                     VALIDATE_SCHEMA, VALIDATE_MODEL, VALIDATE_COMPILATION);
-            assertThat( ValidatorUtil.formatMessages( validate ), validate.size(), is( 2 ) );
+            assertThat(validate).as(ValidatorUtil.formatMessages(validate)).hasSize(2);
             assertTrue( validate.stream().anyMatch( p -> p.getMessageType().equals( DMNMessageType.REQ_NOT_FOUND ) ) );
         }
     }
@@ -51,7 +50,7 @@ public class ValidatorArtifactTest extends AbstractValidatorTest {
         final List<DMNMessage> validate = validator.validate(
                 getFile( "artifact/ASSOC_REFERENCES_NOT_EMPTY.dmn" ),
                 VALIDATE_SCHEMA, VALIDATE_MODEL, VALIDATE_COMPILATION);
-        assertThat( ValidatorUtil.formatMessages( validate ), validate.size(), is( 2 ) );
+        assertThat(validate).as(ValidatorUtil.formatMessages(validate)).hasSize(2);
         assertTrue( validate.stream().anyMatch( p -> p.getMessageType().equals( DMNMessageType.REQ_NOT_FOUND ) ) );
     }
 
@@ -62,7 +61,7 @@ public class ValidatorArtifactTest extends AbstractValidatorTest {
                                 "https://github.com/kiegroup/kie-dmn",
                                 "ASSOC_REFERENCES_NOT_EMPTY"),
                 VALIDATE_MODEL, VALIDATE_COMPILATION);
-        assertThat( ValidatorUtil.formatMessages( validate ), validate.size(), is( 2 ) );
+        assertThat(validate).as(ValidatorUtil.formatMessages(validate)).hasSize(2);
         assertTrue( validate.stream().anyMatch( p -> p.getMessageType().equals( DMNMessageType.REQ_NOT_FOUND ) ) );
     }
 }

--- a/kie-dmn/kie-dmn-legacy-tests/src/test/java/org/kie/dmn/legacy/tests/validation/v1_1/ValidatorAuthorityRequirementTest.java
+++ b/kie-dmn/kie-dmn-legacy-tests/src/test/java/org/kie/dmn/legacy/tests/validation/v1_1/ValidatorAuthorityRequirementTest.java
@@ -26,8 +26,7 @@ import org.kie.dmn.api.core.DMNMessageType;
 import org.kie.dmn.validation.AbstractValidatorTest;
 import org.kie.dmn.validation.ValidatorUtil;
 
-import static org.hamcrest.CoreMatchers.is;
-import static org.hamcrest.MatcherAssert.assertThat;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.Assert.assertTrue;
 import static org.kie.dmn.validation.DMNValidator.Validation.VALIDATE_COMPILATION;
 import static org.kie.dmn.validation.DMNValidator.Validation.VALIDATE_MODEL;
@@ -41,7 +40,7 @@ public class ValidatorAuthorityRequirementTest extends AbstractValidatorTest {
             final List<DMNMessage> validate = validator.validate(
                     reader,
                     VALIDATE_SCHEMA, VALIDATE_MODEL, VALIDATE_COMPILATION);
-            assertThat(ValidatorUtil.formatMessages(validate), validate.size(), is(3));
+             assertThat(validate).as(ValidatorUtil.formatMessages(validate)).hasSize(3);
             assertTrue(validate.stream().anyMatch(p -> p.getMessageType().equals(DMNMessageType.REQ_NOT_FOUND)));
         }
     }
@@ -51,7 +50,7 @@ public class ValidatorAuthorityRequirementTest extends AbstractValidatorTest {
         final List<DMNMessage> validate = validator.validate(
                 getFile("authorityrequirement/AUTHREQ_MISSING_DEPENDENCY_REQ_AUTH.dmn"),
                 VALIDATE_SCHEMA, VALIDATE_MODEL, VALIDATE_COMPILATION);
-        assertThat(ValidatorUtil.formatMessages(validate), validate.size(), is(3));
+         assertThat(validate).as(ValidatorUtil.formatMessages(validate)).hasSize(3);
         assertTrue(validate.stream().anyMatch(p -> p.getMessageType().equals(DMNMessageType.REQ_NOT_FOUND)));
     }
 
@@ -62,7 +61,7 @@ public class ValidatorAuthorityRequirementTest extends AbstractValidatorTest {
                                "https://github.com/kiegroup/kie-dmn",
                                "AUTHREQ_MISSING_DEPENDENCY_REQ_AUTH"),
                 VALIDATE_MODEL, VALIDATE_COMPILATION);
-        assertThat(ValidatorUtil.formatMessages(validate), validate.size(), is(3));
+         assertThat(validate).as(ValidatorUtil.formatMessages(validate)).hasSize(3);
         assertTrue(validate.stream().anyMatch(p -> p.getMessageType().equals(DMNMessageType.REQ_NOT_FOUND)));
     }
 
@@ -72,7 +71,7 @@ public class ValidatorAuthorityRequirementTest extends AbstractValidatorTest {
             final List<DMNMessage> validate = validator.validate(
                     reader,
                     VALIDATE_SCHEMA, VALIDATE_MODEL, VALIDATE_COMPILATION);
-            assertThat(ValidatorUtil.formatMessages(validate), validate.size(), is(3));
+             assertThat(validate).as(ValidatorUtil.formatMessages(validate)).hasSize(3);
             assertTrue(validate.stream().anyMatch(p -> p.getMessageType().equals(DMNMessageType.REQ_NOT_FOUND)));
         }
     }
@@ -82,7 +81,7 @@ public class ValidatorAuthorityRequirementTest extends AbstractValidatorTest {
         final List<DMNMessage> validate = validator.validate(
                 getFile("authorityrequirement/AUTHREQ_MISSING_DEPENDENCY_REQ_DEC.dmn"),
                 VALIDATE_SCHEMA, VALIDATE_MODEL, VALIDATE_COMPILATION);
-        assertThat(ValidatorUtil.formatMessages(validate), validate.size(), is(3));
+         assertThat(validate).as(ValidatorUtil.formatMessages(validate)).hasSize(3);
         assertTrue(validate.stream().anyMatch(p -> p.getMessageType().equals(DMNMessageType.REQ_NOT_FOUND)));
     }
 
@@ -93,7 +92,7 @@ public class ValidatorAuthorityRequirementTest extends AbstractValidatorTest {
                                "https://github.com/kiegroup/kie-dmn",
                                "AUTHREQ_MISSING_DEPENDENCY_REQ_DEC"),
                 VALIDATE_MODEL, VALIDATE_COMPILATION);
-        assertThat(ValidatorUtil.formatMessages(validate), validate.size(), is(3));
+         assertThat(validate).as(ValidatorUtil.formatMessages(validate)).hasSize(3);
         assertTrue(validate.stream().anyMatch(p -> p.getMessageType().equals(DMNMessageType.REQ_NOT_FOUND)));
     }
 
@@ -103,7 +102,7 @@ public class ValidatorAuthorityRequirementTest extends AbstractValidatorTest {
             final List<DMNMessage> validate = validator.validate(
                     reader,
                     VALIDATE_SCHEMA, VALIDATE_MODEL, VALIDATE_COMPILATION);
-            assertThat(ValidatorUtil.formatMessages(validate), validate.size(), is(3));
+             assertThat(validate).as(ValidatorUtil.formatMessages(validate)).hasSize(3);
             assertTrue(validate.stream().anyMatch(p -> p.getMessageType().equals(DMNMessageType.REQ_NOT_FOUND)));
         }
     }
@@ -113,7 +112,7 @@ public class ValidatorAuthorityRequirementTest extends AbstractValidatorTest {
         final List<DMNMessage> validate = validator.validate(
                 getFile("authorityrequirement/AUTHREQ_MISSING_DEPENDENCY_REQ_INPUT.dmn"),
                 VALIDATE_SCHEMA, VALIDATE_MODEL, VALIDATE_COMPILATION);
-        assertThat(ValidatorUtil.formatMessages(validate), validate.size(), is(3));
+         assertThat(validate).as(ValidatorUtil.formatMessages(validate)).hasSize(3);
         assertTrue(validate.stream().anyMatch(p -> p.getMessageType().equals(DMNMessageType.REQ_NOT_FOUND)));
     }
 
@@ -124,7 +123,7 @@ public class ValidatorAuthorityRequirementTest extends AbstractValidatorTest {
                                "https://github.com/kiegroup/kie-dmn",
                                "AUTHREQ_MISSING_DEPENDENCY_REQ_INPUT"),
                 VALIDATE_MODEL, VALIDATE_COMPILATION);
-        assertThat(ValidatorUtil.formatMessages(validate), validate.size(), is(3));
+         assertThat(validate).as(ValidatorUtil.formatMessages(validate)).hasSize(3);
         assertTrue(validate.stream().anyMatch(p -> p.getMessageType().equals(DMNMessageType.REQ_NOT_FOUND)));
     }
 
@@ -134,7 +133,7 @@ public class ValidatorAuthorityRequirementTest extends AbstractValidatorTest {
             final List<DMNMessage> validate = validator.validate(
                     reader,
                     VALIDATE_SCHEMA, VALIDATE_MODEL, VALIDATE_COMPILATION);
-            assertThat(ValidatorUtil.formatMessages(validate), validate.size(), is(3));
+             assertThat(validate).as(ValidatorUtil.formatMessages(validate)).hasSize(3);
             assertTrue(validate.stream().anyMatch(p -> p.getMessageType().equals(DMNMessageType.REQ_NOT_FOUND)));
         }
     }
@@ -144,7 +143,7 @@ public class ValidatorAuthorityRequirementTest extends AbstractValidatorTest {
         final List<DMNMessage> validate = validator.validate(
                 getFile("authorityrequirement/AUTHREQ_DEP_REQ_AUTH_NOT_KNOWLEDGESOURCE.dmn"),
                 VALIDATE_SCHEMA, VALIDATE_MODEL, VALIDATE_COMPILATION);
-        assertThat(ValidatorUtil.formatMessages(validate), validate.size(), is(3));
+         assertThat(validate).as(ValidatorUtil.formatMessages(validate)).hasSize(3);
         assertTrue(validate.stream().anyMatch(p -> p.getMessageType().equals(DMNMessageType.REQ_NOT_FOUND)));
     }
 
@@ -155,7 +154,7 @@ public class ValidatorAuthorityRequirementTest extends AbstractValidatorTest {
                                "https://github.com/kiegroup/kie-dmn",
                                "AUTHREQ_DEP_REQ_AUTH_NOT_KNOWLEDGESOURCE"),
                 VALIDATE_MODEL, VALIDATE_COMPILATION);
-        assertThat(ValidatorUtil.formatMessages(validate), validate.size(), is(3));
+         assertThat(validate).as(ValidatorUtil.formatMessages(validate)).hasSize(3);
         assertTrue(validate.stream().anyMatch(p -> p.getMessageType().equals(DMNMessageType.REQ_NOT_FOUND)));
     }
 
@@ -165,7 +164,7 @@ public class ValidatorAuthorityRequirementTest extends AbstractValidatorTest {
             final List<DMNMessage> validate = validator.validate(
                     reader,
                     VALIDATE_SCHEMA, VALIDATE_MODEL, VALIDATE_COMPILATION);
-            assertThat(ValidatorUtil.formatMessages(validate), validate.size(), is(3));
+             assertThat(validate).as(ValidatorUtil.formatMessages(validate)).hasSize(3);
             assertTrue(validate.stream().anyMatch(p -> p.getMessageType().equals(DMNMessageType.REQ_NOT_FOUND)));
         }
     }
@@ -175,7 +174,7 @@ public class ValidatorAuthorityRequirementTest extends AbstractValidatorTest {
         final List<DMNMessage> validate = validator.validate(
                 getFile("authorityrequirement/AUTHREQ_DEP_REQ_DEC_NOT_DECISION.dmn"),
                 VALIDATE_SCHEMA, VALIDATE_MODEL, VALIDATE_COMPILATION);
-        assertThat(ValidatorUtil.formatMessages(validate), validate.size(), is(3));
+         assertThat(validate).as(ValidatorUtil.formatMessages(validate)).hasSize(3);
         assertTrue(validate.stream().anyMatch(p -> p.getMessageType().equals(DMNMessageType.REQ_NOT_FOUND)));
     }
 
@@ -186,7 +185,7 @@ public class ValidatorAuthorityRequirementTest extends AbstractValidatorTest {
                                "https://github.com/kiegroup/kie-dmn",
                                "AUTHREQ_DEP_REQ_DEC_NOT_DECISION"),
                 VALIDATE_MODEL, VALIDATE_COMPILATION);
-        assertThat(ValidatorUtil.formatMessages(validate), validate.size(), is(3));
+         assertThat(validate).as(ValidatorUtil.formatMessages(validate)).hasSize(3);
         assertTrue(validate.stream().anyMatch(p -> p.getMessageType().equals(DMNMessageType.REQ_NOT_FOUND)));
     }
 
@@ -196,7 +195,7 @@ public class ValidatorAuthorityRequirementTest extends AbstractValidatorTest {
             final List<DMNMessage> validate = validator.validate(
                     reader,
                     VALIDATE_SCHEMA, VALIDATE_MODEL, VALIDATE_COMPILATION);
-            assertThat(ValidatorUtil.formatMessages(validate), validate.size(), is(3));
+             assertThat(validate).as(ValidatorUtil.formatMessages(validate)).hasSize(3);
             assertTrue(validate.stream().anyMatch(p -> p.getMessageType().equals(DMNMessageType.REQ_NOT_FOUND)));
         }
     }
@@ -206,7 +205,7 @@ public class ValidatorAuthorityRequirementTest extends AbstractValidatorTest {
         final List<DMNMessage> validate = validator.validate(
                 getFile("authorityrequirement/AUTHREQ_DEP_REQ_INPUT_NOT_INPUT.dmn"),
                 VALIDATE_SCHEMA, VALIDATE_MODEL, VALIDATE_COMPILATION);
-        assertThat(ValidatorUtil.formatMessages(validate), validate.size(), is(3));
+         assertThat(validate).as(ValidatorUtil.formatMessages(validate)).hasSize(3);
         assertTrue(validate.stream().anyMatch(p -> p.getMessageType().equals(DMNMessageType.REQ_NOT_FOUND)));
     }
 
@@ -217,7 +216,7 @@ public class ValidatorAuthorityRequirementTest extends AbstractValidatorTest {
                                "https://github.com/kiegroup/kie-dmn",
                                "AUTHREQ_DEP_REQ_INPUT_NOT_INPUT"),
                 VALIDATE_MODEL, VALIDATE_COMPILATION);
-        assertThat(ValidatorUtil.formatMessages(validate), validate.size(), is(3));
+         assertThat(validate).as(ValidatorUtil.formatMessages(validate)).hasSize(3);
         assertTrue(validate.stream().anyMatch(p -> p.getMessageType().equals(DMNMessageType.REQ_NOT_FOUND)));
     }
 }

--- a/kie-dmn/kie-dmn-legacy-tests/src/test/java/org/kie/dmn/legacy/tests/validation/v1_1/ValidatorBusinessContextTest.java
+++ b/kie-dmn/kie-dmn-legacy-tests/src/test/java/org/kie/dmn/legacy/tests/validation/v1_1/ValidatorBusinessContextTest.java
@@ -26,8 +26,7 @@ import org.kie.dmn.api.core.DMNMessageType;
 import org.kie.dmn.validation.AbstractValidatorTest;
 import org.kie.dmn.validation.ValidatorUtil;
 
-import static org.hamcrest.CoreMatchers.is;
-import static org.hamcrest.MatcherAssert.assertThat;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.Assert.assertTrue;
 import static org.kie.dmn.validation.DMNValidator.Validation.VALIDATE_COMPILATION;
 import static org.kie.dmn.validation.DMNValidator.Validation.VALIDATE_MODEL;
@@ -41,7 +40,7 @@ public class ValidatorBusinessContextTest extends AbstractValidatorTest {
             final List<DMNMessage> validate = validator.validate(
                     reader,
                     VALIDATE_SCHEMA, VALIDATE_MODEL, VALIDATE_COMPILATION);
-            assertThat(ValidatorUtil.formatMessages(validate), validate.size(), is(2));
+             assertThat(validate).as(ValidatorUtil.formatMessages(validate)).hasSize(2);
             assertTrue(validate.stream().anyMatch(p -> p.getMessageType().equals(DMNMessageType.REQ_NOT_FOUND)));
         }
     }
@@ -51,7 +50,7 @@ public class ValidatorBusinessContextTest extends AbstractValidatorTest {
         final List<DMNMessage> validate = validator.validate(
                 getFile("businesscontext/ORG_UNIT_DECISION_MADE_WRONG_TYPE.dmn"),
                 VALIDATE_SCHEMA, VALIDATE_MODEL, VALIDATE_COMPILATION);
-        assertThat(ValidatorUtil.formatMessages(validate), validate.size(), is(2));
+         assertThat(validate).as(ValidatorUtil.formatMessages(validate)).hasSize(2);
         assertTrue(validate.stream().anyMatch(p -> p.getMessageType().equals(DMNMessageType.REQ_NOT_FOUND)));
     }
 
@@ -62,7 +61,7 @@ public class ValidatorBusinessContextTest extends AbstractValidatorTest {
                                "https://github.com/kiegroup/kie-dmn",
                                "ORG_UNIT_DECISION_MADE_WRONG_TYPE"),
                 VALIDATE_MODEL, VALIDATE_COMPILATION);
-        assertThat(ValidatorUtil.formatMessages(validate), validate.size(), is(2));
+         assertThat(validate).as(ValidatorUtil.formatMessages(validate)).hasSize(2);
         assertTrue(validate.stream().anyMatch(p -> p.getMessageType().equals(DMNMessageType.REQ_NOT_FOUND)));
     }
 
@@ -72,7 +71,7 @@ public class ValidatorBusinessContextTest extends AbstractValidatorTest {
             final List<DMNMessage> validate = validator.validate(
                     reader,
                     VALIDATE_SCHEMA, VALIDATE_MODEL, VALIDATE_COMPILATION);
-            assertThat(ValidatorUtil.formatMessages(validate), validate.size(), is(2));
+             assertThat(validate).as(ValidatorUtil.formatMessages(validate)).hasSize(2);
             assertTrue(validate.stream().anyMatch(p -> p.getMessageType().equals(DMNMessageType.REQ_NOT_FOUND)));
         }
     }
@@ -82,7 +81,7 @@ public class ValidatorBusinessContextTest extends AbstractValidatorTest {
         final List<DMNMessage> validate = validator.validate(
                 getFile("businesscontext/ORG_UNIT_DECISION_OWNED_WRONG_TYPE.dmn"),
                 VALIDATE_SCHEMA, VALIDATE_MODEL, VALIDATE_COMPILATION);
-        assertThat(ValidatorUtil.formatMessages(validate), validate.size(), is(2));
+         assertThat(validate).as(ValidatorUtil.formatMessages(validate)).hasSize(2);
         assertTrue(validate.stream().anyMatch(p -> p.getMessageType().equals(DMNMessageType.REQ_NOT_FOUND)));
     }
 
@@ -93,7 +92,7 @@ public class ValidatorBusinessContextTest extends AbstractValidatorTest {
                                "https://github.com/kiegroup/kie-dmn",
                                "ORG_UNIT_DECISION_OWNED_WRONG_TYPE"),
                 VALIDATE_MODEL, VALIDATE_COMPILATION);
-        assertThat(ValidatorUtil.formatMessages(validate), validate.size(), is(2));
+         assertThat(validate).as(ValidatorUtil.formatMessages(validate)).hasSize(2);
         assertTrue(validate.stream().anyMatch(p -> p.getMessageType().equals(DMNMessageType.REQ_NOT_FOUND)));
     }
 
@@ -103,7 +102,7 @@ public class ValidatorBusinessContextTest extends AbstractValidatorTest {
             final List<DMNMessage> validate = validator.validate(
                     reader,
                     VALIDATE_SCHEMA, VALIDATE_MODEL, VALIDATE_COMPILATION);
-            assertThat(ValidatorUtil.formatMessages(validate), validate.size(), is(2));
+             assertThat(validate).as(ValidatorUtil.formatMessages(validate)).hasSize(2);
             assertTrue(validate.stream().anyMatch(p -> p.getMessageType().equals(DMNMessageType.REQ_NOT_FOUND)));
         }
     }
@@ -113,7 +112,7 @@ public class ValidatorBusinessContextTest extends AbstractValidatorTest {
         final List<DMNMessage> validate = validator.validate(
                 getFile("businesscontext/PERF_INDICATOR_IMP_DECISION_WRONG_TYPE.dmn"),
                 VALIDATE_SCHEMA, VALIDATE_MODEL, VALIDATE_COMPILATION);
-        assertThat(ValidatorUtil.formatMessages(validate), validate.size(), is(2));
+         assertThat(validate).as(ValidatorUtil.formatMessages(validate)).hasSize(2);
         assertTrue(validate.stream().anyMatch(p -> p.getMessageType().equals(DMNMessageType.REQ_NOT_FOUND)));
     }
 
@@ -124,7 +123,7 @@ public class ValidatorBusinessContextTest extends AbstractValidatorTest {
                                "https://github.com/kiegroup/kie-dmn",
                                "PERF_INDICATOR_IMP_DECISION_WRONG_TYPE"),
                 VALIDATE_MODEL, VALIDATE_COMPILATION);
-        assertThat(ValidatorUtil.formatMessages(validate), validate.size(), is(2));
+         assertThat(validate).as(ValidatorUtil.formatMessages(validate)).hasSize(2);
         assertTrue(validate.stream().anyMatch(p -> p.getMessageType().equals(DMNMessageType.REQ_NOT_FOUND)));
     }
 }

--- a/kie-dmn/kie-dmn-legacy-tests/src/test/java/org/kie/dmn/legacy/tests/validation/v1_1/ValidatorBusinessKnowledgeModelTest.java
+++ b/kie-dmn/kie-dmn-legacy-tests/src/test/java/org/kie/dmn/legacy/tests/validation/v1_1/ValidatorBusinessKnowledgeModelTest.java
@@ -26,8 +26,7 @@ import org.kie.dmn.api.core.DMNMessageType;
 import org.kie.dmn.validation.AbstractValidatorTest;
 import org.kie.dmn.validation.ValidatorUtil;
 
-import static org.hamcrest.CoreMatchers.is;
-import static org.hamcrest.MatcherAssert.assertThat;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.Assert.assertTrue;
 import static org.kie.dmn.validation.DMNValidator.Validation.VALIDATE_COMPILATION;
 import static org.kie.dmn.validation.DMNValidator.Validation.VALIDATE_MODEL;
@@ -41,7 +40,7 @@ public class ValidatorBusinessKnowledgeModelTest extends AbstractValidatorTest {
             final List<DMNMessage> validate = validator.validate(
                     reader,
                     VALIDATE_SCHEMA, VALIDATE_MODEL, VALIDATE_COMPILATION);
-            assertThat(ValidatorUtil.formatMessages(validate), validate.size(), is(1));
+            assertThat(validate).as(ValidatorUtil.formatMessages(validate)).hasSize(1);
             assertTrue(validate.stream().anyMatch(p -> p.getMessageType().equals(DMNMessageType.MISSING_VARIABLE)));
         }
     }
@@ -51,7 +50,7 @@ public class ValidatorBusinessKnowledgeModelTest extends AbstractValidatorTest {
         final List<DMNMessage> validate = validator.validate(
                 getFile("businessknowledgemodel/BKM_MISSING_VAR.dmn"),
                 VALIDATE_SCHEMA, VALIDATE_MODEL, VALIDATE_COMPILATION);
-        assertThat(ValidatorUtil.formatMessages(validate), validate.size(), is(1));
+        assertThat(validate).as(ValidatorUtil.formatMessages(validate)).hasSize(1);
         assertTrue(validate.stream().anyMatch(p -> p.getMessageType().equals(DMNMessageType.MISSING_VARIABLE)));
     }
 
@@ -62,7 +61,7 @@ public class ValidatorBusinessKnowledgeModelTest extends AbstractValidatorTest {
                                "https://github.com/kiegroup/kie-dmn",
                                "BKM_MISSING_VAR"),
                 VALIDATE_MODEL, VALIDATE_COMPILATION);
-        assertThat(ValidatorUtil.formatMessages(validate), validate.size(), is(1));
+        assertThat(validate).as(ValidatorUtil.formatMessages(validate)).hasSize(1);
         assertTrue(validate.stream().anyMatch(p -> p.getMessageType().equals(DMNMessageType.MISSING_VARIABLE)));
     }
 
@@ -72,7 +71,7 @@ public class ValidatorBusinessKnowledgeModelTest extends AbstractValidatorTest {
             final List<DMNMessage> validate = validator.validate(
                     reader,
                     VALIDATE_SCHEMA, VALIDATE_MODEL, VALIDATE_COMPILATION);
-            assertThat(ValidatorUtil.formatMessages(validate), validate.size(), is(1));
+            assertThat(validate).as(ValidatorUtil.formatMessages(validate)).hasSize(1);
             assertTrue(validate.stream().anyMatch(p -> p.getMessageType().equals(DMNMessageType.VARIABLE_NAME_MISMATCH)));
         }
     }
@@ -82,7 +81,7 @@ public class ValidatorBusinessKnowledgeModelTest extends AbstractValidatorTest {
         final List<DMNMessage> validate = validator.validate(
                 getFile("businessknowledgemodel/BKM_MISMATCH_VAR.dmn"),
                 VALIDATE_SCHEMA, VALIDATE_MODEL, VALIDATE_COMPILATION);
-        assertThat(ValidatorUtil.formatMessages(validate), validate.size(), is(1));
+        assertThat(validate).as(ValidatorUtil.formatMessages(validate)).hasSize(1);
         assertTrue(validate.stream().anyMatch(p -> p.getMessageType().equals(DMNMessageType.VARIABLE_NAME_MISMATCH)));
     }
 
@@ -93,7 +92,7 @@ public class ValidatorBusinessKnowledgeModelTest extends AbstractValidatorTest {
                                "https://github.com/kiegroup/kie-dmn",
                                "BKM_MISSING_VAR"),
                 VALIDATE_MODEL, VALIDATE_COMPILATION);
-        assertThat(ValidatorUtil.formatMessages(validate), validate.size(), is(1));
+        assertThat(validate).as(ValidatorUtil.formatMessages(validate)).hasSize(1);
         assertTrue(validate.stream().anyMatch(p -> p.getMessageType().equals(DMNMessageType.VARIABLE_NAME_MISMATCH)));
     }
 
@@ -103,8 +102,8 @@ public class ValidatorBusinessKnowledgeModelTest extends AbstractValidatorTest {
             final List<DMNMessage> validate = validator.validate(
                     reader,
                     VALIDATE_SCHEMA, VALIDATE_MODEL, VALIDATE_COMPILATION);
-            assertThat(ValidatorUtil.formatMessages(validate), validate.size(), is(1));
-            assertThat(validate.get(0).toString(), validate.get(0).getMessageType(), is(DMNMessageType.MISSING_EXPRESSION));
+            assertThat(validate).as(ValidatorUtil.formatMessages(validate)).hasSize(1);
+            assertThat(validate.get(0).getMessageType()).as(validate.get(0).toString()).isEqualTo(DMNMessageType.MISSING_EXPRESSION);
         }
     }
 
@@ -113,8 +112,8 @@ public class ValidatorBusinessKnowledgeModelTest extends AbstractValidatorTest {
         final List<DMNMessage> validate = validator.validate(
                 getFile("businessknowledgemodel/BKM_MISSING_EXPR.dmn"),
                 VALIDATE_SCHEMA, VALIDATE_MODEL, VALIDATE_COMPILATION);
-        assertThat(ValidatorUtil.formatMessages(validate), validate.size(), is(1));
-        assertThat(validate.get(0).toString(), validate.get(0).getMessageType(), is(DMNMessageType.MISSING_EXPRESSION));
+        assertThat(validate).as(ValidatorUtil.formatMessages(validate)).hasSize(1);
+        assertThat(validate.get(0).getMessageType()).as(validate.get(0).toString()).isEqualTo(DMNMessageType.MISSING_EXPRESSION);
     }
 
     @Test
@@ -124,7 +123,7 @@ public class ValidatorBusinessKnowledgeModelTest extends AbstractValidatorTest {
                                "https://github.com/kiegroup/kie-dmn",
                                "BKM_MISSING_EXPR"),
                 VALIDATE_MODEL, VALIDATE_COMPILATION);
-        assertThat(ValidatorUtil.formatMessages(validate), validate.size(), is(1));
-        assertThat(validate.get(0).toString(), validate.get(0).getMessageType(), is(DMNMessageType.MISSING_EXPRESSION));
+        assertThat(validate).as(ValidatorUtil.formatMessages(validate)).hasSize(1);
+        assertThat(validate.get(0).getMessageType()).as(validate.get(0).toString()).isEqualTo(DMNMessageType.MISSING_EXPRESSION);
     }
 }

--- a/kie-dmn/kie-dmn-legacy-tests/src/test/java/org/kie/dmn/legacy/tests/validation/v1_1/ValidatorContextTest.java
+++ b/kie-dmn/kie-dmn-legacy-tests/src/test/java/org/kie/dmn/legacy/tests/validation/v1_1/ValidatorContextTest.java
@@ -28,8 +28,7 @@ import org.kie.dmn.model.api.ContextEntry;
 import org.kie.dmn.validation.AbstractValidatorTest;
 import org.kie.dmn.validation.ValidatorUtil;
 
-import static org.hamcrest.CoreMatchers.is;
-import static org.hamcrest.MatcherAssert.assertThat;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.Assert.assertTrue;
 import static org.kie.dmn.validation.DMNValidator.Validation.VALIDATE_COMPILATION;
 import static org.kie.dmn.validation.DMNValidator.Validation.VALIDATE_MODEL;
@@ -43,7 +42,7 @@ public class ValidatorContextTest extends AbstractValidatorTest {
             final List<DMNMessage> validate = validator.validate(
                     reader,
                     VALIDATE_SCHEMA, VALIDATE_MODEL, VALIDATE_COMPILATION);
-            assertThat(ValidatorUtil.formatMessages(validate), validate.size(), is(2));
+            assertThat(validate).as(ValidatorUtil.formatMessages(validate)).hasSize(2);
             assertTrue(validate.stream().anyMatch(p -> p.getMessageType().equals(DMNMessageType.FAILED_XML_VALIDATION))); // this is schema validation
             assertTrue(validate.stream().anyMatch(p -> p.getMessageType().equals(DMNMessageType.MISSING_EXPRESSION)));
         }
@@ -54,7 +53,7 @@ public class ValidatorContextTest extends AbstractValidatorTest {
         final List<DMNMessage> validate = validator.validate(
                 getFile("context/CONTEXT_MISSING_EXPR.dmn"),
                 VALIDATE_SCHEMA, VALIDATE_MODEL, VALIDATE_COMPILATION);
-        assertThat(ValidatorUtil.formatMessages(validate), validate.size(), is(2));
+        assertThat(validate).as(ValidatorUtil.formatMessages(validate)).hasSize(2);
         assertTrue(validate.stream().anyMatch(p -> p.getMessageType().equals(DMNMessageType.FAILED_XML_VALIDATION))); // this is schema validation
         assertTrue(validate.stream().anyMatch(p -> p.getMessageType().equals(DMNMessageType.MISSING_EXPRESSION)));
     }
@@ -66,7 +65,7 @@ public class ValidatorContextTest extends AbstractValidatorTest {
                                "https://github.com/kiegroup/kie-dmn",
                                "CONTEXT_MISSING_EXPR"),
                 VALIDATE_MODEL, VALIDATE_COMPILATION);
-        assertThat(ValidatorUtil.formatMessages(validate), validate.size(), is(1));
+        assertThat(validate).as(ValidatorUtil.formatMessages(validate)).hasSize(1);
         assertTrue(validate.stream().anyMatch(p -> p.getMessageType().equals(DMNMessageType.MISSING_EXPRESSION)));
     }
 
@@ -76,7 +75,7 @@ public class ValidatorContextTest extends AbstractValidatorTest {
             final List<DMNMessage> validate = validator.validate(
                     reader,
                     VALIDATE_SCHEMA, VALIDATE_MODEL, VALIDATE_COMPILATION);
-            assertThat(ValidatorUtil.formatMessages(validate), validate.size(), is(1));
+            assertThat(validate).as(ValidatorUtil.formatMessages(validate)).hasSize(1);
             assertTrue(validate.stream().anyMatch(p -> p.getMessageType().equals(DMNMessageType.MISSING_EXPRESSION)));
         }
     }
@@ -86,7 +85,7 @@ public class ValidatorContextTest extends AbstractValidatorTest {
         final List<DMNMessage> validate = validator.validate(
                 getFile("context/CONTEXT_MISSING_ENTRIES.dmn"),
                 VALIDATE_SCHEMA, VALIDATE_MODEL, VALIDATE_COMPILATION);
-        assertThat(ValidatorUtil.formatMessages(validate), validate.size(), is(1));
+        assertThat(validate).as(ValidatorUtil.formatMessages(validate)).hasSize(1);
         assertTrue(validate.stream().anyMatch(p -> p.getMessageType().equals(DMNMessageType.MISSING_EXPRESSION)));
     }
 
@@ -97,7 +96,7 @@ public class ValidatorContextTest extends AbstractValidatorTest {
                                "https://github.com/kiegroup/kie-dmn",
                                "CONTEXT_MISSING_EXPR"),
                 VALIDATE_MODEL, VALIDATE_COMPILATION);
-        assertThat(ValidatorUtil.formatMessages(validate), validate.size(), is(1));
+        assertThat(validate).as(ValidatorUtil.formatMessages(validate)).hasSize(1);
         assertTrue(validate.stream().anyMatch(p -> p.getMessageType().equals(DMNMessageType.MISSING_EXPRESSION)));
     }
 
@@ -107,11 +106,11 @@ public class ValidatorContextTest extends AbstractValidatorTest {
             final List<DMNMessage> validate = validator.validate(
                     reader,
                     VALIDATE_SCHEMA, VALIDATE_MODEL, VALIDATE_COMPILATION);
-            assertThat(ValidatorUtil.formatMessages(validate), validate.size(), is(1));
+            assertThat(validate).as(ValidatorUtil.formatMessages(validate)).hasSize(1);
             assertTrue(validate.stream().anyMatch(p -> p.getMessageType().equals(DMNMessageType.MISSING_VARIABLE)));
             // check that it reports and error for the second context entry, but not for the last one
             final ContextEntry ce = (ContextEntry) validate.get(0).getSourceReference();
-            assertThat(((Context) ce.getParent()).getContextEntry().indexOf(ce), is(1));
+            assertThat(((Context) ce.getParent()).getContextEntry().indexOf(ce)).isEqualTo(1);
         }
     }
 
@@ -120,11 +119,11 @@ public class ValidatorContextTest extends AbstractValidatorTest {
         final List<DMNMessage> validate = validator.validate(
                 getFile("context/CONTEXT_ENTRY_MISSING_VARIABLE.dmn"),
                 VALIDATE_SCHEMA, VALIDATE_MODEL, VALIDATE_COMPILATION);
-        assertThat(ValidatorUtil.formatMessages(validate), validate.size(), is(1));
+        assertThat(validate).as(ValidatorUtil.formatMessages(validate)).hasSize(1);
         assertTrue(validate.stream().anyMatch(p -> p.getMessageType().equals(DMNMessageType.MISSING_VARIABLE)));
         // check that it reports and error for the second context entry, but not for the last one
         final ContextEntry ce = (ContextEntry) validate.get(0).getSourceReference();
-        assertThat(((Context) ce.getParent()).getContextEntry().indexOf(ce), is(1));
+        assertThat(((Context) ce.getParent()).getContextEntry().indexOf(ce)).isEqualTo(1);
     }
 
     @Test
@@ -134,11 +133,11 @@ public class ValidatorContextTest extends AbstractValidatorTest {
                                "https://github.com/kiegroup/kie-dmn",
                                "CONTEXT_MISSING_EXPR"),
                 VALIDATE_MODEL, VALIDATE_COMPILATION);
-        assertThat(ValidatorUtil.formatMessages(validate), validate.size(), is(1));
+        assertThat(validate).as(ValidatorUtil.formatMessages(validate)).hasSize(1);
         assertTrue(validate.stream().anyMatch(p -> p.getMessageType().equals(DMNMessageType.MISSING_VARIABLE)));
         // check that it reports and error for the second context entry, but not for the last one
         final ContextEntry ce = (ContextEntry) validate.get(0).getSourceReference();
-        assertThat(((Context) ce.getParent()).getContextEntry().indexOf(ce), is(1));
+        assertThat(((Context) ce.getParent()).getContextEntry().indexOf(ce)).isEqualTo(1);
     }
 
     @Test
@@ -147,7 +146,7 @@ public class ValidatorContextTest extends AbstractValidatorTest {
             final List<DMNMessage> validate = validator.validate(
                     reader,
                     VALIDATE_SCHEMA, VALIDATE_MODEL, VALIDATE_COMPILATION);
-            assertThat(ValidatorUtil.formatMessages(validate), validate.size(), is(2));
+            assertThat(validate).as(ValidatorUtil.formatMessages(validate)).hasSize(2);
             assertTrue(validate.stream().anyMatch(p -> p.getMessageType().equals(DMNMessageType.DUPLICATE_NAME)));
         }
     }
@@ -157,7 +156,7 @@ public class ValidatorContextTest extends AbstractValidatorTest {
         final List<DMNMessage> validate = validator.validate(
                 getFile("context/CONTEXT_DUP_ENTRY.dmn"),
                 VALIDATE_SCHEMA, VALIDATE_MODEL, VALIDATE_COMPILATION);
-        assertThat(ValidatorUtil.formatMessages(validate), validate.size(), is(2));
+        assertThat(validate).as(ValidatorUtil.formatMessages(validate)).hasSize(2);
         assertTrue(validate.stream().anyMatch(p -> p.getMessageType().equals(DMNMessageType.DUPLICATE_NAME)));
     }
 
@@ -168,7 +167,7 @@ public class ValidatorContextTest extends AbstractValidatorTest {
                                "https://github.com/kiegroup/kie-dmn",
                                "CONTEXT_DUP_ENTRY"),
                 VALIDATE_MODEL, VALIDATE_COMPILATION);
-        assertThat(ValidatorUtil.formatMessages(validate), validate.size(), is(2));
+        assertThat(validate).as(ValidatorUtil.formatMessages(validate)).hasSize(2);
         assertTrue(validate.stream().anyMatch(p -> p.getMessageType().equals(DMNMessageType.DUPLICATE_NAME)));
     }
 
@@ -178,7 +177,7 @@ public class ValidatorContextTest extends AbstractValidatorTest {
             final List<DMNMessage> validate = validator.validate(
                     reader,
                     VALIDATE_SCHEMA, VALIDATE_MODEL, VALIDATE_COMPILATION);
-            assertThat(ValidatorUtil.formatMessages(validate), validate.size(), is(2));
+            assertThat(validate).as(ValidatorUtil.formatMessages(validate)).hasSize(2);
             assertTrue(validate.stream().anyMatch(p -> p.getMessageType().equals(DMNMessageType.MISSING_TYPE_REF)));
         }
     }
@@ -188,7 +187,7 @@ public class ValidatorContextTest extends AbstractValidatorTest {
         final List<DMNMessage> validate = validator.validate(
                 getFile("context/CONTEXT_ENTRY_NOTYPEREF.dmn"),
                 VALIDATE_SCHEMA, VALIDATE_MODEL, VALIDATE_COMPILATION);
-        assertThat(ValidatorUtil.formatMessages(validate), validate.size(), is(2));
+        assertThat(validate).as(ValidatorUtil.formatMessages(validate)).hasSize(2);
         assertTrue(validate.stream().anyMatch(p -> p.getMessageType().equals(DMNMessageType.MISSING_TYPE_REF)));
     }
 
@@ -199,7 +198,7 @@ public class ValidatorContextTest extends AbstractValidatorTest {
                                "https://github.com/kiegroup/kie-dmn",
                                "CONTEXT_ENTRY_NOTYPEREF"),
                 VALIDATE_MODEL, VALIDATE_COMPILATION);
-        assertThat(ValidatorUtil.formatMessages(validate), validate.size(), is(2));
+        assertThat(validate).as(ValidatorUtil.formatMessages(validate)).hasSize(2);
         assertTrue(validate.stream().anyMatch(p -> p.getMessageType().equals(DMNMessageType.MISSING_TYPE_REF)));
     }
 }

--- a/kie-dmn/kie-dmn-legacy-tests/src/test/java/org/kie/dmn/legacy/tests/validation/v1_1/ValidatorDMNElementReferenceTest.java
+++ b/kie-dmn/kie-dmn-legacy-tests/src/test/java/org/kie/dmn/legacy/tests/validation/v1_1/ValidatorDMNElementReferenceTest.java
@@ -26,8 +26,7 @@ import org.kie.dmn.api.core.DMNMessageType;
 import org.kie.dmn.validation.AbstractValidatorTest;
 import org.kie.dmn.validation.ValidatorUtil;
 
-import static org.hamcrest.CoreMatchers.is;
-import static org.hamcrest.MatcherAssert.assertThat;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.Assert.assertTrue;
 import static org.kie.dmn.validation.DMNValidator.Validation.VALIDATE_COMPILATION;
 import static org.kie.dmn.validation.DMNValidator.Validation.VALIDATE_MODEL;
@@ -64,7 +63,7 @@ public class ValidatorDMNElementReferenceTest extends AbstractValidatorTest {
     }
 
     private void assertValiadationResult(List<DMNMessage> validationMessages) {
-        assertThat(ValidatorUtil.formatMessages(validationMessages), validationMessages.size(), is(3));
+    	assertThat(validationMessages).as(ValidatorUtil.formatMessages(validationMessages)).hasSize(3);
         assertTrue(validationMessages.stream().anyMatch(p -> p.getMessageType().equals(DMNMessageType.MISSING_EXPRESSION)));
         assertTrue(validationMessages.stream().anyMatch(p -> p.getMessageType().equals(DMNMessageType.INVALID_HREF_SYNTAX)));
         assertTrue(validationMessages.stream().anyMatch(p -> p.getMessageType().equals(DMNMessageType.REQ_NOT_FOUND)));

--- a/kie-dmn/kie-dmn-legacy-tests/src/test/java/org/kie/dmn/legacy/tests/validation/v1_1/ValidatorDecisionTableTest.java
+++ b/kie-dmn/kie-dmn-legacy-tests/src/test/java/org/kie/dmn/legacy/tests/validation/v1_1/ValidatorDecisionTableTest.java
@@ -26,8 +26,7 @@ import org.kie.dmn.api.core.DMNMessageType;
 import org.kie.dmn.validation.AbstractValidatorTest;
 import org.kie.dmn.validation.ValidatorUtil;
 
-import static org.hamcrest.CoreMatchers.is;
-import static org.hamcrest.MatcherAssert.assertThat;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.Assert.assertTrue;
 import static org.kie.dmn.validation.DMNValidator.Validation.VALIDATE_COMPILATION;
 import static org.kie.dmn.validation.DMNValidator.Validation.VALIDATE_MODEL;
@@ -42,7 +41,7 @@ public class ValidatorDecisionTableTest
             final List<DMNMessage> validate = validator.validate(
                     reader,
                     VALIDATE_MODEL, VALIDATE_COMPILATION);
-            assertThat(ValidatorUtil.formatMessages(validate), validate.size(), is(2));
+            assertThat(validate).as(ValidatorUtil.formatMessages(validate)).hasSize(2);
             assertTrue(validate.stream().anyMatch(p -> p.getMessageType().equals(DMNMessageType.MISSING_EXPRESSION)));
         }
     }
@@ -52,7 +51,7 @@ public class ValidatorDecisionTableTest
         final List<DMNMessage> validate = validator.validate(
                 getFile("DTABLE_EMPTY_ENTRY.dmn"),
                 VALIDATE_MODEL, VALIDATE_COMPILATION);
-        assertThat(ValidatorUtil.formatMessages(validate), validate.size(), is(2));
+        assertThat(validate).as(ValidatorUtil.formatMessages(validate)).hasSize(2);
         assertTrue(validate.stream().anyMatch(p -> p.getMessageType().equals(DMNMessageType.MISSING_EXPRESSION)));
     }
 
@@ -63,7 +62,7 @@ public class ValidatorDecisionTableTest
                                "https://github.com/kiegroup/kie-dmn",
                                "DTABLE_PRIORITY_MISSING_OUTVALS"),
                 VALIDATE_MODEL, VALIDATE_COMPILATION);
-        assertThat(ValidatorUtil.formatMessages(validate), validate.size(), is(2));
+        assertThat(validate).as(ValidatorUtil.formatMessages(validate)).hasSize(2);
         assertTrue(validate.stream().anyMatch(p -> p.getMessageType().equals(DMNMessageType.MISSING_EXPRESSION)));
     }
 
@@ -71,7 +70,7 @@ public class ValidatorDecisionTableTest
     public void testDTABLE_MULTIPLEOUT_NAME_ReaderInput() throws IOException {
         try (final Reader reader = getReader( "DTABLE_MULTIPLEOUTPUT_WRONG_OUTPUT.dmn" )) {
             List<DMNMessage> validate = validator.validate( reader, VALIDATE_SCHEMA, VALIDATE_MODEL, VALIDATE_COMPILATION);
-            assertThat( ValidatorUtil.formatMessages( validate ), validate.size(), is( 5 ) );
+            assertThat(validate).as(ValidatorUtil.formatMessages(validate)).hasSize(5);
             assertTrue( validate.stream().anyMatch( p -> p.getMessageType().equals( DMNMessageType.MISSING_NAME ) ) );
             assertTrue( validate.stream().anyMatch( p -> p.getMessageType().equals( DMNMessageType.MISSING_TYPE_REF ) ) );
             assertTrue( validate.stream().anyMatch( p -> p.getMessageType().equals( DMNMessageType.INVALID_NAME ) ) );
@@ -81,7 +80,7 @@ public class ValidatorDecisionTableTest
     @Test
     public void testDTABLE_MULTIPLEOUT_NAME_FileInput() {
         List<DMNMessage> validate = validator.validate( getFile( "DTABLE_MULTIPLEOUTPUT_WRONG_OUTPUT.dmn" ), VALIDATE_SCHEMA, VALIDATE_MODEL, VALIDATE_COMPILATION);
-        assertThat( ValidatorUtil.formatMessages( validate ), validate.size(), is( 5 ) );
+        assertThat(validate).as(ValidatorUtil.formatMessages(validate)).hasSize(5);
         assertTrue( validate.stream().anyMatch( p -> p.getMessageType().equals( DMNMessageType.MISSING_NAME ) ) );
         assertTrue( validate.stream().anyMatch( p -> p.getMessageType().equals( DMNMessageType.MISSING_TYPE_REF ) ) );
         assertTrue( validate.stream().anyMatch( p -> p.getMessageType().equals( DMNMessageType.INVALID_NAME ) ) );
@@ -94,7 +93,7 @@ public class ValidatorDecisionTableTest
                                 "https://github.com/kiegroup/kie-dmn",
                                 "DTABLE_MULTIPLEOUTPUT_WRONG_OUTPUT"),
                 VALIDATE_MODEL, VALIDATE_COMPILATION);
-        assertThat( ValidatorUtil.formatMessages( validate ), validate.size(), is( 5 ) );
+        assertThat(validate).as(ValidatorUtil.formatMessages(validate)).hasSize(5);
         assertTrue( validate.stream().anyMatch( p -> p.getMessageType().equals( DMNMessageType.MISSING_NAME ) ) );
         assertTrue( validate.stream().anyMatch( p -> p.getMessageType().equals( DMNMessageType.MISSING_TYPE_REF ) ) );
         assertTrue( validate.stream().anyMatch( p -> p.getMessageType().equals( DMNMessageType.INVALID_NAME ) ) );
@@ -104,7 +103,7 @@ public class ValidatorDecisionTableTest
     public void testDTABLE_PRIORITY_MISSING_OUTVALS_ReaderInput() throws IOException {
         try (final Reader reader = getReader( "DTABLE_PRIORITY_MISSING_OUTVALS.dmn" )) {
             List<DMNMessage> validate = validator.validate( reader, VALIDATE_SCHEMA, VALIDATE_MODEL, VALIDATE_COMPILATION);
-            assertThat( ValidatorUtil.formatMessages( validate ), validate.isEmpty(), is( false ) );
+            assertThat(validate.isEmpty()).as(ValidatorUtil.formatMessages(validate)).isFalse();
             assertTrue( validate.stream().anyMatch( p -> p.getMessageType().equals( DMNMessageType.MISSING_OUTPUT_VALUES ) ) );
         }
     }
@@ -112,7 +111,7 @@ public class ValidatorDecisionTableTest
     @Test
     public void testDTABLE_PRIORITY_MISSING_OUTVALS_FileInput() {
         List<DMNMessage> validate = validator.validate( getFile( "DTABLE_PRIORITY_MISSING_OUTVALS.dmn" ), VALIDATE_SCHEMA, VALIDATE_MODEL, VALIDATE_COMPILATION);
-        assertThat( ValidatorUtil.formatMessages( validate ), validate.isEmpty(), is( false ) );
+        assertThat(validate.isEmpty()).as(ValidatorUtil.formatMessages(validate)).isFalse();
         assertTrue( validate.stream().anyMatch( p -> p.getMessageType().equals( DMNMessageType.MISSING_OUTPUT_VALUES ) ) );
     }
 
@@ -123,7 +122,7 @@ public class ValidatorDecisionTableTest
                                 "https://github.com/kiegroup/kie-dmn",
                                 "DTABLE_PRIORITY_MISSING_OUTVALS"),
                 VALIDATE_MODEL, VALIDATE_COMPILATION);
-        assertThat( ValidatorUtil.formatMessages( validate ), validate.isEmpty(), is( false ) );
+        assertThat(validate.isEmpty()).as(ValidatorUtil.formatMessages(validate)).isFalse();
         assertTrue( validate.stream().anyMatch( p -> p.getMessageType().equals( DMNMessageType.MISSING_OUTPUT_VALUES ) ) );
     }
 
@@ -131,7 +130,7 @@ public class ValidatorDecisionTableTest
     public void testDTABLE_SINGLEOUT_NONAME_ReaderInput() throws IOException {
         try (final Reader reader = getReader( "DTABLE_SINGLEOUTPUT_WRONG_OUTPUT.dmn" )) {
             List<DMNMessage> validate = validator.validate( reader, VALIDATE_SCHEMA, VALIDATE_MODEL, VALIDATE_COMPILATION);
-            assertThat( ValidatorUtil.formatMessages( validate ), validate.size(), is( 2 ) );
+            assertThat(validate).as(ValidatorUtil.formatMessages(validate)).hasSize(2);
             assertTrue( validate.stream().anyMatch( p -> p.getMessageType().equals( DMNMessageType.ILLEGAL_USE_OF_NAME ) ) );
             assertTrue( validate.stream().anyMatch( p -> p.getMessageType().equals( DMNMessageType.ILLEGAL_USE_OF_TYPEREF ) ) );
         }
@@ -140,7 +139,7 @@ public class ValidatorDecisionTableTest
     @Test
     public void testDTABLE_SINGLEOUT_NONAME_FileInput() {
         List<DMNMessage> validate = validator.validate( getFile( "DTABLE_SINGLEOUTPUT_WRONG_OUTPUT.dmn" ), VALIDATE_SCHEMA, VALIDATE_MODEL, VALIDATE_COMPILATION);
-        assertThat( ValidatorUtil.formatMessages( validate ), validate.size(), is( 2 ) );
+        assertThat(validate).as(ValidatorUtil.formatMessages(validate)).hasSize(2);
         assertTrue( validate.stream().anyMatch( p -> p.getMessageType().equals( DMNMessageType.ILLEGAL_USE_OF_NAME ) ) );
         assertTrue( validate.stream().anyMatch( p -> p.getMessageType().equals( DMNMessageType.ILLEGAL_USE_OF_TYPEREF ) ) );
     }
@@ -152,7 +151,7 @@ public class ValidatorDecisionTableTest
                                "https://github.com/kiegroup/kie-dmn",
                                "DTABLE_SINGLEOUTPUT_WRONG_OUTPUT"),
                 VALIDATE_MODEL, VALIDATE_COMPILATION);
-        assertThat( ValidatorUtil.formatMessages( validate ), validate.size(), is( 2 ) );
+        assertThat(validate).as(ValidatorUtil.formatMessages(validate)).hasSize(2);
         assertTrue( validate.stream().anyMatch( p -> p.getMessageType().equals( DMNMessageType.ILLEGAL_USE_OF_NAME ) ) );
         assertTrue( validate.stream().anyMatch( p -> p.getMessageType().equals( DMNMessageType.ILLEGAL_USE_OF_TYPEREF ) ) );
     }

--- a/kie-dmn/kie-dmn-legacy-tests/src/test/java/org/kie/dmn/legacy/tests/validation/v1_1/ValidatorDecisionTest.java
+++ b/kie-dmn/kie-dmn-legacy-tests/src/test/java/org/kie/dmn/legacy/tests/validation/v1_1/ValidatorDecisionTest.java
@@ -26,8 +26,7 @@ import org.kie.dmn.api.core.DMNMessageType;
 import org.kie.dmn.validation.AbstractValidatorTest;
 import org.kie.dmn.validation.ValidatorUtil;
 
-import static org.hamcrest.CoreMatchers.is;
-import static org.hamcrest.MatcherAssert.assertThat;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.Assert.assertTrue;
 import static org.kie.dmn.validation.DMNValidator.Validation.VALIDATE_COMPILATION;
 import static org.kie.dmn.validation.DMNValidator.Validation.VALIDATE_MODEL;
@@ -41,8 +40,8 @@ public class ValidatorDecisionTest extends AbstractValidatorTest {
             final List<DMNMessage> validate = validator.validate(
                     reader,
                     VALIDATE_SCHEMA, VALIDATE_MODEL, VALIDATE_COMPILATION);
-            assertThat(ValidatorUtil.formatMessages(validate), validate.size(), is(1));
-            assertThat(validate.get(0).toString(), validate.get(0).getMessageType(), is(DMNMessageType.MISSING_EXPRESSION));
+            assertThat(validate).as(ValidatorUtil.formatMessages(validate)).hasSize(1);
+            assertThat(validate.get(0).getMessageType()).as(validate.get(0).toString()).isEqualTo(DMNMessageType.MISSING_EXPRESSION);
         }
     }
 
@@ -51,8 +50,8 @@ public class ValidatorDecisionTest extends AbstractValidatorTest {
         final List<DMNMessage> validate = validator.validate(
                 getFile("decision/DECISION_MISSING_EXPR.dmn"),
                 VALIDATE_SCHEMA, VALIDATE_MODEL, VALIDATE_COMPILATION);
-        assertThat(ValidatorUtil.formatMessages(validate), validate.size(), is(1));
-        assertThat(validate.get(0).toString(), validate.get(0).getMessageType(), is(DMNMessageType.MISSING_EXPRESSION));
+        assertThat(validate).as(ValidatorUtil.formatMessages(validate)).hasSize(1);
+        assertThat(validate.get(0).getMessageType()).as(validate.get(0).toString()).isEqualTo(DMNMessageType.MISSING_EXPRESSION);
     }
 
     @Test
@@ -62,8 +61,8 @@ public class ValidatorDecisionTest extends AbstractValidatorTest {
                                "https://github.com/kiegroup/kie-dmn",
                                "DECISION_MISSING_EXPR"),
                 VALIDATE_MODEL, VALIDATE_COMPILATION);
-        assertThat(ValidatorUtil.formatMessages(validate), validate.size(), is(1));
-        assertThat(validate.get(0).toString(), validate.get(0).getMessageType(), is(DMNMessageType.MISSING_EXPRESSION));
+        assertThat(validate).as(ValidatorUtil.formatMessages(validate)).hasSize(1);
+        assertThat(validate.get(0).getMessageType()).as(validate.get(0).toString()).isEqualTo(DMNMessageType.MISSING_EXPRESSION);
     }
 
     @Test
@@ -72,7 +71,7 @@ public class ValidatorDecisionTest extends AbstractValidatorTest {
             final List<DMNMessage> validate = validator.validate(
                     reader,
                     VALIDATE_SCHEMA, VALIDATE_MODEL, VALIDATE_COMPILATION);
-            assertThat(ValidatorUtil.formatMessages(validate), validate.size(), is(1));
+            assertThat(validate).as(ValidatorUtil.formatMessages(validate)).hasSize(1);
             assertTrue(validate.stream().anyMatch(p -> p.getMessageType().equals(DMNMessageType.MISSING_VARIABLE)));
         }
     }
@@ -82,7 +81,7 @@ public class ValidatorDecisionTest extends AbstractValidatorTest {
         final List<DMNMessage> validate = validator.validate(
                 getFile("decision/DECISION_MISSING_VAR.dmn"),
                 VALIDATE_SCHEMA, VALIDATE_MODEL, VALIDATE_COMPILATION);
-        assertThat(ValidatorUtil.formatMessages(validate), validate.size(), is(1));
+        assertThat(validate).as(ValidatorUtil.formatMessages(validate)).hasSize(1);
         assertTrue(validate.stream().anyMatch(p -> p.getMessageType().equals(DMNMessageType.MISSING_VARIABLE)));
     }
 
@@ -93,7 +92,7 @@ public class ValidatorDecisionTest extends AbstractValidatorTest {
                                "https://github.com/kiegroup/kie-dmn",
                                "DECISION_MISSING_VAR"),
                 VALIDATE_MODEL, VALIDATE_COMPILATION);
-        assertThat(ValidatorUtil.formatMessages(validate), validate.size(), is(1));
+        assertThat(validate).as(ValidatorUtil.formatMessages(validate)).hasSize(1);
         assertTrue(validate.stream().anyMatch(p -> p.getMessageType().equals(DMNMessageType.MISSING_VARIABLE)));
     }
 
@@ -101,7 +100,7 @@ public class ValidatorDecisionTest extends AbstractValidatorTest {
     public void testDECISION_MISSING_VARbis_ReaderInput() throws IOException {
         try (final Reader reader = getReader("decision/DECISION_MISSING_VARbis.dmn")) {
             final List<DMNMessage> validate = validator.validate(reader, VALIDATE_SCHEMA, VALIDATE_MODEL, VALIDATE_COMPILATION);
-            assertThat(ValidatorUtil.formatMessages(validate), validate.size(), is(1));
+            assertThat(validate).as(ValidatorUtil.formatMessages(validate)).hasSize(1);
             assertTrue(validate.stream().anyMatch(p -> p.getMessageType().equals(DMNMessageType.MISSING_VARIABLE)));
         }
     }
@@ -110,7 +109,7 @@ public class ValidatorDecisionTest extends AbstractValidatorTest {
     public void testDECISION_MISSING_VARbis_FileInput() {
         final List<DMNMessage> validate = validator.validate(
                 getFile("decision/DECISION_MISSING_VARbis.dmn"), VALIDATE_SCHEMA, VALIDATE_MODEL, VALIDATE_COMPILATION);
-        assertThat(ValidatorUtil.formatMessages(validate), validate.size(), is(1));
+        assertThat(validate).as(ValidatorUtil.formatMessages(validate)).hasSize(1);
         assertTrue(validate.stream().anyMatch(p -> p.getMessageType().equals(DMNMessageType.MISSING_VARIABLE)));
     }
 
@@ -121,7 +120,7 @@ public class ValidatorDecisionTest extends AbstractValidatorTest {
                                "https://github.com/kiegroup/kie-dmn",
                                "DECISION_MISSING_VARbis"),
                 VALIDATE_MODEL, VALIDATE_COMPILATION);
-        assertThat(ValidatorUtil.formatMessages(validate), validate.size(), is(1));
+        assertThat(validate).as(ValidatorUtil.formatMessages(validate)).hasSize(1);
         assertTrue(validate.stream().anyMatch(p -> p.getMessageType().equals(DMNMessageType.MISSING_VARIABLE)));
     }
 
@@ -129,7 +128,7 @@ public class ValidatorDecisionTest extends AbstractValidatorTest {
     public void testDECISION_MISMATCH_VAR_ReaderInput() throws IOException {
         try (final Reader reader = getReader("decision/DECISION_MISMATCH_VAR.dmn")) {
             final List<DMNMessage> validate = validator.validate(reader, VALIDATE_SCHEMA, VALIDATE_MODEL, VALIDATE_COMPILATION);
-            assertThat(ValidatorUtil.formatMessages(validate), validate.size(), is(1));
+            assertThat(validate).as(ValidatorUtil.formatMessages(validate)).hasSize(1);
             assertTrue(validate.stream().anyMatch(p -> p.getMessageType().equals(DMNMessageType.VARIABLE_NAME_MISMATCH)));
         }
     }
@@ -138,7 +137,7 @@ public class ValidatorDecisionTest extends AbstractValidatorTest {
     public void testDECISION_MISMATCH_VAR_FileInput() {
         final List<DMNMessage> validate = validator.validate(
                 getFile("decision/DECISION_MISMATCH_VAR.dmn"), VALIDATE_SCHEMA, VALIDATE_MODEL, VALIDATE_COMPILATION);
-        assertThat(ValidatorUtil.formatMessages(validate), validate.size(), is(1));
+        assertThat(validate).as(ValidatorUtil.formatMessages(validate)).hasSize(1);
         assertTrue(validate.stream().anyMatch(p -> p.getMessageType().equals(DMNMessageType.VARIABLE_NAME_MISMATCH)));
     }
 
@@ -149,7 +148,7 @@ public class ValidatorDecisionTest extends AbstractValidatorTest {
                                "https://github.com/kiegroup/kie-dmn",
                                "DECISION_MISSING_VAR"),
                 VALIDATE_MODEL, VALIDATE_COMPILATION);
-        assertThat(ValidatorUtil.formatMessages(validate), validate.size(), is(1));
+        assertThat(validate).as(ValidatorUtil.formatMessages(validate)).hasSize(1);
         assertTrue(validate.stream().anyMatch(p -> p.getMessageType().equals(DMNMessageType.VARIABLE_NAME_MISMATCH)));
     }
 
@@ -157,7 +156,7 @@ public class ValidatorDecisionTest extends AbstractValidatorTest {
     public void testDECISION_MULTIPLE_EXPRESSIONS_ReaderInput() throws IOException {
         try (final Reader reader = getReader("decision/DECISION_MULTIPLE_EXPRESSIONS.dmn")) {
             final List<DMNMessage> validate = validator.validate(reader, VALIDATE_SCHEMA, VALIDATE_MODEL, VALIDATE_COMPILATION);
-            assertThat(ValidatorUtil.formatMessages(validate), validate.size(), is(1));
+            assertThat(validate).as(ValidatorUtil.formatMessages(validate)).hasSize(1);
             assertTrue(validate.stream().anyMatch(p -> p.getMessageType().equals(DMNMessageType.FAILED_XML_VALIDATION)));
         }
     }
@@ -166,7 +165,7 @@ public class ValidatorDecisionTest extends AbstractValidatorTest {
     public void testDECISION_MULTIPLE_EXPRESSIONS_FileInput() {
         final List<DMNMessage> validate = validator.validate(
                 getFile("decision/DECISION_MULTIPLE_EXPRESSIONS.dmn"), VALIDATE_SCHEMA, VALIDATE_MODEL, VALIDATE_COMPILATION);
-        assertThat(ValidatorUtil.formatMessages(validate), validate.size(), is(1));
+        assertThat(validate).as(ValidatorUtil.formatMessages(validate)).hasSize(1);
         assertTrue(validate.stream().anyMatch(p -> p.getMessageType().equals(DMNMessageType.FAILED_XML_VALIDATION)));
     }
 
@@ -177,14 +176,14 @@ public class ValidatorDecisionTest extends AbstractValidatorTest {
                                "https://github.com/kiegroup/kie-dmn",
                                "DECISION_MULTIPLE_EXPRESSIONS"),
                 VALIDATE_MODEL, VALIDATE_COMPILATION);
-        assertThat(ValidatorUtil.formatMessages(validate), validate.size(), is(0));
+        assertThat(validate).as(ValidatorUtil.formatMessages(validate)).hasSize(0);
     }
 
     @Test
     public void testDECISION_PERF_INDICATOR_WRONG_TYPE_ReaderInput() throws IOException {
         try (final Reader reader = getReader("decision/DECISION_PERF_INDICATOR_WRONG_TYPE.dmn")) {
             final List<DMNMessage> validate = validator.validate(reader, VALIDATE_SCHEMA, VALIDATE_MODEL, VALIDATE_COMPILATION);
-            assertThat(ValidatorUtil.formatMessages(validate), validate.size(), is(2));
+            assertThat(validate).as(ValidatorUtil.formatMessages(validate)).hasSize(2);
             assertTrue(validate.stream().anyMatch(p -> p.getMessageType().equals(DMNMessageType.REQ_NOT_FOUND)));
         }
     }
@@ -193,7 +192,7 @@ public class ValidatorDecisionTest extends AbstractValidatorTest {
     public void testDECISION_PERF_INDICATOR_WRONG_TYPE_FileInput() {
         final List<DMNMessage> validate = validator.validate(
                 getFile("decision/DECISION_PERF_INDICATOR_WRONG_TYPE.dmn"), VALIDATE_SCHEMA, VALIDATE_MODEL, VALIDATE_COMPILATION);
-        assertThat(ValidatorUtil.formatMessages(validate), validate.size(), is(2));
+        assertThat(validate).as(ValidatorUtil.formatMessages(validate)).hasSize(2);
         assertTrue(validate.stream().anyMatch(p -> p.getMessageType().equals(DMNMessageType.REQ_NOT_FOUND)));
     }
 
@@ -204,7 +203,7 @@ public class ValidatorDecisionTest extends AbstractValidatorTest {
                                "https://github.com/kiegroup/kie-dmn",
                                "DECISION_PERF_INDICATOR_WRONG_TYPE"),
                 VALIDATE_MODEL, VALIDATE_COMPILATION);
-        assertThat(ValidatorUtil.formatMessages(validate), validate.size(), is(2));
+        assertThat(validate).as(ValidatorUtil.formatMessages(validate)).hasSize(2);
         assertTrue(validate.stream().anyMatch(p -> p.getMessageType().equals(DMNMessageType.REQ_NOT_FOUND)));
     }
 
@@ -212,7 +211,7 @@ public class ValidatorDecisionTest extends AbstractValidatorTest {
     public void testDECISION_DECISION_MAKER_WRONG_TYPE_ReaderInput() throws IOException {
         try (final Reader reader = getReader("decision/DECISION_DECISION_MAKER_WRONG_TYPE.dmn")) {
             final List<DMNMessage> validate = validator.validate(reader, VALIDATE_SCHEMA, VALIDATE_MODEL, VALIDATE_COMPILATION);
-            assertThat(ValidatorUtil.formatMessages(validate), validate.size(), is(2));
+            assertThat(validate).as(ValidatorUtil.formatMessages(validate)).hasSize(2);
             assertTrue(validate.stream().anyMatch(p -> p.getMessageType().equals(DMNMessageType.REQ_NOT_FOUND)));
         }
     }
@@ -221,7 +220,7 @@ public class ValidatorDecisionTest extends AbstractValidatorTest {
     public void testDECISION_DECISION_MAKER_WRONG_TYPE_FileInput() {
         final List<DMNMessage> validate = validator.validate(
                 getFile("decision/DECISION_DECISION_MAKER_WRONG_TYPE.dmn"), VALIDATE_SCHEMA, VALIDATE_MODEL, VALIDATE_COMPILATION);
-        assertThat(ValidatorUtil.formatMessages(validate), validate.size(), is(2));
+        assertThat(validate).as(ValidatorUtil.formatMessages(validate)).hasSize(2);
         assertTrue(validate.stream().anyMatch(p -> p.getMessageType().equals(DMNMessageType.REQ_NOT_FOUND)));
     }
 
@@ -232,7 +231,7 @@ public class ValidatorDecisionTest extends AbstractValidatorTest {
                                "https://github.com/kiegroup/kie-dmn",
                                "DECISION_DECISION_MAKER_WRONG_TYPE"),
                 VALIDATE_MODEL, VALIDATE_COMPILATION);
-        assertThat(ValidatorUtil.formatMessages(validate), validate.size(), is(2));
+        assertThat(validate).as(ValidatorUtil.formatMessages(validate)).hasSize(2);
         assertTrue(validate.stream().anyMatch(p -> p.getMessageType().equals(DMNMessageType.REQ_NOT_FOUND)));
     }
 
@@ -240,7 +239,7 @@ public class ValidatorDecisionTest extends AbstractValidatorTest {
     public void testDECISION_DECISION_OWNER_WRONG_TYPE_ReaderInput() throws IOException {
         try (final Reader reader = getReader("decision/DECISION_DECISION_OWNER_WRONG_TYPE.dmn")) {
             final List<DMNMessage> validate = validator.validate(reader, VALIDATE_SCHEMA, VALIDATE_MODEL, VALIDATE_COMPILATION);
-            assertThat(ValidatorUtil.formatMessages(validate), validate.size(), is(2));
+            assertThat(validate).as(ValidatorUtil.formatMessages(validate)).hasSize(2);
             assertTrue(validate.stream().anyMatch(p -> p.getMessageType().equals(DMNMessageType.REQ_NOT_FOUND)));
         }
     }
@@ -249,7 +248,7 @@ public class ValidatorDecisionTest extends AbstractValidatorTest {
     public void testDECISION_DECISION_OWNER_WRONG_TYPE_FileInput() {
         final List<DMNMessage> validate = validator.validate(
                 getFile("decision/DECISION_DECISION_OWNER_WRONG_TYPE.dmn"), VALIDATE_SCHEMA, VALIDATE_MODEL, VALIDATE_COMPILATION);
-        assertThat(ValidatorUtil.formatMessages(validate), validate.size(), is(2));
+        assertThat(validate).as(ValidatorUtil.formatMessages(validate)).hasSize(2);
         assertTrue(validate.stream().anyMatch(p -> p.getMessageType().equals(DMNMessageType.REQ_NOT_FOUND)));
     }
 
@@ -260,7 +259,7 @@ public class ValidatorDecisionTest extends AbstractValidatorTest {
                                "https://github.com/kiegroup/kie-dmn",
                                "DECISION_DECISION_MAKER_WRONG_TYPE"),
                 VALIDATE_MODEL, VALIDATE_COMPILATION);
-        assertThat(ValidatorUtil.formatMessages(validate), validate.size(), is(2));
+        assertThat(validate).as(ValidatorUtil.formatMessages(validate)).hasSize(2);
         assertTrue(validate.stream().anyMatch(p -> p.getMessageType().equals(DMNMessageType.REQ_NOT_FOUND)));
     }
 
@@ -268,7 +267,7 @@ public class ValidatorDecisionTest extends AbstractValidatorTest {
     public void testDECISION_CYCLIC_DEPENDENCY_ReaderInput() throws IOException {
         try (final Reader reader = getReader("decision/DECISION_CYCLIC_DEPENDENCY.dmn")) {
             final List<DMNMessage> validate = validator.validate( reader, VALIDATE_SCHEMA, VALIDATE_MODEL, VALIDATE_COMPILATION );
-            assertThat(ValidatorUtil.formatMessages(validate), validate.size(), is(2));
+            assertThat(validate).as(ValidatorUtil.formatMessages(validate)).hasSize(2);
             assertTrue(validate.stream().anyMatch(p -> p.getMessageType().equals(DMNMessageType.REQ_NOT_FOUND)));
         }
     }
@@ -276,7 +275,7 @@ public class ValidatorDecisionTest extends AbstractValidatorTest {
     @Test
     public void testDECISION_CYCLIC_DEPENDENCY_FileInput() {
         final List<DMNMessage> validate = validator.validate( getFile("decision/DECISION_CYCLIC_DEPENDENCY.dmn"), VALIDATE_SCHEMA, VALIDATE_MODEL, VALIDATE_COMPILATION );
-        assertThat(ValidatorUtil.formatMessages(validate), validate.size(), is(2));
+        assertThat(validate).as(ValidatorUtil.formatMessages(validate)).hasSize(2);
         assertTrue(validate.stream().anyMatch(p -> p.getMessageType().equals(DMNMessageType.REQ_NOT_FOUND)));
     }
 
@@ -287,7 +286,7 @@ public class ValidatorDecisionTest extends AbstractValidatorTest {
                                "https://github.com/kiegroup/kie-dmn",
                                "DECISION_CYCLIC_DEPENDENCY"),
                 VALIDATE_MODEL, VALIDATE_COMPILATION );
-        assertThat(ValidatorUtil.formatMessages(validate), validate.size(), is(2));
+        assertThat(validate).as(ValidatorUtil.formatMessages(validate)).hasSize(2);
         assertTrue(validate.stream().anyMatch(p -> p.getMessageType().equals(DMNMessageType.REQ_NOT_FOUND)));
     }
 
@@ -295,7 +294,7 @@ public class ValidatorDecisionTest extends AbstractValidatorTest {
     public void testDECISION_CYCLIC_DEPENDENCY_SELF_REFERENCE_ReaderInput() throws IOException {
         try (final Reader reader = getReader("decision/DECISION_CYCLIC_DEPENDENCY_SELF_REFERENCE.dmn")) {
             final List<DMNMessage> validate = validator.validate( reader, VALIDATE_SCHEMA, VALIDATE_MODEL, VALIDATE_COMPILATION );
-            assertThat(ValidatorUtil.formatMessages(validate), validate.size(), is(1));
+            assertThat(validate).as(ValidatorUtil.formatMessages(validate)).hasSize(1);
             assertTrue(validate.stream().anyMatch(p -> p.getMessageType().equals(DMNMessageType.REQ_NOT_FOUND)));
         }
     }
@@ -303,7 +302,7 @@ public class ValidatorDecisionTest extends AbstractValidatorTest {
     @Test
     public void testDECISION_CYCLIC_DEPENDENCY_SELF_REFERENCE_FileInput() {
         final List<DMNMessage> validate = validator.validate( getFile("decision/DECISION_CYCLIC_DEPENDENCY_SELF_REFERENCE.dmn"), VALIDATE_SCHEMA, VALIDATE_MODEL, VALIDATE_COMPILATION );
-        assertThat(ValidatorUtil.formatMessages(validate), validate.size(), is(1));
+        assertThat(validate).as(ValidatorUtil.formatMessages(validate)).hasSize(1);
         assertTrue(validate.stream().anyMatch(p -> p.getMessageType().equals(DMNMessageType.REQ_NOT_FOUND)));
     }
 
@@ -314,7 +313,7 @@ public class ValidatorDecisionTest extends AbstractValidatorTest {
                                "https://github.com/kiegroup/kie-dmn",
                                "DECISION_CYCLIC_DEPENDENCY_SELF_REFERENCE"),
                 VALIDATE_MODEL, VALIDATE_COMPILATION );
-        assertThat(ValidatorUtil.formatMessages(validate), validate.size(), is(1));
+        assertThat(validate).as(ValidatorUtil.formatMessages(validate)).hasSize(1);
         assertTrue(validate.stream().anyMatch(p -> p.getMessageType().equals(DMNMessageType.REQ_NOT_FOUND)));
     }
 
@@ -322,14 +321,14 @@ public class ValidatorDecisionTest extends AbstractValidatorTest {
     public void testDECISION_DEADLY_DIAMOND_ReaderInput() throws IOException {
         try (final Reader reader = getReader("decision/DECISION_DEADLY_DIAMOND.dmn")) {
             final List<DMNMessage> validate = validator.validate( reader, VALIDATE_SCHEMA, VALIDATE_MODEL, VALIDATE_COMPILATION );
-            assertThat(ValidatorUtil.formatMessages(validate), validate.size(), is(0));
+            assertThat(validate).as(ValidatorUtil.formatMessages(validate)).hasSize(0);
         }
     }
 
     @Test
     public void testDECISION_DEADLY_DIAMOND_FileInput() {
         final List<DMNMessage> validate = validator.validate( getFile("decision/DECISION_DEADLY_DIAMOND.dmn"), VALIDATE_SCHEMA, VALIDATE_MODEL, VALIDATE_COMPILATION );
-        assertThat(ValidatorUtil.formatMessages(validate), validate.size(), is(0));
+        assertThat(validate).as(ValidatorUtil.formatMessages(validate)).hasSize(0);
     }
 
     @Test
@@ -339,21 +338,21 @@ public class ValidatorDecisionTest extends AbstractValidatorTest {
                                "https://github.com/kiegroup/kie-dmn",
                                "DECISION_DEADLY_DIAMOND"),
                 VALIDATE_MODEL, VALIDATE_COMPILATION );
-        assertThat(ValidatorUtil.formatMessages(validate), validate.size(), is(0));
+        assertThat(validate).as(ValidatorUtil.formatMessages(validate)).hasSize(0);
     }
 
     @Test
     public void testDECISION_DEADLY_KITE_ReaderInput() throws IOException {
         try (final Reader reader = getReader("decision/DECISION_DEADLY_KITE.dmn")) {
             final List<DMNMessage> validate = validator.validate( reader, VALIDATE_SCHEMA, VALIDATE_MODEL, VALIDATE_COMPILATION );
-            assertThat(ValidatorUtil.formatMessages(validate), validate.size(), is(0));
+            assertThat(validate).as(ValidatorUtil.formatMessages(validate)).hasSize(0);
         }
     }
 
     @Test
     public void testDECISION_DEADLY_KITE_FileInput() {
         final List<DMNMessage> validate = validator.validate( getFile("decision/DECISION_DEADLY_KITE.dmn"), VALIDATE_SCHEMA, VALIDATE_MODEL, VALIDATE_COMPILATION );
-        assertThat(ValidatorUtil.formatMessages(validate), validate.size(), is(0));
+        assertThat(validate).as(ValidatorUtil.formatMessages(validate)).hasSize(0);
     }
 
     @Test
@@ -363,6 +362,6 @@ public class ValidatorDecisionTest extends AbstractValidatorTest {
                                "https://github.com/kiegroup/kie-dmn",
                                "DECISION_DEADLY_KITE"),
                 VALIDATE_MODEL, VALIDATE_COMPILATION );
-        assertThat(ValidatorUtil.formatMessages(validate), validate.size(), is(0));
+        assertThat(validate).as(ValidatorUtil.formatMessages(validate)).hasSize(0);
     }
 }

--- a/kie-dmn/kie-dmn-legacy-tests/src/test/java/org/kie/dmn/legacy/tests/validation/v1_1/ValidatorImportTest.java
+++ b/kie-dmn/kie-dmn-legacy-tests/src/test/java/org/kie/dmn/legacy/tests/validation/v1_1/ValidatorImportTest.java
@@ -38,9 +38,7 @@ import org.kie.dmn.validation.ValidatorUtil;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import static org.hamcrest.CoreMatchers.is;
-import static org.hamcrest.CoreMatchers.notNullValue;
-import static org.hamcrest.MatcherAssert.assertThat;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.Assert.assertTrue;
 import static org.kie.dmn.core.util.DynamicTypeUtils.entry;
 import static org.kie.dmn.core.util.DynamicTypeUtils.mapOf;
@@ -54,14 +52,14 @@ public class ValidatorImportTest extends AbstractValidatorTest {
     public void testBaseModelOK() {
         DMNRuntime runtime = DMNRuntimeUtil.createRuntimeWithAdditionalResources("import/Base-model.dmn", this.getClass(), "import/Import-base-model.dmn");
         DMNModel dmnModel = runtime.getModel("http://www.trisotech.com/dmn/definitions/_b33fa7d9-f501-423b-afa8-15ded7e7f493", "Import base model");
-        assertThat(dmnModel, notNullValue());
-        assertThat(DMNRuntimeUtil.formatMessages(dmnModel.getMessages()), dmnModel.hasErrors(), is(false));
+        assertThat(dmnModel).isNotNull();
+        assertThat(dmnModel.hasErrors()).as(DMNRuntimeUtil.formatMessages(dmnModel.getMessages())).isFalse();
 
         DMNContext context = DMNFactory.newContext();
         context.set("Customer", mapOf(entry("full name", "John Doe"), entry("age", 47)));
         DMNResult dmnResult = runtime.evaluateAll(dmnModel, context);
         LOG.debug("{}", dmnResult);
-        assertThat(DMNRuntimeUtil.formatMessages(dmnResult.getMessages()), dmnResult.hasErrors(), is(false));
+        assertThat(dmnResult.hasErrors()).as(DMNRuntimeUtil.formatMessages(dmnResult.getMessages())).isFalse();
     }
 
     @Test
@@ -72,7 +70,7 @@ public class ValidatorImportTest extends AbstractValidatorTest {
                                                                       Validation.VALIDATE_MODEL,
                                                                       Validation.VALIDATE_COMPILATION)
                                                        .theseModels(reader0, reader1);
-            assertThat(ValidatorUtil.formatMessages(messages), messages.size(), is(0));
+            assertThat(messages).as(ValidatorUtil.formatMessages(messages)).hasSize(0);
         }
     }
 
@@ -83,7 +81,7 @@ public class ValidatorImportTest extends AbstractValidatorTest {
                                                                   Validation.VALIDATE_COMPILATION)
                                                    .theseModels(getFile("import/Import-base-model.dmn"), // switch order for DROOLS-2936 
                                                                 getFile("import/Base-model.dmn"));
-        assertThat(ValidatorUtil.formatMessages(messages), messages.size(), is(0));
+        assertThat(messages).as(ValidatorUtil.formatMessages(messages)).hasSize(0);
     }
 
     @Test
@@ -91,7 +89,7 @@ public class ValidatorImportTest extends AbstractValidatorTest {
         final List<DMNMessage> messages = validator.validateUsing(Validation.VALIDATE_MODEL)
                                                    .theseModels(getFile("import/Import-base-model-modelnameattribute.dmn"), // DROOLS-2938
                                                                 getFile("import/Base-model.dmn"));
-        assertThat(ValidatorUtil.formatMessages(messages), messages.size(), is(0));
+        assertThat(messages).as(ValidatorUtil.formatMessages(messages)).hasSize(0);
     }
 
     @Test
@@ -105,7 +103,7 @@ public class ValidatorImportTest extends AbstractValidatorTest {
                                                                 getDefinitions(Arrays.asList("import/Base-model.dmn", "import/Import-base-model.dmn"),
                                                                                "http://www.trisotech.com/dmn/definitions/_b33fa7d9-f501-423b-afa8-15ded7e7f493",
                                                                                "Import base model"));
-        assertThat(ValidatorUtil.formatMessages(messages), messages.size(), is(0));
+        assertThat(messages).as(ValidatorUtil.formatMessages(messages)).hasSize(0);
     }
 
     @Test
@@ -114,7 +112,7 @@ public class ValidatorImportTest extends AbstractValidatorTest {
                 final Reader reader1 = getReader("import/Wrong-Import-base-model.dmn");) {
             final List<DMNMessage> messages = validator.validateUsing(Validation.VALIDATE_MODEL)
                                                        .theseModels(reader0, reader1);
-            assertThat(ValidatorUtil.formatMessages(messages), messages.size(), is(1));
+            assertThat(messages).as(ValidatorUtil.formatMessages(messages)).hasSize(1);
             assertTrue(messages.stream().anyMatch(p -> p.getMessageType().equals(DMNMessageType.REQ_NOT_FOUND) &&
                                                        p.getSourceReference() instanceof DMNElementReference &&
                                                        ((DMNElementReference) p.getSourceReference()).getHref()
@@ -127,7 +125,7 @@ public class ValidatorImportTest extends AbstractValidatorTest {
         final List<DMNMessage> messages = validator.validateUsing(Validation.VALIDATE_MODEL)
                                                    .theseModels(getFile("import/Base-model.dmn"),
                                                                 getFile("import/Wrong-Import-base-model.dmn"));
-        assertThat(ValidatorUtil.formatMessages(messages), messages.size(), is(1));
+        assertThat(messages).as(ValidatorUtil.formatMessages(messages)).hasSize(1);
         assertTrue(messages.stream().anyMatch(p -> p.getMessageType().equals(DMNMessageType.REQ_NOT_FOUND) &&
                                                    p.getSourceReference() instanceof DMNElementReference &&
                                                    ((DMNElementReference) p.getSourceReference()).getHref()

--- a/kie-dmn/kie-dmn-legacy-tests/src/test/java/org/kie/dmn/legacy/tests/validation/v1_1/ValidatorInformationRequirementTest.java
+++ b/kie-dmn/kie-dmn-legacy-tests/src/test/java/org/kie/dmn/legacy/tests/validation/v1_1/ValidatorInformationRequirementTest.java
@@ -26,8 +26,7 @@ import org.kie.dmn.api.core.DMNMessageType;
 import org.kie.dmn.validation.AbstractValidatorTest;
 import org.kie.dmn.validation.ValidatorUtil;
 
-import static org.hamcrest.CoreMatchers.is;
-import static org.hamcrest.MatcherAssert.assertThat;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.Assert.assertTrue;
 import static org.kie.dmn.validation.DMNValidator.Validation.VALIDATE_COMPILATION;
 import static org.kie.dmn.validation.DMNValidator.Validation.VALIDATE_MODEL;
@@ -41,7 +40,7 @@ public class ValidatorInformationRequirementTest extends AbstractValidatorTest {
             final List<DMNMessage> validate = validator.validate(
                     reader,
                     VALIDATE_SCHEMA, VALIDATE_MODEL, VALIDATE_COMPILATION);
-            assertThat( ValidatorUtil.formatMessages( validate ), validate.size(), is( 2 ) );
+            assertThat(validate).as(ValidatorUtil.formatMessages(validate)).hasSize(2);
             assertTrue( validate.stream().anyMatch( p -> p.getMessageType().equals( DMNMessageType.MISSING_EXPRESSION ) ) );
             assertTrue( validate.stream().anyMatch( p -> p.getMessageType().equals( DMNMessageType.REQ_NOT_FOUND ) ) );
         }
@@ -52,7 +51,7 @@ public class ValidatorInformationRequirementTest extends AbstractValidatorTest {
         final List<DMNMessage> validate = validator.validate(
                 getFile( "informationrequirement/INFOREQ_MISSING_INPUT.dmn" ),
                 VALIDATE_SCHEMA, VALIDATE_MODEL, VALIDATE_COMPILATION);
-        assertThat( ValidatorUtil.formatMessages( validate ), validate.size(), is( 2 ) );
+        assertThat(validate).as(ValidatorUtil.formatMessages(validate)).hasSize(2);
         assertTrue( validate.stream().anyMatch( p -> p.getMessageType().equals( DMNMessageType.MISSING_EXPRESSION ) ) );
         assertTrue( validate.stream().anyMatch( p -> p.getMessageType().equals( DMNMessageType.REQ_NOT_FOUND ) ) );
     }
@@ -64,7 +63,7 @@ public class ValidatorInformationRequirementTest extends AbstractValidatorTest {
                                 "https://github.com/kiegroup/kie-dmn",
                                 "INFOREQ_MISSING_INPUT"),
                 VALIDATE_MODEL, VALIDATE_COMPILATION);
-        assertThat( ValidatorUtil.formatMessages( validate ), validate.size(), is( 2 ) );
+        assertThat(validate).as(ValidatorUtil.formatMessages(validate)).hasSize(2);
         assertTrue( validate.stream().anyMatch( p -> p.getMessageType().equals( DMNMessageType.MISSING_EXPRESSION ) ) );
         assertTrue( validate.stream().anyMatch( p -> p.getMessageType().equals( DMNMessageType.REQ_NOT_FOUND ) ) );
     }
@@ -75,7 +74,7 @@ public class ValidatorInformationRequirementTest extends AbstractValidatorTest {
             final List<DMNMessage> validate = validator.validate(
                     reader,
                     VALIDATE_SCHEMA, VALIDATE_MODEL, VALIDATE_COMPILATION);
-            assertThat( ValidatorUtil.formatMessages( validate ), validate.size(), is( 2 ) );
+            assertThat(validate).as(ValidatorUtil.formatMessages(validate)).hasSize(2);
             assertTrue( validate.stream().anyMatch( p -> p.getMessageType().equals( DMNMessageType.MISSING_EXPRESSION ) ) );
             assertTrue( validate.stream().anyMatch( p -> p.getMessageType().equals( DMNMessageType.REQ_NOT_FOUND ) ) );
         }
@@ -86,7 +85,7 @@ public class ValidatorInformationRequirementTest extends AbstractValidatorTest {
         final List<DMNMessage> validate = validator.validate(
                 getFile( "informationrequirement/INFOREQ_INPUT_NOT_INPUTDATA.dmn" ),
                 VALIDATE_SCHEMA, VALIDATE_MODEL, VALIDATE_COMPILATION);
-        assertThat( ValidatorUtil.formatMessages( validate ), validate.size(), is( 2 ) );
+        assertThat(validate).as(ValidatorUtil.formatMessages(validate)).hasSize(2);
         assertTrue( validate.stream().anyMatch( p -> p.getMessageType().equals( DMNMessageType.MISSING_EXPRESSION ) ) );
         assertTrue( validate.stream().anyMatch( p -> p.getMessageType().equals( DMNMessageType.REQ_NOT_FOUND ) ) );
     }
@@ -98,7 +97,7 @@ public class ValidatorInformationRequirementTest extends AbstractValidatorTest {
                                 "https://github.com/kiegroup/kie-dmn",
                                 "INFOREQ_INPUT_NOT_INPUTDATA"),
                 VALIDATE_MODEL, VALIDATE_COMPILATION);
-        assertThat( ValidatorUtil.formatMessages( validate ), validate.size(), is( 2 ) );
+        assertThat(validate).as(ValidatorUtil.formatMessages(validate)).hasSize(2);
         assertTrue( validate.stream().anyMatch( p -> p.getMessageType().equals( DMNMessageType.MISSING_EXPRESSION ) ) );
         assertTrue( validate.stream().anyMatch( p -> p.getMessageType().equals( DMNMessageType.REQ_NOT_FOUND ) ) );
     }
@@ -109,7 +108,7 @@ public class ValidatorInformationRequirementTest extends AbstractValidatorTest {
             final List<DMNMessage> validate = validator.validate(
                     reader,
                     VALIDATE_SCHEMA, VALIDATE_MODEL, VALIDATE_COMPILATION);
-            assertThat( ValidatorUtil.formatMessages( validate ), validate.size(), is( 2 ) );
+            assertThat(validate).as(ValidatorUtil.formatMessages(validate)).hasSize(2);
             assertTrue( validate.stream().anyMatch( p -> p.getMessageType().equals( DMNMessageType.MISSING_EXPRESSION ) ) );
             assertTrue( validate.stream().anyMatch( p -> p.getMessageType().equals( DMNMessageType.REQ_NOT_FOUND ) ) );
         }
@@ -120,7 +119,7 @@ public class ValidatorInformationRequirementTest extends AbstractValidatorTest {
         final List<DMNMessage> validate = validator.validate(
                 getFile( "informationrequirement/INFOREQ_MISSING_DECISION.dmn" ),
                 VALIDATE_SCHEMA, VALIDATE_MODEL, VALIDATE_COMPILATION);
-        assertThat( ValidatorUtil.formatMessages( validate ), validate.size(), is( 2 ) );
+        assertThat(validate).as(ValidatorUtil.formatMessages(validate)).hasSize(2);
         assertTrue( validate.stream().anyMatch( p -> p.getMessageType().equals( DMNMessageType.MISSING_EXPRESSION ) ) );
         assertTrue( validate.stream().anyMatch( p -> p.getMessageType().equals( DMNMessageType.REQ_NOT_FOUND ) ) );
     }
@@ -132,7 +131,7 @@ public class ValidatorInformationRequirementTest extends AbstractValidatorTest {
                                 "https://github.com/kiegroup/kie-dmn",
                                 "INFOREQ_MISSING_DECISION"),
                 VALIDATE_MODEL, VALIDATE_COMPILATION);
-        assertThat( ValidatorUtil.formatMessages( validate ), validate.size(), is( 2 ) );
+        assertThat(validate).as(ValidatorUtil.formatMessages(validate)).hasSize(2);
         assertTrue( validate.stream().anyMatch( p -> p.getMessageType().equals( DMNMessageType.MISSING_EXPRESSION ) ) );
         assertTrue( validate.stream().anyMatch( p -> p.getMessageType().equals( DMNMessageType.REQ_NOT_FOUND ) ) );
     }
@@ -143,7 +142,7 @@ public class ValidatorInformationRequirementTest extends AbstractValidatorTest {
             final List<DMNMessage> validate = validator.validate(
                     reader,
                     VALIDATE_SCHEMA, VALIDATE_MODEL, VALIDATE_COMPILATION);
-            assertThat( ValidatorUtil.formatMessages( validate ), validate.size(), is( 2 ) );
+            assertThat(validate).as(ValidatorUtil.formatMessages(validate)).hasSize(2);
             assertTrue( validate.stream().anyMatch( p -> p.getMessageType().equals( DMNMessageType.MISSING_EXPRESSION ) ) );
             assertTrue( validate.stream().anyMatch( p -> p.getMessageType().equals( DMNMessageType.REQ_NOT_FOUND ) ) );
         }
@@ -154,7 +153,7 @@ public class ValidatorInformationRequirementTest extends AbstractValidatorTest {
         final List<DMNMessage> validate = validator.validate(
                 getFile( "informationrequirement/INFOREQ_DECISION_NOT_DECISION.dmn" ),
                 VALIDATE_SCHEMA, VALIDATE_MODEL, VALIDATE_COMPILATION);
-        assertThat( ValidatorUtil.formatMessages( validate ), validate.size(), is( 2 ) );
+        assertThat(validate).as(ValidatorUtil.formatMessages(validate)).hasSize(2);
         assertTrue( validate.stream().anyMatch( p -> p.getMessageType().equals( DMNMessageType.MISSING_EXPRESSION ) ) );
         assertTrue( validate.stream().anyMatch( p -> p.getMessageType().equals( DMNMessageType.REQ_NOT_FOUND ) ) );
     }
@@ -166,7 +165,7 @@ public class ValidatorInformationRequirementTest extends AbstractValidatorTest {
                                 "https://github.com/kiegroup/kie-dmn",
                                 "INFOREQ_DECISION_NOT_DECISION"),
                 VALIDATE_MODEL, VALIDATE_COMPILATION);
-        assertThat( ValidatorUtil.formatMessages( validate ), validate.size(), is( 2 ) );
+        assertThat(validate).as(ValidatorUtil.formatMessages(validate)).hasSize(2);
         assertTrue( validate.stream().anyMatch( p -> p.getMessageType().equals( DMNMessageType.MISSING_EXPRESSION ) ) );
         assertTrue( validate.stream().anyMatch( p -> p.getMessageType().equals( DMNMessageType.REQ_NOT_FOUND ) ) );
     }

--- a/kie-dmn/kie-dmn-legacy-tests/src/test/java/org/kie/dmn/legacy/tests/validation/v1_1/ValidatorInputDataTest.java
+++ b/kie-dmn/kie-dmn-legacy-tests/src/test/java/org/kie/dmn/legacy/tests/validation/v1_1/ValidatorInputDataTest.java
@@ -26,8 +26,7 @@ import org.kie.dmn.api.core.DMNMessageType;
 import org.kie.dmn.validation.AbstractValidatorTest;
 import org.kie.dmn.validation.ValidatorUtil;
 
-import static org.hamcrest.CoreMatchers.is;
-import static org.hamcrest.MatcherAssert.assertThat;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.Assert.assertTrue;
 import static org.kie.dmn.validation.DMNValidator.Validation.VALIDATE_COMPILATION;
 import static org.kie.dmn.validation.DMNValidator.Validation.VALIDATE_MODEL;
@@ -41,7 +40,7 @@ public class ValidatorInputDataTest extends AbstractValidatorTest {
             final List<DMNMessage> validate = validator.validate(
                     reader,
                     VALIDATE_SCHEMA, VALIDATE_MODEL, VALIDATE_COMPILATION);
-            assertThat(ValidatorUtil.formatMessages(validate), validate.size(), is(1));
+            assertThat(validate).as(ValidatorUtil.formatMessages(validate)).hasSize(1);
             assertTrue(validate.stream().anyMatch(p -> p.getMessageType().equals(DMNMessageType.MISSING_VARIABLE)));
         }
     }
@@ -51,7 +50,7 @@ public class ValidatorInputDataTest extends AbstractValidatorTest {
         final List<DMNMessage> validate = validator.validate(
                 getFile("inputdata/INPUTDATA_MISSING_VAR.dmn"),
                 VALIDATE_SCHEMA, VALIDATE_MODEL, VALIDATE_COMPILATION);
-        assertThat(ValidatorUtil.formatMessages(validate), validate.size(), is(1));
+        assertThat(validate).as(ValidatorUtil.formatMessages(validate)).hasSize(1);
         assertTrue(validate.stream().anyMatch(p -> p.getMessageType().equals(DMNMessageType.MISSING_VARIABLE)));
     }
 
@@ -62,7 +61,7 @@ public class ValidatorInputDataTest extends AbstractValidatorTest {
                                "https://github.com/kiegroup/kie-dmn",
                                "INPUTDATA_MISSING_VAR"),
                 VALIDATE_MODEL, VALIDATE_COMPILATION);
-        assertThat(ValidatorUtil.formatMessages(validate), validate.size(), is(1));
+        assertThat(validate).as(ValidatorUtil.formatMessages(validate)).hasSize(1);
         assertTrue(validate.stream().anyMatch(p -> p.getMessageType().equals(DMNMessageType.MISSING_VARIABLE)));
     }
 
@@ -72,7 +71,7 @@ public class ValidatorInputDataTest extends AbstractValidatorTest {
             final List<DMNMessage> validate = validator.validate(
                     reader,
                     VALIDATE_SCHEMA, VALIDATE_MODEL, VALIDATE_COMPILATION);
-            assertThat(ValidatorUtil.formatMessages(validate), validate.size(), is(1));
+            assertThat(validate).as(ValidatorUtil.formatMessages(validate)).hasSize(1);
             assertTrue(validate.stream().anyMatch(p -> p.getMessageType().equals(DMNMessageType.VARIABLE_NAME_MISMATCH)));
         }
     }
@@ -82,7 +81,7 @@ public class ValidatorInputDataTest extends AbstractValidatorTest {
         final List<DMNMessage> validate = validator.validate(
                 getFile("inputdata/INPUTDATA_MISMATCH_VAR.dmn"),
                 VALIDATE_SCHEMA, VALIDATE_MODEL, VALIDATE_COMPILATION);
-        assertThat(ValidatorUtil.formatMessages(validate), validate.size(), is(1));
+        assertThat(validate).as(ValidatorUtil.formatMessages(validate)).hasSize(1);
         assertTrue(validate.stream().anyMatch(p -> p.getMessageType().equals(DMNMessageType.VARIABLE_NAME_MISMATCH)));
     }
 
@@ -93,7 +92,7 @@ public class ValidatorInputDataTest extends AbstractValidatorTest {
                                "https://github.com/kiegroup/kie-dmn",
                                "INPUTDATA_MISSING_VAR"),
                 VALIDATE_MODEL, VALIDATE_COMPILATION);
-        assertThat(ValidatorUtil.formatMessages(validate), validate.size(), is(1));
+        assertThat(validate).as(ValidatorUtil.formatMessages(validate)).hasSize(1);
         assertTrue(validate.stream().anyMatch(p -> p.getMessageType().equals(DMNMessageType.VARIABLE_NAME_MISMATCH)));
     }
 }

--- a/kie-dmn/kie-dmn-legacy-tests/src/test/java/org/kie/dmn/legacy/tests/validation/v1_1/ValidatorKnowledgeRequirementTest.java
+++ b/kie-dmn/kie-dmn-legacy-tests/src/test/java/org/kie/dmn/legacy/tests/validation/v1_1/ValidatorKnowledgeRequirementTest.java
@@ -26,8 +26,7 @@ import org.kie.dmn.api.core.DMNMessageType;
 import org.kie.dmn.validation.AbstractValidatorTest;
 import org.kie.dmn.validation.ValidatorUtil;
 
-import static org.hamcrest.CoreMatchers.is;
-import static org.hamcrest.MatcherAssert.assertThat;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.Assert.assertTrue;
 import static org.kie.dmn.validation.DMNValidator.Validation.VALIDATE_COMPILATION;
 import static org.kie.dmn.validation.DMNValidator.Validation.VALIDATE_MODEL;
@@ -41,7 +40,7 @@ public class ValidatorKnowledgeRequirementTest extends AbstractValidatorTest {
             final List<DMNMessage> validate = validator.validate(
                     reader,
                     VALIDATE_SCHEMA, VALIDATE_MODEL, VALIDATE_COMPILATION);
-            assertThat( ValidatorUtil.formatMessages( validate ), validate.size(), is( 2 ) );
+            assertThat(validate).as(ValidatorUtil.formatMessages(validate)).hasSize(2);
             assertTrue( validate.stream().anyMatch( p -> p.getMessageType().equals( DMNMessageType.MISSING_EXPRESSION ) ) );
             assertTrue( validate.stream().anyMatch( p -> p.getMessageType().equals( DMNMessageType.REQ_NOT_FOUND ) ) );
         }
@@ -52,7 +51,7 @@ public class ValidatorKnowledgeRequirementTest extends AbstractValidatorTest {
         final List<DMNMessage> validate = validator.validate(
                 getFile( "knowledgerequirement/KNOWREQ_MISSING_BKM.dmn" ),
                 VALIDATE_SCHEMA, VALIDATE_MODEL, VALIDATE_COMPILATION);
-        assertThat( ValidatorUtil.formatMessages( validate ), validate.size(), is( 2 ) );
+        assertThat(validate).as(ValidatorUtil.formatMessages(validate)).hasSize(2);
         assertTrue( validate.stream().anyMatch( p -> p.getMessageType().equals( DMNMessageType.MISSING_EXPRESSION ) ) );
         assertTrue( validate.stream().anyMatch( p -> p.getMessageType().equals( DMNMessageType.REQ_NOT_FOUND ) ) );
     }
@@ -64,7 +63,7 @@ public class ValidatorKnowledgeRequirementTest extends AbstractValidatorTest {
                                 "https://github.com/kiegroup/kie-dmn",
                                 "KNOWREQ_MISSING_BKM"),
                 VALIDATE_MODEL, VALIDATE_COMPILATION);
-        assertThat( ValidatorUtil.formatMessages( validate ), validate.size(), is( 2 ) );
+        assertThat(validate).as(ValidatorUtil.formatMessages(validate)).hasSize(2);
         assertTrue( validate.stream().anyMatch( p -> p.getMessageType().equals( DMNMessageType.MISSING_EXPRESSION ) ) );
         assertTrue( validate.stream().anyMatch( p -> p.getMessageType().equals( DMNMessageType.REQ_NOT_FOUND ) ) );
     }
@@ -75,7 +74,7 @@ public class ValidatorKnowledgeRequirementTest extends AbstractValidatorTest {
             final List<DMNMessage> validate = validator.validate(
                     reader,
                     VALIDATE_SCHEMA, VALIDATE_MODEL, VALIDATE_COMPILATION);
-            assertThat( ValidatorUtil.formatMessages( validate ), validate.size(), is( 2 ) );
+            assertThat(validate).as(ValidatorUtil.formatMessages(validate)).hasSize(2);
             assertTrue( validate.stream().anyMatch( p -> p.getMessageType().equals( DMNMessageType.MISSING_EXPRESSION ) ) );
             assertTrue( validate.stream().anyMatch( p -> p.getMessageType().equals( DMNMessageType.REQ_NOT_FOUND ) ) );
         }
@@ -86,7 +85,7 @@ public class ValidatorKnowledgeRequirementTest extends AbstractValidatorTest {
         final List<DMNMessage> validate = validator.validate(
                 getFile( "knowledgerequirement/KNOWREQ_REQ_DECISION_NOT_BKM.dmn" ),
                 VALIDATE_SCHEMA, VALIDATE_MODEL, VALIDATE_COMPILATION);
-        assertThat( ValidatorUtil.formatMessages( validate ), validate.size(), is( 2 ) );
+        assertThat(validate).as(ValidatorUtil.formatMessages(validate)).hasSize(2);
         assertTrue( validate.stream().anyMatch( p -> p.getMessageType().equals( DMNMessageType.MISSING_EXPRESSION ) ) );
         assertTrue( validate.stream().anyMatch( p -> p.getMessageType().equals( DMNMessageType.REQ_NOT_FOUND ) ) );
     }
@@ -98,7 +97,7 @@ public class ValidatorKnowledgeRequirementTest extends AbstractValidatorTest {
                                 "https://github.com/kiegroup/kie-dmn",
                                 "KNOWREQ_REQ_DECISION_NOT_BKM"),
                 VALIDATE_MODEL, VALIDATE_COMPILATION);
-        assertThat( ValidatorUtil.formatMessages( validate ), validate.size(), is( 2 ) );
+        assertThat(validate).as(ValidatorUtil.formatMessages(validate)).hasSize(2);
         assertTrue( validate.stream().anyMatch( p -> p.getMessageType().equals( DMNMessageType.MISSING_EXPRESSION ) ) );
         assertTrue( validate.stream().anyMatch( p -> p.getMessageType().equals( DMNMessageType.REQ_NOT_FOUND ) ) );
     }

--- a/kie-dmn/kie-dmn-legacy-tests/src/test/java/org/kie/dmn/legacy/tests/validation/v1_1/ValidatorKnowledgeSourceTest.java
+++ b/kie-dmn/kie-dmn-legacy-tests/src/test/java/org/kie/dmn/legacy/tests/validation/v1_1/ValidatorKnowledgeSourceTest.java
@@ -26,8 +26,7 @@ import org.kie.dmn.api.core.DMNMessageType;
 import org.kie.dmn.validation.AbstractValidatorTest;
 import org.kie.dmn.validation.ValidatorUtil;
 
-import static org.hamcrest.CoreMatchers.is;
-import static org.hamcrest.MatcherAssert.assertThat;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.Assert.assertTrue;
 import static org.kie.dmn.validation.DMNValidator.Validation.VALIDATE_COMPILATION;
 import static org.kie.dmn.validation.DMNValidator.Validation.VALIDATE_MODEL;
@@ -41,7 +40,7 @@ public class ValidatorKnowledgeSourceTest extends AbstractValidatorTest {
             final List<DMNMessage> validate = validator.validate(
                     reader,
                     VALIDATE_SCHEMA, VALIDATE_MODEL, VALIDATE_COMPILATION);
-            assertThat( ValidatorUtil.formatMessages( validate ), validate.size(), is( 1 ) );
+            assertThat(validate).as(ValidatorUtil.formatMessages(validate)).hasSize(1);
             assertTrue( validate.stream().anyMatch( p -> p.getMessageType().equals( DMNMessageType.REQ_NOT_FOUND ) ) );
         }
     }
@@ -51,7 +50,7 @@ public class ValidatorKnowledgeSourceTest extends AbstractValidatorTest {
         final List<DMNMessage> validate = validator.validate(
                 getFile( "knowledgesource/KNOW_SOURCE_MISSING_OWNER.dmn" ),
                 VALIDATE_SCHEMA, VALIDATE_MODEL, VALIDATE_COMPILATION);
-        assertThat( ValidatorUtil.formatMessages( validate ), validate.size(), is( 1 ) );
+        assertThat(validate).as(ValidatorUtil.formatMessages(validate)).hasSize(1);
         assertTrue( validate.stream().anyMatch( p -> p.getMessageType().equals( DMNMessageType.REQ_NOT_FOUND ) ) );
     }
 
@@ -62,7 +61,7 @@ public class ValidatorKnowledgeSourceTest extends AbstractValidatorTest {
                                 "https://github.com/kiegroup/kie-dmn",
                                 "KNOW_SOURCE_MISSING_OWNER"),
                 VALIDATE_MODEL, VALIDATE_COMPILATION);
-        assertThat( ValidatorUtil.formatMessages( validate ), validate.size(), is( 1 ) );
+        assertThat(validate).as(ValidatorUtil.formatMessages(validate)).hasSize(1);
         assertTrue( validate.stream().anyMatch( p -> p.getMessageType().equals( DMNMessageType.REQ_NOT_FOUND ) ) );
     }
 
@@ -72,7 +71,7 @@ public class ValidatorKnowledgeSourceTest extends AbstractValidatorTest {
             final List<DMNMessage> validate = validator.validate(
                     reader,
                     VALIDATE_SCHEMA, VALIDATE_MODEL, VALIDATE_COMPILATION);
-            assertThat( ValidatorUtil.formatMessages( validate ), validate.size(), is( 3 ) );
+            assertThat(validate).as(ValidatorUtil.formatMessages(validate)).hasSize(3);
             assertTrue( validate.stream().anyMatch( p -> p.getMessageType().equals( DMNMessageType.REQ_NOT_FOUND ) ) );
         }
     }
@@ -82,7 +81,7 @@ public class ValidatorKnowledgeSourceTest extends AbstractValidatorTest {
         final List<DMNMessage> validate = validator.validate(
                 getFile( "knowledgesource/KNOW_SOURCE_OWNER_NOT_ORG_UNIT.dmn" ),
                 VALIDATE_SCHEMA, VALIDATE_MODEL, VALIDATE_COMPILATION);
-        assertThat( ValidatorUtil.formatMessages( validate ), validate.size(), is( 3 ) );
+        assertThat(validate).as(ValidatorUtil.formatMessages(validate)).hasSize(3);
         assertTrue( validate.stream().anyMatch( p -> p.getMessageType().equals( DMNMessageType.REQ_NOT_FOUND ) ) );
     }
 
@@ -93,7 +92,7 @@ public class ValidatorKnowledgeSourceTest extends AbstractValidatorTest {
                                 "https://github.com/kiegroup/kie-dmn",
                                 "KNOW_SOURCE_OWNER_NOT_ORG_UNIT"),
                 VALIDATE_MODEL, VALIDATE_COMPILATION);
-        assertThat( ValidatorUtil.formatMessages( validate ), validate.size(), is( 3 ) );
+        assertThat(validate).as(ValidatorUtil.formatMessages(validate)).hasSize(3);
         assertTrue( validate.stream().anyMatch( p -> p.getMessageType().equals( DMNMessageType.REQ_NOT_FOUND ) ) );
     }
 }

--- a/kie-dmn/kie-dmn-legacy-tests/src/test/java/org/kie/dmn/legacy/tests/validation/v1_1/ValidatorTest.java
+++ b/kie-dmn/kie-dmn-legacy-tests/src/test/java/org/kie/dmn/legacy/tests/validation/v1_1/ValidatorTest.java
@@ -39,10 +39,7 @@ import org.kie.dmn.validation.DMNValidator;
 import org.kie.dmn.validation.DMNValidatorFactory;
 import org.kie.dmn.validation.ValidatorUtil;
 
-import static org.hamcrest.CoreMatchers.is;
-import static org.hamcrest.CoreMatchers.notNullValue;
-import static org.hamcrest.Matchers.greaterThan;
-import static org.hamcrest.MatcherAssert.assertThat;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 import static org.kie.dmn.validation.DMNValidator.Validation.VALIDATE_COMPILATION;
@@ -55,10 +52,11 @@ public class ValidatorTest extends AbstractValidatorTest {
     public void testDryRun() {
         DMNRuntime runtime = DMNRuntimeUtil.createRuntime( "0001-input-data-string.dmn", DMNInputRuntimeTest.class );
         DMNModel dmnModel = runtime.getModel( "https://github.com/kiegroup/drools/kie-dmn", "_0001-input-data-string" );
-        assertThat( dmnModel, notNullValue() );
+        assertThat(dmnModel).isNotNull();
+        
 
         Definitions definitions = dmnModel.getDefinitions();
-        assertThat( definitions, notNullValue() );
+        assertThat(definitions).isNotNull();
         
         DMNValidatorFactory.newValidator().validate(definitions);
     }
@@ -67,21 +65,21 @@ public class ValidatorTest extends AbstractValidatorTest {
     public void testMACDInputDefinitions() {
         DMNRuntime runtime = DMNRuntimeUtil.createRuntime( "MACD-enhanced_iteration.dmn", DMNInputRuntimeTest.class );
         DMNModel dmnModel = runtime.getModel( "http://www.trisotech.com/definitions/_6cfe7d88-6741-45d1-968c-b61a597d0964", "MACD-enhanced iteration" );
-        assertThat( dmnModel, notNullValue() );
+        assertThat(dmnModel).isNotNull();
 
         Definitions definitions = dmnModel.getDefinitions();
-        assertThat( definitions, notNullValue() );
+        assertThat(definitions).isNotNull();
 
         List<DMNMessage> messages = DMNValidatorFactory.newValidator().validate(definitions, VALIDATE_MODEL, VALIDATE_COMPILATION);
 
-        assertThat( messages.toString(), messages.size(), is( 0 ) );
+        assertThat(messages).as(messages.toString()).hasSize(0);
     }
 
     @Test
     public void testMACDInputReader() throws IOException {
         try (final Reader reader = new InputStreamReader(getClass().getResourceAsStream("/org/kie/dmn/core/MACD-enhanced_iteration.dmn") )) {
             List<DMNMessage> messages = DMNValidatorFactory.newValidator().validate(reader, VALIDATE_MODEL, VALIDATE_COMPILATION);
-            assertThat( messages.toString(), messages.size(), is( 0 ) );
+            assertThat(messages).as(messages.toString()).hasSize(0);
         }
     }
 
@@ -98,7 +96,7 @@ public class ValidatorTest extends AbstractValidatorTest {
         DMNMarshaller marshaller = DMNMarshallerFactory.newDefaultMarshaller();
         try( InputStreamReader isr = new InputStreamReader( getClass().getResourceAsStream( filename ) ) ) {
             Definitions definitions = marshaller.unmarshal( isr );
-            assertThat( definitions, notNullValue() );
+            assertThat(definitions).isNotNull();
             return definitions;
         } catch ( IOException e ) {
             e.printStackTrace();
@@ -110,27 +108,27 @@ public class ValidatorTest extends AbstractValidatorTest {
     @Test
     public void testInvalidXml() throws URISyntaxException {
         List<DMNMessage> validateXML = validator.validate( new File(this.getClass().getResource( "invalidXml.dmn" ).toURI()), DMNValidator.Validation.VALIDATE_SCHEMA);
-        assertThat( ValidatorUtil.formatMessages( validateXML ), validateXML.size(), is( 1 ) );
-        assertThat( validateXML.get( 0 ).toString(), validateXML.get( 0 ).getMessageType(), is( DMNMessageType.FAILED_XML_VALIDATION ) );
+        assertThat(validateXML).as(ValidatorUtil.formatMessages( validateXML )).hasSize(1);
+        assertThat(validateXML.get(0).getMessageType()).as(validateXML.get(0).toString()).isEqualTo(DMNMessageType.FAILED_XML_VALIDATION);
     }
 
     @Test
     public void testINVOCATION_MISSING_EXPR() {
         List<DMNMessage> validate = validator.validate( getReader( "INVOCATION_MISSING_EXPR.dmn" ), VALIDATE_SCHEMA, VALIDATE_MODEL, VALIDATE_COMPILATION);
-        assertThat(ValidatorUtil.formatMessages(validate), validate.size(), greaterThan(0));
-        assertThat( validate.get( 0 ).toString(), validate.get( 0 ).getMessageType(), is( DMNMessageType.MISSING_EXPRESSION ) );
+        assertThat(validate).as(ValidatorUtil.formatMessages(validate)).hasSizeGreaterThan(0);
+        assertThat(validate.get(0).getMessageType()).as(validate.get(0).toString()).isEqualTo(DMNMessageType.MISSING_EXPRESSION);
     }
 
     @Test
     public void testNAME_IS_VALID() {
         List<DMNMessage> validate = validator.validate( getReader( "NAME_IS_VALID.dmn" ), VALIDATE_SCHEMA, VALIDATE_MODEL, VALIDATE_COMPILATION);
-        assertThat( ValidatorUtil.formatMessages( validate ), validate.size(), is( 0 ) );
+        assertThat(validate).as(ValidatorUtil.formatMessages(validate)).hasSize(0);
     }
 
     @Test
     public void testNAME_INVALID_empty_name() {
         List<DMNMessage> validate = validator.validate( getReader( "DROOLS-1447.dmn" ), VALIDATE_SCHEMA, VALIDATE_MODEL, VALIDATE_COMPILATION);
-        assertThat( ValidatorUtil.formatMessages( validate ), validate.size(), is( 4 ) );
+        assertThat(validate).as(ValidatorUtil.formatMessages(validate)).hasSize(4);
         assertTrue( validate.stream().anyMatch( p -> p.getMessageType().equals( DMNMessageType.FAILED_XML_VALIDATION ) ) );
         assertTrue( validate.stream().anyMatch( p -> p.getMessageType().equals( DMNMessageType.VARIABLE_NAME_MISMATCH ) ) );
         assertTrue( validate.stream().anyMatch( p -> p.getMessageType().equals( DMNMessageType.INVALID_NAME ) && p.getSourceId().equals( "_5e43b55c-888e-443c-b1b9-80e4aa6746bd" ) ) );
@@ -140,21 +138,21 @@ public class ValidatorTest extends AbstractValidatorTest {
     @Test
     public void testDRGELEM_NOT_UNIQUE() {
         List<DMNMessage> validate = validator.validate( getReader( "DRGELEM_NOT_UNIQUE.dmn" ), VALIDATE_SCHEMA, VALIDATE_MODEL, VALIDATE_COMPILATION);
-        assertThat( ValidatorUtil.formatMessages( validate ), validate.size(), is( 2 ) );
+        assertThat(validate).as(ValidatorUtil.formatMessages(validate)).hasSize(2);
         assertTrue( validate.stream().anyMatch( p -> p.getMessageType().equals( DMNMessageType.DUPLICATE_NAME ) ) );
     }
     
     @Test
     public void testFORMAL_PARAM_DUPLICATED() {
         List<DMNMessage> validate = validator.validate( getReader( "FORMAL_PARAM_DUPLICATED.dmn" ), VALIDATE_SCHEMA, VALIDATE_MODEL, VALIDATE_COMPILATION);
-        assertThat( ValidatorUtil.formatMessages( validate ), validate.size(), is( 3 ) );
+        assertThat(validate).as(ValidatorUtil.formatMessages(validate)).hasSize(3);
         assertTrue( validate.stream().anyMatch( p -> p.getMessageType().equals( DMNMessageType.DUPLICATED_PARAM ) ) );
     }
     
     @Test
     public void testINVOCATION_INCONSISTENT_PARAM_NAMES() {
         List<DMNMessage> validate = validator.validate( getReader( "INVOCATION_INCONSISTENT_PARAM_NAMES.dmn" ), VALIDATE_SCHEMA, VALIDATE_MODEL, VALIDATE_COMPILATION);
-        assertThat(ValidatorUtil.formatMessages(validate), validate.size(), greaterThan(0));
+        assertThat(validate).as(ValidatorUtil.formatMessages(validate)).hasSizeGreaterThan(0);
         assertTrue( validate.stream().anyMatch( p -> p.getMessageType().equals( DMNMessageType.PARAMETER_MISMATCH ) ) );
     }
     
@@ -178,21 +176,21 @@ public class ValidatorTest extends AbstractValidatorTest {
     @Test
     public void testINVOCATION_WRONG_PARAM_COUNT() {
         List<DMNMessage> validate = validator.validate( getReader( "INVOCATION_WRONG_PARAM_COUNT.dmn" ), VALIDATE_SCHEMA, VALIDATE_MODEL, VALIDATE_COMPILATION);
-        assertThat(ValidatorUtil.formatMessages(validate), validate.size(), greaterThan(0));
+        assertThat(validate).as(ValidatorUtil.formatMessages(validate)).hasSizeGreaterThan(0);
         assertTrue( validate.stream().anyMatch( p -> p.getMessageType().equals( DMNMessageType.PARAMETER_MISMATCH ) ) );
     }
     
     @Test
     public void testITEMCOMP_DUPLICATED() {
         List<DMNMessage> validate = validator.validate( getReader( "ITEMCOMP_DUPLICATED.dmn" ), VALIDATE_SCHEMA, VALIDATE_MODEL, VALIDATE_COMPILATION);
-        assertThat( ValidatorUtil.formatMessages( validate ), validate.size(), is( 2 ) );
+        assertThat(validate).as(ValidatorUtil.formatMessages(validate)).hasSize(2);
         assertTrue( validate.stream().anyMatch( p -> p.getMessageType().equals( DMNMessageType.DUPLICATED_ITEM_DEF ) ) );
     }
     
     @Test
     public void testITEMDEF_NOT_UNIQUE() {
         List<DMNMessage> validate = validator.validate( getReader( "ITEMDEF_NOT_UNIQUE.dmn" ), VALIDATE_SCHEMA, VALIDATE_MODEL, VALIDATE_COMPILATION);
-        assertThat( ValidatorUtil.formatMessages( validate ), validate.size(), is( 2 ) );
+        assertThat(validate).as(ValidatorUtil.formatMessages(validate)).hasSize(2);
         assertTrue( validate.stream().anyMatch( p -> p.getMessageType().equals( DMNMessageType.DUPLICATED_ITEM_DEF ) ) );
     }
     
@@ -200,20 +198,20 @@ public class ValidatorTest extends AbstractValidatorTest {
     public void testITEMDEF_NOT_UNIQUE_DROOLS_1450() {
         // DROOLS-1450
         List<DMNMessage> validate = validator.validate( getReader( "ITEMDEF_NOT_UNIQUE_DROOLS-1450.dmn" ), VALIDATE_SCHEMA, VALIDATE_MODEL, VALIDATE_COMPILATION);
-        assertThat( ValidatorUtil.formatMessages( validate ), validate.size(), is( 0 ) );
+        assertThat(validate).as(ValidatorUtil.formatMessages(validate)).hasSize(0);
     }
     
     @Test
     public void testRELATION_DUP_COLUMN() {
         List<DMNMessage> validate = validator.validate( getReader( "RELATION_DUP_COLUMN.dmn" ), VALIDATE_SCHEMA, VALIDATE_MODEL, VALIDATE_COMPILATION);
-        assertThat( ValidatorUtil.formatMessages( validate ), validate.size(), is( 2 ) );
+        assertThat(validate).as(ValidatorUtil.formatMessages(validate)).hasSize(2);
         assertTrue( validate.stream().anyMatch( p -> p.getMessageType().equals( DMNMessageType.DUPLICATED_RELATION_COLUMN ) ) );
     }
     
     @Test
     public void testRELATION_ROW_CELL_NOTLITERAL() {
         List<DMNMessage> validate = validator.validate( getReader( "RELATION_ROW_CELL_NOTLITERAL.dmn" ), VALIDATE_SCHEMA, VALIDATE_MODEL, VALIDATE_COMPILATION);
-        assertThat( ValidatorUtil.formatMessages( validate ), validate.size(), is( 2 ) );
+        assertThat(validate).as(ValidatorUtil.formatMessages(validate)).hasSize(2);
         assertTrue( validate.stream().anyMatch( p -> p.getMessageType().equals( DMNMessageType.RELATION_CELL_NOT_LITERAL ) ) );
         assertTrue( validate.stream().anyMatch( p -> p.getMessageType().equals( DMNMessageType.MISSING_EXPRESSION ) ) );
     }
@@ -221,7 +219,7 @@ public class ValidatorTest extends AbstractValidatorTest {
     @Test
     public void testRELATION_ROW_CELLCOUNTMISMATCH() {
         List<DMNMessage> validate = validator.validate( getReader( "RELATION_ROW_CELLCOUNTMISMATCH.dmn" ), VALIDATE_SCHEMA, VALIDATE_MODEL, VALIDATE_COMPILATION);
-        assertThat( ValidatorUtil.formatMessages( validate ), validate.size(), is( 1 ) );
+        assertThat(validate).as(ValidatorUtil.formatMessages(validate)).hasSize(1);
         assertTrue( validate.stream().anyMatch( p -> p.getMessageType().equals( DMNMessageType.RELATION_CELL_COUNT_MISMATCH ) ) );
     }
 
@@ -230,35 +228,35 @@ public class ValidatorTest extends AbstractValidatorTest {
         // This file has a gazillion errors. The goal of this test is simply check that the validator itself is not blowing up
         // and raising an exception. The errors in the file itself are irrelevant.
         List<DMNMessage> validate = validator.validate( getReader( "MortgageRecommender.dmn" ), VALIDATE_SCHEMA, VALIDATE_MODEL, VALIDATE_COMPILATION);
-        assertThat( ValidatorUtil.formatMessages( validate ), validate.isEmpty(), is( false ) );
+        assertThat(validate.isEmpty()).as(ValidatorUtil.formatMessages(validate)).isFalse();
     }
 
     @Test
     public void testREQAUTH_NOT_KNOWLEDGESOURCEbis() {
         // DROOLS-1435
         List<DMNMessage> validate = validator.validate( getReader( "REQAUTH_NOT_KNOWLEDGESOURCEbis.dmn" ), VALIDATE_SCHEMA, VALIDATE_MODEL, VALIDATE_COMPILATION);
-        assertThat( ValidatorUtil.formatMessages( validate ), validate.size(), is( 1 ) );
+        assertThat(validate).as(ValidatorUtil.formatMessages(validate)).hasSize(1);
     }
 
     @Test
     public void testVARIABLE_LEADING_TRAILING_SPACES() {
         List<DMNMessage> validate = validator.validate( getReader( "VARIABLE_LEADING_TRAILING_SPACES.dmn" ), VALIDATE_SCHEMA, VALIDATE_MODEL, VALIDATE_COMPILATION);
-        assertThat( ValidatorUtil.formatMessages( validate ), validate.size(), is( 1 ) );
+        assertThat(validate).as(ValidatorUtil.formatMessages(validate)).hasSize(1);
         assertTrue( validate.stream().anyMatch( p -> p.getMessageType().equals( DMNMessageType.INVALID_NAME ) ) );
-        assertThat( validate.get(0).getSourceId(), is("_dd662d27-7896-42cb-9d14-bd74203bdbec") );
+        assertThat( validate.get(0).getSourceId()).isEqualTo("_dd662d27-7896-42cb-9d14-bd74203bdbec");
     }
 
     @Test
     public void testUNKNOWN_VARIABLE() {
         List<DMNMessage> validate = validator.validate( getReader( "UNKNOWN_VARIABLE.dmn" ), VALIDATE_SCHEMA, VALIDATE_MODEL, VALIDATE_COMPILATION);
-        assertThat( ValidatorUtil.formatMessages( validate ), validate.size(), is( 1 ) );
+        assertThat(validate).as(ValidatorUtil.formatMessages(validate)).hasSize(1);
         assertTrue( validate.stream().anyMatch( p -> p.getMessageType().equals( DMNMessageType.ERR_COMPILING_FEEL ) ) );
     }
 
     @Test
     public void testVALIDATION() {
         List<DMNMessage> validate = validator.validate( getReader( "validation.dmn" ), VALIDATE_MODEL, VALIDATE_COMPILATION);
-        assertThat( ValidatorUtil.formatMessages( validate ), validate.size(), is( 5 ) );
+        assertThat(validate).as(ValidatorUtil.formatMessages(validate)).hasSize(5);
         assertTrue( validate.stream().anyMatch( p -> p.getMessageType().equals( DMNMessageType.INVALID_NAME ) ) );
         assertTrue( validate.stream().anyMatch( p -> p.getMessageType().equals( DMNMessageType.MISSING_TYPE_REF ) ) );
         assertTrue( validate.stream().anyMatch( p -> p.getMessageType().equals( DMNMessageType.MISSING_EXPRESSION ) ) );
@@ -271,21 +269,21 @@ public class ValidatorTest extends AbstractValidatorTest {
     public void testUsingSemanticNamespacePrefix() {
         // DROOLS-2419
         List<DMNMessage> validate = validator.validate(getReader("UsingSemanticNS.dmn"), VALIDATE_SCHEMA, VALIDATE_MODEL, VALIDATE_COMPILATION);
-        assertThat(ValidatorUtil.formatMessages(validate), validate.size(), is(0));
+        assertThat(validate).as(ValidatorUtil.formatMessages(validate)).hasSize(0);
     }
 
     @Test
     public void testUsingSemanticNamespacePrefixAndExtensions() {
         // DROOLS-2447
         List<DMNMessage> validate = validator.validate(getReader("Hello_World_semantic_namespace_with_extensions.dmn"), VALIDATE_SCHEMA, VALIDATE_MODEL, VALIDATE_COMPILATION);
-        assertThat(ValidatorUtil.formatMessages(validate), validate.size(), is(0));
+        assertThat(validate).as(ValidatorUtil.formatMessages(validate)).hasSize(0);
     }
 
     @Test
     public void testNoPrefixAndExtensions() {
         // DROOLS-2447
         List<DMNMessage> validate = validator.validate(getReader("Hello_World_no_prefix_with_extensions.dmn"), VALIDATE_SCHEMA, VALIDATE_MODEL, VALIDATE_COMPILATION);
-        assertThat(ValidatorUtil.formatMessages(validate), validate.size(), is(0));
+        assertThat(validate).as(ValidatorUtil.formatMessages(validate)).hasSize(0);
     }
 
     @Test
@@ -294,11 +292,11 @@ public class ValidatorTest extends AbstractValidatorTest {
         List<DMNMessage> validate = validator.validateUsing(VALIDATE_MODEL, VALIDATE_COMPILATION)
                                              .theseModels(getReader("DSWithImport20181008-ModelA.dmn"),
                                                           getReader("DSWithImport20181008-ModelB.dmn"));
-        assertThat(ValidatorUtil.formatMessages(validate), validate.size(), is(0));
+        assertThat(validate).as(ValidatorUtil.formatMessages(validate)).hasSize(0);
 
         List<DMNMessage> missingDMNImport = validator.validateUsing(VALIDATE_MODEL)
                                                      .theseModels(getReader("DSWithImport20181008-ModelA.dmn"),
                                                                   getReader("DSWithImport20181008-ModelB-missingDMNImport.dmn"));
-        assertThat(missingDMNImport.stream().filter(p -> p.getMessageType().equals(DMNMessageType.REQ_NOT_FOUND)).count(), is(2L)); // on Decision and Decision Service missing to locate the dependency given Import is omitted.
+        assertThat(missingDMNImport.stream().filter(p -> p.getMessageType().equals(DMNMessageType.REQ_NOT_FOUND)).count()).isEqualTo(2L); // on Decision and Decision Service missing to locate the dependency given Import is omitted.
     }
 }

--- a/kie-dmn/kie-dmn-legacy-tests/src/test/java/org/kie/dmn/legacy/tests/validation/v1_1/ValidatorTypeRefTest.java
+++ b/kie-dmn/kie-dmn-legacy-tests/src/test/java/org/kie/dmn/legacy/tests/validation/v1_1/ValidatorTypeRefTest.java
@@ -26,8 +26,7 @@ import org.kie.dmn.api.core.DMNMessageType;
 import org.kie.dmn.validation.AbstractValidatorTest;
 import org.kie.dmn.validation.ValidatorUtil;
 
-import static org.hamcrest.CoreMatchers.is;
-import static org.hamcrest.MatcherAssert.assertThat;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.Assert.assertTrue;
 import static org.kie.dmn.validation.DMNValidator.Validation.VALIDATE_COMPILATION;
 import static org.kie.dmn.validation.DMNValidator.Validation.VALIDATE_MODEL;
@@ -41,7 +40,7 @@ public class ValidatorTypeRefTest extends AbstractValidatorTest {
             final List<DMNMessage> validate = validator.validate(
                     reader,
                     VALIDATE_SCHEMA, VALIDATE_MODEL, VALIDATE_COMPILATION);
-            assertThat(ValidatorUtil.formatMessages(validate), validate.size(), is(1));
+     assertThat(validate).as(ValidatorUtil.formatMessages(validate)).hasSize(1);
             assertTrue(validate.stream().anyMatch(p -> p.getMessageType().equals(DMNMessageType.TYPE_REF_NOT_FOUND)));
         }
     }
@@ -51,7 +50,7 @@ public class ValidatorTypeRefTest extends AbstractValidatorTest {
         final List<DMNMessage> validate = validator.validate(
                 getFile("typeref/TYPEREF_NO_FEEL_TYPE.dmn"),
                 VALIDATE_SCHEMA, VALIDATE_MODEL, VALIDATE_COMPILATION);
-        assertThat(ValidatorUtil.formatMessages(validate), validate.size(), is(1));
+        assertThat(validate).as(ValidatorUtil.formatMessages(validate)).hasSize(1);
         assertTrue(validate.stream().anyMatch(p -> p.getMessageType().equals(DMNMessageType.TYPE_REF_NOT_FOUND)));
     }
 
@@ -60,7 +59,7 @@ public class ValidatorTypeRefTest extends AbstractValidatorTest {
         final List<DMNMessage> validate = validator.validate(
                 getDefinitions("typeref/TYPEREF_NO_FEEL_TYPE.dmn", "https://github.com/kiegroup/kie-dmn", "TYPEREF_NO_FEEL_TYPE"),
                 VALIDATE_MODEL, VALIDATE_COMPILATION);
-        assertThat(ValidatorUtil.formatMessages(validate), validate.size(), is(1));
+ assertThat(validate).as(ValidatorUtil.formatMessages(validate)).hasSize(1);
         assertTrue(validate.stream().anyMatch(p -> p.getMessageType().equals(DMNMessageType.TYPE_REF_NOT_FOUND)));
     }
 
@@ -70,7 +69,7 @@ public class ValidatorTypeRefTest extends AbstractValidatorTest {
             final List<DMNMessage> validate = validator.validate(
                     reader,
                     VALIDATE_SCHEMA, VALIDATE_MODEL, VALIDATE_COMPILATION);
-            assertThat(ValidatorUtil.formatMessages(validate), validate.size(), is(2));
+             assertThat(validate).as(ValidatorUtil.formatMessages(validate)).hasSize(2);
             assertTrue(validate.stream().anyMatch(p -> p.getMessageType().equals(DMNMessageType.FAILED_XML_VALIDATION)));
             assertTrue(validate.stream().anyMatch(p -> p.getMessageType().equals(DMNMessageType.TYPE_DEF_NOT_FOUND)));
         }
@@ -81,7 +80,7 @@ public class ValidatorTypeRefTest extends AbstractValidatorTest {
         final List<DMNMessage> validate = validator.validate(
                 getFile("typeref/TYPEREF_NO_NS.dmn"),
                 VALIDATE_SCHEMA, VALIDATE_MODEL, VALIDATE_COMPILATION);
-        assertThat(ValidatorUtil.formatMessages(validate), validate.size(), is(2));
+         assertThat(validate).as(ValidatorUtil.formatMessages(validate)).hasSize(2);
         assertTrue(validate.stream().anyMatch(p -> p.getMessageType().equals(DMNMessageType.FAILED_XML_VALIDATION)));
         assertTrue(validate.stream().anyMatch(p -> p.getMessageType().equals(DMNMessageType.TYPE_DEF_NOT_FOUND)));
     }
@@ -91,7 +90,7 @@ public class ValidatorTypeRefTest extends AbstractValidatorTest {
         final List<DMNMessage> validate = validator.validate(
                 getDefinitions("typeref/TYPEREF_NO_NS.dmn", "https://github.com/kiegroup/kie-dmn", "TYPEREF_NO_NS"),
                 VALIDATE_MODEL, VALIDATE_COMPILATION);
-        assertThat(ValidatorUtil.formatMessages(validate), validate.size(), is(1));
+ assertThat(validate).as(ValidatorUtil.formatMessages(validate)).hasSize(1);
         assertTrue(validate.stream().anyMatch(p -> p.getMessageType().equals(DMNMessageType.TYPE_DEF_NOT_FOUND)));
     }
 
@@ -101,7 +100,7 @@ public class ValidatorTypeRefTest extends AbstractValidatorTest {
             final List<DMNMessage> validate = validator.validate(
                     reader,
                     VALIDATE_SCHEMA, VALIDATE_MODEL, VALIDATE_COMPILATION);
-            assertThat(ValidatorUtil.formatMessages(validate), validate.size(), is(2));
+             assertThat(validate).as(ValidatorUtil.formatMessages(validate)).hasSize(2);
             assertTrue(validate.stream().anyMatch(p -> p.getMessageType().equals(DMNMessageType.INVALID_NAME)));
             assertTrue(validate.stream().anyMatch(p -> p.getMessageType().equals(DMNMessageType.TYPE_DEF_NOT_FOUND)));
         }
@@ -112,7 +111,7 @@ public class ValidatorTypeRefTest extends AbstractValidatorTest {
         final List<DMNMessage> validate = validator.validate(
                 getFile("typeref/TYPEREF_NOT_FEEL_NOT_DEF.dmn"),
                 VALIDATE_SCHEMA, VALIDATE_MODEL, VALIDATE_COMPILATION);
-        assertThat(ValidatorUtil.formatMessages(validate), validate.size(), is(2));
+         assertThat(validate).as(ValidatorUtil.formatMessages(validate)).hasSize(2);
         assertTrue(validate.stream().anyMatch(p -> p.getMessageType().equals(DMNMessageType.INVALID_NAME)));
         assertTrue(validate.stream().anyMatch(p -> p.getMessageType().equals(DMNMessageType.TYPE_DEF_NOT_FOUND)));
     }
@@ -122,7 +121,7 @@ public class ValidatorTypeRefTest extends AbstractValidatorTest {
         final List<DMNMessage> validate = validator.validate(
                 getDefinitions("typeref/TYPEREF_NOT_FEEL_NOT_DEF.dmn", "https://github.com/kiegroup/kie-dmn", "TYPEREF_NOT_FEEL_NOT_DEF"),
                 VALIDATE_MODEL, VALIDATE_COMPILATION);
-        assertThat(ValidatorUtil.formatMessages(validate), validate.size(), is(2));
+         assertThat(validate).as(ValidatorUtil.formatMessages(validate)).hasSize(2);
         assertTrue(validate.stream().anyMatch(p -> p.getMessageType().equals(DMNMessageType.INVALID_NAME)));
         assertTrue(validate.stream().anyMatch(p -> p.getMessageType().equals(DMNMessageType.TYPE_DEF_NOT_FOUND)));
     }
@@ -136,7 +135,7 @@ public class ValidatorTypeRefTest extends AbstractValidatorTest {
             final List<DMNMessage> validate = validator.validate(
                     reader,
                     VALIDATE_SCHEMA, VALIDATE_MODEL, VALIDATE_COMPILATION);
-            assertThat(ValidatorUtil.formatMessages(validate), validate.size(), is(0));
+             assertThat(validate).as(ValidatorUtil.formatMessages(validate)).hasSize(0);
         }
     }
 
@@ -148,7 +147,7 @@ public class ValidatorTypeRefTest extends AbstractValidatorTest {
         final List<DMNMessage> validate = validator.validate(
                 getFile("typeref/TYPEREF_NOT_FEEL_NOT_DEF_valid.dmn"),
                 VALIDATE_SCHEMA, VALIDATE_MODEL, VALIDATE_COMPILATION);
-        assertThat(ValidatorUtil.formatMessages(validate), validate.size(), is(0));
+         assertThat(validate).as(ValidatorUtil.formatMessages(validate)).hasSize(0);
     }
 
     @Test
@@ -159,7 +158,7 @@ public class ValidatorTypeRefTest extends AbstractValidatorTest {
         final List<DMNMessage> validate = validator.validate(
                 getDefinitions("typeref/TYPEREF_NOT_FEEL_NOT_DEF_valid.dmn", "https://github.com/kiegroup/kie-dmn", "TYPEREF_NOT_FEEL_NOT_DEF_valid"),
                 VALIDATE_MODEL, VALIDATE_COMPILATION);
-        assertThat(ValidatorUtil.formatMessages(validate), validate.size(), is(0));
+         assertThat(validate).as(ValidatorUtil.formatMessages(validate)).hasSize(0);
     }
     
     @Test
@@ -168,6 +167,6 @@ public class ValidatorTypeRefTest extends AbstractValidatorTest {
         final List<DMNMessage> validate = validator.validate(
                 getDefinitions("typeref/BKM_WITH_NO_TYPEREF_IS_OK.dmn", "http://www.trisotech.com/dmn/definitions/_7e8d7561-657a-4729-b2a9-5a6279df6d5d", "Drawing 1"),
                 VALIDATE_MODEL, VALIDATE_COMPILATION);
-        assertThat(ValidatorUtil.formatMessages(validate), validate.size(), is(0));
+         assertThat(validate).as(ValidatorUtil.formatMessages(validate)).hasSize(0);
     }
 }

--- a/kie-dmn/kie-dmn-model/pom.xml
+++ b/kie-dmn/kie-dmn-model/pom.xml
@@ -37,11 +37,6 @@
       <scope>test</scope>
     </dependency>
     <dependency>
-      <groupId>org.hamcrest</groupId>
-      <artifactId>hamcrest-library</artifactId>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
       <groupId>org.assertj</groupId>
       <artifactId>assertj-core</artifactId>
       <scope>test</scope>

--- a/kie-dmn/kie-dmn-pmml-tests-parent/kie-dmn-pmml-tests/pom.xml
+++ b/kie-dmn/kie-dmn-pmml-tests-parent/kie-dmn-pmml-tests/pom.xml
@@ -39,11 +39,6 @@
       <artifactId>slf4j-api</artifactId>
     </dependency>
     <dependency>
-      <groupId>org.hamcrest</groupId>
-      <artifactId>hamcrest-library</artifactId>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
       <groupId>junit</groupId>
       <artifactId>junit</artifactId>
       <scope>test</scope>

--- a/kie-dmn/kie-dmn-pmml-tests-parent/kie-dmn-pmml-tests/src/test/java/org/kie/dmn/pmml/DMNRuntimePMMLTest.java
+++ b/kie-dmn/kie-dmn-pmml-tests-parent/kie-dmn-pmml-tests/src/test/java/org/kie/dmn/pmml/DMNRuntimePMMLTest.java
@@ -53,14 +53,8 @@ import org.kie.internal.services.KieAssemblersImpl;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import static org.hamcrest.CoreMatchers.is;
-import static org.hamcrest.CoreMatchers.notNullValue;
-import static org.hamcrest.Matchers.anything;
-import static org.hamcrest.Matchers.hasEntry;
-import static org.hamcrest.Matchers.hasSize;
-import static org.hamcrest.Matchers.not;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.Assert.assertEquals;
-import static org.hamcrest.MatcherAssert.assertThat;
 
 public abstract class DMNRuntimePMMLTest {
 
@@ -100,34 +94,34 @@ public abstract class DMNRuntimePMMLTest {
 
     static void runDMNModelInvokingPMML(final DMNRuntime runtime) {
         final DMNModel dmnModel = runtime.getModel("http://www.trisotech.com/definitions/_ca466dbe-20b4-4e88-a43f-4ce3aff26e4f", "KiePMMLScoreCard");
-        assertThat( dmnModel, notNullValue() );
-        assertThat( DMNRuntimeUtil.formatMessages( dmnModel.getMessages() ), dmnModel.hasErrors(), is( false ) );
+        assertThat(dmnModel).isNotNull();
+        assertThat(dmnModel.hasErrors()).as(DMNRuntimeUtil.formatMessages(dmnModel.getMessages())).isFalse();
 
         final DMNContext emptyContext = DMNFactory.newContext();
 
         final DMNResult dmnResult = runtime.evaluateAll(dmnModel, emptyContext);
         LOG.debug("{}", dmnResult);
-        assertThat(DMNRuntimeUtil.formatMessages(dmnResult.getMessages()), dmnResult.hasErrors(), is(false));
+        assertThat(dmnResult.hasErrors()).as(DMNRuntimeUtil.formatMessages(dmnResult.getMessages())).isFalse();
 
         final DMNContext result = dmnResult.getContext();
-        assertThat(result.get("my decision"), is(new BigDecimal("41.345")));
+        assertThat(result.get("my decision")).isEqualTo(new BigDecimal("41.345"));
         
         // additional import info.
         Map<String, DMNImportPMMLInfo> pmmlImportInfo = ((DMNModelImpl) dmnModel).getPmmlImportInfo();
-        assertThat(pmmlImportInfo.keySet(), hasSize(1));
+        assertThat(pmmlImportInfo.keySet()).hasSize(1);
         DMNImportPMMLInfo p0 = pmmlImportInfo.values().iterator().next();
-        assertThat(p0.getImportName(), is("iris"));
-        assertThat(p0.getModels(), hasSize(1));
+        assertThat(p0.getImportName()).isEqualTo("iris");
+        assertThat(p0.getModels()).hasSize(1);
         DMNPMMLModelInfo m0 = p0.getModels().iterator().next();
-        assertThat(m0.getName(), is("Sample Score"));
-        assertThat(m0.getInputFields(), hasEntry(is("age"), anything()));
-        assertThat(m0.getInputFields(), hasEntry(is("occupation"), anything()));
-        assertThat(m0.getInputFields(), hasEntry(is("residenceState"), anything()));
-        assertThat(m0.getInputFields(), hasEntry(is("validLicense"), anything()));
-        assertThat(m0.getInputFields(), not(hasEntry(is("overallScore"), anything())));
-        assertThat(m0.getInputFields(), not(hasEntry(is("calculatedScore"), anything())));
+        assertThat(m0.getName()).isEqualTo("Sample Score");
+        assertThat(m0.getInputFields()).containsKey("age");
+        assertThat(m0.getInputFields()).containsKey("occupation");
+        assertThat(m0.getInputFields()).containsKey("residenceState");
+        assertThat(m0.getInputFields()).containsKey("validLicense");
+        assertThat(m0.getInputFields()).doesNotContainKey("overallScore");
+        assertThat(m0.getInputFields()).doesNotContainKey("calculatedScore");
 
-        assertThat(m0.getOutputFields(), hasEntry(is("calculatedScore"), anything()));
+        assertThat(m0.getOutputFields()).containsKey("calculatedScore");
     }
 
     /**
@@ -165,8 +159,8 @@ public abstract class DMNRuntimePMMLTest {
                                                                                        DMNRuntimePMMLTest.class,
                                                                                        "test_regression_clax.pmml");
         final DMNModel dmnModel = runtime.getModel("http://www.trisotech.com/definitions/_ca466dbe-20b4-4e88-a43f-4ce3aff26e4f", "KiePMMLRegressionClax");
-        assertThat( dmnModel, notNullValue() );
-        assertThat( DMNRuntimeUtil.formatMessages( dmnModel.getMessages() ), dmnModel.hasErrors(), is( false ) );
+        assertThat(dmnModel).isNotNull();
+        assertThat(dmnModel.hasErrors()).as(DMNRuntimeUtil.formatMessages(dmnModel.getMessages())).isFalse();
 
         final DMNContext dmnContext = DMNFactory.newContext();
         dmnContext.set("fld1", 1.0);
@@ -175,7 +169,7 @@ public abstract class DMNRuntimePMMLTest {
 
         final DMNResult dmnResult = runtime.evaluateAll(dmnModel, dmnContext);
         LOG.debug("{}", dmnResult);
-        assertThat(DMNRuntimeUtil.formatMessages(dmnResult.getMessages()), dmnResult.hasErrors(), is(false));
+        assertThat(dmnResult.hasErrors()).as(DMNRuntimeUtil.formatMessages(dmnResult.getMessages())).isFalse();
 
         final DMNContext resultContext = dmnResult.getContext();
         final Map<String, Object> result = (Map<String, Object>) resultContext.get("my decision");
@@ -188,12 +182,12 @@ public abstract class DMNRuntimePMMLTest {
 
         // additional import info.
         Map<String, DMNImportPMMLInfo> pmmlImportInfo = ((DMNModelImpl) dmnModel).getPmmlImportInfo();
-        assertThat(pmmlImportInfo.keySet(), hasSize(1));
+        assertThat(pmmlImportInfo.keySet()).hasSize(1);
         DMNImportPMMLInfo p0 = pmmlImportInfo.values().iterator().next();
-        assertThat(p0.getImportName(), is("test_regression_clax"));
-        assertThat(p0.getModels(), hasSize(1));
+        assertThat(p0.getImportName()).isEqualTo("test_regression_clax");
+        assertThat(p0.getModels()).hasSize(1);
         DMNPMMLModelInfo m0 = p0.getModels().iterator().next();
-        assertThat(m0.getName(), is("LinReg"));
+        assertThat(m0.getName()).isEqualTo("LinReg");
 
         Map<String, DMNType> inputFields = m0.getInputFields();
         SimpleTypeImpl fld1 = (SimpleTypeImpl)inputFields.get("fld1");

--- a/kie-dmn/kie-dmn-pmml-tests-parent/kie-dmn-pmml-tests/src/test/java/org/kie/dmn/pmml/PMMLInfoTest.java
+++ b/kie-dmn/kie-dmn-pmml-tests-parent/kie-dmn-pmml-tests/src/test/java/org/kie/dmn/pmml/PMMLInfoTest.java
@@ -25,9 +25,6 @@ import org.slf4j.LoggerFactory;
 import java.io.InputStream;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.hamcrest.CoreMatchers.is;
-import static org.hamcrest.Matchers.hasSize;
-import static org.hamcrest.MatcherAssert.assertThat;
 
 
 public abstract class PMMLInfoTest {
@@ -38,8 +35,8 @@ public abstract class PMMLInfoTest {
     public void testPMMLInfo() throws Exception {
         InputStream inputStream = PMMLInfoTest.class.getResourceAsStream("test_scorecard.pmml");
         PMMLInfo<PMMLModelInfo> p0 = PMMLInfo.from(inputStream);
-        assertThat(p0.getModels(), hasSize(1));
-        assertThat(p0.getHeader().getPmmlNSURI(), is("http://www.dmg.org/PMML-4_2"));
+        assertThat(p0.getModels()).hasSize(1);
+        assertThat(p0.getHeader().getPmmlNSURI()).isEqualTo("http://www.dmg.org/PMML-4_2");
         PMMLModelInfo m0 = p0.getModels().iterator().next();
         assertThat(m0.getName()).isEqualTo("Sample Score");
         assertThat(m0.getInputFieldNames()).contains("age", "occupation", "residenceState", "validLicense");

--- a/kie-dmn/kie-dmn-pmml-tests-parent/kie-dmn-pmml-tests/src/test/java/org/kie/dmn/pmml/PMMLValidatorImportTest.java
+++ b/kie-dmn/kie-dmn-pmml-tests-parent/kie-dmn-pmml-tests/src/test/java/org/kie/dmn/pmml/PMMLValidatorImportTest.java
@@ -28,8 +28,7 @@ import java.io.IOException;
 import java.io.Reader;
 import java.util.List;
 
-import static org.hamcrest.CoreMatchers.is;
-import static org.hamcrest.MatcherAssert.assertThat;
+import static org.assertj.core.api.Assertions.assertThat;
 
 public abstract class PMMLValidatorImportTest extends AbstractValidatorTest {
 
@@ -38,7 +37,7 @@ public abstract class PMMLValidatorImportTest extends AbstractValidatorTest {
         // DROOLS-4187 kie-dmn-validation: Incorrect import detection
         final List<DMNMessage> messages = validator.validateUsing(Validation.VALIDATE_MODEL)
                 .theseModels(getReader("Invoke_Iris.dmn", PMMLValidatorImportTest.class));
-        assertThat(ValidatorUtil.formatMessages(messages), messages.size(), is(0));
+        assertThat(messages).as(ValidatorUtil.formatMessages(messages)).hasSize(0);
 
     }
 
@@ -60,7 +59,7 @@ public abstract class PMMLValidatorImportTest extends AbstractValidatorTest {
                     Validation.VALIDATE_COMPILATION)
                     .usingImports(resolver)
                     .theseModels(defs);
-            assertThat(ValidatorUtil.formatMessages(messages), messages.size(), is(0));
+            assertThat(messages).as(ValidatorUtil.formatMessages(messages)).hasSize(0);
         }
     }
 }

--- a/kie-dmn/kie-dmn-signavio/pom.xml
+++ b/kie-dmn/kie-dmn-signavio/pom.xml
@@ -97,11 +97,12 @@
       <artifactId>logback-classic</artifactId>
       <scope>test</scope>
     </dependency>
+
     <dependency>
-      <groupId>org.hamcrest</groupId>
-      <artifactId>hamcrest-library</artifactId>
+      <groupId>org.assertj</groupId>
+      <artifactId>assertj-core</artifactId>
       <scope>test</scope>
-    </dependency>
+    </dependency>    
     <dependency>
       <groupId>org.mockito</groupId>
       <artifactId>mockito-core</artifactId>

--- a/kie-dmn/kie-dmn-signavio/src/test/java/org/kie/dmn/signavio/MultiInstanceDecisionLogicTest.java
+++ b/kie-dmn/kie-dmn-signavio/src/test/java/org/kie/dmn/signavio/MultiInstanceDecisionLogicTest.java
@@ -34,11 +34,10 @@ import static java.util.Arrays.asList;
 import static java.util.function.Function.identity;
 import static java.util.stream.Collectors.toList;
 import static java.util.stream.Collectors.toMap;
-import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.containsInAnyOrder;
-import static org.hamcrest.Matchers.hasSize;
 import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.mock;
+
+import static org.assertj.core.api.Assertions.assertThat;
 
 public class MultiInstanceDecisionLogicTest {
 	
@@ -106,8 +105,8 @@ public class MultiInstanceDecisionLogicTest {
 		
 		// Assert
 		Collection<String> ids = innerNodes.stream().map(DMNNode::getId).collect(toList());
-		assertThat(ids, containsInAnyOrder("A", "B", "C", "I1"));
-		assertThat(ids, hasSize(4));
+		assertThat(ids).contains("A", "B", "C", "I1");
+		assertThat(ids).hasSize(4);
 	}
 	
 }

--- a/kie-dmn/kie-dmn-signavio/src/test/java/org/kie/dmn/signavio/SignavioTest.java
+++ b/kie-dmn/kie-dmn-signavio/src/test/java/org/kie/dmn/signavio/SignavioTest.java
@@ -40,13 +40,7 @@ import org.kie.dmn.model.api.Definitions;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.contains;
-import static org.hamcrest.Matchers.everyItem;
-import static org.hamcrest.Matchers.instanceOf;
-import static org.hamcrest.Matchers.iterableWithSize;
-import static org.hamcrest.Matchers.notNullValue;
-import static org.hamcrest.core.Is.is;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
@@ -68,7 +62,7 @@ public class SignavioTest {
         DMNResult evaluateAll = runtime.evaluateAll(model0, context);
         LOG.info("{}", evaluateAll);
         
-        assertThat( (List<?>) evaluateAll.getContext().get( "Greeting for each Person in Persons" ), contains( "Hello p1", "Hello p2" ) );
+        assertThat((List<String>) evaluateAll.getContext().get("Greeting for each Person in Persons")).contains("Hello p1", "Hello p2");
     }
     
     @Test
@@ -78,13 +72,13 @@ public class SignavioTest {
         Definitions definitions = model0.getDefinitions();
         DRGElement decision = definitions.getDrgElement().stream().filter(e -> e.getName().equals("greetingForEachPersonInPersons")).findFirst().orElseThrow(IllegalStateException::new);
         Object extElement = decision.getExtensionElements().getAny().get(0);
-        assertThat(extElement, is(instanceOf(MultiInstanceDecisionLogic.class)));
+        assertThat(extElement).isInstanceOf(MultiInstanceDecisionLogic.class);
         MultiInstanceDecisionLogic mid = (MultiInstanceDecisionLogic) extElement;
         LOG.info("{}", mid);
-        assertThat(mid.getIterationExpression(), is("persons"));
-        assertThat(mid.getIteratorShapeId(), is("id-707bbdf74438414623ac5d7067805b38"));
-        assertThat(mid.getAggregationFunction(), is("COLLECT"));
-        assertThat(mid.getTopLevelDecisionId(), is("id-7a23e2f201e3e0db3c991313cff5cd2b"));
+        assertThat(mid.getIterationExpression()).isEqualTo("persons");
+        assertThat(mid.getIteratorShapeId()).isEqualTo("id-707bbdf74438414623ac5d7067805b38");
+        assertThat(mid.getAggregationFunction()).isEqualTo("COLLECT");
+        assertThat(mid.getTopLevelDecisionId()).isEqualTo("id-7a23e2f201e3e0db3c991313cff5cd2b");
     }
 
     @Test
@@ -146,7 +140,7 @@ public class SignavioTest {
         DMNResult evaluateAll = runtime.evaluateAll(model0, context);
         LOG.info("{}", evaluateAll);
 
-        assertThat(evaluateAll.getDecisionResultByName("iterating").getResult(), is(iterating));
+        assertThat(evaluateAll.getDecisionResultByName("iterating").getResult()).isEqualTo(iterating);
     }
 
     private DMNRuntime createRuntime(String modelFileName) {
@@ -234,8 +228,9 @@ public class SignavioTest {
         LOG.info("{}", evaluateAll);
     
         List<Object> result = (List<Object>) evaluateAll.getDecisionResultByName("calculate").getResult();
-        assertThat(result, iterableWithSize(6));
-        assertThat(result, everyItem(notNullValue()));
+        assertThat(result).hasSize(6);
+        
+        assertThat(result).doesNotContainNull();
     }
     
     
@@ -269,8 +264,8 @@ public class SignavioTest {
         DMNResult evaluateAll = runtime.evaluateAll(model0, context);
         LOG.info("{}", evaluateAll);
         
-        assertThat((List<?>) evaluateAll.getDecisionResultByName("zipvararg").getResult(), iterableWithSize(2));
-        assertThat((List<?>) evaluateAll.getDecisionResultByName("zipsinglelist").getResult(), iterableWithSize(2));
+        assertThat((List<?>) evaluateAll.getDecisionResultByName("zipvararg").getResult()).hasSize(2);
+        assertThat((List<?>) evaluateAll.getDecisionResultByName("zipsinglelist").getResult()).hasSize(2);
     }
     
     @Test
@@ -306,7 +301,7 @@ public class SignavioTest {
         DMNResult evaluateAll = runtime.evaluateAll(model0, context);
         LOG.info("{}", evaluateAll);
     
-        assertThat(evaluateAll.getDecisionResultByName("overallage").getResult(), is(new BigDecimal("18")));
+        assertThat(evaluateAll.getDecisionResultByName("overallage").getResult()).isEqualTo(new BigDecimal("18"));
     }
     
     @Test
@@ -322,6 +317,6 @@ public class SignavioTest {
         DMNResult evaluateAll = runtime.evaluateAll(model0, context);
         LOG.info("{}", evaluateAll);
     
-        assertThat(evaluateAll.getDecisionResultByName("sumUp").getResult(), is(new BigDecimal("6")));
+        assertThat(evaluateAll.getDecisionResultByName("sumUp").getResult()).isEqualTo(new BigDecimal("6"));
     }
 }

--- a/kie-dmn/kie-dmn-signavio/src/test/java/org/kie/dmn/signavio/feel/runtime/ExtendedFunctionsBaseFEELTest.java
+++ b/kie-dmn/kie-dmn-signavio/src/test/java/org/kie/dmn/signavio/feel/runtime/ExtendedFunctionsBaseFEELTest.java
@@ -27,10 +27,7 @@ import org.kie.dmn.feel.FEEL;
 import org.kie.dmn.signavio.KieDMNSignavioProfile;
 import org.mockito.ArgumentCaptor;
 
-import static org.hamcrest.Matchers.instanceOf;
-import static org.hamcrest.Matchers.is;
-import static org.hamcrest.Matchers.nullValue;
-import static org.hamcrest.MatcherAssert.assertThat;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.atLeastOnce;
 import static org.mockito.Mockito.mock;
@@ -63,7 +60,7 @@ public abstract class ExtendedFunctionsBaseFEELTest {
         if( severity != null ) {
             ArgumentCaptor<FEELEvent> captor = ArgumentCaptor.forClass( FEELEvent.class );
             verify( listener , atLeastOnce()).onEvent( captor.capture() );
-            assertThat( captor.getValue().getSeverity(), is( severity ) );
+            assertThat(captor.getValue().getSeverity()).isEqualTo(severity);
         } else {
             verify( listener, never() ).onEvent( any(FEELEvent.class) );
         }
@@ -71,11 +68,11 @@ public abstract class ExtendedFunctionsBaseFEELTest {
 
     protected void assertResult(String expression, Object result) {
         if (result == null) {
-            assertThat("Evaluating: '" + expression + "'", feel.evaluate(expression), is(nullValue()));
+            assertThat(feel.evaluate(expression)).as("Evaluating: '" + expression + "'").isNull();
         } else if (result instanceof Class<?>) {
-            assertThat("Evaluating: '" + expression + "'", feel.evaluate(expression), is(instanceOf((Class<?>) result)));
+        	assertThat(feel.evaluate(expression)).as("Evaluating: '" + expression + "'").isInstanceOf((Class<?>) result);
         } else {
-            assertThat("Evaluating: '" + expression + "'", feel.evaluate(expression), is(result));
+        	assertThat(feel.evaluate(expression)).as("Evaluating: '" + expression + "'").isEqualTo(result);
         }
     }
 }

--- a/kie-dmn/kie-dmn-trisotech/pom.xml
+++ b/kie-dmn/kie-dmn-trisotech/pom.xml
@@ -98,11 +98,6 @@
       <scope>test</scope>
     </dependency>
     <dependency>
-      <groupId>org.hamcrest</groupId>
-      <artifactId>hamcrest-library</artifactId>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
       <groupId>org.xmlunit</groupId>
       <artifactId>xmlunit-core</artifactId>
       <scope>test</scope>

--- a/kie-dmn/kie-dmn-validation/pom.xml
+++ b/kie-dmn/kie-dmn-validation/pom.xml
@@ -112,11 +112,6 @@
       <scope>test</scope>
     </dependency>
     <dependency>
-      <groupId>org.hamcrest</groupId>
-      <artifactId>hamcrest-library</artifactId>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
       <groupId>org.assertj</groupId>
       <artifactId>assertj-core</artifactId>
       <scope>test</scope>

--- a/kie-dmn/kie-dmn-validation/src/test/java/org/kie/dmn/validation/AbstractValidatorTest.java
+++ b/kie-dmn/kie-dmn-validation/src/test/java/org/kie/dmn/validation/AbstractValidatorTest.java
@@ -37,9 +37,7 @@ import org.kie.dmn.feel.util.ClassLoaderUtil;
 import org.kie.dmn.model.api.Definitions;
 import org.kie.internal.utils.ChainedProperties;
 
-import static org.hamcrest.CoreMatchers.is;
-import static org.hamcrest.CoreMatchers.notNullValue;
-import static org.hamcrest.MatcherAssert.assertThat;
+import static org.assertj.core.api.Assertions.assertThat;
 
 public abstract class AbstractValidatorTest {
 
@@ -72,7 +70,7 @@ public abstract class AbstractValidatorTest {
      * Return the Reader for the specified Resource with resourceFileName, using the supplied Class to locate it.
      */
     protected Reader getReader(final String resourceFileName, Class<?> clazz) {
-        return new InputStreamReader(clazz.getResourceAsStream(resourceFileName));
+        return new InputStreamReader(clazz.getResourceAsStream(resourceFileName)); 
     }
 
     protected File getFile(final String resourceFileName ) {
@@ -89,17 +87,17 @@ public abstract class AbstractValidatorTest {
 
     protected Definitions getDefinitions(final String resourceName, final String namespace, final String modelName ) {
         final Definitions definitions = marshaller.unmarshal(getReader(resourceName));
-        assertThat( definitions, notNullValue() );
-        assertThat(definitions.getNamespace(), is(namespace));
-        assertThat(definitions.getName(), is(modelName));
+        assertThat(definitions).isNotNull();
+        assertThat(definitions.getNamespace()).isEqualTo(namespace);
+        assertThat(definitions.getName()).isEqualTo(modelName);
         return definitions;
     }
 
     protected Definitions getDefinitions(final Reader resourceReader, final String namespace, final String modelName) {
         final Definitions definitions = marshaller.unmarshal(resourceReader);
-        assertThat(definitions, notNullValue());
-        assertThat(definitions.getNamespace(), is(namespace));
-        assertThat(definitions.getName(), is(modelName));
+        assertThat(definitions).isNotNull();
+        assertThat(definitions.getNamespace()).isEqualTo(namespace);
+        assertThat(definitions.getName()).isEqualTo(modelName);
         return definitions;
     }
 
@@ -111,13 +109,13 @@ public abstract class AbstractValidatorTest {
                                                       .map(this::getReader)
                                                       .map(marshaller::unmarshal)
                                                       .collect(Collectors.toList());
-        assertThat(definitionss.isEmpty(), is(false));
+        assertThat(definitionss.isEmpty()).isFalse();
 
         final Optional<Definitions> definitions = definitionss.stream()
                                                               .filter(d -> {
                                                                   return d.getNamespace().equals(namespace) && d.getName().equals(modelName);
                                                               }).findFirst();
-        assertThat(definitions.isPresent(), is(true));
+        assertThat(definitions.isPresent()).isTrue();
         return definitions.get();
     }
 }

--- a/kie-dmn/kie-dmn-validation/src/test/java/org/kie/dmn/validation/UsingResourceValidatorTest.java
+++ b/kie-dmn/kie-dmn-validation/src/test/java/org/kie/dmn/validation/UsingResourceValidatorTest.java
@@ -16,14 +16,6 @@
 
 package org.kie.dmn.validation;
 
-import static org.hamcrest.CoreMatchers.containsString;
-import static org.hamcrest.CoreMatchers.is;
-import static org.hamcrest.MatcherAssert.assertThat;
-import static org.junit.Assert.assertTrue;
-import static org.kie.dmn.validation.DMNValidator.Validation.VALIDATE_COMPILATION;
-import static org.kie.dmn.validation.DMNValidator.Validation.VALIDATE_MODEL;
-import static org.kie.dmn.validation.DMNValidator.Validation.VALIDATE_SCHEMA;
-
 import java.util.List;
 
 import org.junit.Test;
@@ -34,6 +26,12 @@ import org.kie.dmn.core.decisionservices.DMNDecisionServicesTest;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.Assert.assertTrue;
+import static org.kie.dmn.validation.DMNValidator.Validation.VALIDATE_COMPILATION;
+import static org.kie.dmn.validation.DMNValidator.Validation.VALIDATE_MODEL;
+import static org.kie.dmn.validation.DMNValidator.Validation.VALIDATE_SCHEMA;
+
 public class UsingResourceValidatorTest extends AbstractValidatorTest {
     
     private static final Logger LOG = LoggerFactory.getLogger(UsingResourceValidatorTest.class);
@@ -41,17 +39,17 @@ public class UsingResourceValidatorTest extends AbstractValidatorTest {
     @Test
     public void testInvalidXml_single() {
         List<DMNMessage> validateXML = validator.validate( getResource( "invalidXml.dmn" ), VALIDATE_SCHEMA);
-        assertThat( ValidatorUtil.formatMessages( validateXML ), validateXML.size(), is( 1 ) );
-        assertThat( validateXML.get( 0 ).toString(), validateXML.get( 0 ).getMessageType(), is( DMNMessageType.FAILED_XML_VALIDATION ) );
-        assertThat( validateXML.get(0).getPath(), containsString("invalidXml.dmn") );
+        assertThat(validateXML).as(ValidatorUtil.formatMessages(validateXML)).hasSize(1);
+        assertThat(validateXML.get(0).getMessageType()).as(validateXML.get(0).toString()).isEqualTo(DMNMessageType.FAILED_XML_VALIDATION);
+        assertThat(validateXML.get(0).getPath()).containsSequence("invalidXml.dmn");
     }
     
     @Test
     public void testInvalidXml_builder() {
         List<DMNMessage> validateXML = validator.validateUsing(VALIDATE_SCHEMA).theseModels(getResource( "invalidXml.dmn" ), getResource( "0001-input-data-string.dmn", DMNInputRuntimeTest.class ));
-        assertThat( ValidatorUtil.formatMessages( validateXML ), validateXML.size(), is( 1 ) );
-        assertThat( validateXML.get( 0 ).toString(), validateXML.get( 0 ).getMessageType(), is( DMNMessageType.FAILED_XML_VALIDATION ) );
-        assertThat( validateXML.get(0).getPath(), containsString("invalidXml.dmn") );
+        assertThat(validateXML).as(ValidatorUtil.formatMessages(validateXML)).hasSize(1);
+        assertThat(validateXML.get(0).getMessageType()).as(validateXML.get(0).toString()).isEqualTo(DMNMessageType.FAILED_XML_VALIDATION);
+        assertThat(validateXML.get(0).getPath()).containsSequence("invalidXml.dmn");
     }
     
     @Test

--- a/kie-dmn/kie-dmn-validation/src/test/java/org/kie/dmn/validation/ValidatorArtifactTest.java
+++ b/kie-dmn/kie-dmn-validation/src/test/java/org/kie/dmn/validation/ValidatorArtifactTest.java
@@ -24,8 +24,7 @@ import org.junit.Test;
 import org.kie.dmn.api.core.DMNMessage;
 import org.kie.dmn.api.core.DMNMessageType;
 
-import static org.hamcrest.CoreMatchers.is;
-import static org.hamcrest.MatcherAssert.assertThat;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.Assert.assertTrue;
 import static org.kie.dmn.validation.DMNValidator.Validation.VALIDATE_COMPILATION;
 import static org.kie.dmn.validation.DMNValidator.Validation.VALIDATE_MODEL;
@@ -39,7 +38,7 @@ public class ValidatorArtifactTest extends AbstractValidatorTest {
             final List<DMNMessage> validate = validator.validate(
                     reader,
                     VALIDATE_SCHEMA, VALIDATE_MODEL, VALIDATE_COMPILATION);
-            assertThat( ValidatorUtil.formatMessages( validate ), validate.size(), is( 2 ) );
+            assertThat(validate).as(ValidatorUtil.formatMessages(validate)).hasSize(2);
             assertTrue( validate.stream().anyMatch( p -> p.getMessageType().equals( DMNMessageType.REQ_NOT_FOUND ) ) );
         }
     }
@@ -49,7 +48,7 @@ public class ValidatorArtifactTest extends AbstractValidatorTest {
         final List<DMNMessage> validate = validator.validate(
                 getFile( "artifact/ASSOC_REFERENCES_NOT_EMPTY.dmn" ),
                 VALIDATE_SCHEMA, VALIDATE_MODEL, VALIDATE_COMPILATION);
-        assertThat( ValidatorUtil.formatMessages( validate ), validate.size(), is( 2 ) );
+        assertThat(validate).as(ValidatorUtil.formatMessages(validate)).hasSize(2);
         assertTrue( validate.stream().anyMatch( p -> p.getMessageType().equals( DMNMessageType.REQ_NOT_FOUND ) ) );
     }
 
@@ -60,7 +59,7 @@ public class ValidatorArtifactTest extends AbstractValidatorTest {
                                 "https://github.com/kiegroup/kie-dmn",
                                 "ASSOC_REFERENCES_NOT_EMPTY"),
                 VALIDATE_MODEL, VALIDATE_COMPILATION);
-        assertThat( ValidatorUtil.formatMessages( validate ), validate.size(), is( 2 ) );
+        assertThat(validate).as(ValidatorUtil.formatMessages(validate)).hasSize(2);
         assertTrue( validate.stream().anyMatch( p -> p.getMessageType().equals( DMNMessageType.REQ_NOT_FOUND ) ) );
     }
 }

--- a/kie-dmn/kie-dmn-validation/src/test/java/org/kie/dmn/validation/ValidatorAuthorityRequirementTest.java
+++ b/kie-dmn/kie-dmn-validation/src/test/java/org/kie/dmn/validation/ValidatorAuthorityRequirementTest.java
@@ -24,8 +24,7 @@ import org.junit.Test;
 import org.kie.dmn.api.core.DMNMessage;
 import org.kie.dmn.api.core.DMNMessageType;
 
-import static org.hamcrest.CoreMatchers.is;
-import static org.hamcrest.MatcherAssert.assertThat;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.Assert.assertTrue;
 import static org.kie.dmn.validation.DMNValidator.Validation.VALIDATE_COMPILATION;
 import static org.kie.dmn.validation.DMNValidator.Validation.VALIDATE_MODEL;
@@ -39,7 +38,7 @@ public class ValidatorAuthorityRequirementTest extends AbstractValidatorTest {
             final List<DMNMessage> validate = validator.validate(
                     reader,
                     VALIDATE_SCHEMA, VALIDATE_MODEL, VALIDATE_COMPILATION);
-            assertThat(ValidatorUtil.formatMessages(validate), validate.size(), is(3));
+            assertThat(validate).as(ValidatorUtil.formatMessages(validate)).hasSize(3);
             assertTrue(validate.stream().anyMatch(p -> p.getMessageType().equals(DMNMessageType.REQ_NOT_FOUND)));
         }
     }
@@ -49,7 +48,7 @@ public class ValidatorAuthorityRequirementTest extends AbstractValidatorTest {
         final List<DMNMessage> validate = validator.validate(
                 getFile("authorityrequirement/AUTHREQ_MISSING_DEPENDENCY_REQ_AUTH.dmn"),
                 VALIDATE_SCHEMA, VALIDATE_MODEL, VALIDATE_COMPILATION);
-        assertThat(ValidatorUtil.formatMessages(validate), validate.size(), is(3));
+        assertThat(validate).as(ValidatorUtil.formatMessages(validate)).hasSize(3);
         assertTrue(validate.stream().anyMatch(p -> p.getMessageType().equals(DMNMessageType.REQ_NOT_FOUND)));
     }
 
@@ -60,7 +59,7 @@ public class ValidatorAuthorityRequirementTest extends AbstractValidatorTest {
                                "https://github.com/kiegroup/kie-dmn",
                                "AUTHREQ_MISSING_DEPENDENCY_REQ_AUTH"),
                 VALIDATE_MODEL, VALIDATE_COMPILATION);
-        assertThat(ValidatorUtil.formatMessages(validate), validate.size(), is(3));
+        assertThat(validate).as(ValidatorUtil.formatMessages(validate)).hasSize(3);
         assertTrue(validate.stream().anyMatch(p -> p.getMessageType().equals(DMNMessageType.REQ_NOT_FOUND)));
     }
 
@@ -70,7 +69,7 @@ public class ValidatorAuthorityRequirementTest extends AbstractValidatorTest {
             final List<DMNMessage> validate = validator.validate(
                     reader,
                     VALIDATE_SCHEMA, VALIDATE_MODEL, VALIDATE_COMPILATION);
-            assertThat(ValidatorUtil.formatMessages(validate), validate.size(), is(3));
+            assertThat(validate).as(ValidatorUtil.formatMessages(validate)).hasSize(3);
             assertTrue(validate.stream().anyMatch(p -> p.getMessageType().equals(DMNMessageType.REQ_NOT_FOUND)));
         }
     }
@@ -80,7 +79,7 @@ public class ValidatorAuthorityRequirementTest extends AbstractValidatorTest {
         final List<DMNMessage> validate = validator.validate(
                 getFile("authorityrequirement/AUTHREQ_MISSING_DEPENDENCY_REQ_DEC.dmn"),
                 VALIDATE_SCHEMA, VALIDATE_MODEL, VALIDATE_COMPILATION);
-        assertThat(ValidatorUtil.formatMessages(validate), validate.size(), is(3));
+        assertThat(validate).as(ValidatorUtil.formatMessages(validate)).hasSize(3);
         assertTrue(validate.stream().anyMatch(p -> p.getMessageType().equals(DMNMessageType.REQ_NOT_FOUND)));
     }
 
@@ -91,7 +90,7 @@ public class ValidatorAuthorityRequirementTest extends AbstractValidatorTest {
                                "https://github.com/kiegroup/kie-dmn",
                                "AUTHREQ_MISSING_DEPENDENCY_REQ_DEC"),
                 VALIDATE_MODEL, VALIDATE_COMPILATION);
-        assertThat(ValidatorUtil.formatMessages(validate), validate.size(), is(3));
+        assertThat(validate).as(ValidatorUtil.formatMessages(validate)).hasSize(3);
         assertTrue(validate.stream().anyMatch(p -> p.getMessageType().equals(DMNMessageType.REQ_NOT_FOUND)));
     }
 
@@ -101,7 +100,7 @@ public class ValidatorAuthorityRequirementTest extends AbstractValidatorTest {
             final List<DMNMessage> validate = validator.validate(
                     reader,
                     VALIDATE_SCHEMA, VALIDATE_MODEL, VALIDATE_COMPILATION);
-            assertThat(ValidatorUtil.formatMessages(validate), validate.size(), is(3));
+            assertThat(validate).as(ValidatorUtil.formatMessages(validate)).hasSize(3);
             assertTrue(validate.stream().anyMatch(p -> p.getMessageType().equals(DMNMessageType.REQ_NOT_FOUND)));
         }
     }
@@ -111,7 +110,7 @@ public class ValidatorAuthorityRequirementTest extends AbstractValidatorTest {
         final List<DMNMessage> validate = validator.validate(
                 getFile("authorityrequirement/AUTHREQ_MISSING_DEPENDENCY_REQ_INPUT.dmn"),
                 VALIDATE_SCHEMA, VALIDATE_MODEL, VALIDATE_COMPILATION);
-        assertThat(ValidatorUtil.formatMessages(validate), validate.size(), is(3));
+        assertThat(validate).as(ValidatorUtil.formatMessages(validate)).hasSize(3);
         assertTrue(validate.stream().anyMatch(p -> p.getMessageType().equals(DMNMessageType.REQ_NOT_FOUND)));
     }
 
@@ -122,7 +121,7 @@ public class ValidatorAuthorityRequirementTest extends AbstractValidatorTest {
                                "https://github.com/kiegroup/kie-dmn",
                                "AUTHREQ_MISSING_DEPENDENCY_REQ_INPUT"),
                 VALIDATE_MODEL, VALIDATE_COMPILATION);
-        assertThat(ValidatorUtil.formatMessages(validate), validate.size(), is(3));
+        assertThat(validate).as(ValidatorUtil.formatMessages(validate)).hasSize(3);
         assertTrue(validate.stream().anyMatch(p -> p.getMessageType().equals(DMNMessageType.REQ_NOT_FOUND)));
     }
 
@@ -132,7 +131,7 @@ public class ValidatorAuthorityRequirementTest extends AbstractValidatorTest {
             final List<DMNMessage> validate = validator.validate(
                     reader,
                     VALIDATE_SCHEMA, VALIDATE_MODEL, VALIDATE_COMPILATION);
-            assertThat(ValidatorUtil.formatMessages(validate), validate.size(), is(3));
+            assertThat(validate).as(ValidatorUtil.formatMessages(validate)).hasSize(3);
             assertTrue(validate.stream().anyMatch(p -> p.getMessageType().equals(DMNMessageType.REQ_NOT_FOUND)));
         }
     }
@@ -142,7 +141,7 @@ public class ValidatorAuthorityRequirementTest extends AbstractValidatorTest {
         final List<DMNMessage> validate = validator.validate(
                 getFile("authorityrequirement/AUTHREQ_DEP_REQ_AUTH_NOT_KNOWLEDGESOURCE.dmn"),
                 VALIDATE_SCHEMA, VALIDATE_MODEL, VALIDATE_COMPILATION);
-        assertThat(ValidatorUtil.formatMessages(validate), validate.size(), is(3));
+        assertThat(validate).as(ValidatorUtil.formatMessages(validate)).hasSize(3);
         assertTrue(validate.stream().anyMatch(p -> p.getMessageType().equals(DMNMessageType.REQ_NOT_FOUND)));
     }
 
@@ -153,7 +152,7 @@ public class ValidatorAuthorityRequirementTest extends AbstractValidatorTest {
                                "https://github.com/kiegroup/kie-dmn",
                                "AUTHREQ_DEP_REQ_AUTH_NOT_KNOWLEDGESOURCE"),
                 VALIDATE_MODEL, VALIDATE_COMPILATION);
-        assertThat(ValidatorUtil.formatMessages(validate), validate.size(), is(3));
+        assertThat(validate).as(ValidatorUtil.formatMessages(validate)).hasSize(3);
         assertTrue(validate.stream().anyMatch(p -> p.getMessageType().equals(DMNMessageType.REQ_NOT_FOUND)));
     }
 
@@ -163,7 +162,7 @@ public class ValidatorAuthorityRequirementTest extends AbstractValidatorTest {
             final List<DMNMessage> validate = validator.validate(
                     reader,
                     VALIDATE_SCHEMA, VALIDATE_MODEL, VALIDATE_COMPILATION);
-            assertThat(ValidatorUtil.formatMessages(validate), validate.size(), is(3));
+            assertThat(validate).as(ValidatorUtil.formatMessages(validate)).hasSize(3);
             assertTrue(validate.stream().anyMatch(p -> p.getMessageType().equals(DMNMessageType.REQ_NOT_FOUND)));
         }
     }
@@ -173,7 +172,7 @@ public class ValidatorAuthorityRequirementTest extends AbstractValidatorTest {
         final List<DMNMessage> validate = validator.validate(
                 getFile("authorityrequirement/AUTHREQ_DEP_REQ_DEC_NOT_DECISION.dmn"),
                 VALIDATE_SCHEMA, VALIDATE_MODEL, VALIDATE_COMPILATION);
-        assertThat(ValidatorUtil.formatMessages(validate), validate.size(), is(3));
+        assertThat(validate).as(ValidatorUtil.formatMessages(validate)).hasSize(3);
         assertTrue(validate.stream().anyMatch(p -> p.getMessageType().equals(DMNMessageType.REQ_NOT_FOUND)));
     }
 
@@ -184,7 +183,7 @@ public class ValidatorAuthorityRequirementTest extends AbstractValidatorTest {
                                "https://github.com/kiegroup/kie-dmn",
                                "AUTHREQ_DEP_REQ_DEC_NOT_DECISION"),
                 VALIDATE_MODEL, VALIDATE_COMPILATION);
-        assertThat(ValidatorUtil.formatMessages(validate), validate.size(), is(3));
+        assertThat(validate).as(ValidatorUtil.formatMessages(validate)).hasSize(3);
         assertTrue(validate.stream().anyMatch(p -> p.getMessageType().equals(DMNMessageType.REQ_NOT_FOUND)));
     }
 
@@ -194,7 +193,7 @@ public class ValidatorAuthorityRequirementTest extends AbstractValidatorTest {
             final List<DMNMessage> validate = validator.validate(
                     reader,
                     VALIDATE_SCHEMA, VALIDATE_MODEL, VALIDATE_COMPILATION);
-            assertThat(ValidatorUtil.formatMessages(validate), validate.size(), is(3));
+            assertThat(validate).as(ValidatorUtil.formatMessages(validate)).hasSize(3);
             assertTrue(validate.stream().anyMatch(p -> p.getMessageType().equals(DMNMessageType.REQ_NOT_FOUND)));
         }
     }
@@ -204,7 +203,7 @@ public class ValidatorAuthorityRequirementTest extends AbstractValidatorTest {
         final List<DMNMessage> validate = validator.validate(
                 getFile("authorityrequirement/AUTHREQ_DEP_REQ_INPUT_NOT_INPUT.dmn"),
                 VALIDATE_SCHEMA, VALIDATE_MODEL, VALIDATE_COMPILATION);
-        assertThat(ValidatorUtil.formatMessages(validate), validate.size(), is(3));
+        assertThat(validate).as(ValidatorUtil.formatMessages(validate)).hasSize(3);
         assertTrue(validate.stream().anyMatch(p -> p.getMessageType().equals(DMNMessageType.REQ_NOT_FOUND)));
     }
 
@@ -215,7 +214,7 @@ public class ValidatorAuthorityRequirementTest extends AbstractValidatorTest {
                                "https://github.com/kiegroup/kie-dmn",
                                "AUTHREQ_DEP_REQ_INPUT_NOT_INPUT"),
                 VALIDATE_MODEL, VALIDATE_COMPILATION);
-        assertThat(ValidatorUtil.formatMessages(validate), validate.size(), is(3));
+        assertThat(validate).as(ValidatorUtil.formatMessages(validate)).hasSize(3);
         assertTrue(validate.stream().anyMatch(p -> p.getMessageType().equals(DMNMessageType.REQ_NOT_FOUND)));
     }
 }

--- a/kie-dmn/kie-dmn-validation/src/test/java/org/kie/dmn/validation/ValidatorBusinessContextTest.java
+++ b/kie-dmn/kie-dmn-validation/src/test/java/org/kie/dmn/validation/ValidatorBusinessContextTest.java
@@ -24,8 +24,7 @@ import org.junit.Test;
 import org.kie.dmn.api.core.DMNMessage;
 import org.kie.dmn.api.core.DMNMessageType;
 
-import static org.hamcrest.CoreMatchers.is;
-import static org.hamcrest.MatcherAssert.assertThat;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.Assert.assertTrue;
 import static org.kie.dmn.validation.DMNValidator.Validation.VALIDATE_COMPILATION;
 import static org.kie.dmn.validation.DMNValidator.Validation.VALIDATE_MODEL;
@@ -39,7 +38,7 @@ public class ValidatorBusinessContextTest extends AbstractValidatorTest {
             final List<DMNMessage> validate = validator.validate(
                     reader,
                     VALIDATE_SCHEMA, VALIDATE_MODEL, VALIDATE_COMPILATION);
-            assertThat(ValidatorUtil.formatMessages(validate), validate.size(), is(2));
+            assertThat(validate).as(ValidatorUtil.formatMessages(validate)).hasSize(2);
             assertTrue(validate.stream().anyMatch(p -> p.getMessageType().equals(DMNMessageType.REQ_NOT_FOUND)));
         }
     }
@@ -49,7 +48,7 @@ public class ValidatorBusinessContextTest extends AbstractValidatorTest {
         final List<DMNMessage> validate = validator.validate(
                 getFile("businesscontext/ORG_UNIT_DECISION_MADE_WRONG_TYPE.dmn"),
                 VALIDATE_SCHEMA, VALIDATE_MODEL, VALIDATE_COMPILATION);
-        assertThat(ValidatorUtil.formatMessages(validate), validate.size(), is(2));
+        assertThat(validate).as(ValidatorUtil.formatMessages(validate)).hasSize(2);
         assertTrue(validate.stream().anyMatch(p -> p.getMessageType().equals(DMNMessageType.REQ_NOT_FOUND)));
     }
 
@@ -60,7 +59,7 @@ public class ValidatorBusinessContextTest extends AbstractValidatorTest {
                                "https://github.com/kiegroup/kie-dmn",
                                "ORG_UNIT_DECISION_MADE_WRONG_TYPE"),
                 VALIDATE_MODEL, VALIDATE_COMPILATION);
-        assertThat(ValidatorUtil.formatMessages(validate), validate.size(), is(2));
+        assertThat(validate).as(ValidatorUtil.formatMessages(validate)).hasSize(2);
         assertTrue(validate.stream().anyMatch(p -> p.getMessageType().equals(DMNMessageType.REQ_NOT_FOUND)));
     }
 
@@ -70,7 +69,7 @@ public class ValidatorBusinessContextTest extends AbstractValidatorTest {
             final List<DMNMessage> validate = validator.validate(
                     reader,
                     VALIDATE_SCHEMA, VALIDATE_MODEL, VALIDATE_COMPILATION);
-            assertThat(ValidatorUtil.formatMessages(validate), validate.size(), is(2));
+            assertThat(validate).as(ValidatorUtil.formatMessages(validate)).hasSize(2);
             assertTrue(validate.stream().anyMatch(p -> p.getMessageType().equals(DMNMessageType.REQ_NOT_FOUND)));
         }
     }
@@ -80,7 +79,7 @@ public class ValidatorBusinessContextTest extends AbstractValidatorTest {
         final List<DMNMessage> validate = validator.validate(
                 getFile("businesscontext/ORG_UNIT_DECISION_OWNED_WRONG_TYPE.dmn"),
                 VALIDATE_SCHEMA, VALIDATE_MODEL, VALIDATE_COMPILATION);
-        assertThat(ValidatorUtil.formatMessages(validate), validate.size(), is(2));
+        assertThat(validate).as(ValidatorUtil.formatMessages(validate)).hasSize(2);
         assertTrue(validate.stream().anyMatch(p -> p.getMessageType().equals(DMNMessageType.REQ_NOT_FOUND)));
     }
 
@@ -91,7 +90,7 @@ public class ValidatorBusinessContextTest extends AbstractValidatorTest {
                                "https://github.com/kiegroup/kie-dmn",
                                "ORG_UNIT_DECISION_OWNED_WRONG_TYPE"),
                 VALIDATE_MODEL, VALIDATE_COMPILATION);
-        assertThat(ValidatorUtil.formatMessages(validate), validate.size(), is(2));
+        assertThat(validate).as(ValidatorUtil.formatMessages(validate)).hasSize(2);
         assertTrue(validate.stream().anyMatch(p -> p.getMessageType().equals(DMNMessageType.REQ_NOT_FOUND)));
     }
 
@@ -101,7 +100,7 @@ public class ValidatorBusinessContextTest extends AbstractValidatorTest {
             final List<DMNMessage> validate = validator.validate(
                     reader,
                     VALIDATE_SCHEMA, VALIDATE_MODEL, VALIDATE_COMPILATION);
-            assertThat(ValidatorUtil.formatMessages(validate), validate.size(), is(2));
+            assertThat(validate).as(ValidatorUtil.formatMessages(validate)).hasSize(2);
             assertTrue(validate.stream().anyMatch(p -> p.getMessageType().equals(DMNMessageType.REQ_NOT_FOUND)));
         }
     }
@@ -111,7 +110,7 @@ public class ValidatorBusinessContextTest extends AbstractValidatorTest {
         final List<DMNMessage> validate = validator.validate(
                 getFile("businesscontext/PERF_INDICATOR_IMP_DECISION_WRONG_TYPE.dmn"),
                 VALIDATE_SCHEMA, VALIDATE_MODEL, VALIDATE_COMPILATION);
-        assertThat(ValidatorUtil.formatMessages(validate), validate.size(), is(2));
+        assertThat(validate).as(ValidatorUtil.formatMessages(validate)).hasSize(2);
         assertTrue(validate.stream().anyMatch(p -> p.getMessageType().equals(DMNMessageType.REQ_NOT_FOUND)));
     }
 
@@ -122,7 +121,7 @@ public class ValidatorBusinessContextTest extends AbstractValidatorTest {
                                "https://github.com/kiegroup/kie-dmn",
                                "PERF_INDICATOR_IMP_DECISION_WRONG_TYPE"),
                 VALIDATE_MODEL, VALIDATE_COMPILATION);
-        assertThat(ValidatorUtil.formatMessages(validate), validate.size(), is(2));
+        assertThat(validate).as(ValidatorUtil.formatMessages(validate)).hasSize(2);
         assertTrue(validate.stream().anyMatch(p -> p.getMessageType().equals(DMNMessageType.REQ_NOT_FOUND)));
     }
 }

--- a/kie-dmn/kie-dmn-validation/src/test/java/org/kie/dmn/validation/ValidatorDMNDITest.java
+++ b/kie-dmn/kie-dmn-validation/src/test/java/org/kie/dmn/validation/ValidatorDMNDITest.java
@@ -25,8 +25,7 @@ import org.kie.api.builder.Message.Level;
 import org.kie.dmn.api.core.DMNMessage;
 import org.kie.dmn.api.core.DMNMessageType;
 
-import static org.hamcrest.CoreMatchers.is;
-import static org.hamcrest.MatcherAssert.assertThat;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.kie.dmn.validation.DMNValidator.Validation.VALIDATE_COMPILATION;
 import static org.kie.dmn.validation.DMNValidator.Validation.VALIDATE_MODEL;
 import static org.kie.dmn.validation.DMNValidator.Validation.VALIDATE_SCHEMA;
@@ -38,7 +37,7 @@ public class ValidatorDMNDITest extends AbstractValidatorTest {
         try (final Reader reader = getReader("dmndi/all-elements.dmn")) {
             final List<DMNMessage> validate = validator.validate(reader, VALIDATE_SCHEMA, VALIDATE_MODEL, VALIDATE_COMPILATION);
 
-            assertThat(ValidatorUtil.formatMessages(validate), validate.size(), is(0));
+            assertThat(validate).as(ValidatorUtil.formatMessages(validate)).hasSize(0);
         }
     }
 
@@ -47,9 +46,9 @@ public class ValidatorDMNDITest extends AbstractValidatorTest {
         try (final Reader reader = getReader("dmndi/all-elements-with-dmndi-no-dmnshape.dmn")) {
             final List<DMNMessage> validate = validator.validate(reader, VALIDATE_SCHEMA, VALIDATE_MODEL, VALIDATE_COMPILATION);
 
-            assertThat(ValidatorUtil.formatMessages(validate), validate.size(), is(12));
+            assertThat(validate).as(ValidatorUtil.formatMessages(validate)).hasSize(12);
             assertThat(validate.stream().filter(p -> p.getLevel() == Level.WARNING &&
-                                                     p.getMessageType().equals(DMNMessageType.DMNDI_MISSING_DIAGRAM)).count(), is(12L));
+                                                     p.getMessageType().equals(DMNMessageType.DMNDI_MISSING_DIAGRAM)).count()).isEqualTo(12L);
         }
     }
 
@@ -58,11 +57,11 @@ public class ValidatorDMNDITest extends AbstractValidatorTest {
         try (final Reader reader = getReader("dmndi/all-elements-invalid-ref.dmn")) {
             final List<DMNMessage> validate = validator.validate(reader, VALIDATE_SCHEMA, VALIDATE_MODEL, VALIDATE_COMPILATION);
 
-            assertThat(ValidatorUtil.formatMessages(validate), validate.size(), is(24));
+            assertThat(validate).as(ValidatorUtil.formatMessages(validate)).hasSize(24);
             assertThat(validate.stream().filter(p -> p.getLevel() == Level.WARNING &&
-                                                     p.getMessageType().equals(DMNMessageType.DMNDI_MISSING_DIAGRAM)).count(), is(12L));
+                                                     p.getMessageType().equals(DMNMessageType.DMNDI_MISSING_DIAGRAM)).count()).isEqualTo(12L);
             assertThat(validate.stream().filter(p -> p.getLevel() == Level.ERROR &&
-                                                     p.getMessageType().equals(DMNMessageType.DMNDI_UNKNOWN_REF)).count(), is(12L));
+                                                     p.getMessageType().equals(DMNMessageType.DMNDI_UNKNOWN_REF)).count()).isEqualTo(12L);
         }
     }
 }

--- a/kie-dmn/kie-dmn-validation/src/test/java/org/kie/dmn/validation/ValidatorDMNElementReferenceTest.java
+++ b/kie-dmn/kie-dmn-validation/src/test/java/org/kie/dmn/validation/ValidatorDMNElementReferenceTest.java
@@ -24,8 +24,7 @@ import org.junit.Test;
 import org.kie.dmn.api.core.DMNMessage;
 import org.kie.dmn.api.core.DMNMessageType;
 
-import static org.hamcrest.CoreMatchers.is;
-import static org.hamcrest.MatcherAssert.assertThat;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.Assert.assertTrue;
 import static org.kie.dmn.validation.DMNValidator.Validation.VALIDATE_COMPILATION;
 import static org.kie.dmn.validation.DMNValidator.Validation.VALIDATE_MODEL;
@@ -62,7 +61,7 @@ public class ValidatorDMNElementReferenceTest extends AbstractValidatorTest {
     }
 
     private void assertValiadationResult(List<DMNMessage> validationMessages) {
-        assertThat(ValidatorUtil.formatMessages(validationMessages), validationMessages.size(), is(3));
+    	assertThat(validationMessages).as(ValidatorUtil.formatMessages(validationMessages)).hasSize(3);
         assertTrue(validationMessages.stream().anyMatch(p -> p.getMessageType().equals(DMNMessageType.MISSING_EXPRESSION)));
         assertTrue(validationMessages.stream().anyMatch(p -> p.getMessageType().equals(DMNMessageType.INVALID_HREF_SYNTAX)));
         assertTrue(validationMessages.stream().anyMatch(p -> p.getMessageType().equals(DMNMessageType.REQ_NOT_FOUND)));

--- a/kie-dmn/kie-dmn-validation/src/test/java/org/kie/dmn/validation/ValidatorDecisionServiceTest.java
+++ b/kie-dmn/kie-dmn-validation/src/test/java/org/kie/dmn/validation/ValidatorDecisionServiceTest.java
@@ -32,11 +32,7 @@ import org.kie.dmn.model.api.Definitions;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import static org.hamcrest.CoreMatchers.is;
-import static org.hamcrest.CoreMatchers.notNullValue;
-import static org.hamcrest.CoreMatchers.nullValue;
-import static org.hamcrest.Matchers.greaterThanOrEqualTo;
-import static org.hamcrest.MatcherAssert.assertThat;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.kie.dmn.validation.DMNValidator.Validation.VALIDATE_COMPILATION;
 import static org.kie.dmn.validation.DMNValidator.Validation.VALIDATE_MODEL;
 import static org.kie.dmn.validation.DMNValidator.Validation.VALIDATE_SCHEMA;
@@ -51,8 +47,8 @@ public class ValidatorDecisionServiceTest extends AbstractValidatorTest {
             final List<DMNMessage> validate = validator.validate(
                     reader,
                     VALIDATE_SCHEMA, VALIDATE_MODEL, VALIDATE_COMPILATION);
-            assertThat(ValidatorUtil.formatMessages(validate), validate.size(), is(1));
-            assertThat(validate.get(0).toString(), validate.get(0).getMessageType(), is(DMNMessageType.REQ_NOT_FOUND));
+            assertThat(validate).as(ValidatorUtil.formatMessages(validate)).hasSize(1);
+            assertThat(validate.get(0).getMessageType()).as(validate.get(0).toString()).isEqualTo(DMNMessageType.REQ_NOT_FOUND);
         }
     }
 
@@ -61,8 +57,8 @@ public class ValidatorDecisionServiceTest extends AbstractValidatorTest {
         final List<DMNMessage> validate = validator.validate(
                 getFile("decisionservice/HelloDS_noOutput.dmn"),
                 VALIDATE_SCHEMA, VALIDATE_MODEL, VALIDATE_COMPILATION);
-        assertThat(ValidatorUtil.formatMessages(validate), validate.size(), is(1));
-        assertThat(validate.get(0).toString(), validate.get(0).getMessageType(), is(DMNMessageType.REQ_NOT_FOUND));
+        assertThat(validate).as(ValidatorUtil.formatMessages(validate)).hasSize(1);
+        assertThat(validate.get(0).getMessageType()).as(validate.get(0).toString()).isEqualTo(DMNMessageType.REQ_NOT_FOUND);
     }
 
     @Test
@@ -72,8 +68,8 @@ public class ValidatorDecisionServiceTest extends AbstractValidatorTest {
                                "https://kiegroup.org/dmn/_7C3C7416-2F33-4718-AE35-F3843C5250DB",
                                "HelloDS"),
                 VALIDATE_MODEL, VALIDATE_COMPILATION);
-        assertThat(ValidatorUtil.formatMessages(validate), validate.size(), is(1));
-        assertThat(validate.get(0).toString(), validate.get(0).getMessageType(), is(DMNMessageType.REQ_NOT_FOUND));
+        assertThat(validate).as(ValidatorUtil.formatMessages(validate)).hasSize(1);
+        assertThat(validate.get(0).getMessageType()).as(validate.get(0).toString()).isEqualTo(DMNMessageType.REQ_NOT_FOUND);
     }
 
     @Test
@@ -81,18 +77,18 @@ public class ValidatorDecisionServiceTest extends AbstractValidatorTest {
         DMNRuntime runtime = DMNRuntimeUtil.createRuntime("decisionservice/HelloDS_OK.dmn", this.getClass());
         DMNModel dmnModel = runtime.getModel("https://kiegroup.org/dmn/_7C3C7416-2F33-4718-AE35-F3843C5250DB",
                                              "HelloDS");
-        assertThat(dmnModel, notNullValue());
+        assertThat(dmnModel).isNotNull();
 
         Definitions definitions = dmnModel.getDefinitions();
-        assertThat(definitions, notNullValue());
+        assertThat(definitions).isNotNull();
 
         List<DMNMessage> messages = DMNValidatorFactory.newValidator().validate(definitions, VALIDATE_MODEL, VALIDATE_COMPILATION);
-        assertThat(messages.toString(), messages.size(), is(0));
+        assertThat(messages).as(messages.toString()).hasSize(0);
 
         DMNResult evaluateAll = runtime.evaluateAll(dmnModel, runtime.newContext());
         LOG.debug("{}", evaluateAll);
 
-        assertThat(evaluateAll.getDecisionResultByName("Decision-1").getResult(), is("Hello World"));
+        assertThat(evaluateAll.getDecisionResultByName("Decision-1").getResult()).isEqualTo("Hello World");
     }
 
     @Test
@@ -100,13 +96,13 @@ public class ValidatorDecisionServiceTest extends AbstractValidatorTest {
         DMNRuntime runtime = DMNRuntimeUtil.createRuntime("decisionservice/DS1ofEach_OK.dmn", this.getClass());
         DMNModel dmnModel = runtime.getModel("https://kiegroup.org/dmn/_40B3D02F-868C-4925-A1F2-5710DFEEF51E",
                                              "DS1ofEach");
-        assertThat(dmnModel, notNullValue());
+        assertThat(dmnModel).isNotNull();
 
         Definitions definitions = dmnModel.getDefinitions();
-        assertThat(definitions, notNullValue());
+        assertThat(definitions).isNotNull();
 
         List<DMNMessage> messages = DMNValidatorFactory.newValidator().validate(definitions, VALIDATE_MODEL, VALIDATE_COMPILATION);
-        assertThat(messages.toString(), messages.size(), is(0));
+        assertThat(messages).as(messages.toString()).hasSize(0);
 
         DMNContext dmnContext = runtime.newContext();
         dmnContext.set("InputData-1", "id1");
@@ -114,8 +110,8 @@ public class ValidatorDecisionServiceTest extends AbstractValidatorTest {
         DMNResult evaluateDS1 = runtime.evaluateDecisionService(dmnModel, dmnContext, "DecisionService-1");
         LOG.debug("{}", evaluateDS1);
 
-        assertThat(evaluateDS1.getDecisionResultByName("Decision-2"), nullValue());
-        assertThat(evaluateDS1.getDecisionResultByName("Decision-3").getResult(), is("d3:d2:id1od1"));
+        assertThat(evaluateDS1.getDecisionResultByName("Decision-2")).isNull();
+        assertThat(evaluateDS1.getDecisionResultByName("Decision-3").getResult()).isEqualTo("d3:d2:id1od1");
     }
 
     @Test
@@ -123,9 +119,9 @@ public class ValidatorDecisionServiceTest extends AbstractValidatorTest {
         try (final Reader reader = getReader("decisionservice/DS1ofEach_missingEncapsulated.dmn")) {
             final List<DMNMessage> validate = validator.validate(reader,
                                                                  VALIDATE_SCHEMA, VALIDATE_MODEL);
-            assertThat(ValidatorUtil.formatMessages(validate), validate.size(), is(2)); // DS-1 and Decision-3 are missing their reference now.
-            assertThat(validate.get(0).toString(), validate.get(0).getMessageType(), is(DMNMessageType.REQ_NOT_FOUND));
-            assertThat(validate.get(1).toString(), validate.get(1).getMessageType(), is(DMNMessageType.REQ_NOT_FOUND));
+            assertThat(validate).as(ValidatorUtil.formatMessages(validate)).hasSize(2); // DS-1 and Decision-3 are missing their reference now.
+            assertThat(validate.get(0).getMessageType()).as(validate.get(0).toString()).isEqualTo(DMNMessageType.REQ_NOT_FOUND);
+            assertThat(validate.get(1).getMessageType()).as(validate.get(1).toString()).isEqualTo(DMNMessageType.REQ_NOT_FOUND);
         }
     }
 
@@ -133,9 +129,9 @@ public class ValidatorDecisionServiceTest extends AbstractValidatorTest {
     public void testENCAPSULATED_NOT_FOUND_FOR_DS_FileInput() {
         final List<DMNMessage> validate = validator.validate(getFile("decisionservice/DS1ofEach_missingEncapsulated.dmn"),
                                                              VALIDATE_SCHEMA, VALIDATE_MODEL);
-        assertThat(ValidatorUtil.formatMessages(validate), validate.size(), is(2));
-        assertThat(validate.get(0).toString(), validate.get(0).getMessageType(), is(DMNMessageType.REQ_NOT_FOUND));
-        assertThat(validate.get(1).toString(), validate.get(1).getMessageType(), is(DMNMessageType.REQ_NOT_FOUND));
+        assertThat(validate).as(ValidatorUtil.formatMessages(validate)).hasSize(2);
+        assertThat(validate.get(0).getMessageType()).as(validate.get(0).toString()).isEqualTo(DMNMessageType.REQ_NOT_FOUND);
+        assertThat(validate.get(1).getMessageType()).as(validate.get(1).toString()).isEqualTo(DMNMessageType.REQ_NOT_FOUND);
     }
 
     @Test
@@ -144,9 +140,9 @@ public class ValidatorDecisionServiceTest extends AbstractValidatorTest {
                                                                             "https://kiegroup.org/dmn/_40B3D02F-868C-4925-A1F2-5710DFEEF51E",
                                                                             "DS1ofEach"),
                                                              VALIDATE_MODEL, VALIDATE_COMPILATION);
-        assertThat(ValidatorUtil.formatMessages(validate), validate.size(), greaterThanOrEqualTo(2));
-        assertThat(validate.get(0).toString(), validate.get(0).getMessageType(), is(DMNMessageType.REQ_NOT_FOUND));
-        assertThat(validate.get(1).toString(), validate.get(1).getMessageType(), is(DMNMessageType.REQ_NOT_FOUND));
+        assertThat(validate).as(ValidatorUtil.formatMessages(validate)).hasSizeGreaterThanOrEqualTo(2);
+        assertThat(validate.get(0).getMessageType()).as(validate.get(0).toString()).isEqualTo(DMNMessageType.REQ_NOT_FOUND);
+        assertThat(validate.get(1).getMessageType()).as(validate.get(1).toString()).isEqualTo(DMNMessageType.REQ_NOT_FOUND);
     }
 
     @Test
@@ -154,9 +150,9 @@ public class ValidatorDecisionServiceTest extends AbstractValidatorTest {
         try (final Reader reader = getReader("decisionservice/DS1ofEach_missingDecisionInput.dmn")) {
             final List<DMNMessage> validate = validator.validate(reader,
                                                                  VALIDATE_SCHEMA, VALIDATE_MODEL);
-            assertThat(ValidatorUtil.formatMessages(validate), validate.size(), is(2)); // DS-1 and Decision-2 are missing their reference now.
-            assertThat(validate.get(0).toString(), validate.get(0).getMessageType(), is(DMNMessageType.REQ_NOT_FOUND));
-            assertThat(validate.get(1).toString(), validate.get(1).getMessageType(), is(DMNMessageType.REQ_NOT_FOUND));
+            assertThat(validate).as(ValidatorUtil.formatMessages(validate)).hasSize(2); // DS-1 and Decision-2 are missing their reference now.
+            assertThat(validate.get(0).getMessageType()).as(validate.get(0).toString()).isEqualTo(DMNMessageType.REQ_NOT_FOUND);
+            assertThat(validate.get(1).getMessageType()).as(validate.get(1).toString()).isEqualTo(DMNMessageType.REQ_NOT_FOUND);
         }
     }
 
@@ -164,9 +160,9 @@ public class ValidatorDecisionServiceTest extends AbstractValidatorTest {
     public void testDECISIONINPUT_NOT_FOUND_FOR_DS_FileInput() {
         final List<DMNMessage> validate = validator.validate(getFile("decisionservice/DS1ofEach_missingDecisionInput.dmn"),
                                                              VALIDATE_SCHEMA, VALIDATE_MODEL);
-        assertThat(ValidatorUtil.formatMessages(validate), validate.size(), is(2));
-        assertThat(validate.get(0).toString(), validate.get(0).getMessageType(), is(DMNMessageType.REQ_NOT_FOUND));
-        assertThat(validate.get(1).toString(), validate.get(1).getMessageType(), is(DMNMessageType.REQ_NOT_FOUND));
+        assertThat(validate).as(ValidatorUtil.formatMessages(validate)).hasSize(2);
+        assertThat(validate.get(0).getMessageType()).as(validate.get(0).toString()).isEqualTo(DMNMessageType.REQ_NOT_FOUND);
+        assertThat(validate.get(1).getMessageType()).as(validate.get(1).toString()).isEqualTo(DMNMessageType.REQ_NOT_FOUND);
     }
 
     @Test
@@ -175,9 +171,9 @@ public class ValidatorDecisionServiceTest extends AbstractValidatorTest {
                                                                             "https://kiegroup.org/dmn/_40B3D02F-868C-4925-A1F2-5710DFEEF51E",
                                                                             "DS1ofEach"),
                                                              VALIDATE_MODEL, VALIDATE_COMPILATION);
-        assertThat(ValidatorUtil.formatMessages(validate), validate.size(), greaterThanOrEqualTo(2));
-        assertThat(validate.get(0).toString(), validate.get(0).getMessageType(), is(DMNMessageType.REQ_NOT_FOUND));
-        assertThat(validate.get(1).toString(), validate.get(1).getMessageType(), is(DMNMessageType.REQ_NOT_FOUND));
+        assertThat(validate).as(ValidatorUtil.formatMessages(validate)).hasSizeGreaterThanOrEqualTo(2);
+        assertThat(validate.get(0).getMessageType()).as(validate.get(0).toString()).isEqualTo(DMNMessageType.REQ_NOT_FOUND);
+        assertThat(validate.get(1).getMessageType()).as(validate.get(1).toString()).isEqualTo(DMNMessageType.REQ_NOT_FOUND);
     }
 
     @Test
@@ -185,9 +181,9 @@ public class ValidatorDecisionServiceTest extends AbstractValidatorTest {
         try (final Reader reader = getReader("decisionservice/DS1ofEach_missingInputData.dmn")) {
             final List<DMNMessage> validate = validator.validate(reader,
                                                                  VALIDATE_SCHEMA, VALIDATE_MODEL);
-            assertThat(ValidatorUtil.formatMessages(validate), validate.size(), is(2)); // DS-1 and Decision-2 are missing their reference now.
-            assertThat(validate.get(0).toString(), validate.get(0).getMessageType(), is(DMNMessageType.REQ_NOT_FOUND));
-            assertThat(validate.get(1).toString(), validate.get(1).getMessageType(), is(DMNMessageType.REQ_NOT_FOUND));
+            assertThat(validate).as(ValidatorUtil.formatMessages(validate)).hasSize(2); // DS-1 and Decision-2 are missing their reference now.
+            assertThat(validate.get(0).getMessageType()).as(validate.get(0).toString()).isEqualTo(DMNMessageType.REQ_NOT_FOUND);
+            assertThat(validate.get(1).getMessageType()).as(validate.get(1).toString()).isEqualTo(DMNMessageType.REQ_NOT_FOUND);
         }
     }
 
@@ -195,9 +191,9 @@ public class ValidatorDecisionServiceTest extends AbstractValidatorTest {
     public void testINPUTDATA_NOT_FOUND_FOR_DS_FileInput() {
         final List<DMNMessage> validate = validator.validate(getFile("decisionservice/DS1ofEach_missingInputData.dmn"),
                                                              VALIDATE_SCHEMA, VALIDATE_MODEL);
-        assertThat(ValidatorUtil.formatMessages(validate), validate.size(), is(2));
-        assertThat(validate.get(0).toString(), validate.get(0).getMessageType(), is(DMNMessageType.REQ_NOT_FOUND));
-        assertThat(validate.get(1).toString(), validate.get(1).getMessageType(), is(DMNMessageType.REQ_NOT_FOUND));
+        assertThat(validate).as(ValidatorUtil.formatMessages(validate)).hasSize(2);
+        assertThat(validate.get(0).getMessageType()).as(validate.get(0).toString()).isEqualTo(DMNMessageType.REQ_NOT_FOUND);
+        assertThat(validate.get(1).getMessageType()).as(validate.get(1).toString()).isEqualTo(DMNMessageType.REQ_NOT_FOUND);
     }
 
     @Test
@@ -206,9 +202,9 @@ public class ValidatorDecisionServiceTest extends AbstractValidatorTest {
                                                                             "https://kiegroup.org/dmn/_40B3D02F-868C-4925-A1F2-5710DFEEF51E",
                                                                             "DS1ofEach"),
                                                              VALIDATE_MODEL, VALIDATE_COMPILATION);
-        assertThat(ValidatorUtil.formatMessages(validate), validate.size(), greaterThanOrEqualTo(2));
-        assertThat(validate.get(0).toString(), validate.get(0).getMessageType(), is(DMNMessageType.REQ_NOT_FOUND));
-        assertThat(validate.get(1).toString(), validate.get(1).getMessageType(), is(DMNMessageType.REQ_NOT_FOUND));
+        assertThat(validate).as(ValidatorUtil.formatMessages(validate)).hasSizeGreaterThanOrEqualTo(2);
+        assertThat(validate.get(0).getMessageType()).as(validate.get(0).toString()).isEqualTo(DMNMessageType.REQ_NOT_FOUND);
+        assertThat(validate.get(1).getMessageType()).as(validate.get(1).toString()).isEqualTo(DMNMessageType.REQ_NOT_FOUND);
     }
 
     @Test
@@ -216,8 +212,8 @@ public class ValidatorDecisionServiceTest extends AbstractValidatorTest {
         try (final Reader reader = getReader("decisionservice/DS1ofEach_missingOutput.dmn")) {
             final List<DMNMessage> validate = validator.validate(reader,
                                                                  VALIDATE_SCHEMA, VALIDATE_MODEL);
-            assertThat(ValidatorUtil.formatMessages(validate), validate.size(), is(1)); // DS-1 missing its reference now.
-            assertThat(validate.get(0).toString(), validate.get(0).getMessageType(), is(DMNMessageType.REQ_NOT_FOUND));
+            assertThat(validate).as(ValidatorUtil.formatMessages(validate)).hasSize(1); // DS-1 missing its reference now.
+            assertThat(validate.get(0).getMessageType()).as(validate.get(0).toString()).isEqualTo(DMNMessageType.REQ_NOT_FOUND);
         }
     }
 
@@ -225,8 +221,8 @@ public class ValidatorDecisionServiceTest extends AbstractValidatorTest {
     public void testOUTPUTELEMENT_NOT_FOUND_FOR_DS_FileInput() {
         final List<DMNMessage> validate = validator.validate(getFile("decisionservice/DS1ofEach_missingOutput.dmn"),
                                                              VALIDATE_SCHEMA, VALIDATE_MODEL);
-        assertThat(ValidatorUtil.formatMessages(validate), validate.size(), is(1));
-        assertThat(validate.get(0).toString(), validate.get(0).getMessageType(), is(DMNMessageType.REQ_NOT_FOUND));
+        assertThat(validate).as(ValidatorUtil.formatMessages(validate)).hasSize(1);
+        assertThat(validate.get(0).getMessageType()).as(validate.get(0).toString()).isEqualTo(DMNMessageType.REQ_NOT_FOUND);
     }
 
     @Test
@@ -235,7 +231,7 @@ public class ValidatorDecisionServiceTest extends AbstractValidatorTest {
                                                                             "https://kiegroup.org/dmn/_40B3D02F-868C-4925-A1F2-5710DFEEF51E",
                                                                             "DS1ofEach"),
                                                              VALIDATE_MODEL, VALIDATE_COMPILATION);
-        assertThat(ValidatorUtil.formatMessages(validate), validate.size(), greaterThanOrEqualTo(1));
-        assertThat(validate.get(0).toString(), validate.get(0).getMessageType(), is(DMNMessageType.REQ_NOT_FOUND));
+        assertThat(validate).as(ValidatorUtil.formatMessages(validate)).hasSizeGreaterThanOrEqualTo(2);
+        assertThat(validate.get(0).getMessageType()).as(validate.get(0).toString()).isEqualTo(DMNMessageType.REQ_NOT_FOUND);
     }
 }

--- a/kie-dmn/kie-dmn-validation/src/test/java/org/kie/dmn/validation/ValidatorDecisionTableTest.java
+++ b/kie-dmn/kie-dmn-validation/src/test/java/org/kie/dmn/validation/ValidatorDecisionTableTest.java
@@ -24,8 +24,7 @@ import org.junit.Test;
 import org.kie.dmn.api.core.DMNMessage;
 import org.kie.dmn.api.core.DMNMessageType;
 
-import static org.hamcrest.CoreMatchers.is;
-import static org.hamcrest.MatcherAssert.assertThat;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.Assert.assertTrue;
 import static org.kie.dmn.validation.DMNValidator.Validation.VALIDATE_COMPILATION;
 import static org.kie.dmn.validation.DMNValidator.Validation.VALIDATE_MODEL;
@@ -40,7 +39,7 @@ public class ValidatorDecisionTableTest
             final List<DMNMessage> validate = validator.validate(
                     reader,
                     VALIDATE_MODEL, VALIDATE_COMPILATION);
-            assertThat(ValidatorUtil.formatMessages(validate), validate.size(), is(2));
+            assertThat(validate).as(ValidatorUtil.formatMessages(validate)).hasSize(2);
             assertTrue(validate.stream().anyMatch(p -> p.getMessageType().equals(DMNMessageType.MISSING_EXPRESSION)));
         }
     }
@@ -50,7 +49,7 @@ public class ValidatorDecisionTableTest
         final List<DMNMessage> validate = validator.validate(
                 getFile("DTABLE_EMPTY_ENTRY.dmn"),
                 VALIDATE_MODEL, VALIDATE_COMPILATION);
-        assertThat(ValidatorUtil.formatMessages(validate), validate.size(), is(2));
+        assertThat(validate).as(ValidatorUtil.formatMessages(validate)).hasSize(2);
         assertTrue(validate.stream().anyMatch(p -> p.getMessageType().equals(DMNMessageType.MISSING_EXPRESSION)));
     }
 
@@ -61,7 +60,7 @@ public class ValidatorDecisionTableTest
                                "https://github.com/kiegroup/kie-dmn",
                                "DTABLE_PRIORITY_MISSING_OUTVALS"),
                 VALIDATE_MODEL, VALIDATE_COMPILATION);
-        assertThat(ValidatorUtil.formatMessages(validate), validate.size(), is(2));
+        assertThat(validate).as(ValidatorUtil.formatMessages(validate)).hasSize(2);
         assertTrue(validate.stream().anyMatch(p -> p.getMessageType().equals(DMNMessageType.MISSING_EXPRESSION)));
     }
 
@@ -69,7 +68,7 @@ public class ValidatorDecisionTableTest
     public void testDTABLE_MULTIPLEOUT_NAME_ReaderInput() throws IOException {
         try (final Reader reader = getReader( "DTABLE_MULTIPLEOUTPUT_WRONG_OUTPUT.dmn" )) {
             List<DMNMessage> validate = validator.validate( reader, VALIDATE_SCHEMA, VALIDATE_MODEL, VALIDATE_COMPILATION);
-            assertThat( ValidatorUtil.formatMessages( validate ), validate.size(), is( 5 ) );
+            assertThat(validate).as(ValidatorUtil.formatMessages(validate)).hasSize(5);
             assertTrue( validate.stream().anyMatch( p -> p.getMessageType().equals( DMNMessageType.MISSING_NAME ) ) );
             assertTrue( validate.stream().anyMatch( p -> p.getMessageType().equals( DMNMessageType.MISSING_TYPE_REF ) ) );
             assertTrue( validate.stream().anyMatch( p -> p.getMessageType().equals( DMNMessageType.INVALID_NAME ) ) );
@@ -79,7 +78,7 @@ public class ValidatorDecisionTableTest
     @Test
     public void testDTABLE_MULTIPLEOUT_NAME_FileInput() {
         List<DMNMessage> validate = validator.validate( getFile( "DTABLE_MULTIPLEOUTPUT_WRONG_OUTPUT.dmn" ), VALIDATE_SCHEMA, VALIDATE_MODEL, VALIDATE_COMPILATION);
-        assertThat( ValidatorUtil.formatMessages( validate ), validate.size(), is( 5 ) );
+        assertThat(validate).as(ValidatorUtil.formatMessages(validate)).hasSize(5);
         assertTrue( validate.stream().anyMatch( p -> p.getMessageType().equals( DMNMessageType.MISSING_NAME ) ) );
         assertTrue( validate.stream().anyMatch( p -> p.getMessageType().equals( DMNMessageType.MISSING_TYPE_REF ) ) );
         assertTrue( validate.stream().anyMatch( p -> p.getMessageType().equals( DMNMessageType.INVALID_NAME ) ) );
@@ -92,7 +91,7 @@ public class ValidatorDecisionTableTest
                                 "https://github.com/kiegroup/kie-dmn",
                                 "DTABLE_MULTIPLEOUTPUT_WRONG_OUTPUT"),
                 VALIDATE_MODEL, VALIDATE_COMPILATION);
-        assertThat( ValidatorUtil.formatMessages( validate ), validate.size(), is( 5 ) );
+        assertThat(validate).as(ValidatorUtil.formatMessages(validate)).hasSize(5);
         assertTrue( validate.stream().anyMatch( p -> p.getMessageType().equals( DMNMessageType.MISSING_NAME ) ) );
         assertTrue( validate.stream().anyMatch( p -> p.getMessageType().equals( DMNMessageType.MISSING_TYPE_REF ) ) );
         assertTrue( validate.stream().anyMatch( p -> p.getMessageType().equals( DMNMessageType.INVALID_NAME ) ) );
@@ -102,7 +101,7 @@ public class ValidatorDecisionTableTest
     public void testDTABLE_PRIORITY_MISSING_OUTVALS_ReaderInput() throws IOException {
         try (final Reader reader = getReader( "DTABLE_PRIORITY_MISSING_OUTVALS.dmn" )) {
             List<DMNMessage> validate = validator.validate( reader, VALIDATE_SCHEMA, VALIDATE_MODEL, VALIDATE_COMPILATION);
-            assertThat( ValidatorUtil.formatMessages( validate ), validate.isEmpty(), is( false ) );
+            assertThat(validate.isEmpty()).as(ValidatorUtil.formatMessages(validate)).isFalse();
             assertTrue( validate.stream().anyMatch( p -> p.getMessageType().equals( DMNMessageType.MISSING_OUTPUT_VALUES ) ) );
         }
     }
@@ -110,7 +109,7 @@ public class ValidatorDecisionTableTest
     @Test
     public void testDTABLE_PRIORITY_MISSING_OUTVALS_FileInput() {
         List<DMNMessage> validate = validator.validate( getFile( "DTABLE_PRIORITY_MISSING_OUTVALS.dmn" ), VALIDATE_SCHEMA, VALIDATE_MODEL, VALIDATE_COMPILATION);
-        assertThat( ValidatorUtil.formatMessages( validate ), validate.isEmpty(), is( false ) );
+        assertThat(validate.isEmpty()).as(ValidatorUtil.formatMessages(validate)).isFalse();
         assertTrue( validate.stream().anyMatch( p -> p.getMessageType().equals( DMNMessageType.MISSING_OUTPUT_VALUES ) ) );
     }
 
@@ -121,7 +120,7 @@ public class ValidatorDecisionTableTest
                                 "https://github.com/kiegroup/kie-dmn",
                                 "DTABLE_PRIORITY_MISSING_OUTVALS"),
                 VALIDATE_MODEL, VALIDATE_COMPILATION);
-        assertThat( ValidatorUtil.formatMessages( validate ), validate.isEmpty(), is( false ) );
+        assertThat(validate.isEmpty()).as(ValidatorUtil.formatMessages(validate)).isFalse();
         assertTrue( validate.stream().anyMatch( p -> p.getMessageType().equals( DMNMessageType.MISSING_OUTPUT_VALUES ) ) );
     }
 
@@ -129,7 +128,7 @@ public class ValidatorDecisionTableTest
     public void testDTABLE_SINGLEOUT_NONAME_ReaderInput() throws IOException {
         try (final Reader reader = getReader( "DTABLE_SINGLEOUTPUT_WRONG_OUTPUT.dmn" )) {
             List<DMNMessage> validate = validator.validate( reader, VALIDATE_SCHEMA, VALIDATE_MODEL, VALIDATE_COMPILATION);
-            assertThat( ValidatorUtil.formatMessages( validate ), validate.size(), is( 2 ) );
+            assertThat(validate).as(ValidatorUtil.formatMessages(validate)).hasSize(2);
             assertTrue( validate.stream().anyMatch( p -> p.getMessageType().equals( DMNMessageType.ILLEGAL_USE_OF_NAME ) ) );
             assertTrue( validate.stream().anyMatch( p -> p.getMessageType().equals( DMNMessageType.ILLEGAL_USE_OF_TYPEREF ) ) );
         }
@@ -138,7 +137,7 @@ public class ValidatorDecisionTableTest
     @Test
     public void testDTABLE_SINGLEOUT_NONAME_FileInput() {
         List<DMNMessage> validate = validator.validate( getFile( "DTABLE_SINGLEOUTPUT_WRONG_OUTPUT.dmn" ), VALIDATE_SCHEMA, VALIDATE_MODEL, VALIDATE_COMPILATION);
-        assertThat( ValidatorUtil.formatMessages( validate ), validate.size(), is( 2 ) );
+        assertThat(validate).as(ValidatorUtil.formatMessages(validate)).hasSize(2);
         assertTrue( validate.stream().anyMatch( p -> p.getMessageType().equals( DMNMessageType.ILLEGAL_USE_OF_NAME ) ) );
         assertTrue( validate.stream().anyMatch( p -> p.getMessageType().equals( DMNMessageType.ILLEGAL_USE_OF_TYPEREF ) ) );
     }
@@ -150,7 +149,7 @@ public class ValidatorDecisionTableTest
                                "https://github.com/kiegroup/kie-dmn",
                                "DTABLE_SINGLEOUTPUT_WRONG_OUTPUT"),
                 VALIDATE_MODEL, VALIDATE_COMPILATION);
-        assertThat( ValidatorUtil.formatMessages( validate ), validate.size(), is( 2 ) );
+        assertThat(validate).as(ValidatorUtil.formatMessages(validate)).hasSize(2);
         assertTrue( validate.stream().anyMatch( p -> p.getMessageType().equals( DMNMessageType.ILLEGAL_USE_OF_NAME ) ) );
         assertTrue( validate.stream().anyMatch( p -> p.getMessageType().equals( DMNMessageType.ILLEGAL_USE_OF_TYPEREF ) ) );
     }

--- a/kie-dmn/kie-dmn-validation/src/test/java/org/kie/dmn/validation/ValidatorDecisionTest.java
+++ b/kie-dmn/kie-dmn-validation/src/test/java/org/kie/dmn/validation/ValidatorDecisionTest.java
@@ -30,9 +30,7 @@ import org.kie.dmn.core.DMNRuntimeTest;
 import org.kie.dmn.core.util.DMNRuntimeUtil;
 import org.kie.dmn.model.api.Definitions;
 
-import static org.hamcrest.CoreMatchers.is;
-import static org.hamcrest.CoreMatchers.notNullValue;
-import static org.hamcrest.MatcherAssert.assertThat;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.Assert.assertTrue;
 import static org.kie.dmn.validation.DMNValidator.Validation.VALIDATE_COMPILATION;
 import static org.kie.dmn.validation.DMNValidator.Validation.VALIDATE_MODEL;
@@ -46,8 +44,8 @@ public class ValidatorDecisionTest extends AbstractValidatorTest {
             final List<DMNMessage> validate = validator.validate(
                     reader,
                     VALIDATE_SCHEMA, VALIDATE_MODEL, VALIDATE_COMPILATION);
-            assertThat(ValidatorUtil.formatMessages(validate), validate.size(), is(1));
-            assertThat(validate.get(0).toString(), validate.get(0).getMessageType(), is(DMNMessageType.MISSING_EXPRESSION));
+            assertThat(validate).as(ValidatorUtil.formatMessages(validate)).hasSize(1);
+            assertThat(validate.get(0).getMessageType()).as(validate.get(0).toString()).isEqualTo(DMNMessageType.MISSING_EXPRESSION);
         }
     }
 
@@ -56,8 +54,8 @@ public class ValidatorDecisionTest extends AbstractValidatorTest {
         final List<DMNMessage> validate = validator.validate(
                 getFile("decision/DECISION_MISSING_EXPR.dmn"),
                 VALIDATE_SCHEMA, VALIDATE_MODEL, VALIDATE_COMPILATION);
-        assertThat(ValidatorUtil.formatMessages(validate), validate.size(), is(1));
-        assertThat(validate.get(0).toString(), validate.get(0).getMessageType(), is(DMNMessageType.MISSING_EXPRESSION));
+        assertThat(validate).as(ValidatorUtil.formatMessages(validate)).hasSize(1);
+        assertThat(validate.get(0).getMessageType()).as(validate.get(0).toString()).isEqualTo(DMNMessageType.MISSING_EXPRESSION);
     }
 
     @Test
@@ -67,8 +65,8 @@ public class ValidatorDecisionTest extends AbstractValidatorTest {
                                "https://github.com/kiegroup/kie-dmn",
                                "DECISION_MISSING_EXPR"),
                 VALIDATE_MODEL, VALIDATE_COMPILATION);
-        assertThat(ValidatorUtil.formatMessages(validate), validate.size(), is(1));
-        assertThat(validate.get(0).toString(), validate.get(0).getMessageType(), is(DMNMessageType.MISSING_EXPRESSION));
+        assertThat(validate).as(ValidatorUtil.formatMessages(validate)).hasSize(1);
+        assertThat(validate.get(0).getMessageType()).as(validate.get(0).toString()).isEqualTo(DMNMessageType.MISSING_EXPRESSION);
     }
 
     @Test
@@ -77,7 +75,7 @@ public class ValidatorDecisionTest extends AbstractValidatorTest {
             final List<DMNMessage> validate = validator.validate(
                     reader,
                     VALIDATE_SCHEMA, VALIDATE_MODEL, VALIDATE_COMPILATION);
-            assertThat(ValidatorUtil.formatMessages(validate), validate.size(), is(1));
+            assertThat(validate).as(ValidatorUtil.formatMessages(validate)).hasSize(1);
             assertTrue(validate.stream().anyMatch(p -> p.getMessageType().equals(DMNMessageType.MISSING_VARIABLE)));
         }
     }
@@ -87,7 +85,7 @@ public class ValidatorDecisionTest extends AbstractValidatorTest {
         final List<DMNMessage> validate = validator.validate(
                 getFile("decision/DECISION_MISSING_VAR.dmn"),
                 VALIDATE_SCHEMA, VALIDATE_MODEL, VALIDATE_COMPILATION);
-        assertThat(ValidatorUtil.formatMessages(validate), validate.size(), is(1));
+        assertThat(validate).as(ValidatorUtil.formatMessages(validate)).hasSize(1);
         assertTrue(validate.stream().anyMatch(p -> p.getMessageType().equals(DMNMessageType.MISSING_VARIABLE)));
     }
 
@@ -98,7 +96,7 @@ public class ValidatorDecisionTest extends AbstractValidatorTest {
                                "https://github.com/kiegroup/kie-dmn",
                                "DECISION_MISSING_VAR"),
                 VALIDATE_MODEL, VALIDATE_COMPILATION);
-        assertThat(ValidatorUtil.formatMessages(validate), validate.size(), is(1));
+        assertThat(validate).as(ValidatorUtil.formatMessages(validate)).hasSize(1);
         assertTrue(validate.stream().anyMatch(p -> p.getMessageType().equals(DMNMessageType.MISSING_VARIABLE)));
     }
 
@@ -106,7 +104,7 @@ public class ValidatorDecisionTest extends AbstractValidatorTest {
     public void testDECISION_MISSING_VARbis_ReaderInput() throws IOException {
         try (final Reader reader = getReader("decision/DECISION_MISSING_VARbis.dmn")) {
             final List<DMNMessage> validate = validator.validate(reader, VALIDATE_SCHEMA, VALIDATE_MODEL, VALIDATE_COMPILATION);
-            assertThat(ValidatorUtil.formatMessages(validate), validate.size(), is(1));
+            assertThat(validate).as(ValidatorUtil.formatMessages(validate)).hasSize(1);
             assertTrue(validate.stream().anyMatch(p -> p.getMessageType().equals(DMNMessageType.MISSING_VARIABLE)));
         }
     }
@@ -115,7 +113,7 @@ public class ValidatorDecisionTest extends AbstractValidatorTest {
     public void testDECISION_MISSING_VARbis_FileInput() {
         final List<DMNMessage> validate = validator.validate(
                 getFile("decision/DECISION_MISSING_VARbis.dmn"), VALIDATE_SCHEMA, VALIDATE_MODEL, VALIDATE_COMPILATION);
-        assertThat(ValidatorUtil.formatMessages(validate), validate.size(), is(1));
+        assertThat(validate).as(ValidatorUtil.formatMessages(validate)).hasSize(1);
         assertTrue(validate.stream().anyMatch(p -> p.getMessageType().equals(DMNMessageType.MISSING_VARIABLE)));
     }
 
@@ -126,7 +124,7 @@ public class ValidatorDecisionTest extends AbstractValidatorTest {
                                "https://github.com/kiegroup/kie-dmn",
                                "DECISION_MISSING_VARbis"),
                 VALIDATE_MODEL, VALIDATE_COMPILATION);
-        assertThat(ValidatorUtil.formatMessages(validate), validate.size(), is(1));
+        assertThat(validate).as(ValidatorUtil.formatMessages(validate)).hasSize(1);
         assertTrue(validate.stream().anyMatch(p -> p.getMessageType().equals(DMNMessageType.MISSING_VARIABLE)));
     }
 
@@ -134,7 +132,7 @@ public class ValidatorDecisionTest extends AbstractValidatorTest {
     public void testDECISION_MISMATCH_VAR_ReaderInput() throws IOException {
         try (final Reader reader = getReader("decision/DECISION_MISMATCH_VAR.dmn")) {
             final List<DMNMessage> validate = validator.validate(reader, VALIDATE_SCHEMA, VALIDATE_MODEL, VALIDATE_COMPILATION);
-            assertThat(ValidatorUtil.formatMessages(validate), validate.size(), is(1));
+            assertThat(validate).as(ValidatorUtil.formatMessages(validate)).hasSize(1);
             assertTrue(validate.stream().anyMatch(p -> p.getMessageType().equals(DMNMessageType.VARIABLE_NAME_MISMATCH)));
         }
     }
@@ -143,7 +141,7 @@ public class ValidatorDecisionTest extends AbstractValidatorTest {
     public void testDECISION_MISMATCH_VAR_FileInput() {
         final List<DMNMessage> validate = validator.validate(
                 getFile("decision/DECISION_MISMATCH_VAR.dmn"), VALIDATE_SCHEMA, VALIDATE_MODEL, VALIDATE_COMPILATION);
-        assertThat(ValidatorUtil.formatMessages(validate), validate.size(), is(1));
+        assertThat(validate).as(ValidatorUtil.formatMessages(validate)).hasSize(1);
         assertTrue(validate.stream().anyMatch(p -> p.getMessageType().equals(DMNMessageType.VARIABLE_NAME_MISMATCH)));
     }
 
@@ -154,7 +152,7 @@ public class ValidatorDecisionTest extends AbstractValidatorTest {
                                "https://github.com/kiegroup/kie-dmn",
                                "DECISION_MISSING_VAR"),
                 VALIDATE_MODEL, VALIDATE_COMPILATION);
-        assertThat(ValidatorUtil.formatMessages(validate), validate.size(), is(1));
+        assertThat(validate).as(ValidatorUtil.formatMessages(validate)).hasSize(1);
         assertTrue(validate.stream().anyMatch(p -> p.getMessageType().equals(DMNMessageType.VARIABLE_NAME_MISMATCH)));
     }
 
@@ -162,7 +160,7 @@ public class ValidatorDecisionTest extends AbstractValidatorTest {
     public void testDECISION_MULTIPLE_EXPRESSIONS_ReaderInput() throws IOException {
         try (final Reader reader = getReader("decision/DECISION_MULTIPLE_EXPRESSIONS.dmn")) {
             final List<DMNMessage> validate = validator.validate(reader, VALIDATE_SCHEMA, VALIDATE_MODEL, VALIDATE_COMPILATION);
-            assertThat(ValidatorUtil.formatMessages(validate), validate.size(), is(1));
+            assertThat(validate).as(ValidatorUtil.formatMessages(validate)).hasSize(1);
             assertTrue(validate.stream().anyMatch(p -> p.getMessageType().equals(DMNMessageType.FAILED_XML_VALIDATION)));
         }
     }
@@ -171,7 +169,7 @@ public class ValidatorDecisionTest extends AbstractValidatorTest {
     public void testDECISION_MULTIPLE_EXPRESSIONS_FileInput() {
         final List<DMNMessage> validate = validator.validate(
                 getFile("decision/DECISION_MULTIPLE_EXPRESSIONS.dmn"), VALIDATE_SCHEMA, VALIDATE_MODEL, VALIDATE_COMPILATION);
-        assertThat(ValidatorUtil.formatMessages(validate), validate.size(), is(1));
+        assertThat(validate).as(ValidatorUtil.formatMessages(validate)).hasSize(1);
         assertTrue(validate.stream().anyMatch(p -> p.getMessageType().equals(DMNMessageType.FAILED_XML_VALIDATION)));
     }
 
@@ -182,14 +180,14 @@ public class ValidatorDecisionTest extends AbstractValidatorTest {
                                "https://github.com/kiegroup/kie-dmn",
                                "DECISION_MULTIPLE_EXPRESSIONS"),
                 VALIDATE_MODEL, VALIDATE_COMPILATION);
-        assertThat(ValidatorUtil.formatMessages(validate), validate.size(), is(0));
+        assertThat(validate).as(ValidatorUtil.formatMessages(validate)).hasSize(0);
     }
 
     @Test
     public void testDECISION_PERF_INDICATOR_WRONG_TYPE_ReaderInput() throws IOException {
         try (final Reader reader = getReader("decision/DECISION_PERF_INDICATOR_WRONG_TYPE.dmn")) {
             final List<DMNMessage> validate = validator.validate(reader, VALIDATE_SCHEMA, VALIDATE_MODEL, VALIDATE_COMPILATION);
-            assertThat(ValidatorUtil.formatMessages(validate), validate.size(), is(2));
+            assertThat(validate).as(ValidatorUtil.formatMessages(validate)).hasSize(2);
             assertTrue(validate.stream().anyMatch(p -> p.getMessageType().equals(DMNMessageType.REQ_NOT_FOUND)));
         }
     }
@@ -198,7 +196,7 @@ public class ValidatorDecisionTest extends AbstractValidatorTest {
     public void testDECISION_PERF_INDICATOR_WRONG_TYPE_FileInput() {
         final List<DMNMessage> validate = validator.validate(
                 getFile("decision/DECISION_PERF_INDICATOR_WRONG_TYPE.dmn"), VALIDATE_SCHEMA, VALIDATE_MODEL, VALIDATE_COMPILATION);
-        assertThat(ValidatorUtil.formatMessages(validate), validate.size(), is(2));
+        assertThat(validate).as(ValidatorUtil.formatMessages(validate)).hasSize(2);
         assertTrue(validate.stream().anyMatch(p -> p.getMessageType().equals(DMNMessageType.REQ_NOT_FOUND)));
     }
 
@@ -209,7 +207,7 @@ public class ValidatorDecisionTest extends AbstractValidatorTest {
                                "https://github.com/kiegroup/kie-dmn",
                                "DECISION_PERF_INDICATOR_WRONG_TYPE"),
                 VALIDATE_MODEL, VALIDATE_COMPILATION);
-        assertThat(ValidatorUtil.formatMessages(validate), validate.size(), is(2));
+        assertThat(validate).as(ValidatorUtil.formatMessages(validate)).hasSize(2);
         assertTrue(validate.stream().anyMatch(p -> p.getMessageType().equals(DMNMessageType.REQ_NOT_FOUND)));
     }
 
@@ -217,7 +215,7 @@ public class ValidatorDecisionTest extends AbstractValidatorTest {
     public void testDECISION_DECISION_MAKER_WRONG_TYPE_ReaderInput() throws IOException {
         try (final Reader reader = getReader("decision/DECISION_DECISION_MAKER_WRONG_TYPE.dmn")) {
             final List<DMNMessage> validate = validator.validate(reader, VALIDATE_SCHEMA, VALIDATE_MODEL, VALIDATE_COMPILATION);
-            assertThat(ValidatorUtil.formatMessages(validate), validate.size(), is(2));
+            assertThat(validate).as(ValidatorUtil.formatMessages(validate)).hasSize(2);
             assertTrue(validate.stream().anyMatch(p -> p.getMessageType().equals(DMNMessageType.REQ_NOT_FOUND)));
         }
     }
@@ -226,7 +224,7 @@ public class ValidatorDecisionTest extends AbstractValidatorTest {
     public void testDECISION_DECISION_MAKER_WRONG_TYPE_FileInput() {
         final List<DMNMessage> validate = validator.validate(
                 getFile("decision/DECISION_DECISION_MAKER_WRONG_TYPE.dmn"), VALIDATE_SCHEMA, VALIDATE_MODEL, VALIDATE_COMPILATION);
-        assertThat(ValidatorUtil.formatMessages(validate), validate.size(), is(2));
+        assertThat(validate).as(ValidatorUtil.formatMessages(validate)).hasSize(2);
         assertTrue(validate.stream().anyMatch(p -> p.getMessageType().equals(DMNMessageType.REQ_NOT_FOUND)));
     }
 
@@ -237,7 +235,7 @@ public class ValidatorDecisionTest extends AbstractValidatorTest {
                                "https://github.com/kiegroup/kie-dmn",
                                "DECISION_DECISION_MAKER_WRONG_TYPE"),
                 VALIDATE_MODEL, VALIDATE_COMPILATION);
-        assertThat(ValidatorUtil.formatMessages(validate), validate.size(), is(2));
+        assertThat(validate).as(ValidatorUtil.formatMessages(validate)).hasSize(2);
         assertTrue(validate.stream().anyMatch(p -> p.getMessageType().equals(DMNMessageType.REQ_NOT_FOUND)));
     }
 
@@ -245,7 +243,7 @@ public class ValidatorDecisionTest extends AbstractValidatorTest {
     public void testDECISION_DECISION_OWNER_WRONG_TYPE_ReaderInput() throws IOException {
         try (final Reader reader = getReader("decision/DECISION_DECISION_OWNER_WRONG_TYPE.dmn")) {
             final List<DMNMessage> validate = validator.validate(reader, VALIDATE_SCHEMA, VALIDATE_MODEL, VALIDATE_COMPILATION);
-            assertThat(ValidatorUtil.formatMessages(validate), validate.size(), is(2));
+            assertThat(validate).as(ValidatorUtil.formatMessages(validate)).hasSize(2);
             assertTrue(validate.stream().anyMatch(p -> p.getMessageType().equals(DMNMessageType.REQ_NOT_FOUND)));
         }
     }
@@ -254,7 +252,7 @@ public class ValidatorDecisionTest extends AbstractValidatorTest {
     public void testDECISION_DECISION_OWNER_WRONG_TYPE_FileInput() {
         final List<DMNMessage> validate = validator.validate(
                 getFile("decision/DECISION_DECISION_OWNER_WRONG_TYPE.dmn"), VALIDATE_SCHEMA, VALIDATE_MODEL, VALIDATE_COMPILATION);
-        assertThat(ValidatorUtil.formatMessages(validate), validate.size(), is(2));
+        assertThat(validate).as(ValidatorUtil.formatMessages(validate)).hasSize(2);
         assertTrue(validate.stream().anyMatch(p -> p.getMessageType().equals(DMNMessageType.REQ_NOT_FOUND)));
     }
 
@@ -265,7 +263,7 @@ public class ValidatorDecisionTest extends AbstractValidatorTest {
                                "https://github.com/kiegroup/kie-dmn",
                                "DECISION_DECISION_MAKER_WRONG_TYPE"),
                 VALIDATE_MODEL, VALIDATE_COMPILATION);
-        assertThat(ValidatorUtil.formatMessages(validate), validate.size(), is(2));
+        assertThat(validate).as(ValidatorUtil.formatMessages(validate)).hasSize(2);
         assertTrue(validate.stream().anyMatch(p -> p.getMessageType().equals(DMNMessageType.REQ_NOT_FOUND)));
     }
 
@@ -273,7 +271,7 @@ public class ValidatorDecisionTest extends AbstractValidatorTest {
     public void testDECISION_CYCLIC_DEPENDENCY_ReaderInput() throws IOException {
         try (final Reader reader = getReader("decision/DECISION_CYCLIC_DEPENDENCY.dmn")) {
             final List<DMNMessage> validate = validator.validate( reader, VALIDATE_SCHEMA, VALIDATE_MODEL, VALIDATE_COMPILATION );
-            assertThat(ValidatorUtil.formatMessages(validate), validate.size(), is(2));
+            assertThat(validate).as(ValidatorUtil.formatMessages(validate)).hasSize(2);
             assertTrue(validate.stream().anyMatch(p -> p.getMessageType().equals(DMNMessageType.REQ_NOT_FOUND)));
         }
     }
@@ -281,7 +279,7 @@ public class ValidatorDecisionTest extends AbstractValidatorTest {
     @Test
     public void testDECISION_CYCLIC_DEPENDENCY_FileInput() {
         final List<DMNMessage> validate = validator.validate( getFile("decision/DECISION_CYCLIC_DEPENDENCY.dmn"), VALIDATE_SCHEMA, VALIDATE_MODEL, VALIDATE_COMPILATION );
-        assertThat(ValidatorUtil.formatMessages(validate), validate.size(), is(2));
+        assertThat(validate).as(ValidatorUtil.formatMessages(validate)).hasSize(2);
         assertTrue(validate.stream().anyMatch(p -> p.getMessageType().equals(DMNMessageType.REQ_NOT_FOUND)));
     }
 
@@ -292,7 +290,7 @@ public class ValidatorDecisionTest extends AbstractValidatorTest {
                                "https://github.com/kiegroup/kie-dmn",
                                "DECISION_CYCLIC_DEPENDENCY"),
                 VALIDATE_MODEL, VALIDATE_COMPILATION );
-        assertThat(ValidatorUtil.formatMessages(validate), validate.size(), is(2));
+        assertThat(validate).as(ValidatorUtil.formatMessages(validate)).hasSize(2);
         assertTrue(validate.stream().anyMatch(p -> p.getMessageType().equals(DMNMessageType.REQ_NOT_FOUND)));
     }
 
@@ -300,7 +298,7 @@ public class ValidatorDecisionTest extends AbstractValidatorTest {
     public void testDECISION_CYCLIC_DEPENDENCY_SELF_REFERENCE_ReaderInput() throws IOException {
         try (final Reader reader = getReader("decision/DECISION_CYCLIC_DEPENDENCY_SELF_REFERENCE.dmn")) {
             final List<DMNMessage> validate = validator.validate( reader, VALIDATE_SCHEMA, VALIDATE_MODEL, VALIDATE_COMPILATION );
-            assertThat(ValidatorUtil.formatMessages(validate), validate.size(), is(1));
+            assertThat(validate).as(ValidatorUtil.formatMessages(validate)).hasSize(1);
             assertTrue(validate.stream().anyMatch(p -> p.getMessageType().equals(DMNMessageType.REQ_NOT_FOUND)));
         }
     }
@@ -308,7 +306,7 @@ public class ValidatorDecisionTest extends AbstractValidatorTest {
     @Test
     public void testDECISION_CYCLIC_DEPENDENCY_SELF_REFERENCE_FileInput() {
         final List<DMNMessage> validate = validator.validate( getFile("decision/DECISION_CYCLIC_DEPENDENCY_SELF_REFERENCE.dmn"), VALIDATE_SCHEMA, VALIDATE_MODEL, VALIDATE_COMPILATION );
-        assertThat(ValidatorUtil.formatMessages(validate), validate.size(), is(1));
+        assertThat(validate).as(ValidatorUtil.formatMessages(validate)).hasSize(1);
         assertTrue(validate.stream().anyMatch(p -> p.getMessageType().equals(DMNMessageType.REQ_NOT_FOUND)));
     }
 
@@ -319,7 +317,7 @@ public class ValidatorDecisionTest extends AbstractValidatorTest {
                                "https://github.com/kiegroup/kie-dmn",
                                "DECISION_CYCLIC_DEPENDENCY_SELF_REFERENCE"),
                 VALIDATE_MODEL, VALIDATE_COMPILATION );
-        assertThat(ValidatorUtil.formatMessages(validate), validate.size(), is(1));
+        assertThat(validate).as(ValidatorUtil.formatMessages(validate)).hasSize(1);
         assertTrue(validate.stream().anyMatch(p -> p.getMessageType().equals(DMNMessageType.REQ_NOT_FOUND)));
     }
 
@@ -327,14 +325,14 @@ public class ValidatorDecisionTest extends AbstractValidatorTest {
     public void testDECISION_DEADLY_DIAMOND_ReaderInput() throws IOException {
         try (final Reader reader = getReader("decision/DECISION_DEADLY_DIAMOND.dmn")) {
             final List<DMNMessage> validate = validator.validate( reader, VALIDATE_SCHEMA, VALIDATE_MODEL, VALIDATE_COMPILATION );
-            assertThat(ValidatorUtil.formatMessages(validate), validate.size(), is(0));
+            assertThat(validate).as(ValidatorUtil.formatMessages(validate)).hasSize(0);
         }
     }
 
     @Test
     public void testDECISION_DEADLY_DIAMOND_FileInput() {
         final List<DMNMessage> validate = validator.validate( getFile("decision/DECISION_DEADLY_DIAMOND.dmn"), VALIDATE_SCHEMA, VALIDATE_MODEL, VALIDATE_COMPILATION );
-        assertThat(ValidatorUtil.formatMessages(validate), validate.size(), is(0));
+        assertThat(validate).as(ValidatorUtil.formatMessages(validate)).hasSize(0);
     }
 
     @Test
@@ -344,21 +342,21 @@ public class ValidatorDecisionTest extends AbstractValidatorTest {
                                "https://github.com/kiegroup/kie-dmn",
                                "DECISION_DEADLY_DIAMOND"),
                 VALIDATE_MODEL, VALIDATE_COMPILATION );
-        assertThat(ValidatorUtil.formatMessages(validate), validate.size(), is(0));
+        assertThat(validate).as(ValidatorUtil.formatMessages(validate)).hasSize(0);
     }
 
     @Test
     public void testDECISION_DEADLY_KITE_ReaderInput() throws IOException {
         try (final Reader reader = getReader("decision/DECISION_DEADLY_KITE.dmn")) {
             final List<DMNMessage> validate = validator.validate( reader, VALIDATE_SCHEMA, VALIDATE_MODEL, VALIDATE_COMPILATION );
-            assertThat(ValidatorUtil.formatMessages(validate), validate.size(), is(0));
+            assertThat(validate).as(ValidatorUtil.formatMessages(validate)).hasSize(0);
         }
     }
 
     @Test
     public void testDECISION_DEADLY_KITE_FileInput() {
         final List<DMNMessage> validate = validator.validate( getFile("decision/DECISION_DEADLY_KITE.dmn"), VALIDATE_SCHEMA, VALIDATE_MODEL, VALIDATE_COMPILATION );
-        assertThat(ValidatorUtil.formatMessages(validate), validate.size(), is(0));
+        assertThat(validate).as(ValidatorUtil.formatMessages(validate)).hasSize(0);
     }
 
     @Test
@@ -368,14 +366,14 @@ public class ValidatorDecisionTest extends AbstractValidatorTest {
                                "https://github.com/kiegroup/kie-dmn",
                                "DECISION_DEADLY_KITE"),
                 VALIDATE_MODEL, VALIDATE_COMPILATION );
-        assertThat(ValidatorUtil.formatMessages(validate), validate.size(), is(0));
+        assertThat(validate).as(ValidatorUtil.formatMessages(validate)).hasSize(0);
     }
 
     @Test
     public void testDECISION_MISSING_REQ_ReaderInput() throws IOException { // ELEMREF_MISSING
         try (final Reader reader = getReader("decision/DECISION_MISSING_REQ.dmn")) {
             final List<DMNMessage> validate = validator.validate(reader, VALIDATE_SCHEMA, VALIDATE_MODEL);
-            assertThat(ValidatorUtil.formatMessages(validate), validate.size(), is(1));
+            assertThat(validate).as(ValidatorUtil.formatMessages(validate)).hasSize(1);
             assertTrue(validate.stream().anyMatch(p -> p.getMessageType().equals(DMNMessageType.REQ_NOT_FOUND)));
         }
     }
@@ -383,7 +381,7 @@ public class ValidatorDecisionTest extends AbstractValidatorTest {
     @Test
     public void testDECISION_MISSING_REQ_FileInput() {
         final List<DMNMessage> validate = validator.validate( getFile("decision/DECISION_MISSING_REQ.dmn"), VALIDATE_SCHEMA, VALIDATE_MODEL );
-        assertThat(ValidatorUtil.formatMessages(validate), validate.size(), is(1));
+        assertThat(validate).as(ValidatorUtil.formatMessages(validate)).hasSize(1);
         assertTrue(validate.stream().anyMatch(p -> p.getMessageType().equals(DMNMessageType.REQ_NOT_FOUND)));
     }
 
@@ -394,7 +392,7 @@ public class ValidatorDecisionTest extends AbstractValidatorTest {
                                "https://github.com/kiegroup/kie-dmn",
                                "DECISION_MISSING_REQ"),
                 VALIDATE_MODEL );
-        assertThat(ValidatorUtil.formatMessages(validate), validate.size(), is(1));
+        assertThat(validate).as(ValidatorUtil.formatMessages(validate)).hasSize(1);
         assertTrue(validate.stream().anyMatch(p -> p.getMessageType().equals(DMNMessageType.REQ_NOT_FOUND)));
     }
     
@@ -403,13 +401,13 @@ public class ValidatorDecisionTest extends AbstractValidatorTest {
         // DROOLS-6590 DMN composite output on DT Collect with operators - this is beyond the spec.
         DMNRuntime runtime = DMNRuntimeUtil.createRuntime("multipleOutputsCollectDT.dmn", DMNRuntimeTest.class);
         DMNModel dmnModel = runtime.getModel("https://kiegroup.org/dmn/_943A3581-5FD1-4BCF-9A52-AC7242CC451C", "multipleOutputsCollectDT");
-        assertThat(dmnModel, notNullValue());
+        assertThat(dmnModel).isNotNull();
 
         Definitions definitions = dmnModel.getDefinitions();
-        assertThat(definitions, notNullValue());
+        assertThat(definitions).isNotNull();
 
         List<DMNMessage> validate = DMNValidatorFactory.newValidator().validate(definitions, VALIDATE_MODEL, VALIDATE_COMPILATION);
-        assertThat(ValidatorUtil.formatMessages(validate), validate.size(), is(1));
+        assertThat(validate).as(ValidatorUtil.formatMessages(validate)).hasSize(1);
         assertTrue(ValidatorUtil.formatMessages(validate), validate.stream()
                    .allMatch(p -> p.getLevel() == Level.WARNING && 
                        p.getText().contains("Collect with Operator for compound outputs")));

--- a/kie-dmn/kie-dmn-validation/src/test/java/org/kie/dmn/validation/ValidatorImportTest.java
+++ b/kie-dmn/kie-dmn-validation/src/test/java/org/kie/dmn/validation/ValidatorImportTest.java
@@ -34,15 +34,11 @@ import org.kie.dmn.core.api.DMNFactory;
 import org.kie.dmn.core.decisionservices.DMNDecisionServicesTest;
 import org.kie.dmn.core.util.DMNRuntimeUtil;
 import org.kie.dmn.model.api.DMNElementReference;
-import org.kie.dmn.model.api.Definitions;
 import org.kie.dmn.validation.DMNValidator.Validation;
-import org.kie.dmn.validation.DMNValidator.ValidatorBuilder.ValidatorImportReaderResolver;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import static org.hamcrest.CoreMatchers.is;
-import static org.hamcrest.CoreMatchers.notNullValue;
-import static org.hamcrest.MatcherAssert.assertThat;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.Assert.assertTrue;
 import static org.kie.dmn.core.util.DynamicTypeUtils.entry;
 import static org.kie.dmn.core.util.DynamicTypeUtils.mapOf;
@@ -56,14 +52,14 @@ public class ValidatorImportTest extends AbstractValidatorTest {
     public void testBaseModelOK() {
         DMNRuntime runtime = DMNRuntimeUtil.createRuntimeWithAdditionalResources("import/Base-model.dmn", this.getClass(), "import/Import-base-model.dmn");
         DMNModel dmnModel = runtime.getModel("http://www.trisotech.com/dmn/definitions/_b33fa7d9-f501-423b-afa8-15ded7e7f493", "Import base model");
-        assertThat(dmnModel, notNullValue());
-        assertThat(DMNRuntimeUtil.formatMessages(dmnModel.getMessages()), dmnModel.hasErrors(), is(false));
+        assertThat(dmnModel).isNotNull();
+        assertThat(dmnModel.hasErrors()).as(DMNRuntimeUtil.formatMessages(dmnModel.getMessages())).isFalse();
 
         DMNContext context = DMNFactory.newContext();
         context.set("Customer", mapOf(entry("full name", "John Doe"), entry("age", 47)));
         DMNResult dmnResult = runtime.evaluateAll(dmnModel, context);
         LOG.debug("{}", dmnResult);
-        assertThat(DMNRuntimeUtil.formatMessages(dmnResult.getMessages()), dmnResult.hasErrors(), is(false));
+        assertThat(dmnResult.hasErrors()).as(DMNRuntimeUtil.formatMessages(dmnResult.getMessages())).isFalse();
     }
 
     @Test
@@ -74,7 +70,7 @@ public class ValidatorImportTest extends AbstractValidatorTest {
                                                                       Validation.VALIDATE_MODEL,
                                                                       Validation.VALIDATE_COMPILATION)
                                                        .theseModels(reader0, reader1);
-            assertThat(ValidatorUtil.formatMessages(messages), messages.size(), is(0));
+            assertThat(messages).as(ValidatorUtil.formatMessages(messages)).hasSize(0);
         }
     }
 
@@ -85,7 +81,7 @@ public class ValidatorImportTest extends AbstractValidatorTest {
                                                                   Validation.VALIDATE_COMPILATION)
                                                    .theseModels(getFile("import/Import-base-model.dmn"), // switch order for DROOLS-2936 
                                                                 getFile("import/Base-model.dmn"));
-        assertThat(ValidatorUtil.formatMessages(messages), messages.size(), is(0));
+        assertThat(messages).as(ValidatorUtil.formatMessages(messages)).hasSize(0);
     }
 
     @Test
@@ -93,7 +89,7 @@ public class ValidatorImportTest extends AbstractValidatorTest {
         final List<DMNMessage> messages = validator.validateUsing(Validation.VALIDATE_MODEL)
                                                    .theseModels(getFile("import/Import-base-model-modelnameattribute.dmn"), // DROOLS-2938
                                                                 getFile("import/Base-model.dmn"));
-        assertThat(ValidatorUtil.formatMessages(messages), messages.size(), is(0));
+        assertThat(messages).as(ValidatorUtil.formatMessages(messages)).hasSize(0);
     }
 
     @Test
@@ -107,7 +103,7 @@ public class ValidatorImportTest extends AbstractValidatorTest {
                                                                 getDefinitions(Arrays.asList("import/Base-model.dmn", "import/Import-base-model.dmn"),
                                                                                "http://www.trisotech.com/dmn/definitions/_b33fa7d9-f501-423b-afa8-15ded7e7f493",
                                                                                "Import base model"));
-        assertThat(ValidatorUtil.formatMessages(messages), messages.size(), is(0));
+        assertThat(messages).as(ValidatorUtil.formatMessages(messages)).hasSize(0);
     }
 
     @Test
@@ -116,7 +112,7 @@ public class ValidatorImportTest extends AbstractValidatorTest {
                 final Reader reader1 = getReader("import/Wrong-Import-base-model.dmn");) {
             final List<DMNMessage> messages = validator.validateUsing(Validation.VALIDATE_MODEL)
                                                        .theseModels(reader0, reader1);
-            assertThat(ValidatorUtil.formatMessages(messages), messages.size(), is(1));
+            assertThat(messages).as(ValidatorUtil.formatMessages(messages)).hasSize(1);
             assertTrue(messages.stream().anyMatch(p -> p.getMessageType().equals(DMNMessageType.REQ_NOT_FOUND) &&
                                                        p.getSourceReference() instanceof DMNElementReference &&
                                                        ((DMNElementReference) p.getSourceReference()).getHref()
@@ -129,7 +125,7 @@ public class ValidatorImportTest extends AbstractValidatorTest {
         final List<DMNMessage> messages = validator.validateUsing(Validation.VALIDATE_MODEL)
                                                    .theseModels(getFile("import/Base-model.dmn"),
                                                                 getFile("import/Wrong-Import-base-model.dmn"));
-        assertThat(ValidatorUtil.formatMessages(messages), messages.size(), is(1));
+        assertThat(messages).as(ValidatorUtil.formatMessages(messages)).hasSize(1);
         assertTrue(messages.stream().anyMatch(p -> p.getMessageType().equals(DMNMessageType.REQ_NOT_FOUND) &&
                                                    p.getSourceReference() instanceof DMNElementReference &&
                                                    ((DMNElementReference) p.getSourceReference()).getHref()
@@ -181,18 +177,18 @@ public class ValidatorImportTest extends AbstractValidatorTest {
                                                                   Validation.VALIDATE_COMPILATION)
                                                    .theseModels(getFile("import/DROOLS-4187a.dmn"),
                                                                 getFile("import/DROOLS-4187b.dmn"));
-        assertThat(ValidatorUtil.formatMessages(messages), messages.size(), is(0));
+        assertThat(messages).as(ValidatorUtil.formatMessages(messages)).hasSize(0);
 
         DMNRuntime runtime = DMNRuntimeUtil.createRuntimeWithAdditionalResources("import/DROOLS-4187a.dmn", this.getClass(), "import/DROOLS-4187b.dmn");
         DMNModel dmnModel = runtime.getModel("https://kiegroup.org/dmn/_D0CFBAE7-4EBD-4FA5-A15F-DA00581ADA0B", "b");
-        assertThat(dmnModel, notNullValue());
-        assertThat(DMNRuntimeUtil.formatMessages(dmnModel.getMessages()), dmnModel.hasErrors(), is(false));
+        assertThat(dmnModel).isNotNull();
+        assertThat(dmnModel.hasErrors()).as(DMNRuntimeUtil.formatMessages(dmnModel.getMessages())).isFalse();
 
         DMNContext context = DMNFactory.newContext();
         DMNResult dmnResult = runtime.evaluateAll(dmnModel, context);
         LOG.debug("{}", dmnResult);
-        assertThat(DMNRuntimeUtil.formatMessages(dmnResult.getMessages()), dmnResult.hasErrors(), is(false));
-        assertThat(dmnResult.getDecisionResultByName("aaa").getResult(), is(new BigDecimal(2)));
+        assertThat(dmnResult.hasErrors()).as(DMNRuntimeUtil.formatMessages(dmnResult.getMessages())).isFalse();
+        assertThat(dmnResult.getDecisionResultByName("aaa").getResult()).isEqualTo(new BigDecimal(2));
     }
     
     @Test
@@ -200,7 +196,7 @@ public class ValidatorImportTest extends AbstractValidatorTest {
         final List<DMNMessage> messages = validator.validateUsing(Validation.VALIDATE_MODEL, Validation.VALIDATE_COMPILATION)
                                                    .theseModels(getReader("myHelloDS.dmn", DMNDecisionServicesTest.class),
                                                                 getReader("importingMyHelloDSbkmBoxedInvocation.dmn", DMNDecisionServicesTest.class));
-        assertThat(ValidatorUtil.formatMessages(messages), messages.size(), is(0));
+        assertThat(messages).as(ValidatorUtil.formatMessages(messages)).hasSize(0);
     }
     
     @Test
@@ -224,7 +220,7 @@ public class ValidatorImportTest extends AbstractValidatorTest {
         final List<DMNMessage> messages = validator.validateUsing(Validation.VALIDATE_MODEL, Validation.VALIDATE_COMPILATION)
                                                    .theseModels(getReader("myHelloDS.dmn", DMNDecisionServicesTest.class),
                                                                 getReader("import/importingMyHelloDSbkmBoxedInvocation_okItemDefName.dmn"));
-        assertThat(ValidatorUtil.formatMessages(messages), messages.size(), is(0));
+        assertThat(messages).as(ValidatorUtil.formatMessages(messages)).hasSize(0);
     }
     
     @Test

--- a/kie-dmn/kie-dmn-validation/src/test/java/org/kie/dmn/validation/ValidatorInformationRequirementTest.java
+++ b/kie-dmn/kie-dmn-validation/src/test/java/org/kie/dmn/validation/ValidatorInformationRequirementTest.java
@@ -24,8 +24,7 @@ import org.junit.Test;
 import org.kie.dmn.api.core.DMNMessage;
 import org.kie.dmn.api.core.DMNMessageType;
 
-import static org.hamcrest.CoreMatchers.is;
-import static org.hamcrest.MatcherAssert.assertThat;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.Assert.assertTrue;
 import static org.kie.dmn.validation.DMNValidator.Validation.VALIDATE_COMPILATION;
 import static org.kie.dmn.validation.DMNValidator.Validation.VALIDATE_MODEL;
@@ -39,7 +38,7 @@ public class ValidatorInformationRequirementTest extends AbstractValidatorTest {
             final List<DMNMessage> validate = validator.validate(
                     reader,
                     VALIDATE_SCHEMA, VALIDATE_MODEL, VALIDATE_COMPILATION);
-            assertThat( ValidatorUtil.formatMessages( validate ), validate.size(), is( 2 ) );
+            assertThat(validate).as(ValidatorUtil.formatMessages(validate)).hasSize(2);
             assertTrue( validate.stream().anyMatch( p -> p.getMessageType().equals( DMNMessageType.MISSING_EXPRESSION ) ) );
             assertTrue( validate.stream().anyMatch( p -> p.getMessageType().equals( DMNMessageType.REQ_NOT_FOUND ) ) );
         }
@@ -50,7 +49,7 @@ public class ValidatorInformationRequirementTest extends AbstractValidatorTest {
         final List<DMNMessage> validate = validator.validate(
                 getFile( "informationrequirement/INFOREQ_MISSING_INPUT.dmn" ),
                 VALIDATE_SCHEMA, VALIDATE_MODEL, VALIDATE_COMPILATION);
-        assertThat( ValidatorUtil.formatMessages( validate ), validate.size(), is( 2 ) );
+        assertThat(validate).as(ValidatorUtil.formatMessages(validate)).hasSize(2);
         assertTrue( validate.stream().anyMatch( p -> p.getMessageType().equals( DMNMessageType.MISSING_EXPRESSION ) ) );
         assertTrue( validate.stream().anyMatch( p -> p.getMessageType().equals( DMNMessageType.REQ_NOT_FOUND ) ) );
     }
@@ -62,7 +61,7 @@ public class ValidatorInformationRequirementTest extends AbstractValidatorTest {
                                 "https://github.com/kiegroup/kie-dmn",
                                 "INFOREQ_MISSING_INPUT"),
                 VALIDATE_MODEL, VALIDATE_COMPILATION);
-        assertThat( ValidatorUtil.formatMessages( validate ), validate.size(), is( 2 ) );
+        assertThat(validate).as(ValidatorUtil.formatMessages(validate)).hasSize(2);
         assertTrue( validate.stream().anyMatch( p -> p.getMessageType().equals( DMNMessageType.MISSING_EXPRESSION ) ) );
         assertTrue( validate.stream().anyMatch( p -> p.getMessageType().equals( DMNMessageType.REQ_NOT_FOUND ) ) );
     }
@@ -73,7 +72,7 @@ public class ValidatorInformationRequirementTest extends AbstractValidatorTest {
             final List<DMNMessage> validate = validator.validate(
                     reader,
                     VALIDATE_SCHEMA, VALIDATE_MODEL, VALIDATE_COMPILATION);
-            assertThat( ValidatorUtil.formatMessages( validate ), validate.size(), is( 2 ) );
+            assertThat(validate).as(ValidatorUtil.formatMessages(validate)).hasSize(2);
             assertTrue( validate.stream().anyMatch( p -> p.getMessageType().equals( DMNMessageType.MISSING_EXPRESSION ) ) );
             assertTrue( validate.stream().anyMatch( p -> p.getMessageType().equals( DMNMessageType.REQ_NOT_FOUND ) ) );
         }
@@ -84,7 +83,7 @@ public class ValidatorInformationRequirementTest extends AbstractValidatorTest {
         final List<DMNMessage> validate = validator.validate(
                 getFile( "informationrequirement/INFOREQ_INPUT_NOT_INPUTDATA.dmn" ),
                 VALIDATE_SCHEMA, VALIDATE_MODEL, VALIDATE_COMPILATION);
-        assertThat( ValidatorUtil.formatMessages( validate ), validate.size(), is( 2 ) );
+        assertThat(validate).as(ValidatorUtil.formatMessages(validate)).hasSize(2);
         assertTrue( validate.stream().anyMatch( p -> p.getMessageType().equals( DMNMessageType.MISSING_EXPRESSION ) ) );
         assertTrue( validate.stream().anyMatch( p -> p.getMessageType().equals( DMNMessageType.REQ_NOT_FOUND ) ) );
     }
@@ -96,7 +95,7 @@ public class ValidatorInformationRequirementTest extends AbstractValidatorTest {
                                 "https://github.com/kiegroup/kie-dmn",
                                 "INFOREQ_INPUT_NOT_INPUTDATA"),
                 VALIDATE_MODEL, VALIDATE_COMPILATION);
-        assertThat( ValidatorUtil.formatMessages( validate ), validate.size(), is( 2 ) );
+        assertThat(validate).as(ValidatorUtil.formatMessages(validate)).hasSize(2);
         assertTrue( validate.stream().anyMatch( p -> p.getMessageType().equals( DMNMessageType.MISSING_EXPRESSION ) ) );
         assertTrue( validate.stream().anyMatch( p -> p.getMessageType().equals( DMNMessageType.REQ_NOT_FOUND ) ) );
     }
@@ -107,7 +106,7 @@ public class ValidatorInformationRequirementTest extends AbstractValidatorTest {
             final List<DMNMessage> validate = validator.validate(
                     reader,
                     VALIDATE_SCHEMA, VALIDATE_MODEL, VALIDATE_COMPILATION);
-            assertThat( ValidatorUtil.formatMessages( validate ), validate.size(), is( 2 ) );
+            assertThat(validate).as(ValidatorUtil.formatMessages(validate)).hasSize(2);
             assertTrue( validate.stream().anyMatch( p -> p.getMessageType().equals( DMNMessageType.MISSING_EXPRESSION ) ) );
             assertTrue( validate.stream().anyMatch( p -> p.getMessageType().equals( DMNMessageType.REQ_NOT_FOUND ) ) );
         }
@@ -118,7 +117,7 @@ public class ValidatorInformationRequirementTest extends AbstractValidatorTest {
         final List<DMNMessage> validate = validator.validate(
                 getFile( "informationrequirement/INFOREQ_MISSING_DECISION.dmn" ),
                 VALIDATE_SCHEMA, VALIDATE_MODEL, VALIDATE_COMPILATION);
-        assertThat( ValidatorUtil.formatMessages( validate ), validate.size(), is( 2 ) );
+        assertThat(validate).as(ValidatorUtil.formatMessages(validate)).hasSize(2);
         assertTrue( validate.stream().anyMatch( p -> p.getMessageType().equals( DMNMessageType.MISSING_EXPRESSION ) ) );
         assertTrue( validate.stream().anyMatch( p -> p.getMessageType().equals( DMNMessageType.REQ_NOT_FOUND ) ) );
     }
@@ -130,7 +129,7 @@ public class ValidatorInformationRequirementTest extends AbstractValidatorTest {
                                 "https://github.com/kiegroup/kie-dmn",
                                 "INFOREQ_MISSING_DECISION"),
                 VALIDATE_MODEL, VALIDATE_COMPILATION);
-        assertThat( ValidatorUtil.formatMessages( validate ), validate.size(), is( 2 ) );
+        assertThat(validate).as(ValidatorUtil.formatMessages(validate)).hasSize(2);
         assertTrue( validate.stream().anyMatch( p -> p.getMessageType().equals( DMNMessageType.MISSING_EXPRESSION ) ) );
         assertTrue( validate.stream().anyMatch( p -> p.getMessageType().equals( DMNMessageType.REQ_NOT_FOUND ) ) );
     }
@@ -141,7 +140,7 @@ public class ValidatorInformationRequirementTest extends AbstractValidatorTest {
             final List<DMNMessage> validate = validator.validate(
                     reader,
                     VALIDATE_SCHEMA, VALIDATE_MODEL, VALIDATE_COMPILATION);
-            assertThat( ValidatorUtil.formatMessages( validate ), validate.size(), is( 2 ) );
+            assertThat(validate).as(ValidatorUtil.formatMessages(validate)).hasSize(2);
             assertTrue( validate.stream().anyMatch( p -> p.getMessageType().equals( DMNMessageType.MISSING_EXPRESSION ) ) );
             assertTrue( validate.stream().anyMatch( p -> p.getMessageType().equals( DMNMessageType.REQ_NOT_FOUND ) ) );
         }
@@ -152,7 +151,7 @@ public class ValidatorInformationRequirementTest extends AbstractValidatorTest {
         final List<DMNMessage> validate = validator.validate(
                 getFile( "informationrequirement/INFOREQ_DECISION_NOT_DECISION.dmn" ),
                 VALIDATE_SCHEMA, VALIDATE_MODEL, VALIDATE_COMPILATION);
-        assertThat( ValidatorUtil.formatMessages( validate ), validate.size(), is( 2 ) );
+        assertThat(validate).as(ValidatorUtil.formatMessages(validate)).hasSize(2);
         assertTrue( validate.stream().anyMatch( p -> p.getMessageType().equals( DMNMessageType.MISSING_EXPRESSION ) ) );
         assertTrue( validate.stream().anyMatch( p -> p.getMessageType().equals( DMNMessageType.REQ_NOT_FOUND ) ) );
     }
@@ -164,7 +163,7 @@ public class ValidatorInformationRequirementTest extends AbstractValidatorTest {
                                 "https://github.com/kiegroup/kie-dmn",
                                 "INFOREQ_DECISION_NOT_DECISION"),
                 VALIDATE_MODEL, VALIDATE_COMPILATION);
-        assertThat( ValidatorUtil.formatMessages( validate ), validate.size(), is( 2 ) );
+        assertThat(validate).as(ValidatorUtil.formatMessages(validate)).hasSize(2);
         assertTrue( validate.stream().anyMatch( p -> p.getMessageType().equals( DMNMessageType.MISSING_EXPRESSION ) ) );
         assertTrue( validate.stream().anyMatch( p -> p.getMessageType().equals( DMNMessageType.REQ_NOT_FOUND ) ) );
     }

--- a/kie-dmn/kie-dmn-validation/src/test/java/org/kie/dmn/validation/ValidatorKnowledgeSourceTest.java
+++ b/kie-dmn/kie-dmn-validation/src/test/java/org/kie/dmn/validation/ValidatorKnowledgeSourceTest.java
@@ -24,8 +24,7 @@ import org.junit.Test;
 import org.kie.dmn.api.core.DMNMessage;
 import org.kie.dmn.api.core.DMNMessageType;
 
-import static org.hamcrest.CoreMatchers.is;
-import static org.hamcrest.MatcherAssert.assertThat;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.Assert.assertTrue;
 import static org.kie.dmn.validation.DMNValidator.Validation.VALIDATE_COMPILATION;
 import static org.kie.dmn.validation.DMNValidator.Validation.VALIDATE_MODEL;
@@ -39,7 +38,7 @@ public class ValidatorKnowledgeSourceTest extends AbstractValidatorTest {
             final List<DMNMessage> validate = validator.validate(
                     reader,
                     VALIDATE_SCHEMA, VALIDATE_MODEL, VALIDATE_COMPILATION);
-            assertThat( ValidatorUtil.formatMessages( validate ), validate.size(), is( 1 ) );
+            assertThat(validate).as(ValidatorUtil.formatMessages(validate)).hasSize(1);
             assertTrue( validate.stream().anyMatch( p -> p.getMessageType().equals( DMNMessageType.REQ_NOT_FOUND ) ) );
         }
     }
@@ -49,7 +48,7 @@ public class ValidatorKnowledgeSourceTest extends AbstractValidatorTest {
         final List<DMNMessage> validate = validator.validate(
                 getFile( "knowledgesource/KNOW_SOURCE_MISSING_OWNER.dmn" ),
                 VALIDATE_SCHEMA, VALIDATE_MODEL, VALIDATE_COMPILATION);
-        assertThat( ValidatorUtil.formatMessages( validate ), validate.size(), is( 1 ) );
+        assertThat(validate).as(ValidatorUtil.formatMessages(validate)).hasSize(1);
         assertTrue( validate.stream().anyMatch( p -> p.getMessageType().equals( DMNMessageType.REQ_NOT_FOUND ) ) );
     }
 
@@ -60,7 +59,7 @@ public class ValidatorKnowledgeSourceTest extends AbstractValidatorTest {
                                 "https://github.com/kiegroup/kie-dmn",
                                 "KNOW_SOURCE_MISSING_OWNER"),
                 VALIDATE_MODEL, VALIDATE_COMPILATION);
-        assertThat( ValidatorUtil.formatMessages( validate ), validate.size(), is( 1 ) );
+        assertThat(validate).as(ValidatorUtil.formatMessages(validate)).hasSize(1);
         assertTrue( validate.stream().anyMatch( p -> p.getMessageType().equals( DMNMessageType.REQ_NOT_FOUND ) ) );
     }
 
@@ -70,7 +69,7 @@ public class ValidatorKnowledgeSourceTest extends AbstractValidatorTest {
             final List<DMNMessage> validate = validator.validate(
                     reader,
                     VALIDATE_SCHEMA, VALIDATE_MODEL, VALIDATE_COMPILATION);
-            assertThat( ValidatorUtil.formatMessages( validate ), validate.size(), is( 3 ) );
+            assertThat(validate).as(ValidatorUtil.formatMessages(validate)).hasSize(3);
             assertTrue( validate.stream().anyMatch( p -> p.getMessageType().equals( DMNMessageType.REQ_NOT_FOUND ) ) );
         }
     }
@@ -80,7 +79,7 @@ public class ValidatorKnowledgeSourceTest extends AbstractValidatorTest {
         final List<DMNMessage> validate = validator.validate(
                 getFile( "knowledgesource/KNOW_SOURCE_OWNER_NOT_ORG_UNIT.dmn" ),
                 VALIDATE_SCHEMA, VALIDATE_MODEL, VALIDATE_COMPILATION);
-        assertThat( ValidatorUtil.formatMessages( validate ), validate.size(), is( 3 ) );
+        assertThat(validate).as(ValidatorUtil.formatMessages(validate)).hasSize(3);
         assertTrue( validate.stream().anyMatch( p -> p.getMessageType().equals( DMNMessageType.REQ_NOT_FOUND ) ) );
     }
 
@@ -91,7 +90,7 @@ public class ValidatorKnowledgeSourceTest extends AbstractValidatorTest {
                                 "https://github.com/kiegroup/kie-dmn",
                                 "KNOW_SOURCE_OWNER_NOT_ORG_UNIT"),
                 VALIDATE_MODEL, VALIDATE_COMPILATION);
-        assertThat( ValidatorUtil.formatMessages( validate ), validate.size(), is( 3 ) );
+        assertThat(validate).as(ValidatorUtil.formatMessages(validate)).hasSize(3);
         assertTrue( validate.stream().anyMatch( p -> p.getMessageType().equals( DMNMessageType.REQ_NOT_FOUND ) ) );
     }
 }

--- a/kie-dmn/kie-dmn-validation/src/test/java/org/kie/dmn/validation/ValidatorTypeRefTest.java
+++ b/kie-dmn/kie-dmn-validation/src/test/java/org/kie/dmn/validation/ValidatorTypeRefTest.java
@@ -24,8 +24,7 @@ import org.junit.Test;
 import org.kie.dmn.api.core.DMNMessage;
 import org.kie.dmn.api.core.DMNMessageType;
 
-import static org.hamcrest.CoreMatchers.is;
-import static org.hamcrest.MatcherAssert.assertThat;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.Assert.assertTrue;
 import static org.kie.dmn.validation.DMNValidator.Validation.VALIDATE_COMPILATION;
 import static org.kie.dmn.validation.DMNValidator.Validation.VALIDATE_MODEL;
@@ -39,7 +38,7 @@ public class ValidatorTypeRefTest extends AbstractValidatorTest {
             final List<DMNMessage> validate = validator.validate(
                     reader,
                     VALIDATE_SCHEMA, VALIDATE_MODEL, VALIDATE_COMPILATION);
-            assertThat(ValidatorUtil.formatMessages(validate), validate.size(), is(1));
+            assertThat(validate).as(ValidatorUtil.formatMessages(validate)).hasSize(1);
             assertTrue(validate.stream().anyMatch(p -> p.getMessageType().equals(DMNMessageType.TYPE_DEF_NOT_FOUND)));
         }
     }
@@ -49,7 +48,7 @@ public class ValidatorTypeRefTest extends AbstractValidatorTest {
         final List<DMNMessage> validate = validator.validate(
                 getFile("typeref/TYPEREF_NO_FEEL_TYPE.dmn"),
                 VALIDATE_SCHEMA, VALIDATE_MODEL, VALIDATE_COMPILATION);
-        assertThat(ValidatorUtil.formatMessages(validate), validate.size(), is(1));
+        assertThat(validate).as(ValidatorUtil.formatMessages(validate)).hasSize(1);
         assertTrue(validate.stream().anyMatch(p -> p.getMessageType().equals(DMNMessageType.TYPE_DEF_NOT_FOUND)));
     }
 
@@ -58,7 +57,7 @@ public class ValidatorTypeRefTest extends AbstractValidatorTest {
         final List<DMNMessage> validate = validator.validate(
                 getDefinitions("typeref/TYPEREF_NO_FEEL_TYPE.dmn", "https://github.com/kiegroup/kie-dmn", "TYPEREF_NO_FEEL_TYPE"),
                 VALIDATE_MODEL, VALIDATE_COMPILATION);
-        assertThat(ValidatorUtil.formatMessages(validate), validate.size(), is(1));
+        assertThat(validate).as(ValidatorUtil.formatMessages(validate)).hasSize(1);
         assertTrue(validate.stream().anyMatch(p -> p.getMessageType().equals(DMNMessageType.TYPE_DEF_NOT_FOUND)));
     }
 
@@ -68,7 +67,7 @@ public class ValidatorTypeRefTest extends AbstractValidatorTest {
             final List<DMNMessage> validate = validator.validate(
                     reader,
                     VALIDATE_SCHEMA, VALIDATE_MODEL, VALIDATE_COMPILATION);
-            assertThat(ValidatorUtil.formatMessages(validate), validate.size(), is(1));
+            assertThat(validate).as(ValidatorUtil.formatMessages(validate)).hasSize(1);
             assertTrue(validate.stream().anyMatch(p -> p.getMessageType().equals(DMNMessageType.TYPE_DEF_NOT_FOUND)));
         }
     }
@@ -78,7 +77,7 @@ public class ValidatorTypeRefTest extends AbstractValidatorTest {
         final List<DMNMessage> validate = validator.validate(
                 getFile("typeref/TYPEREF_NO_NS.dmn"),
                 VALIDATE_SCHEMA, VALIDATE_MODEL, VALIDATE_COMPILATION);
-        assertThat(ValidatorUtil.formatMessages(validate), validate.size(), is(1));
+        assertThat(validate).as(ValidatorUtil.formatMessages(validate)).hasSize(1);
         assertTrue(validate.stream().anyMatch(p -> p.getMessageType().equals(DMNMessageType.TYPE_DEF_NOT_FOUND)));
     }
 
@@ -87,7 +86,7 @@ public class ValidatorTypeRefTest extends AbstractValidatorTest {
         final List<DMNMessage> validate = validator.validate(
                 getDefinitions("typeref/TYPEREF_NO_NS.dmn", "https://github.com/kiegroup/kie-dmn", "TYPEREF_NO_NS"),
                 VALIDATE_MODEL, VALIDATE_COMPILATION);
-        assertThat(ValidatorUtil.formatMessages(validate), validate.size(), is(1));
+        assertThat(validate).as(ValidatorUtil.formatMessages(validate)).hasSize(1);
         assertTrue(validate.stream().anyMatch(p -> p.getMessageType().equals(DMNMessageType.TYPE_DEF_NOT_FOUND)));
     }
 
@@ -97,7 +96,7 @@ public class ValidatorTypeRefTest extends AbstractValidatorTest {
             final List<DMNMessage> validate = validator.validate(
                     reader,
                     VALIDATE_SCHEMA, VALIDATE_MODEL, VALIDATE_COMPILATION);
-            assertThat(ValidatorUtil.formatMessages(validate), validate.size(), is(2));
+            assertThat(validate).as(ValidatorUtil.formatMessages(validate)).hasSize(2);
             assertTrue(validate.stream().anyMatch(p -> p.getMessageType().equals(DMNMessageType.INVALID_NAME)));
             assertTrue(validate.stream().anyMatch(p -> p.getMessageType().equals(DMNMessageType.TYPE_DEF_NOT_FOUND)));
         }
@@ -108,7 +107,7 @@ public class ValidatorTypeRefTest extends AbstractValidatorTest {
         final List<DMNMessage> validate = validator.validate(
                 getFile("typeref/TYPEREF_NOT_FEEL_NOT_DEF.dmn"),
                 VALIDATE_SCHEMA, VALIDATE_MODEL, VALIDATE_COMPILATION);
-        assertThat(ValidatorUtil.formatMessages(validate), validate.size(), is(2));
+        assertThat(validate).as(ValidatorUtil.formatMessages(validate)).hasSize(2);
         assertTrue(validate.stream().anyMatch(p -> p.getMessageType().equals(DMNMessageType.INVALID_NAME)));
         assertTrue(validate.stream().anyMatch(p -> p.getMessageType().equals(DMNMessageType.TYPE_DEF_NOT_FOUND)));
     }
@@ -118,7 +117,7 @@ public class ValidatorTypeRefTest extends AbstractValidatorTest {
         final List<DMNMessage> validate = validator.validate(
                 getDefinitions("typeref/TYPEREF_NOT_FEEL_NOT_DEF.dmn", "https://github.com/kiegroup/kie-dmn", "TYPEREF_NOT_FEEL_NOT_DEF"),
                 VALIDATE_MODEL, VALIDATE_COMPILATION);
-        assertThat(ValidatorUtil.formatMessages(validate), validate.size(), is(2));
+        assertThat(validate).as(ValidatorUtil.formatMessages(validate)).hasSize(2);
         assertTrue(validate.stream().anyMatch(p -> p.getMessageType().equals(DMNMessageType.INVALID_NAME)));
         assertTrue(validate.stream().anyMatch(p -> p.getMessageType().equals(DMNMessageType.TYPE_DEF_NOT_FOUND)));
     }
@@ -132,7 +131,7 @@ public class ValidatorTypeRefTest extends AbstractValidatorTest {
             final List<DMNMessage> validate = validator.validate(
                     reader,
                     VALIDATE_SCHEMA, VALIDATE_MODEL, VALIDATE_COMPILATION);
-            assertThat(ValidatorUtil.formatMessages(validate), validate.size(), is(0));
+            assertThat(validate).as(ValidatorUtil.formatMessages(validate)).hasSize(0);
         }
     }
 
@@ -144,7 +143,7 @@ public class ValidatorTypeRefTest extends AbstractValidatorTest {
         final List<DMNMessage> validate = validator.validate(
                 getFile("typeref/TYPEREF_NOT_FEEL_NOT_DEF_valid.dmn"),
                 VALIDATE_SCHEMA, VALIDATE_MODEL, VALIDATE_COMPILATION);
-        assertThat(ValidatorUtil.formatMessages(validate), validate.size(), is(0));
+        assertThat(validate).as(ValidatorUtil.formatMessages(validate)).hasSize(0);
     }
 
     @Test
@@ -155,7 +154,7 @@ public class ValidatorTypeRefTest extends AbstractValidatorTest {
         final List<DMNMessage> validate = validator.validate(
                 getDefinitions("typeref/TYPEREF_NOT_FEEL_NOT_DEF_valid.dmn", "https://github.com/kiegroup/kie-dmn", "TYPEREF_NOT_FEEL_NOT_DEF_valid"),
                 VALIDATE_MODEL, VALIDATE_COMPILATION);
-        assertThat(ValidatorUtil.formatMessages(validate), validate.size(), is(0));
+        assertThat(validate).as(ValidatorUtil.formatMessages(validate)).hasSize(0);
     }
     
     @Test
@@ -164,6 +163,6 @@ public class ValidatorTypeRefTest extends AbstractValidatorTest {
         final List<DMNMessage> validate = validator.validate(
                 getDefinitions("typeref/BKM_WITH_NO_TYPEREF_IS_OK.dmn", "http://www.trisotech.com/dmn/definitions/_7e8d7561-657a-4729-b2a9-5a6279df6d5d", "Drawing 1"),
                 VALIDATE_MODEL, VALIDATE_COMPILATION);
-        assertThat(ValidatorUtil.formatMessages(validate), validate.size(), is(0));
+        assertThat(validate).as(ValidatorUtil.formatMessages(validate)).hasSize(0);
     }
 }

--- a/kie-dmn/kie-dmn-validation/src/test/java/org/kie/dmn/validation/classloader/ValidatorClassloaderTest.java
+++ b/kie-dmn/kie-dmn-validation/src/test/java/org/kie/dmn/validation/classloader/ValidatorClassloaderTest.java
@@ -40,8 +40,7 @@ import org.kie.internal.utils.ChainedProperties;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import static org.hamcrest.CoreMatchers.is;
-import static org.hamcrest.MatcherAssert.assertThat;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.Assert.assertTrue;
 import static org.kie.dmn.validation.DMNValidator.Validation.VALIDATE_COMPILATION;
 import static org.kie.dmn.validation.DMNValidator.Validation.VALIDATE_MODEL;
@@ -75,7 +74,7 @@ public class ValidatorClassloaderTest extends AbstractValidatorTest {
 
         DMNResult evaluateAll = runtime.evaluateAll(dmnModel, runtime.newContext());
         LOG.debug("{}", evaluateAll);
-        assertThat(evaluateAll.getDecisionResultByName("Decision-1").getResult(), is("Hello World"));
+        assertThat(evaluateAll.getDecisionResultByName("Decision-1").getResult()).isEqualTo("Hello World");
 
         final ClassLoader kieProjectCL = container.getClassLoader();
 
@@ -85,6 +84,6 @@ public class ValidatorClassloaderTest extends AbstractValidatorTest {
                                                                         VALIDATE_MODEL,
                                                                         VALIDATE_COMPILATION)
                                                          .theseModels(getReader("DummyInvocation.dmn"));
-        assertThat(ValidatorUtil.formatMessages(validate), validate.size(), is(0));
+        assertThat(validate).as(ValidatorUtil.formatMessages(validate)).hasSize(0);
     }
 }

--- a/kie-dmn/kie-dmn-validation/src/test/java/org/kie/dmn/validation/dtanalysis/AK0100domainOnTableTest.java
+++ b/kie-dmn/kie-dmn-validation/src/test/java/org/kie/dmn/validation/dtanalysis/AK0100domainOnTableTest.java
@@ -28,9 +28,7 @@ import org.kie.dmn.validation.dtanalysis.model.DTAnalysis;
 import org.kie.dmn.validation.dtanalysis.model.Hyperrectangle;
 import org.kie.dmn.validation.dtanalysis.model.Interval;
 
-import static org.hamcrest.Matchers.contains;
-import static org.hamcrest.Matchers.hasSize;
-import static org.hamcrest.MatcherAssert.assertThat;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.kie.dmn.validation.DMNValidator.Validation.ANALYZE_DECISION_TABLE;
 import static org.kie.dmn.validation.DMNValidator.Validation.VALIDATE_COMPILATION;
 
@@ -41,7 +39,7 @@ public class AK0100domainOnTableTest extends AbstractDTAnalysisTest {
         List<DMNMessage> validate = validator.validate(getReader("AK0100-domainOnTable.dmn"), VALIDATE_COMPILATION, ANALYZE_DECISION_TABLE);
         DTAnalysis analysis = getAnalysis(validate, "_e9e5c68a-ebc3-4f09-a107-2049edbe554d");
 
-        assertThat(analysis.getGaps(), hasSize(2));
+        assertThat(analysis.getGaps()).hasSize(2);
         
         @SuppressWarnings({"unchecked", "rawtypes"})
         List<Hyperrectangle> gaps = Arrays.asList(new Hyperrectangle(2,
@@ -64,9 +62,9 @@ public class AK0100domainOnTableTest extends AbstractDTAnalysisTest {
                                                                                                           new Bound(new BigDecimal("50"),
                                                                                                                     RangeBoundary.OPEN,
                                                                                                                     null)))));
-        assertThat(gaps, hasSize(2));
+        assertThat(gaps).hasSize(2);
 
         // Assert GAPS
-        assertThat(analysis.getGaps(), contains(gaps.toArray()));
+        assertThat(analysis.getGaps()).containsAll(gaps);
     }
 }

--- a/kie-dmn/kie-dmn-validation/src/test/java/org/kie/dmn/validation/dtanalysis/AK0100v2domainOnTableTest.java
+++ b/kie-dmn/kie-dmn-validation/src/test/java/org/kie/dmn/validation/dtanalysis/AK0100v2domainOnTableTest.java
@@ -28,9 +28,7 @@ import org.kie.dmn.validation.dtanalysis.model.DTAnalysis;
 import org.kie.dmn.validation.dtanalysis.model.Hyperrectangle;
 import org.kie.dmn.validation.dtanalysis.model.Interval;
 
-import static org.hamcrest.Matchers.contains;
-import static org.hamcrest.Matchers.hasSize;
-import static org.hamcrest.MatcherAssert.assertThat;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.kie.dmn.validation.DMNValidator.Validation.ANALYZE_DECISION_TABLE;
 import static org.kie.dmn.validation.DMNValidator.Validation.VALIDATE_COMPILATION;
 
@@ -41,7 +39,7 @@ public class AK0100v2domainOnTableTest extends AbstractDTAnalysisTest {
         List<DMNMessage> validate = validator.validate(getReader("AK0100v2-domainOnTable.dmn"), VALIDATE_COMPILATION, ANALYZE_DECISION_TABLE);
         DTAnalysis analysis = getAnalysis(validate, "_e9e5c68a-ebc3-4f09-a107-2049edbe554d");
 
-        assertThat(analysis.getGaps(), hasSize(2));
+        assertThat(analysis.getGaps()).hasSize(2);
 
         @SuppressWarnings({"unchecked", "rawtypes"})
         List<Hyperrectangle> gaps = Arrays.asList(new Hyperrectangle(2,
@@ -64,9 +62,9 @@ public class AK0100v2domainOnTableTest extends AbstractDTAnalysisTest {
                                                                                                           new Bound(new BigDecimal("100"),
                                                                                                                     RangeBoundary.CLOSED,
                                                                                                                     null)))));
-        assertThat(gaps, hasSize(2));
+        assertThat(gaps).hasSize(2);
 
         // Assert GAPS
-        assertThat(analysis.getGaps(), contains(gaps.toArray()));
+        assertThat(analysis.getGaps()).containsAll(gaps);
     }
 }

--- a/kie-dmn/kie-dmn-validation/src/test/java/org/kie/dmn/validation/dtanalysis/AbstractDTAnalysisTest.java
+++ b/kie-dmn/kie-dmn-validation/src/test/java/org/kie/dmn/validation/dtanalysis/AbstractDTAnalysisTest.java
@@ -33,18 +33,14 @@ import org.kie.dmn.validation.dtanalysis.utils.DTAnalysisMeta;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import static org.hamcrest.CoreMatchers.is;
-import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.empty;
-import static org.hamcrest.Matchers.not;
-import static org.hamcrest.Matchers.notNullValue;
+import static org.assertj.core.api.Assertions.assertThat;
 
 public abstract class AbstractDTAnalysisTest extends AbstractValidatorTest {
 
     public static final Logger LOG = LoggerFactory.getLogger(AbstractDTAnalysisTest.class);
 
     protected static DTAnalysis getAnalysis(List<DMNMessage> dmnMessages, String id) {
-        assertThat("Expected to find DTAnalysis but messages are empty.", dmnMessages, not(empty()));
+        assertThat(dmnMessages).as("Expected to find DTAnalysis but messages are empty.").isNotEmpty();
 
         if (LOG.isDebugEnabled() ) {
             LOG.debug("List<DMNMessage> dmnMessages: \n{}", ValidatorUtil.formatMessages(dmnMessages));
@@ -55,7 +51,7 @@ public abstract class AbstractDTAnalysisTest extends AbstractValidatorTest {
             if (dmnMessage.getSourceId().equals(id) && dmnMessage instanceof DMNDTAnalysisMessage) {
                 DMNDTAnalysisMessage dmndtAnalysisMessage = (DMNDTAnalysisMessage) dmnMessage;
                 if (as.containsKey(id)) {
-                    assertThat("Inconsistency detected", as.get(id), is(dmndtAnalysisMessage.getAnalysis()));
+                    assertThat(as.get(id)).as("Inconsistency detected").isEqualTo(dmndtAnalysisMessage.getAnalysis());
                 } else {
                     as.put(id, dmndtAnalysisMessage.getAnalysis());
                 }
@@ -63,7 +59,7 @@ public abstract class AbstractDTAnalysisTest extends AbstractValidatorTest {
         }
 
         DTAnalysis analysis = as.get(id);
-        assertThat("Null analysis value for key.", analysis, notNullValue());
+        assertThat(analysis).as("Null analysis value for key.").isNotNull();
 
         debugAnalysis(analysis);
 

--- a/kie-dmn/kie-dmn-validation/src/test/java/org/kie/dmn/validation/dtanalysis/AgeKittenTest.java
+++ b/kie-dmn/kie-dmn-validation/src/test/java/org/kie/dmn/validation/dtanalysis/AgeKittenTest.java
@@ -30,9 +30,7 @@ import org.kie.dmn.validation.dtanalysis.model.DTAnalysis;
 import org.kie.dmn.validation.dtanalysis.model.Hyperrectangle;
 import org.kie.dmn.validation.dtanalysis.model.Interval;
 
-import static org.hamcrest.Matchers.contains;
-import static org.hamcrest.Matchers.hasSize;
-import static org.hamcrest.MatcherAssert.assertThat;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.kie.dmn.validation.DMNValidator.Validation.ANALYZE_DECISION_TABLE;
 import static org.kie.dmn.validation.DMNValidator.Validation.VALIDATE_COMPILATION;
 
@@ -63,7 +61,7 @@ public class AgeKittenTest extends AbstractDTAnalysisTest {
     private void checkAnalysis(List<DMNMessage> validate) {
         DTAnalysis analysis = getAnalysis(validate, "_5e3e4546-69c2-43f2-b93a-7ea285878ca0");
 
-        assertThat(analysis.getGaps(), hasSize(2));
+        assertThat(analysis.getGaps()).hasSize(2);
         
         @SuppressWarnings({"unchecked", "rawtypes"})
         List<Hyperrectangle> gaps = Arrays.asList(new Hyperrectangle(2,
@@ -86,12 +84,12 @@ public class AgeKittenTest extends AbstractDTAnalysisTest {
                                                                                                           new Bound("Dog",
                                                                                                                     RangeBoundary.CLOSED,
                                                                                                                     null)))));
-        assertThat(gaps, hasSize(2));
+        assertThat(gaps).hasSize(2);
 
         // Assert GAPS
-        assertThat(analysis.getGaps(), contains(gaps.toArray()));
+        assertThat(analysis.getGaps()).containsAll(gaps);
 
         // assert OVERLAPs count.
-        assertThat(analysis.getOverlaps(), hasSize(0));
+        assertThat(analysis.getOverlaps()).hasSize(0);
     }
 }

--- a/kie-dmn/kie-dmn-validation/src/test/java/org/kie/dmn/validation/dtanalysis/BuiltinAndOtherValuesTest.java
+++ b/kie-dmn/kie-dmn-validation/src/test/java/org/kie/dmn/validation/dtanalysis/BuiltinAndOtherValuesTest.java
@@ -29,9 +29,7 @@ import org.kie.dmn.validation.dtanalysis.model.Hyperrectangle;
 import org.kie.dmn.validation.dtanalysis.model.Interval;
 import org.kie.dmn.validation.dtanalysis.model.Overlap;
 
-import static org.hamcrest.Matchers.contains;
-import static org.hamcrest.Matchers.hasSize;
-import static org.hamcrest.MatcherAssert.assertThat;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.kie.dmn.validation.DMNValidator.Validation.ANALYZE_DECISION_TABLE;
 
 public class BuiltinAndOtherValuesTest extends AbstractDTAnalysisTest {
@@ -53,7 +51,7 @@ public class BuiltinAndOtherValuesTest extends AbstractDTAnalysisTest {
     }
 
     private void checkComplexDTDates(DTAnalysis analysis) {
-        assertThat(analysis.getGaps(), hasSize(2));
+        assertThat(analysis.getGaps()).hasSize(2);
         @SuppressWarnings({"unchecked", "rawtypes"})
         List<Hyperrectangle> gaps = Arrays.asList(new Hyperrectangle(1,
                                                                      Arrays.asList(Interval.newFromBounds(new Bound(java.time.LocalDate.parse("2019-03-31"),
@@ -69,13 +67,13 @@ public class BuiltinAndOtherValuesTest extends AbstractDTAnalysisTest {
                                                                                                           new Bound(java.time.LocalDate.parse("2019-12-31"),
                                                                                                                     RangeBoundary.CLOSED,
                                                                                                                     null)))));
-        assertThat(gaps, hasSize(2));
+        assertThat(gaps).hasSize(2);
 
         // Assert GAPS same values
-        assertThat(analysis.getGaps(), contains(gaps.toArray()));
+        assertThat(analysis.getGaps()).containsAll(gaps);
 
         // assert OVERLAPs count.
-        assertThat(analysis.getOverlaps(), hasSize(1));
+        assertThat(analysis.getOverlaps()).hasSize(1);
         @SuppressWarnings({"unchecked", "rawtypes"})
         List<Overlap> overlaps = Arrays.asList(new Overlap(Arrays.asList(2,
                                                                          3),
@@ -86,9 +84,9 @@ public class BuiltinAndOtherValuesTest extends AbstractDTAnalysisTest {
                                                                                                                    new Bound(java.time.LocalDate.parse("2019-06-30"),
                                                                                                                              RangeBoundary.CLOSED,
                                                                                                                              null))))));
-        assertThat(overlaps, hasSize(1));
+        assertThat(overlaps).hasSize(1);
         // Assert OVERLAPs same values
-        assertThat(analysis.getOverlaps(), contains(overlaps.toArray()));
+        assertThat(analysis.getOverlaps()).containsAll(overlaps);
     }
 
     @Test
@@ -96,7 +94,7 @@ public class BuiltinAndOtherValuesTest extends AbstractDTAnalysisTest {
         List<DMNMessage> validate = validator.validate(getReader("weirdPosNeg.dmn"), ANALYZE_DECISION_TABLE);
         DTAnalysis analysis = getAnalysis(validate, "_54ae95be-6866-4dc1-8c10-1c5a4dd15c93");
 
-        assertThat(analysis.getGaps(), hasSize(1));
+        assertThat(analysis.getGaps()).hasSize(1);
         @SuppressWarnings({"unchecked", "rawtypes"})
         List<Hyperrectangle> gaps = Arrays.asList(new Hyperrectangle(1,
                                                                      Arrays.asList(Interval.newFromBounds(new Bound(new BigDecimal("0"),
@@ -105,13 +103,13 @@ public class BuiltinAndOtherValuesTest extends AbstractDTAnalysisTest {
                                                                                                           new Bound(new BigDecimal("0"),
                                                                                                                     RangeBoundary.CLOSED,
                                                                                                                     null)))));
-        assertThat(gaps, hasSize(1));
+        assertThat(gaps).hasSize(1);
 
         // Assert GAPS same values
-        assertThat(analysis.getGaps(), contains(gaps.toArray()));
+        assertThat(analysis.getGaps()).containsAll(gaps);
 
         // assert OVERLAPs count.
-        assertThat(analysis.getOverlaps(), hasSize(0));
+        assertThat(analysis.getOverlaps()).hasSize(0);
     }
 
     @Test
@@ -119,7 +117,7 @@ public class BuiltinAndOtherValuesTest extends AbstractDTAnalysisTest {
         List<DMNMessage> validate = validator.validate(getReader("weirdYMduration.dmn"), ANALYZE_DECISION_TABLE);
         DTAnalysis analysis = getAnalysis(validate, "_fe7d267b-d770-461e-8300-e09981147341");
 
-        assertThat(analysis.getGaps(), hasSize(1));
+        assertThat(analysis.getGaps()).hasSize(1);
         @SuppressWarnings({"unchecked", "rawtypes"})
         List<Hyperrectangle> gaps = Arrays.asList(new Hyperrectangle(1,
                                                                      Arrays.asList(Interval.newFromBounds(new Bound(org.kie.dmn.feel.lang.types.impl.ComparablePeriod.parse("P1M"),
@@ -128,12 +126,12 @@ public class BuiltinAndOtherValuesTest extends AbstractDTAnalysisTest {
                                                                                                           new Bound(org.kie.dmn.feel.lang.types.impl.ComparablePeriod.parse("P1M"),
                                                                                                                     RangeBoundary.CLOSED,
                                                                                                                     null)))));
-        assertThat(gaps, hasSize(1));
+        assertThat(gaps).hasSize(1);
 
         // Assert GAPS same values
-        assertThat(analysis.getGaps(), contains(gaps.toArray()));
+        assertThat(analysis.getGaps()).containsAll(gaps);
 
         // assert OVERLAPs count.
-        assertThat(analysis.getOverlaps(), hasSize(0));
+        assertThat(analysis.getOverlaps()).hasSize(0);
     }
 }

--- a/kie-dmn/kie-dmn-validation/src/test/java/org/kie/dmn/validation/dtanalysis/Check1stNFViolationTest.java
+++ b/kie-dmn/kie-dmn-validation/src/test/java/org/kie/dmn/validation/dtanalysis/Check1stNFViolationTest.java
@@ -26,10 +26,7 @@ import org.kie.dmn.api.core.DMNMessage;
 import org.kie.dmn.api.core.DMNMessageType;
 import org.kie.dmn.validation.dtanalysis.model.DTAnalysis;
 
-import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.contains;
-import static org.hamcrest.Matchers.hasSize;
-import static org.hamcrest.Matchers.is;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.Assert.assertTrue;
 import static org.kie.dmn.validation.DMNValidator.Validation.ANALYZE_DECISION_TABLE;
 
@@ -40,19 +37,19 @@ public class Check1stNFViolationTest extends AbstractDTAnalysisTest {
         List<DMNMessage> validate = validator.validate(getReader("DT1stNFViolation.dmn"), ANALYZE_DECISION_TABLE);
 
         DTAnalysis analysisDuplicate = getAnalysis(validate, "_053034d5-0e1f-4c4a-8513-ab3c6ba538db");
-        assertThat(analysisDuplicate.is1stNFViolation(), is(true));
-        assertThat(analysisDuplicate.getDuplicateRulesTuples(), hasSize(1));
-        assertThat(analysisDuplicate.getDuplicateRulesTuples(), contains(Collections.singletonList(Arrays.asList(1, 2)).toArray()));
+        assertThat(analysisDuplicate.is1stNFViolation()).isTrue();
+        assertThat(analysisDuplicate.getDuplicateRulesTuples()).hasSize(1);
+        assertThat(analysisDuplicate.getDuplicateRulesTuples()).containsAll(Collections.singletonList(Arrays.asList(1, 2)));
         assertTrue("It should contain at DMNMessage for the 1st NF Violation",
                    validate.stream().anyMatch(p -> p.getSourceId().equals("_053034d5-0e1f-4c4a-8513-ab3c6ba538db") && p.getMessageType().equals(DMNMessageType.DECISION_TABLE_1STNFVIOLATION)));
 
         DTAnalysis analysisFIRST = getAnalysis(validate, "_1ca6acde-c1d4-4c50-8e21-f3b11e106f3d");
-        assertThat(analysisFIRST.is1stNFViolation(), is(true));
+        assertThat(analysisFIRST.is1stNFViolation()).isTrue();
         assertTrue("It should contain at DMNMessage for the 1st NF Violation",
                    validate.stream().anyMatch(p -> p.getSourceId().equals("_1ca6acde-c1d4-4c50-8e21-f3b11e106f3d") && p.getMessageType().equals(DMNMessageType.DECISION_TABLE_1STNFVIOLATION)));
 
         DTAnalysis analysisRULE_ORDER = getAnalysis(validate, "_03522945-b520-4b45-ac5e-ef3cbd7f1eaf");
-        assertThat(analysisRULE_ORDER.is1stNFViolation(), is(true));
+        assertThat(analysisRULE_ORDER.is1stNFViolation()).isTrue();
         assertTrue("It should contain at DMNMessage for the 1st NF Violation",
                    validate.stream().anyMatch(p -> p.getSourceId().equals("_03522945-b520-4b45-ac5e-ef3cbd7f1eaf") && p.getMessageType().equals(DMNMessageType.DECISION_TABLE_1STNFVIOLATION)));
     }
@@ -62,9 +59,9 @@ public class Check1stNFViolationTest extends AbstractDTAnalysisTest {
         List<DMNMessage> validate = validator.validate(getReader("DT1stNFViolationB.dmn"), ANALYZE_DECISION_TABLE);
 
         DTAnalysis analysisDuplicate = getAnalysis(validate, "_053034d5-0e1f-4c4a-8513-ab3c6ba538db");
-        assertThat(analysisDuplicate.is1stNFViolation(), is(true));
-        assertThat(analysisDuplicate.getDuplicateRulesTuples(), hasSize(1));
-        assertThat(analysisDuplicate.getDuplicateRulesTuples(), contains(Collections.singletonList(Arrays.asList(1, 2)).toArray()));
+        assertThat(analysisDuplicate.is1stNFViolation()).isTrue();
+        assertThat(analysisDuplicate.getDuplicateRulesTuples()).hasSize(1);
+        assertThat(analysisDuplicate.getDuplicateRulesTuples()).containsAll(Collections.singletonList(Arrays.asList(1, 2)));
         assertTrue("It should contain at DMNMessage for the 1st NF Violation",
                    validate.stream().anyMatch(p -> p.getSourceId().equals("_053034d5-0e1f-4c4a-8513-ab3c6ba538db") && p.getMessageType().equals(DMNMessageType.DECISION_TABLE_1STNFVIOLATION)));
     }
@@ -74,12 +71,12 @@ public class Check1stNFViolationTest extends AbstractDTAnalysisTest {
         List<DMNMessage> validate = validator.validate(getReader("DT1stNFViolationDuplicateNoSubsumption.dmn"), ANALYZE_DECISION_TABLE);
 
         DTAnalysis analysis = getAnalysis(validate, "_221BF4A4-F8D4-466C-96E4-311FE3C9867B");
-        assertThat(analysis.is1stNFViolation(), is(true));
-        assertThat(analysis.getDuplicateRulesTuples(), hasSize(1));
-        assertThat(analysis.getDuplicateRulesTuples(), contains(Collections.singletonList(Arrays.asList(1, 2)).toArray()));
+        assertThat(analysis.is1stNFViolation()).isTrue();
+        assertThat(analysis.getDuplicateRulesTuples()).hasSize(1);
+        assertThat(analysis.getDuplicateRulesTuples()).containsAll(Collections.singletonList(Arrays.asList(1, 2)));
         assertTrue("It should contain at DMNMessage for the 1st NF Violation",
                    validate.stream().anyMatch(p -> p.getMessageType().equals(DMNMessageType.DECISION_TABLE_1STNFVIOLATION)));
-        assertThat(analysis.getSubsumptions().isEmpty(), is(false));
+        assertThat(analysis.getSubsumptions().isEmpty()).isFalse();
         assertTrue("No message about subsumption",
                    validate.stream().noneMatch(p -> p.getMessageType().equals(DMNMessageType.DECISION_TABLE_SUBSUMPTION_RULE)));
     }
@@ -89,8 +86,8 @@ public class Check1stNFViolationTest extends AbstractDTAnalysisTest {
         List<DMNMessage> validate = validator.validate(getReader("DT1stNFViolationCollect.dmn"), ANALYZE_DECISION_TABLE);
 
         DTAnalysis analysisDuplicate = getAnalysis(validate, "_4237d55b-2589-48a5-8183-f9f4e0e00c07");
-        assertThat(analysisDuplicate.is1stNFViolation(), is(true));
-        assertThat(analysisDuplicate.getDuplicateRulesTuples(), hasSize(2));
+        assertThat(analysisDuplicate.is1stNFViolation()).isTrue();
+        assertThat(analysisDuplicate.getDuplicateRulesTuples()).hasSize(2);
         assertTrue("It should contain DMNMessage(s) for the 1st NF Violation",
                    validate.stream().anyMatch(p -> p.getSourceId().equals("_4237d55b-2589-48a5-8183-f9f4e0e00c07") && p.getMessageType().equals(DMNMessageType.DECISION_TABLE_1STNFVIOLATION)));
         assertTrue("Being a C table, DMNMessage(s) for the 1st NF Violation are of type Warning",

--- a/kie-dmn/kie-dmn-validation/src/test/java/org/kie/dmn/validation/dtanalysis/Check2ndNFViolationTest.java
+++ b/kie-dmn/kie-dmn-validation/src/test/java/org/kie/dmn/validation/dtanalysis/Check2ndNFViolationTest.java
@@ -24,10 +24,7 @@ import org.kie.dmn.api.core.DMNMessageType;
 import org.kie.dmn.validation.dtanalysis.model.Contraction;
 import org.kie.dmn.validation.dtanalysis.model.DTAnalysis;
 
-import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.contains;
-import static org.hamcrest.Matchers.hasSize;
-import static org.hamcrest.Matchers.is;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.Assert.assertTrue;
 import static org.kie.dmn.validation.DMNValidator.Validation.ANALYZE_DECISION_TABLE;
 
@@ -38,12 +35,12 @@ public class Check2ndNFViolationTest extends AbstractDTAnalysisTest {
         List<DMNMessage> validate = validator.validate(getReader("DT2ndNFViolation.dmn"), ANALYZE_DECISION_TABLE);
 
         DTAnalysis analysis = getAnalysis(validate, "_4e358bae-7012-42dd-acea-e88b3aa3c8b2");
-        assertThat(analysis.is2ndNFViolation(), is(true));
-        assertThat(analysis.getContractionsViolating2ndNF(), hasSize(1));
+        assertThat(analysis.is2ndNFViolation()).isTrue();
+        assertThat(analysis.getContractionsViolating2ndNF()).hasSize(1);
         Contraction c2NFViolation = analysis.getContractionsViolating2ndNF().iterator().next();
-        assertThat(c2NFViolation.rule, is(1));
-        assertThat(c2NFViolation.pairedRules, contains(2));
-        assertThat(c2NFViolation.adjacentDimension, is(3));
+        assertThat(c2NFViolation.rule).isEqualTo(1);
+        assertThat(c2NFViolation.pairedRules).contains(2);
+        assertThat(c2NFViolation.adjacentDimension).isEqualTo(3);
         assertTrue("It should contain at DMNMessage for the 2nd NF Violation",
                    validate.stream().anyMatch(p -> p.getSourceId().equals("_4e358bae-7012-42dd-acea-e88b3aa3c8b2") && p.getMessageType().equals(DMNMessageType.DECISION_TABLE_2NDNFVIOLATION)));
 
@@ -54,8 +51,8 @@ public class Check2ndNFViolationTest extends AbstractDTAnalysisTest {
         List<DMNMessage> validate = validator.validate(getReader("DT2ndNF3combo.dmn"), ANALYZE_DECISION_TABLE);
 
         DTAnalysis analysis = getAnalysis(validate, "_BA703D04-803A-44AA-8A31-F5EEDD4FD54E");
-        assertThat(analysis.is2ndNFViolation(), is(true));
-        assertThat(analysis.getContractionsViolating2ndNF(), hasSize(2));
+        assertThat(analysis.is2ndNFViolation()).isTrue();
+        assertThat(analysis.getContractionsViolating2ndNF()).hasSize(2);
     }
 
     @Test
@@ -63,8 +60,8 @@ public class Check2ndNFViolationTest extends AbstractDTAnalysisTest {
         List<DMNMessage> validate = validator.validate(getReader("DT2ndNFWasADash.dmn"), ANALYZE_DECISION_TABLE);
 
         DTAnalysis analysis = getAnalysis(validate, "_C40525EF-9735-410B-A070-E0336E108268");
-        assertThat(analysis.is2ndNFViolation(), is(true));
-        assertThat(analysis.getCellsViolating2ndNF(), hasSize(1));
+        assertThat(analysis.is2ndNFViolation()).isTrue();
+        assertThat(analysis.getCellsViolating2ndNF()).hasSize(1);
     }
 
     @Test
@@ -72,8 +69,8 @@ public class Check2ndNFViolationTest extends AbstractDTAnalysisTest {
         List<DMNMessage> validate = validator.validate(getReader("DT2ndNFWasADash2.dmn"), ANALYZE_DECISION_TABLE);
 
         DTAnalysis analysis = getAnalysis(validate, "_D3F1D5B8-642B-446D-9099-DE4CB978CB94");
-        assertThat(analysis.is2ndNFViolation(), is(true));
-        assertThat(analysis.getCellsViolating2ndNF(), hasSize(1));
+        assertThat(analysis.is2ndNFViolation()).isTrue();
+        assertThat(analysis.getCellsViolating2ndNF()).hasSize(1);
     }
 
 }

--- a/kie-dmn/kie-dmn-validation/src/test/java/org/kie/dmn/validation/dtanalysis/ContractionRulesTest.java
+++ b/kie-dmn/kie-dmn-validation/src/test/java/org/kie/dmn/validation/dtanalysis/ContractionRulesTest.java
@@ -29,9 +29,7 @@ import org.kie.dmn.validation.dtanalysis.model.Contraction;
 import org.kie.dmn.validation.dtanalysis.model.DTAnalysis;
 import org.kie.dmn.validation.dtanalysis.model.Interval;
 
-import static org.hamcrest.Matchers.contains;
-import static org.hamcrest.Matchers.hasSize;
-import static org.hamcrest.MatcherAssert.assertThat;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.kie.dmn.validation.DMNValidator.Validation.ANALYZE_DECISION_TABLE;
 
 public class ContractionRulesTest extends AbstractDTAnalysisTest {
@@ -40,11 +38,11 @@ public class ContractionRulesTest extends AbstractDTAnalysisTest {
     public void testContractionRules() {
         List<DMNMessage> validate = validator.validate(getReader("Contraction.dmn"), ANALYZE_DECISION_TABLE);
         DTAnalysis analysis = getAnalysis(validate, "_01d9abb9-b968-49c0-b6ab-909f3e03d8d3");
-        assertThat(analysis.getGaps(), hasSize(0));
-        assertThat(analysis.getOverlaps(), hasSize(0));
+        assertThat(analysis.getGaps()).hasSize(0);
+        assertThat(analysis.getOverlaps()).hasSize(0);
 
         // Contraction count.
-        assertThat(analysis.getContractions(), hasSize(2));
+        assertThat(analysis.getContractions()).hasSize(2);
         List<Contraction> results = Arrays.asList(new Contraction(4,
                                                                   Arrays.asList(5),
                                                                   2,
@@ -53,10 +51,10 @@ public class ContractionRulesTest extends AbstractDTAnalysisTest {
                                                                   Arrays.asList(6),
                                                                   1,
                                                                   Arrays.asList(new Interval(RangeBoundary.CLOSED, new BigDecimal("600"), Interval.POS_INF, RangeBoundary.CLOSED, 0, 0))));
-        assertThat(results, hasSize(2));
-        assertThat(analysis.getContractions(), contains(results.toArray()));
-        assertThat("It should contain 2 DMNMessage for the Contraction",
-                   validate.stream().filter(p -> p.getMessageType().equals(DMNMessageType.DECISION_TABLE_CONTRACTION_RULE)).collect(Collectors.toList()),
-                   hasSize(2));
+        assertThat(results).hasSize(2);
+        assertThat(analysis.getContractions()).containsAll(results);
+        assertThat(validate.stream().filter(p -> p.getMessageType().equals(DMNMessageType.DECISION_TABLE_CONTRACTION_RULE)).collect(Collectors.toList()))
+        	.as("It should contain 2 DMNMessage for the Contraction")
+        	.hasSize(2);
     }
 }

--- a/kie-dmn/kie-dmn-validation/src/test/java/org/kie/dmn/validation/dtanalysis/DTNestingTest.java
+++ b/kie-dmn/kie-dmn-validation/src/test/java/org/kie/dmn/validation/dtanalysis/DTNestingTest.java
@@ -28,9 +28,7 @@ import org.kie.dmn.validation.dtanalysis.model.DTAnalysis;
 import org.kie.dmn.validation.dtanalysis.model.Hyperrectangle;
 import org.kie.dmn.validation.dtanalysis.model.Interval;
 
-import static org.hamcrest.Matchers.contains;
-import static org.hamcrest.Matchers.hasSize;
-import static org.hamcrest.MatcherAssert.assertThat;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.kie.dmn.validation.DMNValidator.Validation.ANALYZE_DECISION_TABLE;
 
 public class DTNestingTest extends AbstractDTAnalysisTest {
@@ -45,7 +43,7 @@ public class DTNestingTest extends AbstractDTAnalysisTest {
     private void checkPositiveTableNestedInSubcontextOfDecision(List<DMNMessage> validate) {
         DTAnalysis analysis = getAnalysis(validate, "_83a8fbd6-ffcb-4068-ab6a-4a19086ce9c7");
 
-        assertThat(analysis.getGaps(), hasSize(1));
+        assertThat(analysis.getGaps()).hasSize(1);
 
         @SuppressWarnings({"unchecked", "rawtypes"})
         List<Hyperrectangle> gaps = Arrays.asList(new Hyperrectangle(1,
@@ -55,19 +53,19 @@ public class DTNestingTest extends AbstractDTAnalysisTest {
                                                                                                           new Bound(new BigDecimal("0"),
                                                                                                                     RangeBoundary.CLOSED,
                                                                                                                     null)))));
-        assertThat(gaps, hasSize(1));
+        assertThat(gaps).hasSize(1);
 
         // Assert GAPS
-        assertThat(analysis.getGaps(), contains(gaps.toArray()));
+        assertThat(analysis.getGaps()).containsAll(gaps);
 
         // assert OVERLAPs count.
-        assertThat(analysis.getOverlaps(), hasSize(0));
+        assertThat(analysis.getOverlaps()).hasSize(0);
     }
 
     private void checkNegativeTableInBKM(List<DMNMessage> validate) {
         DTAnalysis analysis = getAnalysis(validate, "_68839ac9-1d1b-4e12-9c4f-6b9048b860e1");
 
-        assertThat(analysis.getGaps(), hasSize(1));
+        assertThat(analysis.getGaps()).hasSize(1);
 
         @SuppressWarnings({"unchecked", "rawtypes"})
         List<Hyperrectangle> gaps = Arrays.asList(new Hyperrectangle(1,
@@ -77,12 +75,12 @@ public class DTNestingTest extends AbstractDTAnalysisTest {
                                                                                                           new Bound(Interval.POS_INF,
                                                                                                                     RangeBoundary.CLOSED,
                                                                                                                     null)))));
-        assertThat(gaps, hasSize(1));
+        assertThat(gaps).hasSize(1);
 
         // Assert GAPS
-        assertThat(analysis.getGaps(), contains(gaps.toArray()));
+        assertThat(analysis.getGaps()).containsAll(gaps);
 
         // assert OVERLAPs count.
-        assertThat(analysis.getOverlaps(), hasSize(0));
+        assertThat(analysis.getOverlaps()).hasSize(0);
     }
 }

--- a/kie-dmn/kie-dmn-validation/src/test/java/org/kie/dmn/validation/dtanalysis/DTinBKMTest.java
+++ b/kie-dmn/kie-dmn-validation/src/test/java/org/kie/dmn/validation/dtanalysis/DTinBKMTest.java
@@ -23,9 +23,7 @@ import org.kie.dmn.api.core.DMNMessage;
 import org.kie.dmn.api.core.DMNMessageType;
 import org.kie.dmn.validation.dtanalysis.model.DTAnalysis;
 
-import static org.hamcrest.Matchers.hasSize;
-import static org.hamcrest.Matchers.is;
-import static org.hamcrest.MatcherAssert.assertThat;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.kie.dmn.validation.DMNValidator.Validation.ANALYZE_DECISION_TABLE;
 
 public class DTinBKMTest extends AbstractDTAnalysisTest {
@@ -34,9 +32,9 @@ public class DTinBKMTest extends AbstractDTAnalysisTest {
         List<DMNMessage> validate = validator.validate(getReader("dtInBKM.dmn"), ANALYZE_DECISION_TABLE);
         DTAnalysis analysis = getAnalysis(validate, "_860A5A56-0C43-4B42-B1DB-7415984E5624");
 
-        assertThat(analysis.getGaps(), hasSize(0));
-        assertThat(analysis.getOverlaps(), hasSize(0));
-        assertThat(validate, hasSize(1));
-        assertThat(validate.get(0).getMessageType(), is(DMNMessageType.DECISION_TABLE_ANALYSIS_EMPTY));
+        assertThat(analysis.getGaps()).hasSize(0);
+        assertThat(analysis.getOverlaps()).hasSize(0);
+        assertThat(validate).hasSize(1);
+        assertThat(validate.get(0).getMessageType()).isEqualTo(DMNMessageType.DECISION_TABLE_ANALYSIS_EMPTY);
     }
 }

--- a/kie-dmn/kie-dmn-validation/src/test/java/org/kie/dmn/validation/dtanalysis/EnumerationWithNullTest.java
+++ b/kie-dmn/kie-dmn-validation/src/test/java/org/kie/dmn/validation/dtanalysis/EnumerationWithNullTest.java
@@ -27,9 +27,7 @@ import org.kie.dmn.validation.dtanalysis.model.DTAnalysis;
 import org.kie.dmn.validation.dtanalysis.model.Hyperrectangle;
 import org.kie.dmn.validation.dtanalysis.model.Interval;
 
-import static org.hamcrest.Matchers.contains;
-import static org.hamcrest.Matchers.hasSize;
-import static org.hamcrest.MatcherAssert.assertThat;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.kie.dmn.validation.DMNValidator.Validation.ANALYZE_DECISION_TABLE;
 
 public class EnumerationWithNullTest extends AbstractDTAnalysisTest {
@@ -39,7 +37,7 @@ public class EnumerationWithNullTest extends AbstractDTAnalysisTest {
         List<DMNMessage> validate = validator.validate(getReader("EnumerationWithNull.dmn"), ANALYZE_DECISION_TABLE);
         DTAnalysis analysis = getAnalysis(validate, "_5ef1ff81-621d-4c9a-9881-0aaf865758cb");
 
-        assertThat(analysis.getGaps(), hasSize(1));
+        assertThat(analysis.getGaps()).hasSize(1);
 
         @SuppressWarnings({"unchecked", "rawtypes"})
         List<Hyperrectangle> gaps = Arrays.asList(new Hyperrectangle(1,
@@ -49,9 +47,9 @@ public class EnumerationWithNullTest extends AbstractDTAnalysisTest {
                                                                                                           new Bound("c",
                                                                                                                     RangeBoundary.CLOSED,
                                                                                                                     null)))));
-        assertThat(gaps, hasSize(1));
+        assertThat(gaps).hasSize(1);
 
         // Assert GAPS
-        assertThat(analysis.getGaps(), contains(gaps.toArray()));
+        assertThat(analysis.getGaps()).containsAll(gaps);
     }
 }

--- a/kie-dmn/kie-dmn-validation/src/test/java/org/kie/dmn/validation/dtanalysis/FailingOutputConstraintsTest.java
+++ b/kie-dmn/kie-dmn-validation/src/test/java/org/kie/dmn/validation/dtanalysis/FailingOutputConstraintsTest.java
@@ -23,9 +23,7 @@ import org.kie.dmn.api.core.DMNMessage;
 import org.kie.dmn.api.core.DMNMessageType;
 import org.kie.dmn.validation.dtanalysis.model.DTAnalysis;
 
-import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.hasSize;
-import static org.hamcrest.Matchers.is;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.Assert.assertTrue;
 import static org.kie.dmn.validation.DMNValidator.Validation.ANALYZE_DECISION_TABLE;
 
@@ -39,9 +37,9 @@ public class FailingOutputConstraintsTest extends AbstractDTAnalysisTest {
         debugValidatorMsg(validate);
 
         DTAnalysis analysis = getAnalysis(validate, "_E72BD036-C550-4992-AA6D-A8AD4666C63A");
-        assertThat(analysis.isError(), is(false));
-        assertThat(analysis.getGaps(), hasSize(1));
-        assertThat(analysis.getOverlaps(), hasSize(0));
+        assertThat(analysis.isError()).isFalse();
+        assertThat(analysis.getGaps()).hasSize(1);
+        assertThat(analysis.getOverlaps()).hasSize(0);
     }
     
     @Test
@@ -52,8 +50,8 @@ public class FailingOutputConstraintsTest extends AbstractDTAnalysisTest {
                    validate.stream().noneMatch(p -> p.getMessageType().equals(DMNMessageType.DECISION_TABLE_ANALYSIS_ERROR)));
 
         DTAnalysis analysis = getAnalysis(validate, "_E72BD036-C550-4992-AA6D-A8AD4666C63A");
-        assertThat(analysis.isError(), is(false));
-        assertThat(analysis.getGaps(), hasSize(1));
-        assertThat(analysis.getOverlaps(), hasSize(0));
+        assertThat(analysis.isError()).isFalse();
+        assertThat(analysis.getGaps()).hasSize(1);
+        assertThat(analysis.getOverlaps()).hasSize(0);
     }
 }

--- a/kie-dmn/kie-dmn-validation/src/test/java/org/kie/dmn/validation/dtanalysis/Gaps0100domainOnTableTest.java
+++ b/kie-dmn/kie-dmn-validation/src/test/java/org/kie/dmn/validation/dtanalysis/Gaps0100domainOnTableTest.java
@@ -28,9 +28,7 @@ import org.kie.dmn.validation.dtanalysis.model.DTAnalysis;
 import org.kie.dmn.validation.dtanalysis.model.Hyperrectangle;
 import org.kie.dmn.validation.dtanalysis.model.Interval;
 
-import static org.hamcrest.Matchers.contains;
-import static org.hamcrest.Matchers.hasSize;
-import static org.hamcrest.MatcherAssert.assertThat;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.kie.dmn.validation.DMNValidator.Validation.ANALYZE_DECISION_TABLE;
 import static org.kie.dmn.validation.DMNValidator.Validation.VALIDATE_COMPILATION;
 
@@ -41,7 +39,7 @@ public class Gaps0100domainOnTableTest extends AbstractDTAnalysisTest {
         List<DMNMessage> validate = validator.validate(getReader("Gaps0100-domainOnTable.dmn"), VALIDATE_COMPILATION, ANALYZE_DECISION_TABLE);
         DTAnalysis analysis = getAnalysis(validate, "_70a95e62-8f5b-4b75-8cb9-9a9f781077da");
 
-        assertThat(analysis.getGaps(), hasSize(2));
+        assertThat(analysis.getGaps()).hasSize(2);
         
         @SuppressWarnings({"unchecked", "rawtypes"})
         List<Hyperrectangle> gaps = Arrays.asList(new Hyperrectangle(1,
@@ -58,9 +56,9 @@ public class Gaps0100domainOnTableTest extends AbstractDTAnalysisTest {
                                                                                                           new Bound(new BigDecimal("100"),
                                                                                                                     RangeBoundary.CLOSED,
                                                                                                                     null)))));
-        assertThat(gaps, hasSize(2));
+        assertThat(gaps).hasSize(2);
 
         // Assert GAPS
-        assertThat(analysis.getGaps(), contains(gaps.toArray()));
+        assertThat(analysis.getGaps()).containsAll(gaps);
     }
 }

--- a/kie-dmn/kie-dmn-validation/src/test/java/org/kie/dmn/validation/dtanalysis/GapsAndOverlaps1Test.java
+++ b/kie-dmn/kie-dmn-validation/src/test/java/org/kie/dmn/validation/dtanalysis/GapsAndOverlaps1Test.java
@@ -29,9 +29,7 @@ import org.kie.dmn.validation.dtanalysis.model.Hyperrectangle;
 import org.kie.dmn.validation.dtanalysis.model.Interval;
 import org.kie.dmn.validation.dtanalysis.model.Overlap;
 
-import static org.hamcrest.Matchers.contains;
-import static org.hamcrest.Matchers.hasSize;
-import static org.hamcrest.MatcherAssert.assertThat;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.kie.dmn.validation.DMNValidator.Validation.ANALYZE_DECISION_TABLE;
 import static org.kie.dmn.validation.DMNValidator.Validation.VALIDATE_COMPILATION;
 
@@ -42,7 +40,7 @@ public class GapsAndOverlaps1Test extends AbstractDTAnalysisTest {
         List<DMNMessage> validate = validator.validate(getReader("GapsAndOverlaps1.dmn"), VALIDATE_COMPILATION, ANALYZE_DECISION_TABLE);
         DTAnalysis analysis = getAnalysis(validate, "_cd2e0a28-3cc2-456b-90b6-392d9c3574af");
         
-        assertThat(analysis.getGaps(), hasSize(17));
+        assertThat(analysis.getGaps()).hasSize(17);
 
         @SuppressWarnings({"unchecked", "rawtypes"})
         List<Hyperrectangle> gaps = Arrays.asList(new Hyperrectangle(2,
@@ -248,13 +246,13 @@ public class GapsAndOverlaps1Test extends AbstractDTAnalysisTest {
                                                                                                           new Bound(Interval.POS_INF,
                                                                                                                     RangeBoundary.CLOSED,
                                                                                                                     null)))));
-        assertThat(gaps, hasSize(17));
+        assertThat(gaps).hasSize(17);
 
         // Assert GAPS
-        assertThat(analysis.getGaps(), contains(gaps.toArray()));
+        assertThat(analysis.getGaps()).containsAll(gaps);
 
         // assert OVERLAPs count.
-        assertThat(analysis.getOverlaps(), hasSize(1));
+        assertThat(analysis.getOverlaps()).hasSize(1);
 
         @SuppressWarnings({"unchecked", "rawtypes"})
         List<Overlap> overlaps = Arrays.asList(new Overlap(Arrays.asList(1,
@@ -272,9 +270,9 @@ public class GapsAndOverlaps1Test extends AbstractDTAnalysisTest {
                                                                                                                    new Bound(new BigDecimal("2"),
                                                                                                                              RangeBoundary.CLOSED,
                                                                                                                              null))))));
-        assertThat(overlaps, hasSize(1));
+        assertThat(overlaps).hasSize(1);
 
         // Assert OVERLAPs same values
-        assertThat(analysis.getOverlaps(), contains(overlaps.toArray()));
+        assertThat(analysis.getOverlaps()).containsAll(overlaps);
     }
 }

--- a/kie-dmn/kie-dmn-validation/src/test/java/org/kie/dmn/validation/dtanalysis/GapsAndOverlaps1domainOnTableTest.java
+++ b/kie-dmn/kie-dmn-validation/src/test/java/org/kie/dmn/validation/dtanalysis/GapsAndOverlaps1domainOnTableTest.java
@@ -29,9 +29,7 @@ import org.kie.dmn.validation.dtanalysis.model.Hyperrectangle;
 import org.kie.dmn.validation.dtanalysis.model.Interval;
 import org.kie.dmn.validation.dtanalysis.model.Overlap;
 
-import static org.hamcrest.Matchers.contains;
-import static org.hamcrest.Matchers.hasSize;
-import static org.hamcrest.MatcherAssert.assertThat;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.kie.dmn.validation.DMNValidator.Validation.ANALYZE_DECISION_TABLE;
 import static org.kie.dmn.validation.DMNValidator.Validation.VALIDATE_COMPILATION;
 
@@ -42,7 +40,7 @@ public class GapsAndOverlaps1domainOnTableTest extends AbstractDTAnalysisTest {
         List<DMNMessage> validate = validator.validate(getReader("GapsAndOverlaps1-domainOnTable.dmn"), VALIDATE_COMPILATION, ANALYZE_DECISION_TABLE);
         DTAnalysis analysis = getAnalysis(validate, "_cd2e0a28-3cc2-456b-90b6-392d9c3574af");
 
-        assertThat(analysis.getGaps(), hasSize(11));
+        assertThat(analysis.getGaps()).hasSize(11);
 
         @SuppressWarnings({"unchecked", "rawtypes"})
         List<Hyperrectangle> gaps = Arrays.asList(new Hyperrectangle(2,
@@ -176,13 +174,13 @@ public class GapsAndOverlaps1domainOnTableTest extends AbstractDTAnalysisTest {
                                                                                                           new Bound(Interval.POS_INF,
                                                                                                                     RangeBoundary.CLOSED,
                                                                                                                     null)))));
-        assertThat(gaps, hasSize(11));
+        assertThat(gaps).hasSize(11);
 
         // Assert GAPs same values
-        assertThat(analysis.getGaps(), contains(gaps.toArray()));
+        assertThat(analysis.getGaps()).containsAll(gaps);
 
         // assert OVERLAPs count.
-        assertThat(analysis.getOverlaps(), hasSize(1));
+        assertThat(analysis.getOverlaps()).hasSize(1);
 
         @SuppressWarnings({"unchecked", "rawtypes"})
         List<Overlap> overlaps = Arrays.asList(new Overlap(Arrays.asList(1,
@@ -200,9 +198,9 @@ public class GapsAndOverlaps1domainOnTableTest extends AbstractDTAnalysisTest {
                                                                                                                    new Bound(new BigDecimal("2"),
                                                                                                                              RangeBoundary.CLOSED,
                                                                                                                              null))))));
-        assertThat(overlaps, hasSize(1));
+        assertThat(overlaps).hasSize(1);
 
         // Assert OVERLAPs same values
-        assertThat(analysis.getOverlaps(), contains(overlaps.toArray()));
+        assertThat(analysis.getOverlaps()).containsAll(overlaps);
     }
 }

--- a/kie-dmn/kie-dmn-validation/src/test/java/org/kie/dmn/validation/dtanalysis/GapsCube3Test.java
+++ b/kie-dmn/kie-dmn-validation/src/test/java/org/kie/dmn/validation/dtanalysis/GapsCube3Test.java
@@ -28,9 +28,7 @@ import org.kie.dmn.validation.dtanalysis.model.DTAnalysis;
 import org.kie.dmn.validation.dtanalysis.model.Hyperrectangle;
 import org.kie.dmn.validation.dtanalysis.model.Interval;
 
-import static org.hamcrest.Matchers.contains;
-import static org.hamcrest.Matchers.hasSize;
-import static org.hamcrest.MatcherAssert.assertThat;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.kie.dmn.validation.DMNValidator.Validation.ANALYZE_DECISION_TABLE;
 import static org.kie.dmn.validation.DMNValidator.Validation.VALIDATE_COMPILATION;
 
@@ -41,7 +39,7 @@ public class GapsCube3Test extends AbstractDTAnalysisTest {
         List<DMNMessage> validate = validator.validate(getReader("GapsCube3.dmn"), VALIDATE_COMPILATION, ANALYZE_DECISION_TABLE);
         DTAnalysis analysis = getAnalysis(validate, "_4b41743d-ff04-4855-bf0b-993d475a9d62");
 
-        assertThat(analysis.getGaps(), hasSize(4));
+        assertThat(analysis.getGaps()).hasSize(4);
 
         @SuppressWarnings({"unchecked", "rawtypes"})
         List<Hyperrectangle> gaps = Arrays.asList(new Hyperrectangle(3,
@@ -96,9 +94,9 @@ public class GapsCube3Test extends AbstractDTAnalysisTest {
                                                                                                           new Bound(new BigDecimal("1"),
                                                                                                                     RangeBoundary.OPEN,
                                                                                                                     null)))));
-        assertThat(gaps, hasSize(4));
+        assertThat(gaps).hasSize(4);
 
         // Assert GAPS
-        assertThat(analysis.getGaps(), contains(gaps.toArray()));
+        assertThat(analysis.getGaps()).containsAll(gaps);
     }
 }

--- a/kie-dmn/kie-dmn-validation/src/test/java/org/kie/dmn/validation/dtanalysis/GapsOverlapsBooleanTest.java
+++ b/kie-dmn/kie-dmn-validation/src/test/java/org/kie/dmn/validation/dtanalysis/GapsOverlapsBooleanTest.java
@@ -28,9 +28,7 @@ import org.kie.dmn.validation.dtanalysis.model.Hyperrectangle;
 import org.kie.dmn.validation.dtanalysis.model.Interval;
 import org.kie.dmn.validation.dtanalysis.model.Overlap;
 
-import static org.hamcrest.Matchers.contains;
-import static org.hamcrest.Matchers.hasSize;
-import static org.hamcrest.MatcherAssert.assertThat;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.kie.dmn.validation.DMNValidator.Validation.ANALYZE_DECISION_TABLE;
 import static org.kie.dmn.validation.DMNValidator.Validation.VALIDATE_COMPILATION;
 
@@ -41,7 +39,7 @@ public class GapsOverlapsBooleanTest extends AbstractDTAnalysisTest {
         List<DMNMessage> validate = validator.validate(getReader("GapsOverlapsBoolean.dmn"), VALIDATE_COMPILATION, ANALYZE_DECISION_TABLE);
         DTAnalysis analysis = getAnalysis(validate, "_EE34FD37-00D1-47A7-B2F6-CC9BCEF30005");
 
-        assertThat(analysis.getGaps(), hasSize(1));
+        assertThat(analysis.getGaps()).hasSize(1);
 
         @SuppressWarnings({"unchecked", "rawtypes"})
         List<Hyperrectangle> gaps = Arrays.asList(new Hyperrectangle(2,
@@ -57,13 +55,13 @@ public class GapsOverlapsBooleanTest extends AbstractDTAnalysisTest {
                                                                                                           new Bound(true,
                                                                                                                     RangeBoundary.CLOSED,
                                                                                                                     null)))));
-        assertThat(gaps, hasSize(1));
+        assertThat(gaps).hasSize(1);
 
         // Assert GAPS
-        assertThat(analysis.getGaps(), contains(gaps.toArray()));
+        assertThat(analysis.getGaps()).containsAll(gaps);
 
         // assert OVERLAPs count.
-        assertThat(analysis.getOverlaps(), hasSize(1));
+        assertThat(analysis.getOverlaps()).hasSize(1);
 
         @SuppressWarnings({"unchecked", "rawtypes"})
         List<Overlap> overlaps = Arrays.asList(new Overlap(Arrays.asList(1,
@@ -81,9 +79,9 @@ public class GapsOverlapsBooleanTest extends AbstractDTAnalysisTest {
                                                                                                                    new Bound(true,
                                                                                                                              RangeBoundary.OPEN,
                                                                                                                              null))))));
-        assertThat(overlaps, hasSize(1));
+        assertThat(overlaps).hasSize(1);
 
         // Assert OVERLAPs same values
-        assertThat(analysis.getOverlaps(), contains(overlaps.toArray()));
+        assertThat(analysis.getOverlaps()).containsAll(overlaps);
     }
 }

--- a/kie-dmn/kie-dmn-validation/src/test/java/org/kie/dmn/validation/dtanalysis/GapsXYTest.java
+++ b/kie-dmn/kie-dmn-validation/src/test/java/org/kie/dmn/validation/dtanalysis/GapsXYTest.java
@@ -16,13 +16,6 @@
 
 package org.kie.dmn.validation.dtanalysis;
 
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.contains;
-import static org.hamcrest.Matchers.hasSize;
-import static org.kie.dmn.validation.DMNValidator.Validation.ANALYZE_DECISION_TABLE;
-import static org.kie.dmn.validation.DMNValidator.Validation.VALIDATE_COMPILATION;
-
 import java.math.BigDecimal;
 import java.util.Arrays;
 import java.util.List;
@@ -34,6 +27,10 @@ import org.kie.dmn.validation.dtanalysis.model.Bound;
 import org.kie.dmn.validation.dtanalysis.model.DTAnalysis;
 import org.kie.dmn.validation.dtanalysis.model.Hyperrectangle;
 import org.kie.dmn.validation.dtanalysis.model.Interval;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.kie.dmn.validation.DMNValidator.Validation.ANALYZE_DECISION_TABLE;
+import static org.kie.dmn.validation.DMNValidator.Validation.VALIDATE_COMPILATION;
 
 public class GapsXYTest extends AbstractDTAnalysisTest {
 
@@ -68,7 +65,7 @@ public class GapsXYTest extends AbstractDTAnalysisTest {
     public static void checkAnalysis(List<DMNMessage> validate) {
         DTAnalysis analysis = getAnalysis(validate, "_ce297a95-b16c-4631-8da5-e739dac9e3c4");
 
-        assertThat(analysis.getGaps(), hasSize(3));
+        assertThat(analysis.getGaps()).hasSize(3);
         
         @SuppressWarnings({"unchecked", "rawtypes"})
         List<Hyperrectangle> gaps = Arrays.asList(new Hyperrectangle(2,
@@ -110,12 +107,12 @@ public class GapsXYTest extends AbstractDTAnalysisTest {
                                                                                                           new Bound(new BigDecimal("0"),
                                                                                                                     RangeBoundary.OPEN,
                                                                                                                     null)))));
-        assertThat(gaps, hasSize(3));
+        assertThat(gaps).hasSize(3);
 
         // Assert GAPS
-        assertThat(analysis.getGaps(), contains(gaps.toArray()));
+        assertThat(analysis.getGaps()).containsAll(gaps);
 
         // assert OVERLAPs count.
-        assertThat(analysis.getOverlaps(), hasSize(0));
+        assertThat(analysis.getOverlaps()).hasSize(0);
     }
 }

--- a/kie-dmn/kie-dmn-validation/src/test/java/org/kie/dmn/validation/dtanalysis/HitPolicyFirstTest.java
+++ b/kie-dmn/kie-dmn-validation/src/test/java/org/kie/dmn/validation/dtanalysis/HitPolicyFirstTest.java
@@ -23,8 +23,7 @@ import org.kie.dmn.api.core.DMNMessage;
 import org.kie.dmn.api.core.DMNMessageType;
 import org.kie.dmn.validation.dtanalysis.model.DTAnalysis;
 
-import static org.hamcrest.Matchers.hasSize;
-import static org.hamcrest.MatcherAssert.assertThat;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.Assert.assertTrue;
 import static org.kie.dmn.validation.DMNValidator.Validation.ANALYZE_DECISION_TABLE;
 
@@ -35,8 +34,8 @@ public class HitPolicyFirstTest extends AbstractDTAnalysisTest {
         List<DMNMessage> validate = validator.validate(getReader("DTAnalysisFirst.dmn"), ANALYZE_DECISION_TABLE);
         DTAnalysis analysis = getAnalysis(validate, "_38EB6C20-6DF4-4EA0-A421-206B9F31AF22");
 
-        assertThat(analysis.getGaps(), hasSize(0));
-        assertThat(analysis.getOverlaps(), hasSize(0));
+        assertThat(analysis.getGaps()).hasSize(0);
+        assertThat(analysis.getOverlaps()).hasSize(0);
         assertTrue("It should contain at least 1 DMNMessage for the type " + DMNMessageType.DECISION_TABLE_1STNFVIOLATION,
                    validate.stream().anyMatch(p -> p.getMessageType().equals(DMNMessageType.DECISION_TABLE_1STNFVIOLATION)));
     }

--- a/kie-dmn/kie-dmn-validation/src/test/java/org/kie/dmn/validation/dtanalysis/MaskTest.java
+++ b/kie-dmn/kie-dmn-validation/src/test/java/org/kie/dmn/validation/dtanalysis/MaskTest.java
@@ -31,9 +31,7 @@ import org.kie.dmn.validation.dtanalysis.model.Interval;
 import org.kie.dmn.validation.dtanalysis.model.MaskedRule;
 import org.kie.dmn.validation.dtanalysis.model.Overlap;
 
-import static org.hamcrest.Matchers.contains;
-import static org.hamcrest.Matchers.hasSize;
-import static org.hamcrest.MatcherAssert.assertThat;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.Assert.assertTrue;
 import static org.kie.dmn.validation.DMNValidator.Validation.ANALYZE_DECISION_TABLE;
 import static org.kie.dmn.validation.DMNValidator.Validation.VALIDATE_COMPILATION;
@@ -44,9 +42,9 @@ public class MaskTest extends AbstractDTAnalysisTest {
     public void test_MaskBasic() {
         List<DMNMessage> validate = validator.validate(getReader("MaskBasic.dmn"), VALIDATE_COMPILATION, ANALYZE_DECISION_TABLE);
         DTAnalysis analysis = getAnalysis(validate, "_BA703D04-803A-44AA-8A31-F5EEDD4FD54E");
-        assertThat(analysis.getGaps(), hasSize(0));
+        assertThat(analysis.getGaps()).hasSize(0);
         // assert OVERLAPs count.
-        assertThat(analysis.getOverlaps(), hasSize(1));
+        assertThat(analysis.getOverlaps()).hasSize(1);
         @SuppressWarnings({"unchecked", "rawtypes"})
         List<Overlap> overlaps = Arrays.asList(new Overlap(Arrays.asList(2,
                                                                          1),
@@ -57,15 +55,15 @@ public class MaskTest extends AbstractDTAnalysisTest {
                                                                                                                    new Bound(Interval.POS_INF,
                                                                                                                              RangeBoundary.CLOSED,
                                                                                                                              null))))));
-        assertThat(overlaps, hasSize(1));
+        assertThat(overlaps).hasSize(1);
         // Assert OVERLAPs same values
-        assertThat(analysis.getOverlaps(), contains(overlaps.toArray()));
+        assertThat(analysis.getOverlaps()).containsAll(overlaps);
 
         // MaskedRules count.
-        assertThat(analysis.getMaskedRules(), hasSize(1));
+        assertThat(analysis.getMaskedRules()).hasSize(1);
         List<MaskedRule> maskedRules = Arrays.asList(new MaskedRule(1, 2));
-        assertThat(maskedRules, hasSize(1));
-        assertThat(analysis.getMaskedRules(), contains(maskedRules.toArray()));
+        assertThat(maskedRules).hasSize(1);
+        assertThat(analysis.getMaskedRules()).containsAll(maskedRules);
         assertTrue("It should contain at least 1 DMNMessage for the MaskedRule",
                    validate.stream().anyMatch(p -> p.getMessageType().equals(DMNMessageType.DECISION_TABLE_MASKED_RULE)));
         assertTrue("It should not contain DMNMessage for the MisleadingRule",
@@ -76,9 +74,9 @@ public class MaskTest extends AbstractDTAnalysisTest {
     public void test_MaskTest() {
         List<DMNMessage> validate = validator.validate(getReader("MaskTest.dmn"), VALIDATE_COMPILATION, ANALYZE_DECISION_TABLE);
         DTAnalysis analysis = getAnalysis(validate, "_BA703D04-803A-44AA-8A31-F5EEDD4FD54E");
-        assertThat(analysis.getGaps(), hasSize(0));
+        assertThat(analysis.getGaps()).hasSize(0);
         // assert OVERLAPs count.
-        assertThat(analysis.getOverlaps(), hasSize(1));
+        assertThat(analysis.getOverlaps()).hasSize(1);
         @SuppressWarnings({"unchecked", "rawtypes"})
         List<Overlap> overlaps = Arrays.asList(new Overlap(Arrays.asList(2,
                                                                          1),
@@ -101,15 +99,15 @@ public class MaskTest extends AbstractDTAnalysisTest {
                                                                                                                    new Bound(true,
                                                                                                                              RangeBoundary.CLOSED,
                                                                                                                              null))))));
-        assertThat(overlaps, hasSize(1));
+        assertThat(overlaps).hasSize(1);
         // Assert OVERLAPs same values
-        assertThat(analysis.getOverlaps(), contains(overlaps.toArray()));
+        assertThat(analysis.getOverlaps()).containsAll(overlaps);
 
         // MaskedRules count.
-        assertThat(analysis.getMaskedRules(), hasSize(1));
+        assertThat(analysis.getMaskedRules()).hasSize(1);
         List<MaskedRule> maskedRules = Arrays.asList(new MaskedRule(1, 2));
-        assertThat(maskedRules, hasSize(1));
-        assertThat(analysis.getMaskedRules(), contains(maskedRules.toArray()));
+        assertThat(maskedRules).hasSize(1);
+        assertThat(analysis.getMaskedRules()).containsAll(maskedRules);
         assertTrue("It should contain at least 1 DMNMessage for the MaskedRule",
                    validate.stream().anyMatch(p -> p.getMessageType().equals(DMNMessageType.DECISION_TABLE_MASKED_RULE)));
         assertTrue("It should not contain DMNMessage for the MisleadingRule",

--- a/kie-dmn/kie-dmn-validation/src/test/java/org/kie/dmn/validation/dtanalysis/MisleadingRulesTest.java
+++ b/kie-dmn/kie-dmn-validation/src/test/java/org/kie/dmn/validation/dtanalysis/MisleadingRulesTest.java
@@ -30,9 +30,7 @@ import org.kie.dmn.validation.dtanalysis.model.Interval;
 import org.kie.dmn.validation.dtanalysis.model.MisleadingRule;
 import org.kie.dmn.validation.dtanalysis.model.Overlap;
 
-import static org.hamcrest.Matchers.contains;
-import static org.hamcrest.Matchers.hasSize;
-import static org.hamcrest.MatcherAssert.assertThat;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.Assert.assertTrue;
 import static org.kie.dmn.validation.DMNValidator.Validation.ANALYZE_DECISION_TABLE;
 import static org.kie.dmn.validation.DMNValidator.Validation.VALIDATE_COMPILATION;
@@ -43,9 +41,9 @@ public class MisleadingRulesTest extends AbstractDTAnalysisTest {
     public void testMisleadingRules() {
         List<DMNMessage> validate = validator.validate(getReader("MisleadingRules.dmn"), VALIDATE_COMPILATION, ANALYZE_DECISION_TABLE);
         DTAnalysis analysis = getAnalysis(validate, "_BA703D04-803A-44AA-8A31-F5EEDD4FD54E");
-        assertThat(analysis.getGaps(), hasSize(0));
+        assertThat(analysis.getGaps()).hasSize(0);
         // assert OVERLAPs count.
-        assertThat(analysis.getOverlaps(), hasSize(1));
+        assertThat(analysis.getOverlaps()).hasSize(1);
         @SuppressWarnings({"unchecked", "rawtypes"})
         List<Overlap> overlaps = Arrays.asList(new Overlap(Arrays.asList(4,
                                                                          2),
@@ -62,15 +60,15 @@ public class MisleadingRulesTest extends AbstractDTAnalysisTest {
                                                                                                                    new Bound("M",
                                                                                                                              RangeBoundary.CLOSED,
                                                                                                                              null))))));
-        assertThat(overlaps, hasSize(1));
+        assertThat(overlaps).hasSize(1);
         // Assert OVERLAPs same values
-        assertThat(analysis.getOverlaps(), contains(overlaps.toArray()));
+        assertThat(analysis.getOverlaps()).containsAll(overlaps);
 
         // MisleadingRules count.
-        assertThat(analysis.getMisleadingRules(), hasSize(1));
+        assertThat(analysis.getMisleadingRules()).hasSize(1);
         List<MisleadingRule> misleadingRules = Arrays.asList(new MisleadingRule(4, 2));
-        assertThat(misleadingRules, hasSize(1));
-        assertThat(analysis.getMisleadingRules(), contains(misleadingRules.toArray()));
+        assertThat(misleadingRules).hasSize(1);
+        assertThat(analysis.getMisleadingRules()).containsAll(misleadingRules);
         assertTrue("It should contain at least 1 DMNMessage for the MisleadingRule",
                    validate.stream().anyMatch(p -> p.getMessageType().equals(DMNMessageType.DECISION_TABLE_MISLEADING_RULE)));
         assertTrue("This test case is not a Masked rule example",
@@ -82,11 +80,11 @@ public class MisleadingRulesTest extends AbstractDTAnalysisTest {
         List<DMNMessage> validate = validator.validate(getReader("MisleadingRules2.dmn"), VALIDATE_COMPILATION, ANALYZE_DECISION_TABLE);
         DTAnalysis analysis = getAnalysis(validate, "_0cffdf05-071b-423b-94b9-182c2cc2435c");
 
-        assertThat(analysis.getGaps(), hasSize(0));
+        assertThat(analysis.getGaps()).hasSize(0);
 
         // no need for assert overlaps.
 
         // MisleadingRules count.
-        assertThat(analysis.getMisleadingRules(), hasSize(0));
+        assertThat(analysis.getMisleadingRules()).hasSize(0);
     }
 }

--- a/kie-dmn/kie-dmn-validation/src/test/java/org/kie/dmn/validation/dtanalysis/MultipleModelsTest.java
+++ b/kie-dmn/kie-dmn-validation/src/test/java/org/kie/dmn/validation/dtanalysis/MultipleModelsTest.java
@@ -30,9 +30,7 @@ import org.kie.dmn.validation.dtanalysis.model.DTAnalysis;
 import org.kie.dmn.validation.dtanalysis.model.Hyperrectangle;
 import org.kie.dmn.validation.dtanalysis.model.Interval;
 
-import static org.hamcrest.Matchers.contains;
-import static org.hamcrest.Matchers.hasSize;
-import static org.hamcrest.MatcherAssert.assertThat;
+import static org.assertj.core.api.Assertions.assertThat;
 
 public class MultipleModelsTest extends AbstractDTAnalysisTest {
 
@@ -69,7 +67,7 @@ public class MultipleModelsTest extends AbstractDTAnalysisTest {
     private void checkAnalysis(List<DMNMessage> validate) {
         DTAnalysis analysis = getAnalysis(validate, "_3cde04b9-d5c9-4254-9d27-436889111406");
 
-        assertThat(analysis.getGaps(), hasSize(1));
+        assertThat(analysis.getGaps()).hasSize(1);
         
         @SuppressWarnings({"unchecked", "rawtypes"})
         List<Hyperrectangle> gaps = Arrays.asList(new Hyperrectangle(1,
@@ -79,12 +77,12 @@ public class MultipleModelsTest extends AbstractDTAnalysisTest {
                                                                                                           new Bound("o",
                                                                                                                     RangeBoundary.OPEN,
                                                                                                                     null)))));
-        assertThat(gaps, hasSize(1));
+        assertThat(gaps).hasSize(1);
 
         // Assert GAPS
-        assertThat(analysis.getGaps(), contains(gaps.toArray()));
+        assertThat(analysis.getGaps()).containsAll(gaps);
 
         // assert OVERLAPs count.
-        assertThat(analysis.getOverlaps(), hasSize(0));
+        assertThat(analysis.getOverlaps()).hasSize(0);
     }
 }

--- a/kie-dmn/kie-dmn-validation/src/test/java/org/kie/dmn/validation/dtanalysis/NoGapsDateAdjacentTest.java
+++ b/kie-dmn/kie-dmn-validation/src/test/java/org/kie/dmn/validation/dtanalysis/NoGapsDateAdjacentTest.java
@@ -22,9 +22,7 @@ import org.junit.Test;
 import org.kie.dmn.api.core.DMNMessage;
 import org.kie.dmn.validation.dtanalysis.model.DTAnalysis;
 
-import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.hasSize;
-import static org.hamcrest.Matchers.is;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.kie.dmn.validation.DMNValidator.Validation.ANALYZE_DECISION_TABLE;
 
 public class NoGapsDateAdjacentTest extends AbstractDTAnalysisTest {
@@ -34,9 +32,9 @@ public class NoGapsDateAdjacentTest extends AbstractDTAnalysisTest {
         List<DMNMessage> validate = validator.validate(getReader("NoGapsDateAdjacent.dmn"), ANALYZE_DECISION_TABLE);
 
         DTAnalysis analysis = getAnalysis(validate, "_322732ef-01be-40fb-abd7-ec599c2efa47");
-        assertThat(analysis.isError(), is(false));
-        assertThat(analysis.getGaps(), hasSize(0));
-        assertThat(analysis.getOverlaps(), hasSize(0));
+        assertThat(analysis.isError()).isFalse();
+        assertThat(analysis.getGaps()).hasSize(0);
+        assertThat(analysis.getOverlaps()).hasSize(0);
     }
 
 }

--- a/kie-dmn/kie-dmn-validation/src/test/java/org/kie/dmn/validation/dtanalysis/NoGapsDomainOnTypeRefTest.java
+++ b/kie-dmn/kie-dmn-validation/src/test/java/org/kie/dmn/validation/dtanalysis/NoGapsDomainOnTypeRefTest.java
@@ -22,9 +22,7 @@ import org.junit.Test;
 import org.kie.dmn.api.core.DMNMessage;
 import org.kie.dmn.validation.dtanalysis.model.DTAnalysis;
 
-import static org.hamcrest.Matchers.hasSize;
-import static org.hamcrest.Matchers.is;
-import static org.hamcrest.MatcherAssert.assertThat;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.kie.dmn.validation.DMNValidator.Validation.ANALYZE_DECISION_TABLE;
 
 public class NoGapsDomainOnTypeRefTest extends AbstractDTAnalysisTest {
@@ -45,9 +43,9 @@ public class NoGapsDomainOnTypeRefTest extends AbstractDTAnalysisTest {
 
     private void checkAnalysis(List<DMNMessage> validate) {
         DTAnalysis analysis1 = getAnalysis(validate, "_E064FD38-56EA-40EB-97B4-F061ACD6F58F");
-        assertThat(analysis1.isError(), is(false));
-        assertThat(analysis1.getGaps(), hasSize(0));
-        assertThat(analysis1.getOverlaps(), hasSize(0));
+        assertThat(analysis1.isError()).isFalse();
+        assertThat(analysis1.getGaps()).hasSize(0);
+        assertThat(analysis1.getOverlaps()).hasSize(0);
     }
 
 }

--- a/kie-dmn/kie-dmn-validation/src/test/java/org/kie/dmn/validation/dtanalysis/NotTest.java
+++ b/kie-dmn/kie-dmn-validation/src/test/java/org/kie/dmn/validation/dtanalysis/NotTest.java
@@ -30,9 +30,6 @@ import org.kie.dmn.validation.dtanalysis.model.Interval;
 import org.kie.dmn.validation.dtanalysis.model.Overlap;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.contains;
-import static org.hamcrest.Matchers.hasSize;
 import static org.kie.dmn.validation.DMNValidator.Validation.ANALYZE_DECISION_TABLE;
 
 public class NotTest extends AbstractDTAnalysisTest {
@@ -42,7 +39,7 @@ public class NotTest extends AbstractDTAnalysisTest {
         List<DMNMessage> validate = validator.validate(getReader("DTusingNOT.dmn"), ANALYZE_DECISION_TABLE);
         DTAnalysis analysis = getAnalysis(validate, "_b53fac34-fb12-4601-8605-c226e68292f9");
 
-        assertThat(analysis.getGaps(), hasSize(1));
+        assertThat(analysis.getGaps()).hasSize(1);
 
         @SuppressWarnings({"unchecked", "rawtypes"})
         List<Hyperrectangle> gaps = Arrays.asList(new Hyperrectangle(1,
@@ -52,13 +49,13 @@ public class NotTest extends AbstractDTAnalysisTest {
                                                                                                           new Bound("o",
                                                                                                                     RangeBoundary.OPEN,
                                                                                                                     null)))));
-        assertThat(gaps, hasSize(1));
+        assertThat(gaps).hasSize(1);
 
         // Assert GAPS
-        assertThat(analysis.getGaps(), contains(gaps.toArray()));
+        assertThat(analysis.getGaps()).containsAll(gaps);
 
         // assert OVERLAPs count.
-        assertThat(analysis.getOverlaps(), hasSize(1));
+        assertThat(analysis.getOverlaps()).hasSize(1);
 
         @SuppressWarnings({"unchecked", "rawtypes"})
         List<Overlap> overlaps = Arrays.asList(new Overlap(Arrays.asList(1,
@@ -70,10 +67,10 @@ public class NotTest extends AbstractDTAnalysisTest {
                                                                                                                    new Bound("u",
                                                                                                                              RangeBoundary.OPEN,
                                                                                                                              null))))));
-        assertThat(overlaps, hasSize(1));
+        assertThat(overlaps).hasSize(1);
 
         // Assert OVERLAPs same values
-        assertThat(analysis.getOverlaps(), contains(overlaps.toArray()));
+        assertThat(analysis.getOverlaps()).containsAll(overlaps);
     }
 
     @Test
@@ -81,7 +78,7 @@ public class NotTest extends AbstractDTAnalysisTest {
         List<DMNMessage> validate = validator.validate(getReader("DTusingNOT2.dmn"), ANALYZE_DECISION_TABLE);
         DTAnalysis analysis = getAnalysis(validate, "_b53fac34-fb12-4601-8605-c226e68292f9");
 
-        assertThat(analysis.getGaps(), hasSize(1));
+        assertThat(analysis.getGaps()).hasSize(1);
 
         @SuppressWarnings({"unchecked", "rawtypes"})
         List<Hyperrectangle> gaps = Arrays.asList(new Hyperrectangle(1,
@@ -91,13 +88,13 @@ public class NotTest extends AbstractDTAnalysisTest {
                                                                                                           new Bound("o",
                                                                                                                     RangeBoundary.OPEN,
                                                                                                                     null)))));
-        assertThat(gaps, hasSize(1));
+        assertThat(gaps).hasSize(1);
 
         // Assert GAPS
-        assertThat(analysis.getGaps(), contains(gaps.toArray()));
+        assertThat(analysis.getGaps()).containsAll(gaps);
 
         // assert OVERLAPs count.
-        assertThat(analysis.getOverlaps(), hasSize(0));
+        assertThat(analysis.getOverlaps()).hasSize(0);
 
     }
     
@@ -107,10 +104,10 @@ public class NotTest extends AbstractDTAnalysisTest {
         DTAnalysis analysis = getAnalysis(validate, "_406133D7-96FE-4237-8726-44D839F400D6");
 
         // assert GAPS count
-        assertThat(analysis.getGaps(), hasSize(0));
+        assertThat(analysis.getGaps()).hasSize(0);
 
         // assert OVERLAPs count.
-        assertThat(analysis.getOverlaps(), hasSize(0));
+        assertThat(analysis.getOverlaps()).hasSize(0);
     }
     
     @Test
@@ -133,7 +130,7 @@ public class NotTest extends AbstractDTAnalysisTest {
         List<DMNMessage> validate = validator.validate(getReader("DTusingNOTnumber.dmn"), ANALYZE_DECISION_TABLE);
         DTAnalysis analysis = getAnalysis(validate, "_d0cbacca-55d4-47dd-acc6-131add2a8a53");
 
-        assertThat(analysis.getGaps(), hasSize(1));
+        assertThat(analysis.getGaps()).hasSize(1);
 
         @SuppressWarnings({"unchecked", "rawtypes"})
         List<Hyperrectangle> gaps = Arrays.asList(new Hyperrectangle(1,
@@ -143,13 +140,13 @@ public class NotTest extends AbstractDTAnalysisTest {
                                                                                                           new Bound(new BigDecimal("0"),
                                                                                                                     RangeBoundary.CLOSED,
                                                                                                                     null)))));
-        assertThat(gaps, hasSize(1));
+        assertThat(gaps).hasSize(1);
 
         // Assert GAPS
-        assertThat(analysis.getGaps(), contains(gaps.toArray()));
+        assertThat(analysis.getGaps()).containsAll(gaps);
 
         // assert OVERLAPs count.
-        assertThat(analysis.getOverlaps(), hasSize(1));
+        assertThat(analysis.getOverlaps()).hasSize(1);
 
         @SuppressWarnings({"unchecked", "rawtypes"})
         List<Overlap> overlaps = Arrays.asList(new Overlap(Arrays.asList(1,
@@ -161,10 +158,10 @@ public class NotTest extends AbstractDTAnalysisTest {
                                                                                                                    new Bound(Interval.POS_INF,
                                                                                                                              RangeBoundary.CLOSED,
                                                                                                                              null))))));
-        assertThat(overlaps, hasSize(1));
+        assertThat(overlaps).hasSize(1);
 
         // Assert OVERLAPs same values
-        assertThat(analysis.getOverlaps(), contains(overlaps.toArray()));
+        assertThat(analysis.getOverlaps()).containsAll(overlaps);
     }
 
 }

--- a/kie-dmn/kie-dmn-validation/src/test/java/org/kie/dmn/validation/dtanalysis/NullTest.java
+++ b/kie-dmn/kie-dmn-validation/src/test/java/org/kie/dmn/validation/dtanalysis/NullTest.java
@@ -28,9 +28,7 @@ import org.kie.dmn.validation.dtanalysis.model.DTAnalysis;
 import org.kie.dmn.validation.dtanalysis.model.Hyperrectangle;
 import org.kie.dmn.validation.dtanalysis.model.Interval;
 
-import static org.hamcrest.Matchers.contains;
-import static org.hamcrest.Matchers.hasSize;
-import static org.hamcrest.MatcherAssert.assertThat;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.kie.dmn.validation.DMNValidator.Validation.ANALYZE_DECISION_TABLE;
 import static org.kie.dmn.validation.DMNValidator.Validation.VALIDATE_COMPILATION;
 import static org.kie.dmn.validation.DMNValidator.Validation.VALIDATE_MODEL;
@@ -52,7 +50,7 @@ public class NullTest extends AbstractDTAnalysisTest {
     private void checkNullBoolean(List<DMNMessage> validate) {
         DTAnalysis analysis = getAnalysis(validate, "_76FABA99-C6D0-4C83-81BF-92E807DBDEF8");
 
-        assertThat(analysis.getGaps(), hasSize(1));
+        assertThat(analysis.getGaps()).hasSize(1);
         
         @SuppressWarnings({"unchecked", "rawtypes"})
         List<Hyperrectangle> gaps = Arrays.asList(new Hyperrectangle(1,
@@ -62,13 +60,13 @@ public class NullTest extends AbstractDTAnalysisTest {
                                                                                                           new Bound(true,
                                                                                                                     RangeBoundary.CLOSED,
                                                                                                                     null)))));
-        assertThat(gaps, hasSize(1));
+        assertThat(gaps).hasSize(1);
 
         // Assert GAPS
-        assertThat(analysis.getGaps(), contains(gaps.toArray()));
+        assertThat(analysis.getGaps()).containsAll(gaps);
 
         // assert OVERLAPs count.
-        assertThat(analysis.getOverlaps(), hasSize(0));
+        assertThat(analysis.getOverlaps()).hasSize(0);
     }
 
     @Test
@@ -86,7 +84,7 @@ public class NullTest extends AbstractDTAnalysisTest {
     private void checkNullNumber(List<DMNMessage> validate) {
         DTAnalysis analysis = getAnalysis(validate, "_76FABA99-C6D0-4C83-81BF-92E807DBDEF8");
 
-        assertThat(analysis.getGaps(), hasSize(1));
+        assertThat(analysis.getGaps()).hasSize(1);
 
         @SuppressWarnings({"unchecked", "rawtypes"})
         List<Hyperrectangle> gaps = Arrays.asList(new Hyperrectangle(1,
@@ -96,13 +94,13 @@ public class NullTest extends AbstractDTAnalysisTest {
                                                                                                           new Bound(Interval.POS_INF,
                                                                                                                     RangeBoundary.CLOSED,
                                                                                                                     null)))));
-        assertThat(gaps, hasSize(1));
+        assertThat(gaps).hasSize(1);
 
         // Assert GAPS
-        assertThat(analysis.getGaps(), contains(gaps.toArray()));
+        assertThat(analysis.getGaps()).containsAll(gaps);
 
         // assert OVERLAPs count.
-        assertThat(analysis.getOverlaps(), hasSize(0));
+        assertThat(analysis.getOverlaps()).hasSize(0);
     }
 
     @Test

--- a/kie-dmn/kie-dmn-validation/src/test/java/org/kie/dmn/validation/dtanalysis/OverlapHitPolicyTest.java
+++ b/kie-dmn/kie-dmn-validation/src/test/java/org/kie/dmn/validation/dtanalysis/OverlapHitPolicyTest.java
@@ -38,9 +38,7 @@ import org.kie.dmn.validation.dtanalysis.model.Hyperrectangle;
 import org.kie.dmn.validation.dtanalysis.model.Interval;
 import org.kie.dmn.validation.dtanalysis.model.Overlap;
 
-import static org.hamcrest.Matchers.contains;
-import static org.hamcrest.Matchers.hasSize;
-import static org.hamcrest.MatcherAssert.assertThat;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.Assert.assertTrue;
 import static org.kie.dmn.validation.DMNValidator.Validation.ANALYZE_DECISION_TABLE;
 import static org.kie.dmn.validation.DMNValidator.Validation.VALIDATE_COMPILATION;
@@ -84,10 +82,10 @@ public class OverlapHitPolicyTest extends AbstractDTAnalysisTest {
     private void checkAnalysis(List<DMNMessage> validate) {
         DTAnalysis analysis = getAnalysis(validate, "_C4A1625B-0606-4F2D-9779-49B1A981718E");
 
-        assertThat(analysis.getGaps(), hasSize(0));
+        assertThat(analysis.getGaps()).hasSize(0);
 
         // assert OVERLAPs count.
-        assertThat(analysis.getOverlaps(), hasSize(1));
+        assertThat(analysis.getOverlaps()).hasSize(1);
 
         @SuppressWarnings({"unchecked", "rawtypes"})
         List<Overlap> overlaps = Arrays.asList(new Overlap(Arrays.asList(2,
@@ -99,10 +97,10 @@ public class OverlapHitPolicyTest extends AbstractDTAnalysisTest {
                                                                                                                    new Bound(new BigDecimal("30"),
                                                                                                                              RangeBoundary.CLOSED,
                                                                                                                              null))))));
-        assertThat(overlaps, hasSize(1));
+        assertThat(overlaps).hasSize(1);
 
         // Assert OVERLAPs same values
-        assertThat(analysis.getOverlaps(), contains(overlaps.toArray()));
+        assertThat(analysis.getOverlaps()).containsAll(overlaps);
     }
 
 }

--- a/kie-dmn/kie-dmn-validation/src/test/java/org/kie/dmn/validation/dtanalysis/OverlapsMsgTest.java
+++ b/kie-dmn/kie-dmn-validation/src/test/java/org/kie/dmn/validation/dtanalysis/OverlapsMsgTest.java
@@ -29,10 +29,7 @@ import org.kie.dmn.validation.dtanalysis.model.Hyperrectangle;
 import org.kie.dmn.validation.dtanalysis.model.Interval;
 import org.kie.dmn.validation.dtanalysis.model.Overlap;
 
-import static org.hamcrest.Matchers.contains;
-import static org.hamcrest.Matchers.hasSize;
-import static org.hamcrest.Matchers.is;
-import static org.hamcrest.MatcherAssert.assertThat;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.kie.dmn.validation.DMNValidator.Validation.ANALYZE_DECISION_TABLE;
 import static org.kie.dmn.validation.DMNValidator.Validation.VALIDATE_COMPILATION;
 
@@ -44,10 +41,10 @@ public class OverlapsMsgTest extends AbstractDTAnalysisTest {
         DTAnalysis analysis = getAnalysis(validate, "_CA4B40F8-2354-48B6-B323-5C4E4B2CE467");
 
         // Assert GAPs
-        assertThat(analysis.getGaps(), hasSize(0));
+        assertThat(analysis.getGaps()).hasSize(0);
 
         // assert OVERLAPs
-        assertThat(analysis.getOverlaps(), hasSize(2));
+        assertThat(analysis.getOverlaps()).hasSize(2);
 
         @SuppressWarnings({"unchecked", "rawtypes"})
         List<Overlap> overlaps = Arrays.asList(new Overlap(Arrays.asList(3,
@@ -80,11 +77,11 @@ public class OverlapsMsgTest extends AbstractDTAnalysisTest {
                                                                                                                    new Bound(new BigDecimal("0"),
                                                                                                                              RangeBoundary.CLOSED,
                                                                                                                              null))))));
-        assertThat(overlaps, hasSize(2));
+        assertThat(overlaps).hasSize(2);
 
-        assertThat(analysis.getOverlaps(), contains(overlaps.toArray()));
+        assertThat(analysis.getOverlaps()).containsAll(overlaps);
 
-        assertThat(analysis.getOverlaps().get(0).getOverlap().asHumanFriendly(analysis.getDdtaTable()), is("[ -, >0 ]"));
-        assertThat(analysis.getOverlaps().get(1).getOverlap().asHumanFriendly(analysis.getDdtaTable()), is("[ >47, <=0 ]"));
+        assertThat(analysis.getOverlaps().get(0).getOverlap().asHumanFriendly(analysis.getDdtaTable())).isEqualTo("[ -, >0 ]");
+        assertThat(analysis.getOverlaps().get(1).getOverlap().asHumanFriendly(analysis.getDdtaTable())).isEqualTo("[ >47, <=0 ]");
     }
 }

--- a/kie-dmn/kie-dmn-validation/src/test/java/org/kie/dmn/validation/dtanalysis/PiTest.java
+++ b/kie-dmn/kie-dmn-validation/src/test/java/org/kie/dmn/validation/dtanalysis/PiTest.java
@@ -28,9 +28,7 @@ import org.kie.dmn.validation.dtanalysis.model.DTAnalysis;
 import org.kie.dmn.validation.dtanalysis.model.Hyperrectangle;
 import org.kie.dmn.validation.dtanalysis.model.Interval;
 
-import static org.hamcrest.Matchers.contains;
-import static org.hamcrest.Matchers.hasSize;
-import static org.hamcrest.MatcherAssert.assertThat;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.kie.dmn.validation.DMNValidator.Validation.ANALYZE_DECISION_TABLE;
 import static org.kie.dmn.validation.DMNValidator.Validation.VALIDATE_COMPILATION;
 
@@ -45,7 +43,7 @@ public class PiTest extends AbstractDTAnalysisTest {
     private void checkAnalysis(List<DMNMessage> validate) {
         DTAnalysis analysis = getAnalysis(validate, "_F32338CF-6F14-4E66-95AE-8BD4276BA75F");
 
-        assertThat(analysis.getGaps(), hasSize(1));
+        assertThat(analysis.getGaps()).hasSize(1);
         
         @SuppressWarnings({"unchecked", "rawtypes"})
         List<Hyperrectangle> gaps = Arrays.asList(new Hyperrectangle(1,
@@ -55,12 +53,12 @@ public class PiTest extends AbstractDTAnalysisTest {
                                                                                                           new Bound(new BigDecimal("3.1415926535897932384626433832794"),
                                                                                                                     RangeBoundary.CLOSED,
                                                                                                                     null)))));
-        assertThat(gaps, hasSize(1));
+        assertThat(gaps).hasSize(1);
 
         // Assert GAPS
-        assertThat(analysis.getGaps(), contains(gaps.toArray()));
+        assertThat(analysis.getGaps()).containsAll(gaps);
 
         // assert OVERLAPs count.
-        assertThat(analysis.getOverlaps(), hasSize(0));
+        assertThat(analysis.getOverlaps()).hasSize(0);
     }
 }

--- a/kie-dmn/kie-dmn-validation/src/test/java/org/kie/dmn/validation/dtanalysis/PosDoubleNegHalfTest.java
+++ b/kie-dmn/kie-dmn-validation/src/test/java/org/kie/dmn/validation/dtanalysis/PosDoubleNegHalfTest.java
@@ -28,9 +28,7 @@ import org.kie.dmn.validation.dtanalysis.model.DTAnalysis;
 import org.kie.dmn.validation.dtanalysis.model.Hyperrectangle;
 import org.kie.dmn.validation.dtanalysis.model.Interval;
 
-import static org.hamcrest.Matchers.contains;
-import static org.hamcrest.Matchers.hasSize;
-import static org.hamcrest.MatcherAssert.assertThat;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.kie.dmn.validation.DMNValidator.Validation.ANALYZE_DECISION_TABLE;
 
 public class PosDoubleNegHalfTest extends AbstractDTAnalysisTest {
@@ -40,7 +38,7 @@ public class PosDoubleNegHalfTest extends AbstractDTAnalysisTest {
         List<DMNMessage> validate = validator.validate(getReader("posDoubleNegHalf.dmn"), ANALYZE_DECISION_TABLE);
         DTAnalysis analysis = getAnalysis(validate, "_d18aa93e-3f67-4dda-9b36-93ae75835bdf");
 
-        assertThat(analysis.getGaps(), hasSize(1));
+        assertThat(analysis.getGaps()).hasSize(1);
 
         @SuppressWarnings({"unchecked", "rawtypes"})
         List<Hyperrectangle> gaps = Arrays.asList(new Hyperrectangle(1,
@@ -50,12 +48,12 @@ public class PosDoubleNegHalfTest extends AbstractDTAnalysisTest {
                                                                                                           new Bound(new BigDecimal("0"),
                                                                                                                     RangeBoundary.CLOSED,
                                                                                                                     null)))));
-        assertThat(gaps, hasSize(1));
+        assertThat(gaps).hasSize(1);
 
         // Assert GAPS
-        assertThat(analysis.getGaps(), contains(gaps.toArray()));
+        assertThat(analysis.getGaps()).containsAll(gaps);
 
         // Overlaps:
-        assertThat(analysis.getOverlaps(), hasSize(0));
+        assertThat(analysis.getOverlaps()).hasSize(0);
     }
 }

--- a/kie-dmn/kie-dmn-validation/src/test/java/org/kie/dmn/validation/dtanalysis/RecommenderHitPolicyTest.java
+++ b/kie-dmn/kie-dmn-validation/src/test/java/org/kie/dmn/validation/dtanalysis/RecommenderHitPolicyTest.java
@@ -28,8 +28,7 @@ import org.kie.dmn.model.api.Definitions;
 import org.kie.dmn.model.api.HitPolicy;
 import org.kie.dmn.validation.dtanalysis.model.DTAnalysis;
 
-import static org.hamcrest.Matchers.hasSize;
-import static org.hamcrest.MatcherAssert.assertThat;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.Assert.assertTrue;
 import static org.kie.dmn.validation.DMNValidator.Validation.ANALYZE_DECISION_TABLE;
 import static org.kie.dmn.validation.DMNValidator.Validation.VALIDATE_COMPILATION;
@@ -43,7 +42,7 @@ public class RecommenderHitPolicyTest extends AbstractDTAnalysisTest {
         DTAnalysis analysis = getAnalysis(validate, "_3aa68aee-6314-482f-a0be-84c2411d65d7");
 
         debugValidatorMsg(validate);
-        assertThat(analysis.getGaps(), hasSize(1));
+        assertThat(analysis.getGaps()).hasSize(1);
         assertTrue(validate.stream().noneMatch(m -> m.getMessageType() == DMNMessageType.DECISION_TABLE_HITPOLICY_RECOMMENDER));
     }
 
@@ -67,8 +66,8 @@ public class RecommenderHitPolicyTest extends AbstractDTAnalysisTest {
         DTAnalysis analysis = getAnalysis(validate, "_3aa68aee-6314-482f-a0be-84c2411d65d7");
 
         debugValidatorMsg(validate);
-        assertThat(analysis.getGaps(), hasSize(0));
-        assertThat(analysis.getOverlaps(), hasSize(0));
+        assertThat(analysis.getGaps()).hasSize(0);
+        assertThat(analysis.getOverlaps()).hasSize(0);
         return validate;
     }
 
@@ -92,8 +91,8 @@ public class RecommenderHitPolicyTest extends AbstractDTAnalysisTest {
         DTAnalysis analysis = getAnalysis(validate, "_3aa68aee-6314-482f-a0be-84c2411d65d7");
 
         debugValidatorMsg(validate);
-        assertThat(analysis.getGaps(), hasSize(0));
-        assertThat(analysis.getOverlaps(), hasSize(1));
+        assertThat(analysis.getGaps()).hasSize(0);
+        assertThat(analysis.getOverlaps()).hasSize(1);
         return validate;
     }
 
@@ -117,8 +116,8 @@ public class RecommenderHitPolicyTest extends AbstractDTAnalysisTest {
         DTAnalysis analysis = getAnalysis(validate, "_3aa68aee-6314-482f-a0be-84c2411d65d7");
 
         debugValidatorMsg(validate);
-        assertThat(analysis.getGaps(), hasSize(0));
-        assertThat(analysis.getOverlaps(), hasSize(1));
+        assertThat(analysis.getGaps()).hasSize(0);
+        assertThat(analysis.getOverlaps()).hasSize(1);
         return validate;
     }
 }

--- a/kie-dmn/kie-dmn-validation/src/test/java/org/kie/dmn/validation/dtanalysis/RuleOrderDashTest.java
+++ b/kie-dmn/kie-dmn-validation/src/test/java/org/kie/dmn/validation/dtanalysis/RuleOrderDashTest.java
@@ -29,9 +29,7 @@ import org.kie.dmn.validation.dtanalysis.model.Hyperrectangle;
 import org.kie.dmn.validation.dtanalysis.model.Interval;
 import org.kie.dmn.validation.dtanalysis.model.Overlap;
 
-import static org.hamcrest.Matchers.contains;
-import static org.hamcrest.Matchers.hasSize;
-import static org.hamcrest.MatcherAssert.assertThat;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.kie.dmn.validation.DMNValidator.Validation.ANALYZE_DECISION_TABLE;
 
 public class RuleOrderDashTest extends AbstractDTAnalysisTest {
@@ -42,10 +40,10 @@ public class RuleOrderDashTest extends AbstractDTAnalysisTest {
         DTAnalysis analysis = getAnalysis(validate, "_eb02106a-cee1-47f5-a9d9-3160c5ac868b");
 
         // Assert GAPS count.
-        assertThat(analysis.getGaps(), hasSize(0));
+        assertThat(analysis.getGaps()).hasSize(0);
 
         // assert OVERLAPs count.
-        assertThat(analysis.getOverlaps(), hasSize(3));
+        assertThat(analysis.getOverlaps()).hasSize(3);
 
         @SuppressWarnings({"unchecked", "rawtypes"})
         List<Overlap> overlaps = Arrays.asList(new Overlap(Arrays.asList(3,
@@ -94,9 +92,9 @@ public class RuleOrderDashTest extends AbstractDTAnalysisTest {
                                                                                                                    new Bound(Interval.POS_INF,
                                                                                                                              RangeBoundary.CLOSED,
                                                                                                                              null))))));
-        assertThat(overlaps, hasSize(3));
+        assertThat(overlaps).hasSize(3);
 
         // Assert OVERLAPs same values
-        assertThat(analysis.getOverlaps(), contains(overlaps.toArray()));
+        assertThat(analysis.getOverlaps()).containsAll(overlaps);
     }
 }

--- a/kie-dmn/kie-dmn-validation/src/test/java/org/kie/dmn/validation/dtanalysis/SRGapsOverlapsSubsumption2Test.java
+++ b/kie-dmn/kie-dmn-validation/src/test/java/org/kie/dmn/validation/dtanalysis/SRGapsOverlapsSubsumption2Test.java
@@ -29,9 +29,7 @@ import org.kie.dmn.validation.dtanalysis.model.Hyperrectangle;
 import org.kie.dmn.validation.dtanalysis.model.Interval;
 import org.kie.dmn.validation.dtanalysis.model.Overlap;
 
-import static org.hamcrest.Matchers.contains;
-import static org.hamcrest.Matchers.hasSize;
-import static org.hamcrest.MatcherAssert.assertThat;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.kie.dmn.validation.DMNValidator.Validation.ANALYZE_DECISION_TABLE;
 import static org.kie.dmn.validation.DMNValidator.Validation.VALIDATE_COMPILATION;
 
@@ -42,7 +40,7 @@ public class SRGapsOverlapsSubsumption2Test extends AbstractDTAnalysisTest {
         List<DMNMessage> validate = validator.validate(getReader("SRGapsOverlapsSubsumption2.dmn"), VALIDATE_COMPILATION, ANALYZE_DECISION_TABLE);
         DTAnalysis analysis = getAnalysis(validate, "_ccd87aa2-7081-4338-bafa-3a2cbf27c44c");
 
-        assertThat(analysis.getGaps(), hasSize(1));
+        assertThat(analysis.getGaps()).hasSize(1);
 
         @SuppressWarnings({"unchecked", "rawtypes"})
         List<Hyperrectangle> gaps = Arrays.asList(new Hyperrectangle(2,
@@ -58,13 +56,13 @@ public class SRGapsOverlapsSubsumption2Test extends AbstractDTAnalysisTest {
                                                                                                           new Bound("Good",
                                                                                                                     RangeBoundary.OPEN,
                                                                                                                     null)))));
-        assertThat(gaps, hasSize(1));
+        assertThat(gaps).hasSize(1);
 
         // Assert GAPS
-        assertThat(analysis.getGaps(), contains(gaps.toArray()));
+        assertThat(analysis.getGaps()).containsAll(gaps);
 
         // assert OVERLAPs count.
-        assertThat(analysis.getOverlaps(), hasSize(1));
+        assertThat(analysis.getOverlaps()).hasSize(1);
 
         @SuppressWarnings({"unchecked", "rawtypes"})
         List<Overlap> overlaps = Arrays.asList(new Overlap(Arrays.asList(2,
@@ -82,9 +80,9 @@ public class SRGapsOverlapsSubsumption2Test extends AbstractDTAnalysisTest {
                                                                                                                    new Bound("Fair",
                                                                                                                              RangeBoundary.OPEN,
                                                                                                                              null))))));
-        assertThat(overlaps, hasSize(1));
+        assertThat(overlaps).hasSize(1);
 
         // Assert OVERLAPs same values
-        assertThat(analysis.getOverlaps(), contains(overlaps.toArray()));
+        assertThat(analysis.getOverlaps()).containsAll(overlaps);
     }
 }

--- a/kie-dmn/kie-dmn-validation/src/test/java/org/kie/dmn/validation/dtanalysis/SameMsgInAllAPITest.java
+++ b/kie-dmn/kie-dmn-validation/src/test/java/org/kie/dmn/validation/dtanalysis/SameMsgInAllAPITest.java
@@ -31,9 +31,7 @@ import org.kie.dmn.validation.dtanalysis.model.Interval;
 import org.kie.dmn.validation.dtanalysis.model.MaskedRule;
 import org.kie.dmn.validation.dtanalysis.model.Overlap;
 
-import static org.hamcrest.Matchers.contains;
-import static org.hamcrest.Matchers.hasSize;
-import static org.hamcrest.MatcherAssert.assertThat;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.Assert.assertTrue;
 import static org.kie.dmn.validation.DMNValidator.Validation.ANALYZE_DECISION_TABLE;
 import static org.kie.dmn.validation.DMNValidator.Validation.VALIDATE_COMPILATION;
@@ -54,10 +52,10 @@ public class SameMsgInAllAPITest extends AbstractDTAnalysisTest {
     }
 
     private void verify(List<DMNMessage> validate) {
-        assertThat(validate, hasSize(5));
+        assertThat(validate).hasSize(5);
         DTAnalysis analysis = getAnalysis(validate, "_4771db14-e088-4d5a-8942-211c57ad0b42");
 
-        assertThat(analysis.getGaps(), hasSize(3));
+        assertThat(analysis.getGaps()).hasSize(3);
 
         @SuppressWarnings({"unchecked", "rawtypes"})
         List<Hyperrectangle> gaps = Arrays.asList(new Hyperrectangle(1,
@@ -81,13 +79,13 @@ public class SameMsgInAllAPITest extends AbstractDTAnalysisTest {
                                                                                                           new Bound(new BigDecimal("10"),
                                                                                                                     RangeBoundary.CLOSED,
                                                                                                                     null)))));
-        assertThat(gaps, hasSize(3));
+        assertThat(gaps).hasSize(3);
 
         // Assert GAPS
-        assertThat(analysis.getGaps(), contains(gaps.toArray()));
+        assertThat(analysis.getGaps()).containsAll(gaps);
 
         // assert OVERLAPs count.
-        assertThat(analysis.getOverlaps(), hasSize(2));
+        assertThat(analysis.getOverlaps()).hasSize(2);
 
         @SuppressWarnings({"unchecked", "rawtypes"})
         List<Overlap> overlaps = Arrays.asList(new Overlap(Arrays.asList(1,
@@ -108,17 +106,17 @@ public class SameMsgInAllAPITest extends AbstractDTAnalysisTest {
                                                                                                                    new Bound(new BigDecimal("7"),
                                                                                                                              RangeBoundary.CLOSED,
                                                                                                                              null))))));
-        assertThat(overlaps, hasSize(2));
+        assertThat(overlaps).hasSize(2);
 
         // Assert OVERLAPs same values
-        assertThat(analysis.getOverlaps(), contains(overlaps.toArray()));
+        assertThat(analysis.getOverlaps()).containsAll(overlaps);
 
         // MaskedRules count.
-        assertThat(analysis.getMaskedRules(), hasSize(2));
+        assertThat(analysis.getMaskedRules()).hasSize(2);
         List<MaskedRule> maskedRules = Arrays.asList(new MaskedRule(2, 1),
                                                      new MaskedRule(4, 3));
-        assertThat(maskedRules, hasSize(2));
-        assertThat(analysis.getMaskedRules(), contains(maskedRules.toArray()));
+        assertThat(maskedRules).hasSize(2);
+        assertThat(analysis.getMaskedRules()).containsAll(maskedRules);
         assertTrue("It should contain DMNMessage for the MaskedRule",
                    validate.stream().anyMatch(p -> p.getMessageType().equals(DMNMessageType.DECISION_TABLE_MASKED_RULE)));
     }

--- a/kie-dmn/kie-dmn-validation/src/test/java/org/kie/dmn/validation/dtanalysis/SimpleStringNoGapTest.java
+++ b/kie-dmn/kie-dmn-validation/src/test/java/org/kie/dmn/validation/dtanalysis/SimpleStringNoGapTest.java
@@ -23,8 +23,7 @@ import org.kie.dmn.api.core.DMNMessage;
 import org.kie.dmn.api.core.DMNMessageType;
 import org.kie.dmn.validation.dtanalysis.model.DTAnalysis;
 
-import static org.hamcrest.Matchers.hasSize;
-import static org.hamcrest.MatcherAssert.assertThat;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.Assert.assertTrue;
 import static org.kie.dmn.validation.DMNValidator.Validation.ANALYZE_DECISION_TABLE;
 import static org.kie.dmn.validation.DMNValidator.Validation.VALIDATE_COMPILATION;
@@ -35,14 +34,14 @@ public class SimpleStringNoGapTest extends AbstractDTAnalysisTest {
     @Test
     public void test() {
         List<DMNMessage> validate = validator.validate(getReader("simpleStringNoGap.dmn"), VALIDATE_COMPILATION, VALIDATE_MODEL, ANALYZE_DECISION_TABLE);
-        assertThat(validate, hasSize(1)); // Gap Analysis skipped because of free string.
+        assertThat(validate).hasSize(1); // Gap Analysis skipped because of free string.
         assertTrue("It should contain DMNMessage for the skipped gap analysis",
                    validate.stream().anyMatch(p -> p.getMessageType().equals(DMNMessageType.DECISION_TABLE_GAP)));
         debugValidatorMsg(validate);
 
         DTAnalysis analysis = getAnalysis(validate, "_3D5BDDEF-8B71-4797-8662-5026A9C2A112");
 
-        assertThat(analysis.getGaps(), hasSize(0));
-        assertThat(analysis.getOverlaps(), hasSize(0));
+        assertThat(analysis.getGaps()).hasSize(0);
+        assertThat(analysis.getOverlaps()).hasSize(0);
     }
 }

--- a/kie-dmn/kie-dmn-validation/src/test/java/org/kie/dmn/validation/dtanalysis/SomeProblemTest.java
+++ b/kie-dmn/kie-dmn-validation/src/test/java/org/kie/dmn/validation/dtanalysis/SomeProblemTest.java
@@ -22,9 +22,7 @@ import org.junit.Test;
 import org.kie.dmn.api.core.DMNMessage;
 import org.kie.dmn.validation.dtanalysis.model.DTAnalysis;
 
-import static org.hamcrest.Matchers.hasSize;
-import static org.hamcrest.Matchers.is;
-import static org.hamcrest.MatcherAssert.assertThat;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.kie.dmn.validation.DMNValidator.Validation.ANALYZE_DECISION_TABLE;
 
 public class SomeProblemTest extends AbstractDTAnalysisTest {
@@ -34,11 +32,11 @@ public class SomeProblemTest extends AbstractDTAnalysisTest {
         List<DMNMessage> validate = validator.validate(getReader("SomeProblem.dmn"), ANALYZE_DECISION_TABLE);
 
         DTAnalysis analysis1 = getAnalysis(validate, "_a36e37f8-aae0-4118-8267-cbb37c7955cb");
-        assertThat(analysis1.isError(), is(false));
-        assertThat(analysis1.getGaps(), hasSize(0));
-        assertThat(analysis1.getOverlaps(), hasSize(0));
+        assertThat(analysis1.isError()).isFalse();
+        assertThat(analysis1.getGaps()).hasSize(0);
+        assertThat(analysis1.getOverlaps()).hasSize(0);
         
         DTAnalysis analysis2 = getAnalysis(validate, "_2aea80b4-19fa-4831-8829-4db925a128aa");
-        assertThat(analysis2.isError(), is(true));
+        assertThat(analysis2.isError()).isTrue();
     }
 }

--- a/kie-dmn/kie-dmn-validation/src/test/java/org/kie/dmn/validation/dtanalysis/SomeProblemruleOutsideDomainTest.java
+++ b/kie-dmn/kie-dmn-validation/src/test/java/org/kie/dmn/validation/dtanalysis/SomeProblemruleOutsideDomainTest.java
@@ -22,8 +22,7 @@ import org.junit.Test;
 import org.kie.dmn.api.core.DMNMessage;
 import org.kie.dmn.validation.dtanalysis.model.DTAnalysis;
 
-import static org.hamcrest.Matchers.is;
-import static org.hamcrest.MatcherAssert.assertThat;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.kie.dmn.validation.DMNValidator.Validation.ANALYZE_DECISION_TABLE;
 
 public class SomeProblemruleOutsideDomainTest extends AbstractDTAnalysisTest {
@@ -33,6 +32,6 @@ public class SomeProblemruleOutsideDomainTest extends AbstractDTAnalysisTest {
         List<DMNMessage> validate = validator.validate(getReader("SomeProblem-ruleOutsideDomain.dmn"), ANALYZE_DECISION_TABLE);
         
         DTAnalysis analysis = getAnalysis(validate, "_4466518e-6240-46b0-bcb4-c7ddf5560e3a");
-        assertThat(analysis.isError(), is(true));
+        assertThat(analysis.isError()).isTrue();
     }
 }

--- a/kie-dmn/kie-dmn-validation/src/test/java/org/kie/dmn/validation/dtanalysis/StringWithoutEnumNoGapTest.java
+++ b/kie-dmn/kie-dmn-validation/src/test/java/org/kie/dmn/validation/dtanalysis/StringWithoutEnumNoGapTest.java
@@ -32,10 +32,7 @@ import org.kie.dmn.validation.dtanalysis.model.MaskedRule;
 import org.kie.dmn.validation.dtanalysis.model.MisleadingRule;
 import org.kie.dmn.validation.dtanalysis.model.Overlap;
 
-import static org.hamcrest.Matchers.contains;
-import static org.hamcrest.Matchers.containsInAnyOrder;
-import static org.hamcrest.Matchers.hasSize;
-import static org.hamcrest.MatcherAssert.assertThat;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.Assert.assertTrue;
 import static org.kie.dmn.validation.DMNValidator.Validation.ANALYZE_DECISION_TABLE;
 import static org.kie.dmn.validation.DMNValidator.Validation.VALIDATE_COMPILATION;
@@ -46,16 +43,16 @@ public class StringWithoutEnumNoGapTest extends AbstractDTAnalysisTest {
     @Test
     public void test() {
         List<DMNMessage> validate = validator.validate(getReader("stringWithoutEnumNoGap.dmn"), VALIDATE_COMPILATION, VALIDATE_MODEL, ANALYZE_DECISION_TABLE);
-        assertThat(validate, hasSize(3)); // no gap but no enum "skip Gap analysis" message, (omit 2 overlaps DROOLS-5363), 2 masked, (omit 2 misleading as redundant with Masked).
+        assertThat(validate).hasSize(3); // no gap but no enum "skip Gap analysis" message, (omit 2 overlaps DROOLS-5363), 2 masked, (omit 2 misleading as redundant with Masked).
         debugValidatorMsg(validate);
         
         DTAnalysis analysis = getAnalysis(validate, "_8b48d1c9-265c-47aa-9378-7f11d55dfe55");
 
-        assertThat(analysis.getGaps(), hasSize(0));
+        assertThat(analysis.getGaps()).hasSize(0);
 
 
         // assert OVERLAPs count.
-        assertThat(analysis.getOverlaps(), hasSize(2));
+        assertThat(analysis.getOverlaps()).hasSize(2);
 
         @SuppressWarnings({"unchecked", "rawtypes"})
         List<Overlap> overlaps = Arrays.asList(new Overlap(Arrays.asList(1,
@@ -88,26 +85,26 @@ public class StringWithoutEnumNoGapTest extends AbstractDTAnalysisTest {
                                                                                                                    new Bound(Interval.POS_INF,
                                                                                                                              RangeBoundary.CLOSED,
                                                                                                                              null))))));
-        assertThat(overlaps, hasSize(2));
+        assertThat(overlaps).hasSize(2);
 
         // Assert OVERLAPs same values
-        assertThat(analysis.getOverlaps(), contains(overlaps.toArray()));
+        assertThat(analysis.getOverlaps()).containsAll(overlaps);
 
         // MaskedRules count.
-        assertThat(analysis.getMaskedRules(), hasSize(2));
+        assertThat(analysis.getMaskedRules()).hasSize(2);
         List<MaskedRule> maskedRules = Arrays.asList(new MaskedRule(1, 3),
                                                      new MaskedRule(2, 3));
-        assertThat(maskedRules, hasSize(2));
-        assertThat(analysis.getMaskedRules(), contains(maskedRules.toArray()));
+        assertThat(maskedRules).hasSize(2);
+        assertThat(analysis.getMaskedRules()).containsAll(maskedRules);
         assertTrue("It should contain DMNMessage for the MaskedRule",
                    validate.stream().anyMatch(p -> p.getMessageType().equals(DMNMessageType.DECISION_TABLE_MASKED_RULE)));
 
         // MisleadingRules are duplicate of Masked, so are no longer displayed.
-        assertThat(analysis.getMisleadingRules(), hasSize(2));
+        assertThat(analysis.getMisleadingRules()).hasSize(2);
         List<MisleadingRule> misleadingRules = Arrays.asList(new MisleadingRule(3, 1),
                                                              new MisleadingRule(3, 2));
-        assertThat(misleadingRules, hasSize(2));
-        assertThat(analysis.getMisleadingRules(), containsInAnyOrder(misleadingRules.toArray()));
+        assertThat(misleadingRules).hasSize(2);
+        assertThat(analysis.getMisleadingRules()).containsAll(misleadingRules);
         assertTrue("It should NOT contain DMNMessage for the MisleadingRule",
                    validate.stream().noneMatch(p -> p.getMessageType().equals(DMNMessageType.DECISION_TABLE_MISLEADING_RULE)));
     }

--- a/kie-dmn/kie-dmn-validation/src/test/java/org/kie/dmn/validation/dtanalysis/SubsumptionRulesTest.java
+++ b/kie-dmn/kie-dmn-validation/src/test/java/org/kie/dmn/validation/dtanalysis/SubsumptionRulesTest.java
@@ -31,9 +31,7 @@ import org.kie.dmn.validation.dtanalysis.model.Interval;
 import org.kie.dmn.validation.dtanalysis.model.Overlap;
 import org.kie.dmn.validation.dtanalysis.model.Subsumption;
 
-import static org.hamcrest.Matchers.contains;
-import static org.hamcrest.Matchers.hasSize;
-import static org.hamcrest.MatcherAssert.assertThat;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.Assert.assertTrue;
 import static org.kie.dmn.validation.DMNValidator.Validation.ANALYZE_DECISION_TABLE;
 
@@ -43,9 +41,9 @@ public class SubsumptionRulesTest extends AbstractDTAnalysisTest {
     public void testSubsumptionRules() {
         List<DMNMessage> validate = validator.validate(getReader("Subsumption.dmn"), ANALYZE_DECISION_TABLE);
         DTAnalysis analysis = getAnalysis(validate, "_82100fc5-8799-4ee2-981f-215ded39e68a");
-        assertThat(analysis.getGaps(), hasSize(0));
+        assertThat(analysis.getGaps()).hasSize(0);
         // assert OVERLAPs count.
-        assertThat(analysis.getOverlaps(), hasSize(2));
+        assertThat(analysis.getOverlaps()).hasSize(2);
         @SuppressWarnings({"unchecked", "rawtypes"})
         List<Overlap> overlaps = Arrays.asList(new Overlap(Arrays.asList(2,
                                                                          3),
@@ -77,15 +75,15 @@ public class SubsumptionRulesTest extends AbstractDTAnalysisTest {
                                                                                                                    new Bound(true,
                                                                                                                              RangeBoundary.CLOSED,
                                                                                                                              null))))));
-        assertThat(overlaps, hasSize(2));
+        assertThat(overlaps).hasSize(2);
         // Assert OVERLAPs same values
-        assertThat(analysis.getOverlaps(), contains(overlaps.toArray()));
+        assertThat(analysis.getOverlaps()).containsAll(overlaps);
 
         // Subsumption count.
-        assertThat(analysis.getSubsumptions(), hasSize(1));
+        assertThat(analysis.getSubsumptions()).hasSize(1);
         List<Subsumption> results = Arrays.asList(new Subsumption(2, 4));
-        assertThat(results, hasSize(1));
-        assertThat(analysis.getSubsumptions(), contains(results.toArray()));
+        assertThat(results).hasSize(1);
+        assertThat(analysis.getSubsumptions()).containsAll(results);
         assertTrue("It should contain at least 1 DMNMessage for the Subsumtption",
                    validate.stream().anyMatch(p -> p.getMessageType().equals(DMNMessageType.DECISION_TABLE_SUBSUMPTION_RULE)));
     }

--- a/kie-dmn/kie-dmn-validation/src/test/java/org/kie/dmn/validation/dtanalysis/mcdc/ExampleMCDCTest.java
+++ b/kie-dmn/kie-dmn-validation/src/test/java/org/kie/dmn/validation/dtanalysis/mcdc/ExampleMCDCTest.java
@@ -57,10 +57,7 @@ import org.kie.dmn.validation.dtanalysis.model.DTAnalysis;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import static org.hamcrest.CoreMatchers.hasItems;
-import static org.hamcrest.CoreMatchers.notNullValue;
-import static org.hamcrest.Matchers.hasSize;
-import static org.hamcrest.MatcherAssert.assertThat;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.kie.dmn.validation.DMNValidator.Validation.ANALYZE_DECISION_TABLE;
 import static org.kie.dmn.validation.DMNValidator.Validation.COMPUTE_DECISION_TABLE_MCDC;
 
@@ -75,7 +72,7 @@ public class ExampleMCDCTest extends AbstractDTAnalysisTest {
 
         DTAnalysis analysis = getAnalysis(validate, "_452a0adf-dd49-47c3-b02d-fe0ad45902c7");
         Collection<Record> mcdcCases = computeMCDCCases(analysis.getMCDCSelectedBlocks());
-        assertThat(mcdcCases, hasSize(16));
+        assertThat(mcdcCases).hasSize(16);
 
         assertMCDCCases(resourceFileName, analysis.getSource(), mcdcCases);
         //debugOutputAndOpenXLSX(analysis.getSource(), analysis.getMCDCSelectedBlocks());
@@ -90,7 +87,7 @@ public class ExampleMCDCTest extends AbstractDTAnalysisTest {
 
         DTAnalysis analysis = getAnalysis(validate, "_e31c78b7-63ef-4112-a0bc-b0546043ebe9");
         Collection<Record> mcdcCases = computeMCDCCases(analysis.getMCDCSelectedBlocks());
-        assertThat(mcdcCases, hasSize(14));
+        assertThat(mcdcCases).hasSize(14);
 
         assertMCDCCases(resourceFileName, analysis.getSource(), mcdcCases);
         //debugOutputAndOpenXLSX(analysis.getSource(), analysis.getMCDCSelectedBlocks());
@@ -115,7 +112,7 @@ public class ExampleMCDCTest extends AbstractDTAnalysisTest {
         MCDCListener mcdcListener = new MCDCListener();
         runtime.addListener(mcdcListener);
         DMNModel dmnModel = runtime.getModels().get(0);
-        assertThat(dmnModel, notNullValue());
+        assertThat(dmnModel).isNotNull();
 
         for (Record mcdcCase : mcdcCases) {
             mcdcListener.selectedRule.clear();
@@ -125,7 +122,7 @@ public class ExampleMCDCTest extends AbstractDTAnalysisTest {
             }
             DMNResult evaluateAll = runtime.evaluateAll(dmnModel, context);
             LOG.debug("{}", evaluateAll);
-            assertThat(mcdcListener.selectedRule, hasItems(mcdcCase.ruleIdx + 1));
+            assertThat(mcdcListener.selectedRule).contains(mcdcCase.ruleIdx + 1);
         }
     }
 

--- a/kie-dmn/kie-dmn-xls2dmn-cli/src/test/java/org/kie/dmn/xls2dmn/cli/CardApprovalTest.java
+++ b/kie-dmn/kie-dmn-xls2dmn-cli/src/test/java/org/kie/dmn/xls2dmn/cli/CardApprovalTest.java
@@ -29,8 +29,6 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.hamcrest.CoreMatchers.is;
-import static org.hamcrest.MatcherAssert.assertThat;
 import static org.kie.dmn.xls2dmn.cli.TestUtils.getRuntime;
 
 import picocli.CommandLine;
@@ -71,9 +69,9 @@ public class CardApprovalTest {
         dmnContext.set("Assets", 150);
         DMNResult dmnResult = dmnRuntime.evaluateAll(dmnModel, dmnContext);
         LOG.debug("{}", dmnResult);
-        assertThat(DMNRuntimeUtil.formatMessages(dmnResult.getMessages()), dmnResult.hasErrors(), is(false));
-        assertThat(dmnResult.getDecisionResultByName("Standard card score").getResult(), is(new BigDecimal(562)));
-        assertThat(dmnResult.getDecisionResultByName("Gold card score").getResult(), is(new BigDecimal(468)));
+        assertThat(dmnResult.hasErrors()).as(DMNRuntimeUtil.formatMessages(dmnResult.getMessages())).isFalse();
+        assertThat(dmnResult.getDecisionResultByName("Standard card score").getResult()).isEqualTo(new BigDecimal(562));
+        assertThat(dmnResult.getDecisionResultByName("Gold card score").getResult()).isEqualTo(new BigDecimal(468));
     }
 
 

--- a/kie-dmn/kie-dmn-xls2dmn-cli/src/test/java/org/kie/dmn/xls2dmn/cli/ChineseLunarYearsTest.java
+++ b/kie-dmn/kie-dmn-xls2dmn-cli/src/test/java/org/kie/dmn/xls2dmn/cli/ChineseLunarYearsTest.java
@@ -28,8 +28,7 @@ import org.kie.dmn.core.util.DMNRuntimeUtil;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import static org.hamcrest.CoreMatchers.is;
-import static org.hamcrest.MatcherAssert.assertThat;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.kie.dmn.xls2dmn.cli.TestUtils.getRuntime;
 
 import picocli.CommandLine;
@@ -48,7 +47,7 @@ public class ChineseLunarYearsTest {
         dmnContext.set("Date", LocalDate.of(2021, 4, 1));
         DMNResult dmnResult = dmnRuntime.evaluateAll(dmnModel, dmnContext);
         LOG.debug("{}", dmnResult);
-        assertThat(DMNRuntimeUtil.formatMessages(dmnResult.getMessages()), dmnResult.hasErrors(), is(false));
-        assertThat(dmnResult.getDecisionResultByName("Chinese Year").getResult(), is("Golden Ox"));
+        assertThat(dmnResult.hasErrors()).as(DMNRuntimeUtil.formatMessages(dmnResult.getMessages())).isFalse();
+        assertThat(dmnResult.getDecisionResultByName("Chinese Year").getResult()).isEqualTo("Golden Ox");
     }
 }

--- a/kie-dmn/kie-dmn-xls2dmn-cli/src/test/java/org/kie/dmn/xls2dmn/cli/TestUtils.java
+++ b/kie-dmn/kie-dmn-xls2dmn-cli/src/test/java/org/kie/dmn/xls2dmn/cli/TestUtils.java
@@ -31,8 +31,7 @@ import org.kie.internal.io.ResourceFactory;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import static org.hamcrest.CoreMatchers.is;
-import static org.hamcrest.MatcherAssert.assertThat;
+import static org.assertj.core.api.Assertions.assertThat;
 
 public class TestUtils {
 
@@ -46,7 +45,7 @@ public class TestUtils {
 
     public static DMNRuntime validateRuntime(File outFile) {
         List<DMNMessage> validate = DMNValidatorFactory.newValidator().validate(outFile);
-        assertThat(validate.stream().filter(m -> m.getLevel() == Level.ERROR).count(), is(0L));
+        assertThat(validate.stream().filter(m -> m.getLevel() == Level.ERROR).count()).isEqualTo(0L);
 
         Either<Exception, DMNRuntime> fromResources = DMNRuntimeBuilder.fromDefaults()
                                                                        .buildConfiguration()

--- a/kie-dmn/kie-dmn-xls2dmn-cli/src/test/java/org/kie/dmn/xls2dmn/cli/XLS2DMNParserTest.java
+++ b/kie-dmn/kie-dmn-xls2dmn-cli/src/test/java/org/kie/dmn/xls2dmn/cli/XLS2DMNParserTest.java
@@ -28,8 +28,7 @@ import org.kie.dmn.core.util.DMNRuntimeUtil;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import static org.hamcrest.CoreMatchers.is;
-import static org.hamcrest.MatcherAssert.assertThat;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.kie.dmn.xls2dmn.cli.TestUtils.validateRuntime;
 
 public class XLS2DMNParserTest {
@@ -59,8 +58,8 @@ public class XLS2DMNParserTest {
         dmnContext.set("FICO Score", 650);
         DMNResult dmnResult = dmnRuntime.evaluateAll(dmnModel, dmnContext);
         LOG.debug("{}", dmnResult);
-        assertThat(DMNRuntimeUtil.formatMessages(dmnResult.getMessages()), dmnResult.hasErrors(), is(false));
-        assertThat(dmnResult.getDecisionResultByName("Loan Approval").getResult(), is("Not approved"));
+        assertThat(dmnResult.hasErrors()).as(DMNRuntimeUtil.formatMessages(dmnResult.getMessages())).isFalse();
+        assertThat(dmnResult.getDecisionResultByName("Loan Approval").getResult()).isEqualTo("Not approved");
     }
     
     @Test
@@ -71,7 +70,7 @@ public class XLS2DMNParserTest {
         dmnContext.set("FICO Score", 800);
         DMNResult dmnResult = dmnRuntime.evaluateAll(dmnModel, dmnContext);
         LOG.debug("{}", dmnResult);
-        assertThat(DMNRuntimeUtil.formatMessages(dmnResult.getMessages()), dmnResult.hasErrors(), is(false));
-        assertThat(dmnResult.getDecisionResultByName("Loan Approval").getResult(), is("Approved"));
+        assertThat(dmnResult.hasErrors()).as(DMNRuntimeUtil.formatMessages(dmnResult.getMessages())).isFalse();
+        assertThat(dmnResult.getDecisionResultByName("Loan Approval").getResult()).isEqualTo("Approved");
     }
 }

--- a/kie-memory-compiler/pom.xml
+++ b/kie-memory-compiler/pom.xml
@@ -27,6 +27,12 @@
       <artifactId>junit</artifactId>
       <scope>test</scope>
     </dependency>
+    <dependency>
+      <groupId>org.assertj</groupId>
+      <artifactId>assertj-core</artifactId>
+      <scope>test</scope>
+    </dependency>
+    
 
   </dependencies>
 

--- a/kie-memory-compiler/src/test/java/org/kie/memorycompiler/KieMemoryCompilerTest.java
+++ b/kie-memory-compiler/src/test/java/org/kie/memorycompiler/KieMemoryCompilerTest.java
@@ -21,9 +21,7 @@ import java.util.Map;
 import org.junit.Test;
 
 import static java.util.Collections.singletonMap;
-import static org.hamcrest.CoreMatchers.is;
-import static org.hamcrest.CoreMatchers.notNullValue;
-import static org.hamcrest.MatcherAssert.assertThat;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 
@@ -45,12 +43,12 @@ public class KieMemoryCompilerTest {
         Map<String, Class<?>> compiled = KieMemoryCompiler.compile(source, this.getClass().getClassLoader());
 
         Class<?> exampleClazz = compiled.get("org.kie.memorycompiler.ExampleClass");
-        assertThat(exampleClazz, is(notNullValue()));
+        assertThat(exampleClazz).isNotNull();
 
         Object instance = exampleClazz.getDeclaredConstructors()[0].newInstance();
         Method sumMethod = exampleClazz.getMethod("sum", Integer.class, Integer.class);
         Object result = sumMethod.invoke(instance, 2, 3);
-        assertThat(result, is(5));
+        assertThat(result).isEqualTo(5);
     }
 
     @Test(expected = KieMemoryCompilerException.class)
@@ -84,12 +82,12 @@ public class KieMemoryCompilerTest {
         Map<String, Class<?>> compiled = KieMemoryCompiler.compile(source, this.getClass().getClassLoader());
 
         Class<?> exampleClazz = compiled.get("org.kie.memorycompiler.WarningClass");
-        assertThat(exampleClazz, is(notNullValue()));
+        assertThat(exampleClazz).isNotNull();
 
         Object instance = exampleClazz.getDeclaredConstructors()[0].newInstance();
         Method minusMethod = exampleClazz.getMethod("minus", Integer.class, Integer.class);
         Object result = minusMethod.invoke(instance, 8, 4);
-        assertThat(result, is(4));
+        assertThat(result).isEqualTo(4);
     }
 
     private final static String EXAMPLE_INNER_CLASS =


### PR DESCRIPTION
Backport to 7.x branch of [4336](https://github.com/kiegroup/drools/pull/4336)

<details>
<summary>
How to replicate CI configuration locally?
</summary>

Build Chain tool does "simple" maven build(s), the builds are just Maven commands, but because the repositories relates and depends on each other and any change in API or class method could affect several of those repositories there is a need to use [build-chain tool](https://github.com/kiegroup/github-action-build-chain) to handle cross repository builds and be sure that we always use latest version of the code for each repository.
 
[build-chain tool](https://github.com/kiegroup/github-action-build-chain) is a build tool which can be used on command line locally or in Github Actions workflow(s), in case you need to change multiple repositories and send multiple dependent pull requests related with a change you can easily reproduce the same build by executing it on Github hosted environment or locally in your development environment. See [local execution](https://github.com/kiegroup/github-action-build-chain#local-execution) details to get more information about it.
</details>

<details>
<summary>
How to retest this PR or trigger a specific build:
</summary>

- for <b>pull request checks</b>  
  Please add comment: <b>Jenkins retest this</b>

- for a <b>specific pull request check</b>  
  Please add comment: <b>Jenkins (re)run [drools|kogito-runtimes|optaplanner|kogito-apps|kogito-examples|optaplanner-quickstarts|optaweb-employee-rostering|optaweb-vehicle-routing] tests</b>

- for a <b>full downstream build</b> 
  - for <b>jenkins</b> job: please add comment: <b>Jenkins run fdb</b>
  - for <b>github actions</b> job: add the label `run_fdb`

- <b>a compile downstream build</b> please  add comment: <b>Jenkins run cdb</b>

- <b>a full production downstream build</b> please add comment: <b>Jenkins execute product fdb</b>

- <b>an upstream build</b> please add comment: <b>Jenkins run upstream</b>

- for <b>quarkus branch checks</b>  
  Run checks against Quarkus current used branch  
  Please add comment: <b>Jenkins run quarkus-branch</b>

- for a <b>quarkus branch specific check</b>  
  Run checks against Quarkus current used branch  
  Please add comment: <b>Jenkins (re)run [drools|kogito-runtimes|optaplanner|kogito-apps|kogito-examples|optaplanner-quickstarts|optaweb-employee-rostering|optaweb-vehicle-routing] quarkus-branch</b>

- for <b>quarkus main checks</b>  
  Run checks against Quarkus main branch  
  Please add comment: <b>Jenkins run quarkus-main</b>

- for a <b>specific quarkus main check</b>  
  Run checks against Quarkus main branch  
  Please add comment: <b>Jenkins (re)run [drools|kogito-runtimes|optaplanner|kogito-apps|kogito-examples|optaplanner-quickstarts|optaweb-employee-rostering|optaweb-vehicle-routing] quarkus-branch</b>

- for <b>native checks</b>  
  Run native checks  
  Please add comment: <b>Jenkins run native</b>

- for a <b>specific native check</b>  
  Run native checks 
  Please add comment: <b>Jenkins (re)run [drools|kogito-runtimes|optaplanner|kogito-apps|kogito-examples|optaplanner-quickstarts|optaweb-employee-rostering|optaweb-vehicle-routing] native</b>

- for <b>mandrel checks</b>  
  Run native checks against Mandrel image
  Please add comment: <b>Jenkins run mandrel</b>

- for a <b>specific mandrel check</b>  
  Run native checks against Mandrel image  
  Please add comment: <b>Jenkins (re)run [drools|kogito-runtimes|optaplanner|kogito-apps|kogito-examples|optaplanner-quickstarts|optaweb-employee-rostering|optaweb-vehicle-routing] mandrel</b>
</details>
