### PR TITLE
add oopath test in rule units

### DIFF
--- a/drools-ruleunits/drools-ruleunits-impl/src/test/java/org/drools/ruleunits/impl/InMemoryRuleUnitInstanceFactory.java
+++ b/drools-ruleunits/drools-ruleunits-impl/src/test/java/org/drools/ruleunits/impl/InMemoryRuleUnitInstanceFactory.java
@@ -29,8 +29,8 @@ public class InMemoryRuleUnitInstanceFactory {
 
     private static final Map<Class, ClassLoader> kieModuleClassLoaders = new HashMap<>();
 
-    public static <T extends RuleUnitData> RuleUnitInstance<T> generateAndInstance(T ruleUnit) {
-        ClassLoader kieModuleClassLoader = kieModuleClassLoaders.computeIfAbsent(ruleUnit.getClass(), c -> createRuleUnitKieProject(c).getClassLoader());
+    public static <T extends RuleUnitData> RuleUnitInstance<T> generateAndInstance(T ruleUnit, String... drls) {
+        ClassLoader kieModuleClassLoader = kieModuleClassLoaders.computeIfAbsent(ruleUnit.getClass(), c -> createRuleUnitKieProject(c, drls).getClassLoader());
         return loadRuleUnits(kieModuleClassLoader).get(ruleUnit.getClass().getCanonicalName()).createInstance(ruleUnit);
     }
 

--- a/drools-ruleunits/drools-ruleunits-impl/src/test/java/org/drools/ruleunits/impl/OOPathTest.java
+++ b/drools-ruleunits/drools-ruleunits-impl/src/test/java/org/drools/ruleunits/impl/OOPathTest.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright 2022 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.drools.ruleunits.impl;
+
+import org.drools.ruleunits.api.RuleUnitInstance;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+public class OOPathTest {
+
+    @Test
+    public void testOOPathAfterNot() {
+        OOPathTestUnit unit = new OOPathTestUnit();
+        unit.getStrings().add("Hello World");
+
+        RuleUnitInstance<OOPathTestUnit> unitInstance = InMemoryRuleUnitInstanceFactory.generateAndInstance(unit, "OOPathTest");
+        assertEquals(1, unitInstance.fire());
+        assertTrue(unit.getResults().contains("it worked!"));
+    }
+}

--- a/drools-ruleunits/drools-ruleunits-impl/src/test/java/org/drools/ruleunits/impl/OOPathTestUnit.java
+++ b/drools-ruleunits/drools-ruleunits-impl/src/test/java/org/drools/ruleunits/impl/OOPathTestUnit.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright 2022 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.drools.ruleunits.impl;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.drools.ruleunits.api.DataSource;
+import org.drools.ruleunits.api.DataStore;
+import org.drools.ruleunits.api.RuleUnitData;
+
+public class OOPathTestUnit implements RuleUnitData {
+    private final DataStore<String> strings;
+    private final DataStore<Integer> ints;
+    private final List<String> results = new ArrayList<>();
+
+    public OOPathTestUnit() {
+        this(DataSource.createStore(), DataSource.createStore());
+    }
+
+    public OOPathTestUnit(DataStore<String> strings, DataStore<Integer> ints) {
+        this.strings = strings;
+        this.ints = ints;
+    }
+
+    public DataStore<String> getStrings() {
+        return strings;
+    }
+
+    public DataStore<Integer> getInts() {
+        return ints;
+    }
+
+    public List<String> getResults() {
+        return results;
+    }
+}

--- a/drools-ruleunits/drools-ruleunits-impl/src/test/resources/org/drools/ruleunits/impl/OOPathTest.drl
+++ b/drools-ruleunits/drools-ruleunits-impl/src/test/resources/org/drools/ruleunits/impl/OOPathTest.drl
@@ -1,0 +1,26 @@
+/**
+ * Copyright 2019 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.drools.ruleunits.impl;
+unit OOPathTestUnit;
+
+rule Test
+when
+    /strings[ this == "Hello World" ]
+    not( /ints[ this == 1 ] )
+    /strings[ length > 3 ]
+then
+    results.add("it worked!");
+end


### PR DESCRIPTION
@tkobayas in drools we don't have any tests for "rule-unit style" oopath, i.e. entire oopath pattern instead of simple oopath constraints as we have in a few test classes. This commit is a first introduction of this type of tests, based on the problem reported by Masato.