### PR TITLE
[DROOLS-6936] BigDecimalLiteral with binding in mvel dialect causes C…

### DIFF
--- a/drools-model/drools-model-compiler/src/test/java/org/drools/modelcompiler/bigdecimaltest/BigDecimalTest.java
+++ b/drools-model/drools-model-compiler/src/test/java/org/drools/modelcompiler/bigdecimaltest/BigDecimalTest.java
@@ -18,7 +18,10 @@
 package org.drools.modelcompiler.bigdecimaltest;
 
 import java.math.BigDecimal;
+import java.util.ArrayList;
+import java.util.List;
 
+import org.assertj.core.api.Assertions;
 import org.drools.modelcompiler.BaseModelTest;
 import org.junit.Test;
 import org.kie.api.runtime.KieSession;
@@ -521,5 +524,31 @@ public class BigDecimalTest extends BaseModelTest {
         ksession.fireAllRules();
 
         assertEquals(new BigDecimal("-10.5"), holder.getBd1());
+    }
+
+    @Test
+    public void testBigDecimalLiteralWithBinding() {
+        // DROOLS-6936
+        String str =
+                "package org.drools.modelcompiler.bigdecimals\n" +
+                        "import " + BdHolder.class.getCanonicalName() + ";\n" +
+                        "global java.util.List result;\n" +
+                        "rule R1 dialect \"mvel\"\n" +
+                        "when\n" +
+                        "    $holder : BdHolder($bd1 : bd1, $zero : 0B)\n" +
+                        "then\n" +
+                        "    result.add($zero);\n" +
+                        "end";
+
+        KieSession ksession = getKieSession(str);
+        List<BigDecimal> result = new ArrayList<>();
+        ksession.setGlobal("result", result);
+
+        BdHolder holder = new BdHolder();
+        holder.setBd1(new BigDecimal("10"));
+        ksession.insert(holder);
+        ksession.fireAllRules();
+
+        Assertions.assertThat(result).containsExactly(new BigDecimal("0"));
     }
 }

--- a/drools-model/drools-model-compiler/src/test/java/org/drools/modelcompiler/builder/generator/drlxparse/ConstraintParserTest.java
+++ b/drools-model/drools-model-compiler/src/test/java/org/drools/modelcompiler/builder/generator/drlxparse/ConstraintParserTest.java
@@ -24,6 +24,7 @@ import com.github.javaparser.ast.expr.Expression;
 import org.drools.util.ClassTypeResolver;
 import org.drools.util.TypeResolver;
 import org.drools.modelcompiler.builder.PackageModel;
+import org.drools.modelcompiler.builder.generator.DRLIdGenerator;
 import org.drools.modelcompiler.builder.generator.RuleContext;
 import org.drools.modelcompiler.domain.Person;
 import org.junit.Before;
@@ -38,7 +39,7 @@ public class ConstraintParserTest {
 
     @Before
     public void setup() {
-        PackageModel packageModel = new PackageModel("org.kie.test:constraint-parser-test:1.0.0", "org.kie.test", null, null, null);
+        PackageModel packageModel = new PackageModel("org.kie.test:constraint-parser-test:1.0.0", "org.kie.test", null, null, new DRLIdGenerator());
         Set<String> imports = new HashSet<>();
         imports.add("org.drools.modelcompiler.domain.Person");
         TypeResolver typeResolver = new ClassTypeResolver(imports, getClass().getClassLoader());
@@ -97,9 +98,21 @@ public class ConstraintParserTest {
     public void testMultiplyStringIntWithBindVariableCompareToBigDecimal() {
         SingleDrlxParseSuccess result = (SingleDrlxParseSuccess) parser.drlxParse(Person.class, "$p", "money == likes * 10"); // assuming likes contains number String
 
-        System.out.println(result.getExpr().toString());
-
         assertEquals("org.drools.modelcompiler.util.EvaluationUtil.equals(org.drools.modelcompiler.util.EvaluationUtil.toBigDecimal(_this.getMoney()), org.drools.modelcompiler.util.EvaluationUtil.toBigDecimal(Double.valueOf(_this.getLikes()) * 10))",
                      result.getExpr().toString());
+    }
+
+    @Test
+    public void testBigDecimalLiteralWithBindVariable() {
+        SingleDrlxParseSuccess result = (SingleDrlxParseSuccess) parser.drlxParse(Person.class, "$p", "$bd : 10.3B");
+
+        assertEquals("new java.math.BigDecimal(\"10.3\")", result.getExpr().toString());
+    }
+
+    @Test
+    public void testBigIntegerLiteralWithBindVariable() {
+        SingleDrlxParseSuccess result = (SingleDrlxParseSuccess) parser.drlxParse(Person.class, "$p", "$bi : 10I");
+
+        assertEquals("new java.math.BigInteger(\"10\")", result.getExpr().toString());
     }
 }

--- a/drools-model/drools-mvel-parser/src/main/java/org/drools/mvel/parser/ast/expr/BigDecimalLiteralExpr.java
+++ b/drools-model/drools-mvel-parser/src/main/java/org/drools/mvel/parser/ast/expr/BigDecimalLiteralExpr.java
@@ -28,14 +28,18 @@ import java.math.BigDecimal;
 import com.github.javaparser.TokenRange;
 import com.github.javaparser.ast.AllFieldsConstructor;
 import com.github.javaparser.ast.Node;
+import com.github.javaparser.ast.NodeList;
 import com.github.javaparser.ast.expr.LiteralStringValueExpr;
+import com.github.javaparser.ast.expr.ObjectCreationExpr;
+import com.github.javaparser.ast.expr.StringLiteralExpr;
+import com.github.javaparser.ast.type.ClassOrInterfaceType;
 import com.github.javaparser.ast.visitor.CloneVisitor;
-import org.drools.mvel.parser.ast.visitor.DrlGenericVisitor;
-import org.drools.mvel.parser.ast.visitor.DrlVoidVisitor;
 import com.github.javaparser.ast.visitor.GenericVisitor;
 import com.github.javaparser.ast.visitor.VoidVisitor;
 import com.github.javaparser.metamodel.JavaParserMetaModel;
 import com.github.javaparser.metamodel.LongLiteralExprMetaModel;
+import org.drools.mvel.parser.ast.visitor.DrlGenericVisitor;
+import org.drools.mvel.parser.ast.visitor.DrlVoidVisitor;
 
 public final class BigDecimalLiteralExpr extends LiteralStringValueExpr {
 
@@ -107,5 +111,9 @@ public final class BigDecimalLiteralExpr extends LiteralStringValueExpr {
     @Override
     public LongLiteralExprMetaModel getMetaModel() {
         return JavaParserMetaModel.longLiteralExprMetaModel;
+    }
+
+    public ObjectCreationExpr convertToObjectCreationExpr() {
+        return new ObjectCreationExpr(null, new ClassOrInterfaceType(null, BigDecimal.class.getCanonicalName()), NodeList.nodeList(new StringLiteralExpr(getValue())));
     }
 }

--- a/drools-model/drools-mvel-parser/src/main/java/org/drools/mvel/parser/ast/expr/BigIntegerLiteralExpr.java
+++ b/drools-model/drools-mvel-parser/src/main/java/org/drools/mvel/parser/ast/expr/BigIntegerLiteralExpr.java
@@ -28,14 +28,18 @@ import java.math.BigInteger;
 import com.github.javaparser.TokenRange;
 import com.github.javaparser.ast.AllFieldsConstructor;
 import com.github.javaparser.ast.Node;
+import com.github.javaparser.ast.NodeList;
 import com.github.javaparser.ast.expr.LiteralStringValueExpr;
+import com.github.javaparser.ast.expr.ObjectCreationExpr;
+import com.github.javaparser.ast.expr.StringLiteralExpr;
+import com.github.javaparser.ast.type.ClassOrInterfaceType;
 import com.github.javaparser.ast.visitor.CloneVisitor;
-import org.drools.mvel.parser.ast.visitor.DrlGenericVisitor;
-import org.drools.mvel.parser.ast.visitor.DrlVoidVisitor;
 import com.github.javaparser.ast.visitor.GenericVisitor;
 import com.github.javaparser.ast.visitor.VoidVisitor;
 import com.github.javaparser.metamodel.JavaParserMetaModel;
 import com.github.javaparser.metamodel.LongLiteralExprMetaModel;
+import org.drools.mvel.parser.ast.visitor.DrlGenericVisitor;
+import org.drools.mvel.parser.ast.visitor.DrlVoidVisitor;
 
 public final class BigIntegerLiteralExpr extends LiteralStringValueExpr {
 
@@ -108,5 +112,9 @@ public final class BigIntegerLiteralExpr extends LiteralStringValueExpr {
     @Override
     public LongLiteralExprMetaModel getMetaModel() {
         return JavaParserMetaModel.longLiteralExprMetaModel;
+    }
+
+    public ObjectCreationExpr convertToObjectCreationExpr() {
+        return new ObjectCreationExpr(null, new ClassOrInterfaceType(null, BigInteger.class.getCanonicalName()), NodeList.nodeList(new StringLiteralExpr(getValue())));
     }
 }


### PR DESCRIPTION
…lassCastException in executable model build (#4352)

**Ports** 
This PR is a forward-port of https://github.com/kiegroup/drools/pull/4352 for main

**JIRA**: 
https://issues.redhat.com/browse/DROOLS-6936

<details>
<summary>
How to replicate CI configuration locally?
</summary>

Build Chain tool does "simple" maven build(s), the builds are just Maven commands, but because the repositories relates and depends on each other and any change in API or class method could affect several of those repositories there is a need to use [build-chain tool](https://github.com/kiegroup/github-action-build-chain) to handle cross repository builds and be sure that we always use latest version of the code for each repository.
 
[build-chain tool](https://github.com/kiegroup/github-action-build-chain) is a build tool which can be used on command line locally or in Github Actions workflow(s), in case you need to change multiple repositories and send multiple dependent pull requests related with a change you can easily reproduce the same build by executing it on Github hosted environment or locally in your development environment. See [local execution](https://github.com/kiegroup/github-action-build-chain#local-execution) details to get more information about it.
</details>

<details>
<summary>
How to retest this PR or trigger a specific build:
</summary>

- for <b>pull request checks</b>  
  Please add comment: <b>Jenkins retest this</b>

- for a <b>specific pull request check</b>  
  Please add comment: <b>Jenkins (re)run [drools|kogito-runtimes|optaplanner|kogito-apps|kogito-examples|optaplanner-quickstarts|optaweb-employee-rostering|optaweb-vehicle-routing] tests</b>

- for a <b>full downstream build</b> 
  - for <b>jenkins</b> job: please add comment: <b>Jenkins run fdb</b>
  - for <b>github actions</b> job: add the label `run_fdb`

- <b>a compile downstream build</b> please  add comment: <b>Jenkins run cdb</b>

- <b>a full production downstream build</b> please add comment: <b>Jenkins execute product fdb</b>

- <b>an upstream build</b> please add comment: <b>Jenkins run upstream</b>

- for <b>quarkus branch checks</b>  
  Run checks against Quarkus current used branch  
  Please add comment: <b>Jenkins run quarkus-branch</b>

- for a <b>quarkus branch specific check</b>  
  Run checks against Quarkus current used branch  
  Please add comment: <b>Jenkins (re)run [drools|kogito-runtimes|optaplanner|kogito-apps|kogito-examples|optaplanner-quickstarts|optaweb-employee-rostering|optaweb-vehicle-routing] quarkus-branch</b>

- for <b>quarkus main checks</b>  
  Run checks against Quarkus main branch  
  Please add comment: <b>Jenkins run quarkus-main</b>

- for a <b>specific quarkus main check</b>  
  Run checks against Quarkus main branch  
  Please add comment: <b>Jenkins (re)run [drools|kogito-runtimes|optaplanner|kogito-apps|kogito-examples|optaplanner-quickstarts|optaweb-employee-rostering|optaweb-vehicle-routing] quarkus-branch</b>

- for <b>native checks</b>  
  Run native checks  
  Please add comment: <b>Jenkins run native</b>

- for a <b>specific native check</b>  
  Run native checks 
  Please add comment: <b>Jenkins (re)run [drools|kogito-runtimes|optaplanner|kogito-apps|kogito-examples|optaplanner-quickstarts|optaweb-employee-rostering|optaweb-vehicle-routing] native</b>

- for <b>mandrel checks</b>  
  Run native checks against Mandrel image
  Please add comment: <b>Jenkins run mandrel</b>

- for a <b>specific mandrel check</b>  
  Run native checks against Mandrel image  
  Please add comment: <b>Jenkins (re)run [drools|kogito-runtimes|optaplanner|kogito-apps|kogito-examples|optaplanner-quickstarts|optaweb-employee-rostering|optaweb-vehicle-routing] mandrel</b>
</details>
