### PR TITLE
[DROOLS-6961] NullPointerException in LambdaConsequence with global i…

### DIFF
--- a/drools-model/drools-model-compiler/src/main/java/org/drools/modelcompiler/consequence/LambdaConsequence.java
+++ b/drools-model/drools-model-compiler/src/main/java/org/drools/modelcompiler/consequence/LambdaConsequence.java
@@ -45,7 +45,6 @@ public class LambdaConsequence implements Consequence {
     private TupleFactSupplier[] factSuppliers;
     private GlobalSupplier[]    globalSuppliers;
     private Object[]            facts;
-    private boolean             suppliersInitialized = false;
 
     private FactHandleLookup    fhLookup;
 
@@ -118,7 +117,7 @@ public class LambdaConsequence implements Consequence {
     }
 
     private Object[] fetchFacts( KnowledgeHelper knowledgeHelper, InternalWorkingMemory workingMemory ) {
-        if (!suppliersInitialized) {
+        if (factSuppliers == null) {
             return initConsequence(knowledgeHelper, workingMemory);
         }
 
@@ -212,14 +211,14 @@ public class LambdaConsequence implements Consequence {
             tupleFactSupplier.resolveAndStore(facts, workingMemory, current.getFactHandle(), fhLookup);
         }
 
-        this.factSuppliers = factSuppliers.toArray( new TupleFactSupplier[factSuppliers.size()] );
+        // factSuppliers has to be last because factSuppliers is used as an initialization flag in fetchFacts(). See DROOLS-6961
         this.globalSuppliers = globalSuppliers.isEmpty() ? null : globalSuppliers.toArray( new GlobalSupplier[globalSuppliers.size()] );
+        this.factSuppliers = factSuppliers.toArray( new TupleFactSupplier[factSuppliers.size()] );
 
         if (!workingMemory.getSessionConfiguration().isThreadSafe()) {
             this.facts = facts;
             this.fhLookup = fhLookup;
         }
-        suppliersInitialized = true;
         return facts;
     }
 

--- a/drools-model/drools-model-compiler/src/main/java/org/drools/modelcompiler/consequence/LambdaConsequence.java
+++ b/drools-model/drools-model-compiler/src/main/java/org/drools/modelcompiler/consequence/LambdaConsequence.java
@@ -45,6 +45,7 @@ public class LambdaConsequence implements Consequence {
     private TupleFactSupplier[] factSuppliers;
     private GlobalSupplier[]    globalSuppliers;
     private Object[]            facts;
+    private boolean             suppliersInitialized = false;
 
     private FactHandleLookup    fhLookup;
 
@@ -117,7 +118,7 @@ public class LambdaConsequence implements Consequence {
     }
 
     private Object[] fetchFacts( KnowledgeHelper knowledgeHelper, InternalWorkingMemory workingMemory ) {
-        if (factSuppliers == null) {
+        if (!suppliersInitialized) {
             return initConsequence(knowledgeHelper, workingMemory);
         }
 
@@ -218,6 +219,7 @@ public class LambdaConsequence implements Consequence {
             this.facts = facts;
             this.fhLookup = fhLookup;
         }
+        suppliersInitialized = true;
         return facts;
     }
 

--- a/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/compiler/integrationtests/concurrency/GlobalConcurrencyTest.java
+++ b/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/compiler/integrationtests/concurrency/GlobalConcurrencyTest.java
@@ -1,0 +1,142 @@
+/*
+ * Copyright 2022 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.drools.compiler.integrationtests.concurrency;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
+
+import org.drools.testcoverage.common.model.Person;
+import org.drools.testcoverage.common.model.Result;
+import org.drools.testcoverage.common.util.KieBaseTestConfiguration;
+import org.drools.testcoverage.common.util.KieBaseUtil;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+import org.kie.api.KieBase;
+import org.kie.api.runtime.KieSession;
+import org.kie.test.testcategory.TurtleTestCategory;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@RunWith(Parameterized.class)
+@Category(TurtleTestCategory.class)
+public class GlobalConcurrencyTest {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(GlobalConcurrencyTest.class);
+    
+    protected static int LOOP = 3000;
+    protected static int MAX_THREAD = 30;
+    protected final KieBaseTestConfiguration kieBaseTestConfiguration;
+
+    public GlobalConcurrencyTest(final KieBaseTestConfiguration kieBaseTestConfiguration) {
+        this.kieBaseTestConfiguration = kieBaseTestConfiguration;
+    }
+
+    @Parameterized.Parameters(name = "KieBase type={0}")
+    public static Collection<Object[]> getParameters() {
+        Collection<Object[]> parameters = new ArrayList<>();
+        parameters.add(new Object[]{KieBaseTestConfiguration.CLOUD_IDENTITY_MODEL_PATTERN}); // DROOLS-6961 : exec-model only
+        return parameters;
+    }
+
+    @Test
+    public void testGlobalConcurrency() {
+        String str =
+                "package org.mypkg;" +
+                     "import " + Person.class.getCanonicalName() + ";" +
+                     "import " + Result.class.getCanonicalName() + ";" +
+                     "global Result globalResult;" +
+                     "rule R1 when\n" +
+                     "  $p1 : Person(name == \"Mark\")\n" +
+                     "then\n" +
+                     "  globalResult.setValue($p1.getName() + \" is \" + $p1.getAge());\n" +
+                     "end\n" +
+                     "rule R2 when\n" +
+                     "  $p1 : Person(name == \"Edson\")\n" +
+                     "then\n" +
+                     "  globalResult.setValue($p1.getName() + \" is \" + $p1.getAge());\n" +
+                     "end";
+
+        List<Exception> exceptionList = new ArrayList<>();
+
+        for (int i = 0; i < LOOP; i++) {
+            if (i % 100 == 0) {
+                System.out.println("loop : " + i);
+            }
+
+            KieBase kieBase = KieBaseUtil.getKieBaseFromKieModuleFromDrl("global-test", kieBaseTestConfiguration, str);
+
+            ExecutorService executor = Executors.newFixedThreadPool(MAX_THREAD);
+            final CountDownLatch latch = new CountDownLatch(MAX_THREAD);
+            for (int n = 0; n < MAX_THREAD; n++) {
+                executor.execute(new Runnable() {
+
+                    public void run() {
+
+                        KieSession ksession = kieBase.newKieSession();
+                        Result result = new Result();
+                        ksession.setGlobal("globalResult", result);
+
+                        ksession.insert(new Person("Mark", 37));
+                        ksession.insert(new Person("Edson", 35));
+                        ksession.insert(new Person("Mario", 40));
+
+                        latch.countDown();
+                        try {
+                            latch.await();
+                        } catch (InterruptedException e) {
+                            LOGGER.error(e.getMessage(), e);
+                        }
+
+                        try {
+                            ksession.fireAllRules();
+                        } catch (Exception e) {
+                            exceptionList.add(e);
+                        }
+
+                        ksession.dispose();
+                    }
+                });
+            }
+
+            executor.shutdown();
+            try {
+                executor.awaitTermination(100, TimeUnit.SECONDS);
+            } catch (InterruptedException e) {
+                LOGGER.error(e.getMessage(), e);
+            }
+
+            if (!exceptionList.isEmpty()) {
+                break;
+            }
+        }
+
+        if (exceptionList.size() > 0) {
+            LOGGER.error(exceptionList.get(0).getMessage(), exceptionList.get(0));
+        }
+
+        assertThat(exceptionList).isEmpty();
+
+    }
+}


### PR DESCRIPTION
…n executable-model

**Ports** 
This PR is for 7.x
for main -> https://github.com/kiegroup/drools/pull/4402

**JIRA**: 
https://issues.redhat.com/browse/DROOLS-6961


<details>
<summary>
How to replicate CI configuration locally?
</summary>

Build Chain tool does "simple" maven build(s), the builds are just Maven commands, but because the repositories relates and depends on each other and any change in API or class method could affect several of those repositories there is a need to use [build-chain tool](https://github.com/kiegroup/github-action-build-chain) to handle cross repository builds and be sure that we always use latest version of the code for each repository.
 
[build-chain tool](https://github.com/kiegroup/github-action-build-chain) is a build tool which can be used on command line locally or in Github Actions workflow(s), in case you need to change multiple repositories and send multiple dependent pull requests related with a change you can easily reproduce the same build by executing it on Github hosted environment or locally in your development environment. See [local execution](https://github.com/kiegroup/github-action-build-chain#local-execution) details to get more information about it.
</details>

<details>
<summary>
How to retest this PR or trigger a specific build:
</summary>

- for <b>pull request checks</b>  
  Please add comment: <b>Jenkins retest this</b>

- for a <b>specific pull request check</b>  
  Please add comment: <b>Jenkins (re)run [drools|kogito-runtimes|optaplanner|kogito-apps|kogito-examples|optaplanner-quickstarts|optaweb-employee-rostering|optaweb-vehicle-routing] tests</b>

- for a <b>full downstream build</b> 
  - for <b>jenkins</b> job: please add comment: <b>Jenkins run fdb</b>
  - for <b>github actions</b> job: add the label `run_fdb`

- <b>a compile downstream build</b> please  add comment: <b>Jenkins run cdb</b>

- <b>a full production downstream build</b> please add comment: <b>Jenkins execute product fdb</b>

- <b>an upstream build</b> please add comment: <b>Jenkins run upstream</b>

- for <b>quarkus branch checks</b>  
  Run checks against Quarkus current used branch  
  Please add comment: <b>Jenkins run quarkus-branch</b>

- for a <b>quarkus branch specific check</b>  
  Run checks against Quarkus current used branch  
  Please add comment: <b>Jenkins (re)run [drools|kogito-runtimes|optaplanner|kogito-apps|kogito-examples|optaplanner-quickstarts|optaweb-employee-rostering|optaweb-vehicle-routing] quarkus-branch</b>

- for <b>quarkus main checks</b>  
  Run checks against Quarkus main branch  
  Please add comment: <b>Jenkins run quarkus-main</b>

- for a <b>specific quarkus main check</b>  
  Run checks against Quarkus main branch  
  Please add comment: <b>Jenkins (re)run [drools|kogito-runtimes|optaplanner|kogito-apps|kogito-examples|optaplanner-quickstarts|optaweb-employee-rostering|optaweb-vehicle-routing] quarkus-branch</b>

- for <b>native checks</b>  
  Run native checks  
  Please add comment: <b>Jenkins run native</b>

- for a <b>specific native check</b>  
  Run native checks 
  Please add comment: <b>Jenkins (re)run [drools|kogito-runtimes|optaplanner|kogito-apps|kogito-examples|optaplanner-quickstarts|optaweb-employee-rostering|optaweb-vehicle-routing] native</b>

- for <b>mandrel checks</b>  
  Run native checks against Mandrel image
  Please add comment: <b>Jenkins run mandrel</b>

- for a <b>specific mandrel check</b>  
  Run native checks against Mandrel image  
  Please add comment: <b>Jenkins (re)run [drools|kogito-runtimes|optaplanner|kogito-apps|kogito-examples|optaplanner-quickstarts|optaweb-employee-rostering|optaweb-vehicle-routing] mandrel</b>
</details>
