### PR TITLE
[DROOLS-6957] Investigate NPE in SmokeParserTest

### DIFF
--- a/drools-model/drools-model-compiler/src/main/java/org/drools/modelcompiler/builder/generator/operatorspec/TemporalOperatorSpec.java
+++ b/drools-model/drools-model-compiler/src/main/java/org/drools/modelcompiler/builder/generator/operatorspec/TemporalOperatorSpec.java
@@ -36,7 +36,7 @@ public class TemporalOperatorSpec implements OperatorSpec {
     public static final TemporalOperatorSpec INSTANCE = new TemporalOperatorSpec();
 
     public Expression getExpression(RuleContext context, PointFreeExpr pointFreeExpr, TypedExpression left, ExpressionTyper expressionTyper) {
-        MethodCallExpr methodCallExpr = new MethodCallExpr( DSL_NAMESPACE, pointFreeExpr.getOperator().asString() );
+        MethodCallExpr methodCallExpr = new MethodCallExpr( DSL_NAMESPACE.clone(), pointFreeExpr.getOperator().asString() );
         if (pointFreeExpr.getArg1() != null) {
             addArgumentToMethodCall( pointFreeExpr.getArg1(), methodCallExpr );
             if (pointFreeExpr.getArg2() != null) {

--- a/drools-test-coverage/test-suite/src/test/java/org/drools/testcoverage/functional/parser/SmokeParserTest.java
+++ b/drools-test-coverage/test-suite/src/test/java/org/drools/testcoverage/functional/parser/SmokeParserTest.java
@@ -26,8 +26,14 @@ import org.junit.Test;
 import org.junit.runners.Parameterized.Parameters;
 import org.kie.api.KieServices;
 import org.kie.api.io.Resource;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 public class SmokeParserTest extends ParserTest {
+
+    private final Logger LOGGER = LoggerFactory.getLogger(SmokeParserTest.class);
+
+    private static int count = 0;
 
     public SmokeParserTest(final File file, final KieBaseTestConfiguration kieBaseTestConfiguration) {
         super(file, kieBaseTestConfiguration);
@@ -40,7 +46,9 @@ public class SmokeParserTest extends ParserTest {
 
     @Test
     public void testParserSmoke() {
+        LOGGER.warn(count++ + " : " + file.getName());
         final Resource fileResource = KieServices.Factory.get().getResources().newFileSystemResource(file);
         KieUtil.getKieBuilderFromResources(kieBaseTestConfiguration, true, fileResource);
+        LOGGER.warn("done : " + file.getName());
     }
 }


### PR DESCRIPTION
**Ports** 
Back-port PR of https://github.com/kiegroup/drools/pull/4387 for 7.x

**JIRA**: 
https://issues.redhat.com/browse/DROOLS-6957

<details>
<summary>
How to replicate CI configuration locally?
</summary>

Build Chain tool does "simple" maven build(s), the builds are just Maven commands, but because the repositories relates and depends on each other and any change in API or class method could affect several of those repositories there is a need to use [build-chain tool](https://github.com/kiegroup/github-action-build-chain) to handle cross repository builds and be sure that we always use latest version of the code for each repository.
 
[build-chain tool](https://github.com/kiegroup/github-action-build-chain) is a build tool which can be used on command line locally or in Github Actions workflow(s), in case you need to change multiple repositories and send multiple dependent pull requests related with a change you can easily reproduce the same build by executing it on Github hosted environment or locally in your development environment. See [local execution](https://github.com/kiegroup/github-action-build-chain#local-execution) details to get more information about it.
</details>

<details>
<summary>
How to retest this PR or trigger a specific build:
</summary>

- for <b>pull request checks</b>  
  Please add comment: <b>Jenkins retest this</b>

- for a <b>specific pull request check</b>  
  Please add comment: <b>Jenkins (re)run [drools|kogito-runtimes|optaplanner|kogito-apps|kogito-examples|optaplanner-quickstarts|optaweb-employee-rostering|optaweb-vehicle-routing] tests</b>

- for a <b>full downstream build</b> 
  - for <b>jenkins</b> job: please add comment: <b>Jenkins run fdb</b>
  - for <b>github actions</b> job: add the label `run_fdb`

- <b>a compile downstream build</b> please  add comment: <b>Jenkins run cdb</b>

- <b>a full production downstream build</b> please add comment: <b>Jenkins execute product fdb</b>

- <b>an upstream build</b> please add comment: <b>Jenkins run upstream</b>

- for <b>quarkus branch checks</b>  
  Run checks against Quarkus current used branch  
  Please add comment: <b>Jenkins run quarkus-branch</b>

- for a <b>quarkus branch specific check</b>  
  Run checks against Quarkus current used branch  
  Please add comment: <b>Jenkins (re)run [drools|kogito-runtimes|optaplanner|kogito-apps|kogito-examples|optaplanner-quickstarts|optaweb-employee-rostering|optaweb-vehicle-routing] quarkus-branch</b>

- for <b>quarkus main checks</b>  
  Run checks against Quarkus main branch  
  Please add comment: <b>Jenkins run quarkus-main</b>

- for a <b>specific quarkus main check</b>  
  Run checks against Quarkus main branch  
  Please add comment: <b>Jenkins (re)run [drools|kogito-runtimes|optaplanner|kogito-apps|kogito-examples|optaplanner-quickstarts|optaweb-employee-rostering|optaweb-vehicle-routing] quarkus-branch</b>

- for <b>native checks</b>  
  Run native checks  
  Please add comment: <b>Jenkins run native</b>

- for a <b>specific native check</b>  
  Run native checks 
  Please add comment: <b>Jenkins (re)run [drools|kogito-runtimes|optaplanner|kogito-apps|kogito-examples|optaplanner-quickstarts|optaweb-employee-rostering|optaweb-vehicle-routing] native</b>

- for <b>mandrel checks</b>  
  Run native checks against Mandrel image
  Please add comment: <b>Jenkins run mandrel</b>

- for a <b>specific mandrel check</b>  
  Run native checks against Mandrel image  
  Please add comment: <b>Jenkins (re)run [drools|kogito-runtimes|optaplanner|kogito-apps|kogito-examples|optaplanner-quickstarts|optaweb-employee-rostering|optaweb-vehicle-routing] mandrel</b>
</details>
