### PR TITLE
[RHPAM-4304] Unable to reimport kjar in OSGI using kie scanner and IB…

### DIFF
--- a/drools-compiler/src/main/java/org/drools/compiler/kproject/models/KieModuleMarshaller.java
+++ b/drools-compiler/src/main/java/org/drools/compiler/kproject/models/KieModuleMarshaller.java
@@ -37,12 +37,18 @@ import org.drools.core.util.AbstractXStreamConverter;
 import org.drools.core.util.IoUtils;
 import org.kie.api.builder.model.KieBaseModel;
 import org.kie.api.builder.model.KieModuleModel;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.xml.sax.SAXException;
+import org.xml.sax.SAXNotRecognizedException;
+import org.xml.sax.SAXNotSupportedException;
 
 import static org.drools.core.util.IoUtils.readBytesFromInputStream;
 import static org.kie.soup.xstream.XStreamUtils.createNonTrustingXStream;
 
 public class KieModuleMarshaller {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(KieModuleMarshaller.class);
 
     static final KieModuleMarshaller MARSHALLER = new KieModuleMarshaller();
 
@@ -204,8 +210,16 @@ public class KieModuleMarshaller {
             try {
                 Thread.currentThread().setContextClassLoader(ClassLoader.getSystemClassLoader());
                 Validator validator = schema.newValidator();
-                validator.setProperty(XMLConstants.ACCESS_EXTERNAL_DTD, "");
-                validator.setProperty(XMLConstants.ACCESS_EXTERNAL_SCHEMA, "");
+                try {
+                    validator.setProperty(XMLConstants.ACCESS_EXTERNAL_DTD, "");
+                } catch (SAXNotRecognizedException | SAXNotSupportedException notSupportedException) {
+                    LOGGER.warn("{} is not supported", XMLConstants.ACCESS_EXTERNAL_DTD);
+                }
+                try {
+                    validator.setProperty(XMLConstants.ACCESS_EXTERNAL_SCHEMA, "");
+                } catch (SAXNotRecognizedException | SAXNotSupportedException notSupportedException) {
+                    LOGGER.warn("{} is not supported", XMLConstants.ACCESS_EXTERNAL_SCHEMA);
+                }
                 validator.validate(source);
             } finally {
                 Thread.currentThread().setContextClassLoader(tccl);


### PR DESCRIPTION
…M Java (#4375)

**Ports** 
This PR is forward-port of https://github.com/kiegroup/drools/pull/4375 for 7.x

**JIRA**: 
https://issues.redhat.com/browse/RHPAM-4304


<details>
<summary>
How to replicate CI configuration locally?
</summary>

Build Chain tool does "simple" maven build(s), the builds are just Maven commands, but because the repositories relates and depends on each other and any change in API or class method could affect several of those repositories there is a need to use [build-chain tool](https://github.com/kiegroup/github-action-build-chain) to handle cross repository builds and be sure that we always use latest version of the code for each repository.
 
[build-chain tool](https://github.com/kiegroup/github-action-build-chain) is a build tool which can be used on command line locally or in Github Actions workflow(s), in case you need to change multiple repositories and send multiple dependent pull requests related with a change you can easily reproduce the same build by executing it on Github hosted environment or locally in your development environment. See [local execution](https://github.com/kiegroup/github-action-build-chain#local-execution) details to get more information about it.
</details>

<details>
<summary>
How to retest this PR or trigger a specific build:
</summary>

- for <b>pull request checks</b>  
  Please add comment: <b>Jenkins retest this</b>

- for a <b>specific pull request check</b>  
  Please add comment: <b>Jenkins (re)run [drools|kogito-runtimes|optaplanner|kogito-apps|kogito-examples|optaplanner-quickstarts|optaweb-employee-rostering|optaweb-vehicle-routing] tests</b>

- for a <b>full downstream build</b> 
  - for <b>jenkins</b> job: please add comment: <b>Jenkins run fdb</b>
  - for <b>github actions</b> job: add the label `run_fdb`

- <b>a compile downstream build</b> please  add comment: <b>Jenkins run cdb</b>

- <b>a full production downstream build</b> please add comment: <b>Jenkins execute product fdb</b>

- <b>an upstream build</b> please add comment: <b>Jenkins run upstream</b>

- for <b>quarkus branch checks</b>  
  Run checks against Quarkus current used branch  
  Please add comment: <b>Jenkins run quarkus-branch</b>

- for a <b>quarkus branch specific check</b>  
  Run checks against Quarkus current used branch  
  Please add comment: <b>Jenkins (re)run [drools|kogito-runtimes|optaplanner|kogito-apps|kogito-examples|optaplanner-quickstarts|optaweb-employee-rostering|optaweb-vehicle-routing] quarkus-branch</b>

- for <b>quarkus main checks</b>  
  Run checks against Quarkus main branch  
  Please add comment: <b>Jenkins run quarkus-main</b>

- for a <b>specific quarkus main check</b>  
  Run checks against Quarkus main branch  
  Please add comment: <b>Jenkins (re)run [drools|kogito-runtimes|optaplanner|kogito-apps|kogito-examples|optaplanner-quickstarts|optaweb-employee-rostering|optaweb-vehicle-routing] quarkus-branch</b>

- for <b>native checks</b>  
  Run native checks  
  Please add comment: <b>Jenkins run native</b>

- for a <b>specific native check</b>  
  Run native checks 
  Please add comment: <b>Jenkins (re)run [drools|kogito-runtimes|optaplanner|kogito-apps|kogito-examples|optaplanner-quickstarts|optaweb-employee-rostering|optaweb-vehicle-routing] native</b>

- for <b>mandrel checks</b>  
  Run native checks against Mandrel image
  Please add comment: <b>Jenkins run mandrel</b>

- for a <b>specific mandrel check</b>  
  Run native checks against Mandrel image  
  Please add comment: <b>Jenkins (re)run [drools|kogito-runtimes|optaplanner|kogito-apps|kogito-examples|optaplanner-quickstarts|optaweb-employee-rostering|optaweb-vehicle-routing] mandrel</b>
</details>
