### PR TITLE
[7.x][DROOLS-6931] Migrate assertions in kie-pmml-trusty tests to assertj

### DIFF
--- a/kie-pmml-trusty/kie-pmml-api/src/test/java/org/kie/pmml/api/enums/BUILTIN_FUNCTIONSTest.java
+++ b/kie-pmml-trusty/kie-pmml-api/src/test/java/org/kie/pmml/api/enums/BUILTIN_FUNCTIONSTest.java
@@ -17,15 +17,14 @@
 package org.kie.pmml.api.enums;
 
 import java.util.ArrayList;
-import java.util.Collections;
 import java.util.List;
 
 import org.junit.Test;
 import org.kie.pmml.api.exceptions.KiePMMLException;
 import org.kie.pmml.api.models.MiningField;
 
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.fail;
 import static org.kie.pmml.api.enums.builtinfunctions.ArithmeticFunctionsTest.supportedArithmeticFunctions;
 import static org.kie.pmml.api.enums.builtinfunctions.ArithmeticFunctionsTest.unsupportedArithmeticFunctions;
 import static org.kie.pmml.api.enums.builtinfunctions.BooleanFunctionsTest.supportedBooleanFunctions;
@@ -72,7 +71,7 @@ public class BUILTIN_FUNCTIONSTest {
                                                                 null, null, null, null, null));
                 fail("Expecting IllegalArgumentException");
             } catch (Exception e) {
-                assertTrue(e instanceof IllegalArgumentException);
+                assertThat(e).isInstanceOf(IllegalArgumentException.class);
             }
         });
     }
@@ -85,7 +84,7 @@ public class BUILTIN_FUNCTIONSTest {
                 builtinFunction.getValue(input, null);
                 fail("Expecting KiePMMLException");
             } catch (Exception e) {
-                assertTrue(e instanceof KiePMMLException);
+                assertThat(e).isInstanceOf(KiePMMLException.class);
             }
         });
     }

--- a/kie-pmml-trusty/kie-pmml-api/src/test/java/org/kie/pmml/api/enums/CAST_INTEGERTest.java
+++ b/kie-pmml-trusty/kie-pmml-api/src/test/java/org/kie/pmml/api/enums/CAST_INTEGERTest.java
@@ -18,43 +18,43 @@ package org.kie.pmml.api.enums;
 
 import org.junit.Test;
 
-import static org.junit.Assert.*;
+import static org.assertj.core.api.Assertions.assertThat;
 
 public class CAST_INTEGERTest {
 
     @Test
     public void getRound() {
         int retrieved = CAST_INTEGER.getRound(2.718);
-        assertEquals(3, retrieved);
+        assertThat(retrieved).isEqualTo(3);
         retrieved = CAST_INTEGER.getRound(-2.718);
-        assertEquals(-3, retrieved);
+        assertThat(retrieved).isEqualTo(-3);
         retrieved = CAST_INTEGER.getRound(2.418);
-        assertEquals(2, retrieved);
+        assertThat(retrieved).isEqualTo(2);
         retrieved = CAST_INTEGER.getRound(-2.418);
-        assertEquals(-2, retrieved);
+        assertThat(retrieved).isEqualTo(-2);
     }
 
     @Test
     public void getCeiling() {
         int retrieved = CAST_INTEGER.getCeiling(2.718);
-        assertEquals(3, retrieved);
+        assertThat(retrieved).isEqualTo(3);
         retrieved = CAST_INTEGER.getCeiling(-2.718);
-        assertEquals(-2, retrieved);
+        assertThat(retrieved).isEqualTo(-2);
         retrieved = CAST_INTEGER.getCeiling(2.418);
-        assertEquals(3, retrieved);
+        assertThat(retrieved).isEqualTo(3);
         retrieved = CAST_INTEGER.getCeiling(-2.418);
-        assertEquals(-2, retrieved);
+        assertThat(retrieved).isEqualTo(-2);
     }
 
     @Test
     public void getFloor() {
         int retrieved = CAST_INTEGER.getFloor(2.718);
-        assertEquals(2, retrieved);
+        assertThat(retrieved).isEqualTo(2);
         retrieved = CAST_INTEGER.getFloor(-2.718);
-        assertEquals(-3, retrieved);
+        assertThat(retrieved).isEqualTo(-3);
         retrieved = CAST_INTEGER.getFloor(2.418);
-        assertEquals(2, retrieved);
+        assertThat(retrieved).isEqualTo(2);
         retrieved = CAST_INTEGER.getFloor(-2.418);
-        assertEquals(-3, retrieved);
+        assertThat(retrieved).isEqualTo(-3);
     }
 }

--- a/kie-pmml-trusty/kie-pmml-api/src/test/java/org/kie/pmml/api/enums/DATA_TYPETest.java
+++ b/kie-pmml-trusty/kie-pmml-api/src/test/java/org/kie/pmml/api/enums/DATA_TYPETest.java
@@ -24,7 +24,7 @@ import java.util.Map;
 import org.junit.Before;
 import org.junit.Test;
 
-import static org.junit.Assert.*;
+import static org.assertj.core.api.Assertions.assertThat;
 
 public class DATA_TYPETest {
 
@@ -76,20 +76,20 @@ public class DATA_TYPETest {
 
     @Test
     public void getActualValue() {
-        unconvertedValues.forEach((dataType, o) -> assertEquals(o, dataType.getActualValue(o)));
+        unconvertedValues.forEach((dataType, o) -> assertThat(dataType.getActualValue(o)).isEqualTo(o));
         convertedValues.forEach((dataType, o) -> {
             switch (dataType) {
                 case DATE:
-                    assertEquals(((Date) unconvertedValues.get(dataType)).toInstant().atZone(ZONE_ID).toLocalDate(), dataType.getActualValue(o));
+                    assertThat(dataType.getActualValue(o)).isEqualTo(((Date) unconvertedValues.get(dataType)).toInstant().atZone(ZONE_ID).toLocalDate());
                     break;
                 case TIME:
-                    assertEquals(((Date) unconvertedValues.get(dataType)).toInstant().atZone(ZONE_ID).toLocalTime(), dataType.getActualValue(o));
+                    assertThat(dataType.getActualValue(o)).isEqualTo(((Date) unconvertedValues.get(dataType)).toInstant().atZone(ZONE_ID).toLocalTime());
                     break;
                 case DATE_TIME:
-                    assertEquals(((Date) unconvertedValues.get(dataType)).toInstant().atZone(ZONE_ID).toLocalDateTime(), dataType.getActualValue(o));
+                    assertThat(dataType.getActualValue(o)).isEqualTo(((Date) unconvertedValues.get(dataType)).toInstant().atZone(ZONE_ID).toLocalDateTime());
                     break;
                 default:
-                    assertEquals(unconvertedValues.get(dataType), dataType.getActualValue(o));
+                    assertThat(dataType.getActualValue(o)).isEqualTo(unconvertedValues.get(dataType));
             }
         });
     }

--- a/kie-pmml-trusty/kie-pmml-api/src/test/java/org/kie/pmml/api/enums/builtinfunctions/ArithmeticFunctionsTest.java
+++ b/kie-pmml-trusty/kie-pmml-api/src/test/java/org/kie/pmml/api/enums/builtinfunctions/ArithmeticFunctionsTest.java
@@ -19,9 +19,10 @@ package org.kie.pmml.api.enums.builtinfunctions;
 import java.util.ArrayList;
 import java.util.List;
 
+import org.assertj.core.data.Offset;
 import org.junit.Test;
 
-import static org.junit.Assert.assertEquals;
+import static org.assertj.core.api.Assertions.assertThat;
 
 public class ArithmeticFunctionsTest {
 
@@ -59,10 +60,10 @@ public class ArithmeticFunctionsTest {
     public void getAvgValueCorrectInput() {
         Object[] input1 = {35, 12, 347, 2, 123};
         Object retrieved = ArithmeticFunctions.AVG.getValue(input1);
-        assertEquals(103.8, retrieved);
+        assertThat(retrieved).isEqualTo(103.8);
         Object[] input2 = {35, 12, -347, 2, 123};
         retrieved = ArithmeticFunctions.AVG.getValue(input2);
-        assertEquals(-35.0, retrieved);
+        assertThat(retrieved).isEqualTo(-35.0);
     }
 
     @Test(expected = IllegalArgumentException.class)
@@ -75,7 +76,7 @@ public class ArithmeticFunctionsTest {
     public void getDivisionValueCorrectInput() {
         final Object[] input = {35, 5};
         Object retrieved = ArithmeticFunctions.DIVISION.getValue(input);
-        assertEquals(7.0, retrieved);
+        assertThat(retrieved).isEqualTo(7.0);
     }
 
     @Test(expected = IllegalArgumentException.class)
@@ -94,10 +95,10 @@ public class ArithmeticFunctionsTest {
     public void getMaxValueCorrectInput() {
         Object[] input1 = {35, 12, 347, 2, 123};
         Object retrieved = ArithmeticFunctions.MAX.getValue(input1);
-        assertEquals(347.0, retrieved);
+        assertThat(retrieved).isEqualTo(347.0);
         Object[] input2 = {35, 12, -347, 2, 123};
         retrieved = ArithmeticFunctions.MAX.getValue(input2);
-        assertEquals(123.0, retrieved);
+        assertThat(retrieved).isEqualTo(123.0);
     }
 
     @Test(expected = IllegalArgumentException.class)
@@ -110,10 +111,10 @@ public class ArithmeticFunctionsTest {
     public void getMedianValueCorrectInput() {
         Object[] input1 = {35, 12, 347, 2, 123};
         Object retrieved = ArithmeticFunctions.MEDIAN.getValue(input1);
-        assertEquals(35.0, retrieved);
+        assertThat(retrieved).isEqualTo(35.0);
         Object[] input2 = {35, 12, 2, 123};
         retrieved = ArithmeticFunctions.MEDIAN.getValue(input2);
-        assertEquals(23.5, retrieved);
+        assertThat(retrieved).isEqualTo(23.5);
     }
 
     @Test(expected = IllegalArgumentException.class)
@@ -126,10 +127,10 @@ public class ArithmeticFunctionsTest {
     public void getMinValueCorrectInput() {
         Object[] input1 = {35, 12, 347, 2, 123};
         Object retrieved = ArithmeticFunctions.MIN.getValue(input1);
-        assertEquals(2.0, retrieved);
+        assertThat(retrieved).isEqualTo(2.0);
         Object[] input2 = {35, 12, -347, 2, 123};
         retrieved = ArithmeticFunctions.MIN.getValue(input2);
-        assertEquals(-347.0, retrieved);
+        assertThat(retrieved).isEqualTo(-347.0);
     }
 
     @Test(expected = IllegalArgumentException.class)
@@ -142,7 +143,7 @@ public class ArithmeticFunctionsTest {
     public void getMinusValueCorrectInput() {
         final Object[] input = {35, 12};
         Object retrieved = ArithmeticFunctions.MINUS.getValue(input);
-        assertEquals(23.0, retrieved);
+        assertThat(retrieved).isEqualTo(23.0);
     }
 
     @Test(expected = IllegalArgumentException.class)
@@ -161,7 +162,7 @@ public class ArithmeticFunctionsTest {
     public void getMultiValueCorrectInput() {
         final Object[] input = {7, 5};
         Object retrieved = ArithmeticFunctions.MULTI.getValue(input);
-        assertEquals(35.0, retrieved);
+        assertThat(retrieved).isEqualTo(35.0);
     }
 
     @Test(expected = IllegalArgumentException.class)
@@ -180,7 +181,7 @@ public class ArithmeticFunctionsTest {
     public void getPlusValueCorrectInput() {
         final Object[] input = {35, 12};
         Object retrieved = ArithmeticFunctions.PLUS.getValue(input);
-        assertEquals(47.0, retrieved);
+        assertThat(retrieved).isEqualTo(47.0);
     }
 
     @Test(expected = IllegalArgumentException.class)
@@ -199,10 +200,10 @@ public class ArithmeticFunctionsTest {
     public void getProductValueCorrectInput() {
         Object[] input1 = {35, 12, 347, 2, 123};
         Object retrieved = ArithmeticFunctions.PRODUCT.getValue(input1);
-        assertEquals(35852040.0, retrieved);
+        assertThat(retrieved).isEqualTo(35852040.0);
         Object[] input2 = {35, 12, -2, 123};
         retrieved = ArithmeticFunctions.PRODUCT.getValue(input2);
-        assertEquals(-103320.0, retrieved);
+        assertThat(retrieved).isEqualTo(-103320.0);
     }
 
     @Test(expected = IllegalArgumentException.class)
@@ -215,10 +216,10 @@ public class ArithmeticFunctionsTest {
     public void getSumValueCorrectInput() {
         Object[] input1 = {35, 12, 347, 2, 123};
         Object retrieved = ArithmeticFunctions.SUM.getValue(input1);
-        assertEquals(519.0, retrieved);
+        assertThat(retrieved).isEqualTo(519.0);
         Object[] input2 = {35, 12, -347, 2, 123};
         retrieved = ArithmeticFunctions.SUM.getValue(input2);
-        assertEquals(-175.0, retrieved);
+        assertThat(retrieved).isEqualTo(-175.0);
     }
 
     @Test(expected = IllegalArgumentException.class)
@@ -231,7 +232,7 @@ public class ArithmeticFunctionsTest {
     public void getLog10ValueCorrectInput() {
         Object[] input = {35};
         Object retrieved = ArithmeticFunctions.LOG10.getValue(input);
-        assertEquals(1.5440680443503, (double)retrieved, 0.00000001);
+        assertThat((double)retrieved).isCloseTo(1.5440680443503, Offset.offset(0.00000001));
     }
 
     @Test(expected = IllegalArgumentException.class)
@@ -244,7 +245,7 @@ public class ArithmeticFunctionsTest {
     public void getLnValueCorrectInput() {
         Object[] input = {35};
         Object retrieved = ArithmeticFunctions.LN.getValue(input);
-        assertEquals(3.5553480614894, (double)retrieved, 0.00000001);
+        assertThat((double)retrieved).isCloseTo(3.5553480614894, Offset.offset(0.00000001));
     }
 
     @Test(expected = IllegalArgumentException.class)
@@ -257,7 +258,7 @@ public class ArithmeticFunctionsTest {
     public void getSqrtValueCorrectInput() {
         Object[] input = {81};
         Object retrieved = ArithmeticFunctions.SQRT.getValue(input);
-        assertEquals(9, (double)retrieved, 0.00000001);
+        assertThat((double)retrieved).isCloseTo(9, Offset.offset(0.00000001));
     }
 
     @Test(expected = IllegalArgumentException.class)
@@ -270,7 +271,7 @@ public class ArithmeticFunctionsTest {
     public void getAbsValueCorrectInput() {
         Object[] input = {-3.5553480614894};
         Object retrieved = ArithmeticFunctions.ABS.getValue(input);
-        assertEquals(3.5553480614894, (double)retrieved, 0.00000001);
+        assertThat((double)retrieved).isCloseTo(3.5553480614894, Offset.offset(0.00000001));
     }
 
     @Test(expected = IllegalArgumentException.class)
@@ -283,7 +284,7 @@ public class ArithmeticFunctionsTest {
     public void getExpValueCorrectInput() {
         Object[] input = {-3.5553480614894};
         Object retrieved = ArithmeticFunctions.EXP.getValue(input);
-        assertEquals(0.0285714285714, (double)retrieved, 0.00000001);
+        assertThat((double)retrieved).isCloseTo(0.0285714285714, Offset.offset(0.00000001));
     }
 
     @Test(expected = IllegalArgumentException.class)
@@ -296,7 +297,7 @@ public class ArithmeticFunctionsTest {
     public void getPowValueCorrectInput() {
         Object[] input = {3, 4};
         Object retrieved = ArithmeticFunctions.POW.getValue(input);
-        assertEquals(81.0, retrieved);
+        assertThat(retrieved).isEqualTo(81.0);
     }
 
     @Test(expected = IllegalArgumentException.class)
@@ -309,13 +310,13 @@ public class ArithmeticFunctionsTest {
     public void getThresholdValueCorrectInput() {
         Object[] input1 = {5, 4};
         Object retrieved = ArithmeticFunctions.THRESHOLD.getValue(input1);
-        assertEquals(1.0, retrieved);
+        assertThat(retrieved).isEqualTo(1.0);
         Object[] input2 = {5, 5};
         retrieved = ArithmeticFunctions.THRESHOLD.getValue(input2);
-        assertEquals(0.0, retrieved);
+        assertThat(retrieved).isEqualTo(0.0);
         Object[] input3 = {4, 5};
         retrieved = ArithmeticFunctions.THRESHOLD.getValue(input3);
-        assertEquals(0.0, retrieved);
+        assertThat(retrieved).isEqualTo(0.0);
     }
 
     @Test(expected = IllegalArgumentException.class)
@@ -328,10 +329,10 @@ public class ArithmeticFunctionsTest {
     public void getFloorValueCorrectInput() {
         Object[] input1 = {-3.5553480614894};
         Object retrieved = ArithmeticFunctions.FLOOR.getValue(input1);
-        assertEquals(-4.0, retrieved);
+        assertThat(retrieved).isEqualTo(-4.0);
         Object[] input2 = {3.5553480614894};
         retrieved = ArithmeticFunctions.FLOOR.getValue(input2);
-        assertEquals(3.0, retrieved);
+        assertThat(retrieved).isEqualTo(3.0);
     }
 
     @Test(expected = IllegalArgumentException.class)
@@ -344,10 +345,10 @@ public class ArithmeticFunctionsTest {
     public void getCeilValueCorrectInput() {
         Object[] input1 = {-3.5553480614894};
         Object retrieved = ArithmeticFunctions.CEIL.getValue(input1);
-        assertEquals(-3.0, retrieved);
+        assertThat(retrieved).isEqualTo(-3.0);
         Object[] input2 = {3.5553480614894};
         retrieved = ArithmeticFunctions.CEIL.getValue(input2);
-        assertEquals(4.0, retrieved);
+        assertThat(retrieved).isEqualTo(4.0);
     }
 
     @Test(expected = IllegalArgumentException.class)
@@ -360,10 +361,10 @@ public class ArithmeticFunctionsTest {
     public void getRoundValueCorrectInput() {
         Object[] input1 = {3.3553480614894};
         Object retrieved = ArithmeticFunctions.ROUND.getValue(input1);
-        assertEquals(3.0, retrieved);
+        assertThat(retrieved).isEqualTo(3.0);
         Object[] input2 = {3.5553480614894};
         retrieved = ArithmeticFunctions.ROUND.getValue(input2);
-        assertEquals(4.0, retrieved);
+        assertThat(retrieved).isEqualTo(4.0);
     }
 
     @Test(expected = IllegalArgumentException.class)
@@ -376,7 +377,7 @@ public class ArithmeticFunctionsTest {
     public void getModuloValueCorrectInput() {
         Object[] input = {35, 8};
         Object retrieved = ArithmeticFunctions.MODULO.getValue(input);
-        assertEquals(3.0, retrieved);
+        assertThat(retrieved).isEqualTo(3.0);
     }
 
     @Test(expected = IllegalArgumentException.class)

--- a/kie-pmml-trusty/kie-pmml-api/src/test/java/org/kie/pmml/api/enums/builtinfunctions/BooleanFunctionsTest.java
+++ b/kie-pmml-trusty/kie-pmml-api/src/test/java/org/kie/pmml/api/enums/builtinfunctions/BooleanFunctionsTest.java
@@ -26,10 +26,7 @@ import org.kie.pmml.api.enums.INVALID_VALUE_TREATMENT_METHOD;
 import org.kie.pmml.api.models.Interval;
 import org.kie.pmml.api.models.MiningField;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertTrue;
+import static org.assertj.core.api.Assertions.assertThat;
 
 public class BooleanFunctionsTest {
 
@@ -72,10 +69,10 @@ public class BooleanFunctionsTest {
     public void getIsMissingValueCorrectInput() {
         Object[] input1 = {null};
         Object retrieved = BooleanFunctions.IS_MISSING.getValue(input1, EMPTY_MINING_FIELD);
-        assertTrue((boolean) retrieved);
+        assertThat((boolean) retrieved).isTrue();
         Object[] input2 = {35};
         retrieved = BooleanFunctions.IS_MISSING.getValue(input2, EMPTY_MINING_FIELD);
-        assertFalse((boolean) retrieved);
+        assertThat((boolean) retrieved).isFalse();
         for (INVALID_VALUE_TREATMENT_METHOD invalidValueTreatmentMethod : INVALID_VALUE_TREATMENT_METHOD.values()) {
             MiningField referredByFieldRef = getReferredByFieldRef(
                     invalidValueTreatmentMethod,
@@ -83,7 +80,7 @@ public class BooleanFunctionsTest {
                     Arrays.asList(new Interval(20, 29),
                                   new Interval(41, 50)));
             boolean expected = INVALID_VALUE_TREATMENT_METHOD.AS_MISSING.equals(invalidValueTreatmentMethod);
-            assertEquals(expected, BooleanFunctions.IS_MISSING.getValue(input2, referredByFieldRef));
+            assertThat(BooleanFunctions.IS_MISSING.getValue(input2, referredByFieldRef)).isEqualTo(expected);
         }
     }
 
@@ -103,17 +100,17 @@ public class BooleanFunctionsTest {
     public void getIsNotMissingValueCorrectInput() {
         Object[] input1 = {35};
         Object retrieved = BooleanFunctions.IS_NOT_MISSING.getValue(input1, EMPTY_MINING_FIELD);
-        assertTrue((boolean) retrieved);
+        assertThat((boolean) retrieved).isTrue();
         Object[] input2 = {null};
         retrieved = BooleanFunctions.IS_NOT_MISSING.getValue(input2, EMPTY_MINING_FIELD);
-        assertFalse((boolean) retrieved);
+        assertThat((boolean) retrieved).isFalse();
         for (INVALID_VALUE_TREATMENT_METHOD invalidValueTreatmentMethod : INVALID_VALUE_TREATMENT_METHOD.values()) {
             MiningField referredByFieldRef = getReferredByFieldRef(
                     invalidValueTreatmentMethod,
                     null,
                     Arrays.asList(new Interval(20, 29), new Interval(41, 50)));
             boolean expected = !INVALID_VALUE_TREATMENT_METHOD.AS_MISSING.equals(invalidValueTreatmentMethod);
-            assertEquals(expected, BooleanFunctions.IS_NOT_MISSING.getValue(input1, referredByFieldRef));
+            assertThat(BooleanFunctions.IS_NOT_MISSING.getValue(input1, referredByFieldRef)).isEqualTo(expected);
         }
     }
 
@@ -138,41 +135,41 @@ public class BooleanFunctionsTest {
                                                                                                                 40),
                                                                              new Interval(41, 50)));
         Object retrieved = BooleanFunctions.IS_VALID.getValue(input1, referredByFieldRef);
-        assertTrue((boolean) retrieved);
+        assertThat((boolean) retrieved).isTrue();
         referredByFieldRef = getReferredByFieldRef(
                 null,
                 null,
                 Arrays.asList(new Interval(20, 29), new Interval(41, 50)));
         retrieved = BooleanFunctions.IS_VALID.getValue(input1, referredByFieldRef);
-        assertFalse((boolean) retrieved);
+        assertThat((boolean) retrieved).isFalse();
 
         referredByFieldRef = getReferredByFieldRef(null,
                                                    Arrays.asList("123", "35"),
                                                    Arrays.asList(new Interval(20, 29), new Interval(41, 50)));
         retrieved = BooleanFunctions.IS_VALID.getValue(input1, referredByFieldRef);
-        assertTrue((boolean) retrieved);
+        assertThat((boolean) retrieved).isTrue();
 
         referredByFieldRef = getReferredByFieldRef(null,
                                                    Arrays.asList("123", "36"),
                                                    Arrays.asList(new Interval(20, 29), new Interval(41, 50)));
         retrieved = BooleanFunctions.IS_VALID.getValue(input1, referredByFieldRef);
-        assertFalse((boolean) retrieved);
+        assertThat((boolean) retrieved).isFalse();
 
         Object[] input2 = {"VALUE"};
         referredByFieldRef = getReferredByFieldRef(null,
                                                    Arrays.asList("123", "VALUE"),
                                                    Collections.emptyList());
         retrieved = BooleanFunctions.IS_VALID.getValue(input2, referredByFieldRef);
-        assertTrue((boolean) retrieved);
+        assertThat((boolean) retrieved).isTrue();
 
         referredByFieldRef = getReferredByFieldRef(null,
                                                    Arrays.asList("123", "VELUE"),
                                                    Collections.emptyList());
         retrieved = BooleanFunctions.IS_VALID.getValue(input2, referredByFieldRef);
-        assertFalse((boolean) retrieved);
+        assertThat((boolean) retrieved).isFalse();
         Object[] input3 = {null};
         retrieved = BooleanFunctions.IS_VALID.getValue(input3, referredByFieldRef);
-        assertFalse((boolean) retrieved);
+        assertThat((boolean) retrieved).isFalse();
     }
 
     @Test(expected = IllegalArgumentException.class)
@@ -212,52 +209,52 @@ public class BooleanFunctionsTest {
                                                                                                                 40),
                                                                              new Interval(41, 50)));
         Object retrieved = BooleanFunctions.IS_NOT_VALID.getValue(input1, referredByFieldRef);
-        assertFalse((boolean) retrieved);
+        assertThat((boolean) retrieved).isFalse();
         referredByFieldRef = getReferredByFieldRef(null,
                                                    null,
                                                    Arrays.asList(new Interval(20, 29), new Interval(41, 50)));
         retrieved = BooleanFunctions.IS_NOT_VALID.getValue(input1, referredByFieldRef);
-        assertTrue((boolean) retrieved);
+        assertThat((boolean) retrieved).isTrue();
 
         referredByFieldRef = getReferredByFieldRef(null,
                                                    Arrays.asList("123", "35"),
                                                    Arrays.asList(new Interval(20, 29), new Interval(41, 50)));
         retrieved = BooleanFunctions.IS_NOT_VALID.getValue(input1, referredByFieldRef);
-        assertFalse((boolean) retrieved);
+        assertThat((boolean) retrieved).isFalse();
 
         referredByFieldRef = getReferredByFieldRef(INVALID_VALUE_TREATMENT_METHOD.AS_MISSING,
                                                    Arrays.asList("123", "36"),
                                                    Arrays.asList(new Interval(20, 29), new Interval(41, 50)));
         retrieved = BooleanFunctions.IS_NOT_VALID.getValue(input1, referredByFieldRef);
-        assertFalse((boolean) retrieved);
+        assertThat((boolean) retrieved).isFalse();
 
         referredByFieldRef = getReferredByFieldRef(INVALID_VALUE_TREATMENT_METHOD.AS_IS,
                                                    Arrays.asList("123", "36"),
                                                    Arrays.asList(new Interval(20, 29), new Interval(41, 50)));
         retrieved = BooleanFunctions.IS_NOT_VALID.getValue(input1, referredByFieldRef);
-        assertTrue((boolean) retrieved);
+        assertThat((boolean) retrieved).isTrue();
 
         referredByFieldRef = getReferredByFieldRef(null,
                                                    Arrays.asList("123", "36"),
                                                    Arrays.asList(new Interval(20, 29), new Interval(41, 50)));
         retrieved = BooleanFunctions.IS_NOT_VALID.getValue(input1, referredByFieldRef);
-        assertTrue((boolean) retrieved);
+        assertThat((boolean) retrieved).isTrue();
 
         Object[] input2 = {"VALUE"};
         referredByFieldRef = getReferredByFieldRef(null,
                                                    Arrays.asList("123", "VALUE"),
                                                    Collections.emptyList());
         retrieved = BooleanFunctions.IS_NOT_VALID.getValue(input2, referredByFieldRef);
-        assertFalse((boolean) retrieved);
+        assertThat((boolean) retrieved).isFalse();
 
         referredByFieldRef = getReferredByFieldRef(null,
                                                    Arrays.asList("123", "VELUE"),
                                                    Collections.emptyList());
         retrieved = BooleanFunctions.IS_NOT_VALID.getValue(input2, referredByFieldRef);
-        assertTrue((boolean) retrieved);
+        assertThat((boolean) retrieved).isTrue();
         Object[] input3 = {null};
         retrieved = BooleanFunctions.IS_NOT_VALID.getValue(input3, referredByFieldRef);
-        assertFalse((boolean) retrieved);
+        assertThat((boolean) retrieved).isFalse();
     }
 
     @Test(expected = IllegalArgumentException.class)
@@ -292,10 +289,10 @@ public class BooleanFunctionsTest {
     public void getEqualValueCorrectInput() {
         Object[] input1 = {35, 12};
         Object retrieved = BooleanFunctions.EQUAL.getValue(input1, null);
-        assertFalse((boolean) retrieved);
+        assertThat((boolean) retrieved).isFalse();
         Object[] input2 = {35, 35};
         retrieved = BooleanFunctions.EQUAL.getValue(input2, null);
-        assertTrue((boolean) retrieved);
+        assertThat((boolean) retrieved).isTrue();
     }
 
     @Test(expected = IllegalArgumentException.class)
@@ -308,10 +305,10 @@ public class BooleanFunctionsTest {
     public void getNotEqualValueCorrectInput() {
         Object[] input1 = {35, 12};
         Object retrieved = BooleanFunctions.NOT_EQUAL.getValue(input1, null);
-        assertTrue((boolean) retrieved);
+        assertThat((boolean) retrieved).isTrue();
         Object[] input2 = {35, 35};
         retrieved = BooleanFunctions.NOT_EQUAL.getValue(input2, null);
-        assertFalse((boolean) retrieved);
+        assertThat((boolean) retrieved).isFalse();
     }
 
     @Test(expected = IllegalArgumentException.class)
@@ -324,13 +321,13 @@ public class BooleanFunctionsTest {
     public void getLessThanValueCorrectInput() {
         Object[] input1 = {35, 37};
         Object retrieved = BooleanFunctions.LESS_THAN.getValue(input1, null);
-        assertTrue((boolean) retrieved);
+        assertThat((boolean) retrieved).isTrue();
         Object[] input2 = {35, 35};
         retrieved = BooleanFunctions.LESS_THAN.getValue(input2, null);
-        assertFalse((boolean) retrieved);
+        assertThat((boolean) retrieved).isFalse();
         Object[] input3 = {35, 12};
         retrieved = BooleanFunctions.LESS_THAN.getValue(input3, null);
-        assertFalse((boolean) retrieved);
+        assertThat((boolean) retrieved).isFalse();
     }
 
     @Test(expected = IllegalArgumentException.class)
@@ -343,13 +340,13 @@ public class BooleanFunctionsTest {
     public void getLessOrEqualValueCorrectInput() {
         Object[] input1 = {35, 37};
         Object retrieved = BooleanFunctions.LESS_OR_EQUAL.getValue(input1, null);
-        assertTrue((boolean) retrieved);
+        assertThat((boolean) retrieved).isTrue();
         Object[] input2 = {35, 35};
         retrieved = BooleanFunctions.LESS_OR_EQUAL.getValue(input2, null);
-        assertTrue((boolean) retrieved);
+        assertThat((boolean) retrieved).isTrue();
         Object[] input3 = {35, 12};
         retrieved = BooleanFunctions.LESS_OR_EQUAL.getValue(input3, null);
-        assertFalse((boolean) retrieved);
+        assertThat((boolean) retrieved).isFalse();
     }
 
     @Test(expected = IllegalArgumentException.class)
@@ -362,13 +359,13 @@ public class BooleanFunctionsTest {
     public void getGreaterThanValueCorrectInput() {
         Object[] input1 = {35, 37};
         Object retrieved = BooleanFunctions.GREATER_THAN.getValue(input1, null);
-        assertFalse((boolean) retrieved);
+        assertThat((boolean) retrieved).isFalse();
         Object[] input2 = {35, 35};
         retrieved = BooleanFunctions.GREATER_THAN.getValue(input2, null);
-        assertFalse((boolean) retrieved);
+        assertThat((boolean) retrieved).isFalse();
         Object[] input3 = {35, 12};
         retrieved = BooleanFunctions.GREATER_THAN.getValue(input3, null);
-        assertTrue((boolean) retrieved);
+        assertThat((boolean) retrieved).isTrue();
     }
 
     @Test(expected = IllegalArgumentException.class)
@@ -381,13 +378,13 @@ public class BooleanFunctionsTest {
     public void getGreaterOrEqualValueCorrectInput() {
         Object[] input1 = {35, 37};
         Object retrieved = BooleanFunctions.GREATER_OR_EQUAL.getValue(input1, null);
-        assertFalse((boolean) retrieved);
+        assertThat((boolean) retrieved).isFalse();
         Object[] input2 = {35, 35};
         retrieved = BooleanFunctions.GREATER_OR_EQUAL.getValue(input2, null);
-        assertTrue((boolean) retrieved);
+        assertThat((boolean) retrieved).isTrue();
         Object[] input3 = {35, 12};
         retrieved = BooleanFunctions.GREATER_OR_EQUAL.getValue(input3, null);
-        assertTrue((boolean) retrieved);
+        assertThat((boolean) retrieved).isTrue();
     }
 
     @Test(expected = IllegalArgumentException.class)
@@ -400,10 +397,10 @@ public class BooleanFunctionsTest {
     public void getAndValueCorrectInput() {
         Object[] input1 = {true, Boolean.valueOf("false")};
         Object retrieved = BooleanFunctions.AND.getValue(input1, null);
-        assertFalse((boolean) retrieved);
+        assertThat((boolean) retrieved).isFalse();
         Object[] input2 = {true, Boolean.valueOf("true")};
         retrieved = BooleanFunctions.AND.getValue(input2, null);
-        assertTrue((boolean) retrieved);
+        assertThat((boolean) retrieved).isTrue();
     }
 
     @Test(expected = IllegalArgumentException.class)
@@ -416,13 +413,13 @@ public class BooleanFunctionsTest {
     public void getOrValueCorrectInput() {
         Object[] input1 = {true, Boolean.valueOf("false")};
         Object retrieved = BooleanFunctions.OR.getValue(input1, null);
-        assertTrue((boolean) retrieved);
+        assertThat((boolean) retrieved).isTrue();
         Object[] input2 = {false, Boolean.valueOf("true")};
         retrieved = BooleanFunctions.OR.getValue(input2, null);
-        assertTrue((boolean) retrieved);
+        assertThat((boolean) retrieved).isTrue();
         Object[] input3 = {false, Boolean.valueOf("false")};
         retrieved = BooleanFunctions.OR.getValue(input3, null);
-        assertFalse((boolean) retrieved);
+        assertThat((boolean) retrieved).isFalse();
     }
 
     @Test(expected = IllegalArgumentException.class)
@@ -435,10 +432,10 @@ public class BooleanFunctionsTest {
     public void getNotValueCorrectInput() {
         Object[] input1 = {true};
         Object retrieved = BooleanFunctions.NOT.getValue(input1, null);
-        assertFalse((boolean) retrieved);
+        assertThat((boolean) retrieved).isFalse();
         Object[] input2 = {Boolean.valueOf("false")};
         retrieved = BooleanFunctions.NOT.getValue(input2, null);
-        assertTrue((boolean) retrieved);
+        assertThat((boolean) retrieved).isTrue();
     }
 
     @Test(expected = IllegalArgumentException.class)
@@ -451,10 +448,10 @@ public class BooleanFunctionsTest {
     public void getIsInValueCorrectInput() {
         Object[] input1 = {35, 12, 35, 435, "A"};
         Object retrieved = BooleanFunctions.IS_IN.getValue(input1, null);
-        assertTrue((boolean) retrieved);
+        assertThat((boolean) retrieved).isTrue();
         Object[] input2 = {35, 36, "35"};
         retrieved = BooleanFunctions.IS_IN.getValue(input2, null);
-        assertFalse((boolean) retrieved);
+        assertThat((boolean) retrieved).isFalse();
     }
 
     @Test(expected = IllegalArgumentException.class)
@@ -467,10 +464,10 @@ public class BooleanFunctionsTest {
     public void getIsNotInValueCorrectInput() {
         Object[] input1 = {35, 36, "35"};
         Object retrieved = BooleanFunctions.IS_NOT_IN.getValue(input1, null);
-        assertTrue((boolean) retrieved);
+        assertThat((boolean) retrieved).isTrue();
         Object[] input2 = {35, 12, 35, 435, "A"};
         retrieved = BooleanFunctions.IS_NOT_IN.getValue(input2, null);
-        assertFalse((boolean) retrieved);
+        assertThat((boolean) retrieved).isFalse();
     }
 
     @Test(expected = IllegalArgumentException.class)
@@ -483,13 +480,13 @@ public class BooleanFunctionsTest {
     public void getIfFValueCorrectInput() {
         Object[] input1 = {true, 36, "35"};
         Object retrieved = BooleanFunctions.IF.getValue(input1, null);
-        assertEquals(36, retrieved);
+        assertThat(retrieved).isEqualTo(36);
         Object[] input2 = {false, 12, 35};
         retrieved = BooleanFunctions.IF.getValue(input2, null);
-        assertEquals(35, retrieved);
+        assertThat(retrieved).isEqualTo(35);
         Object[] input3 = {false, 12};
         retrieved = BooleanFunctions.IF.getValue(input3, null);
-        assertNull(retrieved);
+        assertThat(retrieved).isNull();
     }
 
     @Test(expected = IllegalArgumentException.class)

--- a/kie-pmml-trusty/kie-pmml-api/src/test/java/org/kie/pmml/api/enums/builtinfunctions/DateFunctionsTest.java
+++ b/kie-pmml-trusty/kie-pmml-api/src/test/java/org/kie/pmml/api/enums/builtinfunctions/DateFunctionsTest.java
@@ -29,9 +29,8 @@ import org.junit.Test;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.fail;
 
 public class DateFunctionsTest {
 
@@ -59,7 +58,7 @@ public class DateFunctionsTest {
         logger.debug("{}", inputDate.getTime());
         Object[] input1 = {inputDate, 1960};
         Object retrieved = DateFunctions.DATE_DAYS_SINCE_YEAR.getValue(input1);
-        assertEquals(0, retrieved);
+        assertThat(retrieved).isEqualTo(0);
         //--
         inputDateLocalDateTime = LocalDateTime.of(2003, 4, 1, 0, 0, 0);
         logger.debug("inputDateLocalDateTime {}", inputDateLocalDateTime);
@@ -70,7 +69,7 @@ public class DateFunctionsTest {
         logger.debug("{}", inputDate.getTime());
         Object[] input2 = {inputDate, 1960};
         retrieved = DateFunctions.DATE_DAYS_SINCE_YEAR.getValue(input2);
-        assertEquals(15796, retrieved);
+        assertThat(retrieved).isEqualTo(15796);
 
 
 
@@ -94,7 +93,7 @@ public class DateFunctionsTest {
                 DateFunctions.DATE_DAYS_SINCE_YEAR.getValue(input);
                 fail("Expecting IllegalArgumentException");
             } catch (Exception e) {
-                assertTrue(e instanceof IllegalArgumentException);
+                assertThat(e).isInstanceOf(IllegalArgumentException.class);
             }
         }
     }
@@ -104,7 +103,7 @@ public class DateFunctionsTest {
         Date inputDate = new GregorianCalendar(1960, Calendar.JANUARY, 3, 3, 30, 3).getTime();
         Object[] input1 = {inputDate, 1960};
         Object retrieved = DateFunctions.DATE_SECONDS_SINCE_YEAR.getValue(input1);
-        assertEquals(185403, retrieved);
+        assertThat(retrieved).isEqualTo(185403);
     }
 
     @Test(expected = IllegalArgumentException.class)
@@ -124,7 +123,7 @@ public class DateFunctionsTest {
                 DateFunctions.DATE_SECONDS_SINCE_YEAR.getValue(input);
                 fail("Expecting IllegalArgumentException");
             } catch (Exception e) {
-                assertTrue(e instanceof IllegalArgumentException);
+                assertThat(e).isInstanceOf(IllegalArgumentException.class);
             }
         }
     }
@@ -134,15 +133,15 @@ public class DateFunctionsTest {
         Date inputDate = new GregorianCalendar(1960, Calendar.JANUARY, 2, 0, 0, 1).getTime();
         Object[] input1 = {inputDate};
         Object retrieved = DateFunctions.DATE_SECONDS_SINCE_MIDNIGHT.getValue(input1);
-        assertEquals(1, retrieved);
+        assertThat(retrieved).isEqualTo(1);
         inputDate = new GregorianCalendar(1960, Calendar.MARCH, 12, 0, 1, 0).getTime();
         Object[] input2 = {inputDate};
         retrieved = DateFunctions.DATE_SECONDS_SINCE_MIDNIGHT.getValue(input2);
-        assertEquals(60, retrieved);
+        assertThat(retrieved).isEqualTo(60);
         inputDate = new GregorianCalendar(1960, Calendar.DECEMBER, 23, 5, 23, 30).getTime();
         Object[] input3 = {inputDate};
         retrieved = DateFunctions.DATE_SECONDS_SINCE_MIDNIGHT.getValue(input3);
-        assertEquals(19410, retrieved);
+        assertThat(retrieved).isEqualTo(19410);
     }
 
     @Test(expected = IllegalArgumentException.class)
@@ -163,7 +162,7 @@ public class DateFunctionsTest {
                 DateFunctions.DATE_SECONDS_SINCE_MIDNIGHT.getValue(input);
                 fail("Expecting IllegalArgumentException");
             } catch (Exception e) {
-                assertTrue(e instanceof IllegalArgumentException);
+                assertThat(e).isInstanceOf(IllegalArgumentException.class);
             }
         }
     }

--- a/kie-pmml-trusty/kie-pmml-api/src/test/java/org/kie/pmml/api/enums/builtinfunctions/DistributionFunctionsTest.java
+++ b/kie-pmml-trusty/kie-pmml-api/src/test/java/org/kie/pmml/api/enums/builtinfunctions/DistributionFunctionsTest.java
@@ -19,9 +19,10 @@ package org.kie.pmml.api.enums.builtinfunctions;
 import java.util.ArrayList;
 import java.util.List;
 
+import org.assertj.core.data.Offset;
 import org.junit.Test;
 
-import static org.junit.Assert.assertEquals;
+import static org.assertj.core.api.Assertions.assertThat;
 
 public class DistributionFunctionsTest {
 
@@ -45,10 +46,10 @@ public class DistributionFunctionsTest {
     public void getNormalCDFValueCorrectInput() {
         Object[] input1 = {24.11, 24.54, 1.23};
         Object retrieved = DistributionFunctions.NORMAL_CDF.getValue(input1);
-        assertEquals(0.363, (Double) retrieved, 0.001);
+        assertThat((Double) retrieved).isCloseTo(0.363, Offset.offset(0.001));
         Object[] input2 = {9.12, 11.35, 3.78};
         retrieved = DistributionFunctions.NORMAL_CDF.getValue(input2);
-        assertEquals(0.278,  (Double) retrieved, 0.001);
+        assertThat((Double) retrieved).isCloseTo(0.278, Offset.offset(0.001));
     }
 
     @Test(expected = IllegalArgumentException.class)
@@ -67,10 +68,10 @@ public class DistributionFunctionsTest {
     public void getNormalPDFValueCorrectInput() {
         Object[] input1 = {2, 7, 2};
         Object retrieved = DistributionFunctions.NORMAL_PDF.getValue(input1);
-        assertEquals(0.00876, (Double) retrieved, 0.001);
+        assertThat((Double) retrieved).isCloseTo(0.00876, Offset.offset(0.001));
         Object[] input2 = {9.12, 11.35, 3.78};
         retrieved = DistributionFunctions.NORMAL_PDF.getValue(input2);
-        assertEquals(0.08868,  (Double) retrieved, 0.001);
+        assertThat((Double) retrieved).isCloseTo(0.08868, Offset.offset(0.001));
     }
 
     @Test(expected = IllegalArgumentException.class)
@@ -89,10 +90,10 @@ public class DistributionFunctionsTest {
     public void getStdNormalCDFValueCorrectInput() {
         Object[] input1 = {2};
         Object retrieved = DistributionFunctions.STD_NORMAL_CDF.getValue(input1);
-        assertEquals(0.97725, (Double) retrieved, 0.001);
+        assertThat((Double) retrieved).isCloseTo(0.97725, Offset.offset(0.001));
         Object[] input2 = {1.243};
         retrieved = DistributionFunctions.STD_NORMAL_CDF.getValue(input2);
-        assertEquals(0.89307,  (Double) retrieved, 0.001);
+        assertThat((Double) retrieved).isCloseTo(0.89307, Offset.offset(0.001));
     }
 
     @Test(expected = IllegalArgumentException.class)
@@ -111,10 +112,10 @@ public class DistributionFunctionsTest {
     public void getStdNormalPDFValueCorrectInput() {
         Object[] input1 = {2};
         Object retrieved = DistributionFunctions.STD_NORMAL_PDF.getValue(input1);
-        assertEquals(0.05399, (Double) retrieved, 0.001);
+        assertThat((Double) retrieved).isCloseTo(0.05399, Offset.offset(0.001));
         Object[] input2 = {1.243};
         retrieved = DistributionFunctions.STD_NORMAL_PDF.getValue(input2);
-        assertEquals(0.18425,  (Double) retrieved, 0.001);
+        assertThat((Double) retrieved).isCloseTo(0.18425, Offset.offset(0.001));
     }
 
     @Test(expected = IllegalArgumentException.class)
@@ -133,10 +134,10 @@ public class DistributionFunctionsTest {
     public void getErfValueCorrectInput() {
         Object[] input1 = {2};
         Object retrieved = DistributionFunctions.ERF.getValue(input1);
-        assertEquals(0.9953223, (Double) retrieved, 0.001);
+        assertThat((Double) retrieved).isCloseTo(0.9953223, Offset.offset(0.001));
         Object[] input2 = {1.243};
         retrieved = DistributionFunctions.ERF.getValue(input2);
-        assertEquals(0.92123,  (Double) retrieved, 0.001);
+        assertThat((Double) retrieved).isCloseTo(0.92123, Offset.offset(0.001));
     }
 
     @Test(expected = IllegalArgumentException.class)
@@ -155,10 +156,10 @@ public class DistributionFunctionsTest {
     public void getNormalIDFValueCorrectInput() {
         Object[] input1 = {0.75, 1.23, 0.2};
         Object retrieved = DistributionFunctions.NORMAL_IDF.getValue(input1);
-        assertEquals(1.36, (Double) retrieved, 0.01);
+        assertThat((Double) retrieved).isCloseTo(1.36, Offset.offset(0.01));
         Object[] input2 = {0.912, 11.35, 3.78};
         retrieved = DistributionFunctions.NORMAL_IDF.getValue(input2);
-        assertEquals(16.46,  (Double) retrieved, 0.01);
+        assertThat((Double) retrieved).isCloseTo(16.46, Offset.offset(0.01));
     }
 
     @Test(expected = IllegalArgumentException.class)
@@ -177,10 +178,10 @@ public class DistributionFunctionsTest {
     public void getStdNormalIDFValueCorrectInput() {
         Object[] input1 = {0.75};
         Object retrieved = DistributionFunctions.STD_NORMAL_IDF.getValue(input1);
-        assertEquals(0.67, (Double) retrieved, 0.01);
+        assertThat((Double) retrieved).isCloseTo(0.67, Offset.offset(0.01));
         Object[] input2 = {0.912};
         retrieved = DistributionFunctions.STD_NORMAL_IDF.getValue(input2);
-        assertEquals(1.35, (Double) retrieved, 0.01);
+        assertThat((Double) retrieved).isCloseTo(1.35, Offset.offset(0.01));
     }
 
     @Test(expected = IllegalArgumentException.class)

--- a/kie-pmml-trusty/kie-pmml-api/src/test/java/org/kie/pmml/api/enums/builtinfunctions/MathematicalFunctionsTest.java
+++ b/kie-pmml-trusty/kie-pmml-api/src/test/java/org/kie/pmml/api/enums/builtinfunctions/MathematicalFunctionsTest.java
@@ -19,9 +19,10 @@ package org.kie.pmml.api.enums.builtinfunctions;
 import java.util.ArrayList;
 import java.util.List;
 
+import org.assertj.core.data.Offset;
 import org.junit.Test;
 
-import static org.junit.Assert.assertEquals;
+import static org.assertj.core.api.Assertions.assertThat;
 
 public class MathematicalFunctionsTest {
 
@@ -51,7 +52,7 @@ public class MathematicalFunctionsTest {
     public void getExpm1ValueCorrectInput() {
         Object[] input = {24.11};
         Object retrieved = MathematicalFunctions.EXPM1.getValue(input);
-        assertEquals(2.956922613825104E10, (Double) retrieved, 0.0000001);
+        assertThat((Double) retrieved).isCloseTo(2.956922613825104E10, Offset.offset(0.0000001));
     }
 
     @Test(expected = IllegalArgumentException.class)
@@ -70,7 +71,7 @@ public class MathematicalFunctionsTest {
     public void getHypotValueCorrectInput() {
         Object[] input = {24.11, 11};
         Object retrieved = MathematicalFunctions.HYPOT.getValue(input);
-        assertEquals(26.500, (Double) retrieved, 0.001);
+        assertThat((Double) retrieved).isCloseTo(26.500, Offset.offset(0.001));
     }
 
     @Test(expected = IllegalArgumentException.class)
@@ -89,7 +90,7 @@ public class MathematicalFunctionsTest {
     public void getLn1pValueCorrectInput() {
         Object[] input = {24.11};
         Object retrieved = MathematicalFunctions.LN1P.getValue(input);
-        assertEquals(3.223, (Double) retrieved, 0.001);
+        assertThat((Double) retrieved).isCloseTo(3.223, Offset.offset(0.001));
     }
 
     @Test(expected = IllegalArgumentException.class)
@@ -107,11 +108,11 @@ public class MathematicalFunctionsTest {
     @Test
     public void getRintValueCorrectInput() {
         Object[] input1 = {24.11};
-        Object retrieved = MathematicalFunctions.RINT.getValue(input1);
-        assertEquals(24, (Double) retrieved, 0);
+        Double retrieved = (Double) MathematicalFunctions.RINT.getValue(input1);
+        assertThat(retrieved).isCloseTo(24.0, Offset.offset(0.0));
         Object[] input2 = {24.91};
-        retrieved = MathematicalFunctions.RINT.getValue(input2);
-        assertEquals(25, (Double) retrieved, 0);
+        retrieved = (Double) MathematicalFunctions.RINT.getValue(input2);
+        assertThat(retrieved).isCloseTo(25, Offset.offset(0.0));
     }
 
     @Test(expected = IllegalArgumentException.class)
@@ -130,7 +131,7 @@ public class MathematicalFunctionsTest {
     public void getSinValueCorrectInput() {
         Object[] input = {24.11};
         Object retrieved = MathematicalFunctions.SIN.getValue(input);
-        assertEquals(-0.8535, (Double) retrieved, 0.0001);
+        assertThat((Double) retrieved).isCloseTo(-0.8535, Offset.offset(0.0001));
     }
 
     @Test(expected = IllegalArgumentException.class)
@@ -149,7 +150,7 @@ public class MathematicalFunctionsTest {
     public void getAsinValueCorrectInput() {
         Object[] input = {0.93};
         Object retrieved = MathematicalFunctions.ASIN.getValue(input);
-        assertEquals(1.1944, (Double) retrieved, 0.0001);
+        assertThat((Double) retrieved).isCloseTo(1.1944, Offset.offset(0.0001));
     }
 
     @Test(expected = IllegalArgumentException.class)
@@ -168,7 +169,7 @@ public class MathematicalFunctionsTest {
     public void getSinhValueCorrectInput() {
         Object[] input = {0.93};
         Object retrieved = MathematicalFunctions.SINH.getValue(input);
-        assertEquals(1.0699, (Double) retrieved, 0.0001);
+        assertThat((Double) retrieved).isCloseTo(1.0699, Offset.offset(0.0001));
     }
 
     @Test(expected = IllegalArgumentException.class)
@@ -187,7 +188,7 @@ public class MathematicalFunctionsTest {
     public void getCosValueCorrectInput() {
         Object[] input = {0.93};
         Object retrieved = MathematicalFunctions.COS.getValue(input);
-        assertEquals(0.5978, (Double) retrieved, 0.0001);
+        assertThat((Double) retrieved).isCloseTo(0.5978, Offset.offset(0.0001));
     }
 
     @Test(expected = IllegalArgumentException.class)
@@ -206,7 +207,7 @@ public class MathematicalFunctionsTest {
     public void getAcosValueCorrectInput() {
         Object[] input = {0.93};
         Object retrieved = MathematicalFunctions.ACOS.getValue(input);
-        assertEquals(0.3763, (Double) retrieved, 0.0001);
+        assertThat((Double) retrieved).isCloseTo(0.3763, Offset.offset(0.0001));
     }
 
     @Test(expected = IllegalArgumentException.class)
@@ -225,7 +226,7 @@ public class MathematicalFunctionsTest {
     public void getCoshValueCorrectInput() {
         Object[] input = {0.93};
         Object retrieved = MathematicalFunctions.COSH.getValue(input);
-        assertEquals(1.4645, (Double) retrieved, 0.0001);
+        assertThat((Double) retrieved).isCloseTo(1.4645, Offset.offset(0.0001));
     }
 
     @Test(expected = IllegalArgumentException.class)
@@ -244,7 +245,7 @@ public class MathematicalFunctionsTest {
     public void getTanValueCorrectInput() {
         Object[] input = {0.93};
         Object retrieved = MathematicalFunctions.TAN.getValue(input);
-        assertEquals(1.3408, (Double) retrieved, 0.0001);
+        assertThat((Double) retrieved).isCloseTo(1.3408, Offset.offset(0.0001));
     }
 
     @Test(expected = IllegalArgumentException.class)
@@ -263,7 +264,7 @@ public class MathematicalFunctionsTest {
     public void getAtanValueCorrectInput() {
         Object[] input = {0.93};
         Object retrieved = MathematicalFunctions.ATAN.getValue(input);
-        assertEquals(0.7491, (Double) retrieved, 0.0001);
+        assertThat((Double) retrieved).isCloseTo(0.7491, Offset.offset(0.0001));
     }
 
     @Test(expected = IllegalArgumentException.class)
@@ -282,7 +283,7 @@ public class MathematicalFunctionsTest {
     public void getTanhValueCorrectInput() {
         Object[] input = {0.93};
         Object retrieved = MathematicalFunctions.TANH.getValue(input);
-        assertEquals(0.7305, (Double) retrieved, 0.0001);
+        assertThat((Double) retrieved).isCloseTo(0.7305, Offset.offset(0.0001));
     }
 
     @Test(expected = IllegalArgumentException.class)

--- a/kie-pmml-trusty/kie-pmml-api/src/test/java/org/kie/pmml/api/enums/builtinfunctions/StringFunctionsTest.java
+++ b/kie-pmml-trusty/kie-pmml-api/src/test/java/org/kie/pmml/api/enums/builtinfunctions/StringFunctionsTest.java
@@ -24,9 +24,7 @@ import java.util.List;
 
 import org.junit.Test;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
+import static org.assertj.core.api.Assertions.assertThat;
 
 public class StringFunctionsTest {
 
@@ -53,7 +51,7 @@ public class StringFunctionsTest {
     public void getLowercaseValueCorrectInput() {
         final Object[] input = {"AwdC"};
         Object retrieved = StringFunctions.LOWERCASE.getValue(input);
-        assertEquals("awdc", retrieved);
+        assertThat(retrieved).isEqualTo("awdc");
     }
 
     @Test(expected = IllegalArgumentException.class)
@@ -72,7 +70,7 @@ public class StringFunctionsTest {
     public void getUppercaseValueCorrectInput() {
         final Object[] input = {"AwdC"};
         Object retrieved = StringFunctions.UPPERCASE.getValue(input);
-        assertEquals("AWDC", retrieved);
+        assertThat(retrieved).isEqualTo("AWDC");
     }
 
     @Test(expected = IllegalArgumentException.class)
@@ -91,7 +89,7 @@ public class StringFunctionsTest {
     public void getStringLengthValueCorrectInput() {
         final Object[] input = {"AwdC"};
         Object retrieved = StringFunctions.STRING_LENGTH.getValue(input);
-        assertEquals(4, retrieved);
+        assertThat(retrieved).isEqualTo(4);
     }
 
     @Test(expected = IllegalArgumentException.class)
@@ -110,7 +108,7 @@ public class StringFunctionsTest {
     public void getSubstringValueCorrectInput() {
         final Object[] input = {"aBc9x", 2, 3};
         Object retrieved = StringFunctions.SUBSTRING.getValue(input);
-        assertEquals("Bc9", retrieved);
+        assertThat(retrieved).isEqualTo("Bc9");
     }
 
     @Test(expected = IllegalArgumentException.class)
@@ -129,10 +127,10 @@ public class StringFunctionsTest {
     public void getTrimBlanksValueCorrectInput() {
         final Object[] input1 = {" aBcas9x  "};
         Object retrieved = StringFunctions.TRIM_BLANKS.getValue(input1);
-        assertEquals("aBcas9x", retrieved);
+        assertThat(retrieved).isEqualTo("aBcas9x");
         final Object[] input2 = {" aB ca  s9x  "};
         retrieved = StringFunctions.TRIM_BLANKS.getValue(input2);
-        assertEquals("aB ca  s9x", retrieved);
+        assertThat(retrieved).isEqualTo("aB ca  s9x");
     }
 
     @Test(expected = IllegalArgumentException.class)
@@ -151,16 +149,16 @@ public class StringFunctionsTest {
     public void getConcatValueCorrectInput() {
         final Object[] input1 = {" aBc", "as9x  "};
         Object retrieved = StringFunctions.CONCAT.getValue(input1);
-        assertEquals(" aBcas9x  ", retrieved);
+        assertThat(retrieved).isEqualTo(" aBcas9x  ");
         final Object[] input2 = {" aB ", "ca  s9x"};
         retrieved = StringFunctions.CONCAT.getValue(input2);
-        assertEquals(" aB ca  s9x", retrieved);
+        assertThat(retrieved).isEqualTo(" aB ca  s9x");
         final Object[] input3 = {2, "-", 2000};
         retrieved = StringFunctions.CONCAT.getValue(input3);
-        assertEquals("2-2000", retrieved);
+        assertThat(retrieved).isEqualTo("2-2000");
         final Object[] input4 = {2, null, 2000};
         retrieved = StringFunctions.CONCAT.getValue(input4);
-        assertEquals("2null2000", retrieved);
+        assertThat(retrieved).isEqualTo("2null2000");
     }
 
     @Test(expected = IllegalArgumentException.class)
@@ -173,7 +171,7 @@ public class StringFunctionsTest {
     public void getReplaceValueCorrectInput() {
         final Object[] input = {"BBBB", "B+", "c"};
         Object retrieved = StringFunctions.REPLACE.getValue(input);
-        assertEquals("c", retrieved);
+        assertThat(retrieved).isEqualTo("c");
     }
 
     @Test(expected = IllegalArgumentException.class)
@@ -191,15 +189,15 @@ public class StringFunctionsTest {
     @Test
     public void getMatchesValueCorrectInput() {
         final Object[] input1 = {"BBBB", "B+"};
-        assertTrue((boolean)StringFunctions.MATCHES.getValue(input1));
+        assertThat((boolean)StringFunctions.MATCHES.getValue(input1)).isTrue();
         final Object[] input2 = {"BBBB", "."};
-        assertTrue((boolean)StringFunctions.MATCHES.getValue(input2));
+        assertThat((boolean)StringFunctions.MATCHES.getValue(input2)).isTrue();
         final Object[] input3 = {"aBcDDeFF", "DeF"};
-        assertTrue((boolean)StringFunctions.MATCHES.getValue(input3));
+        assertThat((boolean)StringFunctions.MATCHES.getValue(input3)).isTrue();
         final Object[] input4 = {"BBBB", "\\d"};
-        assertFalse((boolean)StringFunctions.MATCHES.getValue(input4));
+        assertThat((boolean)StringFunctions.MATCHES.getValue(input4)).isFalse();
         final Object[] input5 = {"aBcDDeFF", "dell"};
-        assertFalse((boolean)StringFunctions.MATCHES.getValue(input5));
+        assertThat((boolean)StringFunctions.MATCHES.getValue(input5)).isFalse();
     }
 
     @Test(expected = IllegalArgumentException.class)
@@ -218,13 +216,13 @@ public class StringFunctionsTest {
     public void getFormatNumberValueCorrectInput() {
         final Object[] input1 = {2, "%3d"};
         Object retrieved = StringFunctions.FORMAT_NUMBER.getValue(input1);
-        assertEquals("  2", retrieved);
+        assertThat(retrieved).isEqualTo("  2");
         final Object[] input2 = {4.2352989244d, "%.2f"};
         retrieved = StringFunctions.FORMAT_NUMBER.getValue(input2);
-        assertEquals("4.24", retrieved);
+        assertThat(retrieved).isEqualTo("4.24");
         final Object[] input3 = {4.2352989244d, "%.3f"};
         retrieved = StringFunctions.FORMAT_NUMBER.getValue(input3);
-        assertEquals("4.235", retrieved);
+        assertThat(retrieved).isEqualTo("4.235");
     }
 
     @Test(expected = IllegalArgumentException.class)
@@ -244,12 +242,12 @@ public class StringFunctionsTest {
         Date inputDate = new GregorianCalendar(2004, Calendar.AUGUST, 20).getTime();
         final Object[] input1 = {inputDate, "%m/%d/%y"};
         Object retrieved = StringFunctions.FORMAT_DATE_TIME.getValue(input1);
-        assertEquals("08/20/04", retrieved);
+        assertThat(retrieved).isEqualTo("08/20/04");
         final Object[] input2 = {inputDate, "%B/%d/%y"};
         retrieved = StringFunctions.FORMAT_DATE_TIME.getValue(input2);
         String month = String.format("%1$tB", inputDate);
         String expected = String.format("%s/20/04", month);
-        assertEquals(expected, retrieved);
+        assertThat(retrieved).isEqualTo(expected);
     }
 
     @Test(expected = IllegalArgumentException.class)

--- a/kie-pmml-trusty/kie-pmml-api/src/test/java/org/kie/pmml/api/utils/ConverterTypeUtilTest.java
+++ b/kie-pmml-trusty/kie-pmml-api/src/test/java/org/kie/pmml/api/utils/ConverterTypeUtilTest.java
@@ -22,8 +22,8 @@ import java.util.Map;
 import org.junit.Test;
 import org.kie.pmml.api.exceptions.KiePMMLException;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.fail;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.fail;
 
 public class ConverterTypeUtilTest {
 
@@ -96,7 +96,7 @@ public class ConverterTypeUtilTest {
         CONVERTIBLE_TO_STRING.forEach((s, o) -> {
             Class<?> expectedClass = o.getClass();
             Object retrieved = ConverterTypeUtil.convert(expectedClass, s);
-            assertEquals(retrieved, o);
+            assertThat(o).isEqualTo(retrieved);
         });
     }
 
@@ -105,7 +105,7 @@ public class ConverterTypeUtilTest {
         CONVERTIBLE_FROM_STRING.forEach((s, expected) -> {
             Class<?> expectedClass = expected.getClass();
             Object retrieved = ConverterTypeUtil.convert(expectedClass, s);
-            assertEquals(expected, retrieved);
+            assertThat(retrieved).isEqualTo(expected);
         });
     }
 
@@ -117,7 +117,7 @@ public class ConverterTypeUtilTest {
                 ConverterTypeUtil.convert(expectedClass, s);
                 fail(String.format("Expecting KiePMMLException for %s %s", s, o));
             } catch (Exception e) {
-                assertEquals(KiePMMLException.class, e.getClass());
+                assertThat(e.getClass()).isEqualTo(KiePMMLException.class);
             }
         });
     }
@@ -127,7 +127,7 @@ public class ConverterTypeUtilTest {
         CONVERTIBLE_FROM_INTEGER.forEach((s, expected) -> {
             Class<?> expectedClass = expected.getClass();
             Object retrieved = ConverterTypeUtil.convert(expectedClass, s);
-            assertEquals(expected, retrieved);
+            assertThat(retrieved).isEqualTo(expected);
         });
     }
 
@@ -139,7 +139,7 @@ public class ConverterTypeUtilTest {
                 ConverterTypeUtil.convert(expectedClass, s);
                 fail(String.format("Expecting KiePMMLException for %s %s", s, o));
             } catch (Exception e) {
-                assertEquals(KiePMMLException.class, e.getClass());
+                assertThat(e.getClass()).isEqualTo(KiePMMLException.class);
             }
         });
     }
@@ -149,7 +149,7 @@ public class ConverterTypeUtilTest {
         CONVERTIBLE_FROM_DOUBLE.forEach((s, expected) -> {
             Class<?> expectedClass = expected.getClass();
             Object retrieved = ConverterTypeUtil.convert(expectedClass, s);
-            assertEquals(expected, retrieved);
+            assertThat(retrieved).isEqualTo(expected);
         });
     }
 
@@ -161,7 +161,7 @@ public class ConverterTypeUtilTest {
                 ConverterTypeUtil.convert(expectedClass, s);
                 fail(String.format("Expecting KiePMMLException for %s %s", s, o));
             } catch (Exception e) {
-                assertEquals(KiePMMLException.class, e.getClass());
+                assertThat(e.getClass()).isEqualTo(KiePMMLException.class);
             }
         });
     }

--- a/kie-pmml-trusty/kie-pmml-api/src/test/java/org/kie/pmml/api/utils/PrimitiveBoxedUtilsTest.java
+++ b/kie-pmml-trusty/kie-pmml-api/src/test/java/org/kie/pmml/api/utils/PrimitiveBoxedUtilsTest.java
@@ -17,10 +17,8 @@
 package org.kie.pmml.api.utils;
 
 import org.junit.Test;
-import org.kie.pmml.api.utils.PrimitiveBoxedUtils;
 
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
+import static org.assertj.core.api.Assertions.assertThat;
 
 public class PrimitiveBoxedUtilsTest {
 
@@ -35,38 +33,38 @@ public class PrimitiveBoxedUtilsTest {
     @Test
     public void areSameWithBoxing() {
         for (int i = 0; i < types; i++) {
-            assertTrue(PrimitiveBoxedUtils.areSameWithBoxing(primitives[i], boxeds[i]));
-            assertTrue(PrimitiveBoxedUtils.areSameWithBoxing(boxeds[i], primitives[i]));
-            assertTrue(PrimitiveBoxedUtils.areSameWithBoxing(primitives[i], primitives[i]));
-            assertTrue(PrimitiveBoxedUtils.areSameWithBoxing(boxeds[i], boxeds[i]));
+            assertThat(PrimitiveBoxedUtils.areSameWithBoxing(primitives[i], boxeds[i])).isTrue();
+            assertThat(PrimitiveBoxedUtils.areSameWithBoxing(boxeds[i], primitives[i])).isTrue();
+            assertThat(PrimitiveBoxedUtils.areSameWithBoxing(primitives[i], primitives[i])).isTrue();
+            assertThat(PrimitiveBoxedUtils.areSameWithBoxing(boxeds[i], boxeds[i])).isTrue();
         }
         for (int i = 0; i < types; i++) {
-            assertFalse(PrimitiveBoxedUtils.areSameWithBoxing(primitives[i], boxeds[types - 1 - i]));
-            assertFalse(PrimitiveBoxedUtils.areSameWithBoxing(boxeds[i], primitives[types - 1 - i]));
+        	assertThat(PrimitiveBoxedUtils.areSameWithBoxing(primitives[i], boxeds[types - 1 - i])).isFalse();
+        	assertThat(PrimitiveBoxedUtils.areSameWithBoxing(boxeds[i], primitives[types - 1 - i])).isFalse();
         }
-        assertFalse(PrimitiveBoxedUtils.areSameWithBoxing(String.class, String.class));
-        assertFalse(PrimitiveBoxedUtils.areSameWithBoxing(double.class, String.class));
-        assertFalse(PrimitiveBoxedUtils.areSameWithBoxing(String.class, Double.class));
+        assertThat(PrimitiveBoxedUtils.areSameWithBoxing(String.class, String.class)).isFalse();
+        assertThat(PrimitiveBoxedUtils.areSameWithBoxing(double.class, String.class)).isFalse();
+        assertThat(PrimitiveBoxedUtils.areSameWithBoxing(String.class, Double.class)).isFalse();
     }
 
     @Test
     public void getKiePMMLPrimitiveBoxed() {
         for (int i = 0; i < types; i++) {
-            assertTrue(PrimitiveBoxedUtils.getKiePMMLPrimitiveBoxed(primitives[i]).isPresent());
-            assertTrue(PrimitiveBoxedUtils.getKiePMMLPrimitiveBoxed(boxeds[i]).isPresent());
+        	assertThat(PrimitiveBoxedUtils.getKiePMMLPrimitiveBoxed(primitives[i]).isPresent()).isTrue();
+            assertThat(PrimitiveBoxedUtils.getKiePMMLPrimitiveBoxed(boxeds[i]).isPresent()).isTrue();
         }
-        assertFalse(PrimitiveBoxedUtils.getKiePMMLPrimitiveBoxed(String.class).isPresent());
+        assertThat(PrimitiveBoxedUtils.getKiePMMLPrimitiveBoxed(String.class)).isNotPresent();
     }
 
     @Test
     public void isSameWithBoxing() {
         for (int i = 0; i < types; i++) {
-            assertTrue(PrimitiveBoxedUtils.getKiePMMLPrimitiveBoxed(primitives[i]).get().isSameWithBoxing(boxeds[i]));
-            assertTrue(PrimitiveBoxedUtils.getKiePMMLPrimitiveBoxed(boxeds[i]).get().isSameWithBoxing(primitives[i]));
-            assertTrue(PrimitiveBoxedUtils.getKiePMMLPrimitiveBoxed(primitives[i]).get().isSameWithBoxing(primitives[i]));
-            assertTrue(PrimitiveBoxedUtils.getKiePMMLPrimitiveBoxed(boxeds[i]).get().isSameWithBoxing(boxeds[i]));
-            assertFalse(PrimitiveBoxedUtils.getKiePMMLPrimitiveBoxed(primitives[i]).get().isSameWithBoxing(String.class));
-            assertFalse(PrimitiveBoxedUtils.getKiePMMLPrimitiveBoxed(boxeds[i]).get().isSameWithBoxing(String.class));
+        	assertThat(PrimitiveBoxedUtils.getKiePMMLPrimitiveBoxed(primitives[i]).get().isSameWithBoxing(boxeds[i])).isTrue();
+        	assertThat(PrimitiveBoxedUtils.getKiePMMLPrimitiveBoxed(boxeds[i]).get().isSameWithBoxing(primitives[i])).isTrue();
+        	assertThat(PrimitiveBoxedUtils.getKiePMMLPrimitiveBoxed(primitives[i]).get().isSameWithBoxing(primitives[i])).isTrue();
+        	assertThat(PrimitiveBoxedUtils.getKiePMMLPrimitiveBoxed(boxeds[i]).get().isSameWithBoxing(boxeds[i])).isTrue();
+        	assertThat(PrimitiveBoxedUtils.getKiePMMLPrimitiveBoxed(primitives[i]).get().isSameWithBoxing(String.class)).isFalse();
+            assertThat(PrimitiveBoxedUtils.getKiePMMLPrimitiveBoxed(boxeds[i]).get().isSameWithBoxing(String.class)).isFalse();
         }
     }
 }

--- a/kie-pmml-trusty/kie-pmml-commons/src/test/java/org/kie/pmml/commons/model/KiePMMLFactoryModelTest.java
+++ b/kie-pmml-trusty/kie-pmml-commons/src/test/java/org/kie/pmml/commons/model/KiePMMLFactoryModelTest.java
@@ -25,8 +25,7 @@ import org.junit.Test;
 import org.kie.pmml.api.exceptions.KiePMMLException;
 import org.kie.pmml.commons.testingutility.PMMLContextTest;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
+import static org.assertj.core.api.Assertions.assertThat;
 
 public class KiePMMLFactoryModelTest {
 
@@ -46,11 +45,11 @@ public class KiePMMLFactoryModelTest {
     @Test
     public void addSourceMap() {
         Map<String, String> retrieved = kiePMMLFactoryModel.getSourcesMap();
-        assertTrue(retrieved.isEmpty());
+        assertThat(retrieved).isEmpty();
         kiePMMLFactoryModel.addSourceMap("KEY", "VALUE");
         retrieved = kiePMMLFactoryModel.getSourcesMap();
-        assertTrue(retrieved.containsKey("KEY"));
-        assertEquals("VALUE", retrieved.get("KEY"));
+        assertThat(retrieved).containsKey("KEY");
+        assertThat(retrieved.get("KEY")).isEqualTo("VALUE");
     }
 
 

--- a/kie-pmml-trusty/kie-pmml-commons/src/test/java/org/kie/pmml/commons/model/KiePMMLMiningFieldTest.java
+++ b/kie-pmml-trusty/kie-pmml-commons/src/test/java/org/kie/pmml/commons/model/KiePMMLMiningFieldTest.java
@@ -25,8 +25,7 @@ import org.junit.Test;
 import org.kie.pmml.api.enums.CLOSURE;
 import org.kie.pmml.commons.model.expressions.KiePMMLInterval;
 
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
+import static org.assertj.core.api.Assertions.assertThat;
 
 public class KiePMMLMiningFieldTest {
 
@@ -35,8 +34,8 @@ public class KiePMMLMiningFieldTest {
         final KiePMMLMiningField kiePMMLMiningField = KiePMMLMiningField
                 .builder("NAME", Collections.emptyList())
                 .build();
-        assertTrue(kiePMMLMiningField.isMatching(null));
-        assertTrue(kiePMMLMiningField.isMatching("VALUE"));
+        assertThat(kiePMMLMiningField.isMatching(null)).isTrue();
+        assertThat(kiePMMLMiningField.isMatching("VALUE")).isTrue();
     }
 
     @Test
@@ -46,9 +45,9 @@ public class KiePMMLMiningFieldTest {
                 .builder("NAME", Collections.emptyList())
                 .withAllowedValues(allowedValues)
                 .build();
-        assertFalse(kiePMMLMiningField.isMatching(null));
-        assertFalse(kiePMMLMiningField.isMatching("VALUE"));
-        allowedValues.forEach(allowedValue -> assertTrue(kiePMMLMiningField.isMatching(allowedValue)));
+        assertThat(kiePMMLMiningField.isMatching(null)).isFalse();
+        assertThat(kiePMMLMiningField.isMatching("VALUE")).isFalse();
+        allowedValues.forEach(allowedValue -> assertThat(kiePMMLMiningField.isMatching(allowedValue)).isTrue());
     }
 
     @Test
@@ -58,12 +57,12 @@ public class KiePMMLMiningFieldTest {
                 .builder("NAME", Collections.emptyList())
                 .withIntervals(intervals)
                 .build();
-        assertFalse(kiePMMLMiningField.isMatching(null));
-        assertFalse(kiePMMLMiningField.isMatching("VALUE"));
+        assertThat(kiePMMLMiningField.isMatching(null)).isFalse();
+        assertThat(kiePMMLMiningField.isMatching("VALUE")).isFalse();
         intervals.forEach(interval -> {
             double delta = (interval.getRightMargin().doubleValue() - interval.getLeftMargin().doubleValue()) / 2;
             Number toVerify = interval.getLeftMargin().doubleValue() + delta;
-            assertTrue(kiePMMLMiningField.isMatching(toVerify));
+            assertThat(kiePMMLMiningField.isMatching(toVerify)).isTrue();
         });
     }
 
@@ -76,13 +75,13 @@ public class KiePMMLMiningFieldTest {
                 .withAllowedValues(allowedValues)
                 .withIntervals(intervals)
                 .build();
-        assertFalse(kiePMMLMiningField.isMatching(null));
-        assertFalse(kiePMMLMiningField.isMatching("VALUE"));
-        allowedValues.forEach(allowedValue -> assertTrue(kiePMMLMiningField.isMatching(allowedValue)));
+        assertThat(kiePMMLMiningField.isMatching(null)).isFalse();
+        assertThat(kiePMMLMiningField.isMatching("VALUE")).isFalse();
+        allowedValues.forEach(allowedValue -> assertThat(kiePMMLMiningField.isMatching(allowedValue)).isTrue());
         intervals.forEach(interval -> {
             double delta = (interval.getRightMargin().doubleValue() - interval.getLeftMargin().doubleValue()) / 2;
             Number toVerify = interval.getLeftMargin().doubleValue() + delta;
-            assertFalse(kiePMMLMiningField.isMatching(toVerify));
+            assertThat(kiePMMLMiningField.isMatching(toVerify)).isFalse();
         });
     }
 

--- a/kie-pmml-trusty/kie-pmml-commons/src/test/java/org/kie/pmml/commons/model/KiePMMLModelWithSourcesTest.java
+++ b/kie-pmml-trusty/kie-pmml-commons/src/test/java/org/kie/pmml/commons/model/KiePMMLModelWithSourcesTest.java
@@ -25,9 +25,7 @@ import org.junit.Test;
 import org.kie.pmml.api.exceptions.KiePMMLException;
 import org.kie.pmml.commons.testingutility.PMMLContextTest;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
-
+import static org.assertj.core.api.Assertions.assertThat;
 public class KiePMMLModelWithSourcesTest {
 
     private static final String MODEL_NAME = "MODEL_NAME";
@@ -54,7 +52,7 @@ public class KiePMMLModelWithSourcesTest {
 
     @Test
     public void getSourcesMap() {
-        assertEquals(SOURCES_MAP, kiePMMLModelWithSources.getSourcesMap());
+        assertThat(kiePMMLModelWithSources.getSourcesMap()).isEqualTo(SOURCES_MAP);
     }
 
     @Test(expected = UnsupportedOperationException.class)
@@ -66,10 +64,10 @@ public class KiePMMLModelWithSourcesTest {
     @Test
     public void addSourceMap() {
         Map<String, String> retrieved = kiePMMLModelWithSources.getSourcesMap();
-        assertTrue(retrieved.isEmpty());
+        assertThat(retrieved).isEmpty();
         kiePMMLModelWithSources.addSourceMap("KEY", "VALUE");
         retrieved = kiePMMLModelWithSources.getSourcesMap();
-        assertTrue(retrieved.containsKey("KEY"));
-        assertEquals("VALUE", retrieved.get("KEY"));
+        assertThat(retrieved).containsKey("KEY");
+        assertThat(retrieved.get("KEY")).isEqualTo("VALUE");
     }
 }

--- a/kie-pmml-trusty/kie-pmml-commons/src/test/java/org/kie/pmml/commons/model/KiePMMLOutputFieldTest.java
+++ b/kie-pmml-trusty/kie-pmml-commons/src/test/java/org/kie/pmml/commons/model/KiePMMLOutputFieldTest.java
@@ -34,10 +34,6 @@ import org.kie.pmml.commons.model.expressions.KiePMMLFieldRef;
 import org.kie.pmml.commons.model.tuples.KiePMMLNameValue;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertTrue;
 import static org.kie.pmml.commons.CommonTestingUtility.getProcessingDTO;
 
 public class KiePMMLOutputFieldTest {
@@ -55,12 +51,12 @@ public class KiePMMLOutputFieldTest {
                 "val-" + i, i)).collect(Collectors.toList());
         Optional<Object> retrieved = KiePMMLOutputField.getValueFromKiePMMLNameValuesByVariableName(variableName,
                                                                                                     kiePMMLNameValues);
-        assertFalse(retrieved.isPresent());
+        assertThat(retrieved).isNotPresent();
         final Object variableValue = 243.94;
         kiePMMLNameValues.add(new KiePMMLNameValue(variableName, variableValue));
         retrieved = KiePMMLOutputField.getValueFromKiePMMLNameValuesByVariableName(variableName, kiePMMLNameValues);
-        assertTrue(retrieved.isPresent());
-        assertEquals(variableValue, retrieved.get());
+        assertThat(retrieved).isPresent();
+        assertThat(retrieved.get()).isEqualTo(variableValue);
     }
 
     @Test
@@ -69,12 +65,12 @@ public class KiePMMLOutputFieldTest {
         final Map<String, Object> resultsVariables = new HashMap<>();
         Optional<Object> retrieved = KiePMMLOutputField.getValueFromPMMLResultByVariableName(variableName,
                                                                                              resultsVariables);
-        assertFalse(retrieved.isPresent());
+        assertThat(retrieved).isNotPresent();
         final Object variableValue = 243.94;
         resultsVariables.put(variableName, variableValue);
         retrieved = KiePMMLOutputField.getValueFromPMMLResultByVariableName(variableName, resultsVariables);
-        assertTrue(retrieved.isPresent());
-        assertEquals(variableValue, retrieved.get());
+        assertThat(retrieved).isPresent();
+        assertThat(retrieved.get()).isEqualTo(variableValue);
     }
 
     @Test
@@ -88,14 +84,14 @@ public class KiePMMLOutputFieldTest {
                 "val-" + i, i)).collect(Collectors.toList());
         ProcessingDTO processingDTO = getProcessingDTO(Collections.emptyList(),
                                                        kiePMMLNameValues, Collections.emptyList());
-        assertNull(kiePMMLOutputField.evaluate(processingDTO));
+        assertThat(kiePMMLOutputField.evaluate(processingDTO)).isNull();
         final Object variableValue = 243.94;
         kiePMMLNameValues.add(new KiePMMLNameValue(variableName, variableValue));
         processingDTO = getProcessingDTO(Collections.emptyList(),
                                          kiePMMLNameValues, Collections.emptyList());
         Object retrieved = kiePMMLOutputField.evaluate(processingDTO);
         assertThat(retrieved).isNotNull();
-        assertEquals(variableValue, retrieved);
+        assertThat(retrieved).isEqualTo(variableValue);
     }
 
     @Test
@@ -108,13 +104,13 @@ public class KiePMMLOutputFieldTest {
                                                                                 "reasonCode-" + i)
                 .collect(Collectors.toList());
         ProcessingDTO processingDTO = getProcessingDTO(Collections.emptyList(), Collections.emptyList(), reasonCodes);
-        assertNull(kiePMMLOutputField.evaluate(processingDTO));
+        assertThat(kiePMMLOutputField.evaluate(processingDTO)).isNull();
         final String variableValue = "reasonCode-3";
         reasonCodes.add(variableValue);
         processingDTO = getProcessingDTO(Collections.emptyList(), Collections.emptyList(), reasonCodes);
         Object retrieved = kiePMMLOutputField.evaluate(processingDTO);
         assertThat(retrieved).isNotNull();
-        assertEquals(variableValue, retrieved);
+        assertThat(retrieved).isEqualTo(variableValue);
     }
 
     @Test
@@ -130,7 +126,7 @@ public class KiePMMLOutputFieldTest {
         ProcessingDTO processingDTO = getProcessingDTO(Collections.emptyList(), new ArrayList<>(),
                                                        Collections.emptyList());
         Object retrieved = outputField.evaluate(processingDTO);
-        assertEquals(value1, retrieved);
+        assertThat(retrieved).isEqualTo(value1);
     }
 
     @Test
@@ -147,7 +143,7 @@ public class KiePMMLOutputFieldTest {
                                                        Arrays.asList(new KiePMMLNameValue(PARAM_1, value1)),
                                                        Collections.emptyList());
         Object retrieved = outputField.evaluate(processingDTO);
-        assertEquals(value1, retrieved);
+        assertThat(retrieved).isEqualTo(value1);
     }
 
     @Test
@@ -171,7 +167,7 @@ public class KiePMMLOutputFieldTest {
                                                        Collections.emptyList());
         Object retrieved = outputField.evaluate(processingDTO);
         Object expected = value1 / value2;
-        assertEquals(expected, retrieved);
+        assertThat(retrieved).isEqualTo(expected);
     }
 
     @Test
@@ -194,7 +190,7 @@ public class KiePMMLOutputFieldTest {
         ProcessingDTO processingDTO = getProcessingDTO(getOutputFields(), new ArrayList<>(), Collections.emptyList());
         Object retrieved = outputField.evaluate(processingDTO);
         Object expected = value1 / value2;
-        assertEquals(expected, retrieved);
+        assertThat(retrieved).isEqualTo(expected);
     }
 
     private List<KiePMMLNameValue> getKiePMMLNameValues() {

--- a/kie-pmml-trusty/kie-pmml-commons/src/test/java/org/kie/pmml/commons/model/KiePMMLTargetTest.java
+++ b/kie-pmml-trusty/kie-pmml-commons/src/test/java/org/kie/pmml/commons/model/KiePMMLTargetTest.java
@@ -18,11 +18,12 @@ package org.kie.pmml.commons.model;
 
 import java.util.Collections;
 
+import org.assertj.core.data.Offset;
 import org.junit.Test;
 import org.kie.pmml.api.enums.CAST_INTEGER;
 import org.kie.pmml.api.models.TargetField;
 
-import static org.junit.Assert.assertEquals;
+import static org.assertj.core.api.Assertions.assertThat;
 
 public class KiePMMLTargetTest {
 
@@ -34,16 +35,16 @@ public class KiePMMLTargetTest {
         TargetField targetField = new TargetField(Collections.emptyList(), null, "string", null, null, null, null,
                                                   null);
         KiePMMLTarget kiePMMLTarget = getBuilder(targetField).build();
-        assertEquals(object, kiePMMLTarget.modifyPrediction(object));
+        assertThat(kiePMMLTarget.modifyPrediction(object)).isEqualTo(object);
         object = 4.33;
-        assertEquals(object, kiePMMLTarget.modifyPrediction(object));
+        assertThat(kiePMMLTarget.modifyPrediction(object)).isEqualTo(object);
 
         targetField = new TargetField(Collections.emptyList(), null, "string", null, 4.34, null, null, null);
         kiePMMLTarget = getBuilder(targetField).build();
         object = "STRING";
-        assertEquals(object, kiePMMLTarget.modifyPrediction(object));
+        assertThat(kiePMMLTarget.modifyPrediction(object)).isEqualTo(object);
         object = 4.33;
-        assertEquals(4.34, kiePMMLTarget.modifyPrediction(object));
+        assertThat(kiePMMLTarget.modifyPrediction(object)).isEqualTo(4.34);
     }
 
     @Test
@@ -51,11 +52,11 @@ public class KiePMMLTargetTest {
         TargetField targetField = new TargetField(Collections.emptyList(), null, "string", null, null, null, null,
                                                   null);
         KiePMMLTarget kiePMMLTarget = getBuilder(targetField).build();
-        assertEquals(4.33, kiePMMLTarget.applyMin(4.33), 0.0);
+        assertThat(kiePMMLTarget.applyMin(4.33)).isCloseTo(4.33, Offset.offset(0.0));
         targetField = new TargetField(Collections.emptyList(), null, "string", null, 4.34, null, null, null);
         kiePMMLTarget = getBuilder(targetField).build();
-        assertEquals(4.34, kiePMMLTarget.applyMin(4.33), 0.0);
-        assertEquals(4.35, kiePMMLTarget.applyMin(4.35), 0.0);
+        assertThat(kiePMMLTarget.applyMin(4.33)).isCloseTo(4.34, Offset.offset(0.0));
+        assertThat(kiePMMLTarget.applyMin(4.35)).isCloseTo(4.35, Offset.offset(0.0));
     }
 
     @Test
@@ -63,11 +64,11 @@ public class KiePMMLTargetTest {
         TargetField targetField = new TargetField(Collections.emptyList(), null, "string", null, null, null, null,
                                                   null);
         KiePMMLTarget kiePMMLTarget = getBuilder(targetField).build();
-        assertEquals(4.33, kiePMMLTarget.applyMax(4.33), 0.0);
+        assertThat(kiePMMLTarget.applyMax(4.33)).isCloseTo(4.33, Offset.offset(0.0));
         targetField = new TargetField(Collections.emptyList(), null, "string", null, null, 4.34, null, null);
         kiePMMLTarget = getBuilder(targetField).build();
-        assertEquals(4.33, kiePMMLTarget.applyMax(4.33), 0.0);
-        assertEquals(4.34, kiePMMLTarget.applyMax(4.35), 0.0);
+        assertThat(kiePMMLTarget.applyMax(4.33)).isCloseTo(4.33, Offset.offset(0.0));
+        assertThat(kiePMMLTarget.applyMax(4.35)).isCloseTo(4.34, Offset.offset(0.0));
     }
 
     @Test
@@ -75,10 +76,10 @@ public class KiePMMLTargetTest {
         TargetField targetField = new TargetField(Collections.emptyList(), null, "string", null, null, null, null,
                                                   null);
         KiePMMLTarget kiePMMLTarget = getBuilder(targetField).build();
-        assertEquals(4.0, kiePMMLTarget.applyRescaleFactor(4.0), 0.0);
+        assertThat(kiePMMLTarget.applyRescaleFactor(4.0)).isCloseTo(4.0, Offset.offset(0.0));
         targetField = new TargetField(Collections.emptyList(), null, "string", null, null, null, null, 2.0);
         kiePMMLTarget = getBuilder(targetField).build();
-        assertEquals(8.0, kiePMMLTarget.applyRescaleFactor(4.0), 0.0);
+        assertThat(kiePMMLTarget.applyRescaleFactor(4.0)).isCloseTo(8.0, Offset.offset(0.0));
     }
 
     @Test
@@ -86,10 +87,10 @@ public class KiePMMLTargetTest {
         TargetField targetField = new TargetField(Collections.emptyList(), null, "string", null, null, null, null,
                                                   null);
         KiePMMLTarget kiePMMLTarget = getBuilder(targetField).build();
-        assertEquals(6.0, kiePMMLTarget.applyRescaleConstant(6.0), 0.0);
+        assertThat(kiePMMLTarget.applyRescaleConstant(6.0)).isCloseTo(6.0, Offset.offset(0.0));
         targetField = new TargetField(Collections.emptyList(), null, "string", null, null, null, 2.0, null);
         kiePMMLTarget = getBuilder(targetField).build();
-        assertEquals(8.0, kiePMMLTarget.applyRescaleConstant(6.0), 0.0);
+        assertThat(kiePMMLTarget.applyRescaleConstant(6.0)).isCloseTo(8.0, Offset.offset(0.0));
     }
 
     @Test
@@ -97,11 +98,11 @@ public class KiePMMLTargetTest {
         TargetField targetField = new TargetField(Collections.emptyList(), null, "string", null, null, null, null,
                                                   null);
         KiePMMLTarget kiePMMLTarget = getBuilder(targetField).build();
-        assertEquals(2.718, (double) kiePMMLTarget.applyCastInteger(2.718), 0.0);
+        assertThat((double) kiePMMLTarget.applyCastInteger(2.718)).isCloseTo(2.718, Offset.offset(0.0));
         targetField = new TargetField(Collections.emptyList(), null, "string", CAST_INTEGER.ROUND, null, null, null,
                                       null);
         kiePMMLTarget = getBuilder(targetField).build();
-        assertEquals(3.0, (double) kiePMMLTarget.applyCastInteger(2.718), 0.0);
+        assertThat((double) kiePMMLTarget.applyCastInteger(2.718)).isCloseTo(3.0, Offset.offset(0.0));
     }
 
     private KiePMMLTarget.Builder getBuilder(TargetField targetField) {

--- a/kie-pmml-trusty/kie-pmml-commons/src/test/java/org/kie/pmml/commons/model/expressions/KiePMMLApplyTest.java
+++ b/kie-pmml-trusty/kie-pmml-commons/src/test/java/org/kie/pmml/commons/model/expressions/KiePMMLApplyTest.java
@@ -31,9 +31,7 @@ import org.kie.pmml.commons.transformations.KiePMMLDefineFunction;
 import org.kie.pmml.commons.transformations.KiePMMLDerivedField;
 import org.kie.pmml.commons.transformations.KiePMMLParameterField;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.kie.pmml.commons.CommonTestingUtility.getProcessingDTO;
 
 public class KiePMMLApplyTest {
@@ -83,7 +81,7 @@ public class KiePMMLApplyTest {
                 .build();
         ProcessingDTO processingDTO = getProcessingDTO(Collections.emptyList(), Collections.emptyList(), Collections.emptyList(), Collections.emptyList());
         Object retrieved = kiePMMLApply.evaluate(processingDTO);
-        assertEquals(expected, retrieved);
+        assertThat(retrieved).isEqualTo(expected);
         //
         // <Apply function="/">
         //      <Constant>33.0</Constant>
@@ -98,7 +96,7 @@ public class KiePMMLApplyTest {
         List<KiePMMLNameValue> kiePMMLNameValues = Collections.singletonList(new KiePMMLNameValue(FIELD_NAME, value2));
         processingDTO = getProcessingDTO(Collections.emptyList(), Collections.emptyList(), kiePMMLNameValues, Collections.emptyList());
         retrieved = kiePMMLApply.evaluate(processingDTO);
-        assertEquals(expected, retrieved);
+        assertThat(retrieved).isEqualTo(expected);
         // Apply with a Constant and a FieldRef: returns kiePMMLConstant1 divided evaluation of FieldRef from
         // derivedFields
         final KiePMMLDerivedField kiePMMLDerivedField = KiePMMLDerivedField.builder(FIELD_NAME,
@@ -111,7 +109,7 @@ public class KiePMMLApplyTest {
         kiePMMLNameValues = Collections.singletonList(new KiePMMLNameValue("UNKNOWN", "WRONG"));
         processingDTO = getProcessingDTO(Collections.emptyList(), derivedFields, kiePMMLNameValues, Collections.emptyList());
         retrieved = kiePMMLApply.evaluate(processingDTO);
-        assertEquals(expected, retrieved);
+        assertThat(retrieved).isEqualTo(expected);
         // <Apply function="isMissing">
         //      <FieldRef>FIELD_NAME</FieldRef>
         // </Apply>
@@ -121,8 +119,8 @@ public class KiePMMLApplyTest {
                 .build();
         processingDTO = getProcessingDTO(Collections.emptyList(), Collections.emptyList(), Collections.emptyList(), Collections.singletonList(getReferredByFieldRef(FIELD_NAME)));
         retrieved = kiePMMLApply.evaluate(processingDTO);
-        assertTrue(retrieved instanceof Boolean);
-        assertTrue((boolean) retrieved);
+        assertThat(retrieved).isInstanceOf(Boolean.class);
+        assertThat((boolean) retrieved).isTrue();
         // Apply with FieldRef: returns false with corresponding input
         kiePMMLApply = KiePMMLApply.builder("NAME", Collections.emptyList(), "isMissing")
                 .withKiePMMLExpressions(Collections.singletonList(kiePMMLFieldRef))
@@ -130,8 +128,8 @@ public class KiePMMLApplyTest {
         kiePMMLNameValues = Collections.singletonList(new KiePMMLNameValue(FIELD_NAME, value2));
         processingDTO = getProcessingDTO(Collections.emptyList(), Collections.emptyList(), kiePMMLNameValues, Collections.singletonList(getReferredByFieldRef(FIELD_NAME)));
         retrieved = kiePMMLApply.evaluate(processingDTO);
-        assertTrue(retrieved instanceof Boolean);
-        assertFalse((boolean) retrieved);
+        assertThat(retrieved).isInstanceOf(Boolean.class);
+        assertThat((boolean) retrieved).isFalse();
     }
 
     @Test
@@ -158,7 +156,7 @@ public class KiePMMLApplyTest {
         List<KiePMMLDefineFunction> defineFunctions = Collections.singletonList(getDefineFunctionApplyFromConstant());
         ProcessingDTO processingDTO = getProcessingDTO(defineFunctions, Collections.emptyList(), new ArrayList<>(), Collections.emptyList());
         Object retrieved = kiePMMLApply.evaluate(processingDTO);
-        assertEquals(expected, retrieved);
+        assertThat(retrieved).isEqualTo(expected);
         //
         // Apply with a Constant and a FieldRef: returns kiePMMLConstant1 divided evaluation of FieldRef from
         // kiePMMLNameValues
@@ -178,7 +176,7 @@ public class KiePMMLApplyTest {
         processingDTO = getProcessingDTO(defineFunctions, Collections.emptyList(), new ArrayList<>(), Collections.emptyList());
         retrieved = kiePMMLApply.evaluate(processingDTO);
         Double locallyExpected = value1 / valueB;
-        assertEquals(locallyExpected, retrieved);
+        assertThat(retrieved).isEqualTo(locallyExpected);
         //
         // Apply invoking another custom function
         // <Apply function="OUTER_FUNCTION">
@@ -208,7 +206,7 @@ public class KiePMMLApplyTest {
                                         getDefineFunctionApplyFromCustomFunction());
         processingDTO = getProcessingDTO(defineFunctions, Collections.emptyList(), new ArrayList<>(), Collections.emptyList());
         retrieved = kiePMMLApply.evaluate(processingDTO);
-        assertEquals(locallyExpected, retrieved);
+        assertThat(retrieved).isEqualTo(locallyExpected);
     }
 
     private KiePMMLDefineFunction getDefineFunctionApplyFromConstant() {

--- a/kie-pmml-trusty/kie-pmml-commons/src/test/java/org/kie/pmml/commons/model/expressions/KiePMMLConstantTest.java
+++ b/kie-pmml-trusty/kie-pmml-commons/src/test/java/org/kie/pmml/commons/model/expressions/KiePMMLConstantTest.java
@@ -22,7 +22,7 @@ import org.junit.Test;
 import org.kie.pmml.api.enums.DATA_TYPE;
 import org.kie.pmml.commons.model.ProcessingDTO;
 
-import static org.junit.Assert.assertEquals;
+import static org.assertj.core.api.Assertions.assertThat;
 
 public class KiePMMLConstantTest {
 
@@ -32,10 +32,10 @@ public class KiePMMLConstantTest {
         final KiePMMLConstant kiePMMLConstant1 = new KiePMMLConstant("NAME", Collections.emptyList(), value, null);
         ProcessingDTO processingDTO = new ProcessingDTO(Collections.emptyList(), Collections.emptyList(), Collections.emptyList(), Collections.emptyList(), Collections.emptyList(), Collections.emptyList(), Collections.emptyList());
         Object retrieved = kiePMMLConstant1.evaluate(processingDTO);
-        assertEquals(value, retrieved);
+        assertThat(retrieved).isEqualTo(value);
         final KiePMMLConstant kiePMMLConstant2 = new KiePMMLConstant("NAME", Collections.emptyList(), value, DATA_TYPE.STRING);
         processingDTO = new ProcessingDTO(Collections.emptyList(), Collections.emptyList(), Collections.emptyList(), Collections.emptyList(), Collections.emptyList(), Collections.emptyList(), Collections.emptyList());
         retrieved = kiePMMLConstant2.evaluate(processingDTO);
-        assertEquals("234.45", retrieved);
+        assertThat(retrieved).isEqualTo("234.45");
     }
 }

--- a/kie-pmml-trusty/kie-pmml-commons/src/test/java/org/kie/pmml/commons/model/expressions/KiePMMLDiscretizeBinTest.java
+++ b/kie-pmml-trusty/kie-pmml-commons/src/test/java/org/kie/pmml/commons/model/expressions/KiePMMLDiscretizeBinTest.java
@@ -22,9 +22,7 @@ import java.util.Optional;
 import org.junit.Test;
 import org.kie.pmml.api.enums.CLOSURE;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
+import static org.assertj.core.api.Assertions.assertThat;
 
 public class KiePMMLDiscretizeBinTest {
     
@@ -35,136 +33,136 @@ public class KiePMMLDiscretizeBinTest {
     public void evaluateOpenOpen() {
         KiePMMLDiscretizeBin kiePMMLDiscretizeBin = getKiePMMLDiscretizeBin(new KiePMMLInterval(null, 20, CLOSURE.OPEN_OPEN));
         Optional<String> retrieved = kiePMMLDiscretizeBin.evaluate(10);
-        assertTrue(retrieved.isPresent());
-        assertEquals(BINVALUE, retrieved.get());
+        assertThat(retrieved).isPresent();
+        assertThat(retrieved.get()).isEqualTo(BINVALUE);
         retrieved = kiePMMLDiscretizeBin.evaluate(20);
-        assertFalse(retrieved.isPresent());
+        assertThat(retrieved).isNotPresent();
         retrieved = kiePMMLDiscretizeBin.evaluate(30);
-        assertFalse(retrieved.isPresent());
+        assertThat(retrieved).isNotPresent();
         kiePMMLDiscretizeBin = getKiePMMLDiscretizeBin(new KiePMMLInterval(20, null, CLOSURE.OPEN_OPEN));
         retrieved = kiePMMLDiscretizeBin.evaluate(30);
-        assertTrue(retrieved.isPresent());
-        assertEquals(BINVALUE, retrieved.get());
+        assertThat(retrieved).isPresent();
+        assertThat(retrieved.get()).isEqualTo(BINVALUE);
         retrieved = kiePMMLDiscretizeBin.evaluate(20);
-        assertFalse(retrieved.isPresent());
+        assertThat(retrieved).isNotPresent();
         retrieved = kiePMMLDiscretizeBin.evaluate(10);
-        assertFalse(retrieved.isPresent());
+        assertThat(retrieved).isNotPresent();
         kiePMMLDiscretizeBin = getKiePMMLDiscretizeBin(new KiePMMLInterval(20, 40, CLOSURE.OPEN_OPEN));
         retrieved = kiePMMLDiscretizeBin.evaluate(30);
-        assertTrue(retrieved.isPresent());
-        assertEquals(BINVALUE, retrieved.get());
+        assertThat(retrieved).isPresent();
+        assertThat(retrieved.get()).isEqualTo(BINVALUE);
         retrieved = kiePMMLDiscretizeBin.evaluate(10);
-        assertFalse(retrieved.isPresent());
+        assertThat(retrieved).isNotPresent();
         retrieved = kiePMMLDiscretizeBin.evaluate(20);
-        assertFalse(retrieved.isPresent());
+        assertThat(retrieved).isNotPresent();
         retrieved = kiePMMLDiscretizeBin.evaluate(40);
-        assertFalse(retrieved.isPresent());
+        assertThat(retrieved).isNotPresent();
         retrieved = kiePMMLDiscretizeBin.evaluate(50);
-        assertFalse(retrieved.isPresent());
+        assertThat(retrieved).isNotPresent();
     }
 
     @Test
     public void evaluateOpenClosed() {
         KiePMMLDiscretizeBin kiePMMLDiscretizeBin = getKiePMMLDiscretizeBin(new KiePMMLInterval(null, 20, CLOSURE.OPEN_CLOSED));
         Optional<String> retrieved = kiePMMLDiscretizeBin.evaluate(10);
-        assertTrue(retrieved.isPresent());
-        assertEquals(BINVALUE, retrieved.get());
+        assertThat(retrieved).isPresent();
+        assertThat(retrieved.get()).isEqualTo(BINVALUE);
         retrieved = kiePMMLDiscretizeBin.evaluate(20);
-        assertTrue(retrieved.isPresent());
-        assertEquals(BINVALUE, retrieved.get());
+        assertThat(retrieved).isPresent();
+        assertThat(retrieved.get()).isEqualTo(BINVALUE);
         retrieved = kiePMMLDiscretizeBin.evaluate(30);
-        assertFalse(retrieved.isPresent());
+        assertThat(retrieved).isNotPresent();
         kiePMMLDiscretizeBin = getKiePMMLDiscretizeBin(new KiePMMLInterval(20, null, CLOSURE.OPEN_CLOSED));
         retrieved = kiePMMLDiscretizeBin.evaluate(30);
-        assertTrue(retrieved.isPresent());
-        assertEquals(BINVALUE, retrieved.get());
+        assertThat(retrieved).isPresent();
+        assertThat(retrieved.get()).isEqualTo(BINVALUE);
         retrieved = kiePMMLDiscretizeBin.evaluate(20);
-        assertFalse(retrieved.isPresent());
+        assertThat(retrieved).isNotPresent();
         retrieved = kiePMMLDiscretizeBin.evaluate(10);
-        assertFalse(retrieved.isPresent());
+        assertThat(retrieved).isNotPresent();
         kiePMMLDiscretizeBin = getKiePMMLDiscretizeBin(new KiePMMLInterval(20, 40, CLOSURE.OPEN_CLOSED));
         retrieved = kiePMMLDiscretizeBin.evaluate(30);
-        assertTrue(retrieved.isPresent());
-        assertEquals(BINVALUE, retrieved.get());
+        assertThat(retrieved).isPresent();
+        assertThat(retrieved.get()).isEqualTo(BINVALUE);
         retrieved = kiePMMLDiscretizeBin.evaluate(10);
-        assertFalse(retrieved.isPresent());
+        assertThat(retrieved).isNotPresent();
         retrieved = kiePMMLDiscretizeBin.evaluate(20);
-        assertFalse(retrieved.isPresent());
+        assertThat(retrieved).isNotPresent();
         retrieved = kiePMMLDiscretizeBin.evaluate(40);
-        assertTrue(retrieved.isPresent());
-        assertEquals(BINVALUE, retrieved.get());
+        assertThat(retrieved).isPresent();
+        assertThat(retrieved.get()).isEqualTo(BINVALUE);
         retrieved = kiePMMLDiscretizeBin.evaluate(50);
-        assertFalse(retrieved.isPresent());
+        assertThat(retrieved).isNotPresent();
     }
 
     @Test
     public void evaluateClosedOpen() {
         KiePMMLDiscretizeBin kiePMMLDiscretizeBin = getKiePMMLDiscretizeBin(new KiePMMLInterval(null, 20, CLOSURE.CLOSED_OPEN));
         Optional<String> retrieved = kiePMMLDiscretizeBin.evaluate(10);
-        assertTrue(retrieved.isPresent());
-        assertEquals(BINVALUE, retrieved.get());
+        assertThat(retrieved).isPresent();
+        assertThat(retrieved.get()).isEqualTo(BINVALUE);
         retrieved = kiePMMLDiscretizeBin.evaluate(20);
-        assertFalse(retrieved.isPresent());
+        assertThat(retrieved).isNotPresent();
         retrieved = kiePMMLDiscretizeBin.evaluate(30);
-        assertFalse(retrieved.isPresent());
+        assertThat(retrieved).isNotPresent();
         kiePMMLDiscretizeBin = getKiePMMLDiscretizeBin(new KiePMMLInterval(20, null, CLOSURE.CLOSED_OPEN));
         retrieved = kiePMMLDiscretizeBin.evaluate(30);
-        assertTrue(retrieved.isPresent());
-        assertEquals(BINVALUE, retrieved.get());
+        assertThat(retrieved).isPresent();
+        assertThat(retrieved.get()).isEqualTo(BINVALUE);
         retrieved = kiePMMLDiscretizeBin.evaluate(20);
-        assertTrue(retrieved.isPresent());
-        assertEquals(BINVALUE, retrieved.get());
+        assertThat(retrieved).isPresent();
+        assertThat(retrieved.get()).isEqualTo(BINVALUE);
         retrieved = kiePMMLDiscretizeBin.evaluate(10);
-        assertFalse(retrieved.isPresent());
+        assertThat(retrieved).isNotPresent();
         kiePMMLDiscretizeBin = getKiePMMLDiscretizeBin(new KiePMMLInterval(20, 40, CLOSURE.CLOSED_OPEN));
         retrieved = kiePMMLDiscretizeBin.evaluate(30);
-        assertTrue(retrieved.isPresent());
-        assertEquals(BINVALUE, retrieved.get());
+        assertThat(retrieved).isPresent();
+        assertThat(retrieved.get()).isEqualTo(BINVALUE);
         retrieved = kiePMMLDiscretizeBin.evaluate(10);
-        assertFalse(retrieved.isPresent());
+        assertThat(retrieved).isNotPresent();
         retrieved = kiePMMLDiscretizeBin.evaluate(20);
-        assertTrue(retrieved.isPresent());
-        assertEquals(BINVALUE, retrieved.get());
+        assertThat(retrieved).isPresent();
+        assertThat(retrieved.get()).isEqualTo(BINVALUE);
         retrieved = kiePMMLDiscretizeBin.evaluate(40);
-        assertFalse(retrieved.isPresent());
+        assertThat(retrieved).isNotPresent();
         retrieved = kiePMMLDiscretizeBin.evaluate(50);
-        assertFalse(retrieved.isPresent());
+        assertThat(retrieved).isNotPresent();
     }
 
     @Test
     public void evaluateClosedClosed() {
         KiePMMLDiscretizeBin kiePMMLDiscretizeBin = getKiePMMLDiscretizeBin(new KiePMMLInterval(null, 20, CLOSURE.CLOSED_CLOSED));
         Optional<String> retrieved = kiePMMLDiscretizeBin.evaluate(10);
-        assertTrue(retrieved.isPresent());
-        assertEquals(BINVALUE, retrieved.get());
+        assertThat(retrieved).isPresent();
+        assertThat(retrieved.get()).isEqualTo(BINVALUE);
         retrieved = kiePMMLDiscretizeBin.evaluate(20);
-        assertTrue(retrieved.isPresent());
-        assertEquals(BINVALUE, retrieved.get());
+        assertThat(retrieved).isPresent();
+        assertThat(retrieved.get()).isEqualTo(BINVALUE);
         retrieved = kiePMMLDiscretizeBin.evaluate(30);
-        assertFalse(retrieved.isPresent());
+        assertThat(retrieved).isNotPresent();
         kiePMMLDiscretizeBin = getKiePMMLDiscretizeBin(new KiePMMLInterval(20, null, CLOSURE.CLOSED_CLOSED));
         retrieved = kiePMMLDiscretizeBin.evaluate(30);
-        assertTrue(retrieved.isPresent());
-        assertEquals(BINVALUE, retrieved.get());
+        assertThat(retrieved).isPresent();
+        assertThat(retrieved.get()).isEqualTo(BINVALUE);
         retrieved = kiePMMLDiscretizeBin.evaluate(20);
-        assertTrue(retrieved.isPresent());
-        assertEquals(BINVALUE, retrieved.get());
+        assertThat(retrieved).isPresent();
+        assertThat(retrieved.get()).isEqualTo(BINVALUE);
         retrieved = kiePMMLDiscretizeBin.evaluate(10);
-        assertFalse(retrieved.isPresent());
+        assertThat(retrieved).isNotPresent();
         kiePMMLDiscretizeBin = getKiePMMLDiscretizeBin(new KiePMMLInterval(20, 40, CLOSURE.CLOSED_CLOSED));
         retrieved = kiePMMLDiscretizeBin.evaluate(30);
-        assertTrue(retrieved.isPresent());
-        assertEquals(BINVALUE, retrieved.get());
+        assertThat(retrieved).isPresent();
+        assertThat(retrieved.get()).isEqualTo(BINVALUE);
         retrieved = kiePMMLDiscretizeBin.evaluate(10);
-        assertFalse(retrieved.isPresent());
+        assertThat(retrieved).isNotPresent();
         retrieved = kiePMMLDiscretizeBin.evaluate(20);
-        assertTrue(retrieved.isPresent());
-        assertEquals(BINVALUE, retrieved.get());
+        assertThat(retrieved).isPresent();
+        assertThat(retrieved.get()).isEqualTo(BINVALUE);
         retrieved = kiePMMLDiscretizeBin.evaluate(40);
-        assertTrue(retrieved.isPresent());
-        assertEquals(BINVALUE, retrieved.get());
+        assertThat(retrieved).isPresent();
+        assertThat(retrieved.get()).isEqualTo(BINVALUE);
         retrieved = kiePMMLDiscretizeBin.evaluate(50);
-        assertFalse(retrieved.isPresent());
+        assertThat(retrieved).isNotPresent();
     }
     
     private KiePMMLDiscretizeBin getKiePMMLDiscretizeBin(KiePMMLInterval interval) {

--- a/kie-pmml-trusty/kie-pmml-commons/src/test/java/org/kie/pmml/commons/model/expressions/KiePMMLDiscretizeTest.java
+++ b/kie-pmml-trusty/kie-pmml-commons/src/test/java/org/kie/pmml/commons/model/expressions/KiePMMLDiscretizeTest.java
@@ -29,10 +29,6 @@ import org.kie.pmml.commons.model.ProcessingDTO;
 import org.kie.pmml.commons.model.tuples.KiePMMLNameValue;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertTrue;
 import static org.kie.pmml.commons.CommonTestingUtility.getProcessingDTO;
 
 public class KiePMMLDiscretizeTest {
@@ -71,11 +67,11 @@ public class KiePMMLDiscretizeTest {
         KiePMMLDiscretize kiePMMLDiscretize = getKiePMMLDiscretize(null, null);
         ProcessingDTO processingDTO = getProcessingDTO(Collections.emptyList());
         Object retrieved = kiePMMLDiscretize.evaluate(processingDTO);
-        assertNull(retrieved);
+        assertThat(retrieved).isNull();
         kiePMMLDiscretize = getKiePMMLDiscretize(MAP_MISSING_TO, null);
         retrieved = kiePMMLDiscretize.evaluate(processingDTO);
         assertThat(retrieved).isNotNull();
-        assertEquals(MAP_MISSING_TO, retrieved);
+        assertThat(retrieved).isEqualTo(MAP_MISSING_TO);
     }
 
     @Test
@@ -84,63 +80,63 @@ public class KiePMMLDiscretizeTest {
 
         ProcessingDTO processingDTO = getProcessingDTO(Arrays.asList(new KiePMMLNameValue(NAME, 20)));
         Object retrieved = kiePMMLDiscretize.evaluate(processingDTO);
-        assertNull(retrieved);
+        assertThat(retrieved).isNull();
         kiePMMLDiscretize = getKiePMMLDiscretize(MAP_MISSING_TO, DEFAULTVALUE);
         processingDTO = getProcessingDTO(Arrays.asList(new KiePMMLNameValue(NAME, 20)));
         retrieved = kiePMMLDiscretize.evaluate(processingDTO);
         assertThat(retrieved).isNotNull();
-        assertEquals(DEFAULTVALUE, retrieved);
+        assertThat(retrieved).isEqualTo(DEFAULTVALUE);
         processingDTO = getProcessingDTO(Arrays.asList(new KiePMMLNameValue(NAME, 21)));
         retrieved = kiePMMLDiscretize.evaluate(processingDTO);
         assertThat(retrieved).isNotNull();
-        assertEquals(DEFAULTVALUE, retrieved);
+        assertThat(retrieved).isEqualTo(DEFAULTVALUE);
         processingDTO = getProcessingDTO(Arrays.asList(new KiePMMLNameValue(NAME, 40)));
         retrieved = kiePMMLDiscretize.evaluate(processingDTO);
         assertThat(retrieved).isNotNull();
-        assertEquals(DEFAULTVALUE, retrieved);
+        assertThat(retrieved).isEqualTo(DEFAULTVALUE);
     }
 
     @Test
     public void getFromDiscretizeBins() {
         KiePMMLDiscretize kiePMMLDiscretize = getKiePMMLDiscretize(null, null);
         Optional<String> retrieved = kiePMMLDiscretize.getFromDiscretizeBins(10);
-        assertTrue(retrieved.isPresent());
+        assertThat(retrieved).isPresent();
         retrieved = kiePMMLDiscretize.getFromDiscretizeBins(20);
-        assertFalse(retrieved.isPresent());
+        assertThat(retrieved).isNotPresent();
         retrieved = kiePMMLDiscretize.getFromDiscretizeBins(21);
-        assertFalse(retrieved.isPresent());
+        assertThat(retrieved).isNotPresent();
         retrieved = kiePMMLDiscretize.getFromDiscretizeBins(29);
-        assertTrue(retrieved.isPresent());
-        assertEquals(kiePMMLDiscretizeBin2.getBinValue(), retrieved.get());
+        assertThat(retrieved).isPresent();
+        assertThat(retrieved.get()).isEqualTo(kiePMMLDiscretizeBin2.getBinValue());
         retrieved = kiePMMLDiscretize.getFromDiscretizeBins(30);
-        assertTrue(retrieved.isPresent());
-        assertEquals(kiePMMLDiscretizeBin2.getBinValue(), retrieved.get());
+        assertThat(retrieved).isPresent();
+        assertThat(retrieved.get()).isEqualTo(kiePMMLDiscretizeBin2.getBinValue());
         retrieved = kiePMMLDiscretize.getFromDiscretizeBins(31);
-        assertTrue(retrieved.isPresent());
-        assertEquals(kiePMMLDiscretizeBin3.getBinValue(), retrieved.get());
+        assertThat(retrieved).isPresent();
+        assertThat(retrieved.get()).isEqualTo(kiePMMLDiscretizeBin3.getBinValue());
         retrieved = kiePMMLDiscretize.getFromDiscretizeBins(32);
-        assertTrue(retrieved.isPresent());
-        assertEquals(kiePMMLDiscretizeBin3.getBinValue(), retrieved.get());
+        assertThat(retrieved).isPresent();
+        assertThat(retrieved.get()).isEqualTo(kiePMMLDiscretizeBin3.getBinValue());
         retrieved = kiePMMLDiscretize.getFromDiscretizeBins(40);
-        assertFalse(retrieved.isPresent());
+        assertThat(retrieved).isNotPresent();
         retrieved = kiePMMLDiscretize.getFromDiscretizeBins(41);
-        assertTrue(retrieved.isPresent());
-        assertEquals(kiePMMLDiscretizeBin4.getBinValue(), retrieved.get());
+        assertThat(retrieved).isPresent();
+        assertThat(retrieved.get()).isEqualTo(kiePMMLDiscretizeBin4.getBinValue());
         retrieved = kiePMMLDiscretize.getFromDiscretizeBins(42);
-        assertTrue(retrieved.isPresent());
-        assertEquals(kiePMMLDiscretizeBin4.getBinValue(), retrieved.get());
+        assertThat(retrieved).isPresent();
+        assertThat(retrieved.get()).isEqualTo(kiePMMLDiscretizeBin4.getBinValue());
         retrieved = kiePMMLDiscretize.getFromDiscretizeBins(49);
-        assertTrue(retrieved.isPresent());
-        assertEquals(kiePMMLDiscretizeBin4.getBinValue(), retrieved.get());
+        assertThat(retrieved).isPresent();
+        assertThat(retrieved.get()).isEqualTo(kiePMMLDiscretizeBin4.getBinValue());
         retrieved = kiePMMLDiscretize.getFromDiscretizeBins(50);
-        assertTrue(retrieved.isPresent());
-        assertEquals(kiePMMLDiscretizeBin4.getBinValue(), retrieved.get());
+        assertThat(retrieved).isPresent();
+        assertThat(retrieved.get()).isEqualTo(kiePMMLDiscretizeBin4.getBinValue());
         retrieved = kiePMMLDiscretize.getFromDiscretizeBins(51);
-        assertTrue(retrieved.isPresent());
-        assertEquals(kiePMMLDiscretizeBin5.getBinValue(), retrieved.get());
+        assertThat(retrieved).isPresent();
+        assertThat(retrieved.get()).isEqualTo(kiePMMLDiscretizeBin5.getBinValue());
         retrieved = kiePMMLDiscretize.getFromDiscretizeBins(52);
-        assertTrue(retrieved.isPresent());
-        assertEquals(kiePMMLDiscretizeBin5.getBinValue(), retrieved.get());
+        assertThat(retrieved).isPresent();
+        assertThat(retrieved.get()).isEqualTo(kiePMMLDiscretizeBin5.getBinValue());
     }
     
     private KiePMMLDiscretize getKiePMMLDiscretize(String mapMissingTo, String defaultValue) {

--- a/kie-pmml-trusty/kie-pmml-commons/src/test/java/org/kie/pmml/commons/model/expressions/KiePMMLFieldRefTest.java
+++ b/kie-pmml-trusty/kie-pmml-commons/src/test/java/org/kie/pmml/commons/model/expressions/KiePMMLFieldRefTest.java
@@ -26,8 +26,7 @@ import org.kie.pmml.commons.model.ProcessingDTO;
 import org.kie.pmml.commons.model.tuples.KiePMMLNameValue;
 import org.kie.pmml.commons.transformations.KiePMMLDerivedField;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNull;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.kie.pmml.commons.CommonTestingUtility.getProcessingDTO;
 
 public class KiePMMLFieldRefTest {
@@ -42,7 +41,7 @@ public class KiePMMLFieldRefTest {
         final KiePMMLFieldRef kiePMMLFieldRef = new KiePMMLFieldRef(FIELD_NAME, Collections.emptyList(), null);
         ProcessingDTO processingDTO = getProcessingDTO(Collections.emptyList(), kiePMMLNameValues);
         final Object retrieved = kiePMMLFieldRef.evaluate(processingDTO);
-        assertEquals(value, retrieved);
+        assertThat(retrieved).isEqualTo(value);
     }
 
     @Test
@@ -61,7 +60,7 @@ public class KiePMMLFieldRefTest {
         final KiePMMLFieldRef kiePMMLFieldRef = new KiePMMLFieldRef(FIELD_NAME, Collections.emptyList(), null);
         ProcessingDTO processingDTO = getProcessingDTO(derivedFields, kiePMMLNameValues);
         final Object retrieved = kiePMMLFieldRef.evaluate(processingDTO);
-        assertEquals(value, retrieved);
+        assertThat(retrieved).isEqualTo(value);
     }
 
     @Test
@@ -80,7 +79,7 @@ public class KiePMMLFieldRefTest {
         final KiePMMLFieldRef kiePMMLFieldRef = new KiePMMLFieldRef(FIELD_NAME, Collections.emptyList(), value);
         ProcessingDTO processingDTO = getProcessingDTO(derivedFields, kiePMMLNameValues);
         final Object retrieved = kiePMMLFieldRef.evaluate(processingDTO);
-        assertEquals(value, retrieved);
+        assertThat(retrieved).isEqualTo(value);
     }
 
     @Test
@@ -98,7 +97,7 @@ public class KiePMMLFieldRefTest {
         final KiePMMLFieldRef kiePMMLFieldRef = new KiePMMLFieldRef(FIELD_NAME, Collections.emptyList(), null);
         ProcessingDTO processingDTO = getProcessingDTO(derivedFields, kiePMMLNameValues);
         final Object retrieved = kiePMMLFieldRef.evaluate(processingDTO);
-        assertNull(retrieved);
+        assertThat(retrieved).isNull();
     }
 
 }

--- a/kie-pmml-trusty/kie-pmml-commons/src/test/java/org/kie/pmml/commons/model/expressions/KiePMMLInlineTableTest.java
+++ b/kie-pmml-trusty/kie-pmml-commons/src/test/java/org/kie/pmml/commons/model/expressions/KiePMMLInlineTableTest.java
@@ -25,9 +25,7 @@ import java.util.stream.IntStream;
 
 import org.junit.Test;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
+import static org.assertj.core.api.Assertions.assertThat;
 
 public class KiePMMLInlineTableTest {
 
@@ -49,7 +47,7 @@ public class KiePMMLInlineTableTest {
     public void evaluateKeyNotFound() {
         KiePMMLInlineTable kiePMMLInlineTable = new KiePMMLInlineTable("name", Collections.emptyList(), ROWS);
         Optional<Object> retrieved = kiePMMLInlineTable.evaluate(Collections.singletonMap("NOT-KEY", 0), "KEY-0-0", null);
-        assertFalse(retrieved.isPresent());
+        assertThat(retrieved).isNotPresent();
     }
 
     @Test
@@ -57,15 +55,15 @@ public class KiePMMLInlineTableTest {
         KiePMMLInlineTable kiePMMLInlineTable = new KiePMMLInlineTable("name", Collections.emptyList(), ROWS);
         Optional<Object> retrieved = kiePMMLInlineTable.evaluate(Collections.singletonMap("KEY-1-1", 435345), "KEY-0" +
                 "-0", null);
-        assertFalse(retrieved.isPresent());
+        assertThat(retrieved).isNotPresent();
     }
 
     @Test
     public void evaluateKeyFoundMatching() {
         KiePMMLInlineTable kiePMMLInlineTable = new KiePMMLInlineTable("name", Collections.emptyList(), ROWS);
         Optional<Object> retrieved = kiePMMLInlineTable.evaluate(Collections.singletonMap("KEY-1-1", "VALUE-1-1"), "KEY-1-2", null);
-        assertTrue(retrieved.isPresent());
-        assertEquals("VALUE-1-2", retrieved.get());
+        assertThat(retrieved).isPresent();
+        assertThat(retrieved.get()).isEqualTo("VALUE-1-2");
     }
 
     @Test
@@ -76,7 +74,7 @@ public class KiePMMLInlineTableTest {
                                           i -> "VALUE-1-" + i));
         columnPairsMap.put("KEY-1-2", 4);
         Optional<Object> retrieved = kiePMMLInlineTable.evaluate(columnPairsMap, "KEY-0-0", null);
-        assertFalse(retrieved.isPresent());
+        assertThat(retrieved).isNotPresent();
     }
 
     @Test
@@ -86,7 +84,7 @@ public class KiePMMLInlineTableTest {
                 .collect(Collectors.toMap(i -> "KEY-1-" + i,
                                           i -> "VALUE-1-" + i));
         Optional<Object> retrieved = kiePMMLInlineTable.evaluate(columnPairsMap, "KEY-1-2", null);
-        assertTrue(retrieved.isPresent());
-        assertEquals("VALUE-1-2", retrieved.get());
+        assertThat(retrieved).isPresent();
+        assertThat(retrieved.get()).isEqualTo("VALUE-1-2");
     }
 }

--- a/kie-pmml-trusty/kie-pmml-commons/src/test/java/org/kie/pmml/commons/model/expressions/KiePMMLIntervalTest.java
+++ b/kie-pmml-trusty/kie-pmml-commons/src/test/java/org/kie/pmml/commons/model/expressions/KiePMMLIntervalTest.java
@@ -19,107 +19,107 @@ package org.kie.pmml.commons.model.expressions;
 import org.junit.Test;
 import org.kie.pmml.api.enums.CLOSURE;
 
-import static org.junit.Assert.*;
+import static org.assertj.core.api.Assertions.assertThat;
 
 public class KiePMMLIntervalTest {
 
     @Test
     public void isIn() {
         KiePMMLInterval kiePMMLInterval = new KiePMMLInterval(20, 40, CLOSURE.OPEN_OPEN);
-        assertTrue(kiePMMLInterval.isIn(30));
-        assertFalse(kiePMMLInterval.isIn(10));
-        assertFalse(kiePMMLInterval.isIn(20));
-        assertFalse(kiePMMLInterval.isIn(40));
-        assertFalse(kiePMMLInterval.isIn(50));
+        assertThat(kiePMMLInterval.isIn(30)).isTrue();
+        assertThat(kiePMMLInterval.isIn(10)).isFalse();
+        assertThat(kiePMMLInterval.isIn(20)).isFalse();
+        assertThat(kiePMMLInterval.isIn(40)).isFalse();
+        assertThat(kiePMMLInterval.isIn(50)).isFalse();
         kiePMMLInterval = new KiePMMLInterval(20, 40, CLOSURE.OPEN_CLOSED);
-        assertTrue(kiePMMLInterval.isIn(30));
-        assertFalse(kiePMMLInterval.isIn(10));
-        assertFalse(kiePMMLInterval.isIn(20));
-        assertTrue(kiePMMLInterval.isIn(40));
-        assertFalse(kiePMMLInterval.isIn(50));
+        assertThat(kiePMMLInterval.isIn(30)).isTrue();
+        assertThat(kiePMMLInterval.isIn(10)).isFalse();
+        assertThat(kiePMMLInterval.isIn(20)).isFalse();
+        assertThat(kiePMMLInterval.isIn(40)).isTrue();
+        assertThat(kiePMMLInterval.isIn(50)).isFalse();
         kiePMMLInterval = new KiePMMLInterval(20, 40, CLOSURE.CLOSED_OPEN);
-        assertTrue(kiePMMLInterval.isInsideClosedOpen(30));
-        assertFalse(kiePMMLInterval.isInsideClosedOpen(10));
-        assertTrue(kiePMMLInterval.isInsideClosedOpen(20));
-        assertFalse(kiePMMLInterval.isInsideClosedOpen(40));
-        assertFalse(kiePMMLInterval.isInsideClosedOpen(50));
+        assertThat(kiePMMLInterval.isInsideClosedOpen(30)).isTrue();
+        assertThat(kiePMMLInterval.isInsideClosedOpen(10)).isFalse();
+        assertThat(kiePMMLInterval.isInsideClosedOpen(20)).isTrue();
+        assertThat(kiePMMLInterval.isInsideClosedOpen(40)).isFalse();
+        assertThat(kiePMMLInterval.isInsideClosedOpen(50)).isFalse();
         kiePMMLInterval = new KiePMMLInterval(20, 40, CLOSURE.CLOSED_CLOSED);
-        assertTrue(kiePMMLInterval.isIn(30));
-        assertFalse(kiePMMLInterval.isIn(10));
-        assertTrue(kiePMMLInterval.isIn(20));
-        assertTrue(kiePMMLInterval.isIn(40));
-        assertFalse(kiePMMLInterval.isIn(50));
+        assertThat(kiePMMLInterval.isIn(30)).isTrue();
+        assertThat(kiePMMLInterval.isIn(10)).isFalse();
+        assertThat(kiePMMLInterval.isIn(20)).isTrue();
+        assertThat(kiePMMLInterval.isIn(40)).isTrue();
+        assertThat(kiePMMLInterval.isIn(50)).isFalse();
     }
 
     @Test
     public void isInsideOpenOpen() {
         KiePMMLInterval kiePMMLInterval = new KiePMMLInterval(null, 20, CLOSURE.OPEN_OPEN);
-        assertTrue(kiePMMLInterval.isInsideOpenOpen(10));
-        assertFalse(kiePMMLInterval.isInsideOpenOpen(20));
-        assertFalse(kiePMMLInterval.isInsideOpenOpen(30));
+        assertThat(kiePMMLInterval.isInsideOpenOpen(10)).isTrue();
+        assertThat(kiePMMLInterval.isInsideOpenOpen(20)).isFalse();
+        assertThat(kiePMMLInterval.isInsideOpenOpen(30)).isFalse();
         kiePMMLInterval = new KiePMMLInterval(20, null, CLOSURE.OPEN_OPEN);
-        assertTrue(kiePMMLInterval.isInsideOpenOpen(30));
-        assertFalse(kiePMMLInterval.isInsideOpenOpen(20));
-        assertFalse(kiePMMLInterval.isInsideOpenOpen(10));
+        assertThat(kiePMMLInterval.isInsideOpenOpen(30)).isTrue();
+        assertThat(kiePMMLInterval.isInsideOpenOpen(20)).isFalse();
+        assertThat(kiePMMLInterval.isInsideOpenOpen(10)).isFalse();
         kiePMMLInterval = new KiePMMLInterval(20, 40, CLOSURE.OPEN_OPEN);
-        assertTrue(kiePMMLInterval.isInsideOpenOpen(30));
-        assertFalse(kiePMMLInterval.isInsideOpenOpen(10));
-        assertFalse(kiePMMLInterval.isInsideOpenOpen(20));
-        assertFalse(kiePMMLInterval.isInsideOpenOpen(40));
-        assertFalse(kiePMMLInterval.isInsideOpenOpen(50));
+        assertThat(kiePMMLInterval.isInsideOpenOpen(30)).isTrue();
+        assertThat(kiePMMLInterval.isInsideOpenOpen(10)).isFalse();
+        assertThat(kiePMMLInterval.isInsideOpenOpen(20)).isFalse();
+        assertThat(kiePMMLInterval.isInsideOpenOpen(40)).isFalse();
+        assertThat(kiePMMLInterval.isInsideOpenOpen(50)).isFalse();
     }
 
     @Test
     public void isInsideOpenClosed() {
         KiePMMLInterval kiePMMLInterval = new KiePMMLInterval(null, 20, CLOSURE.OPEN_CLOSED);
-        assertTrue(kiePMMLInterval.isInsideOpenClosed(10));
-        assertTrue(kiePMMLInterval.isInsideOpenClosed(20));
-        assertFalse(kiePMMLInterval.isInsideOpenClosed(30));
+        assertThat(kiePMMLInterval.isInsideOpenClosed(10)).isTrue();
+        assertThat(kiePMMLInterval.isInsideOpenClosed(20)).isTrue();
+        assertThat(kiePMMLInterval.isInsideOpenClosed(30)).isFalse();
         kiePMMLInterval = new KiePMMLInterval(20, null, CLOSURE.OPEN_CLOSED);
-        assertTrue(kiePMMLInterval.isInsideOpenClosed(30));
-        assertFalse(kiePMMLInterval.isInsideOpenClosed(20));
-        assertFalse(kiePMMLInterval.isInsideOpenClosed(10));
+        assertThat(kiePMMLInterval.isInsideOpenClosed(30)).isTrue();
+        assertThat(kiePMMLInterval.isInsideOpenClosed(20)).isFalse();
+        assertThat(kiePMMLInterval.isInsideOpenClosed(10)).isFalse();
         kiePMMLInterval = new KiePMMLInterval(20, 40, CLOSURE.OPEN_CLOSED);
-        assertTrue(kiePMMLInterval.isInsideOpenClosed(30));
-        assertFalse(kiePMMLInterval.isInsideOpenClosed(10));
-        assertFalse(kiePMMLInterval.isInsideOpenClosed(20));
-        assertTrue(kiePMMLInterval.isInsideOpenClosed(40));
-        assertFalse(kiePMMLInterval.isInsideOpenClosed(50));
+        assertThat(kiePMMLInterval.isInsideOpenClosed(30)).isTrue();
+        assertThat(kiePMMLInterval.isInsideOpenClosed(10)).isFalse();
+        assertThat(kiePMMLInterval.isInsideOpenClosed(20)).isFalse();
+        assertThat(kiePMMLInterval.isInsideOpenClosed(40)).isTrue();
+        assertThat(kiePMMLInterval.isInsideOpenClosed(50)).isFalse();
     }
 
     @Test
     public void isInsideClosedOpen() {
         KiePMMLInterval kiePMMLInterval = new KiePMMLInterval(null, 20, CLOSURE.CLOSED_OPEN);
-        assertTrue(kiePMMLInterval.isInsideClosedOpen(10));
-        assertFalse(kiePMMLInterval.isInsideClosedOpen(20));
-        assertFalse(kiePMMLInterval.isInsideClosedOpen(30));
+        assertThat(kiePMMLInterval.isInsideClosedOpen(10)).isTrue();
+        assertThat(kiePMMLInterval.isInsideClosedOpen(20)).isFalse();
+        assertThat(kiePMMLInterval.isInsideClosedOpen(30)).isFalse();
         kiePMMLInterval = new KiePMMLInterval(20, null, CLOSURE.CLOSED_OPEN);
-        assertTrue(kiePMMLInterval.isInsideClosedOpen(30));
-        assertTrue(kiePMMLInterval.isInsideClosedOpen(20));
-        assertFalse(kiePMMLInterval.isInsideClosedOpen(10));
+        assertThat(kiePMMLInterval.isInsideClosedOpen(30)).isTrue();
+        assertThat(kiePMMLInterval.isInsideClosedOpen(20)).isTrue();
+        assertThat(kiePMMLInterval.isInsideClosedOpen(10)).isFalse();
         kiePMMLInterval = new KiePMMLInterval(20, 40, CLOSURE.CLOSED_OPEN);
-        assertTrue(kiePMMLInterval.isInsideClosedOpen(30));
-        assertFalse(kiePMMLInterval.isInsideClosedOpen(10));
-        assertTrue(kiePMMLInterval.isInsideClosedOpen(20));
-        assertFalse(kiePMMLInterval.isInsideClosedOpen(40));
-        assertFalse(kiePMMLInterval.isInsideClosedOpen(50));
+        assertThat(kiePMMLInterval.isInsideClosedOpen(30)).isTrue();
+        assertThat(kiePMMLInterval.isInsideClosedOpen(10)).isFalse();
+        assertThat(kiePMMLInterval.isInsideClosedOpen(20)).isTrue();
+        assertThat(kiePMMLInterval.isInsideClosedOpen(40)).isFalse();
+        assertThat(kiePMMLInterval.isInsideClosedOpen(50)).isFalse();
     }
 
     @Test
     public void isInsideClosedClosed() {
         KiePMMLInterval kiePMMLInterval = new KiePMMLInterval(null, 20, CLOSURE.CLOSED_CLOSED);
-        assertTrue(kiePMMLInterval.isInsideClosedClosed(10));
-        assertTrue(kiePMMLInterval.isInsideClosedClosed(20));
-        assertFalse(kiePMMLInterval.isInsideClosedClosed(30));
+        assertThat(kiePMMLInterval.isInsideClosedClosed(10)).isTrue();
+        assertThat(kiePMMLInterval.isInsideClosedClosed(20)).isTrue();
+        assertThat(kiePMMLInterval.isInsideClosedClosed(30)).isFalse();
         kiePMMLInterval = new KiePMMLInterval(20, null, CLOSURE.CLOSED_CLOSED);
-        assertTrue(kiePMMLInterval.isInsideClosedClosed(30));
-        assertTrue(kiePMMLInterval.isInsideClosedClosed(20));
-        assertFalse(kiePMMLInterval.isInsideClosedClosed(10));
+        assertThat(kiePMMLInterval.isInsideClosedClosed(30)).isTrue();
+        assertThat(kiePMMLInterval.isInsideClosedClosed(20)).isTrue();
+        assertThat(kiePMMLInterval.isInsideClosedClosed(10)).isFalse();
         kiePMMLInterval = new KiePMMLInterval(20, 40, CLOSURE.CLOSED_CLOSED);
-        assertTrue(kiePMMLInterval.isInsideClosedClosed(30));
-        assertFalse(kiePMMLInterval.isInsideClosedClosed(10));
-        assertTrue(kiePMMLInterval.isInsideClosedClosed(20));
-        assertTrue(kiePMMLInterval.isInsideClosedClosed(40));
-        assertFalse(kiePMMLInterval.isInsideClosedClosed(50));
+        assertThat(kiePMMLInterval.isInsideClosedClosed(30)).isTrue();
+        assertThat(kiePMMLInterval.isInsideClosedClosed(10)).isFalse();
+        assertThat(kiePMMLInterval.isInsideClosedClosed(20)).isTrue();
+        assertThat(kiePMMLInterval.isInsideClosedClosed(40)).isTrue();
+        assertThat(kiePMMLInterval.isInsideClosedClosed(50)).isFalse();
     }
 }

--- a/kie-pmml-trusty/kie-pmml-commons/src/test/java/org/kie/pmml/commons/model/expressions/KiePMMLMapValuesTest.java
+++ b/kie-pmml-trusty/kie-pmml-commons/src/test/java/org/kie/pmml/commons/model/expressions/KiePMMLMapValuesTest.java
@@ -27,7 +27,6 @@ import org.kie.pmml.commons.model.ProcessingDTO;
 import org.kie.pmml.commons.model.tuples.KiePMMLNameValue;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.Assert.assertEquals;
 import static org.kie.pmml.commons.CommonTestingUtility.getProcessingDTO;
 
 public class KiePMMLMapValuesTest {
@@ -59,7 +58,7 @@ public class KiePMMLMapValuesTest {
     public void evaluateKeyNotFound() {
         KiePMMLMapValues kiePMMLMapValues = getKiePMMLMapValues();
         ProcessingDTO processingDTO = getProcessingDTO(Collections.emptyList());
-        assertEquals(MAPMISSINGTO, kiePMMLMapValues.evaluate(processingDTO));
+        assertThat(kiePMMLMapValues.evaluate(processingDTO)).isEqualTo(MAPMISSINGTO);
     }
 
     @Test
@@ -69,7 +68,7 @@ public class KiePMMLMapValuesTest {
                 .mapToObj(i -> new KiePMMLNameValue("FIELD-" + i, "NOT-VALUE-1-" + i))
                 .collect(Collectors.toList());
         ProcessingDTO processingDTO = getProcessingDTO(kiePMMLNameValues);
-        assertEquals(DEFAULTVALUE, kiePMMLMapValues.evaluate(processingDTO));
+        assertThat(kiePMMLMapValues.evaluate(processingDTO)).isEqualTo(DEFAULTVALUE);
     }
 
     @Test

--- a/kie-pmml-trusty/kie-pmml-commons/src/test/java/org/kie/pmml/commons/model/expressions/KiePMMLNormContinuousTest.java
+++ b/kie-pmml-trusty/kie-pmml-commons/src/test/java/org/kie/pmml/commons/model/expressions/KiePMMLNormContinuousTest.java
@@ -26,7 +26,6 @@ import org.kie.pmml.commons.model.ProcessingDTO;
 import org.kie.pmml.commons.model.tuples.KiePMMLNameValue;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.Assert.assertEquals;
 
 public class KiePMMLNormContinuousTest {
 
@@ -36,13 +35,13 @@ public class KiePMMLNormContinuousTest {
         KiePMMLLinearNorm ln1 = new KiePMMLLinearNorm("1", Collections.emptyList(), 32, 5);
         KiePMMLLinearNorm ln2 = new KiePMMLLinearNorm("2", Collections.emptyList(), 33, 34);
         List<KiePMMLLinearNorm> linearNorms = Arrays.asList(ln0, ln1, ln2);
-        assertEquals(ln0, linearNorms.get(0));
-        assertEquals(ln1, linearNorms.get(1));
-        assertEquals(ln2, linearNorms.get(2));
+        assertThat(linearNorms.get(0)).isEqualTo(ln0);
+        assertThat(linearNorms.get(1)).isEqualTo(ln1);
+        assertThat(linearNorms.get(2)).isEqualTo(ln2);
         KiePMMLNormContinuous.sortLinearNorms(linearNorms);
-        assertEquals(ln1, linearNorms.get(0));
-        assertEquals(ln2, linearNorms.get(1));
-        assertEquals(ln0, linearNorms.get(2));
+        assertThat(linearNorms.get(0)).isEqualTo(ln1);
+        assertThat(linearNorms.get(1)).isEqualTo(ln2);
+        assertThat(linearNorms.get(2)).isEqualTo(ln0);
     }
 
     @Test
@@ -62,7 +61,7 @@ public class KiePMMLNormContinuousTest {
                 kiePMMLNormContinuous.linearNorms.get(0).getNorm() +
                         ((input.doubleValue() - kiePMMLNormContinuous.linearNorms.get(0).getOrig()) / (kiePMMLNormContinuous.linearNorms.get(1).getOrig() - kiePMMLNormContinuous.linearNorms.get(0).getOrig()))
                                 * (kiePMMLNormContinuous.linearNorms.get(1).getNorm() - kiePMMLNormContinuous.linearNorms.get(0).getNorm());
-        assertEquals(expected, retrieved);
+        assertThat(retrieved).isEqualTo(expected);
     }
 
     @Test
@@ -74,49 +73,49 @@ public class KiePMMLNormContinuousTest {
                 kiePMMLNormContinuous.linearNorms.get(0).getNorm() +
                         ((input.doubleValue() - kiePMMLNormContinuous.linearNorms.get(0).getOrig()) / (kiePMMLNormContinuous.linearNorms.get(1).getOrig() - kiePMMLNormContinuous.linearNorms.get(0).getOrig()))
                                 * (kiePMMLNormContinuous.linearNorms.get(1).getNorm() - kiePMMLNormContinuous.linearNorms.get(0).getNorm());
-        assertEquals(expected, retrieved);
+        assertThat(retrieved).isEqualTo(expected);
         input = 28;
         expected =
                 kiePMMLNormContinuous.linearNorms.get(0).getNorm() +
                         ((input.doubleValue() - kiePMMLNormContinuous.linearNorms.get(0).getOrig()) / (kiePMMLNormContinuous.linearNorms.get(1).getOrig() - kiePMMLNormContinuous.linearNorms.get(0).getOrig()))
                                 * (kiePMMLNormContinuous.linearNorms.get(1).getNorm() - kiePMMLNormContinuous.linearNorms.get(0).getNorm());
         retrieved = kiePMMLNormContinuous.evaluate(input);
-        assertEquals(expected, retrieved);
+        assertThat(retrieved).isEqualTo(expected);
         input = 30;
         retrieved = kiePMMLNormContinuous.evaluate(input);
         expected =
                 kiePMMLNormContinuous.linearNorms.get(1).getNorm() +
                         ((input.doubleValue() - kiePMMLNormContinuous.linearNorms.get(1).getOrig()) / (kiePMMLNormContinuous.linearNorms.get(2).getOrig() - kiePMMLNormContinuous.linearNorms.get(1).getOrig()))
                                 * (kiePMMLNormContinuous.linearNorms.get(2).getNorm() - kiePMMLNormContinuous.linearNorms.get(1).getNorm());
-        assertEquals(expected, retrieved);
+        assertThat(retrieved).isEqualTo(expected);
         input = 31;
         retrieved = kiePMMLNormContinuous.evaluate(input);
         expected =
                 kiePMMLNormContinuous.linearNorms.get(1).getNorm() +
                         ((input.doubleValue() - kiePMMLNormContinuous.linearNorms.get(1).getOrig()) / (kiePMMLNormContinuous.linearNorms.get(2).getOrig() - kiePMMLNormContinuous.linearNorms.get(1).getOrig()))
                                 * (kiePMMLNormContinuous.linearNorms.get(2).getNorm() - kiePMMLNormContinuous.linearNorms.get(1).getNorm());
-        assertEquals(expected, retrieved);
+        assertThat(retrieved).isEqualTo(expected);
         input = 36;
         retrieved = kiePMMLNormContinuous.evaluate(input);
         expected =
                 kiePMMLNormContinuous.linearNorms.get(2).getNorm() +
                         ((input.doubleValue() - kiePMMLNormContinuous.linearNorms.get(2).getOrig()) / (kiePMMLNormContinuous.linearNorms.get(3).getOrig() - kiePMMLNormContinuous.linearNorms.get(2).getOrig()))
                                 * (kiePMMLNormContinuous.linearNorms.get(3).getNorm() - kiePMMLNormContinuous.linearNorms.get(2).getNorm());
-        assertEquals(expected, retrieved);
+        assertThat(retrieved).isEqualTo(expected);
         input = 37;
         retrieved = kiePMMLNormContinuous.evaluate(input);
         expected =
                 kiePMMLNormContinuous.linearNorms.get(2).getNorm() +
                         ((input.doubleValue() - kiePMMLNormContinuous.linearNorms.get(2).getOrig()) / (kiePMMLNormContinuous.linearNorms.get(3).getOrig() - kiePMMLNormContinuous.linearNorms.get(2).getOrig()))
                                 * (kiePMMLNormContinuous.linearNorms.get(3).getNorm() - kiePMMLNormContinuous.linearNorms.get(2).getNorm());
-        assertEquals(expected, retrieved);
+        assertThat(retrieved).isEqualTo(expected);
         input = 40;
         retrieved = kiePMMLNormContinuous.evaluate(input);
         expected =
                 kiePMMLNormContinuous.linearNorms.get(2).getNorm() +
                         ((input.doubleValue() - kiePMMLNormContinuous.linearNorms.get(2).getOrig()) / (kiePMMLNormContinuous.linearNorms.get(3).getOrig() - kiePMMLNormContinuous.linearNorms.get(2).getOrig()))
                                 * (kiePMMLNormContinuous.linearNorms.get(3).getNorm() - kiePMMLNormContinuous.linearNorms.get(2).getNorm());
-        assertEquals(expected, retrieved);
+        assertThat(retrieved).isEqualTo(expected);
     }
 
     @Test
@@ -129,14 +128,14 @@ public class KiePMMLNormContinuousTest {
                         ((input.doubleValue() - kiePMMLNormContinuous.linearNorms.get(0).getOrig()) / (kiePMMLNormContinuous.linearNorms.get(1).getOrig() - kiePMMLNormContinuous.linearNorms.get(0).getOrig()))
                                 * (kiePMMLNormContinuous.linearNorms.get(1).getNorm() - kiePMMLNormContinuous.linearNorms.get(0).getNorm());
 
-        assertEquals(expected, retrieved);
+        assertThat(retrieved).isEqualTo(expected);
         input = 41;
         retrieved = kiePMMLNormContinuous.evaluate(input);
         expected =
                 kiePMMLNormContinuous.linearNorms.get(2).getNorm() +
                         ((input.doubleValue() - kiePMMLNormContinuous.linearNorms.get(2).getOrig()) / (kiePMMLNormContinuous.linearNorms.get(3).getOrig() - kiePMMLNormContinuous.linearNorms.get(2).getOrig()))
                                 * (kiePMMLNormContinuous.linearNorms.get(3).getNorm() - kiePMMLNormContinuous.linearNorms.get(2).getNorm());
-        assertEquals(expected, retrieved);
+        assertThat(retrieved).isEqualTo(expected);
     }
 
     @Test
@@ -145,10 +144,10 @@ public class KiePMMLNormContinuousTest {
         KiePMMLNormContinuous kiePMMLNormContinuous = getKiePMMLNormContinuous(null, OUTLIER_TREATMENT_METHOD.AS_MISSING_VALUES, missingValue);
         Number input = 23;
         Number retrieved = kiePMMLNormContinuous.evaluate(input);
-        assertEquals(missingValue, retrieved);
+        assertThat(retrieved).isEqualTo(missingValue);
         input = 41;
         retrieved = kiePMMLNormContinuous.evaluate(input);
-        assertEquals(missingValue, retrieved);
+        assertThat(retrieved).isEqualTo(missingValue);
     }
 
     @Test
@@ -156,10 +155,10 @@ public class KiePMMLNormContinuousTest {
         KiePMMLNormContinuous kiePMMLNormContinuous = getKiePMMLNormContinuous(null, OUTLIER_TREATMENT_METHOD.AS_EXTREME_VALUES, null);
         Number input = 23;
         Number retrieved = kiePMMLNormContinuous.evaluate(input);
-        assertEquals(kiePMMLNormContinuous.linearNorms.get(0).getNorm(), retrieved);
+        assertThat(retrieved).isEqualTo(kiePMMLNormContinuous.linearNorms.get(0).getNorm());
         input = 41;
         retrieved = kiePMMLNormContinuous.evaluate(input);
-        assertEquals(kiePMMLNormContinuous.linearNorms.get(3).getNorm(), retrieved);
+        assertThat(retrieved).isEqualTo(kiePMMLNormContinuous.linearNorms.get(3).getNorm());
     }
 
     @Test
@@ -171,49 +170,49 @@ public class KiePMMLNormContinuousTest {
                 kiePMMLNormContinuous.linearNorms.get(0).getNorm() +
                         ((input.doubleValue() - kiePMMLNormContinuous.linearNorms.get(0).getOrig()) / (kiePMMLNormContinuous.linearNorms.get(1).getOrig() - kiePMMLNormContinuous.linearNorms.get(0).getOrig()))
                                 * (kiePMMLNormContinuous.linearNorms.get(1).getNorm() - kiePMMLNormContinuous.linearNorms.get(0).getNorm());
-        assertEquals(expected, retrieved);
+        assertThat(retrieved).isEqualTo(expected);
         input = 28;
         expected =
                 kiePMMLNormContinuous.linearNorms.get(0).getNorm() +
                         ((input.doubleValue() - kiePMMLNormContinuous.linearNorms.get(0).getOrig()) / (kiePMMLNormContinuous.linearNorms.get(1).getOrig() - kiePMMLNormContinuous.linearNorms.get(0).getOrig()))
                                 * (kiePMMLNormContinuous.linearNorms.get(1).getNorm() - kiePMMLNormContinuous.linearNorms.get(0).getNorm());
         retrieved = kiePMMLNormContinuous.evaluateExpectedValue(input);
-        assertEquals(expected, retrieved);
+        assertThat(retrieved).isEqualTo(expected);
         input = 30;
         retrieved = kiePMMLNormContinuous.evaluateExpectedValue(input);
         expected =
                 kiePMMLNormContinuous.linearNorms.get(1).getNorm() +
                         ((input.doubleValue() - kiePMMLNormContinuous.linearNorms.get(1).getOrig()) / (kiePMMLNormContinuous.linearNorms.get(2).getOrig() - kiePMMLNormContinuous.linearNorms.get(1).getOrig()))
                                 * (kiePMMLNormContinuous.linearNorms.get(2).getNorm() - kiePMMLNormContinuous.linearNorms.get(1).getNorm());
-        assertEquals(expected, retrieved);
+        assertThat(retrieved).isEqualTo(expected);
         input = 31;
         retrieved = kiePMMLNormContinuous.evaluateExpectedValue(input);
         expected =
                 kiePMMLNormContinuous.linearNorms.get(1).getNorm() +
                         ((input.doubleValue() - kiePMMLNormContinuous.linearNorms.get(1).getOrig()) / (kiePMMLNormContinuous.linearNorms.get(2).getOrig() - kiePMMLNormContinuous.linearNorms.get(1).getOrig()))
                                 * (kiePMMLNormContinuous.linearNorms.get(2).getNorm() - kiePMMLNormContinuous.linearNorms.get(1).getNorm());
-        assertEquals(expected, retrieved);
+        assertThat(retrieved).isEqualTo(expected);
         input = 36;
         retrieved = kiePMMLNormContinuous.evaluateExpectedValue(input);
         expected =
                 kiePMMLNormContinuous.linearNorms.get(2).getNorm() +
                         ((input.doubleValue() - kiePMMLNormContinuous.linearNorms.get(2).getOrig()) / (kiePMMLNormContinuous.linearNorms.get(3).getOrig() - kiePMMLNormContinuous.linearNorms.get(2).getOrig()))
                                 * (kiePMMLNormContinuous.linearNorms.get(3).getNorm() - kiePMMLNormContinuous.linearNorms.get(2).getNorm());
-        assertEquals(expected, retrieved);
+        assertThat(retrieved).isEqualTo(expected);
         input = 37;
         retrieved = kiePMMLNormContinuous.evaluateExpectedValue(input);
         expected =
                 kiePMMLNormContinuous.linearNorms.get(2).getNorm() +
                         ((input.doubleValue() - kiePMMLNormContinuous.linearNorms.get(2).getOrig()) / (kiePMMLNormContinuous.linearNorms.get(3).getOrig() - kiePMMLNormContinuous.linearNorms.get(2).getOrig()))
                                 * (kiePMMLNormContinuous.linearNorms.get(3).getNorm() - kiePMMLNormContinuous.linearNorms.get(2).getNorm());
-        assertEquals(expected, retrieved);
+        assertThat(retrieved).isEqualTo(expected);
         input = 40;
         retrieved = kiePMMLNormContinuous.evaluateExpectedValue(input);
         expected =
                 kiePMMLNormContinuous.linearNorms.get(2).getNorm() +
                         ((input.doubleValue() - kiePMMLNormContinuous.linearNorms.get(2).getOrig()) / (kiePMMLNormContinuous.linearNorms.get(3).getOrig() - kiePMMLNormContinuous.linearNorms.get(2).getOrig()))
                                 * (kiePMMLNormContinuous.linearNorms.get(3).getNorm() - kiePMMLNormContinuous.linearNorms.get(2).getNorm());
-        assertEquals(expected, retrieved);
+        assertThat(retrieved).isEqualTo(expected);
     }
 
     @Test
@@ -226,14 +225,14 @@ public class KiePMMLNormContinuousTest {
                         ((input.doubleValue() - kiePMMLNormContinuous.linearNorms.get(0).getOrig()) / (kiePMMLNormContinuous.linearNorms.get(1).getOrig() - kiePMMLNormContinuous.linearNorms.get(0).getOrig()))
                                 * (kiePMMLNormContinuous.linearNorms.get(1).getNorm() - kiePMMLNormContinuous.linearNorms.get(0).getNorm());
 
-        assertEquals(expected, retrieved);
+        assertThat(retrieved).isEqualTo(expected);
         input = 41;
         retrieved = kiePMMLNormContinuous.evaluateOutlierValue(input);
         expected =
                 kiePMMLNormContinuous.linearNorms.get(2).getNorm() +
                         ((input.doubleValue() - kiePMMLNormContinuous.linearNorms.get(2).getOrig()) / (kiePMMLNormContinuous.linearNorms.get(3).getOrig() - kiePMMLNormContinuous.linearNorms.get(2).getOrig()))
                                 * (kiePMMLNormContinuous.linearNorms.get(3).getNorm() - kiePMMLNormContinuous.linearNorms.get(2).getNorm());
-        assertEquals(expected, retrieved);
+        assertThat(retrieved).isEqualTo(expected);
     }
 
     @Test
@@ -242,10 +241,10 @@ public class KiePMMLNormContinuousTest {
         KiePMMLNormContinuous kiePMMLNormContinuous = getKiePMMLNormContinuous(null, OUTLIER_TREATMENT_METHOD.AS_MISSING_VALUES, missingValue);
         Number input = 23;
         Number retrieved = kiePMMLNormContinuous.evaluateOutlierValue(input);
-        assertEquals(missingValue, retrieved);
+        assertThat(retrieved).isEqualTo(missingValue);
         input = 41;
         retrieved = kiePMMLNormContinuous.evaluateOutlierValue(input);
-        assertEquals(missingValue, retrieved);
+        assertThat(retrieved).isEqualTo(missingValue);
     }
 
     @Test
@@ -253,10 +252,10 @@ public class KiePMMLNormContinuousTest {
         KiePMMLNormContinuous kiePMMLNormContinuous = getKiePMMLNormContinuous(null, OUTLIER_TREATMENT_METHOD.AS_EXTREME_VALUES, null);
         Number input = 23;
         Number retrieved = kiePMMLNormContinuous.evaluateOutlierValue(input);
-        assertEquals(kiePMMLNormContinuous.linearNorms.get(0).getNorm(), retrieved);
+        assertThat(retrieved).isEqualTo(kiePMMLNormContinuous.linearNorms.get(0).getNorm());
         input = 41;
         retrieved = kiePMMLNormContinuous.evaluateOutlierValue(input);
-        assertEquals(kiePMMLNormContinuous.linearNorms.get(3).getNorm(), retrieved);
+        assertThat(retrieved).isEqualTo(kiePMMLNormContinuous.linearNorms.get(3).getNorm());
     }
 
     @Test
@@ -264,32 +263,32 @@ public class KiePMMLNormContinuousTest {
         KiePMMLNormContinuous kiePMMLNormContinuous = getKiePMMLNormContinuous(null, null, null);
         Number input = 24;
         KiePMMLLinearNorm[] retrieved = kiePMMLNormContinuous.getLimitExpectedValue(input);
-        assertEquals(kiePMMLNormContinuous.linearNorms.get(0), retrieved[0]);
-        assertEquals(kiePMMLNormContinuous.linearNorms.get(1), retrieved[1]);
+        assertThat(retrieved[0]).isEqualTo(kiePMMLNormContinuous.linearNorms.get(0));
+        assertThat(retrieved[1]).isEqualTo(kiePMMLNormContinuous.linearNorms.get(1));
         input = 28;
         retrieved = kiePMMLNormContinuous.getLimitExpectedValue(input);
-        assertEquals(kiePMMLNormContinuous.linearNorms.get(0), retrieved[0]);
-        assertEquals(kiePMMLNormContinuous.linearNorms.get(1), retrieved[1]);
+        assertThat(retrieved[0]).isEqualTo(kiePMMLNormContinuous.linearNorms.get(0));
+        assertThat(retrieved[1]).isEqualTo(kiePMMLNormContinuous.linearNorms.get(1));
         input = 30;
         retrieved = kiePMMLNormContinuous.getLimitExpectedValue(input);
-        assertEquals(kiePMMLNormContinuous.linearNorms.get(1), retrieved[0]);
-        assertEquals(kiePMMLNormContinuous.linearNorms.get(2), retrieved[1]);
+        assertThat(retrieved[0]).isEqualTo(kiePMMLNormContinuous.linearNorms.get(1));
+        assertThat(retrieved[1]).isEqualTo(kiePMMLNormContinuous.linearNorms.get(2));
         input = 31;
         retrieved = kiePMMLNormContinuous.getLimitExpectedValue(input);
-        assertEquals(kiePMMLNormContinuous.linearNorms.get(1), retrieved[0]);
-        assertEquals(kiePMMLNormContinuous.linearNorms.get(2), retrieved[1]);
+        assertThat(retrieved[0]).isEqualTo(kiePMMLNormContinuous.linearNorms.get(1));
+        assertThat(retrieved[1]).isEqualTo(kiePMMLNormContinuous.linearNorms.get(2));
         input = 36;
         retrieved = kiePMMLNormContinuous.getLimitExpectedValue(input);
-        assertEquals(kiePMMLNormContinuous.linearNorms.get(2), retrieved[0]);
-        assertEquals(kiePMMLNormContinuous.linearNorms.get(3), retrieved[1]);
+        assertThat(retrieved[0]).isEqualTo(kiePMMLNormContinuous.linearNorms.get(2));
+        assertThat(retrieved[1]).isEqualTo(kiePMMLNormContinuous.linearNorms.get(3));
         input = 37;
         retrieved = kiePMMLNormContinuous.getLimitExpectedValue(input);
-        assertEquals(kiePMMLNormContinuous.linearNorms.get(2), retrieved[0]);
-        assertEquals(kiePMMLNormContinuous.linearNorms.get(3), retrieved[1]);
+        assertThat(retrieved[0]).isEqualTo(kiePMMLNormContinuous.linearNorms.get(2));
+        assertThat(retrieved[1]).isEqualTo(kiePMMLNormContinuous.linearNorms.get(3));
         input = 40;
         retrieved = kiePMMLNormContinuous.getLimitExpectedValue(input);
-        assertEquals(kiePMMLNormContinuous.linearNorms.get(2), retrieved[0]);
-        assertEquals(kiePMMLNormContinuous.linearNorms.get(3), retrieved[1]);
+        assertThat(retrieved[0]).isEqualTo(kiePMMLNormContinuous.linearNorms.get(2));
+        assertThat(retrieved[1]).isEqualTo(kiePMMLNormContinuous.linearNorms.get(3));
     }
 
     @Test
@@ -312,7 +311,7 @@ public class KiePMMLNormContinuousTest {
         assertThat(retrieved).isNotNull();
         Number expected =
                 startNorm + ((input.doubleValue() - startOrig) / (endOrig - startOrig)) * (endNorm - startNorm);
-        assertEquals(expected, retrieved);
+        assertThat(retrieved).isEqualTo(expected);
     }
 
     private KiePMMLNormContinuous getKiePMMLNormContinuous(String name,

--- a/kie-pmml-trusty/kie-pmml-commons/src/test/java/org/kie/pmml/commons/model/expressions/KiePMMLNormDiscreteTest.java
+++ b/kie-pmml-trusty/kie-pmml-commons/src/test/java/org/kie/pmml/commons/model/expressions/KiePMMLNormDiscreteTest.java
@@ -23,7 +23,6 @@ import org.kie.pmml.commons.model.ProcessingDTO;
 import org.kie.pmml.commons.model.tuples.KiePMMLNameValue;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.Assert.assertEquals;
 import static org.kie.pmml.commons.CommonTestingUtility.getProcessingDTO;
 
 public class KiePMMLNormDiscreteTest {
@@ -37,7 +36,7 @@ public class KiePMMLNormDiscreteTest {
         ProcessingDTO processingDTO = getProcessingDTO(Collections.emptyList());
         Object retrieved = kiePMMLNormContinuous.evaluate(processingDTO);
         assertThat(retrieved).isNotNull();
-        assertEquals(mapMissingTo, retrieved);
+        assertThat(retrieved).isEqualTo(mapMissingTo);
     }
 
     @Test
@@ -49,7 +48,7 @@ public class KiePMMLNormDiscreteTest {
         ProcessingDTO processingDTO = getProcessingDTO(Collections.singletonList(new KiePMMLNameValue(fieldName, fieldValue)));
         Object retrieved = kiePMMLNormContinuous.evaluate(processingDTO);
         assertThat(retrieved).isNotNull();
-        assertEquals(1.0, retrieved);
+        assertThat(retrieved).isEqualTo(1.0);
     }
 
     @Test
@@ -61,7 +60,7 @@ public class KiePMMLNormDiscreteTest {
         ProcessingDTO processingDTO = getProcessingDTO(Collections.singletonList(new KiePMMLNameValue(fieldName, "anotherValue")));
         Object retrieved = kiePMMLNormContinuous.evaluate(processingDTO);
         assertThat(retrieved).isNotNull();
-        assertEquals(0.0, retrieved);
+        assertThat(retrieved).isEqualTo(0.0);
     }
 
     private KiePMMLNormDiscrete getKiePMMLNormDiscrete(String name,

--- a/kie-pmml-trusty/kie-pmml-commons/src/test/java/org/kie/pmml/commons/model/expressions/KiePMMLRowTest.java
+++ b/kie-pmml-trusty/kie-pmml-commons/src/test/java/org/kie/pmml/commons/model/expressions/KiePMMLRowTest.java
@@ -24,9 +24,7 @@ import java.util.stream.IntStream;
 
 import org.junit.Test;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
+import static org.assertj.core.api.Assertions.assertThat;
 
 public class KiePMMLRowTest {
 
@@ -45,37 +43,37 @@ public class KiePMMLRowTest {
     public void evaluateKeyNotFound() {
         KiePMMLRow kiePMMLRow = new KiePMMLRow(COLUMN_VALUES);
         Optional<Object> retrieved = kiePMMLRow.evaluate(Collections.singletonMap("NOT-KEY", 0), "KEY-0", null);
-        assertFalse(retrieved.isPresent());
+        assertThat(retrieved).isNotPresent();
     }
 
     @Test
     public void evaluateKeyFoundNotMatching() {
         KiePMMLRow kiePMMLRow = new KiePMMLRow(COLUMN_VALUES);
         Optional<Object> retrieved = kiePMMLRow.evaluate(Collections.singletonMap("KEY-1", 435345), "KEY-0", null);
-        assertFalse(retrieved.isPresent());
+        assertThat(retrieved).isNotPresent();
     }
 
     @Test
     public void evaluateKeyFoundMatching() {
         KiePMMLRow kiePMMLRow = new KiePMMLRow(COLUMN_VALUES);
         Optional<Object> retrieved = kiePMMLRow.evaluate(Collections.singletonMap("KEY-1", 1), "KEY-0", null);
-        assertTrue(retrieved.isPresent());
-        assertEquals(COLUMN_VALUES.get("KEY-0"), retrieved.get());
+        assertThat(retrieved).isPresent();
+        assertThat(retrieved.get()).isEqualTo(COLUMN_VALUES.get("KEY-0"));
     }
 
     @Test
     public void evaluateKeyFoundNotMatchingRegex() {
         KiePMMLRow kiePMMLRow = new KiePMMLRow(COLUMN_VALUES);
         Optional<Object> retrieved = kiePMMLRow.evaluate(Collections.singletonMap("KEY-1", "[435345]"), "KEY-0", REGEX_FIELD);
-        assertFalse(retrieved.isPresent());
+        assertThat(retrieved).isNotPresent();
     }
 
     @Test
     public void evaluateKeyFoundMatchingRegex() {
         KiePMMLRow kiePMMLRow = new KiePMMLRow(COLUMN_VALUES);
         Optional<Object> retrieved = kiePMMLRow.evaluate(Collections.singletonMap("KEY-1", "[0-9]"), "KEY-0", REGEX_FIELD);
-        assertTrue(retrieved.isPresent());
-        assertEquals(COLUMN_VALUES.get("KEY-0"), retrieved.get());
+        assertThat(retrieved).isPresent();
+        assertThat(retrieved.get()).isEqualTo(COLUMN_VALUES.get("KEY-0"));
     }
 
     @Test
@@ -86,22 +84,22 @@ public class KiePMMLRowTest {
                                           integer -> integer));
         columnPairsMap.put("NOT-KEY", 4);
         Optional<Object> retrieved = kiePMMLRow.evaluate(columnPairsMap, "KEY-0", null);
-        assertFalse(retrieved.isPresent());
+        assertThat(retrieved).isNotPresent();
     }
 
     @Test
     public void evaluateKeyFoundMatchingNoOutputColumnFound() {
         KiePMMLRow kiePMMLRow = new KiePMMLRow(COLUMN_VALUES);
         Optional<Object> retrieved = kiePMMLRow.evaluate(Collections.singletonMap("KEY-1", 1), "NOT-KEY", null);
-        assertFalse(retrieved.isPresent());
+        assertThat(retrieved).isNotPresent();
     }
 
     @Test
     public void evaluateKeyFoundMatchingOutputColumnFound() {
         KiePMMLRow kiePMMLRow = new KiePMMLRow(COLUMN_VALUES);
         Optional<Object> retrieved = kiePMMLRow.evaluate(Collections.singletonMap("KEY-1", 1), "KEY-0", null);
-        assertTrue(retrieved.isPresent());
-        assertEquals(COLUMN_VALUES.get("KEY-0"), retrieved.get());
+        assertThat(retrieved).isPresent();
+        assertThat(retrieved.get()).isEqualTo(COLUMN_VALUES.get("KEY-0"));
     }
 
     @Test
@@ -111,8 +109,8 @@ public class KiePMMLRowTest {
                 .collect(Collectors.toMap(i -> "KEY-" + i,
                                           integer -> integer));
         Optional<Object> retrieved = kiePMMLRow.evaluate(columnPairsMap, "KEY-0", null);
-        assertTrue(retrieved.isPresent());
-        assertEquals(COLUMN_VALUES.get("KEY-0"), retrieved.get());
+        assertThat(retrieved).isPresent();
+        assertThat(retrieved.get()).isEqualTo(COLUMN_VALUES.get("KEY-0"));
     }
 
 }

--- a/kie-pmml-trusty/kie-pmml-commons/src/test/java/org/kie/pmml/commons/model/expressions/KiePMMLTextIndexNormalizationTest.java
+++ b/kie-pmml-trusty/kie-pmml-commons/src/test/java/org/kie/pmml/commons/model/expressions/KiePMMLTextIndexNormalizationTest.java
@@ -23,7 +23,7 @@ import java.util.Map;
 
 import org.junit.Test;
 
-import static org.junit.Assert.*;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.kie.pmml.commons.model.expressions.KiePMMLTextIndex.DEFAULT_TOKENIZER;
 
 public class KiePMMLTextIndexNormalizationTest {
@@ -42,7 +42,7 @@ public class KiePMMLTextIndexNormalizationTest {
                 .build();
         String text = "interfacea";
         String retrieved = indexNormalization.replace(text, true, 0, false, DEFAULT_TOKENIZER);
-        assertEquals("fooa", retrieved);
+        assertThat(retrieved).isEqualTo("fooa");
 
         //---
         columnValues.put("string", "is|are|seem(ed|s?)|were?");
@@ -55,7 +55,7 @@ public class KiePMMLTextIndexNormalizationTest {
                 .build();
         text = "Why they seem so ?";
         retrieved = indexNormalization.replace(text, true, 0, false, DEFAULT_TOKENIZER);
-        assertEquals( "Why they be so ?", retrieved);
+        assertThat(retrieved).isEqualTo("Why they be so ?");
     }
 
     @Test
@@ -77,7 +77,7 @@ public class KiePMMLTextIndexNormalizationTest {
                 .build();
         String text = "Why the interfacea seem so ?";
         String retrieved = indexNormalization.replace(text, true, 0, false, DEFAULT_TOKENIZER);
-        assertEquals("Why the fooa be so ?", retrieved);
+        assertThat(retrieved).isEqualTo("Why the fooa be so ?");
     }
 
     @Test
@@ -105,6 +105,6 @@ public class KiePMMLTextIndexNormalizationTest {
                 .build();
         String text = "Why they interfaceems so ?";
         String retrieved = indexNormalization.replace(text, true, 0, false, DEFAULT_TOKENIZER);
-        assertEquals("Why they final so ?", retrieved);
+        assertThat(retrieved).isEqualTo("Why they final so ?");
     }
 }

--- a/kie-pmml-trusty/kie-pmml-commons/src/test/java/org/kie/pmml/commons/model/expressions/KiePMMLTextIndexTest.java
+++ b/kie-pmml-trusty/kie-pmml-commons/src/test/java/org/kie/pmml/commons/model/expressions/KiePMMLTextIndexTest.java
@@ -26,15 +26,14 @@ import java.util.regex.Pattern;
 import java.util.stream.IntStream;
 
 import org.apache.commons.text.similarity.LevenshteinDistance;
+import org.assertj.core.data.Offset;
 import org.junit.Test;
 import org.kie.pmml.api.enums.COUNT_HITS;
 import org.kie.pmml.api.enums.LOCAL_TERM_WEIGHTS;
 import org.kie.pmml.commons.model.ProcessingDTO;
 import org.kie.pmml.commons.model.tuples.KiePMMLNameValue;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.kie.pmml.api.enums.LOCAL_TERM_WEIGHTS.AUGMENTED_NORMALIZED_TERM_FREQUENCY;
 import static org.kie.pmml.api.enums.LOCAL_TERM_WEIGHTS.BINARY;
 import static org.kie.pmml.api.enums.LOCAL_TERM_WEIGHTS.LOGARITHMIC;
@@ -84,7 +83,7 @@ public class KiePMMLTextIndexTest {
                     .withIsCaseSensitive(true)
                     .withWordSeparatorCharacterRE("\\s+")
                     .build();
-            assertEquals(expected, kiePMMLTextIndex.evaluate(processingDTO));
+            assertThat(kiePMMLTextIndex.evaluate(processingDTO)).isEqualTo(expected);
         });
     }
 
@@ -114,7 +113,7 @@ public class KiePMMLTextIndexTest {
                     .withIsCaseSensitive(true)
                     .withTextIndexNormalizations(getKiePMMLTextIndexNormalizations())
                     .build();
-            assertEquals(expected, kiePMMLTextIndex.evaluate(processingDTO));
+            assertThat(kiePMMLTextIndex.evaluate(processingDTO)).isEqualTo(expected);
         });
     }
 
@@ -204,7 +203,7 @@ public class KiePMMLTextIndexTest {
                                                                  new KiePMMLNameValue("reviewText",
                                                                                       NOT_NORMALIZED_TEXT_1));
         ProcessingDTO processingDTO = getProcessingDTO(kiePMMLNameValues);
-        assertEquals(1.0, kiePMMLTextIndex.evaluate(processingDTO));
+        assertThat(kiePMMLTextIndex.evaluate(processingDTO)).isEqualTo(1.0);
     }
 
     @Test
@@ -220,15 +219,17 @@ public class KiePMMLTextIndexTest {
         expectedResults.put(BINARY, 1.0);
         expectedResults.put(LOGARITHMIC, logarithmic);
         expectedResults.put(AUGMENTED_NORMALIZED_TERM_FREQUENCY, augmentedNormalizedTermFrequency);
-        expectedResults.forEach((localTermWeights, expected) -> assertEquals(expected,
-                                                                             KiePMMLTextIndex.evaluateRaw(true,
-                                                                                                          true,
-                                                                                                          TERM_0,
-                                                                                                          TEXT_0,
-                                                                                                          "\\s+",
-                                                                                                          localTermWeights,
-                                                                                                          COUNT_HITS.ALL_HITS,
-                                                                                                          levenshteinDistance), 0.0000001));
+        expectedResults.forEach((localTermWeights, expected) -> {
+			double evaluateRaw = KiePMMLTextIndex.evaluateRaw(true,
+															  true,
+                                                              TERM_0,
+                                                              TEXT_0,
+                                                              "\\s+",
+                                                              localTermWeights,
+                                                              COUNT_HITS.ALL_HITS,
+                                                              levenshteinDistance);
+			assertThat(evaluateRaw).isCloseTo(expected, Offset.offset(0.0000001));
+		});
         //---
         maxFrequency = 3;
         augmentedNormalizedTermFrequency = 0.5 * (1 + (frequency / (double) maxFrequency)); // cast
@@ -238,15 +239,17 @@ public class KiePMMLTextIndexTest {
         expectedResults.put(BINARY, 1.0);
         expectedResults.put(LOGARITHMIC, logarithmic);
         expectedResults.put(AUGMENTED_NORMALIZED_TERM_FREQUENCY, augmentedNormalizedTermFrequency);
-        expectedResults.forEach((localTermWeights, expected) -> assertEquals(expected,
-                                                                             KiePMMLTextIndex.evaluateRaw(false,
-                                                                                                          true,
-                                                                                                          TERM_0,
-                                                                                                          TEXT_0,
-                                                                                                          "\\s+",
-                                                                                                          localTermWeights,
-                                                                                                          COUNT_HITS.ALL_HITS,
-                                                                                                          levenshteinDistance), 0.0000001));
+        expectedResults.forEach((localTermWeights, expected) -> {
+			double evaluateRaw = KiePMMLTextIndex.evaluateRaw(false,
+			                              true,
+			                              TERM_0,
+			                              TEXT_0,
+			                              "\\s+",
+			                              localTermWeights,
+			                              COUNT_HITS.ALL_HITS,
+			                              levenshteinDistance);
+			assertThat(evaluateRaw).isCloseTo(expected,  Offset.offset(0.0000001));
+		});
         //---
         frequency = 4.0;
         logarithmic = Math.log10(1 + frequency);
@@ -257,15 +260,17 @@ public class KiePMMLTextIndexTest {
         expectedResults.put(BINARY, 1.0);
         expectedResults.put(LOGARITHMIC, logarithmic);
         expectedResults.put(AUGMENTED_NORMALIZED_TERM_FREQUENCY, augmentedNormalizedTermFrequency);
-        expectedResults.forEach((localTermWeights, expected) -> assertEquals(expected,
-                                                                             KiePMMLTextIndex.evaluateRaw(false,
-                                                                                                          true,
-                                                                                                          TERM_0,
-                                                                                                          TEXT_0,
-                                                                                                          "[\\s\\-]",
-                                                                                                          localTermWeights,
-                                                                                                          COUNT_HITS.ALL_HITS,
-                                                                                                          levenshteinDistance), 0.0000001));
+        expectedResults.forEach((localTermWeights, expected) -> {
+			double evaluateRaw = KiePMMLTextIndex.evaluateRaw(false,
+			                              true,
+			                              TERM_0,
+			                              TEXT_0,
+			                              "[\\s\\-]",
+			                              localTermWeights,
+			                              COUNT_HITS.ALL_HITS,
+			                              levenshteinDistance);
+			assertThat(evaluateRaw).isCloseTo(expected, Offset.offset(0.0000001));
+		});
     }
 
     @Test
@@ -281,15 +286,17 @@ public class KiePMMLTextIndexTest {
         expectedResults.put(BINARY, 1.0);
         expectedResults.put(LOGARITHMIC, logarithmic);
         expectedResults.put(AUGMENTED_NORMALIZED_TERM_FREQUENCY, augmentedNormalizedTermFrequency);
-        expectedResults.forEach((localTermWeights, expected) -> assertEquals(expected,
-                                                                             KiePMMLTextIndex.evaluateRaw(true,
-                                                                                                          false,
-                                                                                                          TERM_0,
-                                                                                                          TEXT_0,
-                                                                                                          "\\s+",
-                                                                                                          localTermWeights,
-                                                                                                          COUNT_HITS.ALL_HITS,
-                                                                                                          levenshteinDistance), 0.0000001));
+        expectedResults.forEach((localTermWeights, expected) -> {
+			double evaluateRaw = KiePMMLTextIndex.evaluateRaw(true,
+			                              false,
+			                              TERM_0,
+			                              TEXT_0,
+			                              "\\s+",
+			                              localTermWeights,
+			                              COUNT_HITS.ALL_HITS,
+			                              levenshteinDistance);
+			assertThat(evaluateRaw).isCloseTo(expected, Offset.offset(0.0000001));
+		});
         //---
         maxFrequency = 3;
         augmentedNormalizedTermFrequency = 0.5 * (1 + (frequency / (double) maxFrequency)); // cast
@@ -299,15 +306,17 @@ public class KiePMMLTextIndexTest {
         expectedResults.put(BINARY, 1.0);
         expectedResults.put(LOGARITHMIC, logarithmic);
         expectedResults.put(AUGMENTED_NORMALIZED_TERM_FREQUENCY, augmentedNormalizedTermFrequency);
-        expectedResults.forEach((localTermWeights, expected) -> assertEquals(expected,
-                                                                             KiePMMLTextIndex.evaluateRaw(false,
-                                                                                                          false,
-                                                                                                          TERM_0,
-                                                                                                          TEXT_0,
-                                                                                                          "\\s+",
-                                                                                                          localTermWeights,
-                                                                                                          COUNT_HITS.ALL_HITS,
-                                                                                                          levenshteinDistance), 0.0000001));
+        expectedResults.forEach((localTermWeights, expected) -> {
+			double evaluateRaw = KiePMMLTextIndex.evaluateRaw(false,
+			                              false,
+			                              TERM_0,
+			                              TEXT_0,
+			                              "\\s+",
+			                              localTermWeights,
+			                              COUNT_HITS.ALL_HITS,
+			                              levenshteinDistance);
+			assertThat(evaluateRaw).isCloseTo(expected, Offset.offset(0.0000001));
+		});
         //---
         frequency = 3.0;
         logarithmic = Math.log10(1 + frequency);
@@ -318,15 +327,17 @@ public class KiePMMLTextIndexTest {
         expectedResults.put(BINARY, 1.0);
         expectedResults.put(LOGARITHMIC, logarithmic);
         expectedResults.put(AUGMENTED_NORMALIZED_TERM_FREQUENCY, augmentedNormalizedTermFrequency);
-        expectedResults.forEach((localTermWeights, expected) -> assertEquals(expected,
-                                                                             KiePMMLTextIndex.evaluateRaw(false,
-                                                                                                          false,
-                                                                                                          TERM_0,
-                                                                                                          TEXT_0,
-                                                                                                          "[\\s\\-]",
-                                                                                                          localTermWeights,
-                                                                                                          COUNT_HITS.ALL_HITS,
-                                                                                                          levenshteinDistance), 0.0000001));
+        expectedResults.forEach((localTermWeights, expected) -> {
+			double evaluateRaw = KiePMMLTextIndex.evaluateRaw(false,
+			                              false,
+			                              TERM_0,
+			                              TEXT_0,
+			                              "[\\s\\-]",
+			                              localTermWeights,
+			                              COUNT_HITS.ALL_HITS,
+			                              levenshteinDistance);
+			assertThat(evaluateRaw).isCloseTo(expected, Offset.offset(0.0000001));
+		});
     }
 
     @Test
@@ -344,9 +355,7 @@ public class KiePMMLTextIndexTest {
         int binaryEvaluation = 1;
         double expected = 0.5 * (binaryEvaluation + (calculatedLevenshteinDistance / (double) maxFrequency)); // cast
         // for java:S2184
-        assertEquals(expected,
-                     KiePMMLTextIndex.evaluateAugmentedNormalizedTermFrequency(calculatedLevenshteinDistance, texts),
-                     0.0);
+        assertThat(KiePMMLTextIndex.evaluateAugmentedNormalizedTermFrequency(calculatedLevenshteinDistance, texts)).isCloseTo(expected, Offset.offset(0.0));
     }
 
     @Test
@@ -356,22 +365,22 @@ public class KiePMMLTextIndexTest {
         List<String> terms = KiePMMLTextIndex.splitText(TERM_0, pattern);
         List<String> texts = KiePMMLTextIndex.splitText(TEXT_0, pattern);
         LevenshteinDistance levenshteinDistance = new LevenshteinDistance(0);
-        assertEquals(1, KiePMMLTextIndex.evaluateLevenshteinDistanceAllHits(levenshteinDistance, terms, texts));
+        assertThat(KiePMMLTextIndex.evaluateLevenshteinDistanceAllHits(levenshteinDistance, terms, texts)).isEqualTo(1);
         levenshteinDistance = new LevenshteinDistance(1);
-        assertEquals(2, KiePMMLTextIndex.evaluateLevenshteinDistanceAllHits(levenshteinDistance, terms, texts));
+        assertThat(KiePMMLTextIndex.evaluateLevenshteinDistanceAllHits(levenshteinDistance, terms, texts)).isEqualTo(2);
         levenshteinDistance = new LevenshteinDistance(2);
-        assertEquals(3, KiePMMLTextIndex.evaluateLevenshteinDistanceAllHits(levenshteinDistance, terms, texts));
+        assertThat(KiePMMLTextIndex.evaluateLevenshteinDistanceAllHits(levenshteinDistance, terms, texts)).isEqualTo(3);
         //---
         wordSeparatorCharacterRE = "[\\s\\-]"; // brown-foxy match
         pattern = Pattern.compile(wordSeparatorCharacterRE);
         terms = KiePMMLTextIndex.splitText(TERM_0, pattern);
         texts = KiePMMLTextIndex.splitText(TEXT_0, pattern);
         levenshteinDistance = new LevenshteinDistance(0);
-        assertEquals(1, KiePMMLTextIndex.evaluateLevenshteinDistanceAllHits(levenshteinDistance, terms, texts));
+        assertThat(KiePMMLTextIndex.evaluateLevenshteinDistanceAllHits(levenshteinDistance, terms, texts)).isEqualTo(1);
         levenshteinDistance = new LevenshteinDistance(1);
-        assertEquals(3, KiePMMLTextIndex.evaluateLevenshteinDistanceAllHits(levenshteinDistance, terms, texts));
+        assertThat(KiePMMLTextIndex.evaluateLevenshteinDistanceAllHits(levenshteinDistance, terms, texts)).isEqualTo(3);
         levenshteinDistance = new LevenshteinDistance(2);
-        assertEquals(4, KiePMMLTextIndex.evaluateLevenshteinDistanceAllHits(levenshteinDistance, terms, texts));
+        assertThat(KiePMMLTextIndex.evaluateLevenshteinDistanceAllHits(levenshteinDistance, terms, texts)).isEqualTo(4);
     }
 
     @Test
@@ -381,22 +390,22 @@ public class KiePMMLTextIndexTest {
         List<String> terms = KiePMMLTextIndex.splitText("The", pattern);
         List<String> texts = KiePMMLTextIndex.splitText(TEXT_0, pattern);
         LevenshteinDistance levenshteinDistance = new LevenshteinDistance(0);
-        assertEquals(2, KiePMMLTextIndex.evaluateLevenshteinDistanceBestHits(levenshteinDistance, terms, texts));
+        assertThat(KiePMMLTextIndex.evaluateLevenshteinDistanceBestHits(levenshteinDistance, terms, texts)).isEqualTo(2);
         levenshteinDistance = new LevenshteinDistance(1);
-        assertEquals(2, KiePMMLTextIndex.evaluateLevenshteinDistanceBestHits(levenshteinDistance, terms, texts));
+        assertThat(KiePMMLTextIndex.evaluateLevenshteinDistanceBestHits(levenshteinDistance, terms, texts)).isEqualTo(2);
         levenshteinDistance = new LevenshteinDistance(2);
-        assertEquals(2, KiePMMLTextIndex.evaluateLevenshteinDistanceBestHits(levenshteinDistance, terms, texts));
+        assertThat(KiePMMLTextIndex.evaluateLevenshteinDistanceBestHits(levenshteinDistance, terms, texts)).isEqualTo(2);
         //---
         wordSeparatorCharacterRE = "[\\s\\-]"; // brown-foxy match
         pattern = Pattern.compile(wordSeparatorCharacterRE);
         terms = KiePMMLTextIndex.splitText("The", pattern);
         texts = KiePMMLTextIndex.splitText(TEXT_0, pattern);
         levenshteinDistance = new LevenshteinDistance(0);
-        assertEquals(2, KiePMMLTextIndex.evaluateLevenshteinDistanceBestHits(levenshteinDistance, terms, texts));
+        assertThat(KiePMMLTextIndex.evaluateLevenshteinDistanceBestHits(levenshteinDistance, terms, texts)).isEqualTo(2);
         levenshteinDistance = new LevenshteinDistance(1);
-        assertEquals(2, KiePMMLTextIndex.evaluateLevenshteinDistanceBestHits(levenshteinDistance, terms, texts));
+        assertThat(KiePMMLTextIndex.evaluateLevenshteinDistanceBestHits(levenshteinDistance, terms, texts)).isEqualTo(2);
         levenshteinDistance = new LevenshteinDistance(2);
-        assertEquals(2, KiePMMLTextIndex.evaluateLevenshteinDistanceBestHits(levenshteinDistance, terms, texts));
+        assertThat(KiePMMLTextIndex.evaluateLevenshteinDistanceBestHits(levenshteinDistance, terms, texts)).isEqualTo(2);
     }
 
     @Test
@@ -404,25 +413,25 @@ public class KiePMMLTextIndexTest {
         String toSearch = "brown fox";
         String toScan = "brown fox";
         LevenshteinDistance levenshteinDistance = new LevenshteinDistance(0);
-        assertEquals(0, KiePMMLTextIndex.evaluateLevenshteinDistance(levenshteinDistance, toSearch, toScan));
+        assertThat(KiePMMLTextIndex.evaluateLevenshteinDistance(levenshteinDistance, toSearch, toScan)).isEqualTo(0);
         levenshteinDistance = new LevenshteinDistance(1);
-        assertEquals(0, KiePMMLTextIndex.evaluateLevenshteinDistance(levenshteinDistance, toSearch, toScan));
+        assertThat(KiePMMLTextIndex.evaluateLevenshteinDistance(levenshteinDistance, toSearch, toScan)).isEqualTo(0);
         levenshteinDistance = new LevenshteinDistance(2);
-        assertEquals(0, KiePMMLTextIndex.evaluateLevenshteinDistance(levenshteinDistance, toSearch, toScan));
+        assertThat(KiePMMLTextIndex.evaluateLevenshteinDistance(levenshteinDistance, toSearch, toScan)).isEqualTo(0);
         toScan = "brown foxy";
         levenshteinDistance = new LevenshteinDistance(0);
-        assertEquals(-1, KiePMMLTextIndex.evaluateLevenshteinDistance(levenshteinDistance, toSearch, toScan));
+        assertThat(KiePMMLTextIndex.evaluateLevenshteinDistance(levenshteinDistance, toSearch, toScan)).isEqualTo(-1);
         levenshteinDistance = new LevenshteinDistance(1);
-        assertEquals(1, KiePMMLTextIndex.evaluateLevenshteinDistance(levenshteinDistance, toSearch, toScan));
+        assertThat(KiePMMLTextIndex.evaluateLevenshteinDistance(levenshteinDistance, toSearch, toScan)).isEqualTo(1);
         levenshteinDistance = new LevenshteinDistance(2);
-        assertEquals(1, KiePMMLTextIndex.evaluateLevenshteinDistance(levenshteinDistance, toSearch, toScan));
+        assertThat(KiePMMLTextIndex.evaluateLevenshteinDistance(levenshteinDistance, toSearch, toScan)).isEqualTo(1);
         toScan = "browny foxy";
         levenshteinDistance = new LevenshteinDistance(0);
-        assertEquals(-1, KiePMMLTextIndex.evaluateLevenshteinDistance(levenshteinDistance, toSearch, toScan));
+        assertThat(KiePMMLTextIndex.evaluateLevenshteinDistance(levenshteinDistance, toSearch, toScan)).isEqualTo(-1);
         levenshteinDistance = new LevenshteinDistance(1);
-        assertEquals(-1, KiePMMLTextIndex.evaluateLevenshteinDistance(levenshteinDistance, toSearch, toScan));
+        assertThat(KiePMMLTextIndex.evaluateLevenshteinDistance(levenshteinDistance, toSearch, toScan)).isEqualTo(-1);
         levenshteinDistance = new LevenshteinDistance(2);
-        assertEquals(2, KiePMMLTextIndex.evaluateLevenshteinDistance(levenshteinDistance, toSearch, toScan));
+        assertThat(KiePMMLTextIndex.evaluateLevenshteinDistance(levenshteinDistance, toSearch, toScan)).isEqualTo(2);
     }
 
     @Test
@@ -431,17 +440,17 @@ public class KiePMMLTextIndexTest {
         final Pattern wantedPattern = Pattern.compile("[a-zA-Z0-9]");
         Pattern pattern = Pattern.compile("\\s+");
         List<String> retrieved = KiePMMLTextIndex.splitText(TEXT_0, pattern);
-        assertEquals(25, retrieved.size());
+        assertThat(retrieved).hasSize(25);
         retrieved.forEach(txt -> {
-            assertFalse(unwantedPattern.matcher(txt).find());
-            assertTrue(wantedPattern.matcher(txt).find());
+            assertThat(unwantedPattern.matcher(txt).find()).isFalse();
+            assertThat(wantedPattern.matcher(txt).find()).isTrue();
         });
         pattern = Pattern.compile("[\\s\\-]");
         retrieved = KiePMMLTextIndex.splitText(TEXT_0, pattern);
-        assertEquals(26, retrieved.size());
+        assertThat(retrieved).hasSize(26);
         retrieved.forEach(txt -> {
-            assertFalse(unwantedPattern.matcher(txt).find());
-            assertTrue(wantedPattern.matcher(txt).find());
+            assertThat(unwantedPattern.matcher(txt).find()).isFalse();
+            assertThat(wantedPattern.matcher(txt).find()).isTrue();
         });
     }
 

--- a/kie-pmml-trusty/kie-pmml-commons/src/test/java/org/kie/pmml/commons/model/predicates/KiePMMLCompoundPredicateTest.java
+++ b/kie-pmml-trusty/kie-pmml-commons/src/test/java/org/kie/pmml/commons/model/predicates/KiePMMLCompoundPredicateTest.java
@@ -31,9 +31,7 @@ import org.kie.pmml.api.enums.ARRAY_TYPE;
 import org.kie.pmml.api.enums.BOOLEAN_OPERATOR;
 import org.kie.pmml.api.enums.IN_NOTIN;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
+import static org.assertj.core.api.Assertions.assertThat;
 
 public class KiePMMLCompoundPredicateTest {
 
@@ -52,9 +50,9 @@ public class KiePMMLCompoundPredicateTest {
         KiePMMLCompoundPredicate kiePMMLCompoundPredicate = getKiePMMLCompoundPredicate(BOOLEAN_OPERATOR.AND, Collections.singletonList(kiePMMLSimpleSetPredicateString));
         Map<String, Object> inputData = new HashMap<>();
         inputData.put(SIMPLE_SET_PREDICATE_STRING_NAME, "NOT");
-        assertFalse(kiePMMLCompoundPredicate.evaluate(inputData));
+        assertThat(kiePMMLCompoundPredicate.evaluate(inputData)).isFalse();
         inputData.put(SIMPLE_SET_PREDICATE_STRING_NAME, stringValues.get(0));
-        assertTrue(kiePMMLCompoundPredicate.evaluate(inputData));
+        assertThat(kiePMMLCompoundPredicate.evaluate(inputData)).isTrue();
 
         arrayType = ARRAY_TYPE.INT;
         List<Object> intValues = getObjects(arrayType, 4);
@@ -65,9 +63,9 @@ public class KiePMMLCompoundPredicateTest {
         kiePMMLCompoundPredicate = getKiePMMLCompoundPredicate(BOOLEAN_OPERATOR.AND, Collections.singletonList(kiePMMLSimpleSetPredicateInt));
         inputData = new HashMap<>();
         inputData.put(SIMPLE_SET_PREDICATE_INT_NAME, intValues.get(0));
-        assertFalse(kiePMMLCompoundPredicate.evaluate(inputData));
+        assertThat(kiePMMLCompoundPredicate.evaluate(inputData)).isFalse();
         inputData.put(SIMPLE_SET_PREDICATE_INT_NAME, "234");
-        assertTrue(kiePMMLCompoundPredicate.evaluate(inputData));
+        assertThat(kiePMMLCompoundPredicate.evaluate(inputData)).isTrue();
     }
 
     @Test
@@ -89,17 +87,17 @@ public class KiePMMLCompoundPredicateTest {
         Map<String, Object> inputData = new HashMap<>();
         inputData.put(SIMPLE_SET_PREDICATE_STRING_NAME, stringValues.get(0));
         inputData.put(SIMPLE_SET_PREDICATE_INT_NAME, intValues.get(0));
-        assertFalse(kiePMMLCompoundPredicate.evaluate(inputData));
+        assertThat(kiePMMLCompoundPredicate.evaluate(inputData)).isFalse();
 
         inputData = new HashMap<>();
         inputData.put(SIMPLE_SET_PREDICATE_STRING_NAME, "NOT");
         inputData.put(SIMPLE_SET_PREDICATE_INT_NAME, "234");
-        assertFalse(kiePMMLCompoundPredicate.evaluate(inputData));
+        assertThat(kiePMMLCompoundPredicate.evaluate(inputData)).isFalse();
 
         inputData = new HashMap<>();
         inputData.put(SIMPLE_SET_PREDICATE_STRING_NAME, stringValues.get(0));
         inputData.put(SIMPLE_SET_PREDICATE_INT_NAME, "234");
-        assertTrue(kiePMMLCompoundPredicate.evaluate(inputData));
+        assertThat(kiePMMLCompoundPredicate.evaluate(inputData)).isTrue();
     }
 
     @Test
@@ -121,21 +119,21 @@ public class KiePMMLCompoundPredicateTest {
         Map<String, Object> inputData = new HashMap<>();
         inputData.put(SIMPLE_SET_PREDICATE_STRING_NAME, "NOT");
         inputData.put(SIMPLE_SET_PREDICATE_INT_NAME, intValues.get(0));
-        assertFalse(kiePMMLCompoundPredicate.evaluate(inputData));
+        assertThat(kiePMMLCompoundPredicate.evaluate(inputData)).isFalse();
 
         inputData.put(SIMPLE_SET_PREDICATE_STRING_NAME, stringValues.get(0));
         inputData.put(SIMPLE_SET_PREDICATE_INT_NAME, intValues.get(0));
-        assertTrue(kiePMMLCompoundPredicate.evaluate(inputData));
+        assertThat(kiePMMLCompoundPredicate.evaluate(inputData)).isTrue();
 
         inputData = new HashMap<>();
         inputData.put(SIMPLE_SET_PREDICATE_STRING_NAME, "NOT");
         inputData.put(SIMPLE_SET_PREDICATE_INT_NAME, "234");
-        assertTrue(kiePMMLCompoundPredicate.evaluate(inputData));
+        assertThat(kiePMMLCompoundPredicate.evaluate(inputData)).isTrue();
 
         inputData = new HashMap<>();
         inputData.put(SIMPLE_SET_PREDICATE_STRING_NAME, stringValues.get(0));
         inputData.put(SIMPLE_SET_PREDICATE_INT_NAME, "234");
-        assertTrue(kiePMMLCompoundPredicate.evaluate(inputData));
+        assertThat(kiePMMLCompoundPredicate.evaluate(inputData)).isTrue();
     }
 
     @Test
@@ -157,97 +155,97 @@ public class KiePMMLCompoundPredicateTest {
         Map<String, Object> inputData = new HashMap<>();
         inputData.put(SIMPLE_SET_PREDICATE_STRING_NAME, "NOT"); // This predicate verify the "IN" condition
         inputData.put(SIMPLE_SET_PREDICATE_INT_NAME, intValues.get(0)); // This predicate verify the "NOT_IN" condition
-        assertFalse(kiePMMLCompoundPredicate.evaluate(inputData));
+        assertThat(kiePMMLCompoundPredicate.evaluate(inputData)).isFalse();
 
         inputData.put(SIMPLE_SET_PREDICATE_STRING_NAME, stringValues.get(0)); // This predicate verify the "IN" condition
         inputData.put(SIMPLE_SET_PREDICATE_INT_NAME, intValues.get(0)); // This predicate verify the "NOT_IN" condition
-        assertTrue(kiePMMLCompoundPredicate.evaluate(inputData));
+        assertThat(kiePMMLCompoundPredicate.evaluate(inputData)).isTrue();
 
         inputData.put(SIMPLE_SET_PREDICATE_STRING_NAME, "NOT"); // This predicate verify the "IN" condition
         inputData.put(SIMPLE_SET_PREDICATE_INT_NAME, 1); // This predicate verify the "NOT_IN" condition
-        assertFalse(kiePMMLCompoundPredicate.evaluate(inputData));
+        assertThat(kiePMMLCompoundPredicate.evaluate(inputData)).isFalse();
 
         inputData.put(SIMPLE_SET_PREDICATE_STRING_NAME, stringValues.get(0)); // This predicate verify the "IN" condition
         inputData.put(SIMPLE_SET_PREDICATE_INT_NAME, 1); // This predicate verify the "NOT_IN" condition
-        assertTrue(kiePMMLCompoundPredicate.evaluate(inputData));
+        assertThat(kiePMMLCompoundPredicate.evaluate(inputData)).isTrue();
     }
 
     @Test
     public void orOperator() {
         Boolean aBoolean = null;
         Boolean aBoolean2 = true;
-        assertTrue(KiePMMLCompoundPredicate.orOperator(aBoolean, aBoolean2));
+        assertThat(KiePMMLCompoundPredicate.orOperator(aBoolean, aBoolean2)).isTrue();
 
         aBoolean2 = false;
-        assertFalse(KiePMMLCompoundPredicate.orOperator(aBoolean, aBoolean2));
+        assertThat(KiePMMLCompoundPredicate.orOperator(aBoolean, aBoolean2)).isFalse();
 
         aBoolean = false;
         aBoolean2 = false;
-        assertFalse(KiePMMLCompoundPredicate.orOperator(aBoolean, aBoolean2));
+        assertThat(KiePMMLCompoundPredicate.orOperator(aBoolean, aBoolean2)).isFalse();
 
         aBoolean = true;
         aBoolean2 = false;
-        assertTrue(KiePMMLCompoundPredicate.orOperator(aBoolean, aBoolean2));
+        assertThat(KiePMMLCompoundPredicate.orOperator(aBoolean, aBoolean2)).isTrue();
 
         aBoolean = false;
         aBoolean2 = true;
-        assertTrue(KiePMMLCompoundPredicate.orOperator(aBoolean, aBoolean2));
+        assertThat(KiePMMLCompoundPredicate.orOperator(aBoolean, aBoolean2)).isTrue();
 
         aBoolean = true;
         aBoolean2 = true;
-        assertTrue(KiePMMLCompoundPredicate.orOperator(aBoolean, aBoolean2));
+        assertThat(KiePMMLCompoundPredicate.orOperator(aBoolean, aBoolean2)).isTrue();
     }
 
     @Test
     public void andOperator() {
         Boolean aBoolean = null;
         Boolean aBoolean2 = true;
-        assertTrue(KiePMMLCompoundPredicate.andOperator(aBoolean, aBoolean2));
+        assertThat(KiePMMLCompoundPredicate.andOperator(aBoolean, aBoolean2)).isTrue();
 
         aBoolean2 = false;
-        assertFalse(KiePMMLCompoundPredicate.andOperator(aBoolean, aBoolean2));
+        assertThat(KiePMMLCompoundPredicate.andOperator(aBoolean, aBoolean2)).isFalse();
 
         aBoolean = false;
         aBoolean2 = false;
-        assertFalse(KiePMMLCompoundPredicate.andOperator(aBoolean, aBoolean2));
+        assertThat(KiePMMLCompoundPredicate.andOperator(aBoolean, aBoolean2)).isFalse();
 
         aBoolean = true;
         aBoolean2 = false;
-        assertFalse(KiePMMLCompoundPredicate.andOperator(aBoolean, aBoolean2));
+        assertThat(KiePMMLCompoundPredicate.andOperator(aBoolean, aBoolean2)).isFalse();
 
         aBoolean = false;
         aBoolean2 = true;
-        assertFalse(KiePMMLCompoundPredicate.andOperator(aBoolean, aBoolean2));
+        assertThat(KiePMMLCompoundPredicate.andOperator(aBoolean, aBoolean2)).isFalse();
 
         aBoolean = true;
         aBoolean2 = true;
-        assertTrue(KiePMMLCompoundPredicate.andOperator(aBoolean, aBoolean2));
+        assertThat(KiePMMLCompoundPredicate.andOperator(aBoolean, aBoolean2)).isTrue();
     }
 
     @Test
     public void xorOperator() {
         Boolean aBoolean = null;
         Boolean aBoolean2 = true;
-        assertTrue(KiePMMLCompoundPredicate.xorOperator(aBoolean, aBoolean2));
+        assertThat(KiePMMLCompoundPredicate.xorOperator(aBoolean, aBoolean2)).isTrue();
 
         aBoolean2 = false;
-        assertFalse(KiePMMLCompoundPredicate.xorOperator(aBoolean, aBoolean2));
+        assertThat(KiePMMLCompoundPredicate.xorOperator(aBoolean, aBoolean2)).isFalse();
 
         aBoolean = false;
         aBoolean2 = false;
-        assertFalse(KiePMMLCompoundPredicate.xorOperator(aBoolean, aBoolean2));
+        assertThat(KiePMMLCompoundPredicate.xorOperator(aBoolean, aBoolean2)).isFalse();
 
         aBoolean = true;
         aBoolean2 = false;
-        assertTrue(KiePMMLCompoundPredicate.xorOperator(aBoolean, aBoolean2));
+        assertThat(KiePMMLCompoundPredicate.xorOperator(aBoolean, aBoolean2)).isTrue();
 
         aBoolean = false;
         aBoolean2 = true;
-        assertTrue(KiePMMLCompoundPredicate.xorOperator(aBoolean, aBoolean2));
+        assertThat(KiePMMLCompoundPredicate.xorOperator(aBoolean, aBoolean2)).isTrue();
 
         aBoolean = true;
         aBoolean2 = true;
-        assertFalse(KiePMMLCompoundPredicate.xorOperator(aBoolean, aBoolean2));
+        assertThat(KiePMMLCompoundPredicate.xorOperator(aBoolean, aBoolean2)).isFalse();
 
     }
 
@@ -255,26 +253,26 @@ public class KiePMMLCompoundPredicateTest {
     public void surrogateOperator() {
         Boolean aBoolean = null;
         Boolean aBoolean2 = true;
-        assertTrue(KiePMMLCompoundPredicate.surrogateOperator(aBoolean, aBoolean2));
+        assertThat(KiePMMLCompoundPredicate.surrogateOperator(aBoolean, aBoolean2)).isTrue();
 
         aBoolean2 = false;
-        assertFalse(KiePMMLCompoundPredicate.surrogateOperator(aBoolean, aBoolean2));
+        assertThat(KiePMMLCompoundPredicate.surrogateOperator(aBoolean, aBoolean2)).isFalse();
 
         aBoolean = false;
         aBoolean2 = false;
-        assertFalse(KiePMMLCompoundPredicate.surrogateOperator(aBoolean, aBoolean2));
+        assertThat(KiePMMLCompoundPredicate.surrogateOperator(aBoolean, aBoolean2)).isFalse();
 
         aBoolean = true;
         aBoolean2 = false;
-        assertTrue(KiePMMLCompoundPredicate.surrogateOperator(aBoolean, aBoolean2));
+        assertThat(KiePMMLCompoundPredicate.surrogateOperator(aBoolean, aBoolean2)).isTrue();
 
         aBoolean = false;
         aBoolean2 = true;
-        assertFalse(KiePMMLCompoundPredicate.surrogateOperator(aBoolean, aBoolean2));
+        assertThat(KiePMMLCompoundPredicate.surrogateOperator(aBoolean, aBoolean2)).isFalse();
 
         aBoolean = true;
         aBoolean2 = true;
-        assertTrue(KiePMMLCompoundPredicate.surrogateOperator(aBoolean, aBoolean2));
+        assertThat(KiePMMLCompoundPredicate.surrogateOperator(aBoolean, aBoolean2)).isTrue();
     }
 
     private KiePMMLCompoundPredicate getKiePMMLCompoundPredicate(final BOOLEAN_OPERATOR booleanOperator,

--- a/kie-pmml-trusty/kie-pmml-commons/src/test/java/org/kie/pmml/commons/model/predicates/KiePMMLSimplePredicateTest.java
+++ b/kie-pmml-trusty/kie-pmml-commons/src/test/java/org/kie/pmml/commons/model/predicates/KiePMMLSimplePredicateTest.java
@@ -23,8 +23,7 @@ import java.util.Map;
 import org.junit.Test;
 import org.kie.pmml.api.enums.OPERATOR;
 
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
+import static org.assertj.core.api.Assertions.assertThat;
 
 public class KiePMMLSimplePredicateTest {
 
@@ -36,13 +35,13 @@ public class KiePMMLSimplePredicateTest {
         KiePMMLSimplePredicate kiePMMLSimplePredicate = getKiePMMLSimplePredicate(OPERATOR.EQUAL, value);
         Map<String, Object> inputData = new HashMap<>();
         inputData.put("FAKE", "NOT");
-        assertFalse(kiePMMLSimplePredicate.evaluate(inputData));
+        assertThat(kiePMMLSimplePredicate.evaluate(inputData)).isFalse();
         inputData = new HashMap<>();
         inputData.put(SIMPLE_PREDICATE_NAME, "NOT");
-        assertFalse(kiePMMLSimplePredicate.evaluate(inputData));
+        assertThat(kiePMMLSimplePredicate.evaluate(inputData)).isFalse();
         inputData = new HashMap<>();
         inputData.put(SIMPLE_PREDICATE_NAME, value);
-        assertTrue(kiePMMLSimplePredicate.evaluate(inputData));
+        assertThat(kiePMMLSimplePredicate.evaluate(inputData)).isTrue();
     }
 
     @Test
@@ -51,13 +50,13 @@ public class KiePMMLSimplePredicateTest {
         KiePMMLSimplePredicate kiePMMLSimplePredicate = getKiePMMLSimplePredicate(OPERATOR.NOT_EQUAL, value);
         Map<String, Object> inputData = new HashMap<>();
         inputData.put("FAKE", "NOT");
-        assertFalse(kiePMMLSimplePredicate.evaluate(inputData));
+        assertThat(kiePMMLSimplePredicate.evaluate(inputData)).isFalse();
         inputData = new HashMap<>();
         inputData.put(SIMPLE_PREDICATE_NAME, value);
-        assertFalse(kiePMMLSimplePredicate.evaluate(inputData));
+        assertThat(kiePMMLSimplePredicate.evaluate(inputData)).isFalse();
         inputData = new HashMap<>();
         inputData.put(SIMPLE_PREDICATE_NAME, "NOT");
-        assertTrue(kiePMMLSimplePredicate.evaluate(inputData));
+        assertThat(kiePMMLSimplePredicate.evaluate(inputData)).isTrue();
     }
 
     @Test(expected = IllegalArgumentException.class)
@@ -82,16 +81,16 @@ public class KiePMMLSimplePredicateTest {
     public void evaluationStringEqual() {
         Object value = "43";
         KiePMMLSimplePredicate kiePMMLSimplePredicate = getKiePMMLSimplePredicate(OPERATOR.EQUAL, value);
-        assertFalse(kiePMMLSimplePredicate.evaluation("NOT"));
-        assertTrue(kiePMMLSimplePredicate.evaluation(value));
+        assertThat(kiePMMLSimplePredicate.evaluation("NOT")).isFalse();
+        assertThat(kiePMMLSimplePredicate.evaluation(value)).isTrue();
     }
 
     @Test
     public void evaluationStringNotEqual() {
         Object value = "43";
         KiePMMLSimplePredicate kiePMMLSimplePredicate = getKiePMMLSimplePredicate(OPERATOR.NOT_EQUAL, value);
-        assertFalse(kiePMMLSimplePredicate.evaluation(value));
-        assertTrue(kiePMMLSimplePredicate.evaluation("NOT"));
+        assertThat(kiePMMLSimplePredicate.evaluation(value)).isFalse();
+        assertThat(kiePMMLSimplePredicate.evaluation("NOT")).isTrue();
     }
 
     @Test(expected = IllegalArgumentException.class)

--- a/kie-pmml-trusty/kie-pmml-commons/src/test/java/org/kie/pmml/commons/model/predicates/KiePMMLSimpleSetPredicateTest.java
+++ b/kie-pmml-trusty/kie-pmml-commons/src/test/java/org/kie/pmml/commons/model/predicates/KiePMMLSimpleSetPredicateTest.java
@@ -29,8 +29,7 @@ import org.junit.Test;
 import org.kie.pmml.api.enums.ARRAY_TYPE;
 import org.kie.pmml.api.enums.IN_NOTIN;
 
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
+import static org.assertj.core.api.Assertions.assertThat;
 
 public class KiePMMLSimpleSetPredicateTest {
 
@@ -44,11 +43,11 @@ public class KiePMMLSimpleSetPredicateTest {
                                                                                            IN_NOTIN.IN);
         Map<String, Object> inputData = new HashMap<>();
         inputData.put("FAKE", "NOT");
-        assertFalse(kiePMMLSimpleSetPredicate.evaluate(inputData));
+        assertThat(kiePMMLSimpleSetPredicate.evaluate(inputData)).isFalse();
         inputData.put(SIMPLE_SET_PREDICATE_NAME, "NOT");
-        assertFalse(kiePMMLSimpleSetPredicate.evaluate(inputData));
+        assertThat(kiePMMLSimpleSetPredicate.evaluate(inputData)).isFalse();
         inputData.put(SIMPLE_SET_PREDICATE_NAME, values.get(0));
-        assertTrue(kiePMMLSimpleSetPredicate.evaluate(inputData));
+        assertThat(kiePMMLSimpleSetPredicate.evaluate(inputData)).isTrue();
     }
 
     @Test
@@ -59,11 +58,11 @@ public class KiePMMLSimpleSetPredicateTest {
                                                                                            IN_NOTIN.NOT_IN);
         Map<String, Object> inputData = new HashMap<>();
         inputData.put("FAKE", "NOT");
-        assertFalse(kiePMMLSimpleSetPredicate.evaluate(inputData));
+        assertThat(kiePMMLSimpleSetPredicate.evaluate(inputData)).isFalse();
         inputData.put(SIMPLE_SET_PREDICATE_NAME, values.get(0));
-        assertFalse(kiePMMLSimpleSetPredicate.evaluate(inputData));
+        assertThat(kiePMMLSimpleSetPredicate.evaluate(inputData)).isFalse();
         inputData.put(SIMPLE_SET_PREDICATE_NAME, "NOT");
-        assertTrue(kiePMMLSimpleSetPredicate.evaluate(inputData));
+        assertThat(kiePMMLSimpleSetPredicate.evaluate(inputData)).isTrue();
     }
 
     @Test
@@ -74,11 +73,11 @@ public class KiePMMLSimpleSetPredicateTest {
                                                                                            IN_NOTIN.IN);
         Map<String, Object> inputData = new HashMap<>();
         inputData.put("FAKE", "234");
-        assertFalse(kiePMMLSimpleSetPredicate.evaluate(inputData));
+        assertThat(kiePMMLSimpleSetPredicate.evaluate(inputData)).isFalse();
         inputData.put(SIMPLE_SET_PREDICATE_NAME, "432");
-        assertFalse(kiePMMLSimpleSetPredicate.evaluate(inputData));
+        assertThat(kiePMMLSimpleSetPredicate.evaluate(inputData)).isFalse();
         inputData.put(SIMPLE_SET_PREDICATE_NAME, values.get(0));
-        assertTrue(kiePMMLSimpleSetPredicate.evaluate(inputData));
+        assertThat(kiePMMLSimpleSetPredicate.evaluate(inputData)).isTrue();
     }
 
     @Test
@@ -89,11 +88,11 @@ public class KiePMMLSimpleSetPredicateTest {
                                                                                            IN_NOTIN.NOT_IN);
         Map<String, Object> inputData = new HashMap<>();
         inputData.put("FAKE", "234");
-        assertFalse(kiePMMLSimpleSetPredicate.evaluate(inputData));
+        assertThat(kiePMMLSimpleSetPredicate.evaluate(inputData)).isFalse();
         inputData.put(SIMPLE_SET_PREDICATE_NAME, values.get(0));
-        assertFalse(kiePMMLSimpleSetPredicate.evaluate(inputData));
+        assertThat(kiePMMLSimpleSetPredicate.evaluate(inputData)).isFalse();
         inputData.put(SIMPLE_SET_PREDICATE_NAME, "432");
-        assertTrue(kiePMMLSimpleSetPredicate.evaluate(inputData));
+        assertThat(kiePMMLSimpleSetPredicate.evaluate(inputData)).isTrue();
     }
 
     @Test
@@ -104,11 +103,11 @@ public class KiePMMLSimpleSetPredicateTest {
                                                                                            IN_NOTIN.IN);
         Map<String, Object> inputData = new HashMap<>();
         inputData.put("FAKE", "23.4");
-        assertFalse(kiePMMLSimpleSetPredicate.evaluate(inputData));
+        assertThat(kiePMMLSimpleSetPredicate.evaluate(inputData)).isFalse();
         inputData.put(SIMPLE_SET_PREDICATE_NAME, "4.32");
-        assertFalse(kiePMMLSimpleSetPredicate.evaluate(inputData));
+        assertThat(kiePMMLSimpleSetPredicate.evaluate(inputData)).isFalse();
         inputData.put(SIMPLE_SET_PREDICATE_NAME, values.get(0));
-        assertTrue(kiePMMLSimpleSetPredicate.evaluate(inputData));
+        assertThat(kiePMMLSimpleSetPredicate.evaluate(inputData)).isTrue();
     }
 
     @Test
@@ -119,11 +118,11 @@ public class KiePMMLSimpleSetPredicateTest {
                                                                                            IN_NOTIN.NOT_IN);
         Map<String, Object> inputData = new HashMap<>();
         inputData.put("FAKE", "23.4");
-        assertFalse(kiePMMLSimpleSetPredicate.evaluate(inputData));
+        assertThat(kiePMMLSimpleSetPredicate.evaluate(inputData)).isFalse();
         inputData.put(SIMPLE_SET_PREDICATE_NAME, values.get(0));
-        assertFalse(kiePMMLSimpleSetPredicate.evaluate(inputData));
+        assertThat(kiePMMLSimpleSetPredicate.evaluate(inputData)).isFalse();
         inputData.put(SIMPLE_SET_PREDICATE_NAME, "4.32");
-        assertTrue(kiePMMLSimpleSetPredicate.evaluate(inputData));
+        assertThat(kiePMMLSimpleSetPredicate.evaluate(inputData)).isTrue();
     }
 
     @Test
@@ -132,8 +131,8 @@ public class KiePMMLSimpleSetPredicateTest {
         List<Object> values = getObjects(arrayType, 1);
         KiePMMLSimpleSetPredicate kiePMMLSimpleSetPredicate = getKiePMMLSimpleSetPredicate(values, arrayType,
                                                                                            IN_NOTIN.IN);
-        assertFalse(kiePMMLSimpleSetPredicate.evaluation("NOT"));
-        assertTrue(kiePMMLSimpleSetPredicate.evaluation(values.get(0)));
+        assertThat(kiePMMLSimpleSetPredicate.evaluation("NOT")).isFalse();
+        assertThat(kiePMMLSimpleSetPredicate.evaluation(values.get(0))).isTrue();
     }
 
     @Test
@@ -142,8 +141,8 @@ public class KiePMMLSimpleSetPredicateTest {
         List<Object> values = getObjects(arrayType, 1);
         KiePMMLSimpleSetPredicate kiePMMLSimpleSetPredicate = getKiePMMLSimpleSetPredicate(values, arrayType,
                                                                                            IN_NOTIN.NOT_IN);
-        assertFalse(kiePMMLSimpleSetPredicate.evaluation(values.get(0)));
-        assertTrue(kiePMMLSimpleSetPredicate.evaluation("NOT"));
+        assertThat(kiePMMLSimpleSetPredicate.evaluation(values.get(0))).isFalse();
+        assertThat(kiePMMLSimpleSetPredicate.evaluation("NOT")).isTrue();
     }
 
     @Test
@@ -152,8 +151,8 @@ public class KiePMMLSimpleSetPredicateTest {
         List<Object> values = getObjects(arrayType, 1);
         KiePMMLSimpleSetPredicate kiePMMLSimpleSetPredicate = getKiePMMLSimpleSetPredicate(values, arrayType,
                                                                                            IN_NOTIN.IN);
-        assertFalse(kiePMMLSimpleSetPredicate.evaluation("234"));
-        assertTrue(kiePMMLSimpleSetPredicate.evaluation(values.get(0)));
+        assertThat(kiePMMLSimpleSetPredicate.evaluation("234")).isFalse();
+        assertThat(kiePMMLSimpleSetPredicate.evaluation(values.get(0))).isTrue();
     }
 
     @Test
@@ -162,8 +161,8 @@ public class KiePMMLSimpleSetPredicateTest {
         List<Object> values = getObjects(arrayType, 1);
         KiePMMLSimpleSetPredicate kiePMMLSimpleSetPredicate = getKiePMMLSimpleSetPredicate(values, arrayType,
                                                                                            IN_NOTIN.NOT_IN);
-        assertFalse(kiePMMLSimpleSetPredicate.evaluation(values.get(0)));
-        assertTrue(kiePMMLSimpleSetPredicate.evaluation("234"));
+        assertThat(kiePMMLSimpleSetPredicate.evaluation(values.get(0))).isFalse();
+        assertThat(kiePMMLSimpleSetPredicate.evaluation("234")).isTrue();
     }
 
     @Test
@@ -172,8 +171,8 @@ public class KiePMMLSimpleSetPredicateTest {
         List<Object> values = getObjects(arrayType, 1);
         KiePMMLSimpleSetPredicate kiePMMLSimpleSetPredicate = getKiePMMLSimpleSetPredicate(values, arrayType,
                                                                                            IN_NOTIN.IN);
-        assertFalse(kiePMMLSimpleSetPredicate.evaluation("23.4"));
-        assertTrue(kiePMMLSimpleSetPredicate.evaluation(values.get(0)));
+        assertThat(kiePMMLSimpleSetPredicate.evaluation("23.4")).isFalse();
+        assertThat(kiePMMLSimpleSetPredicate.evaluation(values.get(0))).isTrue();
     }
 
     @Test
@@ -182,8 +181,8 @@ public class KiePMMLSimpleSetPredicateTest {
         List<Object> values = getObjects(arrayType, 1);
         KiePMMLSimpleSetPredicate kiePMMLSimpleSetPredicate = getKiePMMLSimpleSetPredicate(values, arrayType,
                                                                                            IN_NOTIN.NOT_IN);
-        assertFalse(kiePMMLSimpleSetPredicate.evaluation(values.get(0)));
-        assertTrue(kiePMMLSimpleSetPredicate.evaluation("23.4"));
+        assertThat(kiePMMLSimpleSetPredicate.evaluation(values.get(0))).isFalse();
+        assertThat(kiePMMLSimpleSetPredicate.evaluation("23.4")).isTrue();
     }
 
     private KiePMMLSimpleSetPredicate getKiePMMLSimpleSetPredicate(final List<Object> values,

--- a/kie-pmml-trusty/kie-pmml-commons/src/test/java/org/kie/pmml/commons/transformations/KiePMMLDefineFunctionTest.java
+++ b/kie-pmml-trusty/kie-pmml-commons/src/test/java/org/kie/pmml/commons/transformations/KiePMMLDefineFunctionTest.java
@@ -28,7 +28,7 @@ import org.kie.pmml.commons.model.expressions.KiePMMLApply;
 import org.kie.pmml.commons.model.expressions.KiePMMLConstant;
 import org.kie.pmml.commons.model.expressions.KiePMMLFieldRef;
 
-import static org.junit.Assert.assertEquals;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.kie.pmml.commons.CommonTestingUtility.getProcessingDTO;
 
 public class KiePMMLDefineFunctionTest {
@@ -85,7 +85,7 @@ public class KiePMMLDefineFunctionTest {
                                                                                kiePMMLConstant1);
         ProcessingDTO processingDTO = getProcessingDTO(Collections.emptyList());
         Object retrieved = defineFunction.evaluate(processingDTO, Collections.emptyList());
-        assertEquals(value1, retrieved);
+        assertThat(retrieved).isEqualTo(value1);
     }
 
     @Test
@@ -102,7 +102,7 @@ public class KiePMMLDefineFunctionTest {
                                                                                kiePMMLFieldRef);
         ProcessingDTO processingDTO = getProcessingDTO(new ArrayList<>());
         Object retrieved = defineFunction.evaluate(processingDTO, Collections.singletonList(value1));
-        assertEquals(value1, retrieved);
+        assertThat(retrieved).isEqualTo(value1);
     }
 
     @Test
@@ -133,7 +133,7 @@ public class KiePMMLDefineFunctionTest {
         ProcessingDTO processingDTO = getProcessingDTO(new ArrayList<>());
         Object retrieved = defineFunction.evaluate(processingDTO, Arrays.asList(value1, value2));
         Object expected = value1 / value2;
-        assertEquals(expected, retrieved);
+        assertThat(retrieved).isEqualTo(expected);
     }
 
 }

--- a/kie-pmml-trusty/kie-pmml-commons/src/test/java/org/kie/pmml/commons/transformations/KiePMMLDerivedFieldTest.java
+++ b/kie-pmml-trusty/kie-pmml-commons/src/test/java/org/kie/pmml/commons/transformations/KiePMMLDerivedFieldTest.java
@@ -30,7 +30,7 @@ import org.kie.pmml.commons.model.expressions.KiePMMLConstant;
 import org.kie.pmml.commons.model.expressions.KiePMMLFieldRef;
 import org.kie.pmml.commons.model.tuples.KiePMMLNameValue;
 
-import static org.junit.Assert.assertEquals;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.kie.pmml.commons.CommonTestingUtility.getProcessingDTO;
 
 public class KiePMMLDerivedFieldTest {
@@ -54,7 +54,7 @@ public class KiePMMLDerivedFieldTest {
                 .build();
         ProcessingDTO processingDTO = getProcessingDTO(Collections.emptyList(), new ArrayList<>());
         Object retrieved = derivedField.evaluate(processingDTO);
-        assertEquals(value1, retrieved);
+        assertThat(retrieved).isEqualTo(value1);
     }
 
     @Test
@@ -71,7 +71,7 @@ public class KiePMMLDerivedFieldTest {
         ProcessingDTO processingDTO = getProcessingDTO(Collections.emptyList(),
                                                         Arrays.asList(new KiePMMLNameValue(PARAM_1, value1)));
         Object retrieved = derivedField.evaluate(processingDTO);
-        assertEquals(value1, retrieved);
+        assertThat(retrieved).isEqualTo(value1);
     }
 
     @Test
@@ -95,7 +95,7 @@ public class KiePMMLDerivedFieldTest {
         ProcessingDTO processingDTO = getProcessingDTO(Collections.emptyList(), getKiePMMLNameValues());
         Object retrieved = derivedField.evaluate(processingDTO);
         Object expected = value1 / value2;
-        assertEquals(expected, retrieved);
+        assertThat(retrieved).isEqualTo(expected);
     }
 
     @Test
@@ -119,7 +119,7 @@ public class KiePMMLDerivedFieldTest {
         ProcessingDTO processingDTO = getProcessingDTO(getDerivedFields(), new ArrayList<>());
         Object retrieved = derivedField.evaluate(processingDTO);
         Object expected = value1 / value2;
-        assertEquals(expected, retrieved);
+        assertThat(retrieved).isEqualTo(expected);
     }
 
     private List<KiePMMLNameValue> getKiePMMLNameValues() {

--- a/kie-pmml-trusty/kie-pmml-commons/src/test/java/org/kie/pmml/commons/utils/KiePMMLModelUtilsTest.java
+++ b/kie-pmml-trusty/kie-pmml-commons/src/test/java/org/kie/pmml/commons/utils/KiePMMLModelUtilsTest.java
@@ -22,7 +22,7 @@ import java.util.Map;
 import org.junit.BeforeClass;
 import org.junit.Test;
 
-import static org.junit.Assert.*;
+import static org.assertj.core.api.Assertions.assertThat;
 
 public class KiePMMLModelUtilsTest {
 
@@ -52,11 +52,11 @@ public class KiePMMLModelUtilsTest {
 
     @Test
     public void getSanitizedPackageName() {
-        packageNameMap.forEach((originalName, expectedName) -> assertEquals(expectedName, KiePMMLModelUtils.getSanitizedPackageName(originalName)));
+        packageNameMap.forEach((originalName, expectedName) -> assertThat(KiePMMLModelUtils.getSanitizedPackageName(originalName)).isEqualTo(expectedName));
     }
 
     @Test
     public void getSanitizedClassName() {
-        classNameMap.forEach((originalName, expectedName) -> assertEquals(expectedName, KiePMMLModelUtils.getSanitizedClassName(originalName)));
+        classNameMap.forEach((originalName, expectedName) -> assertThat(KiePMMLModelUtils.getSanitizedClassName(originalName)).isEqualTo(expectedName));
     }
 }

--- a/kie-pmml-trusty/kie-pmml-compiler/kie-pmml-compiler-api/src/test/java/org/kie/pmml/compiler/api/utils/ModelUtilsTest.java
+++ b/kie-pmml-trusty/kie-pmml-compiler/kie-pmml-compiler-api/src/test/java/org/kie/pmml/compiler/api/utils/ModelUtilsTest.java
@@ -56,10 +56,6 @@ import org.kie.pmml.api.exceptions.KiePMMLInternalException;
 import org.kie.pmml.commons.model.tuples.KiePMMLNameOpType;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertTrue;
 import static org.kie.pmml.compiler.api.CommonTestingUtils.getFieldsFromDataDictionary;
 import static org.kie.pmml.compiler.api.testutils.PMMLModelTestUtils.getArray;
 import static org.kie.pmml.compiler.api.testutils.PMMLModelTestUtils.getDataField;
@@ -114,15 +110,15 @@ public class ModelUtilsTest {
         model.setMiningSchema(miningSchema);
         final List<Field<?>> fields = getFieldsFromDataDictionary(dataDictionary);
         Optional<String> retrieved = ModelUtils.getTargetFieldName(fields, model);
-        assertFalse(retrieved.isPresent());
+        assertThat(retrieved.isPresent()).isFalse();
         usageType = MiningField.UsageType.PREDICTED;
         miningField = getMiningField(fieldName, usageType);
         miningSchema = new MiningSchema();
         miningSchema.addMiningFields(miningField);
         model.setMiningSchema(miningSchema);
         retrieved = ModelUtils.getTargetFieldName(fields, model);
-        assertTrue(retrieved.isPresent());
-        assertEquals(fieldName, retrieved.get());
+        assertThat(retrieved.isPresent()).isTrue();
+        assertThat(retrieved.get()).isEqualTo(fieldName);
     }
 
     @Test
@@ -139,7 +135,7 @@ public class ModelUtilsTest {
         model.setMiningSchema(miningSchema);
         DATA_TYPE retrieved = ModelUtils.getTargetFieldType(getFieldsFromDataDictionary(dataDictionary), model);
         assertThat(retrieved).isNotNull();
-        assertEquals(DATA_TYPE.STRING, retrieved);
+        assertThat(retrieved).isEqualTo(DATA_TYPE.STRING);
     }
 
     @Test(expected = Exception.class)
@@ -172,7 +168,7 @@ public class ModelUtilsTest {
         model.setMiningSchema(miningSchema);
         List<KiePMMLNameOpType> retrieved = ModelUtils.getTargetFields(getFieldsFromDataDictionary(dataDictionary), model);
         assertThat(retrieved).isNotNull();
-        assertTrue(retrieved.isEmpty());
+        assertThat(retrieved).isEmpty();
     }
 
     @Test
@@ -191,19 +187,19 @@ public class ModelUtilsTest {
         model.setMiningSchema(miningSchema);
         List<KiePMMLNameOpType> retrieved = ModelUtils.getTargetFields(getFieldsFromDataDictionary(dataDictionary), model);
         assertThat(retrieved).isNotNull();
-        assertEquals(miningSchema.getMiningFields().size(), retrieved.size());
+        assertThat(retrieved).hasSameSizeAs(miningSchema.getMiningFields());
         retrieved.forEach(kiePMMLNameOpType -> {
-            assertTrue(miningSchema.getMiningFields()
+            assertThat(miningSchema.getMiningFields()
                                .stream()
-                               .anyMatch(fld -> kiePMMLNameOpType.getName().equals(fld.getName().getValue())));
+                               .anyMatch(fld -> kiePMMLNameOpType.getName().equals(fld.getName().getValue()))).isTrue();
             Optional<DataField> optionalDataField = dataDictionary.getDataFields()
                     .stream()
                     .filter(fld -> kiePMMLNameOpType.getName().equals(fld.getName().getValue()))
                     .findFirst();
-            assertTrue(optionalDataField.isPresent());
+            assertThat(optionalDataField).isPresent();
             DataField dataField = optionalDataField.get();
             OP_TYPE expected = OP_TYPE.byName(dataField.getOpType().value());
-            assertEquals(expected, kiePMMLNameOpType.getOpType());
+            assertThat(kiePMMLNameOpType.getOpType()).isEqualTo(expected);
         });
     }
 
@@ -223,16 +219,16 @@ public class ModelUtilsTest {
         model.setMiningSchema(miningSchema);
         List<KiePMMLNameOpType> retrieved = ModelUtils.getTargetFields(getFieldsFromDataDictionary(dataDictionary), model);
         assertThat(retrieved).isNotNull();
-        assertEquals(miningSchema.getMiningFields().size(), retrieved.size());
+        assertThat(retrieved).hasSameSizeAs(miningSchema.getMiningFields());
         retrieved.forEach(kiePMMLNameOpType -> {
             Optional<MiningField> optionalMiningField = miningSchema.getMiningFields()
                     .stream()
                     .filter(fld -> kiePMMLNameOpType.getName().equals(fld.getName().getValue()))
                     .findFirst();
-            assertTrue(optionalMiningField.isPresent());
+            assertThat(optionalMiningField).isPresent();
             MiningField miningField = optionalMiningField.get();
             OP_TYPE expected = OP_TYPE.byName(miningField.getOpType().value());
-            assertEquals(expected, kiePMMLNameOpType.getOpType());
+            assertThat(kiePMMLNameOpType.getOpType()).isEqualTo(expected);
         });
     }
 
@@ -256,16 +252,16 @@ public class ModelUtilsTest {
         model.setTargets(targets);
         List<KiePMMLNameOpType> retrieved = ModelUtils.getTargetFields(getFieldsFromDataDictionary(dataDictionary), model);
         assertThat(retrieved).isNotNull();
-        assertEquals(miningSchema.getMiningFields().size(), retrieved.size());
+        assertThat(retrieved).hasSameSizeAs(miningSchema.getMiningFields());
         retrieved.forEach(kiePMMLNameOpType -> {
             Optional<MiningField> optionalMiningField = miningSchema.getMiningFields()
                     .stream()
                     .filter(fld -> kiePMMLNameOpType.getName().equals(fld.getName().getValue()))
                     .findFirst();
-            assertTrue(optionalMiningField.isPresent());
+            assertThat(optionalMiningField).isPresent();
             MiningField miningField = optionalMiningField.get();
             OP_TYPE expected = OP_TYPE.byName(miningField.getOpType().value());
-            assertEquals(expected, kiePMMLNameOpType.getOpType());
+            assertThat(kiePMMLNameOpType.getOpType()).isEqualTo(expected);
         });
     }
 
@@ -289,16 +285,16 @@ public class ModelUtilsTest {
         model.setTargets(targets);
         List<KiePMMLNameOpType> retrieved = ModelUtils.getTargetFields(getFieldsFromDataDictionary(dataDictionary), model);
         assertThat(retrieved).isNotNull();
-        assertEquals(miningSchema.getMiningFields().size(), retrieved.size());
+        assertThat(retrieved).hasSameSizeAs(miningSchema.getMiningFields());
         retrieved.forEach(kiePMMLNameOpType -> {
             Optional<Target> optionalTarget = targets.getTargets()
                     .stream()
                     .filter(fld -> kiePMMLNameOpType.getName().equals(fld.getField().getValue()))
                     .findFirst();
-            assertTrue(optionalTarget.isPresent());
+            assertThat(optionalTarget).isPresent();
             Target target = optionalTarget.get();
             OP_TYPE expected = OP_TYPE.byName(target.getOpType().value());
-            assertEquals(expected, kiePMMLNameOpType.getOpType());
+            assertThat(kiePMMLNameOpType.getOpType()).isEqualTo(expected);
         });
     }
 
@@ -317,8 +313,8 @@ public class ModelUtilsTest {
         model.setMiningSchema(miningSchema);
         Map<String, DATA_TYPE> retrieved = ModelUtils.getTargetFieldsTypeMap(getFieldsFromDataDictionary(dataDictionary), model);
         assertThat(retrieved).isNotNull();
-        assertEquals(miningSchema.getMiningFields().size(), retrieved.size());
-        assertTrue(retrieved instanceof LinkedHashMap);
+        assertThat(retrieved).hasSameSizeAs(miningSchema.getMiningFields());
+        assertThat(retrieved).isInstanceOf(LinkedHashMap.class);
         final Iterator<Map.Entry<String, DATA_TYPE>> iterator = retrieved.entrySet().iterator();
         for (int i = 0; i < miningSchema.getMiningFields().size(); i++) {
             MiningField miningField = miningSchema.getMiningFields().get(i);
@@ -328,7 +324,7 @@ public class ModelUtilsTest {
                     .get();
             DATA_TYPE expected = DATA_TYPE.byName(dataField.getDataType().value());
             final Map.Entry<String, DATA_TYPE> next = iterator.next();
-            assertEquals(expected, next.getValue());
+            assertThat(next.getValue()).isEqualTo(expected);
         }
     }
 
@@ -347,7 +343,7 @@ public class ModelUtilsTest {
         model.setMiningSchema(miningSchema);
         Map<String, DATA_TYPE> retrieved = ModelUtils.getTargetFieldsTypeMap(getFieldsFromDataDictionary(dataDictionary), model);
         assertThat(retrieved).isNotNull();
-        assertTrue(retrieved.isEmpty());
+        assertThat(retrieved).isEmpty();
     }
 
     @Test
@@ -369,7 +365,7 @@ public class ModelUtilsTest {
         model.setTargets(targets);
         Map<String, DATA_TYPE> retrieved = ModelUtils.getTargetFieldsTypeMap(getFieldsFromDataDictionary(dataDictionary), model);
         assertThat(retrieved).isNotNull();
-        assertTrue(retrieved.isEmpty());
+        assertThat(retrieved).isEmpty();
     }
 
     @Test
@@ -387,7 +383,7 @@ public class ModelUtilsTest {
                                                                                             dataField.getName().getValue());
                                                    assertThat(retrieved).isNotNull();
                                                    OP_TYPE expected = OP_TYPE.byName(dataField.getOpType().value());
-                                                    assertEquals(expected, retrieved);
+                                                    assertThat(retrieved).isEqualTo(expected);
                                                });
     }
 
@@ -423,7 +419,7 @@ public class ModelUtilsTest {
                                                      miningField.getName().getValue());
             assertThat(retrieved).isNotNull();
             OP_TYPE expected = OP_TYPE.byName(miningField.getOpType().value());
-            assertEquals(expected, retrieved);
+            assertThat(retrieved).isEqualTo(expected);
         });
     }
 
@@ -470,7 +466,7 @@ public class ModelUtilsTest {
                                                      target.getField().getValue());
             assertThat(retrieved).isNotNull();
             OP_TYPE expected = OP_TYPE.byName(target.getOpType().value());
-            assertEquals(expected, retrieved);
+            assertThat(retrieved).isEqualTo(expected);
         });
     }
 
@@ -502,12 +498,12 @@ public class ModelUtilsTest {
     public void getOpTypeFromFields() {
         Optional<OP_TYPE> opType = ModelUtils.getOpTypeFromFields(null, "vsd");
         assertThat(opType).isNotNull();
-        assertFalse(opType.isPresent());
+        assertThat(opType.isPresent()).isFalse();
         final DataDictionary dataDictionary = new DataDictionary();
         final List<Field<?>> fields = getFieldsFromDataDictionary(dataDictionary);
         opType = ModelUtils.getOpTypeFromFields(fields, "vsd");
         assertThat(opType).isNotNull();
-        assertFalse(opType.isPresent());
+        assertThat(opType.isPresent()).isFalse();
         IntStream.range(0, 3).forEach(i -> {
             final DataField dataField = getRandomDataField();
             dataDictionary.addDataFields(dataField);
@@ -517,9 +513,9 @@ public class ModelUtilsTest {
         dataDictionary.getDataFields().forEach(dataField -> {
             Optional<OP_TYPE> retrieved = ModelUtils.getOpTypeFromFields(fields, dataField.getName().getValue());
             assertThat(retrieved).isNotNull();
-            assertTrue(retrieved.isPresent());
+            assertThat(retrieved).isPresent();
             OP_TYPE expected = OP_TYPE.byName(dataField.getOpType().value());
-            assertEquals(expected, retrieved.get());
+            assertThat(retrieved.get()).isEqualTo(expected);
         });
     }
 
@@ -527,11 +523,11 @@ public class ModelUtilsTest {
     public void getOpTypeFromMiningFields() {
         Optional<OP_TYPE> opType = ModelUtils.getOpTypeFromMiningFields(null, "vsd");
         assertThat(opType).isNotNull();
-        assertFalse(opType.isPresent());
+        assertThat(opType.isPresent()).isFalse();
         final MiningSchema miningSchema = new MiningSchema();
         opType = ModelUtils.getOpTypeFromMiningFields(miningSchema, "vsd");
         assertThat(opType).isNotNull();
-        assertFalse(opType.isPresent());
+        assertThat(opType.isPresent()).isFalse();
         IntStream.range(0, 3).forEach(i -> {
             final MiningField miningField = getRandomMiningField();
             miningSchema.addMiningFields(miningField);
@@ -539,9 +535,9 @@ public class ModelUtilsTest {
         miningSchema.getMiningFields().forEach(miningField -> {
             Optional<OP_TYPE> retrieved = ModelUtils.getOpTypeFromMiningFields(miningSchema, miningField.getName().getValue());
             assertThat(retrieved).isNotNull();
-            assertTrue(retrieved.isPresent());
+            assertThat(retrieved).isPresent();
             OP_TYPE expected = OP_TYPE.byName(miningField.getOpType().value());
-            assertEquals(expected, retrieved.get());
+            assertThat(retrieved.get()).isEqualTo(expected);
         });
     }
 
@@ -549,11 +545,11 @@ public class ModelUtilsTest {
     public void getOpTypeFromTargets() {
         Optional<OP_TYPE> opType = ModelUtils.getOpTypeFromTargets(null, "vsd");
         assertThat(opType).isNotNull();
-        assertFalse(opType.isPresent());
+        assertThat(opType.isPresent()).isFalse();
         final Targets targets = new Targets();
         opType = ModelUtils.getOpTypeFromTargets(targets, "vsd");
         assertThat(opType).isNotNull();
-        assertFalse(opType.isPresent());
+        assertThat(opType.isPresent()).isFalse();
         IntStream.range(0, 3).forEach(i -> {
             final Target target = getRandomTarget();
             targets.addTargets(target);
@@ -561,9 +557,9 @@ public class ModelUtilsTest {
         targets.getTargets().forEach(target -> {
             Optional<OP_TYPE> retrieved = ModelUtils.getOpTypeFromTargets(targets, target.getField().getValue());
             assertThat(retrieved).isNotNull();
-            assertTrue(retrieved.isPresent());
+            assertThat(retrieved).isPresent();
             OP_TYPE expected = OP_TYPE.byName(target.getOpType().value());
-            assertEquals(expected, retrieved.get());
+            assertThat(retrieved.get()).isEqualTo(expected);
         });
     }
 
@@ -599,14 +595,14 @@ public class ModelUtilsTest {
             DataType retrieved = ModelUtils.getDataType(fields, fieldName);
             assertThat(retrieved).isNotNull();
             DataType expected = dataField.getDataType();
-            assertEquals(expected, retrieved);
+            assertThat(retrieved).isEqualTo(expected);
         });
         derivedFields.forEach(derivedField -> {
             String fieldName = derivedField.getName().getValue();
             DataType retrieved = ModelUtils.getDataType(fields, fieldName);
             assertThat(retrieved).isNotNull();
             DataType expected = derivedField.getDataType();
-            assertEquals(expected, retrieved);
+            assertThat(retrieved).isEqualTo(expected);
         });
     }
 
@@ -621,7 +617,7 @@ public class ModelUtilsTest {
             DATA_TYPE retrieved = ModelUtils.getDATA_TYPE(getFieldsFromDataDictionary(dataDictionary), dataField.getName().getValue());
             assertThat(retrieved).isNotNull();
             DATA_TYPE expected = DATA_TYPE.byName(dataField.getDataType().value());
-            assertEquals(expected, retrieved);
+            assertThat(retrieved).isEqualTo(expected);
         });
     }
 
@@ -642,31 +638,31 @@ public class ModelUtilsTest {
         List<String> values = Arrays.asList("32", "11", "43");
         Array array = getArray(Array.Type.INT, values);
         List<Object> retrieved = ModelUtils.getObjectsFromArray(array);
-        assertEquals(values.size(), retrieved.size());
+        assertThat(retrieved).hasSameSizeAs(values);
         for (int i = 0; i < values.size(); i++) {
             Object obj = retrieved.get(i);
-            assertTrue(obj instanceof Integer);
+            assertThat(obj).isInstanceOf(Integer.class);
             Integer expected = Integer.valueOf(values.get(i));
-            assertEquals(expected, obj);
+            assertThat(obj).isEqualTo(expected);
         }
         values = Arrays.asList("just", "11", "fun");
         array = getArray(Array.Type.STRING, values);
         retrieved = ModelUtils.getObjectsFromArray(array);
-        assertEquals(values.size(), retrieved.size());
+        assertThat(retrieved).hasSameSizeAs(values);
         for (int i = 0; i < values.size(); i++) {
             Object obj = retrieved.get(i);
-            assertTrue(obj instanceof String);
-            assertEquals(values.get(i), obj);
+            assertThat(obj).isInstanceOf(String.class);
+            assertThat(obj).isEqualTo(values.get(i));
         }
         values = Arrays.asList("23.11", "11", "123.123");
         array = getArray(Array.Type.REAL, values);
         retrieved = ModelUtils.getObjectsFromArray(array);
-        assertEquals(values.size(), retrieved.size());
+        assertThat(retrieved).hasSameSizeAs(values);
         for (int i = 0; i < values.size(); i++) {
             Object obj = retrieved.get(i);
-            assertTrue(obj instanceof Double);
+            assertThat(obj).isInstanceOf(Double.class);
             Double expected = Double.valueOf(values.get(i));
-            assertEquals(expected, obj);
+            assertThat(obj).isEqualTo(expected);
         }
     }
 
@@ -679,13 +675,13 @@ public class ModelUtilsTest {
         final DataField dataField = getDataField(fieldName, OpType.CATEGORICAL, DataType.STRING);
         org.kie.pmml.api.models.MiningField retrieved = ModelUtils.convertToKieMiningField(toConvert, dataField);
         assertThat(retrieved).isNotNull();
-        assertEquals(fieldName, retrieved.getName());
-        assertEquals(FIELD_USAGE_TYPE.ACTIVE, retrieved.getUsageType());
-        assertEquals(DATA_TYPE.STRING, retrieved.getDataType());
-        assertNull(retrieved.getOpType());
+        assertThat(retrieved.getName()).isEqualTo(fieldName);
+        assertThat(retrieved.getUsageType()).isEqualTo(FIELD_USAGE_TYPE.ACTIVE);
+        assertThat(retrieved.getDataType()).isEqualTo(DATA_TYPE.STRING);
+        assertThat(retrieved.getOpType()).isNull();
         toConvert.setOpType(OpType.CATEGORICAL);
         retrieved = ModelUtils.convertToKieMiningField(toConvert, dataField);
-        assertEquals(OP_TYPE.CATEGORICAL, retrieved.getOpType());
+        assertThat(retrieved.getOpType()).isEqualTo(OP_TYPE.CATEGORICAL);
     }
 
     @Test
@@ -693,19 +689,19 @@ public class ModelUtilsTest {
         final OutputField toConvert = getRandomOutputField();
         org.kie.pmml.api.models.OutputField retrieved = ModelUtils.convertToKieOutputField(toConvert, null);
         assertThat(retrieved).isNotNull();
-        assertEquals(toConvert.getName().getValue(), retrieved.getName());
+        assertThat(retrieved.getName()).isEqualTo(toConvert.getName().getValue());
         OP_TYPE expectedOpType = OP_TYPE.byName(toConvert.getOpType().value());
-        assertEquals(expectedOpType, retrieved.getOpType());
+        assertThat(retrieved.getOpType()).isEqualTo(expectedOpType);
         DATA_TYPE expectedDataType = DATA_TYPE.byName(toConvert.getDataType().value());
-        assertEquals(expectedDataType, retrieved.getDataType());
-        assertEquals(toConvert.getTargetField().getValue(), retrieved.getTargetField());
+        assertThat(retrieved.getDataType()).isEqualTo(expectedDataType);
+        assertThat(retrieved.getTargetField()).isEqualTo(toConvert.getTargetField().getValue());
         RESULT_FEATURE expectedResultFeature = RESULT_FEATURE.byName(toConvert.getResultFeature().value());
-        assertEquals(expectedResultFeature, retrieved.getResultFeature());
+        assertThat(retrieved.getResultFeature()).isEqualTo(expectedResultFeature);
         toConvert.setOpType(null);
         toConvert.setTargetField(null);
         retrieved = ModelUtils.convertToKieOutputField(toConvert, null);
-        assertNull(retrieved.getOpType());
-        assertNull(retrieved.getTargetField());
+        assertThat(retrieved.getOpType()).isNull();
+        assertThat(retrieved.getTargetField()).isNull();
     }
 
     @Test
@@ -740,17 +736,17 @@ public class ModelUtilsTest {
                 .map(OutputCell.class::cast)
                 .findFirst()
                 .get();
-        assertEquals(2, retrieved.size());
+        assertThat(retrieved).hasSize(2);
         String expected = getPrefixedName(inputCell.getName());
-        assertTrue(retrieved.containsKey(expected));
-        assertEquals(inputCell.getValue(), retrieved.get(expected));
+        assertThat(retrieved).containsKey(expected);
+        assertThat(retrieved.get(expected)).isEqualTo(inputCell.getValue());
 
         expected = getPrefixedName(outputCell.getName());
-        assertTrue(retrieved.containsKey(expected));
-        assertEquals(outputCell.getValue(), retrieved.get(expected));
+        assertThat(retrieved).containsKey(expected);
+        assertThat(retrieved.get(expected)).isEqualTo(outputCell.getValue());
     }
 
     private void commonVerifyEventuallyBoxedClassName(String toVerify, DataType dataType) {
-        assertEquals(expectedBoxedClassName.get(dataType.value()), toVerify);
+        assertThat(toVerify).isEqualTo(expectedBoxedClassName.get(dataType.value()));
     }
 }

--- a/kie-pmml-trusty/kie-pmml-compiler/kie-pmml-compiler-commons/src/test/java/org/kie/pmml/compiler/commons/codegenfactories/KiePMMLApplyFactoryTest.java
+++ b/kie-pmml-trusty/kie-pmml-compiler/kie-pmml-compiler-commons/src/test/java/org/kie/pmml/compiler/commons/codegenfactories/KiePMMLApplyFactoryTest.java
@@ -34,7 +34,7 @@ import org.kie.pmml.commons.model.expressions.KiePMMLConstant;
 import org.kie.pmml.commons.model.expressions.KiePMMLFieldRef;
 import org.kie.pmml.compiler.commons.utils.JavaParserUtils;
 
-import static org.junit.Assert.assertTrue;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.kie.pmml.compiler.commons.testutils.CodegenTestUtils.commonValidateCompilationWithImports;
 import static org.kie.test.util.filesystem.FileUtils.getFileContent;
 
@@ -70,7 +70,7 @@ public class KiePMMLApplyFactoryTest {
         Statement expected = JavaParserUtils.parseBlock(String.format(text, value1, value2, variableName, function,
                                                                       defaultValue, mapMissingTo,
                                                                       invalidValueTreatmentMethod.value()));
-        assertTrue(JavaParserUtils.equalsNode(expected, retrieved));
+        assertThat(retrieved).isEqualTo(expected);
         List<Class<?>> imports = Arrays.asList(KiePMMLConstant.class, KiePMMLApply.class, Collections.class,
                                                Arrays.class);
         commonValidateCompilationWithImports(retrieved, imports);
@@ -97,7 +97,7 @@ public class KiePMMLApplyFactoryTest {
         Statement expected = JavaParserUtils.parseBlock(String.format(text, PARAM_1, PARAM_2, variableName, function,
                                                                       defaultValue, mapMissingTo,
                                                                       invalidValueTreatmentMethod.value()));
-        assertTrue(JavaParserUtils.equalsNode(expected, retrieved));
+        assertThat(retrieved).isEqualTo(expected);
         List<Class<?>> imports = Arrays.asList(KiePMMLFieldRef.class, KiePMMLApply.class, Collections.class,
                                                Arrays.class);
         commonValidateCompilationWithImports(retrieved, imports);
@@ -131,7 +131,7 @@ public class KiePMMLApplyFactoryTest {
                                                                       nestedInvalidValueTreatmentMethod.value(),
                                                                       variableName,
                                                                       invalidValueTreatmentMethod.value()));
-        assertTrue(JavaParserUtils.equalsNode(expected, retrieved));
+        assertThat(retrieved).isEqualTo(expected);
         List<Class<?>> imports = Arrays.asList(KiePMMLFieldRef.class, KiePMMLApply.class, Collections.class,
                                                Arrays.class);
         commonValidateCompilationWithImports(retrieved, imports);

--- a/kie-pmml-trusty/kie-pmml-compiler/kie-pmml-compiler-commons/src/test/java/org/kie/pmml/compiler/commons/codegenfactories/KiePMMLApplyFactoryTest.java
+++ b/kie-pmml-trusty/kie-pmml-compiler/kie-pmml-compiler-commons/src/test/java/org/kie/pmml/compiler/commons/codegenfactories/KiePMMLApplyFactoryTest.java
@@ -70,7 +70,7 @@ public class KiePMMLApplyFactoryTest {
         Statement expected = JavaParserUtils.parseBlock(String.format(text, value1, value2, variableName, function,
                                                                       defaultValue, mapMissingTo,
                                                                       invalidValueTreatmentMethod.value()));
-        assertThat(retrieved).isEqualTo(expected);
+        assertThat(JavaParserUtils.equalsNode(expected,  retrieved)).isTrue();
         List<Class<?>> imports = Arrays.asList(KiePMMLConstant.class, KiePMMLApply.class, Collections.class,
                                                Arrays.class);
         commonValidateCompilationWithImports(retrieved, imports);
@@ -97,7 +97,7 @@ public class KiePMMLApplyFactoryTest {
         Statement expected = JavaParserUtils.parseBlock(String.format(text, PARAM_1, PARAM_2, variableName, function,
                                                                       defaultValue, mapMissingTo,
                                                                       invalidValueTreatmentMethod.value()));
-        assertThat(retrieved).isEqualTo(expected);
+        assertThat(JavaParserUtils.equalsNode(expected,  retrieved)).isTrue();
         List<Class<?>> imports = Arrays.asList(KiePMMLFieldRef.class, KiePMMLApply.class, Collections.class,
                                                Arrays.class);
         commonValidateCompilationWithImports(retrieved, imports);
@@ -131,7 +131,7 @@ public class KiePMMLApplyFactoryTest {
                                                                       nestedInvalidValueTreatmentMethod.value(),
                                                                       variableName,
                                                                       invalidValueTreatmentMethod.value()));
-        assertThat(retrieved).isEqualTo(expected);
+        assertThat(JavaParserUtils.equalsNode(expected,  retrieved)).isTrue();
         List<Class<?>> imports = Arrays.asList(KiePMMLFieldRef.class, KiePMMLApply.class, Collections.class,
                                                Arrays.class);
         commonValidateCompilationWithImports(retrieved, imports);

--- a/kie-pmml-trusty/kie-pmml-compiler/kie-pmml-compiler-commons/src/test/java/org/kie/pmml/compiler/commons/codegenfactories/KiePMMLCompoundPredicateFactoryTest.java
+++ b/kie-pmml-trusty/kie-pmml-compiler/kie-pmml-compiler-commons/src/test/java/org/kie/pmml/compiler/commons/codegenfactories/KiePMMLCompoundPredicateFactoryTest.java
@@ -39,7 +39,7 @@ import org.kie.pmml.commons.model.predicates.KiePMMLSimplePredicate;
 import org.kie.pmml.commons.model.predicates.KiePMMLSimpleSetPredicate;
 import org.kie.pmml.compiler.commons.utils.JavaParserUtils;
 
-import static org.junit.Assert.assertTrue;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.kie.pmml.compiler.api.CommonTestingUtils.getFieldsFromDataDictionary;
 import static org.kie.pmml.compiler.api.testutils.PMMLModelTestUtils.getSimplePredicate;
 import static org.kie.pmml.compiler.api.testutils.PMMLModelTestUtils.getStringObjects;
@@ -98,7 +98,7 @@ public class KiePMMLCompoundPredicateFactoryTest {
         Statement expected = JavaParserUtils.parseBlock(String.format(text, variableName,
                                                                       valuesString,
                                                                       booleanOperatorString));
-        assertTrue(JavaParserUtils.equalsNode(expected, retrieved));
+        assertThat(JavaParserUtils.equalsNode(expected, retrieved)).isTrue();
         List<Class<?>> imports = Arrays.asList(KiePMMLCompoundPredicate.class, KiePMMLSimplePredicate.class,
                                                KiePMMLSimpleSetPredicate.class, Arrays.class, Collections.class);
         commonValidateCompilationWithImports(retrieved, imports);

--- a/kie-pmml-trusty/kie-pmml-compiler/kie-pmml-compiler-commons/src/test/java/org/kie/pmml/compiler/commons/codegenfactories/KiePMMLConstantFactoryTest.java
+++ b/kie-pmml-trusty/kie-pmml-compiler/kie-pmml-compiler-commons/src/test/java/org/kie/pmml/compiler/commons/codegenfactories/KiePMMLConstantFactoryTest.java
@@ -28,7 +28,7 @@ import org.junit.Test;
 import org.kie.pmml.commons.model.expressions.KiePMMLConstant;
 import org.kie.pmml.compiler.commons.utils.JavaParserUtils;
 
-import static org.junit.Assert.assertTrue;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.kie.pmml.compiler.commons.testutils.CodegenTestUtils.commonValidateCompilationWithImports;
 import static org.kie.test.util.filesystem.FileUtils.getFileContent;
 
@@ -45,7 +45,7 @@ public class KiePMMLConstantFactoryTest {
         BlockStmt retrieved = KiePMMLConstantFactory.getConstantVariableDeclaration(variableName, constant);
         String text = getFileContent(TEST_01_SOURCE);
         Statement expected = JavaParserUtils.parseBlock(String.format(text, variableName, value));
-        assertTrue(JavaParserUtils.equalsNode(expected, retrieved));
+        assertThat(retrieved).isEqualTo(expected);
         List<Class<?>> imports = Arrays.asList(KiePMMLConstant.class, Collections.class);
         commonValidateCompilationWithImports(retrieved, imports);
     }

--- a/kie-pmml-trusty/kie-pmml-compiler/kie-pmml-compiler-commons/src/test/java/org/kie/pmml/compiler/commons/codegenfactories/KiePMMLConstantFactoryTest.java
+++ b/kie-pmml-trusty/kie-pmml-compiler/kie-pmml-compiler-commons/src/test/java/org/kie/pmml/compiler/commons/codegenfactories/KiePMMLConstantFactoryTest.java
@@ -45,7 +45,7 @@ public class KiePMMLConstantFactoryTest {
         BlockStmt retrieved = KiePMMLConstantFactory.getConstantVariableDeclaration(variableName, constant);
         String text = getFileContent(TEST_01_SOURCE);
         Statement expected = JavaParserUtils.parseBlock(String.format(text, variableName, value));
-        assertThat(retrieved).isEqualTo(expected);
+        assertThat(JavaParserUtils.equalsNode(expected,  retrieved)).isTrue();
         List<Class<?>> imports = Arrays.asList(KiePMMLConstant.class, Collections.class);
         commonValidateCompilationWithImports(retrieved, imports);
     }

--- a/kie-pmml-trusty/kie-pmml-compiler/kie-pmml-compiler-commons/src/test/java/org/kie/pmml/compiler/commons/codegenfactories/KiePMMLDefineFunctionFactoryTest.java
+++ b/kie-pmml-trusty/kie-pmml-compiler/kie-pmml-compiler-commons/src/test/java/org/kie/pmml/compiler/commons/codegenfactories/KiePMMLDefineFunctionFactoryTest.java
@@ -39,7 +39,7 @@ import org.kie.pmml.commons.transformations.KiePMMLDefineFunction;
 import org.kie.pmml.commons.transformations.KiePMMLParameterField;
 import org.kie.pmml.compiler.commons.utils.JavaParserUtils;
 
-import static org.junit.Assert.assertTrue;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.kie.pmml.compiler.api.CommonTestingUtils.getDATA_TYPEString;
 import static org.kie.pmml.compiler.api.CommonTestingUtils.getOP_TYPEString;
 import static org.kie.pmml.compiler.commons.testutils.CodegenTestUtils.commonValidateCompilationWithImports;
@@ -100,7 +100,7 @@ public class KiePMMLDefineFunctionFactoryTest {
                                           apply.getInvalidValueTreatment().value(),
                                           dataType3,
                                           opType3));
-        assertTrue(JavaParserUtils.equalsNode(expected, retrieved));
+        assertThat(JavaParserUtils.equalsNode(expected, retrieved)).isTrue();
         List<Class<?>> imports = Arrays.asList(KiePMMLParameterField.class,
                                                KiePMMLConstant.class,
                                                KiePMMLFieldRef.class,

--- a/kie-pmml-trusty/kie-pmml-compiler/kie-pmml-compiler-commons/src/test/java/org/kie/pmml/compiler/commons/codegenfactories/KiePMMLDerivedFieldFactoryTest.java
+++ b/kie-pmml-trusty/kie-pmml-compiler/kie-pmml-compiler-commons/src/test/java/org/kie/pmml/compiler/commons/codegenfactories/KiePMMLDerivedFieldFactoryTest.java
@@ -37,7 +37,7 @@ import org.kie.pmml.commons.model.expressions.KiePMMLFieldRef;
 import org.kie.pmml.commons.transformations.KiePMMLDerivedField;
 import org.kie.pmml.compiler.commons.utils.JavaParserUtils;
 
-import static org.junit.Assert.assertTrue;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.kie.pmml.compiler.api.CommonTestingUtils.getDATA_TYPEString;
 import static org.kie.pmml.compiler.api.CommonTestingUtils.getOP_TYPEString;
 import static org.kie.pmml.compiler.commons.testutils.CodegenTestUtils.commonValidateCompilationWithImports;
@@ -73,7 +73,7 @@ public class KiePMMLDerivedFieldFactoryTest {
                                           derivedField.getName().getValue(),
                                           dataType,
                                           opType));
-        assertTrue(JavaParserUtils.equalsNode(expected, retrieved));
+        assertThat(JavaParserUtils.equalsNode(expected, retrieved)).isTrue();
         List<Class<?>> imports = Arrays.asList(KiePMMLConstant.class,
                                                KiePMMLDerivedField.class,
                                                Collections.class);
@@ -100,7 +100,7 @@ public class KiePMMLDerivedFieldFactoryTest {
                                           derivedField.getName().getValue(),
                                           dataType,
                                           opType));
-        assertTrue(JavaParserUtils.equalsNode(expected, retrieved));
+        assertThat(JavaParserUtils.equalsNode(expected, retrieved)).isTrue();
         List<Class<?>> imports = Arrays.asList(KiePMMLFieldRef.class,
                                                KiePMMLDerivedField.class,
                                                Collections.class);
@@ -136,7 +136,7 @@ public class KiePMMLDerivedFieldFactoryTest {
                                           derivedField.getName().getValue(),
                                           dataType,
                                           opType));
-        assertTrue(JavaParserUtils.equalsNode(expected, retrieved));
+        assertThat(JavaParserUtils.equalsNode(expected, retrieved)).isTrue();
         List<Class<?>> imports = Arrays.asList(KiePMMLConstant.class,
                                                KiePMMLFieldRef.class,
                                                KiePMMLApply.class,

--- a/kie-pmml-trusty/kie-pmml-compiler/kie-pmml-compiler-commons/src/test/java/org/kie/pmml/compiler/commons/codegenfactories/KiePMMLDiscretizeBinFactoryTest.java
+++ b/kie-pmml-trusty/kie-pmml-compiler/kie-pmml-compiler-commons/src/test/java/org/kie/pmml/compiler/commons/codegenfactories/KiePMMLDiscretizeBinFactoryTest.java
@@ -31,7 +31,7 @@ import org.kie.pmml.commons.model.expressions.KiePMMLDiscretizeBin;
 import org.kie.pmml.commons.model.expressions.KiePMMLInterval;
 import org.kie.pmml.compiler.commons.utils.JavaParserUtils;
 
-import static org.junit.Assert.assertTrue;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.kie.pmml.compiler.commons.testutils.CodegenTestUtils.commonValidateCompilationWithImports;
 import static org.kie.test.util.filesystem.FileUtils.getFileContent;
 
@@ -62,7 +62,7 @@ public class KiePMMLDiscretizeBinFactoryTest {
         String text = getFileContent(TEST_01_SOURCE);
         Statement expected = JavaParserUtils.parseBlock(String.format(text, variableName, leftMargin, closureString,
                                                                       binValue));
-        assertTrue(JavaParserUtils.equalsNode(expected, retrieved));
+        assertThat(JavaParserUtils.equalsNode(expected, retrieved)).isTrue();
         List<Class<?>> imports = Arrays.asList(Collections.class, KiePMMLDiscretizeBin.class, KiePMMLInterval.class);
         commonValidateCompilationWithImports(retrieved, imports);
     }

--- a/kie-pmml-trusty/kie-pmml-compiler/kie-pmml-compiler-commons/src/test/java/org/kie/pmml/compiler/commons/codegenfactories/KiePMMLDiscretizeFactoryTest.java
+++ b/kie-pmml-trusty/kie-pmml-compiler/kie-pmml-compiler-commons/src/test/java/org/kie/pmml/compiler/commons/codegenfactories/KiePMMLDiscretizeFactoryTest.java
@@ -35,7 +35,7 @@ import org.kie.pmml.commons.model.expressions.KiePMMLDiscretizeBin;
 import org.kie.pmml.commons.model.expressions.KiePMMLInterval;
 import org.kie.pmml.compiler.commons.utils.JavaParserUtils;
 
-import static org.junit.Assert.assertTrue;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.kie.pmml.compiler.api.CommonTestingUtils.getDATA_TYPEString;
 import static org.kie.pmml.compiler.commons.testutils.CodegenTestUtils.commonValidateCompilationWithImports;
 import static org.kie.test.util.filesystem.FileUtils.getFileContent;
@@ -76,7 +76,7 @@ public class KiePMMLDiscretizeFactoryTest {
         String text = getFileContent(TEST_01_SOURCE);
         Statement expected = JavaParserUtils.parseBlock(String.format(text, variableName, NAME, MAP_MISSING_TO,
                                                                       DEFAULTVALUE, dataTypeString));
-        assertTrue(JavaParserUtils.equalsNode(expected, retrieved));
+        assertThat(JavaParserUtils.equalsNode(expected, retrieved)).isTrue();
         List<Class<?>> imports = Arrays.asList(Arrays.class, Collections.class, KiePMMLDiscretize.class,
                                                KiePMMLDiscretizeBin.class, KiePMMLInterval.class);
         commonValidateCompilationWithImports(retrieved, imports);

--- a/kie-pmml-trusty/kie-pmml-compiler/kie-pmml-compiler-commons/src/test/java/org/kie/pmml/compiler/commons/codegenfactories/KiePMMLFalsePredicateFactoryTest.java
+++ b/kie-pmml-trusty/kie-pmml-compiler/kie-pmml-compiler-commons/src/test/java/org/kie/pmml/compiler/commons/codegenfactories/KiePMMLFalsePredicateFactoryTest.java
@@ -28,7 +28,7 @@ import org.junit.Test;
 import org.kie.pmml.commons.model.predicates.KiePMMLFalsePredicate;
 import org.kie.pmml.compiler.commons.utils.JavaParserUtils;
 
-import static org.junit.Assert.assertTrue;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.kie.pmml.compiler.commons.testutils.CodegenTestUtils.commonValidateCompilationWithImports;
 import static org.kie.test.util.filesystem.FileUtils.getFileContent;
 
@@ -43,7 +43,7 @@ public class KiePMMLFalsePredicateFactoryTest {
                                                                                                 new False());
         String text = getFileContent(TEST_01_SOURCE);
         Statement expected = JavaParserUtils.parseBlock(String.format(text, variableName));
-        assertTrue(JavaParserUtils.equalsNode(expected, retrieved));
+        assertThat(retrieved).isEqualTo(expected);
         List<Class<?>> imports = Arrays.asList(KiePMMLFalsePredicate.class, Collections.class);
         commonValidateCompilationWithImports(retrieved, imports);
     }

--- a/kie-pmml-trusty/kie-pmml-compiler/kie-pmml-compiler-commons/src/test/java/org/kie/pmml/compiler/commons/codegenfactories/KiePMMLFalsePredicateFactoryTest.java
+++ b/kie-pmml-trusty/kie-pmml-compiler/kie-pmml-compiler-commons/src/test/java/org/kie/pmml/compiler/commons/codegenfactories/KiePMMLFalsePredicateFactoryTest.java
@@ -43,7 +43,7 @@ public class KiePMMLFalsePredicateFactoryTest {
                                                                                                 new False());
         String text = getFileContent(TEST_01_SOURCE);
         Statement expected = JavaParserUtils.parseBlock(String.format(text, variableName));
-        assertThat(retrieved).isEqualTo(expected);
+        assertThat(JavaParserUtils.equalsNode(expected,  retrieved)).isTrue();
         List<Class<?>> imports = Arrays.asList(KiePMMLFalsePredicate.class, Collections.class);
         commonValidateCompilationWithImports(retrieved, imports);
     }

--- a/kie-pmml-trusty/kie-pmml-compiler/kie-pmml-compiler-commons/src/test/java/org/kie/pmml/compiler/commons/codegenfactories/KiePMMLFieldColumnPairFactoryTest.java
+++ b/kie-pmml-trusty/kie-pmml-compiler/kie-pmml-compiler-commons/src/test/java/org/kie/pmml/compiler/commons/codegenfactories/KiePMMLFieldColumnPairFactoryTest.java
@@ -20,29 +20,18 @@ import java.io.IOException;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
-import java.util.Map;
-import java.util.stream.Collectors;
-import java.util.stream.Stream;
 
 import com.github.javaparser.ast.stmt.BlockStmt;
 import com.github.javaparser.ast.stmt.Statement;
-import org.dmg.pmml.DerivedField;
 import org.dmg.pmml.FieldColumnPair;
 import org.dmg.pmml.FieldName;
-import org.dmg.pmml.MapValues;
-import org.dmg.pmml.PMML;
-import org.dmg.pmml.Row;
-import org.junit.BeforeClass;
 import org.junit.Test;
 import org.kie.pmml.commons.model.expressions.KiePMMLFieldColumnPair;
-import org.kie.pmml.commons.model.expressions.KiePMMLRow;
 import org.kie.pmml.compiler.commons.utils.JavaParserUtils;
-import org.kie.pmml.compiler.commons.utils.KiePMMLUtil;
 
-import static org.junit.Assert.assertTrue;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.kie.pmml.compiler.commons.testutils.CodegenTestUtils.commonValidateCompilationWithImports;
 import static org.kie.test.util.filesystem.FileUtils.getFileContent;
-import static org.kie.test.util.filesystem.FileUtils.getFileInputStream;
 
 public class KiePMMLFieldColumnPairFactoryTest {
 
@@ -61,7 +50,7 @@ public class KiePMMLFieldColumnPairFactoryTest {
                                                                                                   fieldColumnPair);
         String text = getFileContent(TEST_01_SOURCE);
         Statement expected = JavaParserUtils.parseBlock(String.format(text, variableName, fieldName, column));
-        assertTrue(JavaParserUtils.equalsNode(expected, retrieved));
+        assertThat(retrieved).isEqualTo(expected);
         List<Class<?>> imports = Arrays.asList(Collections.class, KiePMMLFieldColumnPair.class);
         commonValidateCompilationWithImports(retrieved, imports);
     }

--- a/kie-pmml-trusty/kie-pmml-compiler/kie-pmml-compiler-commons/src/test/java/org/kie/pmml/compiler/commons/codegenfactories/KiePMMLFieldColumnPairFactoryTest.java
+++ b/kie-pmml-trusty/kie-pmml-compiler/kie-pmml-compiler-commons/src/test/java/org/kie/pmml/compiler/commons/codegenfactories/KiePMMLFieldColumnPairFactoryTest.java
@@ -50,7 +50,7 @@ public class KiePMMLFieldColumnPairFactoryTest {
                                                                                                   fieldColumnPair);
         String text = getFileContent(TEST_01_SOURCE);
         Statement expected = JavaParserUtils.parseBlock(String.format(text, variableName, fieldName, column));
-        assertThat(retrieved).isEqualTo(expected);
+        assertThat(JavaParserUtils.equalsNode(expected,  retrieved)).isTrue();
         List<Class<?>> imports = Arrays.asList(Collections.class, KiePMMLFieldColumnPair.class);
         commonValidateCompilationWithImports(retrieved, imports);
     }

--- a/kie-pmml-trusty/kie-pmml-compiler/kie-pmml-compiler-commons/src/test/java/org/kie/pmml/compiler/commons/codegenfactories/KiePMMLFieldRefFactoryTest.java
+++ b/kie-pmml-trusty/kie-pmml-compiler/kie-pmml-compiler-commons/src/test/java/org/kie/pmml/compiler/commons/codegenfactories/KiePMMLFieldRefFactoryTest.java
@@ -27,10 +27,9 @@ import org.dmg.pmml.FieldName;
 import org.dmg.pmml.FieldRef;
 import org.junit.Test;
 import org.kie.pmml.commons.model.expressions.KiePMMLFieldRef;
-import org.kie.pmml.compiler.commons.codegenfactories.KiePMMLFieldRefFactory;
 import org.kie.pmml.compiler.commons.utils.JavaParserUtils;
 
-import static org.junit.Assert.assertTrue;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.kie.pmml.compiler.commons.testutils.CodegenTestUtils.commonValidateCompilationWithImports;
 import static org.kie.test.util.filesystem.FileUtils.getFileContent;
 
@@ -49,7 +48,7 @@ public class KiePMMLFieldRefFactoryTest {
         BlockStmt retrieved = KiePMMLFieldRefFactory.getFieldRefVariableDeclaration(variableName, fieldRef);
         String text = getFileContent(TEST_01_SOURCE);
         Statement expected = JavaParserUtils.parseBlock(String.format(text, variableName, fieldName, mapMissingTo));
-        assertTrue(JavaParserUtils.equalsNode(expected, retrieved));
+        assertThat(retrieved).isEqualTo(expected);
         List<Class<?>> imports = Arrays.asList(KiePMMLFieldRef.class, Collections.class);
         commonValidateCompilationWithImports(retrieved, imports);
     }

--- a/kie-pmml-trusty/kie-pmml-compiler/kie-pmml-compiler-commons/src/test/java/org/kie/pmml/compiler/commons/codegenfactories/KiePMMLFieldRefFactoryTest.java
+++ b/kie-pmml-trusty/kie-pmml-compiler/kie-pmml-compiler-commons/src/test/java/org/kie/pmml/compiler/commons/codegenfactories/KiePMMLFieldRefFactoryTest.java
@@ -48,7 +48,7 @@ public class KiePMMLFieldRefFactoryTest {
         BlockStmt retrieved = KiePMMLFieldRefFactory.getFieldRefVariableDeclaration(variableName, fieldRef);
         String text = getFileContent(TEST_01_SOURCE);
         Statement expected = JavaParserUtils.parseBlock(String.format(text, variableName, fieldName, mapMissingTo));
-        assertThat(retrieved).isEqualTo(expected);
+        assertThat(JavaParserUtils.equalsNode(expected, retrieved)).isTrue();
         List<Class<?>> imports = Arrays.asList(KiePMMLFieldRef.class, Collections.class);
         commonValidateCompilationWithImports(retrieved, imports);
     }

--- a/kie-pmml-trusty/kie-pmml-compiler/kie-pmml-compiler-commons/src/test/java/org/kie/pmml/compiler/commons/codegenfactories/KiePMMLInlineTableFactoryTest.java
+++ b/kie-pmml-trusty/kie-pmml-compiler/kie-pmml-compiler-commons/src/test/java/org/kie/pmml/compiler/commons/codegenfactories/KiePMMLInlineTableFactoryTest.java
@@ -68,7 +68,7 @@ public class KiePMMLInlineTableFactoryTest {
                                                                                           INLINETABLE);
         String text = getFileContent(TEST_01_SOURCE);
         Statement expected = JavaParserUtils.parseBlock(String.format(text, variableName));
-        assertThat(retrieved).isEqualTo(expected);
+        assertThat(JavaParserUtils.equalsNode(expected, retrieved)).isTrue();
         List<Class<?>> imports = Arrays.asList(Arrays.class, Collections.class, Collectors.class,
                                                KiePMMLInlineTable.class, KiePMMLRow.class, Map.class, Stream.class);
         commonValidateCompilationWithImports(retrieved, imports);

--- a/kie-pmml-trusty/kie-pmml-compiler/kie-pmml-compiler-commons/src/test/java/org/kie/pmml/compiler/commons/codegenfactories/KiePMMLInlineTableFactoryTest.java
+++ b/kie-pmml-trusty/kie-pmml-compiler/kie-pmml-compiler-commons/src/test/java/org/kie/pmml/compiler/commons/codegenfactories/KiePMMLInlineTableFactoryTest.java
@@ -37,7 +37,7 @@ import org.kie.pmml.commons.model.expressions.KiePMMLRow;
 import org.kie.pmml.compiler.commons.utils.JavaParserUtils;
 import org.kie.pmml.compiler.commons.utils.KiePMMLUtil;
 
-import static org.junit.Assert.assertTrue;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.kie.pmml.compiler.commons.testutils.CodegenTestUtils.commonValidateCompilationWithImports;
 import static org.kie.test.util.filesystem.FileUtils.getFileContent;
 import static org.kie.test.util.filesystem.FileUtils.getFileInputStream;
@@ -68,7 +68,7 @@ public class KiePMMLInlineTableFactoryTest {
                                                                                           INLINETABLE);
         String text = getFileContent(TEST_01_SOURCE);
         Statement expected = JavaParserUtils.parseBlock(String.format(text, variableName));
-        assertTrue(JavaParserUtils.equalsNode(expected, retrieved));
+        assertThat(retrieved).isEqualTo(expected);
         List<Class<?>> imports = Arrays.asList(Arrays.class, Collections.class, Collectors.class,
                                                KiePMMLInlineTable.class, KiePMMLRow.class, Map.class, Stream.class);
         commonValidateCompilationWithImports(retrieved, imports);

--- a/kie-pmml-trusty/kie-pmml-compiler/kie-pmml-compiler-commons/src/test/java/org/kie/pmml/compiler/commons/codegenfactories/KiePMMLIntervalFactoryTest.java
+++ b/kie-pmml-trusty/kie-pmml-compiler/kie-pmml-compiler-commons/src/test/java/org/kie/pmml/compiler/commons/codegenfactories/KiePMMLIntervalFactoryTest.java
@@ -29,7 +29,7 @@ import org.kie.pmml.api.enums.CLOSURE;
 import org.kie.pmml.commons.model.expressions.KiePMMLInterval;
 import org.kie.pmml.compiler.commons.utils.JavaParserUtils;
 
-import static org.junit.Assert.assertTrue;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.kie.pmml.compiler.commons.testutils.CodegenTestUtils.commonValidateCompilationWithImports;
 import static org.kie.test.util.filesystem.FileUtils.getFileContent;
 
@@ -53,7 +53,7 @@ public class KiePMMLIntervalFactoryTest {
                 CLOSURE.class.getName() + "." + CLOSURE.byName(interval.getClosure().value()).name();
         String text = getFileContent(TEST_01_SOURCE);
         Statement expected = JavaParserUtils.parseBlock(String.format(text, variableName, leftMargin, closureString));
-        assertTrue(JavaParserUtils.equalsNode(expected, retrieved));
+        assertThat(JavaParserUtils.equalsNode(expected, retrieved)).isTrue();
         List<Class<?>> imports = Arrays.asList(Collections.class, KiePMMLInterval.class);
         commonValidateCompilationWithImports(retrieved, imports);
     }

--- a/kie-pmml-trusty/kie-pmml-compiler/kie-pmml-compiler-commons/src/test/java/org/kie/pmml/compiler/commons/codegenfactories/KiePMMLLocalTransformationsFactoryTest.java
+++ b/kie-pmml-trusty/kie-pmml-compiler/kie-pmml-compiler-commons/src/test/java/org/kie/pmml/compiler/commons/codegenfactories/KiePMMLLocalTransformationsFactoryTest.java
@@ -37,7 +37,7 @@ import org.kie.pmml.commons.transformations.KiePMMLDerivedField;
 import org.kie.pmml.commons.transformations.KiePMMLLocalTransformations;
 import org.kie.pmml.compiler.commons.utils.JavaParserUtils;
 
-import static org.junit.Assert.assertTrue;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.kie.pmml.compiler.commons.testutils.CodegenTestUtils.commonValidateCompilationWithImports;
 import static org.kie.test.util.filesystem.FileUtils.getFileContent;
 
@@ -58,7 +58,7 @@ public class KiePMMLLocalTransformationsFactoryTest {
                 KiePMMLLocalTransformationsFactory.getKiePMMLLocalTransformationsVariableDeclaration(localTransformations);
         String text = getFileContent(TEST_01_SOURCE);
         Statement expected = JavaParserUtils.parseBlock(text);
-        assertTrue(JavaParserUtils.equalsNode(expected, retrieved));
+        assertThat(JavaParserUtils.equalsNode(expected, retrieved)).isTrue();
         List<Class<?>> imports = Arrays.asList(KiePMMLConstant.class,
                                                KiePMMLApply.class,
                                                KiePMMLDerivedField.class,

--- a/kie-pmml-trusty/kie-pmml-compiler/kie-pmml-compiler-commons/src/test/java/org/kie/pmml/compiler/commons/codegenfactories/KiePMMLMapValuesFactoryTest.java
+++ b/kie-pmml-trusty/kie-pmml-compiler/kie-pmml-compiler-commons/src/test/java/org/kie/pmml/compiler/commons/codegenfactories/KiePMMLMapValuesFactoryTest.java
@@ -38,7 +38,7 @@ import org.kie.pmml.commons.model.expressions.KiePMMLRow;
 import org.kie.pmml.compiler.commons.utils.JavaParserUtils;
 import org.kie.pmml.compiler.commons.utils.KiePMMLUtil;
 
-import static org.junit.Assert.assertTrue;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.kie.pmml.compiler.commons.testutils.CodegenTestUtils.commonValidateCompilationWithImports;
 import static org.kie.test.util.filesystem.FileUtils.getFileContent;
 import static org.kie.test.util.filesystem.FileUtils.getFileInputStream;
@@ -69,7 +69,7 @@ public class KiePMMLMapValuesFactoryTest {
                                                                                       MAPVALUES);
         String text = getFileContent(TEST_01_SOURCE);
         Statement expected = JavaParserUtils.parseBlock(String.format(text, variableName));
-        assertTrue(JavaParserUtils.equalsNode(expected, retrieved));
+        assertThat(JavaParserUtils.equalsNode(expected, retrieved)).isTrue();
         List<Class<?>> imports = Arrays.asList(Arrays.class, Collections.class, Collectors.class,
                                                KiePMMLFieldColumnPair.class, KiePMMLInlineTable.class,
                                                KiePMMLMapValues.class, KiePMMLRow.class, Map.class, Stream.class);

--- a/kie-pmml-trusty/kie-pmml-compiler/kie-pmml-compiler-commons/src/test/java/org/kie/pmml/compiler/commons/codegenfactories/KiePMMLMiningFieldFactoryTest.java
+++ b/kie-pmml-trusty/kie-pmml-compiler/kie-pmml-compiler-commons/src/test/java/org/kie/pmml/compiler/commons/codegenfactories/KiePMMLMiningFieldFactoryTest.java
@@ -31,8 +31,7 @@ import org.kie.pmml.commons.model.KiePMMLMiningField;
 import org.kie.pmml.commons.model.expressions.KiePMMLInterval;
 import org.kie.pmml.compiler.commons.utils.JavaParserUtils;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.kie.pmml.compiler.api.testutils.PMMLModelTestUtils.getRandomDataField;
 import static org.kie.pmml.compiler.commons.testutils.CodegenTestUtils.commonValidateCompilationWithImports;
 import static org.kie.test.util.filesystem.FileUtils.getFileContent;
@@ -60,7 +59,7 @@ public class KiePMMLMiningFieldFactoryTest {
         Statement expected = JavaParserUtils.parseBlock(String.format(text, VARIABLE_NAME,
                                                                       miningField.getName().getValue(),
                                                                       dataTypeString));
-        assertTrue(JavaParserUtils.equalsNode(expected, retrieved));
+        assertThat(JavaParserUtils.equalsNode(expected, retrieved)).isTrue();
         List<Class<?>> imports = Arrays.asList(Arrays.class, Collections.class, KiePMMLInterval.class,
                                                KiePMMLMiningField.class, DATA_TYPE.class);
         commonValidateCompilationWithImports(retrieved, imports);
@@ -84,7 +83,7 @@ public class KiePMMLMiningFieldFactoryTest {
                                                                       dataField.getValues().get(0).getValue(),
                                                                       dataField.getValues().get(1).getValue(),
                                                                       dataField.getValues().get(2).getValue()));
-        assertTrue(JavaParserUtils.equalsNode(expected, retrieved));
+        assertThat(JavaParserUtils.equalsNode(expected, retrieved)).isTrue();
         List<Class<?>> imports = Arrays.asList(Arrays.class, Collections.class, KiePMMLInterval.class,
                                                KiePMMLMiningField.class, DATA_TYPE.class);
         commonValidateCompilationWithImports(retrieved, imports);
@@ -119,7 +118,7 @@ public class KiePMMLMiningFieldFactoryTest {
                                                                       dataField.getIntervals().get(2).getLeftMargin(),
                                                                       dataField.getIntervals().get(2).getRightMargin(),
                                                                       dataField.getIntervals().get(2).getClosure().name()));
-        assertTrue(JavaParserUtils.equalsNode(expected, retrieved));
+        assertThat(JavaParserUtils.equalsNode(expected, retrieved)).isTrue();
         List<Class<?>> imports = Arrays.asList(Arrays.class, Collections.class, KiePMMLInterval.class,
                                                KiePMMLMiningField.class, DATA_TYPE.class);
         commonValidateCompilationWithImports(retrieved, imports);

--- a/kie-pmml-trusty/kie-pmml-compiler/kie-pmml-compiler-commons/src/test/java/org/kie/pmml/compiler/commons/codegenfactories/KiePMMLModelFactoryUtilsTest.java
+++ b/kie-pmml-trusty/kie-pmml-compiler/kie-pmml-compiler-commons/src/test/java/org/kie/pmml/compiler/commons/codegenfactories/KiePMMLModelFactoryUtilsTest.java
@@ -71,9 +71,7 @@ import org.kie.pmml.compiler.commons.utils.JavaParserUtils;
 import org.kie.pmml.compiler.commons.utils.KiePMMLUtil;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
+import static org.assertj.core.api.Assertions.fail;
 import static org.kie.pmml.commons.Constants.GET_MODEL;
 import static org.kie.pmml.commons.Constants.PACKAGE_NAME;
 import static org.kie.pmml.compiler.api.testutils.PMMLModelTestUtils.getRandomCastInteger;
@@ -151,12 +149,12 @@ public class KiePMMLModelFactoryUtilsTest {
 
         Optional<ExplicitConstructorInvocationStmt> optSuperInvocation =
                 CommonCodegenUtils.getExplicitConstructorInvocationStmt(constructorDeclaration.getBody());
-        assertTrue(optSuperInvocation.isPresent());
+        assertThat(optSuperInvocation).isPresent();
         superInvocation = optSuperInvocation.get();
-        assertEquals("Template", constructorDeclaration.getName().asString()); // as in the original template
-        assertEquals("super(name, Collections.emptyList(), operator, second);", superInvocation.toString()); // as in
+        assertThat(constructorDeclaration.getName().asString()).isEqualTo("Template"); // as in the original template
+        assertThat(superInvocation.toString()).isEqualTo("super(name, Collections.emptyList(), operator, second);"); // as in
         // the original template
-        assertTrue(clonedCompilationUnit.getClassByName(TEMPLATE_CLASS_NAME).isPresent());
+        assertThat(clonedCompilationUnit.getClassByName(TEMPLATE_CLASS_NAME)).isPresent();
     }
 
     @Test
@@ -223,7 +221,7 @@ public class KiePMMLModelFactoryUtilsTest {
         final MethodDeclaration retrieved = modelTemplate.getMethodsByName(GET_CREATED_KIEPMMLMININGFIELDS).get(0);
         String text = getFileContent(TEST_12_SOURCE);
         BlockStmt expected = JavaParserUtils.parseBlock(text);
-        assertTrue(JavaParserUtils.equalsNode(expected, retrieved.getBody().get()));
+        assertThat(JavaParserUtils.equalsNode(expected, retrieved.getBody().get())).isTrue();
     }
 
     @Test
@@ -238,7 +236,7 @@ public class KiePMMLModelFactoryUtilsTest {
                 classOrInterfaceDeclaration.getMethodsByName(GET_CREATED_MININGFIELDS).get(0);
         String text = getFileContent(TEST_14_SOURCE);
         MethodDeclaration expected = JavaParserUtils.parseMethod(text);
-        assertTrue(JavaParserUtils.equalsNode(expected, retrieved));
+        assertThat(JavaParserUtils.equalsNode(expected, retrieved)).isTrue();
     }
 
     @Test
@@ -253,7 +251,7 @@ public class KiePMMLModelFactoryUtilsTest {
                 classOrInterfaceDeclaration.getMethodsByName(GET_CREATED_OUTPUTFIELDS).get(0);
         String text = getFileContent(TEST_13_SOURCE);
         MethodDeclaration expected = JavaParserUtils.parseMethod(text);
-        assertTrue(JavaParserUtils.equalsNode(expected, retrieved));
+        assertThat(JavaParserUtils.equalsNode(expected, retrieved)).isTrue();
     }
 
     @Test
@@ -268,7 +266,7 @@ public class KiePMMLModelFactoryUtilsTest {
                 classOrInterfaceDeclaration.getMethodsByName(GET_CREATED_KIEPMMLMININGFIELDS).get(0);
         String text = getFileContent(TEST_12_SOURCE);
         BlockStmt expected = JavaParserUtils.parseBlock(text);
-        assertTrue(JavaParserUtils.equalsNode(expected, retrieved.getBody().get()));
+        assertThat(JavaParserUtils.equalsNode(expected, retrieved.getBody().get())).isTrue();
     }
 
     @Test
@@ -279,7 +277,7 @@ public class KiePMMLModelFactoryUtilsTest {
         final MethodDeclaration retrieved = modelTemplate.getMethodsByName(GET_CREATED_KIEPMMLOUTPUTFIELDS).get(0);
         String text = getFileContent(TEST_11_SOURCE);
         BlockStmt expected = JavaParserUtils.parseBlock(text);
-        assertTrue(JavaParserUtils.equalsNode(expected, retrieved.getBody().get()));
+        assertThat(JavaParserUtils.equalsNode(expected, retrieved.getBody().get())).isTrue();
     }
 
     @Test
@@ -290,7 +288,7 @@ public class KiePMMLModelFactoryUtilsTest {
                 classOrInterfaceDeclaration.getMethodsByName(GET_CREATED_KIEPMMLOUTPUTFIELDS).get(0);
         String text = getFileContent(TEST_11_SOURCE);
         BlockStmt expected = JavaParserUtils.parseBlock(text);
-        assertTrue(JavaParserUtils.equalsNode(expected, retrieved.getBody().get()));
+        assertThat(JavaParserUtils.equalsNode(expected, retrieved.getBody().get())).isTrue();
     }
 
     @Test
@@ -343,7 +341,7 @@ public class KiePMMLModelFactoryUtilsTest {
                                                                                kiePMMLTargets.get(2).getMax(),
                                                                                kiePMMLTargets.get(2).getRescaleConstant(),
                                                                                kiePMMLTargets.get(2).getRescaleFactor()));
-        assertTrue(JavaParserUtils.equalsNode(expected, retrieved));
+        assertThat(JavaParserUtils.equalsNode(expected, retrieved)).isTrue();
     }
 
     @Test
@@ -354,7 +352,7 @@ public class KiePMMLModelFactoryUtilsTest {
                 classOrInterfaceDeclaration.getMethodsByName(GET_CREATED_TRANSFORMATION_DICTIONARY).get(0);
         String text = getFileContent(TEST_09_SOURCE);
         MethodDeclaration expected = JavaParserUtils.parseMethod(text);
-        assertTrue(JavaParserUtils.equalsNode(expected, retrieved));
+        assertThat(JavaParserUtils.equalsNode(expected, retrieved)).isTrue();
     }
 
     @Test
@@ -365,27 +363,27 @@ public class KiePMMLModelFactoryUtilsTest {
                 classOrInterfaceDeclaration.getMethodsByName(GET_CREATED_LOCAL_TRANSFORMATIONS).get(0);
         String text = getFileContent(TEST_08_SOURCE);
         MethodDeclaration expected = JavaParserUtils.parseMethod(text);
-        assertTrue(JavaParserUtils.equalsNode(expected, retrieved));
+        assertThat(JavaParserUtils.equalsNode(expected, retrieved)).isTrue();
     }
 
     @Test
     public void addTransformationsInClassOrInterfaceDeclaration() throws IOException {
-        assertTrue(classOrInterfaceDeclaration.getMethodsByName("createTransformationDictionary").isEmpty());
-        assertTrue(classOrInterfaceDeclaration.getMethodsByName("createLocalTransformations").isEmpty());
+        assertThat(classOrInterfaceDeclaration.getMethodsByName("createTransformationDictionary")).isEmpty();
+        assertThat(classOrInterfaceDeclaration.getMethodsByName("createLocalTransformations")).isEmpty();
         KiePMMLModelFactoryUtils.addTransformationsInClassOrInterfaceDeclaration(classOrInterfaceDeclaration,
                                                                                  pmmlModel.getTransformationDictionary(),
                                                                                  model.getLocalTransformations());
-        assertEquals(1, classOrInterfaceDeclaration.getMethodsByName("createTransformationDictionary").size());
-        assertEquals(1, classOrInterfaceDeclaration.getMethodsByName("createLocalTransformations").size());
+        assertThat(classOrInterfaceDeclaration.getMethodsByName("createTransformationDictionary")).hasSize(1);
+        assertThat(classOrInterfaceDeclaration.getMethodsByName("createLocalTransformations")).hasSize(1);
         String text = getFileContent(TEST_01_SOURCE);
         MethodDeclaration expected = JavaParserUtils.parseMethod(text);
         MethodDeclaration retrieved =
                 classOrInterfaceDeclaration.getMethodsByName("createTransformationDictionary").get(0);
-        assertTrue(JavaParserUtils.equalsNode(expected, retrieved));
+        assertThat(JavaParserUtils.equalsNode(expected, retrieved)).isTrue();
         text = getFileContent(TEST_02_SOURCE);
         expected = JavaParserUtils.parseMethod(text);
         retrieved = classOrInterfaceDeclaration.getMethodsByName("createLocalTransformations").get(0);
-        assertTrue(JavaParserUtils.equalsNode(expected, retrieved));
+        assertThat(JavaParserUtils.equalsNode(expected, retrieved)).isTrue();
     }
 
     @Test
@@ -398,7 +396,7 @@ public class KiePMMLModelFactoryUtilsTest {
         BlockStmt body = constructorDeclaration.getBody();
         String text = getFileContent(TEST_03_SOURCE);
         Statement expected = JavaParserUtils.parseConstructorBlock(text);
-        assertTrue(JavaParserUtils.equalsNode(expected, body));
+        assertThat(JavaParserUtils.equalsNode(expected, body)).isTrue();
     }
 
     @Test
@@ -410,8 +408,8 @@ public class KiePMMLModelFactoryUtilsTest {
         KiePMMLModelFactoryUtils.initStaticGetter(compilationDTO, classOrInterfaceDeclaration);
         String text = getFileContent(TEST_04_SOURCE);
         MethodDeclaration expected = JavaParserUtils.parseMethod(text);
-        assertEquals(expected.toString(), staticGetterMethod.toString());
-        assertTrue(JavaParserUtils.equalsNode(expected, staticGetterMethod));
+        assertThat(staticGetterMethod.toString()).isEqualTo(expected.toString());
+        assertThat(JavaParserUtils.equalsNode(expected, staticGetterMethod)).isTrue();
     }
 
     @Test
@@ -435,23 +433,23 @@ public class KiePMMLModelFactoryUtilsTest {
                 .collect(Collectors.toList());
         Expression retrieved = KiePMMLModelFactoryUtils.createIntervalsExpression(intervals);
         assertThat(retrieved).isNotNull();
-        assertTrue(retrieved instanceof MethodCallExpr);
+        assertThat(retrieved).isInstanceOf(MethodCallExpr.class);
         MethodCallExpr mtdExp = (MethodCallExpr) retrieved;
         String expected = "java.util.Arrays";
-        assertEquals(expected, mtdExp.getScope().get().asNameExpr().toString());
+        assertThat(mtdExp.getScope().get().asNameExpr().toString()).isEqualTo(expected);
         expected = "asList";
-        assertEquals(expected, mtdExp.getName().asString());
+        assertThat(mtdExp.getName().asString()).isEqualTo(expected);
         NodeList<Expression> arguments = mtdExp.getArguments();
-        assertEquals(intervals.size(), arguments.size());
+        assertThat(arguments).hasSameSizeAs(intervals);
         arguments.forEach(argument -> {
-            assertTrue(argument instanceof ObjectCreationExpr);
+            assertThat(argument).isInstanceOf(ObjectCreationExpr.class);
             ObjectCreationExpr objCrt = (ObjectCreationExpr) argument;
-            assertEquals(Interval.class.getCanonicalName(), objCrt.getType().asString());
+            assertThat(objCrt.getType().asString()).isEqualTo(Interval.class.getCanonicalName());
             Optional<Interval> intervalOpt = intervals.stream()
                     .filter(interval -> String.valueOf(interval.getLeftMargin()).equals(objCrt.getArgument(0).asNameExpr().toString()) &&
                             String.valueOf(interval.getRightMargin()).equals(objCrt.getArgument(1).asNameExpr().toString()))
                     .findFirst();
-            assertTrue(intervalOpt.isPresent());
+            assertThat(intervalOpt).isPresent();
         });
     }
 
@@ -460,27 +458,27 @@ public class KiePMMLModelFactoryUtilsTest {
         Interval interval = new Interval(null, -14);
         ObjectCreationExpr retrieved = KiePMMLModelFactoryUtils.getObjectCreationExprFromInterval(interval);
         assertThat(retrieved).isNotNull();
-        assertEquals(Interval.class.getCanonicalName(), retrieved.getType().asString());
+        assertThat(retrieved.getType().asString()).isEqualTo(Interval.class.getCanonicalName());
         NodeList<Expression> arguments = retrieved.getArguments();
-        assertEquals(2, arguments.size());
-        assertTrue(arguments.get(0) instanceof NullLiteralExpr);
-        assertEquals(String.valueOf(interval.getRightMargin()), arguments.get(1).asNameExpr().toString());
+        assertThat(arguments).hasSize(2);
+        assertThat(arguments.get(0)).isInstanceOf(NullLiteralExpr.class);
+        assertThat(arguments.get(1).asNameExpr().toString()).isEqualTo(String.valueOf(interval.getRightMargin()));
         interval = new Interval(-13, 10);
         retrieved = KiePMMLModelFactoryUtils.getObjectCreationExprFromInterval(interval);
         assertThat(retrieved).isNotNull();
-        assertEquals(Interval.class.getCanonicalName(), retrieved.getType().asString());
+        assertThat(retrieved.getType().asString()).isEqualTo(Interval.class.getCanonicalName());
         arguments = retrieved.getArguments();
-        assertEquals(2, arguments.size());
-        assertEquals(String.valueOf(interval.getLeftMargin()), arguments.get(0).asNameExpr().toString());
-        assertEquals(String.valueOf(interval.getRightMargin()), arguments.get(1).asNameExpr().toString());
+        assertThat(arguments).hasSize(2);
+        assertThat(arguments.get(0).asNameExpr().toString()).isEqualTo(String.valueOf(interval.getLeftMargin()));
+        assertThat(arguments.get(1).asNameExpr().toString()).isEqualTo(String.valueOf(interval.getRightMargin()));
         interval = new Interval(-13, null);
         retrieved = KiePMMLModelFactoryUtils.getObjectCreationExprFromInterval(interval);
         assertThat(retrieved).isNotNull();
-        assertEquals(Interval.class.getCanonicalName(), retrieved.getType().asString());
+        assertThat(retrieved.getType().asString()).isEqualTo(Interval.class.getCanonicalName());
         arguments = retrieved.getArguments();
-        assertEquals(2, arguments.size());
-        assertEquals(String.valueOf(interval.getLeftMargin()), arguments.get(0).asNameExpr().toString());
-        assertTrue(arguments.get(1) instanceof NullLiteralExpr);
+        assertThat(arguments).hasSize(2);
+        assertThat(arguments.get(0).asNameExpr().toString()).isEqualTo(String.valueOf(interval.getLeftMargin()));
+        assertThat(arguments.get(1)).isInstanceOf(NullLiteralExpr.class);
     }
 
     @Test
@@ -502,7 +500,7 @@ public class KiePMMLModelFactoryUtilsTest {
                                                                       createLocalTransformations);
         String text = getFileContent(TEST_07_SOURCE);
         BlockStmt expected = JavaParserUtils.parseConstructorBlock(text);
-        assertTrue(JavaParserUtils.equalsNode(expected, constructorDeclaration.getBody()));
+        assertThat(JavaParserUtils.equalsNode(expected, constructorDeclaration.getBody())).isTrue();
     }
 
     @Test
@@ -516,7 +514,7 @@ public class KiePMMLModelFactoryUtilsTest {
                                                                                    compilationDTO.getMiningSchema().getMiningFields(), compilationDTO.getFields());
         String text = getFileContent(TEST_06_SOURCE);
         MethodDeclaration expected = JavaParserUtils.parseMethod(text);
-        assertTrue(JavaParserUtils.equalsNode(expected, methodDeclaration));
+        assertThat(JavaParserUtils.equalsNode(expected, methodDeclaration)).isTrue();
     }
 
     @Test
@@ -530,80 +528,80 @@ public class KiePMMLModelFactoryUtilsTest {
                                                                                    compilationDTO.getOutput().getOutputFields());
         String text = getFileContent(TEST_05_SOURCE);
         MethodDeclaration expected = JavaParserUtils.parseMethod(text);
-        assertTrue(JavaParserUtils.equalsNode(expected, methodDeclaration));
+        assertThat(JavaParserUtils.equalsNode(expected, methodDeclaration)).isTrue();
     }
 
     private void commonVerifyMiningFieldsObjectCreation(List<Expression> toVerify, List<MiningField> miningFields) {
         toVerify.forEach(expression -> {
-            assertTrue(expression instanceof ObjectCreationExpr);
+            assertThat(expression).isInstanceOf(ObjectCreationExpr.class);
             ObjectCreationExpr objCrt = (ObjectCreationExpr) expression;
-            assertEquals(MiningField.class.getCanonicalName(), objCrt.getType().asString());
+            assertThat(objCrt.getType().asString()).isEqualTo(MiningField.class.getCanonicalName());
             Optional<MiningField> miningFieldOpt = miningFields.stream()
                     .filter(miningField -> miningField.getName().equals(objCrt.getArgument(0).asStringLiteralExpr().asString()))
                     .findFirst();
-            assertTrue(miningFieldOpt.isPresent());
+            assertThat(miningFieldOpt).isPresent();
             MiningField miningField = miningFieldOpt.get();
-            assertEquals(MiningField.class.getCanonicalName(), objCrt.getType().asString());
+            assertThat(objCrt.getType().asString()).isEqualTo(MiningField.class.getCanonicalName());
             String expected = miningField.getUsageType() != null ?
                     FIELD_USAGE_TYPE.class.getCanonicalName() + "." + miningField.getUsageType() : "null";
-            assertEquals(expected, objCrt.getArgument(1).toString());
+            assertThat(objCrt.getArgument(1).toString()).isEqualTo(expected);
             expected = miningField.getOpType() != null ?
                     OP_TYPE.class.getCanonicalName() + "." + miningField.getOpType() : "null";
-            assertEquals(expected, objCrt.getArgument(2).toString());
+            assertThat(objCrt.getArgument(2).toString()).isEqualTo(expected);
             expected = miningField.getDataType() != null ?
                     DATA_TYPE.class.getCanonicalName() + "." + miningField.getDataType() : "null";
-            assertEquals(expected, objCrt.getArgument(3).toString());
+            assertThat(objCrt.getArgument(3).toString()).isEqualTo(expected);
             expected = miningField.getMissingValueTreatmentMethod() != null ?
                     MISSING_VALUE_TREATMENT_METHOD.class.getCanonicalName() + "." + miningField.getMissingValueTreatmentMethod() : "null";
-            assertEquals(expected, objCrt.getArgument(4).toString());
+            assertThat(objCrt.getArgument(4).toString()).isEqualTo(expected);
             expected = miningField.getInvalidValueTreatmentMethod() != null ?
                     INVALID_VALUE_TREATMENT_METHOD.class.getCanonicalName() + "." + miningField.getInvalidValueTreatmentMethod() : "null";
-            assertEquals(expected, objCrt.getArgument(5).toString());
+            assertThat(objCrt.getArgument(5).toString()).isEqualTo(expected);
             expected = miningField.getMissingValueReplacement() != null ? miningField.getMissingValueReplacement() :
                     "null";
-            assertEquals(expected, objCrt.getArgument(6).asStringLiteralExpr().asString());
+            assertThat(objCrt.getArgument(6).asStringLiteralExpr().asString()).isEqualTo(expected);
             expected = miningField.getInvalidValueReplacement() != null ? miningField.getInvalidValueReplacement() :
                     "null";
-            assertEquals(expected, objCrt.getArgument(7).asStringLiteralExpr().asString());
+            assertThat(objCrt.getArgument(7).asStringLiteralExpr().asString()).isEqualTo(expected);
             MethodCallExpr allowedValuesMethod = objCrt.getArgument(8).asMethodCallExpr();
             IntStream.range(0, 3).forEach(i -> {
                 String exp = miningField.getAllowedValues().get(i);
-                assertEquals(exp, allowedValuesMethod.getArgument(i).asStringLiteralExpr().asString());
+                assertThat(allowedValuesMethod.getArgument(i).asStringLiteralExpr().asString()).isEqualTo(exp);
             });
             MethodCallExpr intervalsMethod = objCrt.getArgument(9).asMethodCallExpr();
             IntStream.range(0, 3).forEach(i -> {
                 Interval interval = miningField.getIntervals().get(i);
                 ObjectCreationExpr objectCreationExpr = intervalsMethod.getArgument(i).asObjectCreationExpr();
                 String exp = interval.getLeftMargin().toString();
-                assertEquals(exp, objectCreationExpr.getArgument(0).asNameExpr().toString());
+                assertThat(objectCreationExpr.getArgument(0).asNameExpr().toString()).isEqualTo(exp);
                 exp = interval.getRightMargin().toString();
-                assertEquals(exp, objectCreationExpr.getArgument(1).asNameExpr().toString());
+                assertThat(objectCreationExpr.getArgument(1).asNameExpr().toString()).isEqualTo(exp);
             });
         });
     }
 
     private void commonVerifyOutputFieldsObjectCreation(List<Expression> toVerify, List<OutputField> outputFields) {
         toVerify.forEach(argument -> {
-            assertTrue(argument instanceof ObjectCreationExpr);
+            assertThat(argument).isInstanceOf(ObjectCreationExpr.class);
             ObjectCreationExpr objCrt = (ObjectCreationExpr) argument;
-            assertEquals(OutputField.class.getCanonicalName(), objCrt.getType().asString());
+            assertThat(objCrt.getType().asString()).isEqualTo(OutputField.class.getCanonicalName());
             Optional<OutputField> outputFieldOpt = outputFields.stream()
                     .filter(outputField -> outputField.getName().equals(objCrt.getArgument(0).asStringLiteralExpr().asString()))
                     .findFirst();
-            assertTrue(outputFieldOpt.isPresent());
+            assertThat(outputFieldOpt).isPresent();
             OutputField outputField = outputFieldOpt.get();
             String expected = OP_TYPE.class.getCanonicalName() + "." + outputField.getOpType();
-            assertEquals(expected, objCrt.getArgument(1).asNameExpr().toString());
+            assertThat(objCrt.getArgument(1).asNameExpr().toString()).isEqualTo(expected);
             expected = DATA_TYPE.class.getCanonicalName() + "." + outputField.getDataType();
-            assertEquals(expected, objCrt.getArgument(2).asNameExpr().toString());
+            assertThat(objCrt.getArgument(2).asNameExpr().toString()).isEqualTo(expected);
             expected = outputField.getTargetField();
-            assertEquals(expected, objCrt.getArgument(3).asStringLiteralExpr().asString());
+            assertThat(objCrt.getArgument(3).asStringLiteralExpr().asString()).isEqualTo(expected);
             expected = RESULT_FEATURE.class.getCanonicalName() + "." + outputField.getResultFeature();
-            assertEquals(expected, objCrt.getArgument(4).asNameExpr().toString());
+            assertThat(objCrt.getArgument(4).asNameExpr().toString()).isEqualTo(expected);
             MethodCallExpr allowedValuesMethod = objCrt.getArgument(5).asMethodCallExpr();
             IntStream.range(0, 3).forEach(i -> {
                 String exp = outputField.getAllowedValues().get(i);
-                assertEquals(exp, allowedValuesMethod.getArgument(i).asStringLiteralExpr().asString());
+                assertThat(allowedValuesMethod.getArgument(i).asStringLiteralExpr().asString()).isEqualTo(exp);
             });
         });
     }
@@ -611,14 +609,14 @@ public class KiePMMLModelFactoryUtilsTest {
     private void commonVerifyKiePMMLTargetFieldsMethodCallExpr(List<Expression> toVerify,
                                                                List<TargetField> targetFields) {
         toVerify.forEach(argument -> {
-            assertTrue(argument instanceof MethodCallExpr);
+            assertThat(argument).isInstanceOf(MethodCallExpr.class);
             MethodCallExpr mtdfClExpr = (MethodCallExpr) argument;
-            assertEquals("build", mtdfClExpr.getName().asString());
+            assertThat(mtdfClExpr.getName().asString()).isEqualTo("build");
             final MethodCallExpr builder = getChainedMethodCallExprFrom("builder", mtdfClExpr);
             Optional<TargetField> targetFieldOpt = targetFields.stream()
                     .filter(targetField -> targetField.getName().equals(builder.getArgument(0).asStringLiteralExpr().asString()))
                     .findFirst();
-            assertTrue(targetFieldOpt.isPresent());
+            assertThat(targetFieldOpt).isPresent();
             TargetField targetField = targetFieldOpt.get();
             try {
                 commonVerifyKiePMMLTargetFieldsMethodCallExpr(mtdfClExpr, targetField);
@@ -654,16 +652,16 @@ public class KiePMMLModelFactoryUtilsTest {
                                                                             kieTargetField.getMax(),
                                                                             kieTargetField.getRescaleConstant(),
                                                                             kieTargetField.getRescaleFactor()));
-        assertTrue(JavaParserUtils.equalsNode(expected, retrieved));
+        assertThat(JavaParserUtils.equalsNode(expected, retrieved)).isTrue();
         List<Class<?>> imports = Arrays.asList(Arrays.class, Collections.class, KiePMMLTarget.class,
                                                KiePMMLTargetValue.class, TargetField.class, TargetValue.class);
         commonValidateCompilationWithImports(retrieved, imports);
     }
 
     private void commonVerifySuperInvocation(String generatedClassName, String name) {
-        assertEquals(generatedClassName, constructorDeclaration.getName().asString()); // modified by invocation
+        assertThat(constructorDeclaration.getName().asString()).isEqualTo(generatedClassName); // modified by invocation
         String expected = String.format("super(\"%s\", Collections.emptyList(), operator, second);", name);
-        assertEquals(expected, superInvocation.toString()); // modified by invocation
+        assertThat(superInvocation.toString()).isEqualTo(expected); // modified by invocation
     }
 
     /**
@@ -685,7 +683,7 @@ public class KiePMMLModelFactoryUtilsTest {
                 .map(expression -> (MethodCallExpr) expression)
                 .filter(methodCallExpr -> evaluateMethodCallExpr(methodCallExpr, scope, method))
                 .collect(Collectors.toList());
-        assertEquals(expectedSize, toReturn.size());
+        assertThat(toReturn).hasSize(expectedSize);
         return toReturn;
     }
 

--- a/kie-pmml-trusty/kie-pmml-compiler/kie-pmml-compiler-commons/src/test/java/org/kie/pmml/compiler/commons/codegenfactories/KiePMMLNormContinuousFactoryTest.java
+++ b/kie-pmml-trusty/kie-pmml-compiler/kie-pmml-compiler-commons/src/test/java/org/kie/pmml/compiler/commons/codegenfactories/KiePMMLNormContinuousFactoryTest.java
@@ -32,7 +32,7 @@ import org.kie.pmml.commons.model.expressions.KiePMMLLinearNorm;
 import org.kie.pmml.commons.model.expressions.KiePMMLNormContinuous;
 import org.kie.pmml.compiler.commons.utils.JavaParserUtils;
 
-import static org.junit.Assert.assertTrue;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.kie.pmml.compiler.api.testutils.PMMLModelTestUtils.getRandomLinearNorm;
 import static org.kie.pmml.compiler.api.testutils.PMMLModelTestUtils.getRandomNormContinuous;
 import static org.kie.pmml.compiler.commons.testutils.CodegenTestUtils.commonValidateCompilationWithImports;
@@ -63,7 +63,7 @@ public class KiePMMLNormContinuousFactoryTest {
                                                                       linearNorms.get(2).getOrig(),
                                                                       linearNorms.get(2).getNorm(),
                                                                       outlierString, normContinuous.getMapMissingTo()));
-        assertTrue(JavaParserUtils.equalsNode(expected, retrieved));
+        assertThat(JavaParserUtils.equalsNode(expected, retrieved)).isTrue();
         List<Class<?>> imports = Arrays.asList(Arrays.class, Collections.class, KiePMMLLinearNorm.class,
                                                KiePMMLNormContinuous.class, OUTLIER_TREATMENT_METHOD.class);
         commonValidateCompilationWithImports(retrieved, imports);
@@ -78,6 +78,6 @@ public class KiePMMLNormContinuousFactoryTest {
         Expression expected = JavaParserUtils.parseExpression(String.format(text, name,
                                                                             linearNorm.getOrig(),
                                                                             linearNorm.getNorm()));
-        assertTrue(JavaParserUtils.equalsNode(expected, retrieved));
+        assertThat(JavaParserUtils.equalsNode(expected, retrieved)).isTrue();
     }
 }

--- a/kie-pmml-trusty/kie-pmml-compiler/kie-pmml-compiler-commons/src/test/java/org/kie/pmml/compiler/commons/codegenfactories/KiePMMLNormDiscreteFactoryTest.java
+++ b/kie-pmml-trusty/kie-pmml-compiler/kie-pmml-compiler-commons/src/test/java/org/kie/pmml/compiler/commons/codegenfactories/KiePMMLNormDiscreteFactoryTest.java
@@ -53,7 +53,7 @@ public class KiePMMLNormDiscreteFactoryTest {
                                                                                                 normDiscrete);
         String text = getFileContent(TEST_01_SOURCE);
         Statement expected = JavaParserUtils.parseBlock(String.format(text, variableName, fieldName, fieldValue, mapMissingTo));
-        assertThat(retrieved).isEqualTo(expected);
+        assertThat(JavaParserUtils.equalsNode(expected, retrieved)).isTrue();
         List<Class<?>> imports = Arrays.asList(Collections.class, KiePMMLNormDiscrete.class);
         commonValidateCompilationWithImports(retrieved, imports);
     }

--- a/kie-pmml-trusty/kie-pmml-compiler/kie-pmml-compiler-commons/src/test/java/org/kie/pmml/compiler/commons/codegenfactories/KiePMMLNormDiscreteFactoryTest.java
+++ b/kie-pmml-trusty/kie-pmml-compiler/kie-pmml-compiler-commons/src/test/java/org/kie/pmml/compiler/commons/codegenfactories/KiePMMLNormDiscreteFactoryTest.java
@@ -29,7 +29,7 @@ import org.junit.Test;
 import org.kie.pmml.commons.model.expressions.KiePMMLNormDiscrete;
 import org.kie.pmml.compiler.commons.utils.JavaParserUtils;
 
-import static org.junit.Assert.assertTrue;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.kie.pmml.compiler.commons.testutils.CodegenTestUtils.commonValidateCompilationWithImports;
 import static org.kie.test.util.filesystem.FileUtils.getFileContent;
 
@@ -53,7 +53,7 @@ public class KiePMMLNormDiscreteFactoryTest {
                                                                                                 normDiscrete);
         String text = getFileContent(TEST_01_SOURCE);
         Statement expected = JavaParserUtils.parseBlock(String.format(text, variableName, fieldName, fieldValue, mapMissingTo));
-        assertTrue(JavaParserUtils.equalsNode(expected, retrieved));
+        assertThat(retrieved).isEqualTo(expected);
         List<Class<?>> imports = Arrays.asList(Collections.class, KiePMMLNormDiscrete.class);
         commonValidateCompilationWithImports(retrieved, imports);
     }

--- a/kie-pmml-trusty/kie-pmml-compiler/kie-pmml-compiler-commons/src/test/java/org/kie/pmml/compiler/commons/codegenfactories/KiePMMLParameterFieldFactoryTest.java
+++ b/kie-pmml-trusty/kie-pmml-compiler/kie-pmml-compiler-commons/src/test/java/org/kie/pmml/compiler/commons/codegenfactories/KiePMMLParameterFieldFactoryTest.java
@@ -31,7 +31,7 @@ import org.junit.Test;
 import org.kie.pmml.commons.transformations.KiePMMLParameterField;
 import org.kie.pmml.compiler.commons.utils.JavaParserUtils;
 
-import static org.junit.Assert.assertTrue;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.kie.pmml.compiler.api.CommonTestingUtils.getDATA_TYPEString;
 import static org.kie.pmml.compiler.api.CommonTestingUtils.getOP_TYPEString;
 import static org.kie.pmml.compiler.commons.testutils.CodegenTestUtils.commonValidateCompilationWithImports;
@@ -58,7 +58,7 @@ public class KiePMMLParameterFieldFactoryTest {
                                                                       dataType,
                                                                       opType,
                                                                       parameterField.getDisplayName()));
-        assertTrue(JavaParserUtils.equalsNode(expected, retrieved));
+        assertThat(JavaParserUtils.equalsNode(expected, retrieved)).isTrue();
         List<Class<?>> imports = Arrays.asList(KiePMMLParameterField.class, Collections.class);
         commonValidateCompilationWithImports(retrieved, imports);
     }

--- a/kie-pmml-trusty/kie-pmml-compiler/kie-pmml-compiler-commons/src/test/java/org/kie/pmml/compiler/commons/codegenfactories/KiePMMLRowFactoryTest.java
+++ b/kie-pmml-trusty/kie-pmml-compiler/kie-pmml-compiler-commons/src/test/java/org/kie/pmml/compiler/commons/codegenfactories/KiePMMLRowFactoryTest.java
@@ -35,7 +35,7 @@ import org.kie.pmml.commons.model.expressions.KiePMMLRow;
 import org.kie.pmml.compiler.commons.utils.JavaParserUtils;
 import org.kie.pmml.compiler.commons.utils.KiePMMLUtil;
 
-import static org.junit.Assert.assertTrue;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.kie.pmml.compiler.commons.testutils.CodegenTestUtils.commonValidateCompilationWithImports;
 import static org.kie.test.util.filesystem.FileUtils.getFileContent;
 import static org.kie.test.util.filesystem.FileUtils.getFileInputStream;
@@ -76,7 +76,7 @@ public class KiePMMLRowFactoryTest {
                                                                           MAPVALUED_ROW);
         String text = getFileContent(TEST_01_SOURCE);
         Statement expected = JavaParserUtils.parseBlock(String.format(text, variableName));
-        assertTrue(JavaParserUtils.equalsNode(expected, retrieved));
+        assertThat(retrieved).isEqualTo(expected);
         List<Class<?>> imports = Arrays.asList(Collectors.class, KiePMMLRow.class, Map.class, Stream.class);
         commonValidateCompilationWithImports(retrieved, imports);
     }
@@ -88,7 +88,7 @@ public class KiePMMLRowFactoryTest {
                                                                           DATAENCODED_ROW);
         String text = getFileContent(TEST_02_SOURCE);
         Statement expected = JavaParserUtils.parseBlock(String.format(text, variableName));
-        assertTrue(JavaParserUtils.equalsNode(expected, retrieved));
+        assertThat(retrieved).isEqualTo(expected);
         List<Class<?>> imports = Arrays.asList(Collectors.class, KiePMMLRow.class, Map.class, Stream.class);
         commonValidateCompilationWithImports(retrieved, imports);
     }

--- a/kie-pmml-trusty/kie-pmml-compiler/kie-pmml-compiler-commons/src/test/java/org/kie/pmml/compiler/commons/codegenfactories/KiePMMLRowFactoryTest.java
+++ b/kie-pmml-trusty/kie-pmml-compiler/kie-pmml-compiler-commons/src/test/java/org/kie/pmml/compiler/commons/codegenfactories/KiePMMLRowFactoryTest.java
@@ -76,7 +76,7 @@ public class KiePMMLRowFactoryTest {
                                                                           MAPVALUED_ROW);
         String text = getFileContent(TEST_01_SOURCE);
         Statement expected = JavaParserUtils.parseBlock(String.format(text, variableName));
-        assertThat(retrieved).isEqualTo(expected);
+        assertThat(JavaParserUtils.equalsNode(expected, retrieved)).isTrue();
         List<Class<?>> imports = Arrays.asList(Collectors.class, KiePMMLRow.class, Map.class, Stream.class);
         commonValidateCompilationWithImports(retrieved, imports);
     }
@@ -88,7 +88,7 @@ public class KiePMMLRowFactoryTest {
                                                                           DATAENCODED_ROW);
         String text = getFileContent(TEST_02_SOURCE);
         Statement expected = JavaParserUtils.parseBlock(String.format(text, variableName));
-        assertThat(retrieved).isEqualTo(expected);
+        assertThat(JavaParserUtils.equalsNode(expected, retrieved)).isTrue();
         List<Class<?>> imports = Arrays.asList(Collectors.class, KiePMMLRow.class, Map.class, Stream.class);
         commonValidateCompilationWithImports(retrieved, imports);
     }

--- a/kie-pmml-trusty/kie-pmml-compiler/kie-pmml-compiler-commons/src/test/java/org/kie/pmml/compiler/commons/codegenfactories/KiePMMLSimplePredicateFactoryTest.java
+++ b/kie-pmml-trusty/kie-pmml-compiler/kie-pmml-compiler-commons/src/test/java/org/kie/pmml/compiler/commons/codegenfactories/KiePMMLSimplePredicateFactoryTest.java
@@ -33,7 +33,7 @@ import org.kie.pmml.api.enums.OPERATOR;
 import org.kie.pmml.commons.model.predicates.KiePMMLSimplePredicate;
 import org.kie.pmml.compiler.commons.utils.JavaParserUtils;
 
-import static org.junit.Assert.assertTrue;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.kie.pmml.compiler.api.CommonTestingUtils.getFieldsFromDataDictionary;
 import static org.kie.pmml.compiler.commons.testutils.CodegenTestUtils.commonValidateCompilationWithImports;
 import static org.kie.test.util.filesystem.FileUtils.getFileContent;
@@ -62,7 +62,7 @@ public class KiePMMLSimplePredicateFactoryTest {
                                                                       simplePredicate.getField().getValue(),
                                                                       operatorString,
                                                                       simplePredicate.getValue()));
-        assertTrue(JavaParserUtils.equalsNode(expected, retrieved));
+        assertThat(JavaParserUtils.equalsNode(expected, retrieved)).isTrue();
         List<Class<?>> imports = Arrays.asList(KiePMMLSimplePredicate.class, Collections.class);
         commonValidateCompilationWithImports(retrieved, imports);
     }

--- a/kie-pmml-trusty/kie-pmml-compiler/kie-pmml-compiler-commons/src/test/java/org/kie/pmml/compiler/commons/codegenfactories/KiePMMLSimpleSetPredicateFactoryTest.java
+++ b/kie-pmml-trusty/kie-pmml-compiler/kie-pmml-compiler-commons/src/test/java/org/kie/pmml/compiler/commons/codegenfactories/KiePMMLSimpleSetPredicateFactoryTest.java
@@ -36,7 +36,7 @@ import org.kie.pmml.api.enums.IN_NOTIN;
 import org.kie.pmml.commons.model.predicates.KiePMMLSimpleSetPredicate;
 import org.kie.pmml.compiler.commons.utils.JavaParserUtils;
 
-import static org.junit.Assert.assertTrue;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.kie.pmml.compiler.api.testutils.PMMLModelTestUtils.getArray;
 import static org.kie.pmml.compiler.api.testutils.PMMLModelTestUtils.getStringObjects;
 import static org.kie.pmml.compiler.commons.testutils.CodegenTestUtils.commonValidateCompilationWithImports;
@@ -76,7 +76,7 @@ public class KiePMMLSimpleSetPredicateFactoryTest {
                                                                       arrayTypeString,
                                                                       booleanOperatorString,
                                                                       valuesString));
-        assertTrue(JavaParserUtils.equalsNode(expected, retrieved));
+        assertThat(JavaParserUtils.equalsNode(expected, retrieved)).isTrue();
         List<Class<?>> imports = Arrays.asList(KiePMMLSimpleSetPredicate.class, Arrays.class, Collections.class);
         commonValidateCompilationWithImports(retrieved, imports);
     }

--- a/kie-pmml-trusty/kie-pmml-compiler/kie-pmml-compiler-commons/src/test/java/org/kie/pmml/compiler/commons/codegenfactories/KiePMMLTargetFactoryTest.java
+++ b/kie-pmml-trusty/kie-pmml-compiler/kie-pmml-compiler-commons/src/test/java/org/kie/pmml/compiler/commons/codegenfactories/KiePMMLTargetFactoryTest.java
@@ -33,7 +33,7 @@ import org.kie.pmml.commons.model.KiePMMLTargetValue;
 import org.kie.pmml.compiler.api.utils.ModelUtils;
 import org.kie.pmml.compiler.commons.utils.JavaParserUtils;
 
-import static org.junit.Assert.assertTrue;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.kie.pmml.compiler.api.testutils.PMMLModelTestUtils.getRandomTarget;
 import static org.kie.pmml.compiler.commons.testutils.CodegenTestUtils.commonValidateCompilationWithImports;
 import static org.kie.test.util.filesystem.FileUtils.getFileContent;
@@ -71,7 +71,7 @@ public class KiePMMLTargetFactoryTest {
                                                                             kieTargetField.getMax(),
                                                                             kieTargetField.getRescaleConstant(),
                                                                             kieTargetField.getRescaleFactor()));
-        assertTrue(JavaParserUtils.equalsNode(expected, retrieved));
+        assertThat(JavaParserUtils.equalsNode(expected, retrieved)).isTrue();
         List<Class<?>> imports = Arrays.asList(Arrays.class, Collections.class, KiePMMLTarget.class,
                                                KiePMMLTargetValue.class, TargetField.class, TargetValue.class);
         commonValidateCompilationWithImports(retrieved, imports);

--- a/kie-pmml-trusty/kie-pmml-compiler/kie-pmml-compiler-commons/src/test/java/org/kie/pmml/compiler/commons/codegenfactories/KiePMMLTargetValueFactoryTest.java
+++ b/kie-pmml-trusty/kie-pmml-compiler/kie-pmml-compiler-commons/src/test/java/org/kie/pmml/compiler/commons/codegenfactories/KiePMMLTargetValueFactoryTest.java
@@ -28,7 +28,7 @@ import org.kie.pmml.api.models.TargetValue;
 import org.kie.pmml.commons.model.KiePMMLTargetValue;
 import org.kie.pmml.compiler.commons.utils.JavaParserUtils;
 
-import static org.junit.Assert.assertTrue;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.kie.pmml.compiler.api.testutils.PMMLModelTestUtils.getRandomTargetValue;
 import static org.kie.pmml.compiler.api.utils.ModelUtils.convertToKieTargetValue;
 import static org.kie.pmml.compiler.commons.testutils.CodegenTestUtils.commonValidateCompilationWithImports;
@@ -48,7 +48,7 @@ public class KiePMMLTargetValueFactoryTest {
                                                                             targetValue.getDisplayValue(),
                                                                             targetValue.getPriorProbability(),
                                                                             targetValue.getDefaultValue()));
-        assertTrue(JavaParserUtils.equalsNode(expected, retrieved));
+        assertThat(retrieved).isEqualTo(expected);
         List<Class<?>> imports = Arrays.asList(Arrays.class, Collections.class, KiePMMLTargetValue.class, TargetValue.class);
         commonValidateCompilationWithImports(retrieved, imports);
     }

--- a/kie-pmml-trusty/kie-pmml-compiler/kie-pmml-compiler-commons/src/test/java/org/kie/pmml/compiler/commons/codegenfactories/KiePMMLTargetValueFactoryTest.java
+++ b/kie-pmml-trusty/kie-pmml-compiler/kie-pmml-compiler-commons/src/test/java/org/kie/pmml/compiler/commons/codegenfactories/KiePMMLTargetValueFactoryTest.java
@@ -48,7 +48,7 @@ public class KiePMMLTargetValueFactoryTest {
                                                                             targetValue.getDisplayValue(),
                                                                             targetValue.getPriorProbability(),
                                                                             targetValue.getDefaultValue()));
-        assertThat(retrieved).isEqualTo(expected);
+        assertThat(JavaParserUtils.equalsNode(expected, retrieved)).isTrue();
         List<Class<?>> imports = Arrays.asList(Arrays.class, Collections.class, KiePMMLTargetValue.class, TargetValue.class);
         commonValidateCompilationWithImports(retrieved, imports);
     }

--- a/kie-pmml-trusty/kie-pmml-compiler/kie-pmml-compiler-commons/src/test/java/org/kie/pmml/compiler/commons/codegenfactories/KiePMMLTextIndexFactoryTest.java
+++ b/kie-pmml-trusty/kie-pmml-compiler/kie-pmml-compiler-commons/src/test/java/org/kie/pmml/compiler/commons/codegenfactories/KiePMMLTextIndexFactoryTest.java
@@ -39,7 +39,7 @@ import org.kie.pmml.commons.model.expressions.KiePMMLTextIndexNormalization;
 import org.kie.pmml.compiler.commons.utils.JavaParserUtils;
 import org.kie.pmml.compiler.commons.utils.KiePMMLUtil;
 
-import static org.junit.Assert.assertTrue;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.kie.pmml.compiler.commons.testutils.CodegenTestUtils.commonValidateCompilationWithImports;
 import static org.kie.test.util.filesystem.FileUtils.getFileContent;
 import static org.kie.test.util.filesystem.FileUtils.getFileInputStream;
@@ -71,7 +71,7 @@ public class KiePMMLTextIndexFactoryTest {
         String text = getFileContent(TEST_01_SOURCE);
         Statement expected = JavaParserUtils.parseBlock(String.format(text, variableName,
                                                                       TEXTINDEX.getTextField().getValue()));
-        assertTrue(JavaParserUtils.equalsNode(expected, retrieved));
+        assertThat(JavaParserUtils.equalsNode(expected, retrieved)).isTrue();
         List<Class<?>> imports = Arrays.asList(Arrays.class, Collections.class, Collectors.class,
                                                KiePMMLFieldRef.class, KiePMMLInlineTable.class,
                                                KiePMMLTextIndex.class, KiePMMLTextIndexNormalization.class,

--- a/kie-pmml-trusty/kie-pmml-compiler/kie-pmml-compiler-commons/src/test/java/org/kie/pmml/compiler/commons/codegenfactories/KiePMMLTextIndexNormalizationFactoryTest.java
+++ b/kie-pmml-trusty/kie-pmml-compiler/kie-pmml-compiler-commons/src/test/java/org/kie/pmml/compiler/commons/codegenfactories/KiePMMLTextIndexNormalizationFactoryTest.java
@@ -38,7 +38,7 @@ import org.kie.pmml.commons.model.expressions.KiePMMLTextIndexNormalization;
 import org.kie.pmml.compiler.commons.utils.JavaParserUtils;
 import org.kie.pmml.compiler.commons.utils.KiePMMLUtil;
 
-import static org.junit.Assert.assertTrue;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.kie.pmml.compiler.commons.testutils.CodegenTestUtils.commonValidateCompilationWithImports;
 import static org.kie.test.util.filesystem.FileUtils.getFileContent;
 import static org.kie.test.util.filesystem.FileUtils.getFileInputStream;
@@ -71,7 +71,7 @@ public class KiePMMLTextIndexNormalizationFactoryTest {
                                                                                                                 TEXTINDEXNORMALIZATION);
         String text = getFileContent(TEST_01_SOURCE);
         Statement expected = JavaParserUtils.parseBlock(String.format(text, variableName));
-        assertTrue(JavaParserUtils.equalsNode(expected, retrieved));
+        assertThat(retrieved).isEqualTo(expected);
         List<Class<?>> imports = Arrays.asList(Arrays.class, Collections.class, Collectors.class,
                                                KiePMMLInlineTable.class, KiePMMLTextIndexNormalization.class,
                                                KiePMMLRow.class, Map.class, Stream.class);

--- a/kie-pmml-trusty/kie-pmml-compiler/kie-pmml-compiler-commons/src/test/java/org/kie/pmml/compiler/commons/codegenfactories/KiePMMLTextIndexNormalizationFactoryTest.java
+++ b/kie-pmml-trusty/kie-pmml-compiler/kie-pmml-compiler-commons/src/test/java/org/kie/pmml/compiler/commons/codegenfactories/KiePMMLTextIndexNormalizationFactoryTest.java
@@ -71,7 +71,7 @@ public class KiePMMLTextIndexNormalizationFactoryTest {
                                                                                                                 TEXTINDEXNORMALIZATION);
         String text = getFileContent(TEST_01_SOURCE);
         Statement expected = JavaParserUtils.parseBlock(String.format(text, variableName));
-        assertThat(retrieved).isEqualTo(expected);
+        assertThat(JavaParserUtils.equalsNode(expected, retrieved)).isTrue();
         List<Class<?>> imports = Arrays.asList(Arrays.class, Collections.class, Collectors.class,
                                                KiePMMLInlineTable.class, KiePMMLTextIndexNormalization.class,
                                                KiePMMLRow.class, Map.class, Stream.class);

--- a/kie-pmml-trusty/kie-pmml-compiler/kie-pmml-compiler-commons/src/test/java/org/kie/pmml/compiler/commons/codegenfactories/KiePMMLTransformationDictionaryFactoryTest.java
+++ b/kie-pmml-trusty/kie-pmml-compiler/kie-pmml-compiler-commons/src/test/java/org/kie/pmml/compiler/commons/codegenfactories/KiePMMLTransformationDictionaryFactoryTest.java
@@ -44,7 +44,7 @@ import org.kie.pmml.commons.transformations.KiePMMLParameterField;
 import org.kie.pmml.commons.transformations.KiePMMLTransformationDictionary;
 import org.kie.pmml.compiler.commons.utils.JavaParserUtils;
 
-import static org.junit.Assert.assertTrue;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.kie.pmml.compiler.commons.testutils.CodegenTestUtils.commonValidateCompilationWithImports;
 import static org.kie.test.util.filesystem.FileUtils.getFileContent;
 
@@ -66,7 +66,7 @@ public class KiePMMLTransformationDictionaryFactoryTest {
                 KiePMMLTransformationDictionaryFactory.getKiePMMLTransformationDictionaryVariableDeclaration(transformationDictionary);
         String text = getFileContent(TEST_01_SOURCE);
         Statement expected = JavaParserUtils.parseBlock(text);
-        assertTrue(JavaParserUtils.equalsNode(expected, retrieved));
+        assertThat(JavaParserUtils.equalsNode(expected, retrieved)).isTrue();
         List<Class<?>> imports = Arrays.asList(KiePMMLParameterField.class,
                                                KiePMMLConstant.class,
                                                KiePMMLFieldRef.class,

--- a/kie-pmml-trusty/kie-pmml-compiler/kie-pmml-compiler-commons/src/test/java/org/kie/pmml/compiler/commons/codegenfactories/KiePMMLTruePredicateFactoryTest.java
+++ b/kie-pmml-trusty/kie-pmml-compiler/kie-pmml-compiler-commons/src/test/java/org/kie/pmml/compiler/commons/codegenfactories/KiePMMLTruePredicateFactoryTest.java
@@ -28,7 +28,7 @@ import org.junit.Test;
 import org.kie.pmml.commons.model.predicates.KiePMMLTruePredicate;
 import org.kie.pmml.compiler.commons.utils.JavaParserUtils;
 
-import static org.junit.Assert.assertTrue;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.kie.pmml.compiler.commons.testutils.CodegenTestUtils.commonValidateCompilationWithImports;
 import static org.kie.test.util.filesystem.FileUtils.getFileContent;
 
@@ -42,7 +42,7 @@ public class KiePMMLTruePredicateFactoryTest {
         BlockStmt retrieved = KiePMMLTruePredicateFactory.getTruePredicateVariableDeclaration(variableName, new True());
         String text = getFileContent(TEST_01_SOURCE);
         Statement expected = JavaParserUtils.parseBlock(String.format(text, variableName));
-        assertTrue(JavaParserUtils.equalsNode(expected, retrieved));
+        assertThat(retrieved).isEqualTo(expected);
         List<Class<?>> imports = Arrays.asList(KiePMMLTruePredicate.class, Collections.class);
         commonValidateCompilationWithImports(retrieved, imports);
     }

--- a/kie-pmml-trusty/kie-pmml-compiler/kie-pmml-compiler-commons/src/test/java/org/kie/pmml/compiler/commons/codegenfactories/KiePMMLTruePredicateFactoryTest.java
+++ b/kie-pmml-trusty/kie-pmml-compiler/kie-pmml-compiler-commons/src/test/java/org/kie/pmml/compiler/commons/codegenfactories/KiePMMLTruePredicateFactoryTest.java
@@ -42,7 +42,7 @@ public class KiePMMLTruePredicateFactoryTest {
         BlockStmt retrieved = KiePMMLTruePredicateFactory.getTruePredicateVariableDeclaration(variableName, new True());
         String text = getFileContent(TEST_01_SOURCE);
         Statement expected = JavaParserUtils.parseBlock(String.format(text, variableName));
-        assertThat(retrieved).isEqualTo(expected);
+        assertThat(JavaParserUtils.equalsNode(expected, retrieved)).isTrue();
         List<Class<?>> imports = Arrays.asList(KiePMMLTruePredicate.class, Collections.class);
         commonValidateCompilationWithImports(retrieved, imports);
     }

--- a/kie-pmml-trusty/kie-pmml-compiler/kie-pmml-compiler-commons/src/test/java/org/kie/pmml/compiler/commons/codegenfactories/TargetFieldFactoryTest.java
+++ b/kie-pmml-trusty/kie-pmml-compiler/kie-pmml-compiler-commons/src/test/java/org/kie/pmml/compiler/commons/codegenfactories/TargetFieldFactoryTest.java
@@ -32,7 +32,7 @@ import org.kie.pmml.commons.model.KiePMMLTargetValue;
 import org.kie.pmml.compiler.api.utils.ModelUtils;
 import org.kie.pmml.compiler.commons.utils.JavaParserUtils;
 
-import static org.junit.Assert.*;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.kie.pmml.compiler.api.testutils.PMMLModelTestUtils.getRandomTarget;
 import static org.kie.pmml.compiler.commons.testutils.CodegenTestUtils.commonValidateCompilationWithImports;
 import static org.kie.test.util.filesystem.FileUtils.getFileContent;
@@ -69,8 +69,8 @@ public class TargetFieldFactoryTest {
                                                                             kieTargetField.getMax(),
                                                                             kieTargetField.getRescaleConstant(),
                                                                             kieTargetField.getRescaleFactor()));
-        assertEquals(expected.toString(), retrieved.toString());
-        assertTrue(JavaParserUtils.equalsNode(expected, retrieved));
+        assertThat(retrieved.toString()).isEqualTo(expected.toString());
+        assertThat(JavaParserUtils.equalsNode(expected, retrieved)).isTrue();
         List<Class<?>> imports = Arrays.asList(Arrays.class, Collections.class, KiePMMLTarget.class,
                                                KiePMMLTargetValue.class, TargetField.class, TargetValue.class);
         commonValidateCompilationWithImports(retrieved, imports);

--- a/kie-pmml-trusty/kie-pmml-compiler/kie-pmml-compiler-commons/src/test/java/org/kie/pmml/compiler/commons/codegenfactories/TargetValueFactoryTest.java
+++ b/kie-pmml-trusty/kie-pmml-compiler/kie-pmml-compiler-commons/src/test/java/org/kie/pmml/compiler/commons/codegenfactories/TargetValueFactoryTest.java
@@ -27,7 +27,7 @@ import org.kie.pmml.api.models.TargetValue;
 import org.kie.pmml.commons.model.KiePMMLTargetValue;
 import org.kie.pmml.compiler.commons.utils.JavaParserUtils;
 
-import static org.junit.Assert.assertTrue;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.kie.pmml.compiler.api.testutils.PMMLModelTestUtils.getRandomTargetValue;
 import static org.kie.pmml.compiler.api.utils.ModelUtils.convertToKieTargetValue;
 import static org.kie.pmml.compiler.commons.testutils.CodegenTestUtils.commonValidateCompilationWithImports;
@@ -47,7 +47,7 @@ public class TargetValueFactoryTest {
                                                                             targetValue.getDisplayValue(),
                                                                             targetValue.getPriorProbability(),
                                                                             targetValue.getDefaultValue()));
-        assertTrue(JavaParserUtils.equalsNode(expected, retrieved));
+        assertThat(retrieved).isEqualTo(expected);
         List<Class<?>> imports = Arrays.asList(Arrays.class, Collections.class, KiePMMLTargetValue.class,
                                                TargetValue.class);
         commonValidateCompilationWithImports(retrieved, imports);

--- a/kie-pmml-trusty/kie-pmml-compiler/kie-pmml-compiler-commons/src/test/java/org/kie/pmml/compiler/commons/codegenfactories/TargetValueFactoryTest.java
+++ b/kie-pmml-trusty/kie-pmml-compiler/kie-pmml-compiler-commons/src/test/java/org/kie/pmml/compiler/commons/codegenfactories/TargetValueFactoryTest.java
@@ -47,7 +47,7 @@ public class TargetValueFactoryTest {
                                                                             targetValue.getDisplayValue(),
                                                                             targetValue.getPriorProbability(),
                                                                             targetValue.getDefaultValue()));
-        assertThat(retrieved).isEqualTo(expected);
+        assertThat(JavaParserUtils.equalsNode(expected, retrieved)).isTrue();
         List<Class<?>> imports = Arrays.asList(Arrays.class, Collections.class, KiePMMLTargetValue.class,
                                                TargetValue.class);
         commonValidateCompilationWithImports(retrieved, imports);

--- a/kie-pmml-trusty/kie-pmml-compiler/kie-pmml-compiler-commons/src/test/java/org/kie/pmml/compiler/commons/factories/InstanceFactoriesTestCommon.java
+++ b/kie-pmml-trusty/kie-pmml-compiler/kie-pmml-compiler-commons/src/test/java/org/kie/pmml/compiler/commons/factories/InstanceFactoriesTestCommon.java
@@ -167,7 +167,7 @@ public class InstanceFactoriesTestCommon {
     static void commonVerifyKKiePMMLCompoundPredicate(KiePMMLCompoundPredicate toVerify, CompoundPredicate source) {
         assertThat(toVerify).isNotNull();
         assertThat(toVerify.getBooleanOperator().getName()).isEqualTo(source.getBooleanOperator().value());
-        assertThat(toVerify.getKiePMMLPredicates()).hasSize(source.getPredicates().size());
+        assertThat(toVerify.getKiePMMLPredicates()).hasSameSizeAs(source.getPredicates());
         IntStream.range(0, source.getPredicates().size()).forEach(i -> {
             commonVerifyKiePMMLPredicate(toVerify.getKiePMMLPredicates().get(i), source.getPredicates().get(i));
         });
@@ -262,7 +262,7 @@ public class InstanceFactoriesTestCommon {
         assertThat(toVerify.getDefaultValue()).isEqualTo(source.getDefaultValue());
         assertThat(toVerify.getInvalidValueTreatmentMethod().getName()).isEqualTo(source.getInvalidValueTreatment().value());
         List<KiePMMLExpression> kiePMMLExpressionList = toVerify.getKiePMMLExpressions();
-        assertThat(kiePMMLExpressionList).hasSize(source.getExpressions().size());
+        assertThat(kiePMMLExpressionList).hasSameSizeAs(source.getExpressions());
         IntStream.range(0, source.getExpressions().size()).forEach(i -> commonVerifyKiePMMLExpression(kiePMMLExpressionList.get(i), source.getExpressions().get(i)));
     }
 
@@ -277,7 +277,7 @@ public class InstanceFactoriesTestCommon {
         assertThat(toVerify.getMapMissingTo()).isEqualTo(source.getMapMissingTo());
         assertThat(toVerify.getDefaultValue()).isEqualTo(source.getDefaultValue());
         assertThat(toVerify.getDataType().getName()).isEqualTo(source.getDataType().value());
-        assertThat(toVerify.getDiscretizeBins()).hasSize(source.getDiscretizeBins().size());
+        assertThat(toVerify.getDiscretizeBins()).hasSameSizeAs(source.getDiscretizeBins());
         IntStream.range(0, source.getDiscretizeBins().size()).forEach(i -> commonVerifyKiePMMLDiscretizeBin(toVerify.getDiscretizeBins().get(i), source.getDiscretizeBins().get(i)));
     }
 
@@ -294,7 +294,7 @@ public class InstanceFactoriesTestCommon {
         assertThat(toVerify.getDefaultValue()).isEqualTo(source.getDefaultValue().toString());
         assertThat(toVerify.getDataType().getName()).isEqualTo(source.getDataType().value());
         commonVerifyKiePMMLInlineTableWithCells(toVerify.getInlineTable(), source.getInlineTable());
-        assertThat(toVerify.getFieldColumnPairs()).hasSize(source.getFieldColumnPairs().size());
+        assertThat(toVerify.getFieldColumnPairs()).hasSameSizeAs(source.getFieldColumnPairs());
         IntStream.range(0, source.getFieldColumnPairs().size()).forEach(i -> commonVerifyKiePMMLFieldColumnPair(toVerify.getFieldColumnPairs().get(i), source.getFieldColumnPairs().get(i)));
     }
 
@@ -322,7 +322,7 @@ public class InstanceFactoriesTestCommon {
         assertThat(toVerify.getCountHits().getName()).isEqualTo(source.getCountHits().value());
         assertThat(toVerify.getWordSeparatorCharacterRE()).isEqualTo(StringEscapeUtils.escapeJava(source.getWordSeparatorCharacterRE()));
         commonVerifyKiePMMLExpression(toVerify.getExpression(), source.getExpression());
-        assertThat(toVerify.getTextIndexNormalizations()).hasSize(source.getTextIndexNormalizations().size());
+        assertThat(toVerify.getTextIndexNormalizations()).hasSameSizeAs(source.getTextIndexNormalizations());
         IntStream.range(0, source.getTextIndexNormalizations().size()).forEach(i -> {
             commonVerifyKiePMMLTextIndexNormalization(toVerify.getTextIndexNormalizations().get(i),
                                                       source.getTextIndexNormalizations().get(i));
@@ -353,7 +353,7 @@ public class InstanceFactoriesTestCommon {
 
     static void commonVerifyKiePMMLInlineTableWithCells(KiePMMLInlineTable toVerify, InlineTable source) {
         assertThat(toVerify).isNotNull();
-        assertThat(toVerify.getRows()).hasSize(source.getRows().size());
+        assertThat(toVerify.getRows()).hasSameSizeAs(source.getRows());
         IntStream.range(0, source.getRows().size()).forEach(i -> commonVerifyKiePMMLRowWithCells(toVerify.getRows().get(i), source.getRows().get(i)));
     }
 
@@ -392,7 +392,7 @@ public class InstanceFactoriesTestCommon {
 
     static void commonVerifyKiePMMLTarget(KiePMMLTarget toVerify, Target source) {
         assertThat(toVerify).isNotNull();
-        assertThat(source.getTargetValues()).hasSize(toVerify.getTargetValues().size());
+        assertThat(source.getTargetValues()).hasSameSizeAs(toVerify.getTargetValues());
         OP_TYPE expectedOpType = OP_TYPE.byName(source.getOpType().value());
         assertThat(toVerify.getOpType()).isEqualTo(expectedOpType);
         assertThat(toVerify.getField()).isEqualTo(source.getField().getValue());
@@ -413,7 +413,7 @@ public class InstanceFactoriesTestCommon {
     static void commonVerifyKiePMMLRowWithCells(KiePMMLRow toVerify,
                                                 Row source) {
         assertThat(toVerify).isNotNull();
-        assertThat(toVerify.getColumnValues().size()).isEqualTo(2);
+        assertThat(toVerify.getColumnValues()).hasSize(2);
     }
 
     static void commonVerifyKiePMMLTargetValue(KiePMMLTargetValue toVerify,

--- a/kie-pmml-trusty/kie-pmml-compiler/kie-pmml-compiler-commons/src/test/java/org/kie/pmml/compiler/commons/factories/InstanceFactoriesTestCommon.java
+++ b/kie-pmml-trusty/kie-pmml-compiler/kie-pmml-compiler-commons/src/test/java/org/kie/pmml/compiler/commons/factories/InstanceFactoriesTestCommon.java
@@ -20,6 +20,7 @@ import java.util.Optional;
 import java.util.stream.IntStream;
 
 import org.apache.commons.text.StringEscapeUtils;
+import org.assertj.core.data.Offset;
 import org.dmg.pmml.Apply;
 import org.dmg.pmml.Array;
 import org.dmg.pmml.CompoundPredicate;
@@ -86,9 +87,7 @@ import org.kie.pmml.commons.transformations.KiePMMLDerivedField;
 import org.kie.pmml.commons.transformations.KiePMMLParameterField;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
+import static org.assertj.core.api.Assertions.fail;
 import static org.kie.pmml.commons.Constants.EXPRESSION_NOT_MANAGED;
 
 /**
@@ -99,20 +98,20 @@ public class InstanceFactoriesTestCommon {
     static void commonVerifyKiePMMLDefineFunction(KiePMMLDefineFunction toVerify,
                                                   DefineFunction source) {
         assertThat(toVerify).isNotNull();
-        assertEquals(source.getName(), toVerify.getName());
+        assertThat(toVerify.getName()).isEqualTo(source.getName());
         DATA_TYPE expectedDataType = DATA_TYPE.byName(source.getDataType().value());
-        assertEquals(expectedDataType, toVerify.getDataType());
+        assertThat(toVerify.getDataType()).isEqualTo(expectedDataType);
         OP_TYPE expectedOpType = OP_TYPE.byName(source.getOpType().value());
-        assertEquals(expectedOpType, toVerify.getOpType());
+        assertThat(toVerify.getOpType()).isEqualTo(expectedOpType);
         commonVerifyKiePMMLExpression(toVerify.getKiePMMLExpression(), source.getExpression());
         List<ParameterField> sourcesParameterFields = source.getParameterFields();
         List<KiePMMLParameterField> toVerifyList = toVerify.getParameterFields();
-        assertEquals(sourcesParameterFields.size(), toVerifyList.size());
+        assertThat(toVerifyList).hasSameSizeAs(sourcesParameterFields);
         sourcesParameterFields.forEach(paramSource -> {
             Optional<KiePMMLParameterField> parameterToVerify =
                     toVerifyList.stream().filter(param -> param.getName().equals(paramSource.getName().getValue()))
                             .findFirst();
-            assertTrue(parameterToVerify.isPresent());
+            assertThat(parameterToVerify).isPresent();
             commonVerifyKiePMMLParameterField(parameterToVerify.get(), paramSource);
         });
     }
@@ -120,25 +119,25 @@ public class InstanceFactoriesTestCommon {
     static void commonVerifyKiePMMLDerivedField(KiePMMLDerivedField toVerify,
                                                 DerivedField source) {
         assertThat(toVerify).isNotNull();
-        assertEquals(source.getName().getValue(), toVerify.getName());
+        assertThat(toVerify.getName()).isEqualTo(source.getName().getValue());
         DATA_TYPE expectedDataType = DATA_TYPE.byName(source.getDataType().value());
-        assertEquals(expectedDataType, toVerify.getDataType());
+        assertThat(toVerify.getDataType()).isEqualTo(expectedDataType);
         OP_TYPE expectedOpType = OP_TYPE.byName(source.getOpType().value());
-        assertEquals(expectedOpType, toVerify.getOpType());
+        assertThat(toVerify.getOpType()).isEqualTo(expectedOpType);
         String expectedDisplayName = "Display-" + source.getName().getValue();
-        assertEquals(expectedDisplayName, toVerify.getDisplayName());
+        assertThat(toVerify.getDisplayName()).isEqualTo(expectedDisplayName);
         commonVerifyKiePMMLExpression(toVerify.getKiePMMLExpression(), source.getExpression());
     }
 
     static void commonVerifyKiePMMLParameterField(KiePMMLParameterField toVerify, ParameterField source) {
         assertThat(toVerify).isNotNull();
-        assertEquals(source.getName().getValue(), toVerify.getName());
+        assertThat(toVerify.getName()).isEqualTo(source.getName().getValue());
         DATA_TYPE expectedDataType = DATA_TYPE.byName(source.getDataType().value());
-        assertEquals(expectedDataType, toVerify.getDataType());
+        assertThat(toVerify.getDataType()).isEqualTo(expectedDataType);
         OP_TYPE expectedOpType = OP_TYPE.byName(source.getOpType().value());
-        assertEquals(expectedOpType, toVerify.getOpType());
+        assertThat(toVerify.getOpType()).isEqualTo(expectedOpType);
         String expectedDisplayName = "Display-" + source.getName().getValue();
-        assertEquals(expectedDisplayName, toVerify.getDisplayName());
+        assertThat(toVerify.getDisplayName()).isEqualTo(expectedDisplayName);
     }
 
     // Predicates
@@ -167,8 +166,8 @@ public class InstanceFactoriesTestCommon {
 
     static void commonVerifyKKiePMMLCompoundPredicate(KiePMMLCompoundPredicate toVerify, CompoundPredicate source) {
         assertThat(toVerify).isNotNull();
-        assertEquals(source.getBooleanOperator().value(), toVerify.getBooleanOperator().getName());
-        assertEquals(source.getPredicates().size(), toVerify.getKiePMMLPredicates().size());
+        assertThat(toVerify.getBooleanOperator().getName()).isEqualTo(source.getBooleanOperator().value());
+        assertThat(toVerify.getKiePMMLPredicates()).hasSize(source.getPredicates().size());
         IntStream.range(0, source.getPredicates().size()).forEach(i -> {
             commonVerifyKiePMMLPredicate(toVerify.getKiePMMLPredicates().get(i), source.getPredicates().get(i));
         });
@@ -182,36 +181,36 @@ public class InstanceFactoriesTestCommon {
                                                    DataField dataField) {
         assertThat(toVerify).isNotNull();
         Object value = DATA_TYPE.byName(dataField.getDataType().value()).getActualValue(source.getValue());
-        assertEquals(source.getField().getValue(), toVerify.getName());
-        assertEquals(value, toVerify.getValue());
-        assertEquals(source.getOperator().value(), toVerify.getOperator().getName());
+        assertThat(toVerify.getName()).isEqualTo(source.getField().getValue());
+        assertThat(toVerify.getValue()).isEqualTo(value);
+        assertThat(toVerify.getOperator().getName()).isEqualTo(source.getOperator().value());
     }
 
     static void commonVerifyKiePMMLSimplePredicate(KiePMMLSimplePredicate toVerify, SimplePredicate source) {
         assertThat(toVerify).isNotNull();
-        assertEquals(source.getField().getValue(), toVerify.getName());
-        assertEquals(source.getOperator().value(), toVerify.getOperator().getName());
+        assertThat(toVerify.getName()).isEqualTo(source.getField().getValue());
+        assertThat(toVerify.getOperator().getName()).isEqualTo(source.getOperator().value());
     }
 
     static void commonVerifyKiePMMLSimpleSetPredicate(KiePMMLSimpleSetPredicate toVerify, SimpleSetPredicate source) {
         assertThat(toVerify).isNotNull();
-        assertEquals(source.getField().getValue(), toVerify.getName());
+        assertThat(toVerify.getName()).isEqualTo(source.getField().getValue());
         Array array = source.getArray();
-        assertEquals(array.getType().value(), toVerify.getArrayType().getName());
-        assertEquals(source.getBooleanOperator().value(), toVerify.getInNotIn().getName());
-        assertEquals(array.getN().intValue(), toVerify.getValues().size());
+        assertThat(toVerify.getArrayType().getName()).isEqualTo(array.getType().value());
+        assertThat(toVerify.getInNotIn().getName()).isEqualTo(source.getBooleanOperator().value());
+        assertThat(toVerify.getValues()).hasSize(array.getN().intValue());
         String stringValue = (String) array.getValue();
         String[] valuesArray = stringValue.split(" ");
         IntStream.range(0, array.getN()).forEach(i -> {
             switch (array.getType()) {
                 case INT:
-                    assertEquals(Integer.valueOf(valuesArray[i]), toVerify.getValues().get(i));
+                    assertThat(toVerify.getValues().get(i)).isEqualTo(Integer.valueOf(valuesArray[i]));
                     break;
                 case STRING:
-                    assertEquals(valuesArray[i], toVerify.getValues().get(i));
+                    assertThat(toVerify.getValues().get(i)).isEqualTo(valuesArray[i]);
                     break;
                 case REAL:
-                    assertEquals(Double.valueOf(valuesArray[i]), toVerify.getValues().get(i));
+                    assertThat(toVerify.getValues().get(i)).isEqualTo(Double.valueOf(valuesArray[i]));
                     break;
                 default:
                     throw new KiePMMLException("Unknown Array " + array.getType());
@@ -258,81 +257,79 @@ public class InstanceFactoriesTestCommon {
 
     static void commonVerifyKiePMMLApply(KiePMMLApply toVerify, Apply source) {
         assertThat(toVerify).isNotNull();
-        assertEquals(source.getFunction(), toVerify.getFunction());
-        assertEquals(source.getMapMissingTo(), toVerify.getMapMissingTo());
-        assertEquals(source.getDefaultValue(), toVerify.getDefaultValue());
-        assertEquals(source.getInvalidValueTreatment().value(),
-                     toVerify.getInvalidValueTreatmentMethod().getName());
+        assertThat(toVerify.getFunction()).isEqualTo(source.getFunction());
+        assertThat(toVerify.getMapMissingTo()).isEqualTo(source.getMapMissingTo());
+        assertThat(toVerify.getDefaultValue()).isEqualTo(source.getDefaultValue());
+        assertThat(toVerify.getInvalidValueTreatmentMethod().getName()).isEqualTo(source.getInvalidValueTreatment().value());
         List<KiePMMLExpression> kiePMMLExpressionList = toVerify.getKiePMMLExpressions();
-        assertEquals(source.getExpressions().size(), kiePMMLExpressionList.size());
+        assertThat(kiePMMLExpressionList).hasSize(source.getExpressions().size());
         IntStream.range(0, source.getExpressions().size()).forEach(i -> commonVerifyKiePMMLExpression(kiePMMLExpressionList.get(i), source.getExpressions().get(i)));
     }
 
     static void commonVerifyKiePMMLConstant(KiePMMLConstant toVerify, Constant source) {
         assertThat(toVerify).isNotNull();
-        assertEquals(source.getValue(), toVerify.getValue());
+        assertThat(toVerify.getValue()).isEqualTo(source.getValue());
     }
 
     static void commonVerifyKiePMMLDiscretize(KiePMMLDiscretize toVerify, Discretize source) {
         assertThat(toVerify).isNotNull();
-        assertEquals(source.getField().getValue(), toVerify.getName());
-        assertEquals(source.getMapMissingTo(), toVerify.getMapMissingTo());
-        assertEquals(source.getDefaultValue(), toVerify.getDefaultValue());
-        assertEquals(source.getDataType().value(), toVerify.getDataType().getName());
-        assertEquals(source.getDiscretizeBins().size(), toVerify.getDiscretizeBins().size());
+        assertThat(toVerify.getName()).isEqualTo(source.getField().getValue());
+        assertThat(toVerify.getMapMissingTo()).isEqualTo(source.getMapMissingTo());
+        assertThat(toVerify.getDefaultValue()).isEqualTo(source.getDefaultValue());
+        assertThat(toVerify.getDataType().getName()).isEqualTo(source.getDataType().value());
+        assertThat(toVerify.getDiscretizeBins()).hasSize(source.getDiscretizeBins().size());
         IntStream.range(0, source.getDiscretizeBins().size()).forEach(i -> commonVerifyKiePMMLDiscretizeBin(toVerify.getDiscretizeBins().get(i), source.getDiscretizeBins().get(i)));
     }
 
     static void commonVerifyKiePMMLFieldRef(KiePMMLFieldRef toVerify, FieldRef source) {
         assertThat(toVerify).isNotNull();
-        assertEquals(source.getField().getValue(), toVerify.getName());
-        assertEquals(source.getMapMissingTo(), toVerify.getMapMissingTo());
+        assertThat(toVerify.getName()).isEqualTo(source.getField().getValue());
+        assertThat(toVerify.getMapMissingTo()).isEqualTo(source.getMapMissingTo());
     }
 
     static void commonVerifyKiePMMLMapValues(KiePMMLMapValues toVerify, MapValues source) {
         assertThat(toVerify).isNotNull();
-        assertEquals(source.getOutputColumn(), toVerify.getOutputColumn());
-        assertEquals(source.getMapMissingTo(), toVerify.getMapMissingTo());
-        assertEquals(source.getDefaultValue().toString(), toVerify.getDefaultValue());
-        assertEquals(source.getDataType().value(), toVerify.getDataType().getName());
+        assertThat(toVerify.getOutputColumn()).isEqualTo(source.getOutputColumn());
+        assertThat(toVerify.getMapMissingTo()).isEqualTo(source.getMapMissingTo());
+        assertThat(toVerify.getDefaultValue()).isEqualTo(source.getDefaultValue().toString());
+        assertThat(toVerify.getDataType().getName()).isEqualTo(source.getDataType().value());
         commonVerifyKiePMMLInlineTableWithCells(toVerify.getInlineTable(), source.getInlineTable());
-        assertEquals(source.getFieldColumnPairs().size(), toVerify.getFieldColumnPairs().size());
+        assertThat(toVerify.getFieldColumnPairs()).hasSize(source.getFieldColumnPairs().size());
         IntStream.range(0, source.getFieldColumnPairs().size()).forEach(i -> commonVerifyKiePMMLFieldColumnPair(toVerify.getFieldColumnPairs().get(i), source.getFieldColumnPairs().get(i)));
     }
 
     static void commonVerifyKiePMMLNormContinuous(KiePMMLNormContinuous toVerify, NormContinuous source) {
         assertThat(toVerify).isNotNull();
-        assertEquals(source.getOutliers().value(), toVerify.getOutlierTreatmentMethod().getName());
-        assertEquals(source.getMapMissingTo(), toVerify.getMapMissingTo());
+        assertThat(toVerify.getOutlierTreatmentMethod().getName()).isEqualTo(source.getOutliers().value());
+        assertThat(toVerify.getMapMissingTo()).isEqualTo(source.getMapMissingTo());
         final List<LinearNorm> toConvertLinearNorms = source.getLinearNorms();
         sortLinearNorms(toConvertLinearNorms);
         final List<KiePMMLLinearNorm> retrievedLinearNorms = toVerify.getLinearNorms();
-        assertEquals(toConvertLinearNorms.size(), retrievedLinearNorms.size());
+        assertThat(retrievedLinearNorms).hasSameSizeAs(toConvertLinearNorms);
         IntStream.range(0, toConvertLinearNorms.size()).forEach(i -> commonVerifyKiePMMLLinearNorm(retrievedLinearNorms.get(i), toConvertLinearNorms.get(i)));
     }
 
     static void commonVerifyKiePMMLNormDiscrete(KiePMMLNormDiscrete toVerify, NormDiscrete source) {
         assertThat(toVerify).isNotNull();
-        assertEquals(source.getField().getValue(), toVerify.getName());
-        assertEquals(source.getMapMissingTo(), toVerify.getMapMissingTo());
-        assertEquals(source.getValue().toString(), toVerify.getValue());
+        assertThat(toVerify.getName()).isEqualTo(source.getField().getValue());
+        assertThat(toVerify.getMapMissingTo()).isEqualTo(source.getMapMissingTo());
+        assertThat(toVerify.getValue()).isEqualTo(source.getValue().toString());
     }
 
     static void commonVerifyKiePMMLTextIndex(KiePMMLTextIndex toVerify, TextIndex source) {
         assertThat(toVerify).isNotNull();
-        assertEquals(source.getLocalTermWeights().value(), toVerify.getLocalTermWeights().getName());
-        assertEquals(source.getCountHits().value(), toVerify.getCountHits().getName());
-        assertEquals(StringEscapeUtils.escapeJava(source.getWordSeparatorCharacterRE()),
-                     toVerify.getWordSeparatorCharacterRE());
+        assertThat(toVerify.getLocalTermWeights().getName()).isEqualTo(source.getLocalTermWeights().value());
+        assertThat(toVerify.getCountHits().getName()).isEqualTo(source.getCountHits().value());
+        assertThat(toVerify.getWordSeparatorCharacterRE()).isEqualTo(StringEscapeUtils.escapeJava(source.getWordSeparatorCharacterRE()));
         commonVerifyKiePMMLExpression(toVerify.getExpression(), source.getExpression());
-        assertEquals(source.getTextIndexNormalizations().size(), toVerify.getTextIndexNormalizations().size());
+        assertThat(toVerify.getTextIndexNormalizations()).hasSize(source.getTextIndexNormalizations().size());
         IntStream.range(0, source.getTextIndexNormalizations().size()).forEach(i -> {
             commonVerifyKiePMMLTextIndexNormalization(toVerify.getTextIndexNormalizations().get(i),
                                                       source.getTextIndexNormalizations().get(i));
         });
-        assertEquals(source.isCaseSensitive(), toVerify.isCaseSensitive());
-        assertEquals(source.getMaxLevenshteinDistance().intValue(), toVerify.getMaxLevenshteinDistance());
-        assertEquals(source.isTokenize(), toVerify.isTokenize());
+        assertThat(toVerify.isCaseSensitive()).isEqualTo(source.isCaseSensitive());
+        assertThat(toVerify.getMaxLevenshteinDistance()).isEqualTo(source.getMaxLevenshteinDistance().intValue());
+        assertThat(toVerify.isTokenize()).isEqualTo(source.isTokenize());
     }
 
     static void commonVerifyKiePMMLTextIndexNormalization(KiePMMLTextIndexNormalization toVerify,
@@ -345,94 +342,94 @@ public class InstanceFactoriesTestCommon {
     static void commonVerifyKiePMMLDiscretizeBin(KiePMMLDiscretizeBin toVerify, DiscretizeBin source) {
         assertThat(toVerify).isNotNull();
         commonVerifyKiePMMLInterval(toVerify.getInterval(), source.getInterval());
-        assertEquals(source.getBinValue(), toVerify.getBinValue());
+        assertThat(toVerify.getBinValue()).isEqualTo(source.getBinValue());
     }
 
     static void commonVerifyKiePMMLFieldColumnPair(KiePMMLFieldColumnPair toVerify, FieldColumnPair source) {
         assertThat(toVerify).isNotNull();
-        assertEquals(source.getField().getValue(), toVerify.getName());
-        assertEquals(source.getColumn(), toVerify.getColumn());
+        assertThat(toVerify.getName()).isEqualTo(source.getField().getValue());
+        assertThat(toVerify.getColumn()).isEqualTo(source.getColumn());
     }
 
     static void commonVerifyKiePMMLInlineTableWithCells(KiePMMLInlineTable toVerify, InlineTable source) {
         assertThat(toVerify).isNotNull();
-        assertEquals(source.getRows().size(), toVerify.getRows().size());
+        assertThat(toVerify.getRows()).hasSize(source.getRows().size());
         IntStream.range(0, source.getRows().size()).forEach(i -> commonVerifyKiePMMLRowWithCells(toVerify.getRows().get(i), source.getRows().get(i)));
     }
 
     static void commonVerifyKiePMMLInterval(KiePMMLInterval toVerify, Interval source) {
         assertThat(toVerify).isNotNull();
-        assertEquals(source.getLeftMargin(), toVerify.getLeftMargin());
-        assertEquals(source.getRightMargin(), toVerify.getRightMargin());
-        assertEquals(source.getClosure().value(), toVerify.getClosure().getName());
+        assertThat(toVerify.getLeftMargin()).isEqualTo(source.getLeftMargin());
+        assertThat(toVerify.getRightMargin()).isEqualTo(source.getRightMargin());
+        assertThat(toVerify.getClosure().getName()).isEqualTo(source.getClosure().value());
     }
 
     static void commonVerifyKiePMMLMiningField(KiePMMLMiningField toVerify, MiningField source, DataField dataField) {
         assertThat(toVerify).isNotNull();
-        assertEquals(source.getName().getValue(), toVerify.getName());
-        assertEquals(source.getOpType().value(), toVerify.getOpType().getName());
-        assertEquals(source.getUsageType().value(), toVerify.getFieldUsageType().getName());
-        assertEquals(source.getInvalidValueTreatment().value(), toVerify.getInvalidValueTreatmentMethod().getName());
-        assertEquals(source.getMissingValueTreatment().value(), toVerify.getMissingValueTreatmentMethod().getName());
-        assertEquals(source.getInvalidValueReplacement(), toVerify.getInvalidValueReplacement());
-        assertEquals(source.getMissingValueReplacement(), toVerify.getMissingValueReplacement());
-        assertEquals(dataField.getDataType().value(), toVerify.getDataType().getName());
-        assertEquals(dataField.getIntervals().size(), toVerify.getIntervals().size());
+        assertThat(toVerify.getName()).isEqualTo(source.getName().getValue());
+        assertThat(toVerify.getOpType().getName()).isEqualTo(source.getOpType().value());
+        assertThat(toVerify.getFieldUsageType().getName()).isEqualTo(source.getUsageType().value());
+        assertThat(toVerify.getInvalidValueTreatmentMethod().getName()).isEqualTo(source.getInvalidValueTreatment().value());
+        assertThat(toVerify.getMissingValueTreatmentMethod().getName()).isEqualTo(source.getMissingValueTreatment().value());
+        assertThat(toVerify.getInvalidValueReplacement()).isEqualTo(source.getInvalidValueReplacement());
+        assertThat(toVerify.getMissingValueReplacement()).isEqualTo(source.getMissingValueReplacement());
+        assertThat(toVerify.getDataType().getName()).isEqualTo(dataField.getDataType().value());
+        assertThat(toVerify.getIntervals()).hasSameSizeAs(dataField.getIntervals());
         IntStream.range(0, dataField.getIntervals().size()).forEach(i -> commonVerifyKiePMMLInterval(toVerify.getIntervals().get(i), dataField.getIntervals().get(i)));
     }
 
     static void commonVerifyKiePMMLOutputField(KiePMMLOutputField toVerify, OutputField source) {
         assertThat(toVerify).isNotNull();
-        assertEquals(source.getName().getValue(), toVerify.getName());
-        assertEquals(source.getValue(), toVerify.getValue());
-        assertEquals(source.getDataType().value(), toVerify.getDataType().getName());
-        assertEquals(source.getTargetField().getValue(), toVerify.getTargetField().get());
-        assertEquals(source.getResultFeature().value(), toVerify.getResultFeature().getName());
-        assertEquals(source.getRank(), toVerify.getRank());
-        assertEquals(source.getValue(), toVerify.getValue());
+        assertThat(toVerify.getName()).isEqualTo(source.getName().getValue());
+        assertThat(toVerify.getValue()).isEqualTo(source.getValue());
+        assertThat(toVerify.getDataType().getName()).isEqualTo(source.getDataType().value());
+        assertThat(toVerify.getTargetField().get()).isEqualTo(source.getTargetField().getValue());
+        assertThat(toVerify.getResultFeature().getName()).isEqualTo(source.getResultFeature().value());
+        assertThat(toVerify.getRank()).isEqualTo(source.getRank());
+        assertThat(toVerify.getValue()).isEqualTo(source.getValue());
         commonVerifyKiePMMLExpression(toVerify.getKiePMMLExpression(), source.getExpression());
     }
 
     static void commonVerifyKiePMMLTarget(KiePMMLTarget toVerify, Target source) {
         assertThat(toVerify).isNotNull();
-        assertEquals(toVerify.getTargetValues().size(), source.getTargetValues().size());
+        assertThat(source.getTargetValues()).hasSize(toVerify.getTargetValues().size());
         OP_TYPE expectedOpType = OP_TYPE.byName(source.getOpType().value());
-        assertEquals(expectedOpType, toVerify.getOpType());
-        assertEquals(source.getField().getValue(), toVerify.getField());
+        assertThat(toVerify.getOpType()).isEqualTo(expectedOpType);
+        assertThat(toVerify.getField()).isEqualTo(source.getField().getValue());
         CAST_INTEGER expectedCastInteger = CAST_INTEGER.byName(source.getCastInteger().value());
-        assertEquals(expectedCastInteger, toVerify.getCastInteger());
-        assertEquals(source.getMin().doubleValue(), toVerify.getMin(), 0.0);
-        assertEquals(source.getMax().doubleValue(), toVerify.getMax(), 0.0);
-        assertEquals(source.getRescaleConstant().doubleValue(), toVerify.getRescaleConstant(), 0.0);
-        assertEquals(source.getRescaleFactor().doubleValue(), toVerify.getRescaleFactor(), 0.0);
+        assertThat(toVerify.getCastInteger()).isEqualTo(expectedCastInteger);
+        assertThat(toVerify.getMin()).isCloseTo(source.getMin().doubleValue(), Offset.offset(0.0));
+        assertThat(toVerify.getMax()).isCloseTo(source.getMax().doubleValue(), Offset.offset(0.0));
+        assertThat(toVerify.getRescaleConstant()).isCloseTo(source.getRescaleConstant().doubleValue(), Offset.offset(0.0));
+        assertThat(toVerify.getRescaleFactor()).isCloseTo(source.getRescaleFactor().doubleValue(), Offset.offset(0.0));
     }
 
     static void commonVerifyKiePMMLRow(KiePMMLRow toVerify,
                                        Row source) {
         assertThat(toVerify).isNotNull();
-        assertTrue(toVerify.getColumnValues().isEmpty());
+        assertThat(toVerify.getColumnValues()).isEmpty();
     }
 
     static void commonVerifyKiePMMLRowWithCells(KiePMMLRow toVerify,
                                                 Row source) {
         assertThat(toVerify).isNotNull();
-        assertEquals(2, toVerify.getColumnValues().size());
+        assertThat(toVerify.getColumnValues().size()).isEqualTo(2);
     }
 
     static void commonVerifyKiePMMLTargetValue(KiePMMLTargetValue toVerify,
                                                TargetValue source) {
         assertThat(toVerify).isNotNull();
-        assertEquals(source.getValue().toString(), toVerify.getValue());
-        assertEquals(source.getDisplayValue(), toVerify.getDisplayValue());
-        assertEquals(source.getPriorProbability().doubleValue(), toVerify.getPriorProbability(), 0.0);
-        assertEquals(source.getDefaultValue().doubleValue(), toVerify.getDefaultValue(), 0.0);
+        assertThat(toVerify.getValue()).isEqualTo(source.getValue().toString());
+        assertThat(toVerify.getDisplayValue()).isEqualTo(source.getDisplayValue());
+        assertThat(toVerify.getPriorProbability()).isCloseTo(source.getPriorProbability().doubleValue(), Offset.offset(0.0));
+        assertThat(toVerify.getDefaultValue()).isCloseTo(source.getDefaultValue().doubleValue(), Offset.offset(0.0));
     }
 
     static void commonVerifyKiePMMLLinearNorm(KiePMMLLinearNorm toVerify,
                                               LinearNorm source) {
         assertThat(toVerify).isNotNull();
-        assertEquals(source.getOrig().doubleValue(), toVerify.getOrig(), 0.0);
-        assertEquals(source.getNorm().doubleValue(), toVerify.getNorm(), 0.0);
+        assertThat(toVerify.getOrig()).isCloseTo(source.getOrig().doubleValue(), Offset.offset(0.0));
+        assertThat(toVerify.getNorm()).isCloseTo(source.getNorm().doubleValue(), Offset.offset(0.0));
     }
 
     static void sortLinearNorms(final List<LinearNorm> toSort) {

--- a/kie-pmml-trusty/kie-pmml-compiler/kie-pmml-compiler-commons/src/test/java/org/kie/pmml/compiler/commons/factories/KiePMMLFactoryFactoryTest.java
+++ b/kie-pmml-trusty/kie-pmml-compiler/kie-pmml-compiler-commons/src/test/java/org/kie/pmml/compiler/commons/factories/KiePMMLFactoryFactoryTest.java
@@ -20,8 +20,6 @@ import com.github.javaparser.ast.expr.ObjectCreationExpr;
 import org.junit.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
 import static org.kie.pmml.commons.Constants.GET_MODEL;
 
 public class KiePMMLFactoryFactoryTest {
@@ -37,16 +35,16 @@ public class KiePMMLFactoryFactoryTest {
 
     private void validateNotCodegen(Expression toValidate, String kiePMMLModelClass) {
         assertThat(toValidate).isNotNull();
-        assertTrue(toValidate instanceof MethodCallExpr);
+        assertThat(toValidate).isInstanceOf(MethodCallExpr.class);
         MethodCallExpr methodCallExpr = (MethodCallExpr) toValidate;
-        assertEquals(kiePMMLModelClass, methodCallExpr.getScope().get().asNameExpr().toString());
-        assertEquals(GET_MODEL, methodCallExpr.getName().asString());
+        assertThat(methodCallExpr.getScope().get().asNameExpr().toString()).isEqualTo(kiePMMLModelClass);
+        assertThat(methodCallExpr.getName().asString()).isEqualTo(GET_MODEL);
     }
 
     private void validateCodegen(Expression toValidate, String kiePMMLModelClass) {
         assertThat(toValidate).isNotNull();
-        assertTrue(toValidate instanceof ObjectCreationExpr);
+        assertThat(toValidate).isInstanceOf(ObjectCreationExpr.class);
         ObjectCreationExpr objectCreationExpr = (ObjectCreationExpr) toValidate;
-        assertEquals(kiePMMLModelClass, objectCreationExpr.getType().asString());
+        assertThat(objectCreationExpr.getType().asString()).isEqualTo(kiePMMLModelClass);
     }
 }

--- a/kie-pmml-trusty/kie-pmml-compiler/kie-pmml-compiler-commons/src/test/java/org/kie/pmml/compiler/commons/factories/KiePMMLLocalTransformationsInstanceFactoryTest.java
+++ b/kie-pmml-trusty/kie-pmml-compiler/kie-pmml-compiler-commons/src/test/java/org/kie/pmml/compiler/commons/factories/KiePMMLLocalTransformationsInstanceFactoryTest.java
@@ -26,8 +26,6 @@ import org.kie.pmml.commons.transformations.KiePMMLDerivedField;
 import org.kie.pmml.commons.transformations.KiePMMLLocalTransformations;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
 import static org.kie.pmml.compiler.api.testutils.PMMLModelTestUtils.getRandomLocalTransformations;
 import static org.kie.pmml.compiler.commons.factories.InstanceFactoriesTestCommon.commonVerifyKiePMMLDerivedField;
 
@@ -43,12 +41,12 @@ public class KiePMMLLocalTransformationsInstanceFactoryTest {
 
         List<DerivedField> derivedFields = toConvert.getDerivedFields();
         List<KiePMMLDerivedField> derivedFieldsToVerify = retrieved.getDerivedFields();
-        assertEquals(derivedFields.size(), derivedFieldsToVerify.size());
+        assertThat(derivedFieldsToVerify).hasSameSizeAs(derivedFields);
         derivedFields.forEach(derivedFieldSource -> {
             Optional<KiePMMLDerivedField> derivedFieldToVerify =
                     derivedFieldsToVerify.stream().filter(param -> param.getName().equals(derivedFieldSource.getName().getValue()))
                             .findFirst();
-            assertTrue(derivedFieldToVerify.isPresent());
+            assertThat(derivedFieldToVerify).isPresent();
             commonVerifyKiePMMLDerivedField(derivedFieldToVerify.get(), derivedFieldSource);
         });
     }

--- a/kie-pmml-trusty/kie-pmml-compiler/kie-pmml-compiler-commons/src/test/java/org/kie/pmml/compiler/commons/factories/KiePMMLTransformationDictionaryInstanceFactoryTest.java
+++ b/kie-pmml-trusty/kie-pmml-compiler/kie-pmml-compiler-commons/src/test/java/org/kie/pmml/compiler/commons/factories/KiePMMLTransformationDictionaryInstanceFactoryTest.java
@@ -28,8 +28,6 @@ import org.kie.pmml.commons.transformations.KiePMMLDerivedField;
 import org.kie.pmml.commons.transformations.KiePMMLTransformationDictionary;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
 import static org.kie.pmml.compiler.api.testutils.PMMLModelTestUtils.getRandomTransformationDictionary;
 import static org.kie.pmml.compiler.commons.factories.InstanceFactoriesTestCommon.commonVerifyKiePMMLDefineFunction;
 import static org.kie.pmml.compiler.commons.factories.InstanceFactoriesTestCommon.commonVerifyKiePMMLDerivedField;
@@ -46,23 +44,23 @@ public class KiePMMLTransformationDictionaryInstanceFactoryTest {
 
         List<DerivedField> derivedFields = toConvert.getDerivedFields();
         List<KiePMMLDerivedField> derivedFieldsToVerify = retrieved.getDerivedFields();
-        assertEquals(derivedFields.size(), derivedFieldsToVerify.size());
+        assertThat(derivedFieldsToVerify).hasSameSizeAs(derivedFields);
         derivedFields.forEach(derivedFieldSource -> {
             Optional<KiePMMLDerivedField> derivedFieldToVerify =
                     derivedFieldsToVerify.stream().filter(param -> param.getName().equals(derivedFieldSource.getName().getValue()))
                             .findFirst();
-            assertTrue(derivedFieldToVerify.isPresent());
+            assertThat(derivedFieldToVerify).isPresent();
             commonVerifyKiePMMLDerivedField(derivedFieldToVerify.get(), derivedFieldSource);
         });
 
         List<DefineFunction> defineFunctions = toConvert.getDefineFunctions();
         List<KiePMMLDefineFunction> defineFunctionsToVerify = retrieved.getDefineFunctions();
-        assertEquals(defineFunctions.size(), defineFunctionsToVerify.size());
+        assertThat(defineFunctionsToVerify).hasSameSizeAs(defineFunctions);
         defineFunctions.forEach(defineFunctionSource -> {
             Optional<KiePMMLDefineFunction> defineFunctionToVerify =
                     defineFunctionsToVerify.stream().filter(param -> param.getName().equals(defineFunctionSource.getName()))
                             .findFirst();
-            assertTrue(defineFunctionToVerify.isPresent());
+            assertThat(defineFunctionToVerify).isPresent();
             commonVerifyKiePMMLDefineFunction(defineFunctionToVerify.get(), defineFunctionSource);
         });
     }

--- a/kie-pmml-trusty/kie-pmml-compiler/kie-pmml-compiler-commons/src/test/java/org/kie/pmml/compiler/commons/implementations/KiePMMLModelRetrieverTest.java
+++ b/kie-pmml-trusty/kie-pmml-compiler/kie-pmml-compiler-commons/src/test/java/org/kie/pmml/compiler/commons/implementations/KiePMMLModelRetrieverTest.java
@@ -30,8 +30,6 @@ import org.kie.pmml.compiler.commons.mocks.HasClassLoaderMock;
 import org.kie.pmml.compiler.commons.utils.KiePMMLUtil;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
 import static org.kie.pmml.commons.Constants.PACKAGE_NAME;
 import static org.kie.pmml.compiler.api.testutils.PMMLModelTestUtils.getPMMLWithMiningRandomTestModel;
 import static org.kie.pmml.compiler.api.testutils.PMMLModelTestUtils.getPMMLWithRandomTestModel;
@@ -59,8 +57,8 @@ public class KiePMMLModelRetrieverTest {
                                                                        new HasClassLoaderMock());
         final Optional<KiePMMLModel> retrieved = getFromCommonDataAndTransformationDictionaryAndModel(compilationDTO);
         assertThat(retrieved).isNotNull();
-        assertTrue(retrieved.isPresent());
-        assertTrue(retrieved.get() instanceof KiePMMLTestingModel);
+        assertThat(retrieved).isPresent();
+        assertThat(retrieved.get()).isInstanceOf(KiePMMLTestingModel.class);
     }
 
     @Test
@@ -73,7 +71,7 @@ public class KiePMMLModelRetrieverTest {
                                                                        new HasClassLoaderMock());
         final Optional<KiePMMLModel> retrieved = getFromCommonDataAndTransformationDictionaryAndModel(compilationDTO);
         assertThat(retrieved).isNotNull();
-        assertFalse(retrieved.isPresent());
+        assertThat(retrieved).isNotPresent();
     }
 
     @Test
@@ -100,7 +98,7 @@ public class KiePMMLModelRetrieverTest {
         final Optional<KiePMMLModel> retrieved =
                 getFromCommonDataAndTransformationDictionaryAndModelWithSources(compilationDTO);
         assertThat(retrieved).isNotNull();
-        assertFalse(retrieved.isPresent());
+        assertThat(retrieved).isNotPresent();
     }
 
     @Test
@@ -116,7 +114,7 @@ public class KiePMMLModelRetrieverTest {
         final Optional<KiePMMLModel> retrieved =
                 getFromCommonDataAndTransformationDictionaryAndModelWithSourcesCompiled(compilationDTO);
         assertThat(retrieved).isNotNull();
-        assertTrue(retrieved.isPresent());
+        assertThat(retrieved).isPresent();
     }
 
     @Test
@@ -133,7 +131,7 @@ public class KiePMMLModelRetrieverTest {
         final Optional<KiePMMLModel> retrieved =
                 getFromCommonDataAndTransformationDictionaryAndModelWithSourcesCompiled(compilationDTO);
         assertThat(retrieved).isNotNull();
-        assertFalse(retrieved.isPresent());
+        assertThat(retrieved).isNotPresent();
     }
 
 }

--- a/kie-pmml-trusty/kie-pmml-compiler/kie-pmml-compiler-commons/src/test/java/org/kie/pmml/compiler/commons/implementations/ModelImplementationProviderFinderImplTest.java
+++ b/kie-pmml-trusty/kie-pmml-compiler/kie-pmml-compiler-commons/src/test/java/org/kie/pmml/compiler/commons/implementations/ModelImplementationProviderFinderImplTest.java
@@ -26,8 +26,6 @@ import org.kie.pmml.compiler.api.provider.ModelImplementationProvider;
 import org.kie.pmml.compiler.commons.mocks.TestingModelImplementationProvider;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
 
 public class ModelImplementationProviderFinderImplTest {
 
@@ -42,7 +40,7 @@ public class ModelImplementationProviderFinderImplTest {
     public <T extends Model, E extends KiePMMLModel> void getImplementations() {
         final List<ModelImplementationProvider<T, E>> retrieved = modelImplementationProviderFinder.getImplementations(false);
         assertThat(retrieved).isNotNull();
-        assertEquals(1, retrieved.size());
-        assertTrue(retrieved.get(0) instanceof TestingModelImplementationProvider);
+        assertThat(retrieved).hasSize(1);
+        assertThat(retrieved.get(0)).isInstanceOf(TestingModelImplementationProvider.class);
     }
 }

--- a/kie-pmml-trusty/kie-pmml-compiler/kie-pmml-compiler-commons/src/test/java/org/kie/pmml/compiler/commons/testutils/CodegenTestUtils.java
+++ b/kie-pmml-trusty/kie-pmml-compiler/kie-pmml-compiler-commons/src/test/java/org/kie/pmml/compiler/commons/testutils/CodegenTestUtils.java
@@ -40,9 +40,8 @@ import org.kie.pmml.compiler.commons.utils.CommonCodegenUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.fail;
 
 /**
  * Utility methods for Codegen-related tests
@@ -159,7 +158,7 @@ public class CodegenTestUtils {
                                                  String generatedClassName,
                                                  Map<Integer, Expression> superInvocationExpressionsMap,
                                                  Map<String, Expression> assignExpressionsMap) {
-        assertEquals(new SimpleName(generatedClassName), constructorDeclaration.getName());
+        assertThat(constructorDeclaration.getName()).isEqualTo(new SimpleName(generatedClassName));
         final BlockStmt body = constructorDeclaration.getBody();
         return commonEvaluateSuperInvocationExpr(body, superInvocationExpressionsMap) &&
         commonEvaluateAssignExpr(body, assignExpressionsMap);
@@ -174,7 +173,7 @@ public class CodegenTestUtils {
             @Override
             public void accept(Integer integer, Expression expression) {
                 try {
-                    assertEquals(expression, explicitConstructorInvocationStmt.getArgument(integer));
+                    assertThat(explicitConstructorInvocationStmt.getArgument(integer)).isEqualTo(expression);
                 } catch (AssertionError e) {
                     if (e.getMessage() != null && !e.getMessage().isEmpty()) {
                         LOGGER.error(e.getMessage());
@@ -193,9 +192,9 @@ public class CodegenTestUtils {
         final List<AssertionError> errors = new ArrayList<>();
         for (Map.Entry<String, Expression> entry : assignExpressionMap.entrySet()) {
             try {
-                assertTrue(retrieved.stream()
+                assertThat(retrieved.stream()
                                    .filter(assignExpr -> assignExpr.getTarget().asNameExpr().equals(new NameExpr(entry.getKey())))
-                                   .anyMatch(assignExpr -> assignExpr.getValue().equals(entry.getValue())));
+                                   .anyMatch(assignExpr -> assignExpr.getValue().equals(entry.getValue()))).isTrue();
             } catch (AssertionError e) {
                 if (e.getMessage() != null && !e.getMessage().isEmpty()) {
                     LOGGER.error(e.getMessage());

--- a/kie-pmml-trusty/kie-pmml-compiler/kie-pmml-compiler-commons/src/test/java/org/kie/pmml/compiler/commons/utils/CommonCodegenUtilsTest.java
+++ b/kie-pmml-trusty/kie-pmml-compiler/kie-pmml-compiler-commons/src/test/java/org/kie/pmml/compiler/commons/utils/CommonCodegenUtilsTest.java
@@ -436,7 +436,7 @@ public class CommonCodegenUtilsTest {
         final ClassOrInterfaceDeclaration classOrInterfaceDeclaration = new ClassOrInterfaceDeclaration();
         assertThat(classOrInterfaceDeclaration.getMethodsByName(methodName)).isEmpty();
         CommonCodegenUtils.addMethod(methodTemplate, classOrInterfaceDeclaration, methodName);
-        assertThat(classOrInterfaceDeclaration.getMethodsByName(methodName).size()).isEqualTo(1);
+        assertThat(classOrInterfaceDeclaration.getMethodsByName(methodName)).hasSize(1);
         assertThat(classOrInterfaceDeclaration.getMethodsByName(methodName).get(0).getBody().get()).isEqualTo(body);
     }
 

--- a/kie-pmml-trusty/kie-pmml-compiler/kie-pmml-compiler-commons/src/test/java/org/kie/pmml/compiler/commons/utils/CommonCodegenUtilsTest.java
+++ b/kie-pmml-trusty/kie-pmml-compiler/kie-pmml-compiler-commons/src/test/java/org/kie/pmml/compiler/commons/utils/CommonCodegenUtilsTest.java
@@ -55,6 +55,7 @@ import com.github.javaparser.ast.stmt.ExpressionStmt;
 import com.github.javaparser.ast.stmt.ReturnStmt;
 import com.github.javaparser.ast.stmt.Statement;
 import com.github.javaparser.ast.type.ClassOrInterfaceType;
+import org.assertj.core.data.Offset;
 import org.junit.Test;
 import org.kie.pmml.api.enums.DATA_TYPE;
 import org.kie.pmml.api.exceptions.KiePMMLException;
@@ -63,11 +64,7 @@ import org.kie.pmml.commons.model.tuples.KiePMMLNameValue;
 import static com.github.javaparser.StaticJavaParser.parseBlock;
 import static com.github.javaparser.StaticJavaParser.parseClassOrInterfaceType;
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertSame;
-import static org.junit.Assert.assertThrows;
-import static org.junit.Assert.assertTrue;
+import static org.assertj.core.api.Assertions.assertThatIllegalArgumentException;
 import static org.kie.pmml.compiler.commons.testutils.CodegenTestUtils.commonValidateCompilation;
 import static org.kie.pmml.compiler.commons.utils.CommonCodegenUtils.LAMBDA_PARAMETER_NAME;
 import static org.kie.pmml.compiler.commons.utils.CommonCodegenUtils.OPTIONAL_FILTERED_KIEPMMLNAMEVALUE_NAME;
@@ -82,12 +79,12 @@ public class CommonCodegenUtilsTest {
                 .map(index -> getMethodDeclaration("METHOD_" + index))
                 .collect(Collectors.toList());
         final ClassOrInterfaceDeclaration toPopulate = new ClassOrInterfaceDeclaration();
-        assertTrue(toPopulate.getMembers().isEmpty());
+        assertThat(toPopulate.getMembers()).isEmpty();
         CommonCodegenUtils.populateMethodDeclarations(toPopulate, toAdd);
         final NodeList<BodyDeclaration<?>> retrieved = toPopulate.getMembers();
-        assertEquals(toAdd.size(), retrieved.size());
-        assertTrue(toAdd.stream().anyMatch(methodDeclaration -> retrieved.stream()
-                .anyMatch(bodyDeclaration -> bodyDeclaration.equals(methodDeclaration))));
+        assertThat(retrieved).hasSameSizeAs(toAdd);
+        assertThat(toAdd.stream().anyMatch(methodDeclaration -> retrieved.stream()
+                .anyMatch(bodyDeclaration -> bodyDeclaration.equals(methodDeclaration)))).isTrue();
     }
 
     @Test
@@ -105,7 +102,7 @@ public class CommonCodegenUtilsTest {
                                         Objects.class.getName(),
                                         fieldNameToRef);
         String retrievedString = retrieved.toString();
-        assertEquals(expected, retrievedString);
+        assertThat(retrievedString).isEqualTo(expected);
         BlockStmt body = new BlockStmt();
         body.addStatement(retrieved);
         Parameter listParameter = new Parameter(CommonCodegenUtils.getTypedClassOrInterfaceTypeByTypeNames(List.class.getName(), Collections.singletonList(KiePMMLNameValue.class.getName())), kiePMMLNameValueListParam);
@@ -123,7 +120,7 @@ public class CommonCodegenUtilsTest {
                                         Objects.class.getName(),
                                         fieldNameToRef);
         retrievedString = retrieved.toString();
-        assertEquals(expected, retrievedString);
+        assertThat(retrievedString).isEqualTo(expected);
         body = new BlockStmt();
         body.addStatement(retrieved);
         listParameter = new Parameter(CommonCodegenUtils.getTypedClassOrInterfaceTypeByTypeNames(List.class.getName(), Collections.singletonList(KiePMMLNameValue.class.getName())), kiePMMLNameValueListParam);
@@ -138,23 +135,23 @@ public class CommonCodegenUtilsTest {
         String mapName = "MAP_NAME";
         CommonCodegenUtils.addMapPopulation(toAdd, body, mapName);
         NodeList<Statement> statements = body.getStatements();
-        assertEquals(toAdd.size(), statements.size());
+        assertThat(statements).hasSize(toAdd.size());
         for (Statement statement : statements) {
-            assertTrue(statement instanceof ExpressionStmt);
+            assertThat(statement).isInstanceOf(ExpressionStmt.class);
             ExpressionStmt expressionStmt = (ExpressionStmt) statement;
             com.github.javaparser.ast.expr.Expression expression = expressionStmt.getExpression();
-            assertTrue(expression instanceof MethodCallExpr);
+            assertThat(expression).isInstanceOf(MethodCallExpr.class);
             MethodCallExpr methodCallExpr = (MethodCallExpr) expression;
             final NodeList<com.github.javaparser.ast.expr.Expression> arguments = methodCallExpr.getArguments();
-            assertEquals(2, arguments.size());
-            assertTrue(arguments.get(0) instanceof StringLiteralExpr);
-            assertTrue(arguments.get(1) instanceof MethodReferenceExpr);
+            assertThat(arguments).hasSize(2);
+            assertThat(arguments.get(0)).isInstanceOf(StringLiteralExpr.class);
+            assertThat(arguments.get(1)).isInstanceOf(MethodReferenceExpr.class);
             MethodReferenceExpr methodReferenceExpr = (MethodReferenceExpr) arguments.get(1);
-            assertTrue(methodReferenceExpr.getScope() instanceof ThisExpr);
+            assertThat(methodReferenceExpr.getScope()).isInstanceOf(ThisExpr.class);
             final com.github.javaparser.ast.expr.Expression scope = methodCallExpr.getScope().orElse(null);
             assertThat(scope).isNotNull();
-            assertTrue(scope instanceof NameExpr);
-            assertEquals(mapName, ((NameExpr) scope).getNameAsString());
+            assertThat(scope).isInstanceOf(NameExpr.class);
+            assertThat(((NameExpr) scope).getNameAsString()).isEqualTo(mapName);
         }
         for (Map.Entry<String, MethodDeclaration> entry : toAdd.entrySet()) {
             int matchingDeclarations = (int) statements.stream().filter(statement -> {
@@ -168,7 +165,7 @@ public class CommonCodegenUtilsTest {
                 MethodReferenceExpr methodReferenceExpr = (MethodReferenceExpr) arguments.get(1);
                 return entry.getValue().getName().asString().equals(methodReferenceExpr.getIdentifier());
             }).count();
-            assertEquals(1, matchingDeclarations);
+            assertThat(matchingDeclarations).isEqualTo(1);
         }
     }
 
@@ -186,30 +183,29 @@ public class CommonCodegenUtilsTest {
         CommonCodegenUtils.addMapPopulationExpressions(inputMap, inputBody, inputMapName);
 
         NodeList<Statement> statements = inputBody.getStatements();
-        assertEquals(inputMap.size(), statements.size());
+        assertThat(statements).hasSize(inputMap.size());
 
         List<MethodCallExpr> methodCallExprs = new ArrayList<>(statements.size());
 
         for (Statement statement : statements) {
-            assertTrue(statement instanceof ExpressionStmt);
+            assertThat(statement).isInstanceOf(ExpressionStmt.class);
             Expression expression = ((ExpressionStmt) statement).getExpression();
-            assertTrue(expression instanceof  MethodCallExpr);
+            assertThat(expression).isInstanceOf(MethodCallExpr.class);
             MethodCallExpr methodCallExpr = (MethodCallExpr) expression;
-            assertEquals(inputMapName, methodCallExpr.getScope().map(Node::toString).orElse(null));
-            assertEquals("put", methodCallExpr.getName().asString());
-            assertSame(2, methodCallExpr.getArguments().size());
-            assertTrue(methodCallExpr.getArgument(0) instanceof StringLiteralExpr);
+            assertThat(methodCallExpr.getScope().map(Node::toString).orElse(null)).isEqualTo(inputMapName);
+            assertThat(methodCallExpr.getName().asString()).isEqualTo("put");
+            assertThat(methodCallExpr.getArguments()).hasSize(2);
+            assertThat(methodCallExpr.getArgument(0)).isInstanceOf(StringLiteralExpr.class);
             methodCallExprs.add(methodCallExpr);
         }
 
         for (Map.Entry<String, Expression> inputEntry : inputMap.entrySet()) {
-            assertEquals("Expected one and only one statement for key \"" + inputEntry.getKey() + "\"", 1,
+            assertThat(
                     methodCallExprs.stream().filter(methodCallExpr -> {
                         StringLiteralExpr arg0 = (StringLiteralExpr) methodCallExpr.getArgument(0);
                         return arg0.asString().equals(inputEntry.getKey())
                                 && methodCallExpr.getArgument(1).equals(inputEntry.getValue());
-                    }).count()
-            );
+                    })).as("Expected one and only one statement for key \"" + inputEntry.getKey() + "\"").hasSize(1);
         }
     }
 
@@ -228,21 +224,21 @@ public class CommonCodegenUtilsTest {
         String listName = "LIST_NAME";
         CommonCodegenUtils.addListPopulationByObjectCreationExpr(toAdd, body, listName);
         NodeList<Statement> statements = body.getStatements();
-        assertEquals(toAdd.size(), statements.size());
+        assertThat(statements).hasSameSizeAs(toAdd);
         for (Statement statement : statements) {
-            assertTrue(statement instanceof ExpressionStmt);
+            assertThat(statement).isInstanceOf(ExpressionStmt.class);
             ExpressionStmt expressionStmt = (ExpressionStmt) statement;
-            assertTrue(expressionStmt.getExpression() instanceof MethodCallExpr);
+            assertThat(expressionStmt.getExpression()).isInstanceOf(MethodCallExpr.class);
             MethodCallExpr methodCallExpr = (MethodCallExpr) expressionStmt.getExpression();
-            assertEquals(listName, methodCallExpr.getScope().get().asNameExpr().getNameAsString());
+            assertThat(methodCallExpr.getScope().get().asNameExpr().getNameAsString()).isEqualTo(listName);
             NodeList<com.github.javaparser.ast.expr.Expression> arguments = methodCallExpr.getArguments();
-            assertEquals(1, arguments.size());
-            assertTrue(arguments.get(0) instanceof ObjectCreationExpr);
+            assertThat(arguments).hasSize(1);
+            assertThat(arguments.get(0)).isInstanceOf(ObjectCreationExpr.class);
             ObjectCreationExpr objectCreationExpr = (ObjectCreationExpr) arguments.get(0);
-            assertEquals(objectCreationExpr.getType().asString(), String.class.getSimpleName());
+            assertThat(String.class.getSimpleName()).isEqualTo(objectCreationExpr.getType().asString());
             arguments = objectCreationExpr.getArguments();
-            assertEquals(1, arguments.size());
-            assertTrue(arguments.get(0) instanceof StringLiteralExpr);
+            assertThat(arguments).hasSize(1);
+            assertThat(arguments.get(0)).isInstanceOf(StringLiteralExpr.class);
         }
         for (ObjectCreationExpr entry : toAdd) {
             int matchingDeclarations = (int) statements.stream().filter(statement -> {
@@ -252,7 +248,7 @@ public class CommonCodegenUtilsTest {
                 final NodeList<com.github.javaparser.ast.expr.Expression> arguments = methodCallExpr.getArguments();
                 return entry.equals(arguments.get(0).asObjectCreationExpr());
             }).count();
-            assertEquals(1, matchingDeclarations);
+            assertThat(matchingDeclarations).isEqualTo(1);
         }
     }
 
@@ -262,7 +258,7 @@ public class CommonCodegenUtilsTest {
         assertThat(retrieved).isNotNull();
         String expected = "java.util.Arrays.asList();";
         String retrievedString = retrieved.toString();
-        assertEquals(expected, retrievedString);
+        assertThat(retrievedString).isEqualTo(expected);
     }
 
     @Test
@@ -277,7 +273,7 @@ public class CommonCodegenUtilsTest {
                 .collect(Collectors.joining(", "));
         String expected = String.format("java.util.Arrays.asList(%s);", arguments);
         String retrievedString = retrieved.toString();
-        assertEquals(expected, retrievedString);
+        assertThat(retrievedString).isEqualTo(expected);
         List<Double> doubles = IntStream.range(0, 3)
                 .mapToObj(i ->  i * 0.17)
                 .collect(Collectors.toList());
@@ -288,7 +284,7 @@ public class CommonCodegenUtilsTest {
                 .collect(Collectors.joining(", "));
         expected = String.format("java.util.Arrays.asList(%s);", arguments);
         retrievedString = retrieved.toString();
-        assertEquals(expected, retrievedString);
+        assertThat(retrievedString).isEqualTo(expected);
     }
 
     @Test
@@ -315,7 +311,7 @@ public class CommonCodegenUtilsTest {
         String returnedVariable = "RETURNED_VARIABLE";
         ReturnStmt retrieved = CommonCodegenUtils.getReturnStmt(returnedVariable);
         String expected = String.format("return %s;", returnedVariable);
-        assertEquals(expected, retrieved.toString());
+        assertThat(retrieved.toString()).isEqualTo(expected);
     }
 
     @Test
@@ -325,7 +321,7 @@ public class CommonCodegenUtilsTest {
         ClassOrInterfaceType retrieved = CommonCodegenUtils.getTypedClassOrInterfaceTypeByTypeNames(className, typesName);
         assertThat(retrieved).isNotNull();
         String expected = String.format("%1$s<%2$s,%3$s>", className, typesName.get(0), typesName.get(1));
-        assertEquals(expected, retrieved.asString());
+        assertThat(retrieved.asString()).isEqualTo(expected);
     }
 
     @Test
@@ -336,7 +332,7 @@ public class CommonCodegenUtilsTest {
         body.addStatement(assignExpr);
         final Expression value = new DoubleLiteralExpr(24.22);
         CommonCodegenUtils.setAssignExpressionValue(body, "MATCH", value);
-        assertEquals(value, assignExpr.getValue());
+        assertThat(assignExpr.getValue()).isEqualTo(value);
     }
 
     @Test(expected = KiePMMLException.class)
@@ -359,18 +355,18 @@ public class CommonCodegenUtilsTest {
         BlockStmt body = new BlockStmt();
         Optional<AssignExpr> retrieved = CommonCodegenUtils.getAssignExpression(body, "NOMATCH");
         assertThat(retrieved).isNotNull();
-        assertFalse(retrieved.isPresent());
+        assertThat(retrieved).isNotPresent();
         AssignExpr assignExpr = new AssignExpr();
         assignExpr.setTarget(new NameExpr("MATCH"));
         body.addStatement(assignExpr);
         retrieved = CommonCodegenUtils.getAssignExpression(body, "NOMATCH");
         assertThat(retrieved).isNotNull();
-        assertFalse(retrieved.isPresent());
+        assertThat(retrieved).isNotPresent();
         retrieved = CommonCodegenUtils.getAssignExpression(body, "MATCH");
         assertThat(retrieved).isNotNull();
-        assertTrue(retrieved.isPresent());
+        assertThat(retrieved).isPresent();
         AssignExpr retrievedAssignExpr = retrieved.get();
-        assertEquals(assignExpr, retrievedAssignExpr);
+        assertThat(retrievedAssignExpr).isEqualTo(assignExpr);
     }
 
     @Test
@@ -378,14 +374,14 @@ public class CommonCodegenUtilsTest {
         BlockStmt body = new BlockStmt();
         Optional<ExplicitConstructorInvocationStmt> retrieved = CommonCodegenUtils.getExplicitConstructorInvocationStmt(body);
         assertThat(retrieved).isNotNull();
-        assertFalse(retrieved.isPresent());
+        assertThat(retrieved).isNotPresent();
         ExplicitConstructorInvocationStmt explicitConstructorInvocationStmt = new ExplicitConstructorInvocationStmt();
         body.addStatement(explicitConstructorInvocationStmt);
         retrieved = CommonCodegenUtils.getExplicitConstructorInvocationStmt(body);
         assertThat(retrieved).isNotNull();
-        assertTrue(retrieved.isPresent());
+        assertThat(retrieved).isPresent();
         ExplicitConstructorInvocationStmt retrievedExplicitConstructorInvocationStmt = retrieved.get();
-        assertEquals(explicitConstructorInvocationStmt, retrievedExplicitConstructorInvocationStmt);
+        assertThat(retrievedExplicitConstructorInvocationStmt).isEqualTo(explicitConstructorInvocationStmt);
     }
 
     @Test
@@ -394,10 +390,10 @@ public class CommonCodegenUtilsTest {
         final String value = "VALUE";
         final ExplicitConstructorInvocationStmt explicitConstructorInvocationStmt = new ExplicitConstructorInvocationStmt();
         explicitConstructorInvocationStmt.setArguments(NodeList.nodeList( new NameExpr("NOT_PARAMETER"), new NameExpr(parameterName)));
-        assertTrue(CommonCodegenUtils.getExplicitConstructorInvocationParameter(explicitConstructorInvocationStmt, parameterName).isPresent());
+        assertThat(CommonCodegenUtils.getExplicitConstructorInvocationParameter(explicitConstructorInvocationStmt, parameterName)).isPresent();
         CommonCodegenUtils.setExplicitConstructorInvocationStmtArgument(explicitConstructorInvocationStmt, parameterName, value);
-        assertFalse(CommonCodegenUtils.getExplicitConstructorInvocationParameter(explicitConstructorInvocationStmt, parameterName).isPresent());
-        assertTrue(CommonCodegenUtils.getExplicitConstructorInvocationParameter(explicitConstructorInvocationStmt, value).isPresent());
+        assertThat(CommonCodegenUtils.getExplicitConstructorInvocationParameter(explicitConstructorInvocationStmt, parameterName)).isNotPresent();
+        assertThat(CommonCodegenUtils.getExplicitConstructorInvocationParameter(explicitConstructorInvocationStmt, value)).isPresent();
     }
 
     @Test(expected = KiePMMLException.class)
@@ -412,22 +408,22 @@ public class CommonCodegenUtilsTest {
     public void getExplicitConstructorInvocationParameter() {
         final String parameterName = "PARAMETER_NAME";
         final ExplicitConstructorInvocationStmt explicitConstructorInvocationStmt = new ExplicitConstructorInvocationStmt();
-        assertFalse(CommonCodegenUtils.getExplicitConstructorInvocationParameter(explicitConstructorInvocationStmt, parameterName).isPresent());
+        assertThat(CommonCodegenUtils.getExplicitConstructorInvocationParameter(explicitConstructorInvocationStmt, parameterName)).isNotPresent();
         explicitConstructorInvocationStmt.setArguments(NodeList.nodeList( new NameExpr("NOT_PARAMETER")));
-        assertFalse(CommonCodegenUtils.getExplicitConstructorInvocationParameter(explicitConstructorInvocationStmt, parameterName).isPresent());
+        assertThat(CommonCodegenUtils.getExplicitConstructorInvocationParameter(explicitConstructorInvocationStmt, parameterName)).isNotPresent();
         explicitConstructorInvocationStmt.setArguments(NodeList.nodeList( new NameExpr("NOT_PARAMETER"), new NameExpr(parameterName)));
-        assertTrue(CommonCodegenUtils.getExplicitConstructorInvocationParameter(explicitConstructorInvocationStmt, parameterName).isPresent());
+        assertThat(CommonCodegenUtils.getExplicitConstructorInvocationParameter(explicitConstructorInvocationStmt, parameterName)).isPresent();
     }
 
     @Test
     public void getMethodDeclaration() {
         final String methodName = "METHOD_NAME";
         final ClassOrInterfaceDeclaration classOrInterfaceDeclaration = new ClassOrInterfaceDeclaration();
-        assertFalse(CommonCodegenUtils.getMethodDeclaration(classOrInterfaceDeclaration, methodName).isPresent());
+        assertThat(CommonCodegenUtils.getMethodDeclaration(classOrInterfaceDeclaration, methodName)).isNotPresent();
         classOrInterfaceDeclaration.addMethod("NOT_METHOD");
-        assertFalse(CommonCodegenUtils.getMethodDeclaration(classOrInterfaceDeclaration, methodName).isPresent());
+        assertThat(CommonCodegenUtils.getMethodDeclaration(classOrInterfaceDeclaration, methodName)).isNotPresent();
         classOrInterfaceDeclaration.addMethod(methodName);
-        assertTrue(CommonCodegenUtils.getMethodDeclaration(classOrInterfaceDeclaration, methodName).isPresent());
+        assertThat(CommonCodegenUtils.getMethodDeclaration(classOrInterfaceDeclaration, methodName)).isPresent();
     }
 
     @Test
@@ -438,63 +434,63 @@ public class CommonCodegenUtilsTest {
         methodTemplate.setBody(body);
         final String methodName = "METHOD_NAME";
         final ClassOrInterfaceDeclaration classOrInterfaceDeclaration = new ClassOrInterfaceDeclaration();
-        assertTrue(classOrInterfaceDeclaration.getMethodsByName(methodName).isEmpty());
+        assertThat(classOrInterfaceDeclaration.getMethodsByName(methodName)).isEmpty();
         CommonCodegenUtils.addMethod(methodTemplate, classOrInterfaceDeclaration, methodName);
-        assertEquals(1, classOrInterfaceDeclaration.getMethodsByName(methodName).size());
-        assertEquals(body, classOrInterfaceDeclaration.getMethodsByName(methodName).get(0).getBody().get());
+        assertThat(classOrInterfaceDeclaration.getMethodsByName(methodName).size()).isEqualTo(1);
+        assertThat(classOrInterfaceDeclaration.getMethodsByName(methodName).get(0).getBody().get()).isEqualTo(body);
     }
 
     @Test
     public void getVariableDeclarator() {
         final String variableName = "variableName";
         final BlockStmt body = new BlockStmt();
-        assertFalse(CommonCodegenUtils.getVariableDeclarator(body, variableName).isPresent());
+        assertThat(CommonCodegenUtils.getVariableDeclarator(body, variableName)).isNotPresent();
         final VariableDeclarationExpr variableDeclarationExpr = new VariableDeclarationExpr(parseClassOrInterfaceType("String"), variableName);
         body.addStatement(variableDeclarationExpr);
         Optional<VariableDeclarator> retrieved =  CommonCodegenUtils.getVariableDeclarator(body, variableName);
-        assertTrue(retrieved.isPresent());
+        assertThat(retrieved).isPresent();
         VariableDeclarator variableDeclarator = retrieved.get();
-        assertEquals(variableName, variableDeclarator.getName().asString());
+        assertThat(variableDeclarator.getName().asString()).isEqualTo(variableName);
     }
 
     @Test
     public void getExpressionForObject() {
         String string = "string";
         Expression retrieved = CommonCodegenUtils.getExpressionForObject(string);
-        assertTrue(retrieved instanceof  StringLiteralExpr);
-        assertEquals("\"string\"", retrieved.toString());
+        assertThat(retrieved).isInstanceOf(StringLiteralExpr.class);
+        assertThat(retrieved.toString()).isEqualTo("\"string\"");
         int i = 1;
         retrieved = CommonCodegenUtils.getExpressionForObject(i);
-        assertTrue(retrieved instanceof  IntegerLiteralExpr);
-        assertEquals(i, ((IntegerLiteralExpr)retrieved).asInt());
+        assertThat(retrieved).isInstanceOf(IntegerLiteralExpr.class);
+        assertThat(((IntegerLiteralExpr)retrieved).asInt()).isEqualTo(i);
         Integer j = 3;
         retrieved = CommonCodegenUtils.getExpressionForObject(j);
-        assertTrue(retrieved instanceof  IntegerLiteralExpr);
-        assertEquals(j.intValue(), ((IntegerLiteralExpr)retrieved).asInt());
+        assertThat(retrieved).isInstanceOf(IntegerLiteralExpr.class);
+        assertThat(((IntegerLiteralExpr)retrieved).asInt()).isEqualTo(j.intValue());
         double x = 1.12;
         retrieved = CommonCodegenUtils.getExpressionForObject(x);
-        assertTrue(retrieved instanceof  DoubleLiteralExpr);
-        assertEquals(x, ((DoubleLiteralExpr)retrieved).asDouble(), 0.001);
+        assertThat(retrieved).isInstanceOf(DoubleLiteralExpr.class);
+        assertThat(((DoubleLiteralExpr)retrieved).asDouble()).isCloseTo(x, Offset.offset(0.001));
         Double y = 3.12;
         retrieved = CommonCodegenUtils.getExpressionForObject(y);
-        assertTrue(retrieved instanceof  DoubleLiteralExpr);
-        assertEquals(y, ((DoubleLiteralExpr)retrieved).asDouble(), 0.001);
+        assertThat(retrieved).isInstanceOf(DoubleLiteralExpr.class);
+        assertThat(((DoubleLiteralExpr)retrieved).asDouble()).isCloseTo(y, Offset.offset(0.001));
         float k = 1.12f;
         retrieved = CommonCodegenUtils.getExpressionForObject(k);
-        assertTrue(retrieved instanceof  DoubleLiteralExpr);
-        assertEquals(1.12, ((DoubleLiteralExpr)retrieved).asDouble(), 0.001);
+        assertThat(retrieved).isInstanceOf(DoubleLiteralExpr.class);
+        assertThat(((DoubleLiteralExpr)retrieved).asDouble()).isCloseTo(1.12, Offset.offset(0.001));
         Float z = 3.12f;
         retrieved = CommonCodegenUtils.getExpressionForObject(z);
-        assertTrue(retrieved instanceof  DoubleLiteralExpr);
-        assertEquals(z.doubleValue(), ((DoubleLiteralExpr)retrieved).asDouble(), 0.001);
+        assertThat(retrieved).isInstanceOf(DoubleLiteralExpr.class);
+        assertThat(((DoubleLiteralExpr)retrieved).asDouble()).isCloseTo(z.doubleValue(), Offset.offset(0.001));
         boolean b = true;
         retrieved = CommonCodegenUtils.getExpressionForObject(b);
-        assertTrue(retrieved instanceof BooleanLiteralExpr);
-        assertEquals(b, ((BooleanLiteralExpr)retrieved).getValue());
+        assertThat(retrieved).isInstanceOf(BooleanLiteralExpr.class);
+        assertThat(((BooleanLiteralExpr)retrieved).getValue()).isEqualTo(b);
         Boolean c = false;
         retrieved = CommonCodegenUtils.getExpressionForObject(c);
-        assertTrue(retrieved instanceof BooleanLiteralExpr);
-        assertEquals(c, ((BooleanLiteralExpr)retrieved).getValue());
+        assertThat(retrieved).isInstanceOf(BooleanLiteralExpr.class);
+        assertThat(((BooleanLiteralExpr)retrieved).getValue()).isEqualTo(c);
     }
 
     @Test
@@ -502,11 +498,11 @@ public class CommonCodegenUtilsTest {
         BlockStmt toRead = new BlockStmt();
         List<NameExpr> retrieved = CommonCodegenUtils.getNameExprsFromBlock(toRead, "value");
         assertThat(retrieved).isNotNull();
-        assertTrue(retrieved.isEmpty());
+        assertThat(retrieved).isEmpty();
         toRead = getBlockStmt();
         retrieved = CommonCodegenUtils.getNameExprsFromBlock(toRead, "value");
         assertThat(retrieved).isNotNull();
-        assertEquals(2, retrieved.size());
+        assertThat(retrieved).hasSize(2);
     }
 
     @Test
@@ -531,27 +527,27 @@ public class CommonCodegenUtilsTest {
         inputMap.put(DATA_TYPE.DATE_TIME_SECONDS_SINCE_1980, "90");
 
         for (Map.Entry<DATA_TYPE, String> input : inputMap.entrySet()) {
-            assertTrue(literalExprFrom(input.getKey(), null) instanceof NullLiteralExpr);
+            assertThat(literalExprFrom(input.getKey(), null)).isInstanceOf(NullLiteralExpr.class);
 
             Expression output = literalExprFrom(input.getKey(), input.getValue());
             switch (input.getKey()) {
                 case STRING:
-                    assertTrue(output instanceof StringLiteralExpr);
+                    assertThat(output).isInstanceOf(StringLiteralExpr.class);
                     break;
                 case INTEGER:
-                    assertTrue(output instanceof IntegerLiteralExpr);
+                    assertThat(output).isInstanceOf(IntegerLiteralExpr.class);
                     break;
                 case DOUBLE:
                 case FLOAT:
-                    assertTrue(output instanceof DoubleLiteralExpr);
+                    assertThat(output).isInstanceOf(DoubleLiteralExpr.class);
                     break;
                 case BOOLEAN:
-                    assertTrue(output instanceof BooleanLiteralExpr);
+                    assertThat(output).isInstanceOf(BooleanLiteralExpr.class);
                     break;
                 case DATE:
                 case TIME:
                 case DATE_TIME:
-                    assertTrue(output instanceof MethodCallExpr);
+                    assertThat(output).isInstanceOf(MethodCallExpr.class);
                     break;
                 case DATE_DAYS_SINCE_0:
                 case DATE_DAYS_SINCE_1960:
@@ -562,25 +558,25 @@ public class CommonCodegenUtilsTest {
                 case DATE_TIME_SECONDS_SINCE_1960:
                 case DATE_TIME_SECONDS_SINCE_1970:
                 case DATE_TIME_SECONDS_SINCE_1980:
-                    assertTrue(output instanceof LongLiteralExpr);
+                    assertThat(output).isInstanceOf(LongLiteralExpr.class);
             }
         }
 
-        assertThrows(IllegalArgumentException.class, () -> literalExprFrom(null, null));
-        assertThrows(IllegalArgumentException.class, () -> literalExprFrom(null, "test"));
+        assertThatIllegalArgumentException().isThrownBy(() -> literalExprFrom(null, null));
+        assertThatIllegalArgumentException().isThrownBy(() -> literalExprFrom(null, "test"));
     }
 
     @Test
     public void replaceNodesInBlock() {
         final BlockStmt toRead = getBlockStmt();
         final List<NameExpr> retrieved = CommonCodegenUtils.getNameExprsFromBlock(toRead, "value");
-        assertEquals(2, retrieved.size());
+        assertThat(retrieved).hasSize(2);
         final List<NullLiteralExpr> nullExprs =  toRead.stream()
                 .filter(node -> node instanceof NullLiteralExpr)
                 .map(NullLiteralExpr.class::cast)
                 .collect(Collectors.toList());
         assertThat(nullExprs).isNotNull();
-        assertTrue(nullExprs.isEmpty());
+        assertThat(nullExprs).isEmpty();
 
         final List<CommonCodegenUtils.ReplacementTupla> replacementTuplas =
                 retrieved.stream()
@@ -592,15 +588,15 @@ public class CommonCodegenUtilsTest {
                 .collect(Collectors.toList());
         CommonCodegenUtils.replaceNodesInStatement(toRead, replacementTuplas);
         final List<NameExpr> newRetrieved = CommonCodegenUtils.getNameExprsFromBlock(toRead, "value");
-        assertTrue(newRetrieved.isEmpty());
+        assertThat(newRetrieved).isEmpty();
 
         final List<NullLiteralExpr> retrievedNullExprs =  toRead.stream()
                 .filter(node -> node instanceof NullLiteralExpr)
                 .map(NullLiteralExpr.class::cast)
                 .collect(Collectors.toList());
         assertThat(nullExprs).isNotNull();
-        assertEquals(nullExprs.size(), retrievedNullExprs.size());
-        nullExprs.forEach(nullExpr -> assertTrue(retrievedNullExprs.contains(nullExpr)));
+        assertThat(retrievedNullExprs).hasSameSizeAs(nullExprs);
+        nullExprs.forEach(nullExpr -> assertThat(retrievedNullExprs).contains(nullExpr));
     }
 
     private BlockStmt getBlockStmt() {
@@ -620,16 +616,16 @@ public class CommonCodegenUtilsTest {
 
     private void commonValidateMethodDeclaration(MethodDeclaration toValidate, String methodName) {
         assertThat(toValidate).isNotNull();
-        assertEquals(methodName, toValidate.getName().asString());
+        assertThat(toValidate.getName().asString()).isEqualTo(methodName);
     }
 
     private void commonValidateMethodDeclarationParams(MethodDeclaration toValidate, Map<String, ClassOrInterfaceType> parameterNameTypeMap) {
         final NodeList<Parameter> retrieved = toValidate.getParameters();
         assertThat(retrieved).isNotNull();
-        assertEquals(parameterNameTypeMap.size(), retrieved.size());
+        assertThat(retrieved).hasSize(parameterNameTypeMap.size());
         for (Parameter parameter : retrieved) {
-            assertTrue(parameterNameTypeMap.containsKey(parameter.getNameAsString()));
-            assertEquals(parameterNameTypeMap.get(parameter.getNameAsString()), parameter.getType());
+            assertThat(parameterNameTypeMap).containsKey(parameter.getNameAsString());
+            assertThat(parameter.getType()).isEqualTo(parameterNameTypeMap.get(parameter.getNameAsString()));
         }
     }
 

--- a/kie-pmml-trusty/kie-pmml-compiler/kie-pmml-compiler-commons/src/test/java/org/kie/pmml/compiler/commons/utils/JavaParserUtilsTest.java
+++ b/kie-pmml-trusty/kie-pmml-compiler/kie-pmml-compiler-commons/src/test/java/org/kie/pmml/compiler/commons/utils/JavaParserUtilsTest.java
@@ -25,9 +25,6 @@ import org.junit.Test;
 import org.kie.pmml.api.exceptions.KiePMMLInternalException;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
 
 public class JavaParserUtilsTest {
 
@@ -58,10 +55,10 @@ public class JavaParserUtilsTest {
         String packageName = "apackage";
         CompilationUnit retrieved = JavaParserUtils.getKiePMMLModelCompilationUnit(className, packageName,  TEMPLATE_FILE, TEMPLATE_CLASS);
         assertThat(retrieved).isNotNull();
-        assertTrue(retrieved.getPackageDeclaration().isPresent());
-        assertEquals(packageName, retrieved.getPackageDeclaration().get().getName().asString());
-        assertFalse(retrieved.getClassByName(TEMPLATE_CLASS).isPresent());
-        assertTrue(retrieved.getClassByName(className).isPresent());
+        assertThat(retrieved.getPackageDeclaration()).isPresent();
+        assertThat(retrieved.getPackageDeclaration().get().getName().asString()).isEqualTo(packageName);
+        assertThat(retrieved.getClassByName(TEMPLATE_CLASS)).isNotPresent();
+        assertThat(retrieved.getClassByName(className)).isPresent();
     }
 
     @Test
@@ -69,9 +66,9 @@ public class JavaParserUtilsTest {
         String className = "ClassName";
         CompilationUnit retrieved = JavaParserUtils.getKiePMMLModelCompilationUnit(className, null,  TEMPLATE_FILE, TEMPLATE_CLASS);
         assertThat(retrieved).isNotNull();
-        assertFalse(retrieved.getPackageDeclaration().isPresent());
-        assertFalse(retrieved.getClassByName(TEMPLATE_CLASS).isPresent());
-        assertTrue(retrieved.getClassByName(className).isPresent());
+        assertThat(retrieved.getPackageDeclaration()).isNotPresent();
+        assertThat(retrieved.getClassByName(TEMPLATE_CLASS)).isNotPresent();
+        assertThat(retrieved.getClassByName(className)).isPresent();
     }
 
     @Test
@@ -87,7 +84,7 @@ public class JavaParserUtilsTest {
         compilationUnit.setTypes(NodeList.nodeList(classOrInterfaceDeclaration));
         String retrieved = JavaParserUtils.getFullClassName(compilationUnit);
         String expected = packageName + "." + className;
-        assertEquals(expected, retrieved);
+        assertThat(retrieved).isEqualTo(expected);
 
     }
 }

--- a/kie-pmml-trusty/kie-pmml-compiler/kie-pmml-compiler-commons/src/test/java/org/kie/pmml/compiler/commons/utils/KiePMMLLoadedModelUtilsTest.java
+++ b/kie-pmml-trusty/kie-pmml-compiler/kie-pmml-compiler-commons/src/test/java/org/kie/pmml/compiler/commons/utils/KiePMMLLoadedModelUtilsTest.java
@@ -28,9 +28,6 @@ import org.kie.pmml.api.exceptions.KiePMMLInternalException;
 import org.kie.pmml.commons.model.tuples.KiePMMLNameOpType;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
 import static org.kie.pmml.api.enums.OP_TYPE.CATEGORICAL;
 import static org.kie.pmml.api.enums.OP_TYPE.CONTINUOUS;
 import static org.kie.pmml.compiler.api.CommonTestingUtils.getFieldsFromDataDictionary;
@@ -60,8 +57,8 @@ public class KiePMMLLoadedModelUtilsTest {
     public void getTargetFieldNoTarget() throws Exception {
         pmmlModel = KiePMMLUtil.load(getFileInputStream(NO_TARGET_SOURCE), NO_TARGET_SOURCE);
         final List<Field<?>> fields = getFieldsFromDataDictionary(pmmlModel.getDataDictionary());
-        assertTrue(getTargetFieldName(fields, pmmlModel.getModels().get(0)).isPresent());
-        assertFalse(getTargetFields(fields, pmmlModel.getModels().get(0)).isEmpty());
+        assertThat(getTargetFieldName(fields, pmmlModel.getModels().get(0))).isPresent();
+        assertThat(getTargetFields(fields, pmmlModel.getModels().get(0))).isNotEmpty();
     }
 
     @Test
@@ -69,11 +66,11 @@ public class KiePMMLLoadedModelUtilsTest {
         pmmlModel = KiePMMLUtil.load(getFileInputStream(ONE_MINING_TARGET_SOURCE), ONE_MINING_TARGET_SOURCE);
         final List<Field<?>> fields = getFieldsFromDataDictionary(pmmlModel.getDataDictionary());
         final Optional<String> retrieved = getTargetFieldName(fields, pmmlModel.getModels().get(0));
-        assertTrue(retrieved.isPresent());
-        assertEquals(WHAT_I_DO_TARGET_FIELD, retrieved.get());
+        assertThat(retrieved).isPresent();
+        assertThat(retrieved.get()).isEqualTo(WHAT_I_DO_TARGET_FIELD);
         final List<KiePMMLNameOpType> retrieveds = getTargetFields(fields, pmmlModel.getModels().get(0));
-        assertEquals(1, retrieveds.size());
-        assertEquals(WHAT_I_DO_TARGET_FIELD, retrieveds.get(0).getName());
+        assertThat(retrieveds).hasSize(1);
+        assertThat(retrieveds.get(0).getName()).isEqualTo(WHAT_I_DO_TARGET_FIELD);
     }
 
     @Test
@@ -81,11 +78,11 @@ public class KiePMMLLoadedModelUtilsTest {
         pmmlModel = KiePMMLUtil.load(getFileInputStream(MULTIPLE_TARGETS_SOURCE), MULTIPLE_TARGETS_SOURCE);
         final List<Field<?>> fields = getFieldsFromDataDictionary(pmmlModel.getDataDictionary());
         final Optional<String> retrieved = getTargetFieldName(fields, pmmlModel.getModels().get(0));
-        assertTrue(retrieved.isPresent());
-        assertEquals(CAR_LOCATION_FIELD, retrieved.get());
+        assertThat(retrieved).isPresent();
+        assertThat(retrieved.get()).isEqualTo(CAR_LOCATION_FIELD);
         final List<KiePMMLNameOpType> retrieveds = getTargetFields(fields, pmmlModel.getModels().get(0));
-        assertEquals(1, retrieveds.size());
-        assertEquals(CAR_LOCATION_FIELD, retrieveds.get(0).getName());
+        assertThat(retrieveds).hasSize(1);
+        assertThat(retrieveds.get(0).getName()).isEqualTo(CAR_LOCATION_FIELD);
     }
 
     @Test
@@ -93,7 +90,7 @@ public class KiePMMLLoadedModelUtilsTest {
         pmmlModel = KiePMMLUtil.load(getFileInputStream(NO_TARGET_SOURCE), NO_TARGET_SOURCE);
         final OP_TYPE retrieved = getOpType(getFieldsFromDataDictionary(pmmlModel.getDataDictionary()), pmmlModel.getModels().get(0), TEMPERATURE_FIELD);
         assertThat(retrieved).isNotNull();
-        assertEquals(CONTINUOUS, retrieved);
+        assertThat(retrieved).isEqualTo(CONTINUOUS);
     }
 
     @Test
@@ -101,7 +98,7 @@ public class KiePMMLLoadedModelUtilsTest {
         pmmlModel = KiePMMLUtil.load(getFileInputStream(ONE_MINING_TARGET_SOURCE), ONE_MINING_TARGET_SOURCE);
         final OP_TYPE retrieved = getOpType(getFieldsFromDataDictionary(pmmlModel.getDataDictionary()), pmmlModel.getModels().get(0), OUTLOOK_FIELD);
         assertThat(retrieved).isNotNull();
-        assertEquals(CATEGORICAL, retrieved);
+        assertThat(retrieved).isEqualTo(CATEGORICAL);
     }
 
     @Test(expected = KiePMMLInternalException.class)
@@ -117,12 +114,12 @@ public class KiePMMLLoadedModelUtilsTest {
         for (int i = 0; i < models.size(); i ++) {
             Model model = models.get(i);
             assertThat(model.getModelName()).isNotNull();
-            assertFalse(model.getModelName().isEmpty());
+            assertThat(model.getModelName()).isNotEmpty();
             String expected = String.format(MODELNAME_TEMPLATE,
                                             NO_MODELNAME_SAMPLE_NAME,
                                             model.getClass().getSimpleName(),
                                             i);
-            assertEquals(expected, model.getModelName());
+            assertThat(model.getModelName()).isEqualTo(expected);
         }
 
     }

--- a/kie-pmml-trusty/kie-pmml-compiler/kie-pmml-compiler-commons/src/test/java/org/kie/pmml/compiler/commons/utils/KiePMMLUtilTest.java
+++ b/kie-pmml-trusty/kie-pmml-compiler/kie-pmml-compiler-commons/src/test/java/org/kie/pmml/compiler/commons/utils/KiePMMLUtilTest.java
@@ -52,10 +52,6 @@ import org.junit.Test;
 import org.xml.sax.SAXException;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertTrue;
 import static org.kie.pmml.compiler.commons.utils.KiePMMLUtil.MODELNAME_TEMPLATE;
 import static org.kie.pmml.compiler.commons.utils.KiePMMLUtil.SEGMENTID_TEMPLATE;
 import static org.kie.pmml.compiler.commons.utils.KiePMMLUtil.SEGMENTMODELNAME_TEMPLATE;
@@ -92,14 +88,14 @@ public class KiePMMLUtilTest {
         final InputStream inputStream = getFileInputStream(NO_MODELNAME_SAMPLE_NAME);
         final PMML pmml = org.jpmml.model.PMMLUtil.unmarshal(inputStream);
         final Model toPopulate = pmml.getModels().get(0);
-        assertNull(toPopulate.getModelName());
+        assertThat(toPopulate.getModelName()).isNull();
         KiePMMLUtil.populateMissingModelName(toPopulate, NO_MODELNAME_SAMPLE_NAME, 0);
         assertThat(toPopulate.getModelName()).isNotNull();
         String expected = String.format(MODELNAME_TEMPLATE,
                                         NO_MODELNAME_SAMPLE_NAME,
                                         toPopulate.getClass().getSimpleName(),
                                         0);
-        assertEquals(expected, toPopulate.getModelName());
+        assertThat(toPopulate.getModelName()).isEqualTo(expected);
     }
 
     @Test
@@ -108,17 +104,17 @@ public class KiePMMLUtilTest {
         final PMML pmml = org.jpmml.model.PMMLUtil.unmarshal(inputStream);
         final Model toPopulate = pmml.getModels().get(0);
         List<MiningField> miningTargetFields = getMiningTargetFields(toPopulate.getMiningSchema().getMiningFields());
-        assertTrue(miningTargetFields.isEmpty());
-        assertNull(toPopulate.getTargets().getTargets().get(0).getField());
+        assertThat(miningTargetFields).isEmpty();
+        assertThat(toPopulate.getTargets().getTargets().get(0).getField()).isNull();
         KiePMMLUtil.populateMissingMiningTargetField(toPopulate, pmml.getDataDictionary().getDataFields());
         miningTargetFields = getMiningTargetFields(toPopulate.getMiningSchema().getMiningFields());
-        assertEquals(1, miningTargetFields.size());
+        assertThat(miningTargetFields).hasSize(1);
         final MiningField targetField = miningTargetFields.get(0);
-        assertTrue(pmml.getDataDictionary()
+        assertThat(pmml.getDataDictionary()
                            .getDataFields()
                            .stream()
-                           .anyMatch(dataField -> dataField.getName().equals(targetField.getName())));
-        assertEquals(targetField.getName(), toPopulate.getTargets().getTargets().get(0).getField());
+                           .anyMatch(dataField -> dataField.getName().equals(targetField.getName()))).isTrue();
+        assertThat(toPopulate.getTargets().getTargets().get(0).getField()).isEqualTo(targetField.getName());
     }
 
     @Test
@@ -127,12 +123,12 @@ public class KiePMMLUtilTest {
         final PMML pmml = org.jpmml.model.PMMLUtil.unmarshal(inputStream);
         final Model toPopulate = pmml.getModels().get(0);
         final OutputField outputField = toPopulate.getOutput().getOutputFields().get(0);
-        assertEquals(ResultFeature.PREDICTED_VALUE, outputField.getResultFeature());
-        assertNull(outputField.getTargetField());
+        assertThat(outputField.getResultFeature()).isEqualTo(ResultFeature.PREDICTED_VALUE);
+        assertThat(outputField.getTargetField()).isNull();
         KiePMMLUtil.populateMissingPredictedOutputFieldTarget(toPopulate);
         final MiningField targetField = getMiningTargetFields(toPopulate.getMiningSchema().getMiningFields()).get(0);
         assertThat(outputField.getTargetField()).isNotNull();
-        assertEquals(targetField.getName(), outputField.getTargetField());
+        assertThat(outputField.getTargetField()).isEqualTo(targetField.getName());
     }
 
     @Test
@@ -141,10 +137,10 @@ public class KiePMMLUtilTest {
         final PMML pmml = org.jpmml.model.PMMLUtil.unmarshal(inputStream);
         final Model model = pmml.getModels().get(0);
         Optional<DataField> optionalDataField = KiePMMLUtil.getTargetDataField(model);
-        assertTrue(optionalDataField.isPresent());
+        assertThat(optionalDataField).isPresent();
         DataField retrieved = optionalDataField.get();
         String expected= String.format(TARGETFIELD_TEMPLATE, "golfing");
-        assertEquals(expected, retrieved.getName().getValue());
+        assertThat(retrieved.getName().getValue()).isEqualTo(expected);
     }
 
     @Test
@@ -152,41 +148,41 @@ public class KiePMMLUtilTest {
         MiningFunction miningFunction = MiningFunction.REGRESSION;
         MathContext mathContext = MathContext.DOUBLE;
         DataType retrieved = KiePMMLUtil.getTargetDataType(miningFunction, mathContext);
-        assertEquals(DataType.DOUBLE, retrieved);
+        assertThat(retrieved).isEqualTo(DataType.DOUBLE);
         mathContext = MathContext.FLOAT;
         retrieved = KiePMMLUtil.getTargetDataType(miningFunction, mathContext);
-        assertEquals(DataType.FLOAT, retrieved);
+        assertThat(retrieved).isEqualTo(DataType.FLOAT);
         miningFunction = MiningFunction.CLASSIFICATION;
         retrieved = KiePMMLUtil.getTargetDataType(miningFunction, mathContext);
-        assertEquals(DataType.STRING, retrieved);
+        assertThat(retrieved).isEqualTo(DataType.STRING);
         miningFunction = MiningFunction.CLUSTERING;
         retrieved = KiePMMLUtil.getTargetDataType(miningFunction, mathContext);
-        assertEquals(DataType.STRING, retrieved);
+        assertThat(retrieved).isEqualTo(DataType.STRING);
         List<MiningFunction> notMappedMiningFunctions = Arrays.asList(MiningFunction.ASSOCIATION_RULES,
                                                                       MiningFunction.MIXED,
                                                                       MiningFunction.SEQUENCES,
                                                                       MiningFunction.TIME_SERIES);
 
-        notMappedMiningFunctions.forEach(minFun -> assertNull(KiePMMLUtil.getTargetDataType(minFun, MathContext.DOUBLE)));
+        notMappedMiningFunctions.forEach(minFun -> assertThat(KiePMMLUtil.getTargetDataType(minFun, MathContext.DOUBLE)).isNull());
     }
 
     @Test
     public void getTargetOpType()  {
         MiningFunction miningFunction = MiningFunction.REGRESSION;
         OpType retrieved = KiePMMLUtil.getTargetOpType(miningFunction);
-        assertEquals(OpType.CONTINUOUS, retrieved);
+        assertThat(retrieved).isEqualTo(OpType.CONTINUOUS);
         miningFunction = MiningFunction.CLASSIFICATION;
         retrieved = KiePMMLUtil.getTargetOpType(miningFunction);
-        assertEquals(OpType.CATEGORICAL, retrieved);
+        assertThat(retrieved).isEqualTo(OpType.CATEGORICAL);
         miningFunction = MiningFunction.CLUSTERING;
         retrieved = KiePMMLUtil.getTargetOpType(miningFunction);
-        assertEquals(OpType.CATEGORICAL, retrieved);
+        assertThat(retrieved).isEqualTo(OpType.CATEGORICAL);
         List<MiningFunction> notMappedMiningFunctions = Arrays.asList(MiningFunction.ASSOCIATION_RULES,
                                                                       MiningFunction.MIXED,
                                                                       MiningFunction.SEQUENCES,
                                                                       MiningFunction.TIME_SERIES);
 
-        notMappedMiningFunctions.forEach(minFun -> assertNull(KiePMMLUtil.getTargetOpType(minFun)));
+        notMappedMiningFunctions.forEach(minFun -> assertThat(KiePMMLUtil.getTargetOpType(minFun)).isNull());
     }
 
     @Test
@@ -194,8 +190,8 @@ public class KiePMMLUtilTest {
         final DataField dataField = new DataField();
         dataField.setName(FieldName.create("FIELD_NAME"));
         final MiningField retrieved = KiePMMLUtil.getTargetMiningField(dataField);
-        assertEquals(dataField.getName().getValue(), retrieved.getName().getValue());
-        assertEquals(MiningField.UsageType.TARGET, retrieved.getUsageType());
+        assertThat(retrieved.getName().getValue()).isEqualTo(dataField.getName().getValue());
+        assertThat(retrieved.getUsageType()).isEqualTo(MiningField.UsageType.TARGET);
     }
 
     @Test
@@ -208,8 +204,8 @@ public class KiePMMLUtilTest {
         final Target unnamedTarget = new Target();
         targets.addTargets(namedTarget, unnamedTarget);
         KiePMMLUtil.correctTargetFields(miningField, targets);
-        assertEquals(targetName, namedTarget.getField().getValue());
-        assertEquals(miningField.getName(), unnamedTarget.getField());
+        assertThat(namedTarget.getField().getValue()).isEqualTo(targetName);
+        assertThat(unnamedTarget.getField()).isEqualTo(miningField.getName());
     }
 
     @Test
@@ -217,18 +213,18 @@ public class KiePMMLUtilTest {
         final InputStream inputStream = getFileInputStream(NO_MODELNAME_NO_SEGMENT_ID_NOSEGMENT_TARGET_FIELD_SAMPLE);
         final PMML pmml = org.jpmml.model.PMMLUtil.unmarshal(inputStream);
         final Model retrieved = pmml.getModels().get(0);
-        assertTrue(retrieved instanceof MiningModel);
+        assertThat(retrieved).isInstanceOf(MiningModel.class);
         MiningModel miningModel = (MiningModel) retrieved;
         miningModel.getSegmentation().getSegments().forEach(segment -> {
-            assertNull(segment.getId());
-            assertNull(segment.getModel().getModelName());
-            assertTrue(getMiningTargetFields(segment.getModel().getMiningSchema()).isEmpty());
+            assertThat(segment.getId()).isNull();
+            assertThat(segment.getModel().getModelName()).isNull();
+            assertThat(getMiningTargetFields(segment.getModel().getMiningSchema())).isEmpty();
         });
         KiePMMLUtil.populateCorrectMiningModel(miningModel);
         miningModel.getSegmentation().getSegments().forEach(segment -> {
             assertThat(segment.getId()).isNotNull();
             assertThat(segment.getModel().getModelName()).isNotNull();
-            assertFalse(getMiningTargetFields(segment.getModel().getMiningSchema()).isEmpty());
+            assertThat(getMiningTargetFields(segment.getModel().getMiningSchema())).isNotEmpty();
         });
     }
 
@@ -237,10 +233,10 @@ public class KiePMMLUtilTest {
         final InputStream inputStream = getFileInputStream(NO_MODELNAME_NO_SEGMENTID_SAMPLE_NAME);
         final PMML pmml = org.jpmml.model.PMMLUtil.unmarshal(inputStream);
         final Model retrieved = pmml.getModels().get(0);
-        assertTrue(retrieved instanceof MiningModel);
+        assertThat(retrieved).isInstanceOf(MiningModel.class);
         MiningModel miningModel = (MiningModel) retrieved;
         Segment toPopulate = miningModel.getSegmentation().getSegments().get(0);
-        assertNull(toPopulate.getId());
+        assertThat(toPopulate.getId()).isNull();
         String modelName = "MODEL_NAME";
         int i = 0;
         KiePMMLUtil.populateCorrectSegmentId(toPopulate, modelName, i);
@@ -248,7 +244,7 @@ public class KiePMMLUtilTest {
         String expected = String.format(SEGMENTID_TEMPLATE,
                                         modelName,
                                         i);
-        assertEquals(expected, toPopulate.getId());
+        assertThat(toPopulate.getId()).isEqualTo(expected);
     }
 
     @Test
@@ -256,17 +252,17 @@ public class KiePMMLUtilTest {
         final InputStream inputStream = getFileInputStream(NO_MODELNAME_NO_SEGMENTID_SAMPLE_NAME);
         final PMML pmml = org.jpmml.model.PMMLUtil.unmarshal(inputStream);
         final Model retrieved = pmml.getModels().get(0);
-        assertTrue(retrieved instanceof MiningModel);
+        assertThat(retrieved).isInstanceOf(MiningModel.class);
         MiningModel miningModel = (MiningModel) retrieved;
         Model toPopulate = miningModel.getSegmentation().getSegments().get(0).getModel();
-        assertNull(toPopulate.getModelName());
+        assertThat(toPopulate.getModelName()).isNull();
         String segmentId = "SEG_ID";
         KiePMMLUtil.populateMissingSegmentModelName(toPopulate, segmentId);
         assertThat(toPopulate.getModelName()).isNotNull();
         String expected = String.format(SEGMENTMODELNAME_TEMPLATE,
                                         segmentId,
                                         toPopulate.getClass().getSimpleName());
-        assertEquals(expected, toPopulate.getModelName());
+        assertThat(toPopulate.getModelName()).isEqualTo(expected);
     }
 
     @Test
@@ -274,14 +270,14 @@ public class KiePMMLUtilTest {
         final InputStream inputStream = getFileInputStream(NO_MODELNAME_NO_SEGMENT_ID_NOSEGMENT_TARGET_FIELD_SAMPLE);
         final PMML pmml = org.jpmml.model.PMMLUtil.unmarshal(inputStream);
         final Model retrieved = pmml.getModels().get(0);
-        assertTrue(retrieved instanceof MiningModel);
+        assertThat(retrieved).isInstanceOf(MiningModel.class);
         MiningModel miningModel = (MiningModel) retrieved;
         Model toPopulate = miningModel.getSegmentation().getSegments().get(0).getModel();
-        assertTrue(getMiningTargetFields(toPopulate.getMiningSchema()).isEmpty());
+        assertThat(getMiningTargetFields(toPopulate.getMiningSchema())).isEmpty();
         KiePMMLUtil.populateMissingTargetFieldInSegment(retrieved.getMiningSchema(), toPopulate);
         List<MiningField> childrenTargetFields = getMiningTargetFields(toPopulate.getMiningSchema());
-        assertFalse(childrenTargetFields.isEmpty());
-        getMiningTargetFields(miningModel.getMiningSchema()).forEach(parentTargetField -> assertTrue(childrenTargetFields.contains(parentTargetField)));
+        assertThat(childrenTargetFields).isNotEmpty();
+        getMiningTargetFields(miningModel.getMiningSchema()).forEach(parentTargetField -> assertThat(childrenTargetFields).contains(parentTargetField));
     }
 
 
@@ -333,7 +329,7 @@ public class KiePMMLUtilTest {
         targetingOutputField.setName(FieldName.create(RandomStringUtils.random(6, true, false)));
         targetingOutputField.setTargetField(FieldName.create(targetMiningField.getName().getValue()));
         outputFields.add(targetingOutputField);
-        outputFields.forEach(outputField -> assertNull(outputField.getDataType()));
+        outputFields.forEach(outputField -> assertThat(outputField.getDataType()).isNull());
         IntStream.range(0, 2)
                 .forEach(i -> {
                     OutputField toAdd = new OutputField();
@@ -352,15 +348,15 @@ public class KiePMMLUtilTest {
         String id = "2";
         String expected = String.format(SEGMENTID_TEMPLATE, modelName, id);
         String retrieved = KiePMMLUtil.getSanitizedId(id, modelName);
-        assertEquals(expected, retrieved);
+        assertThat(retrieved).isEqualTo(expected);
         id = "34.5";
         expected = String.format(SEGMENTID_TEMPLATE, modelName, id);
         retrieved = KiePMMLUtil.getSanitizedId(id, modelName);
-        assertEquals(expected, retrieved);
+        assertThat(retrieved).isEqualTo(expected);
         id = "3,45";
         expected = String.format(SEGMENTID_TEMPLATE, modelName, id);
         retrieved = KiePMMLUtil.getSanitizedId(id, modelName);
-        assertEquals(expected, retrieved);
+        assertThat(retrieved).isEqualTo(expected);
     }
 
     @Test
@@ -370,10 +366,10 @@ public class KiePMMLUtilTest {
         final Model model = toPopulate.getModels().get(0);
         List<MiningField> retrieved = KiePMMLUtil.getMiningTargetFields(model.getMiningSchema());
         assertThat(retrieved).isNotNull();
-        assertEquals(1, retrieved.size());
+        assertThat(retrieved).hasSize(1);
         MiningField targetField = retrieved.get(0);
-        assertEquals("car_location", targetField.getName().getValue());
-        assertEquals("target", targetField.getUsageType().value());
+        assertThat(targetField.getName().getValue()).isEqualTo("car_location");
+        assertThat(targetField.getUsageType().value()).isEqualTo("target");
     }
 
     @Test
@@ -383,10 +379,10 @@ public class KiePMMLUtilTest {
         final Model model = toPopulate.getModels().get(0);
         List<MiningField> retrieved = KiePMMLUtil.getMiningTargetFields(model.getMiningSchema().getMiningFields());
         assertThat(retrieved).isNotNull();
-        assertEquals(1, retrieved.size());
+        assertThat(retrieved).hasSize(1);
         MiningField targetField = retrieved.get(0);
-        assertEquals("car_location", targetField.getName().getValue());
-        assertEquals("target", targetField.getUsageType().value());
+        assertThat(targetField.getName().getValue()).isEqualTo("car_location");
+        assertThat(targetField.getUsageType().value()).isEqualTo("target");
     }
 
     private void commonLoadString(String fileName) throws IOException, JAXBException, SAXException {
@@ -433,6 +429,6 @@ public class KiePMMLUtilTest {
                 .stream()
                 .map(segment -> segment.getModel().getModelName())
                 .collect(Collectors.toList());
-        assertEquals(modelNames.size(), modelNames.stream().distinct().count());
+        assertThat(modelNames.stream().distinct()).hasSize(modelNames.size());
     }
 }

--- a/kie-pmml-trusty/kie-pmml-compiler/kie-pmml-compiler-commons/src/test/java/org/kie/pmml/compiler/commons/utils/KiePMMLUtilTest.java
+++ b/kie-pmml-trusty/kie-pmml-compiler/kie-pmml-compiler-commons/src/test/java/org/kie/pmml/compiler/commons/utils/KiePMMLUtilTest.java
@@ -429,6 +429,6 @@ public class KiePMMLUtilTest {
                 .stream()
                 .map(segment -> segment.getModel().getModelName())
                 .collect(Collectors.toList());
-        assertThat(modelNames.stream().distinct()).hasSize(modelNames.size());
+        assertThat(modelNames.stream().distinct()).hasSameSizeAs(modelNames);
     }
 }

--- a/kie-pmml-trusty/kie-pmml-evaluator/kie-pmml-evaluator-assembler/src/test/java/org/kie/pmml/evaluator/assembler/command/PMMLCommandExecutorImplTest.java
+++ b/kie-pmml-trusty/kie-pmml-evaluator/kie-pmml-evaluator-assembler/src/test/java/org/kie/pmml/evaluator/assembler/command/PMMLCommandExecutorImplTest.java
@@ -28,8 +28,6 @@ import org.kie.api.pmml.ParameterInfo;
 import org.kie.pmml.api.exceptions.KiePMMLException;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
 
 public class PMMLCommandExecutorImplTest {
 
@@ -73,18 +71,18 @@ public class PMMLCommandExecutorImplTest {
         PMMLCommandExecutorImpl cmdExecutor = new PMMLCommandExecutorImpl();
         PMMLRequestData retrieved = cmdExecutor.getCleanedRequestData(pmmlRequestData);
         assertThat(retrieved).isNotNull();
-        assertEquals(pmmlRequestData.getSource(), retrieved.getSource());
-        assertEquals(pmmlRequestData.getCorrelationId(), retrieved.getCorrelationId());
-        assertEquals(pmmlRequestData.getModelName(), retrieved.getModelName());
+        assertThat(retrieved.getSource()).isEqualTo(pmmlRequestData.getSource());
+        assertThat(retrieved.getCorrelationId()).isEqualTo(pmmlRequestData.getCorrelationId());
+        assertThat(retrieved.getModelName()).isEqualTo(pmmlRequestData.getModelName());
         Map<String, ParameterInfo> requestParams = retrieved.getMappedRequestParams();
         pmmlRequestData.getRequestParams().forEach(parameterInfo -> {
-            assertTrue(requestParams.containsKey(parameterInfo.getName()));
+        	assertThat(requestParams).containsKey(parameterInfo.getName());
             ParameterInfo cleaned = requestParams.get(parameterInfo.getName());
-            assertEquals(parameterInfo.getName(), cleaned.getName());
-            assertEquals(parameterInfo.getCorrelationId(), cleaned.getCorrelationId());
-            assertEquals(parameterInfo.getType(), cleaned.getType());
-            assertEquals(parameterInfo.getValue(), cleaned.getValue().toString());
-            assertEquals(cleaned.getType(), cleaned.getValue().getClass());
+            assertThat(cleaned.getName()).isEqualTo(parameterInfo.getName());
+            assertThat(cleaned.getCorrelationId()).isEqualTo(parameterInfo.getCorrelationId());
+            assertThat(cleaned.getType()).isEqualTo(parameterInfo.getType());
+            assertThat(cleaned.getValue().toString()).isEqualTo(parameterInfo.getValue());
+            assertThat(cleaned.getValue().getClass()).isEqualTo(cleaned.getType());
         });
 
 

--- a/kie-pmml-trusty/kie-pmml-evaluator/kie-pmml-evaluator-assembler/src/test/java/org/kie/pmml/evaluator/assembler/factories/PMMLCommandExecutorFactoryImplTest.java
+++ b/kie-pmml-trusty/kie-pmml-evaluator/kie-pmml-evaluator-assembler/src/test/java/org/kie/pmml/evaluator/assembler/factories/PMMLCommandExecutorFactoryImplTest.java
@@ -21,7 +21,6 @@ import org.kie.internal.pmml.PMMLCommandExecutor;
 import org.kie.pmml.evaluator.assembler.command.PMMLCommandExecutorImpl;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.Assert.assertTrue;
 
 public class PMMLCommandExecutorFactoryImplTest {
 
@@ -30,6 +29,6 @@ public class PMMLCommandExecutorFactoryImplTest {
         PMMLCommandExecutorFactoryImpl factory = new PMMLCommandExecutorFactoryImpl();
         PMMLCommandExecutor retrieved = factory.newPMMLCommandExecutor();
         assertThat(retrieved).isNotNull();
-        assertTrue(retrieved instanceof PMMLCommandExecutorImpl);
+        assertThat(retrieved).isInstanceOf(PMMLCommandExecutorImpl.class);
     }
 }

--- a/kie-pmml-trusty/kie-pmml-evaluator/kie-pmml-evaluator-assembler/src/test/java/org/kie/pmml/evaluator/assembler/factories/PMMLRuleMapperFactoryTest.java
+++ b/kie-pmml-trusty/kie-pmml-evaluator/kie-pmml-evaluator-assembler/src/test/java/org/kie/pmml/evaluator/assembler/factories/PMMLRuleMapperFactoryTest.java
@@ -19,7 +19,6 @@ package org.kie.pmml.evaluator.assembler.factories;
 import org.junit.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.Assert.assertTrue;
 
 public class PMMLRuleMapperFactoryTest {
 
@@ -29,7 +28,7 @@ public class PMMLRuleMapperFactoryTest {
         String retrieved = PMMLRuleMapperFactory.getPMMLRuleMapperSource(fullRuleName);
         assertThat(retrieved).isNotNull();
         String expected = String.format("public final static Model model = new %s();", fullRuleName);
-        assertTrue(retrieved.contains(expected));
+        assertThat(retrieved).contains(expected);
     }
 
     @Test
@@ -40,8 +39,8 @@ public class PMMLRuleMapperFactoryTest {
         String retrieved = PMMLRuleMapperFactory.getPMMLRuleMapperSource(fullRuleName);
         assertThat(retrieved).isNotNull();
         String expected = String.format("package %s;", packageName);
-        assertTrue(retrieved.contains(expected));
+        assertThat(retrieved).contains(expected);
         expected = String.format("public final static Model model = new %s();", fullRuleName);
-        assertTrue(retrieved.contains(expected));
+        assertThat(retrieved).contains(expected);
     }
 }

--- a/kie-pmml-trusty/kie-pmml-evaluator/kie-pmml-evaluator-assembler/src/test/java/org/kie/pmml/evaluator/assembler/factories/PMMLRuleMappersFactoryTest.java
+++ b/kie-pmml-trusty/kie-pmml-evaluator/kie-pmml-evaluator-assembler/src/test/java/org/kie/pmml/evaluator/assembler/factories/PMMLRuleMappersFactoryTest.java
@@ -7,7 +7,6 @@ import java.util.stream.IntStream;
 import org.junit.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.Assert.assertTrue;
 
 public class PMMLRuleMappersFactoryTest {
 
@@ -21,9 +20,9 @@ public class PMMLRuleMappersFactoryTest {
                                                                            generatedRuleMappers);
         assertThat(retrieved).isNotNull();
         String expected = String.format("package %s;", packageName);
-        assertTrue(retrieved.contains(expected));
+        assertThat(retrieved).contains(expected);
         List<String> mod = generatedRuleMappers.stream().map(gen -> "new " + gen + "()").collect(Collectors.toList());
         expected = "Arrays.asList(" + String.join(", ", mod) + ");";
-        assertTrue(retrieved.contains(expected));
+        assertThat(retrieved).contains(expected);
     }
 }

--- a/kie-pmml-trusty/kie-pmml-evaluator/kie-pmml-evaluator-assembler/src/test/java/org/kie/pmml/evaluator/assembler/factories/PMMLRuntimeFactoryInternalTest.java
+++ b/kie-pmml-trusty/kie-pmml-evaluator/kie-pmml-evaluator-assembler/src/test/java/org/kie/pmml/evaluator/assembler/factories/PMMLRuntimeFactoryInternalTest.java
@@ -47,9 +47,6 @@ import org.kie.pmml.evaluator.assembler.container.PMMLPackageImpl;
 import org.kie.pmml.evaluator.core.service.PMMLRuntimeInternalImpl;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
 import static org.kie.test.util.filesystem.FileUtils.getFile;
 
 public class PMMLRuntimeFactoryInternalTest {
@@ -74,7 +71,7 @@ public class PMMLRuntimeFactoryInternalTest {
         File pmmlFile = getFile("MissingDataRegression.pmml");
         KieBase retrieved = PMMLRuntimeFactoryInternal.createKieBase(pmmlFile);
         assertThat(retrieved).isNotNull();
-        assertTrue(retrieved.getKiePackages().isEmpty());
+        assertThat(retrieved.getKiePackages()).isEmpty();
     }
 
     @Test
@@ -88,8 +85,8 @@ public class PMMLRuntimeFactoryInternalTest {
         pmmlKnowledgePackage.getResourceTypePackages().put(ResourceType.PMML, pmmlPkg);
         KieBase retrieved = PMMLRuntimeFactoryInternal.createKieBase(knowledgeBuilder);
         assertThat(retrieved).isNotNull();
-        assertFalse(retrieved.getKiePackages().isEmpty());
-        assertEquals(knowledgeBuilder.getKnowledgePackages().size(), retrieved.getKiePackages().size());
+        assertThat(retrieved.getKiePackages()).isNotEmpty();
+        assertThat(retrieved.getKiePackages()).hasSameSizeAs(knowledgeBuilder.getKnowledgePackages());
         knowledgeBuilder.getKnowledgePackages()
                 .forEach(kBuilderPackage -> {
                     assertThat(retrieved.getKiePackage(kBuilderPackage.getName())).isNotNull();
@@ -98,7 +95,7 @@ public class PMMLRuntimeFactoryInternalTest {
                         InternalKnowledgePackage retrievedKiePackage = (InternalKnowledgePackage) retrieved.getKiePackage(kBuilderPackage.getName());
                         ResourceTypePackage retrievedResourceTypePackage=  retrievedKiePackage.getResourceTypePackages().get(ResourceType.PMML);
                         assertThat(retrievedKiePackage.getResourceTypePackages().get(ResourceType.PMML)).isNotNull();
-                        assertEquals(knowledgeBuilderResourceTypePackage, retrievedResourceTypePackage);
+                        assertThat(retrievedResourceTypePackage).isEqualTo(knowledgeBuilderResourceTypePackage);
                     }
                 });
     }
@@ -116,11 +113,11 @@ public class PMMLRuntimeFactoryInternalTest {
         PackageDescr packageDescr = new PackageDescr();
         DescrResource retrieved = PMMLRuntimeFactoryInternal.createDescrResource(packageDescr);
         assertThat(retrieved).isNotNull();
-        assertEquals(packageDescr, retrieved.getDescr());
-        assertFalse(retrieved.hasURL());
+        assertThat(retrieved.getDescr()).isEqualTo(packageDescr);
+        assertThat(retrieved.hasURL()).isFalse();
         String retrievedSourcePath = retrieved.getSourcePath();
-        assertTrue(retrievedSourcePath.startsWith("src/main/resources/file_"));
-        assertTrue(retrievedSourcePath.endsWith(".descr"));
+        assertThat(retrievedSourcePath).startsWith("src/main/resources/file_");
+        assertThat(retrievedSourcePath).endsWith(".descr");
     }
 
     @Test
@@ -142,8 +139,8 @@ public class PMMLRuntimeFactoryInternalTest {
                 .populateNestedKiePackageList(Collections.singleton(kiePMMLModel),
                                               toPopulate,
                                               kieBase);
-        assertFalse(toPopulate.isEmpty());
-        assertEquals(kiePackages.size(), toPopulate.size());
+        assertThat(toPopulate).isNotEmpty();
+        assertThat(toPopulate).hasSameSizeAs(kiePackages);
     }
 
     @Test
@@ -169,7 +166,7 @@ public class PMMLRuntimeFactoryInternalTest {
 
     private void commonValidatePMMLRuntime(PMMLRuntime toValidate) {
         assertThat(toValidate).isNotNull();
-        assertTrue(toValidate instanceof PMMLRuntimeInternalImpl);
+        assertThat(toValidate).isInstanceOf(PMMLRuntimeInternalImpl.class);
         assertThat(((PMMLRuntimeInternalImpl)toValidate).getKnowledgeBase()).isNotNull();
     }
 

--- a/kie-pmml-trusty/kie-pmml-evaluator/kie-pmml-evaluator-assembler/src/test/java/org/kie/pmml/evaluator/assembler/implementations/HasKnowledgeBuilderImplTest.java
+++ b/kie-pmml-trusty/kie-pmml-evaluator/kie-pmml-evaluator-assembler/src/test/java/org/kie/pmml/evaluator/assembler/implementations/HasKnowledgeBuilderImplTest.java
@@ -26,9 +26,7 @@ import org.junit.Before;
 import org.junit.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
+import static org.assertj.core.api.Assertions.fail;
 
 public class HasKnowledgeBuilderImplTest {
 
@@ -47,8 +45,8 @@ public class HasKnowledgeBuilderImplTest {
     public void getClassLoader() {
         ClassLoader retrieved = hasKnowledgeBuilder.getClassLoader();
         assertThat(retrieved).isNotNull();
-        assertEquals(knowledgeBuilder.getRootClassLoader(),retrieved);
-        assertTrue(retrieved instanceof ProjectClassLoader);
+        assertThat(retrieved).isEqualTo(knowledgeBuilder.getRootClassLoader());
+        assertThat(retrieved).isInstanceOf(ProjectClassLoader.class);
     }
 
     @Test
@@ -57,7 +55,7 @@ public class HasKnowledgeBuilderImplTest {
         sourcesMap.put(CLASS_SOURCE_NAME, CLASS_SOURCE);
         Class<?> retrieved = hasKnowledgeBuilder.compileAndLoadClass(sourcesMap, CLASS_SOURCE_NAME);
         assertThat(retrieved).isNotNull();
-        assertEquals(CLASS_SOURCE_NAME, retrieved.getName());
+        assertThat(retrieved.getName()).isEqualTo(CLASS_SOURCE_NAME);
     }
 
     @Test

--- a/kie-pmml-trusty/kie-pmml-evaluator/kie-pmml-evaluator-assembler/src/test/java/org/kie/pmml/evaluator/assembler/service/PMMLAssemblerServiceTest.java
+++ b/kie-pmml-trusty/kie-pmml-evaluator/kie-pmml-evaluator-assembler/src/test/java/org/kie/pmml/evaluator/assembler/service/PMMLAssemblerServiceTest.java
@@ -28,7 +28,7 @@ import org.kie.api.io.Resource;
 import org.kie.api.io.ResourceConfiguration;
 import org.kie.api.io.ResourceType;
 
-import static org.junit.Assert.assertEquals;
+import static org.assertj.core.api.Assertions.assertThat;
 
 public class PMMLAssemblerServiceTest {
 
@@ -70,10 +70,10 @@ public class PMMLAssemblerServiceTest {
     }
 
     private void commonVerifyStrings(String[] toVerify, String[] comparison) {
-        assertEquals(toVerify.length, comparison.length);
-        assertEquals(2, toVerify.length);
+        assertThat(comparison.length).isEqualTo(toVerify.length);
+        assertThat(toVerify.length).isEqualTo(2);
         for (int i = 0; i < toVerify.length; i ++) {
-            assertEquals(comparison[i], toVerify[i]);
+        	assertThat(toVerify[i]).isEqualTo(comparison[i]);
         }
     }
 

--- a/kie-pmml-trusty/kie-pmml-evaluator/kie-pmml-evaluator-assembler/src/test/java/org/kie/pmml/evaluator/assembler/service/PMMLCompilerServiceTest.java
+++ b/kie-pmml-trusty/kie-pmml-evaluator/kie-pmml-evaluator-assembler/src/test/java/org/kie/pmml/evaluator/assembler/service/PMMLCompilerServiceTest.java
@@ -37,10 +37,8 @@ import org.kie.pmml.commons.model.KiePMMLModel;
 import org.kie.pmml.commons.testingutility.KiePMMLTestingModel;
 import org.kie.pmml.commons.testingutility.KiePMMLTestingModelWithSources;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.drools.core.util.StringUtils.generateUUID;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
 import static org.kie.pmml.evaluator.assembler.factories.PMMLRuleMapperFactory.KIE_PMML_RULE_MAPPER_CLASS_NAME;
 import static org.kie.pmml.evaluator.assembler.factories.PMMLRuleMappersFactory.KIE_PMML_RULE_MAPPERS_CLASS_NAME;
 
@@ -54,21 +52,21 @@ public class PMMLCompilerServiceTest {
         toPopulate.add( new KiePMMLModelHasRule("TEST", Collections.emptyList()));
         toPopulate.add( new KiePMMLModelHasNestedModelsHasRule("TEST", Collections.emptyList()));
         toPopulate.add( new KiePMMLModelHasNestedModelsHasSourceMap("TEST", Collections.emptyList()));
-        toPopulate.forEach(kiePMMLModel -> assertTrue(((HasSourcesMap) kiePMMLModel).getSourcesMap().isEmpty()));
+        toPopulate.forEach(kiePMMLModel -> assertThat(((HasSourcesMap) kiePMMLModel).getSourcesMap()).isEmpty());
         final File file = new File("foo.pmml");
         final Resource resource = new FileSystemResource(file);
         PMMLCompilerService.populateWithPMMLRuleMappers(toPopulate, resource);
         toPopulate.forEach(kiePmmlModel -> {
             if (kiePmmlModel instanceof HasRule || kiePmmlModel instanceof KiePMMLModelHasNestedModelsHasRule) {
-                assertFalse(((HasSourcesMap) kiePmmlModel).getSourcesMap().isEmpty());
+                assertThat(((HasSourcesMap) kiePmmlModel).getSourcesMap()).isNotEmpty();
                 String expected =  kiePmmlModel.getKModulePackageName() + "." + KIE_PMML_RULE_MAPPERS_CLASS_NAME;
-                assertTrue(((HasSourcesMap) kiePmmlModel).getSourcesMap().containsKey(expected));
+                assertThat(((HasSourcesMap) kiePmmlModel).getSourcesMap()).containsKey(expected);
                 if (kiePmmlModel instanceof HasRule) {
                     expected =  kiePmmlModel.getKModulePackageName() + "." + KIE_PMML_RULE_MAPPER_CLASS_NAME;
-                    assertTrue(((HasSourcesMap) kiePmmlModel).getSourcesMap().containsKey(expected));
+                    assertThat(((HasSourcesMap) kiePmmlModel).getSourcesMap()).containsKey(expected);
                 }
             } else {
-                assertTrue(((HasSourcesMap) kiePmmlModel).getSourcesMap().isEmpty());
+                assertThat(((HasSourcesMap) kiePmmlModel).getSourcesMap()).isEmpty();
             }
         });
     }
@@ -77,36 +75,36 @@ public class PMMLCompilerServiceTest {
     public void addPMMLRuleMapperHasSourcesMap() {
         KiePMMLTestingModelWithSources kiePmmlModel = new KiePMMLTestingModelWithSources("TEST", "kmodulePackageName",
                                                                              Collections.emptyMap());
-        assertTrue(kiePmmlModel.getSourcesMap().isEmpty());
+        assertThat(kiePmmlModel.getSourcesMap()).isEmpty();
         final List<String> generatedRuleMappers = IntStream.range(0, 3).mapToObj(i -> "apackage.Rule_" + i).collect(Collectors.toList());
         PMMLCompilerService.addPMMLRuleMapper(kiePmmlModel, generatedRuleMappers, "source_path");
-        assertTrue(kiePmmlModel.getSourcesMap().isEmpty());
+        assertThat(kiePmmlModel.getSourcesMap()).isEmpty();
     }
 
     @Test
     public void addPMMLRuleMapperHasRule() {
         KiePMMLModelHasRule kiePmmlModel = new KiePMMLModelHasRule("TEST", Collections.emptyList());
-        assertTrue(kiePmmlModel.getSourcesMap().isEmpty());
+        assertThat(kiePmmlModel.getSourcesMap()).isEmpty();
         final List<String> generatedRuleMappers = new ArrayList<>();
         PMMLCompilerService.addPMMLRuleMapper(kiePmmlModel, generatedRuleMappers, "source_path");
         String expected = kiePmmlModel.getKModulePackageName() + "." + KIE_PMML_RULE_MAPPER_CLASS_NAME;
-        assertTrue(kiePmmlModel.getSourcesMap().containsKey(expected));
+        assertThat(kiePmmlModel.getSourcesMap()).containsKey(expected);
         expected =  kiePmmlModel.getKModulePackageName() + "." + KIE_PMML_RULE_MAPPER_CLASS_NAME;
-        assertTrue(generatedRuleMappers.contains(expected));
+        assertThat(generatedRuleMappers).contains(expected);
     }
 
     @Test
     public void addPMMLRuleMapperKiePMMLModelHasNestedModelsHasRule() {
         KiePMMLModelHasNestedModelsHasRule kiePmmlModel = new KiePMMLModelHasNestedModelsHasRule("TEST",
                                                                                                  Collections.emptyList());
-        assertTrue(kiePmmlModel.getSourcesMap().isEmpty());
+        assertThat(kiePmmlModel.getSourcesMap()).isEmpty();
         final List<String> generatedRuleMappers = new ArrayList<>();
         PMMLCompilerService.addPMMLRuleMapper(kiePmmlModel, generatedRuleMappers, "source_path");
-        assertTrue(kiePmmlModel.getSourcesMap().isEmpty());
-        assertEquals(kiePmmlModel.nestedModels.size(), generatedRuleMappers.size());
-        generatedRuleMappers.forEach(ret -> assertEquals(kiePmmlModel.getKModulePackageName() + "." + KIE_PMML_RULE_MAPPER_CLASS_NAME, ret));
+        assertThat(kiePmmlModel.getSourcesMap()).isEmpty();
+        assertThat(generatedRuleMappers).hasSameSizeAs(kiePmmlModel.nestedModels);
+        generatedRuleMappers.forEach(ret -> assertThat(ret).isEqualTo(kiePmmlModel.getKModulePackageName() + "." + KIE_PMML_RULE_MAPPER_CLASS_NAME));
         kiePmmlModel.nestedModels.forEach(nestedModel -> {
-            assertTrue(((HasSourcesMap) nestedModel).getSourcesMap().containsKey(nestedModel.getKModulePackageName() + "." +KIE_PMML_RULE_MAPPER_CLASS_NAME));
+            assertThat(((HasSourcesMap) nestedModel).getSourcesMap()).containsKey(nestedModel.getKModulePackageName() + "." +KIE_PMML_RULE_MAPPER_CLASS_NAME);
         });
     }
 
@@ -114,13 +112,13 @@ public class PMMLCompilerServiceTest {
     public void addPMMLRuleMapperKiePMMLModelHasNestedModelsHasSourceMap() {
         KiePMMLModelHasNestedModelsHasSourceMap kiePmmlModel = new KiePMMLModelHasNestedModelsHasSourceMap("TEST",
                                                                                                            Collections.emptyList());
-        assertTrue(kiePmmlModel.getSourcesMap().isEmpty());
+        assertThat(kiePmmlModel.getSourcesMap()).isEmpty();
         final List<String> generatedRuleMappers = new ArrayList<>();
         PMMLCompilerService.addPMMLRuleMapper(kiePmmlModel, generatedRuleMappers, "source_path");
-        assertTrue(kiePmmlModel.getSourcesMap().isEmpty());
-        assertTrue(generatedRuleMappers.isEmpty());
+        assertThat(kiePmmlModel.getSourcesMap()).isEmpty();
+        assertThat(generatedRuleMappers).isEmpty();
         kiePmmlModel.nestedModels.forEach(nestedModel -> {
-            assertTrue(((HasSourcesMap) nestedModel).getSourcesMap().isEmpty());
+            assertThat(((HasSourcesMap) nestedModel).getSourcesMap()).isEmpty();
         });
     }
 
@@ -134,13 +132,13 @@ public class PMMLCompilerServiceTest {
     public void addPMMLRuleMappersHasSourceMap() {
         KiePMMLTestingModelWithSources kiePmmlModel = new KiePMMLTestingModelWithSources("TEST", "kmodulePackageName",
                                                                                          new HashMap<>());
-        assertTrue(kiePmmlModel.getSourcesMap().isEmpty());
+        assertThat(kiePmmlModel.getSourcesMap()).isEmpty();
         final List<String> generatedRuleMappers = IntStream.range(0, 3)
                 .mapToObj(i -> "apackage" + i + "." + KIE_PMML_RULE_MAPPER_CLASS_NAME).collect(Collectors.toList());
         PMMLCompilerService.addPMMLRuleMappers(kiePmmlModel, generatedRuleMappers, "source_path");
-        assertFalse(kiePmmlModel.getSourcesMap().isEmpty());
+        assertThat(kiePmmlModel.getSourcesMap()).isNotEmpty();
         String expected =  kiePmmlModel.getKModulePackageName() + "." + KIE_PMML_RULE_MAPPERS_CLASS_NAME;
-        assertTrue(kiePmmlModel.getSourcesMap().containsKey(expected));
+        assertThat(kiePmmlModel.getSourcesMap()).containsKey(expected);
     }
 
     @Test(expected = KiePMMLException.class)
@@ -160,12 +158,12 @@ public class PMMLCompilerServiceTest {
                                         File.separator,
                                         fileName);
         String retrieved = PMMLCompilerService.getFileName(fullPath);
-        assertEquals(fileName, retrieved);
+        assertThat(retrieved).isEqualTo(fileName);
         fullPath = String.format("%1$sthis%1$sis%1$sfull%1$spath%1$s%2$s",
                                         "/",
                                         fileName);
         retrieved = PMMLCompilerService.getFileName(fullPath);
-        assertEquals(fileName, retrieved);
+        assertThat(retrieved).isEqualTo(fileName);
     }
 
     private static class KiePMMLModelHasRule extends KiePMMLTestingModelWithSources implements HasRule {

--- a/kie-pmml-trusty/kie-pmml-evaluator/kie-pmml-evaluator-assembler/src/test/java/org/kie/pmml/evaluator/assembler/service/PMMLLoaderServiceTest.java
+++ b/kie-pmml-trusty/kie-pmml-evaluator/kie-pmml-evaluator-assembler/src/test/java/org/kie/pmml/evaluator/assembler/service/PMMLLoaderServiceTest.java
@@ -38,9 +38,6 @@ import org.kie.pmml.compiler.commons.factories.KiePMMLModelFactory;
 import org.kie.pmml.evaluator.assembler.rulemapping.PMMLRuleMapper;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertTrue;
 import static org.kie.pmml.commons.Constants.PACKAGE_NAME;
 
 public class PMMLLoaderServiceTest {
@@ -48,36 +45,36 @@ public class PMMLLoaderServiceTest {
     @Test
     public void getKiePMMLModelsLoadedFromFactory() {
         final KnowledgeBuilderImpl kbuilderImpl = new KnowledgeBuilderImpl();
-        assertTrue(kbuilderImpl.getPackageNames().isEmpty());
-        assertNull(kbuilderImpl.getPackage(PACKAGE_NAME));
+        assertThat(kbuilderImpl.getPackageNames()).isEmpty();
+        assertThat(kbuilderImpl.getPackage(PACKAGE_NAME)).isNull();
         final KiePMMLModelFactory kiePMMLModelFactory = getKiePMMLModelFactory();
         final List<KiePMMLModel> retrieved = PMMLLoaderService.getKiePMMLModelsLoadedFromFactory(kbuilderImpl,
                                                                                                  kiePMMLModelFactory);
-        assertEquals(kiePMMLModelFactory.getKiePMMLModels(), retrieved);
-        assertTrue(kbuilderImpl.getPackageNames().isEmpty());
-        assertNull(kbuilderImpl.getPackage(PACKAGE_NAME));
+        assertThat(retrieved).isEqualTo(kiePMMLModelFactory.getKiePMMLModels());
+        assertThat(kbuilderImpl.getPackageNames()).isEmpty();
+        assertThat(kbuilderImpl.getPackage(PACKAGE_NAME)).isNull();
     }
 
     @Test
     public void loadPMMLRuleMappersNotEmpty() {
         final KnowledgeBuilderImpl kbuilderImpl = new KnowledgeBuilderImpl();
-        assertTrue(kbuilderImpl.getPackageNames().isEmpty());
-        assertNull(kbuilderImpl.getPackage(PACKAGE_NAME));
+        assertThat(kbuilderImpl.getPackageNames()).isEmpty();
+        assertThat(kbuilderImpl.getPackage(PACKAGE_NAME)).isNull();
         final List<PMMLRuleMapper> pmmlRuleMappers = getPMMLRuleMappers();
         PMMLLoaderService.loadPMMLRuleMappers(kbuilderImpl, pmmlRuleMappers);
-        assertEquals(1, kbuilderImpl.getPackageNames().size());
+        assertThat(kbuilderImpl.getPackageNames().size()).isEqualTo(1);
         assertThat(kbuilderImpl.getPackage(PACKAGE_NAME)).isNotNull();
     }
 
     @Test
     public void loadPMMLRuleMappersEmpty() {
         final KnowledgeBuilderImpl kbuilderImpl = new KnowledgeBuilderImpl();
-        assertTrue(kbuilderImpl.getPackageNames().isEmpty());
-        assertNull(kbuilderImpl.getPackage(PACKAGE_NAME));
+        assertThat(kbuilderImpl.getPackageNames()).isEmpty();
+        assertThat(kbuilderImpl.getPackage(PACKAGE_NAME)).isNull();
         final List<PMMLRuleMapper> pmmlRuleMappers = Collections.emptyList();
         PMMLLoaderService.loadPMMLRuleMappers(kbuilderImpl, pmmlRuleMappers);
-        assertTrue(kbuilderImpl.getPackageNames().isEmpty());
-        assertNull(kbuilderImpl.getPackage(PACKAGE_NAME));
+        assertThat(kbuilderImpl.getPackageNames()).isEmpty();
+        assertThat(kbuilderImpl.getPackage(PACKAGE_NAME)).isNull();
     }
 
     private List<PMMLRuleMapper> getPMMLRuleMappers() {

--- a/kie-pmml-trusty/kie-pmml-evaluator/kie-pmml-evaluator-assembler/src/test/java/org/kie/pmml/evaluator/assembler/service/PMMLLoaderServiceTest.java
+++ b/kie-pmml-trusty/kie-pmml-evaluator/kie-pmml-evaluator-assembler/src/test/java/org/kie/pmml/evaluator/assembler/service/PMMLLoaderServiceTest.java
@@ -62,7 +62,7 @@ public class PMMLLoaderServiceTest {
         assertThat(kbuilderImpl.getPackage(PACKAGE_NAME)).isNull();
         final List<PMMLRuleMapper> pmmlRuleMappers = getPMMLRuleMappers();
         PMMLLoaderService.loadPMMLRuleMappers(kbuilderImpl, pmmlRuleMappers);
-        assertThat(kbuilderImpl.getPackageNames().size()).isEqualTo(1);
+        assertThat(kbuilderImpl.getPackageNames()).hasSize(1);
         assertThat(kbuilderImpl.getPackage(PACKAGE_NAME)).isNotNull();
     }
 

--- a/kie-pmml-trusty/kie-pmml-evaluator/kie-pmml-evaluator-core/src/test/java/org/kie/pmml/evaluator/core/service/PMMLRuntimeInternalImplTest.java
+++ b/kie-pmml-trusty/kie-pmml-evaluator/kie-pmml-evaluator-core/src/test/java/org/kie/pmml/evaluator/core/service/PMMLRuntimeInternalImplTest.java
@@ -42,9 +42,7 @@ import org.kie.pmml.evaluator.core.executor.PMMLModelEvaluator;
 import org.kie.pmml.evaluator.core.executor.PMMLModelEvaluatorFinderImpl;
 import org.kie.pmml.evaluator.core.implementations.PMMLRuntimeStep;
 
-import static junit.framework.TestCase.assertEquals;
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.Assert.assertTrue;
 import static org.kie.pmml.api.enums.ResultCode.OK;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
@@ -122,7 +120,7 @@ public class PMMLRuntimeInternalImplTest {
             Optional<PMMLStep> retrieved =
                     pmmlSteps.stream().filter(pmmlStep -> pmml_step.equals(((PMMLRuntimeStep) pmmlStep).getPmmlStep()))
                     .findFirst();
-            assertTrue(retrieved.isPresent());
+            assertThat(retrieved).isPresent();
             commonValuateStep(retrieved.get(), pmml_step, modelMock, requestData);
         });
     }
@@ -138,7 +136,7 @@ public class PMMLRuntimeInternalImplTest {
             Optional<PMMLStep> retrieved =
                     pmmlSteps.stream().filter(pmmlStep -> pmml_step.equals(((PMMLRuntimeStep) pmmlStep).getPmmlStep()))
                     .findFirst();
-            assertTrue(retrieved.isPresent());
+            assertThat(retrieved).isPresent();
             commonValuateStep(retrieved.get(), pmml_step, modelMock, requestData);
         });
     }
@@ -155,20 +153,20 @@ public class PMMLRuntimeInternalImplTest {
     private void commonValuateStep(final PMMLStep toVerify, final PMML_STEP pmmlStep, final KiePMMLModel kiePMMLModel,
                                    final PMMLRequestData requestData) {
         assertThat(toVerify).isNotNull();
-        assertTrue(toVerify instanceof PMMLRuntimeStep);
-        assertEquals(pmmlStep, ((PMMLRuntimeStep) toVerify).getPmmlStep());
+        assertThat(toVerify).isInstanceOf(PMMLRuntimeStep.class);
+        assertThat(((PMMLRuntimeStep) toVerify).getPmmlStep()).isEqualTo(pmmlStep);
         Map<String, Object> info = toVerify.getInfo();
-        assertEquals(info.get("MODEL"), kiePMMLModel.getName());
-        assertEquals(info.get("CORRELATION ID"), requestData.getCorrelationId());
-        assertEquals(info.get("REQUEST MODEL"), requestData.getModelName());
+        assertThat(kiePMMLModel.getName()).isEqualTo(info.get("MODEL"));
+        assertThat(requestData.getCorrelationId()).isEqualTo(info.get("CORRELATION ID"));
+        assertThat(requestData.getModelName()).isEqualTo(info.get("REQUEST MODEL"));
         requestData.getRequestParams()
                 .forEach(requestParam ->
-                                 assertEquals(requestParam.getValue(), info.get(requestParam.getName())));
+                                 assertThat(info.get(requestParam.getName())).isEqualTo(requestParam.getValue()));
     }
 
     private void commonManageException(KiePMMLException toManage) {
         String expectedMessage = String.format("Failed to retrieve model with name %s", MODEL_NAME);
-        assertEquals(expectedMessage, toManage.getMessage());
+        assertThat(toManage.getMessage()).isEqualTo(expectedMessage);
     }
 
     private KiePMMLModel getKiePMMLModelMock() {

--- a/kie-pmml-trusty/kie-pmml-evaluator/kie-pmml-evaluator-core/src/test/java/org/kie/pmml/evaluator/core/utils/PMMLListenerUtilsTest.java
+++ b/kie-pmml-trusty/kie-pmml-evaluator/kie-pmml-evaluator-core/src/test/java/org/kie/pmml/evaluator/core/utils/PMMLListenerUtilsTest.java
@@ -26,9 +26,7 @@ import org.kie.pmml.api.runtime.PMMLContext;
 import org.kie.pmml.api.runtime.PMMLListener;
 import org.kie.pmml.evaluator.core.PMMLContextImpl;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
+import static org.assertj.core.api.Assertions.assertThat;
 
 public class PMMLListenerUtilsTest {
 
@@ -39,10 +37,10 @@ public class PMMLListenerUtilsTest {
         PMMLContext pmmlContext = getPMMLContext(size, listenerFeedback);
         AtomicBoolean invoked = new AtomicBoolean(false);
         PMMLListenerUtils.stepExecuted(() -> new PMMLStepTest(invoked), pmmlContext);
-        assertTrue(invoked.get());
-        assertEquals(size, listenerFeedback.size());
+        assertThat(invoked).isTrue();
+        assertThat(listenerFeedback).hasSize(size);
         final PMMLStep retrieved = listenerFeedback.get(0);
-        IntStream.range(1, size).forEach(i -> assertEquals(retrieved, listenerFeedback.get(i)));
+        IntStream.range(1, size).forEach(i -> assertThat(listenerFeedback.get(i)).isEqualTo(retrieved));
     }
 
     @Test
@@ -50,7 +48,7 @@ public class PMMLListenerUtilsTest {
         PMMLContext pmmlContext = new PMMLContextImpl(new PMMLRequestData());
         AtomicBoolean invoked = new AtomicBoolean(false);
         PMMLListenerUtils.stepExecuted(() -> new PMMLStepTest(invoked), pmmlContext);
-        assertFalse(invoked.get());
+        assertThat(invoked).isFalse();
     }
 
     private PMMLContext getPMMLContext(int size, Map<Integer, PMMLStep> listenerFeedback) {

--- a/kie-pmml-trusty/kie-pmml-evaluator/kie-pmml-evaluator-core/src/test/java/org/kie/pmml/evaluator/core/utils/PostProcessTest.java
+++ b/kie-pmml-trusty/kie-pmml-evaluator/kie-pmml-evaluator-core/src/test/java/org/kie/pmml/evaluator/core/utils/PostProcessTest.java
@@ -47,9 +47,7 @@ import org.kie.pmml.commons.transformations.KiePMMLLocalTransformations;
 import org.kie.pmml.commons.transformations.KiePMMLParameterField;
 import org.kie.pmml.commons.transformations.KiePMMLTransformationDictionary;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.kie.pmml.commons.CommonTestingUtility.getProcessingDTO;
 
 public class PostProcessTest {
@@ -84,16 +82,16 @@ public class PostProcessTest {
         PMML4Result toModify = new PMML4Result();
         toModify.setResultCode(ResultCode.FAIL.getName());
         toModify.addResultVariable(FIELD_NAME, 4.33);
-        assertEquals(4.33, toModify.getResultVariables().get(FIELD_NAME));
+        assertThat(toModify.getResultVariables().get(FIELD_NAME)).isEqualTo(4.33);
         ProcessingDTO processingDTO = getProcessingDTO(model, new ArrayList<>());
         PostProcess.executeTargets(toModify, processingDTO);
-        assertEquals(4.33, toModify.getResultVariables().get(FIELD_NAME));
+        assertThat(toModify.getResultVariables().get(FIELD_NAME)).isEqualTo(4.33);
         toModify.setResultCode(ResultCode.OK.getName());
         PostProcess.executeTargets(toModify, processingDTO);
-        assertEquals(4.33, toModify.getResultVariables().get(FIELD_NAME));
+        assertThat(toModify.getResultVariables().get(FIELD_NAME)).isEqualTo(4.33);
         toModify.setResultObjectName(FIELD_NAME);
         PostProcess.executeTargets(toModify, processingDTO);
-        assertEquals(4.34, toModify.getResultVariables().get(FIELD_NAME));
+        assertThat(toModify.getResultVariables().get(FIELD_NAME)).isEqualTo(4.34);
     }
 
     @Test
@@ -107,7 +105,7 @@ public class PostProcessTest {
 
         PostProcess.populateOutputFields(toUpdate, processingDTO);
 
-        assertTrue(toUpdate.getResultVariables().isEmpty());
+        assertThat(toUpdate.getResultVariables()).isEmpty();
     }
 
     @Test
@@ -124,9 +122,9 @@ public class PostProcessTest {
 
         PostProcess.populateOutputFields(toUpdate, processingDTO);
 
-        assertFalse(toUpdate.getResultVariables().isEmpty());
-        assertTrue(toUpdate.getResultVariables().containsKey(OUTPUT_NAME));
-        assertEquals(kiePMMLNameValue.getValue(), toUpdate.getResultVariables().get(OUTPUT_NAME));
+        assertThat(toUpdate.getResultVariables()).isNotEmpty();
+        assertThat(toUpdate.getResultVariables()).containsKey(OUTPUT_NAME);
+        assertThat(toUpdate.getResultVariables().get(OUTPUT_NAME)).isEqualTo(kiePMMLNameValue.getValue());
     }
 
     @Test
@@ -139,7 +137,7 @@ public class PostProcessTest {
         PMML4Result toUpdate = new PMML4Result();
 
         PostProcess.populateOutputFields(toUpdate, processingDTO);
-        assertTrue(toUpdate.getResultVariables().isEmpty());
+        assertThat(toUpdate.getResultVariables()).isEmpty();
     }
 
     @Test
@@ -156,9 +154,9 @@ public class PostProcessTest {
 
         PostProcess.populateOutputFields(toUpdate, processingDTO);
 
-        assertFalse(toUpdate.getResultVariables().isEmpty());
-        assertTrue(toUpdate.getResultVariables().containsKey(OUTPUT_NAME));
-        assertEquals(kiePMMLConstant.getValue(), toUpdate.getResultVariables().get(OUTPUT_NAME));
+        assertThat(toUpdate.getResultVariables()).isNotEmpty();
+        assertThat(toUpdate.getResultVariables()).containsKey(OUTPUT_NAME);
+        assertThat(toUpdate.getResultVariables().get(OUTPUT_NAME)).isEqualTo(kiePMMLConstant.getValue());
     }
 
     @Test
@@ -183,9 +181,9 @@ public class PostProcessTest {
 
         PostProcess.populateOutputFields(toUpdate, processingDTO);
 
-        assertFalse(toUpdate.getResultVariables().isEmpty());
-        assertTrue(toUpdate.getResultVariables().containsKey(OUTPUT_NAME));
-        assertEquals(value1 / value2, toUpdate.getResultVariables().get(OUTPUT_NAME));
+        assertThat(toUpdate.getResultVariables()).isNotEmpty();
+        assertThat(toUpdate.getResultVariables()).containsKey(OUTPUT_NAME);
+        assertThat(toUpdate.getResultVariables().get(OUTPUT_NAME)).isEqualTo(value1 / value2);
     }
 
     @Test
@@ -227,9 +225,9 @@ public class PostProcessTest {
 
         PostProcess.populateOutputFields(toUpdate1, processingDTO1);
 
-        assertFalse(toUpdate1.getResultVariables().isEmpty());
-        assertTrue(toUpdate1.getResultVariables().containsKey(OUTPUT_NAME));
-        assertEquals(value1 / value2, toUpdate1.getResultVariables().get(OUTPUT_NAME));
+        assertThat(toUpdate1.getResultVariables()).isNotEmpty();
+        assertThat(toUpdate1.getResultVariables()).containsKey(OUTPUT_NAME);
+        assertThat(toUpdate1.getResultVariables().get(OUTPUT_NAME)).isEqualTo(value1 / value2);
 
         // From LocalTransformations
         KiePMMLLocalTransformations localTransformations = KiePMMLLocalTransformations.builder("localTransformations"
@@ -244,9 +242,9 @@ public class PostProcessTest {
 
         PostProcess.populateOutputFields(toUpdate2, processingDTO2);
 
-        assertFalse(toUpdate2.getResultVariables().isEmpty());
-        assertTrue(toUpdate2.getResultVariables().containsKey(OUTPUT_NAME));
-        assertEquals(value1 / value2, toUpdate2.getResultVariables().get(OUTPUT_NAME));
+        assertThat(toUpdate2.getResultVariables()).isNotEmpty();
+        assertThat(toUpdate2.getResultVariables()).containsKey(OUTPUT_NAME);
+        assertThat(toUpdate2.getResultVariables().get(OUTPUT_NAME)).isEqualTo(value1 / value2);
     }
 
     @Test
@@ -297,9 +295,9 @@ public class PostProcessTest {
 
         PostProcess.populateOutputFields(toUpdate1, processingDTO1);
 
-        assertFalse(toUpdate1.getResultVariables().isEmpty());
-        assertTrue(toUpdate1.getResultVariables().containsKey(OUTPUT_NAME));
-        assertEquals(value1 / value2, toUpdate1.getResultVariables().get(OUTPUT_NAME));
+        assertThat(toUpdate1.getResultVariables()).isNotEmpty();
+        assertThat(toUpdate1.getResultVariables()).containsKey(OUTPUT_NAME);
+        assertThat(toUpdate1.getResultVariables().get(OUTPUT_NAME)).isEqualTo(value1 / value2);
 
         // From LocalTransformations
         KiePMMLLocalTransformations localTransformations = KiePMMLLocalTransformations.builder("localTransformations"
@@ -314,9 +312,9 @@ public class PostProcessTest {
 
         PostProcess.populateOutputFields(toUpdate2, processingDTO2);
 
-        assertFalse(toUpdate2.getResultVariables().isEmpty());
-        assertTrue(toUpdate2.getResultVariables().containsKey(OUTPUT_NAME));
-        assertEquals(value1 / value2, toUpdate2.getResultVariables().get(OUTPUT_NAME));
+        assertThat(toUpdate2.getResultVariables()).isNotEmpty();
+        assertThat(toUpdate2.getResultVariables()).containsKey(OUTPUT_NAME);
+        assertThat(toUpdate2.getResultVariables().get(OUTPUT_NAME)).isEqualTo(value1 / value2);
     }
 
     @Test
@@ -364,9 +362,9 @@ public class PostProcessTest {
 
         PostProcess.populateOutputFields(toUpdate1, processingDTO1);
 
-        assertFalse(toUpdate1.getResultVariables().isEmpty());
-        assertTrue(toUpdate1.getResultVariables().containsKey(OUTPUT_NAME));
-        assertEquals(value1 / value2, toUpdate1.getResultVariables().get(OUTPUT_NAME));
+        assertThat(toUpdate1.getResultVariables()).isNotEmpty();
+        assertThat(toUpdate1.getResultVariables()).containsKey(OUTPUT_NAME);
+        assertThat(toUpdate1.getResultVariables().get(OUTPUT_NAME)).isEqualTo(value1 / value2);
 
         // From LocalTransformations
         KiePMMLLocalTransformations localTransformations = KiePMMLLocalTransformations.builder("localTransformations"
@@ -381,9 +379,9 @@ public class PostProcessTest {
 
         PostProcess.populateOutputFields(toUpdate2, processingDTO2);
 
-        assertFalse(toUpdate2.getResultVariables().isEmpty());
-        assertTrue(toUpdate2.getResultVariables().containsKey(OUTPUT_NAME));
-        assertEquals(value1 / value2, toUpdate2.getResultVariables().get(OUTPUT_NAME));
+        assertThat(toUpdate2.getResultVariables()).isNotEmpty();
+        assertThat(toUpdate2.getResultVariables()).containsKey(OUTPUT_NAME);
+        assertThat(toUpdate2.getResultVariables().get(OUTPUT_NAME)).isEqualTo(value1 / value2);
     }
 
     @Test
@@ -426,9 +424,9 @@ public class PostProcessTest {
 
         PostProcess.populateOutputFields(toUpdate, processingDTO);
 
-        assertFalse(toUpdate.getResultVariables().isEmpty());
-        assertTrue(toUpdate.getResultVariables().containsKey(OUTPUT_NAME));
-        assertEquals(value1, toUpdate.getResultVariables().get(OUTPUT_NAME));
+        assertThat(toUpdate.getResultVariables()).isNotEmpty();
+        assertThat(toUpdate.getResultVariables()).containsKey(OUTPUT_NAME);
+        assertThat(toUpdate.getResultVariables().get(OUTPUT_NAME)).isEqualTo(value1);
     }
 
     @Test
@@ -479,9 +477,9 @@ public class PostProcessTest {
 
         PostProcess.populateOutputFields(toUpdate, processingDTO);
 
-        assertFalse(toUpdate.getResultVariables().isEmpty());
-        assertTrue(toUpdate.getResultVariables().containsKey(OUTPUT_NAME));
-        assertEquals(value1, toUpdate.getResultVariables().get(OUTPUT_NAME));
+        assertThat(toUpdate.getResultVariables()).isNotEmpty();
+        assertThat(toUpdate.getResultVariables()).containsKey(OUTPUT_NAME);
+        assertThat(toUpdate.getResultVariables().get(OUTPUT_NAME)).isEqualTo(value1);
     }
 
     @Test
@@ -532,9 +530,9 @@ public class PostProcessTest {
         PMML4Result toUpdate = new PMML4Result();
 
         PostProcess.populateOutputFields(toUpdate, processingDTO);
-        assertFalse(toUpdate.getResultVariables().isEmpty());
-        assertTrue(toUpdate.getResultVariables().containsKey(OUTPUT_NAME));
-        assertEquals(value1/value2, toUpdate.getResultVariables().get(OUTPUT_NAME));
+        assertThat(toUpdate.getResultVariables()).isNotEmpty();
+        assertThat(toUpdate.getResultVariables()).containsKey(OUTPUT_NAME);
+        assertThat(toUpdate.getResultVariables().get(OUTPUT_NAME)).isEqualTo(value1/value2);
     }
 
     @Test
@@ -551,9 +549,9 @@ public class PostProcessTest {
 
         PostProcess.populateOutputFields(toUpdate, processingDTO);
 
-        assertFalse(toUpdate.getResultVariables().isEmpty());
-        assertTrue(toUpdate.getResultVariables().containsKey(OUTPUT_NAME));
-        assertEquals(kiePMMLConstant.getValue(), toUpdate.getResultVariables().get(OUTPUT_NAME));
+        assertThat(toUpdate.getResultVariables()).isNotEmpty();
+        assertThat(toUpdate.getResultVariables()).containsKey(OUTPUT_NAME);
+        assertThat(toUpdate.getResultVariables().get(OUTPUT_NAME)).isEqualTo(kiePMMLConstant.getValue());
     }
 
     @Test
@@ -573,9 +571,9 @@ public class PostProcessTest {
 
         PostProcess.populateOutputFields(toUpdate, processingDTO);
 
-        assertFalse(toUpdate.getResultVariables().isEmpty());
-        assertTrue(toUpdate.getResultVariables().containsKey(OUTPUT_NAME));
-        assertEquals(variableValue, toUpdate.getResultVariables().get(OUTPUT_NAME));
+        assertThat(toUpdate.getResultVariables()).isNotEmpty();
+        assertThat(toUpdate.getResultVariables()).containsKey(OUTPUT_NAME);
+        assertThat(toUpdate.getResultVariables().get(OUTPUT_NAME)).isEqualTo(variableValue);
     }
 
     private static ProcessingDTO buildProcessingDTOWithDefaultNameValues(KiePMMLModel kiePMMLModel) {

--- a/kie-pmml-trusty/kie-pmml-evaluator/kie-pmml-evaluator-core/src/test/java/org/kie/pmml/evaluator/core/utils/PreProcessTest.java
+++ b/kie-pmml-trusty/kie-pmml-evaluator/kie-pmml-evaluator-core/src/test/java/org/kie/pmml/evaluator/core/utils/PreProcessTest.java
@@ -49,9 +49,7 @@ import org.kie.pmml.commons.transformations.KiePMMLDerivedField;
 import org.kie.pmml.commons.transformations.KiePMMLParameterField;
 import org.kie.pmml.commons.transformations.KiePMMLTransformationDictionary;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertTrue;
+import static org.assertj.core.api.Assertions.assertThat;
 
 public class PreProcessTest {
 
@@ -77,13 +75,13 @@ public class PreProcessTest {
         pmmlRequestData.addRequestParam("FIELD-1", "123");
         pmmlRequestData.addRequestParam("FIELD-2", "1.23");
         Map<String, ParameterInfo> mappedRequestParams = pmmlRequestData.getMappedRequestParams();
-        assertEquals(123, mappedRequestParams.get("FIELD-0").getValue());
-        assertEquals("123", mappedRequestParams.get("FIELD-1").getValue());
-        assertEquals("1.23", mappedRequestParams.get("FIELD-2").getValue());
+        assertThat(mappedRequestParams.get("FIELD-0").getValue()).isEqualTo(123);
+        assertThat(mappedRequestParams.get("FIELD-1").getValue()).isEqualTo("123");
+        assertThat(mappedRequestParams.get("FIELD-2").getValue()).isEqualTo("1.23");
         PreProcess.convertInputData(miningFields, pmmlRequestData);
-        assertEquals("123", mappedRequestParams.get("FIELD-0").getValue());
-        assertEquals(123, mappedRequestParams.get("FIELD-1").getValue());
-        assertEquals(1.23f, mappedRequestParams.get("FIELD-2").getValue());
+        assertThat(mappedRequestParams.get("FIELD-0").getValue()).isEqualTo("123");
+        assertThat(mappedRequestParams.get("FIELD-1").getValue()).isEqualTo(123);
+        assertThat(mappedRequestParams.get("FIELD-2").getValue()).isEqualTo(1.23f);
     }
 
     @Test(expected = KiePMMLException.class)
@@ -187,7 +185,7 @@ public class PreProcessTest {
         pmmlRequestData.addRequestParam("FIELD-1", 12.5);
         pmmlRequestData.addRequestParam("FIELD-2", 14.6);
         PreProcess.verifyFixInvalidValues(miningFields, pmmlRequestData);
-        assertTrue(pmmlRequestData.getRequestParams().isEmpty());
+        assertThat(pmmlRequestData.getRequestParams()).isEmpty();
     }
 
     @Test
@@ -219,9 +217,9 @@ public class PreProcessTest {
         pmmlRequestData.addRequestParam("FIELD-2", 14.6);
         PreProcess.verifyFixInvalidValues(miningFields, pmmlRequestData);
         Map<String, ParameterInfo> mappedRequestParams = pmmlRequestData.getMappedRequestParams();
-        assertEquals("123", mappedRequestParams.get("FIELD-0").getValue());
-        assertEquals(1.23, mappedRequestParams.get("FIELD-1").getValue());
-        assertEquals(12.3, mappedRequestParams.get("FIELD-2").getValue());
+        assertThat(mappedRequestParams.get("FIELD-0").getValue()).isEqualTo("123");
+        assertThat(mappedRequestParams.get("FIELD-1").getValue()).isEqualTo(1.23);
+        assertThat(mappedRequestParams.get("FIELD-2").getValue()).isEqualTo(12.3);
     }
 
     @Test(expected = KiePMMLException.class)
@@ -281,9 +279,9 @@ public class PreProcessTest {
         pmmlRequestData.addRequestParam("FIELD-2", 14.6);
         PreProcess.verifyFixInvalidValues(miningFields, pmmlRequestData);
         Map<String, ParameterInfo> mappedRequestParams = pmmlRequestData.getMappedRequestParams();
-        assertEquals("122", mappedRequestParams.get("FIELD-0").getValue());
-        assertEquals(12.5, mappedRequestParams.get("FIELD-1").getValue());
-        assertEquals(14.6, mappedRequestParams.get("FIELD-2").getValue());
+        assertThat(mappedRequestParams.get("FIELD-0").getValue()).isEqualTo("122");
+        assertThat(mappedRequestParams.get("FIELD-1").getValue()).isEqualTo(12.5);
+        assertThat(mappedRequestParams.get("FIELD-2").getValue()).isEqualTo(14.6);
     }
 
     @Test
@@ -342,13 +340,13 @@ public class PreProcessTest {
 
         List<KiePMMLMiningField> miningFields = Arrays.asList(miningField0, miningField1, miningField2);
         PMMLRequestData pmmlRequestData = new PMMLRequestData("123", "modelName");
-        assertTrue(pmmlRequestData.getRequestParams().isEmpty());
+        assertThat(pmmlRequestData.getRequestParams()).isEmpty();
         PreProcess.verifyAddMissingValues(miningFields, pmmlRequestData);
         Map<String, ParameterInfo> mappedRequestParams = pmmlRequestData.getMappedRequestParams();
-        assertEquals(miningFields.size(), mappedRequestParams.size());
-        assertEquals("123", mappedRequestParams.get("FIELD-0").getValue());
-        assertEquals(1.23, mappedRequestParams.get("FIELD-1").getValue());
-        assertEquals(12.9f, mappedRequestParams.get("FIELD-2").getValue());
+        assertThat(mappedRequestParams).hasSameSizeAs(miningFields);
+        assertThat(mappedRequestParams.get("FIELD-0").getValue()).isEqualTo("123");
+        assertThat(mappedRequestParams.get("FIELD-1").getValue()).isEqualTo(1.23);
+        assertThat(mappedRequestParams.get("FIELD-2").getValue()).isEqualTo(12.9f);
     }
 
     @Test(expected = KiePMMLException.class)
@@ -425,20 +423,20 @@ public class PreProcessTest {
                 PreProcess.getKiePMMLNameValuesFromParameterInfos(mappedRequestParams.values());
         Optional<KiePMMLNameValue> retrieved =
                 kiePMMLNameValues.stream().filter(kiePMMLNameValue -> kiePMMLNameValue.getName().equals(INPUT_FIELD)).findFirst();
-        assertTrue(retrieved.isPresent());
-        assertEquals(value1, retrieved.get().getValue());
+        assertThat(retrieved).isPresent();
+        assertThat(retrieved.get().getValue()).isEqualTo(value1);
 
         ProcessingDTO processingDTO = new ProcessingDTO(kiePMMLModel, kiePMMLNameValues);
         PreProcess.executeTransformations(processingDTO, pmmlRequestData);
         mappedRequestParams = pmmlRequestData.getMappedRequestParams();
 
         Object expected = value1 / value2;
-        assertTrue(mappedRequestParams.containsKey(CUSTOM_REF_FIELD));
-        assertEquals(expected, mappedRequestParams.get(CUSTOM_REF_FIELD).getValue());
+        assertThat(mappedRequestParams).containsKey(CUSTOM_REF_FIELD);
+        assertThat(mappedRequestParams.get(CUSTOM_REF_FIELD).getValue()).isEqualTo(expected);
         retrieved =
                 kiePMMLNameValues.stream().filter(kiePMMLNameValue -> kiePMMLNameValue.getName().equals(CUSTOM_REF_FIELD)).findFirst();
-        assertTrue(retrieved.isPresent());
-        assertEquals(expected, retrieved.get().getValue());
+        assertThat(retrieved).isPresent();
+        assertThat(retrieved.get().getValue()).isEqualTo(expected);
     }
 
     @Test
@@ -450,15 +448,15 @@ public class PreProcessTest {
                 .build();
         List<ParameterInfo> toRemove = new ArrayList<>();
         PreProcess.manageInvalidValues(miningField, parameterInfo, toRemove);
-        assertEquals(1, toRemove.size());
-        assertTrue(toRemove.contains(parameterInfo));
+        assertThat(toRemove).hasSize(1);
+        assertThat(toRemove).contains(parameterInfo);
         // AS_IS
         miningField = KiePMMLMiningField.builder("FIELD", null)
                 .withInvalidValueTreatmentMethod(INVALID_VALUE_TREATMENT_METHOD.AS_IS)
                 .build();
         toRemove = new ArrayList<>();
         PreProcess.manageInvalidValues(miningField, parameterInfo, toRemove);
-        assertTrue(toRemove.isEmpty());
+        assertThat(toRemove).isEmpty();
         // AS_VALUE with replacement
         String invalidValueReplacement = "REPLACEMENT";
         miningField = KiePMMLMiningField.builder("FIELD", null)
@@ -467,12 +465,12 @@ public class PreProcessTest {
                 .withInvalidValueReplacement(invalidValueReplacement)
                 .build();
         toRemove = new ArrayList<>();
-        assertNull(parameterInfo.getValue());
-        assertNull(parameterInfo.getType());
+        assertThat(parameterInfo.getValue()).isNull();
+        assertThat(parameterInfo.getType()).isNull();
         PreProcess.manageInvalidValues(miningField, parameterInfo, toRemove);
-        assertTrue(toRemove.isEmpty());
-        assertEquals(invalidValueReplacement, parameterInfo.getValue());
-        assertEquals(String.class, parameterInfo.getType());
+        assertThat(toRemove).isEmpty();
+        assertThat(parameterInfo.getValue()).isEqualTo(invalidValueReplacement);
+        assertThat(parameterInfo.getType()).isEqualTo(String.class);
     }
 
     @Test(expected = KiePMMLException.class)
@@ -484,8 +482,8 @@ public class PreProcessTest {
                 .withInvalidValueTreatmentMethod(INVALID_VALUE_TREATMENT_METHOD.AS_VALUE)
                 .build();
         List<ParameterInfo> toRemove = new ArrayList<>();
-        assertNull(parameterInfo.getValue());
-        assertNull(parameterInfo.getType());
+        assertThat(parameterInfo.getValue()).isNull();
+        assertThat(parameterInfo.getType()).isNull();
         PreProcess.manageInvalidValues(miningField, parameterInfo, toRemove);
     }
 
@@ -514,7 +512,7 @@ public class PreProcessTest {
                     .build();
             PMMLRequestData pmmlRequestData = new PMMLRequestData();
             PreProcess.manageMissingValues(miningField, pmmlRequestData);
-            assertTrue(pmmlRequestData.getRequestParams().isEmpty());
+            assertThat(pmmlRequestData.getRequestParams()).isEmpty();
             String missingValueReplacement = "REPLACEMENT";
             miningField = KiePMMLMiningField.builder(fieldName, null)
                     .withDataType(DATA_TYPE.STRING)
@@ -523,11 +521,11 @@ public class PreProcessTest {
                     .build();
             pmmlRequestData = new PMMLRequestData();
             PreProcess.manageMissingValues(miningField, pmmlRequestData);
-            assertEquals(1, pmmlRequestData.getRequestParams().size());
-            assertTrue(pmmlRequestData.getMappedRequestParams().containsKey(fieldName));
+            assertThat(pmmlRequestData.getRequestParams()).hasSize(1);
+            assertThat(pmmlRequestData.getMappedRequestParams()).containsKey(fieldName);
             ParameterInfo parameterInfo = pmmlRequestData.getMappedRequestParams().get(fieldName);
-            assertEquals(missingValueReplacement, parameterInfo.getValue());
-            assertEquals(String.class, parameterInfo.getType());
+            assertThat(parameterInfo.getValue()).isEqualTo(missingValueReplacement);
+            assertThat(parameterInfo.getType()).isEqualTo(String.class);
         });
     }
 

--- a/kie-pmml-trusty/kie-pmml-models-archetype/src/main/resources/archetype-resources/__rootArtifactId__-compiler/src/test/java/__packageModelName__/compiler/executor/__modelName__ModelImplementationProviderTest.java
+++ b/kie-pmml-trusty/kie-pmml-models-archetype/src/main/resources/archetype-resources/__rootArtifactId__-compiler/src/test/java/__packageModelName__/compiler/executor/__modelName__ModelImplementationProviderTest.java
@@ -21,8 +21,7 @@ package ${package}.${packageModelName}.compiler.executor;
 import org.kie.pmml.api.enums.PMML_MODEL;
 import org.junit.Test;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.fail;
+import static org.assertj.core.api.Assertions.assertThat;
 
 public class ${modelName}ModelImplementationProviderTest {
 
@@ -30,7 +29,7 @@ public class ${modelName}ModelImplementationProviderTest {
 
     @Test
     public void getPMMLModelType(){
-        assertEquals(PMML_MODEL.${modelNameUppercase}_MODEL,PROVIDER.getPMMLModelType());
+        assertThat(PROVIDER.getPMMLModelType()).isEqualTo(PMML_MODEL.${modelNameUppercase}_MODEL);
     }
 
     @Test

--- a/kie-pmml-trusty/kie-pmml-models-archetype/src/main/resources/archetype-resources/__rootArtifactId__-evaluator/src/test/java/__packageModelName__/evaluator/PMML__modelName__ModelEvaluatorTest.java
+++ b/kie-pmml-trusty/kie-pmml-models-archetype/src/main/resources/archetype-resources/__rootArtifactId__-evaluator/src/test/java/__packageModelName__/evaluator/PMML__modelName__ModelEvaluatorTest.java
@@ -22,7 +22,7 @@ import org.junit.Before;
 import org.junit.Test;
 import org.kie.pmml.api.enums.PMML_MODEL;
 
-import static org.junit.Assert.assertEquals;
+import static org.assertj.core.api.Assertions.assertThat;
 
 public class PMML${modelName}ModelEvaluatorTest {
 
@@ -35,7 +35,7 @@ public class PMML${modelName}ModelEvaluatorTest {
 
     @Test
     public void getPMMLModelType(){
-        assertEquals(PMML_MODEL.${modelNameUppercase}_MODEL, evaluator.getPMMLModelType());
+        assertThat(evaluator.getPMMLModelType()).isEqualTo(PMML_MODEL.${modelNameUppercase}_MODEL);
     }
 
 }

--- a/kie-pmml-trusty/kie-pmml-models-archetype/src/test/resources-filtered/projects/generated-naivebayes/reference/kie-pmml-models-naivebayes-compiler/src/test/java/org/kie/pmml/models/naive_bayes/compiler/executor/NaiveBayesModelImplementationProviderTest.java
+++ b/kie-pmml-trusty/kie-pmml-models-archetype/src/test/resources-filtered/projects/generated-naivebayes/reference/kie-pmml-models-naivebayes-compiler/src/test/java/org/kie/pmml/models/naive_bayes/compiler/executor/NaiveBayesModelImplementationProviderTest.java
@@ -18,8 +18,7 @@ package org.kie.pmml.models.naive_bayes.compiler.executor;
 import org.kie.pmml.api.enums.PMML_MODEL;
 import org.junit.Test;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.fail;
+import static org.assertj.core.api.Assertions.assertThat;
 
 public class NaiveBayesModelImplementationProviderTest {
 
@@ -27,7 +26,7 @@ public class NaiveBayesModelImplementationProviderTest {
 
     @Test
     public void getPMMLModelType(){
-        assertEquals(PMML_MODEL.NAIVEBAYES_MODEL,PROVIDER.getPMMLModelType());
+        assertThat(PROVIDER.getPMMLModelType()).isEqualTo(PMML_MODEL.NAIVEBAYES_MODEL);
     }
 
     @Test

--- a/kie-pmml-trusty/kie-pmml-models-archetype/src/test/resources-filtered/projects/generated-naivebayes/reference/kie-pmml-models-naivebayes-evaluator/src/test/java/org/kie/pmml/models/naive_bayes/evaluator/PMMLNaiveBayesModelEvaluatorTest.java
+++ b/kie-pmml-trusty/kie-pmml-models-archetype/src/test/resources-filtered/projects/generated-naivebayes/reference/kie-pmml-models-naivebayes-evaluator/src/test/java/org/kie/pmml/models/naive_bayes/evaluator/PMMLNaiveBayesModelEvaluatorTest.java
@@ -19,7 +19,7 @@ import org.junit.Before;
 import org.junit.Test;
 import org.kie.pmml.api.enums.PMML_MODEL;
 
-import static org.junit.Assert.assertEquals;
+import static org.assertj.core.api.Assertions.assertThat;
 
 public class PMMLNaiveBayesModelEvaluatorTest {
 
@@ -32,7 +32,7 @@ public class PMMLNaiveBayesModelEvaluatorTest {
 
     @Test
     public void getPMMLModelType(){
-        assertEquals(PMML_MODEL.NAIVEBAYES_MODEL, evaluator.getPMMLModelType());
+        assertThat(evaluator.getPMMLModelType()).isEqualTo(PMML_MODEL.NAIVEBAYES_MODEL);
     }
 
 }

--- a/kie-pmml-trusty/kie-pmml-models-drools-archetype/src/main/resources/archetype-resources/__rootArtifactId__-compiler/src/test/java/__packageModelName__/compiler/executor/__modelName__ModelImplementationProviderTest.java
+++ b/kie-pmml-trusty/kie-pmml-models-drools-archetype/src/main/resources/archetype-resources/__rootArtifactId__-compiler/src/test/java/__packageModelName__/compiler/executor/__modelName__ModelImplementationProviderTest.java
@@ -21,8 +21,7 @@ package ${package}.${packageModelName}.compiler.executor;
 import org.kie.pmml.api.enums.PMML_MODEL;
 import org.junit.Test;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.fail;
+import static org.assertj.core.api.Assertions.assertThat;
 
 public class ${modelName}ModelImplementationProviderTest {
 
@@ -30,7 +29,7 @@ public class ${modelName}ModelImplementationProviderTest {
 
     @Test
     public void getPMMLModelType(){
-        assertEquals(PMML_MODEL.${modelNameUppercase}_MODEL,PROVIDER.getPMMLModelType());
+    	assertThat(PROVIDER.getPMMLModelType()).isEqualTo(PMML_MODEL.${modelNameUppercase}_MODEL);
     }
 
     @Test

--- a/kie-pmml-trusty/kie-pmml-models-drools-archetype/src/main/resources/archetype-resources/__rootArtifactId__-evaluator/src/test/java/__packageModelName__/evaluator/PMML__modelName__ModelEvaluatorTest.java
+++ b/kie-pmml-trusty/kie-pmml-models-drools-archetype/src/main/resources/archetype-resources/__rootArtifactId__-evaluator/src/test/java/__packageModelName__/evaluator/PMML__modelName__ModelEvaluatorTest.java
@@ -22,7 +22,7 @@ import org.junit.Before;
 import org.junit.Test;
 import org.kie.pmml.api.enums.PMML_MODEL;
 
-import static org.junit.Assert.assertEquals;
+import static org.assertj.core.api.Assertions.assertThat;
 
 public class PMML${modelName}ModelEvaluatorTest {
 
@@ -35,7 +35,7 @@ public class PMML${modelName}ModelEvaluatorTest {
 
     @Test
     public void getPMMLModelType(){
-        assertEquals(PMML_MODEL.${modelNameUppercase}_MODEL, evaluator.getPMMLModelType());
+        assertThat(evaluator.getPMMLModelType()).isEqualTo(PMML_MODEL.${modelNameUppercase}_MODEL);
     }
 
 }

--- a/kie-pmml-trusty/kie-pmml-models-drools-archetype/src/test/resources-filtered/projects/generated-tree/reference/kie-pmml-models-drools-tree-compiler/src/test/java/org/kie/pmml/models/tree/compiler/executor/TreeModelImplementationProviderTest.java
+++ b/kie-pmml-trusty/kie-pmml-models-drools-archetype/src/test/resources-filtered/projects/generated-tree/reference/kie-pmml-models-drools-tree-compiler/src/test/java/org/kie/pmml/models/tree/compiler/executor/TreeModelImplementationProviderTest.java
@@ -18,8 +18,7 @@ package org.kie.pmml.models.tree.compiler.executor;
 import org.kie.pmml.api.enums.PMML_MODEL;
 import org.junit.Test;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.fail;
+import static org.assertj.core.api.Assertions.assertThat;
 
 public class TreeModelImplementationProviderTest {
 
@@ -27,7 +26,7 @@ public class TreeModelImplementationProviderTest {
 
     @Test
     public void getPMMLModelType(){
-        assertEquals(PMML_MODEL.TREE_MODEL,PROVIDER.getPMMLModelType());
+        assertThat(PROVIDER.getPMMLModelType()).isEqualTo(PMML_MODEL.TREE_MODEL);
     }
 
     @Test

--- a/kie-pmml-trusty/kie-pmml-models-drools-archetype/src/test/resources-filtered/projects/generated-tree/reference/kie-pmml-models-drools-tree-evaluator/src/test/java/org/kie/pmml/models/tree/evaluator/PMMLTreeModelEvaluatorTest.java
+++ b/kie-pmml-trusty/kie-pmml-models-drools-archetype/src/test/resources-filtered/projects/generated-tree/reference/kie-pmml-models-drools-tree-evaluator/src/test/java/org/kie/pmml/models/tree/evaluator/PMMLTreeModelEvaluatorTest.java
@@ -19,7 +19,7 @@ import org.junit.Before;
 import org.junit.Test;
 import org.kie.pmml.api.enums.PMML_MODEL;
 
-import static org.junit.Assert.assertEquals;
+import static org.assertj.core.api.Assertions.assertThat;
 
 public class PMMLTreeModelEvaluatorTest {
 
@@ -32,7 +32,7 @@ public class PMMLTreeModelEvaluatorTest {
 
     @Test
     public void getPMMLModelType(){
-        assertEquals(PMML_MODEL.TREE_MODEL, evaluator.getPMMLModelType());
+        assertThat(evaluator.getPMMLModelType()).isEqualTo(PMML_MODEL.TREE_MODEL);
     }
 
 }

--- a/kie-pmml-trusty/kie-pmml-models/kie-pmml-models-clustering/kie-pmml-models-clustering-compiler/src/test/java/org/kie/pmml/models/clustering/compiler/executor/ClusteringModelImplementationProviderTest.java
+++ b/kie-pmml-trusty/kie-pmml-models/kie-pmml-models-clustering/kie-pmml-models-clustering-compiler/src/test/java/org/kie/pmml/models/clustering/compiler/executor/ClusteringModelImplementationProviderTest.java
@@ -31,9 +31,6 @@ import org.kie.pmml.compiler.commons.mocks.HasClassLoaderMock;
 import org.kie.pmml.models.clustering.model.KiePMMLClusteringModel;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
 import static org.kie.pmml.commons.Constants.PACKAGE_NAME;
 
 public class ClusteringModelImplementationProviderTest {
@@ -44,17 +41,17 @@ public class ClusteringModelImplementationProviderTest {
 
     private static ClusteringModel getModel(PMML pmml) {
         assertThat(pmml).isNotNull();
-        assertEquals(1, pmml.getModels().size());
+        assertThat(pmml.getModels()).hasSize(1);
 
         Model model = pmml.getModels().get(0);
-        assertTrue(model instanceof ClusteringModel);
+        assertThat(model).isInstanceOf(ClusteringModel.class);
 
         return (ClusteringModel) model;
     }
 
     @Test
     public void getPMMLModelType() {
-        assertEquals(PMML_MODEL.CLUSTERING_MODEL, PROVIDER.getPMMLModelType());
+        assertThat(PROVIDER.getPMMLModelType()).isEqualTo(PMML_MODEL.CLUSTERING_MODEL);
     }
 
     @Test
@@ -70,7 +67,7 @@ public class ClusteringModelImplementationProviderTest {
         KiePMMLClusteringModel retrieved = PROVIDER.getKiePMMLModel(compilationDTO);
 
         assertThat(retrieved).isNotNull();
-        assertTrue(retrieved instanceof Serializable);
+        assertThat(retrieved).isInstanceOf(Serializable.class);
     }
 
     @Test
@@ -87,12 +84,12 @@ public class ClusteringModelImplementationProviderTest {
         assertThat(retrieved).isNotNull();
         Map<String, String> sourcesMap = retrieved.getSourcesMap();
         assertThat(sourcesMap).isNotNull();
-        assertFalse(sourcesMap.isEmpty());
+        assertThat(sourcesMap).isNotEmpty();
 
         ClassLoader classLoader = Thread.currentThread().getContextClassLoader();
         Map<String, Class<?>> compiled = KieMemoryCompiler.compile(sourcesMap, classLoader);
         for (Class<?> clazz : compiled.values()) {
-            assertTrue(clazz instanceof Serializable);
+            assertThat(clazz).isInstanceOf(Serializable.class);
         }
     }
 }

--- a/kie-pmml-trusty/kie-pmml-models/kie-pmml-models-clustering/kie-pmml-models-clustering-compiler/src/test/java/org/kie/pmml/models/clustering/compiler/factories/KiePMMLClusteringModelFactoryTest.java
+++ b/kie-pmml-trusty/kie-pmml-models/kie-pmml-models-clustering/kie-pmml-models-clustering-compiler/src/test/java/org/kie/pmml/models/clustering/compiler/factories/KiePMMLClusteringModelFactoryTest.java
@@ -60,9 +60,6 @@ import org.kie.pmml.models.clustering.model.KiePMMLComparisonMeasure;
 import org.kie.pmml.models.clustering.model.KiePMMLMissingValueWeights;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertTrue;
 import static org.kie.pmml.commons.Constants.GET_MODEL;
 import static org.kie.pmml.commons.Constants.PACKAGE_NAME;
 import static org.kie.pmml.compiler.api.testutils.PMMLModelTestUtils.getArray;
@@ -142,15 +139,15 @@ public class KiePMMLClusteringModelFactoryTest {
         KiePMMLClusteringModel retrieved =
                 KiePMMLClusteringModelFactory.getKiePMMLClusteringModel(ClusteringCompilationDTO.fromCompilationDTO(compilationDTO));
         assertThat(retrieved).isNotNull();
-        assertEquals(clusteringModel.getModelName(), retrieved.getName());
-        assertEquals(clusteringModel.getModelClass().value(), retrieved.getModelClass().getName());
+        assertThat(retrieved.getName()).isEqualTo(clusteringModel.getModelName());
+        assertThat(retrieved.getModelClass().getName()).isEqualTo(clusteringModel.getModelClass().value());
         List<KiePMMLCluster> retrievedClusters = retrieved.getClusters();
-        assertEquals(clusteringModel.getClusters().size(), retrievedClusters.size());
+        assertThat(retrievedClusters).hasSameSizeAs(clusteringModel.getClusters());
         IntStream.range(0, clusteringModel.getClusters().size()).forEach(i -> commonEvaluateKiePMMLCluster(retrievedClusters.get(i), clusteringModel.getClusters().get(i)));
         List<KiePMMLClusteringField> retrievedClusteringFields = retrieved.getClusteringFields();
-        assertEquals(clusteringModel.getClusters().size(), retrievedClusters.size());
+        assertThat(retrievedClusters).hasSameSizeAs(clusteringModel.getClusters());
         IntStream.range(0, clusteringModel.getClusters().size()).forEach(i -> commonEvaluateKiePMMLCluster(retrievedClusters.get(i), clusteringModel.getClusters().get(i)));
-        assertEquals(clusteringModel.getClusteringFields().size(), retrievedClusteringFields.size());
+        assertThat(retrievedClusteringFields).hasSameSizeAs(clusteringModel.getClusteringFields());
         IntStream.range(0, clusteringModel.getClusteringFields().size()).forEach(i -> commonEvaluateKiePMMLClusteringField(retrievedClusteringFields.get(i), clusteringModel.getClusteringFields().get(i)));
         commonEvaluateKiePMMLComparisonMeasure(retrieved.getComparisonMeasure(),
                                                clusteringModel.getComparisonMeasure());
@@ -168,7 +165,7 @@ public class KiePMMLClusteringModelFactoryTest {
         Map<String, String> retrieved =
                 KiePMMLClusteringModelFactory.getKiePMMLClusteringModelSourcesMap(ClusteringCompilationDTO.fromCompilationDTO(compilationDTO));
         assertThat(retrieved).isNotNull();
-        assertEquals(1, retrieved.size());
+        assertThat(retrieved).hasSize(1);
     }
 
     @Test
@@ -211,18 +208,18 @@ public class KiePMMLClusteringModelFactoryTest {
         comparisonMeasure.setMeasure(new Euclidean());
         KiePMMLComparisonMeasure retrieved =
                 KiePMMLClusteringModelFactory.getKiePMMLComparisonMeasure(comparisonMeasure);
-        assertEquals(KiePMMLAggregateFunction.EUCLIDEAN, retrieved.getAggregateFunction());
+        assertThat(retrieved.getAggregateFunction()).isEqualTo(KiePMMLAggregateFunction.EUCLIDEAN);
         commonEvaluateKiePMMLComparisonMeasure(retrieved, comparisonMeasure);
     }
 
     @Test
     public void getKiePMMLMissingValueWeights() {
-        assertNull(KiePMMLClusteringModelFactory.getKiePMMLMissingValueWeights(null));
+        assertThat(KiePMMLClusteringModelFactory.getKiePMMLMissingValueWeights(null)).isNull();
         KiePMMLMissingValueWeights retrieved =
                 KiePMMLClusteringModelFactory.getKiePMMLMissingValueWeights(new MissingValueWeights());
         assertThat(retrieved).isNotNull();
         assertThat(retrieved.getValues()).isNotNull();
-        assertTrue(retrieved.getValues().isEmpty());
+        assertThat(retrieved.getValues()).isEmpty();
         MissingValueWeights missingValueWeights = new MissingValueWeights();
         final Random random = new Random();
         final List<Double> doubleValues =
@@ -267,15 +264,15 @@ public class KiePMMLClusteringModelFactoryTest {
                                     expectedCompareFunction,
                                     expectedTargetField);
         MethodDeclaration expected = JavaParserUtils.parseMethod(text);
-        assertTrue(JavaParserUtils.equalsNode(expected, retrieved));
+        assertThat(JavaParserUtils.equalsNode(expected, retrieved)).isTrue();
     }
 
     private void commonEvaluateKiePMMLCluster(KiePMMLCluster retrieved, Cluster cluster) {
         assertThat(retrieved).isNotNull();
-        assertTrue(retrieved.getId().isPresent());
-        assertEquals(cluster.getId(), retrieved.getId().get());
-        assertTrue(retrieved.getName().isPresent());
-        assertEquals(cluster.getName(), retrieved.getName().get());
+        assertThat(retrieved.getId()).isPresent();
+        assertThat(retrieved.getId().get()).isEqualTo(cluster.getId());
+        assertThat(retrieved.getName()).isPresent();
+        assertThat(retrieved.getName().get()).isEqualTo(cluster.getName());
         commonEvaluateDoubles(retrieved.getValues(), cluster.getArray());
     }
 
@@ -283,17 +280,17 @@ public class KiePMMLClusteringModelFactoryTest {
                                                       ClusteringField clusteringField) {
         assertThat(retrieved).isNotNull();
         boolean isCenterField = clusteringField.getCenterField() == ClusteringField.CenterField.TRUE;
-        assertEquals(clusteringField.getField().getValue(), retrieved.getField());
-        assertEquals(clusteringField.getFieldWeight(), retrieved.getFieldWeight());
-        assertEquals(isCenterField, retrieved.getCenterField());
-        assertTrue(retrieved.getCompareFunction().isPresent());
-        assertEquals(clusteringField.getCompareFunction().value(), retrieved.getCompareFunction().get().getName());
+        assertThat(retrieved.getField()).isEqualTo(clusteringField.getField().getValue());
+        assertThat(retrieved.getFieldWeight()).isEqualTo(clusteringField.getFieldWeight());
+        assertThat(retrieved.getCenterField()).isEqualTo(isCenterField);
+        assertThat(retrieved.getCompareFunction()).isPresent();
+        assertThat(retrieved.getCompareFunction().get().getName()).isEqualTo(clusteringField.getCompareFunction().value());
     }
 
     private void commonEvaluateKiePMMLComparisonMeasure(KiePMMLComparisonMeasure retrieved,
                                                         ComparisonMeasure comparisonMeasure) {
-        assertEquals(comparisonMeasure.getKind().value(), retrieved.getKind().getName());
-        assertEquals(comparisonMeasure.getCompareFunction().value(), retrieved.getCompareFunction().getName());
+        assertThat(retrieved.getKind().getName()).isEqualTo(comparisonMeasure.getKind().value());
+        assertThat(retrieved.getCompareFunction().getName()).isEqualTo(comparisonMeasure.getCompareFunction().value());
     }
 
     private void commonEvaluateKiePMMLMissingValueWeights(KiePMMLMissingValueWeights retrieved,
@@ -306,9 +303,9 @@ public class KiePMMLClusteringModelFactoryTest {
         if (array != null) {
             final List<Object> doubleValues = getObjectsFromArray(array);
             assertThat(retrievedValues).isNotNull();
-            assertEquals(doubleValues.size(), retrievedValues.size());
+            assertThat(retrievedValues).hasSameSizeAs(doubleValues);
             IntStream.range(0, doubleValues.size()).forEach(i -> {
-                assertEquals(doubleValues.get(i), retrievedValues.get(i));
+                assertThat(retrievedValues.get(i)).isEqualTo(doubleValues.get(i));
             });
         }
     }

--- a/kie-pmml-trusty/kie-pmml-models/kie-pmml-models-clustering/kie-pmml-models-clustering-evaluator/src/test/java/org/kie/pmml/models/clustering/evaluator/PMMLClusteringModelEvaluatorTest.java
+++ b/kie-pmml-trusty/kie-pmml-models/kie-pmml-models-clustering/kie-pmml-models-clustering-evaluator/src/test/java/org/kie/pmml/models/clustering/evaluator/PMMLClusteringModelEvaluatorTest.java
@@ -19,7 +19,7 @@ import org.junit.Before;
 import org.junit.Test;
 import org.kie.pmml.api.enums.PMML_MODEL;
 
-import static org.junit.Assert.assertEquals;
+import static org.assertj.core.api.Assertions.assertThat;
 
 public class PMMLClusteringModelEvaluatorTest {
 
@@ -32,7 +32,7 @@ public class PMMLClusteringModelEvaluatorTest {
 
     @Test
     public void getPMMLModelType(){
-        assertEquals(PMML_MODEL.CLUSTERING_MODEL, evaluator.getPMMLModelType());
+        assertThat(evaluator.getPMMLModelType()).isEqualTo(PMML_MODEL.CLUSTERING_MODEL);
     }
 
 }

--- a/kie-pmml-trusty/kie-pmml-models/kie-pmml-models-drools/kie-pmml-models-drools-common/src/test/java/org/kie/pmml/models/drools/ast/KiePMMLFieldOperatorValueTest.java
+++ b/kie-pmml-trusty/kie-pmml-models/kie-pmml-models-drools/kie-pmml-models-drools-common/src/test/java/org/kie/pmml/models/drools/ast/KiePMMLFieldOperatorValueTest.java
@@ -25,7 +25,7 @@ import org.kie.pmml.api.enums.BOOLEAN_OPERATOR;
 import org.kie.pmml.api.enums.OPERATOR;
 import org.kie.pmml.models.drools.tuples.KiePMMLOperatorValue;
 
-import static org.junit.Assert.assertEquals;
+import static org.assertj.core.api.Assertions.assertThat;
 
 public class KiePMMLFieldOperatorValueTest {
 
@@ -37,11 +37,11 @@ public class KiePMMLFieldOperatorValueTest {
         KiePMMLFieldOperatorValue kiePMMLFieldOperatorValue = getKiePMMLFieldOperatorValueWithName();
         String expected = "value < 35 surrogate value > 85";
         String retrieved = kiePMMLFieldOperatorValue.getConstraintsAsString();
-        assertEquals(expected, retrieved);
+        assertThat(retrieved).isEqualTo(expected);
         kiePMMLFieldOperatorValue = getKiePMMLFieldOperatorValueWithoutName();
         expected = "value < 35 surrogate value > 85";
         retrieved = kiePMMLFieldOperatorValue.buildConstraintsString();
-        assertEquals(expected, retrieved);
+        assertThat(retrieved).isEqualTo(expected);
     }
 
     @Test
@@ -49,11 +49,11 @@ public class KiePMMLFieldOperatorValueTest {
         KiePMMLFieldOperatorValue kiePMMLFieldOperatorValue = getKiePMMLFieldOperatorValueWithName();
         String expected = "value < 35 surrogate value > 85";
         String retrieved = kiePMMLFieldOperatorValue.buildConstraintsString();
-        assertEquals(expected, retrieved);
+        assertThat(retrieved).isEqualTo(expected);
         kiePMMLFieldOperatorValue = getKiePMMLFieldOperatorValueWithoutName();
         expected = "value < 35 surrogate value > 85";
         retrieved = kiePMMLFieldOperatorValue.buildConstraintsString();
-        assertEquals(expected, retrieved);
+        assertThat(retrieved).isEqualTo(expected);
     }
 
     private KiePMMLFieldOperatorValue getKiePMMLFieldOperatorValueWithName() {

--- a/kie-pmml-trusty/kie-pmml-models/kie-pmml-models-drools/kie-pmml-models-drools-common/src/test/java/org/kie/pmml/models/drools/ast/factories/KiePMMLCompoundPredicateASTFactoryTest.java
+++ b/kie-pmml-trusty/kie-pmml-models/kie-pmml-models-drools/kie-pmml-models-drools-common/src/test/java/org/kie/pmml/models/drools/ast/factories/KiePMMLCompoundPredicateASTFactoryTest.java
@@ -35,8 +35,6 @@ import org.kie.pmml.models.drools.ast.KiePMMLDroolsRule;
 import org.kie.pmml.models.drools.tuples.KiePMMLOriginalTypeGeneratedType;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNull;
 import static org.kie.pmml.commons.Constants.DONE;
 import static org.kie.pmml.commons.utils.KiePMMLModelUtils.getSanitizedClassName;
 import static org.kie.pmml.models.drools.ast.factories.KiePMMLAbstractModelASTFactory.STATUS_PATTERN;
@@ -68,14 +66,14 @@ public class KiePMMLCompoundPredicateASTFactoryTest {
                                                                                          currentRule,
                                                                                          fieldTypeMap);
             KiePMMLCompoundPredicateASTFactory.factory(predicateASTFactoryData).declareRuleFromCompoundPredicate(result, true);
-            assertEquals(1, rules.size());
+            assertThat(rules).hasSize(1);
             final KiePMMLDroolsRule retrieved = rules.get(0);
             assertThat(retrieved).isNotNull();
-            assertEquals(currentRule, retrieved.getName());
-            assertEquals(DONE, retrieved.getStatusToSet());
-            assertEquals(String.format(STATUS_PATTERN, parentPath), retrieved.getStatusConstraint());
-            assertEquals(result, retrieved.getResult());
-            assertEquals(ResultCode.OK, retrieved.getResultCode());
+            assertThat(retrieved.getName()).isEqualTo(currentRule);
+            assertThat(retrieved.getStatusToSet()).isEqualTo(DONE);
+            assertThat(retrieved.getStatusConstraint()).isEqualTo(String.format(STATUS_PATTERN, parentPath));
+            assertThat(retrieved.getResult()).isEqualTo(result);
+            assertThat(retrieved.getResultCode()).isEqualTo(ResultCode.OK);
             switch (compoundPredicate.getBooleanOperator()) {
                 case AND:
                     assertThat(retrieved.getAndConstraints()).isNotNull();
@@ -114,12 +112,12 @@ public class KiePMMLCompoundPredicateASTFactoryTest {
                                                                                          currentRule,
                                                                                          fieldTypeMap);
             KiePMMLCompoundPredicateASTFactory.factory(predicateASTFactoryData).declareRuleFromCompoundPredicate(result, false);
-            assertEquals(1, rules.size());
+            assertThat(rules).hasSize(1);
             final KiePMMLDroolsRule retrieved = rules.get(0);
             assertThat(retrieved).isNotNull();
-            assertEquals(currentRule, retrieved.getName());
-            assertEquals(currentRule, retrieved.getStatusToSet());
-            assertEquals(String.format(STATUS_PATTERN, parentPath), retrieved.getStatusConstraint());
+            assertThat(retrieved.getName()).isEqualTo(currentRule);
+            assertThat(retrieved.getStatusToSet()).isEqualTo(currentRule);
+            assertThat(retrieved.getStatusConstraint()).isEqualTo(String.format(STATUS_PATTERN, parentPath));
             switch (compoundPredicate.getBooleanOperator()) {
                 case AND:
                     assertThat(retrieved.getAndConstraints()).isNotNull();
@@ -155,7 +153,7 @@ public class KiePMMLCompoundPredicateASTFactoryTest {
                                                                                      fieldTypeMap);
         KiePMMLCompoundPredicateASTFactory.factory(predicateASTFactoryData).declareRuleFromCompoundPredicate(result, true);
         int expectedRules = (predicates.size() * 2) + 1; // For each "surrogate" predicate two rules -"TRUE" and "FALSE" - are generated; one more rule is generated for the Compound predicate itself
-        assertEquals(expectedRules, rules.size());
+        assertThat(rules.size()).isEqualTo(expectedRules);
         String agendaActivationGroup = String.format(SURROGATE_GROUP_PATTERN, currentRule);
         for (KiePMMLDroolsRule retrieved : rules) {
             String ruleName = retrieved.getName();
@@ -176,27 +174,27 @@ public class KiePMMLCompoundPredicateASTFactoryTest {
                             .findFirst()
                             .orElse(null);
                     assertThat(mappedPredicate).isNotNull();
-                    assertNull(retrieved.getStatusConstraint());
-                    assertEquals(agendaActivationGroup, retrieved.getActivationGroup());
-                    assertEquals(agendaActivationGroup, retrieved.getAgendaGroup());
+                    assertThat(retrieved.getStatusConstraint()).isNull();
+                    assertThat(retrieved.getActivationGroup()).isEqualTo(agendaActivationGroup);
+                    assertThat(retrieved.getAgendaGroup()).isEqualTo(agendaActivationGroup);
                     // Those are in a final leaf node
                     if (isTrueRule) {
-                        assertEquals(DONE, retrieved.getStatusToSet());
-                        assertEquals(result, retrieved.getResult());
-                        assertEquals(ResultCode.OK, retrieved.getResultCode());
+                        assertThat(retrieved.getStatusToSet()).isEqualTo(DONE);
+                        assertThat(retrieved.getResult()).isEqualTo(result);
+                        assertThat(retrieved.getResultCode()).isEqualTo(ResultCode.OK);
                     } else {
-                        assertEquals(parentPath, retrieved.getStatusToSet());
-                        assertNull(retrieved.getResult());
-                        assertNull(retrieved.getResultCode());
+                        assertThat(retrieved.getStatusToSet()).isEqualTo(parentPath);
+                        assertThat(retrieved.getResult()).isNull();
+                        assertThat(retrieved.getResultCode()).isNull();
                     }
                 }
             } else {
                 assertThat(retrieved.getStatusConstraint()).isNotNull();
-                assertEquals(String.format(STATUS_PATTERN, parentPath), retrieved.getStatusConstraint());
-                assertEquals(agendaActivationGroup, retrieved.getFocusedAgendaGroup());
-                assertNull(retrieved.getStatusToSet());
-                assertNull(retrieved.getResult());
-                assertNull(retrieved.getResultCode());
+                assertThat(retrieved.getStatusConstraint()).isEqualTo(String.format(STATUS_PATTERN, parentPath));
+                assertThat(retrieved.getFocusedAgendaGroup()).isEqualTo(agendaActivationGroup);
+                assertThat(retrieved.getStatusToSet()).isNull();
+                assertThat(retrieved.getResult()).isNull();
+                assertThat(retrieved.getResultCode()).isNull();
             }
         }
     }
@@ -220,7 +218,7 @@ public class KiePMMLCompoundPredicateASTFactoryTest {
                                                                                      fieldTypeMap);
         KiePMMLCompoundPredicateASTFactory.factory(predicateASTFactoryData).declareRuleFromCompoundPredicate(result, false);
         int expectedRules = (predicates.size() * 2) + 1; // For each "surrogate" predicate two rules -"TRUE" and "FALSE" - are generated; one more rule is generated for the Compound predicate itself
-        assertEquals(expectedRules, rules.size());
+        assertThat(rules.size()).isEqualTo(expectedRules);
         String agendaActivationGroup = String.format(SURROGATE_GROUP_PATTERN, currentRule);
         for (KiePMMLDroolsRule retrieved : rules) {
             String ruleName = retrieved.getName();
@@ -239,27 +237,27 @@ public class KiePMMLCompoundPredicateASTFactoryTest {
                     SimplePredicate mappedPredicate = predicates.stream()
                             .filter(pred -> fieldName.get().equals(pred.getField().getValue())).findFirst().orElse(null);
                     assertThat(mappedPredicate).isNotNull();
-                    assertNull(retrieved.getStatusConstraint());
-                    assertEquals(agendaActivationGroup, retrieved.getActivationGroup());
-                    assertEquals(agendaActivationGroup, retrieved.getAgendaGroup());
+                    assertThat(retrieved.getStatusConstraint()).isNull();
+                    assertThat(retrieved.getActivationGroup()).isEqualTo(agendaActivationGroup);
+                    assertThat(retrieved.getAgendaGroup()).isEqualTo(agendaActivationGroup);
                     // Those are not in a final leaf node
                     if (isTrueRule) {
-                        assertEquals(currentRule, retrieved.getStatusToSet());
-                        assertNull(retrieved.getResult());
-                        assertNull(retrieved.getResultCode());
+                        assertThat(retrieved.getStatusToSet()).isEqualTo(currentRule);
+                        assertThat(retrieved.getResult()).isNull();
+                        assertThat(retrieved.getResultCode()).isNull();
                     } else {
-                        assertEquals(parentPath, retrieved.getStatusToSet());
-                        assertNull(retrieved.getResult());
-                        assertNull(retrieved.getResultCode());
+                        assertThat(retrieved.getStatusToSet()).isEqualTo(parentPath);
+                        assertThat(retrieved.getResult()).isNull();
+                        assertThat(retrieved.getResultCode()).isNull();
                     }
                 }
             } else {
                 assertThat(retrieved.getStatusConstraint()).isNotNull();
-                assertEquals(String.format(STATUS_PATTERN, parentPath), retrieved.getStatusConstraint());
-                assertEquals(agendaActivationGroup, retrieved.getFocusedAgendaGroup());
-                assertNull(retrieved.getStatusToSet());
-                assertNull(retrieved.getResult());
-                assertNull(retrieved.getResultCode());
+                assertThat(retrieved.getStatusConstraint()).isEqualTo(String.format(STATUS_PATTERN, parentPath));
+                assertThat(retrieved.getFocusedAgendaGroup()).isEqualTo(agendaActivationGroup);
+                assertThat(retrieved.getStatusToSet()).isNull();
+                assertThat(retrieved.getResult()).isNull();
+                assertThat(retrieved.getResultCode()).isNull();
             }
         }
     }

--- a/kie-pmml-trusty/kie-pmml-models/kie-pmml-models-drools/kie-pmml-models-drools-common/src/test/java/org/kie/pmml/models/drools/ast/factories/KiePMMLCompoundPredicateASTFactoryTest.java
+++ b/kie-pmml-trusty/kie-pmml-models/kie-pmml-models-drools/kie-pmml-models-drools-common/src/test/java/org/kie/pmml/models/drools/ast/factories/KiePMMLCompoundPredicateASTFactoryTest.java
@@ -153,7 +153,7 @@ public class KiePMMLCompoundPredicateASTFactoryTest {
                                                                                      fieldTypeMap);
         KiePMMLCompoundPredicateASTFactory.factory(predicateASTFactoryData).declareRuleFromCompoundPredicate(result, true);
         int expectedRules = (predicates.size() * 2) + 1; // For each "surrogate" predicate two rules -"TRUE" and "FALSE" - are generated; one more rule is generated for the Compound predicate itself
-        assertThat(rules.size()).isEqualTo(expectedRules);
+        assertThat(rules).hasSize(expectedRules);
         String agendaActivationGroup = String.format(SURROGATE_GROUP_PATTERN, currentRule);
         for (KiePMMLDroolsRule retrieved : rules) {
             String ruleName = retrieved.getName();
@@ -218,7 +218,7 @@ public class KiePMMLCompoundPredicateASTFactoryTest {
                                                                                      fieldTypeMap);
         KiePMMLCompoundPredicateASTFactory.factory(predicateASTFactoryData).declareRuleFromCompoundPredicate(result, false);
         int expectedRules = (predicates.size() * 2) + 1; // For each "surrogate" predicate two rules -"TRUE" and "FALSE" - are generated; one more rule is generated for the Compound predicate itself
-        assertThat(rules.size()).isEqualTo(expectedRules);
+        assertThat(rules).hasSize(expectedRules);
         String agendaActivationGroup = String.format(SURROGATE_GROUP_PATTERN, currentRule);
         for (KiePMMLDroolsRule retrieved : rules) {
             String ruleName = retrieved.getName();

--- a/kie-pmml-trusty/kie-pmml-models/kie-pmml-models-drools/kie-pmml-models-drools-common/src/test/java/org/kie/pmml/models/drools/ast/factories/KiePMMLDataDictionaryASTFactoryTest.java
+++ b/kie-pmml-trusty/kie-pmml-models/kie-pmml-models-drools/kie-pmml-models-drools-common/src/test/java/org/kie/pmml/models/drools/ast/factories/KiePMMLDataDictionaryASTFactoryTest.java
@@ -30,8 +30,6 @@ import org.kie.pmml.models.drools.ast.KiePMMLDroolsType;
 import org.kie.pmml.models.drools.tuples.KiePMMLOriginalTypeGeneratedType;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
 import static org.kie.pmml.commons.utils.KiePMMLModelUtils.getSanitizedClassName;
 import static org.kie.pmml.compiler.api.CommonTestingUtils.getFieldsFromDataDictionary;
 import static org.kie.pmml.models.drools.utils.KiePMMLASTTestUtils.getDottedTypeDataField;
@@ -46,7 +44,7 @@ public class KiePMMLDataDictionaryASTFactoryTest {
         final Map<String, KiePMMLOriginalTypeGeneratedType> fieldTypeMap = new HashMap<>();
         List<KiePMMLDroolsType> retrieved = KiePMMLDataDictionaryASTFactory.factory(fieldTypeMap).declareTypes(getFieldsFromDataDictionary(dataDictionary));
         assertThat(retrieved).isNotNull();
-        assertEquals(dataFields.size(), retrieved.size());
+        assertThat(retrieved).hasSameSizeAs(dataFields);
         IntStream.range(0, dataFields.size()).forEach(i -> commonVerifyTypeDeclarationDescr(dataFields.get(i), fieldTypeMap, retrieved.get(i)));
     }
 
@@ -62,11 +60,11 @@ public class KiePMMLDataDictionaryASTFactoryTest {
     private void commonVerifyTypeDeclarationDescr(DataField dataField, Map<String, KiePMMLOriginalTypeGeneratedType> fieldTypeMap, final KiePMMLDroolsType kiePMMLDroolsType) {
         String expectedGeneratedType = getSanitizedClassName(dataField.getName().getValue());
         String expectedMappedOriginalType = DATA_TYPE.byName(dataField.getDataType().value()).getMappedClass().getSimpleName();
-        assertTrue(kiePMMLDroolsType.getName().startsWith(expectedGeneratedType));
-        assertEquals(expectedMappedOriginalType, kiePMMLDroolsType.getType());
-        assertTrue(fieldTypeMap.containsKey(dataField.getName().getValue()));
+        assertThat(kiePMMLDroolsType.getName()).startsWith(expectedGeneratedType);
+        assertThat(kiePMMLDroolsType.getType()).isEqualTo(expectedMappedOriginalType);
+        assertThat(fieldTypeMap).containsKey(dataField.getName().getValue());
         KiePMMLOriginalTypeGeneratedType kiePMMLOriginalTypeGeneratedType = fieldTypeMap.get(dataField.getName().getValue());
-        assertEquals(dataField.getDataType().value(), kiePMMLOriginalTypeGeneratedType.getOriginalType());
-        assertTrue(kiePMMLOriginalTypeGeneratedType.getGeneratedType().startsWith(expectedGeneratedType));
+        assertThat(kiePMMLOriginalTypeGeneratedType.getOriginalType()).isEqualTo(dataField.getDataType().value());
+        assertThat(kiePMMLOriginalTypeGeneratedType.getGeneratedType()).startsWith(expectedGeneratedType);
     }
 }

--- a/kie-pmml-trusty/kie-pmml-models/kie-pmml-models-drools/kie-pmml-models-drools-common/src/test/java/org/kie/pmml/models/drools/ast/factories/KiePMMLDerivedFieldASTFactoryTest.java
+++ b/kie-pmml-trusty/kie-pmml-models/kie-pmml-models-drools/kie-pmml-models-drools-common/src/test/java/org/kie/pmml/models/drools/ast/factories/KiePMMLDerivedFieldASTFactoryTest.java
@@ -33,8 +33,6 @@ import org.kie.pmml.models.drools.ast.KiePMMLDroolsType;
 import org.kie.pmml.models.drools.tuples.KiePMMLOriginalTypeGeneratedType;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
 import static org.kie.pmml.commons.utils.KiePMMLModelUtils.getSanitizedClassName;
 
 public class KiePMMLDerivedFieldASTFactoryTest {
@@ -55,7 +53,7 @@ public class KiePMMLDerivedFieldASTFactoryTest {
                 .mapToObj(value -> getDerivedField("FieldName-" + value))
                 .collect(Collectors.toList());
         List<KiePMMLDroolsType> retrieved = fieldASTFactory.declareTypes(derivedFields);
-        assertEquals(derivedFields.size(), retrieved.size());
+        assertThat(retrieved).hasSameSizeAs(derivedFields);
         for (int i = 0; i < derivedFields.size(); i++)  {
             commonValidateKiePMMLDroolsType(retrieved.get(i), derivedFields.get(i));
         }
@@ -71,13 +69,13 @@ public class KiePMMLDerivedFieldASTFactoryTest {
     private void commonValidateKiePMMLDroolsType(KiePMMLDroolsType toValidate, DerivedField derivedField) {
         String derivedFieldName = derivedField.getName().getValue();
         String expectedName = getSanitizedClassName(derivedFieldName.toUpperCase());
-        assertEquals(expectedName, toValidate.getName());
+        assertThat(toValidate.getName()).isEqualTo(expectedName);
         String expectedType = DATA_TYPE.byName(derivedField.getDataType().value()).getMappedClass().getSimpleName();
-        assertEquals(expectedType, toValidate.getType());
-        assertTrue(fieldTypeMap.containsKey(derivedFieldName));
+        assertThat(toValidate.getType()).isEqualTo(expectedType);
+        assertThat(fieldTypeMap).containsKey(derivedFieldName);
         KiePMMLOriginalTypeGeneratedType retrieved = fieldTypeMap.get(derivedFieldName);
-        assertEquals(derivedField.getDataType().value(), retrieved.getOriginalType());
-        assertEquals(expectedName, retrieved.getGeneratedType());
+        assertThat(retrieved.getOriginalType()).isEqualTo(derivedField.getDataType().value());
+        assertThat(retrieved.getGeneratedType()).isEqualTo(expectedName);
     }
 
     private DerivedField getDerivedField(String fieldName) {

--- a/kie-pmml-trusty/kie-pmml-models/kie-pmml-models-drools/kie-pmml-models-drools-common/src/test/java/org/kie/pmml/models/drools/ast/factories/KiePMMLSimplePredicateASTFactoryTest.java
+++ b/kie-pmml-trusty/kie-pmml-models/kie-pmml-models-drools/kie-pmml-models-drools-common/src/test/java/org/kie/pmml/models/drools/ast/factories/KiePMMLSimplePredicateASTFactoryTest.java
@@ -33,8 +33,6 @@ import org.kie.pmml.models.drools.ast.KiePMMLFieldOperatorValue;
 import org.kie.pmml.models.drools.tuples.KiePMMLOriginalTypeGeneratedType;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNull;
 import static org.kie.pmml.commons.Constants.DONE;
 import static org.kie.pmml.commons.utils.KiePMMLModelUtils.getSanitizedClassName;
 import static org.kie.pmml.models.drools.utils.KiePMMLASTTestUtils.getPredicateASTFactoryData;
@@ -61,7 +59,7 @@ public class KiePMMLSimplePredicateASTFactoryTest {
                                                                                      fieldTypeMap);
         KiePMMLSimplePredicateASTFactory.factory(predicateASTFactoryData)
                 .declareRuleFromSimplePredicateSurrogate(agendaActivationGroup, result, true);
-        assertEquals(2, rules.size());
+        assertThat(rules).hasSize(2);
         // This is the "TRUE" matching rule
         KiePMMLDroolsRule retrieved = rules.get(0);
         assertThat(retrieved).isNotNull();
@@ -69,44 +67,44 @@ public class KiePMMLSimplePredicateASTFactoryTest {
                                                 currentRule,
                                                 fieldTypeMap.get(simplePredicate.getField().getValue()).getGeneratedType());
         String expectedRule = baseExpectedRule + "_TRUE";
-        assertEquals(expectedRule, retrieved.getName());
-        assertEquals(DONE, retrieved.getStatusToSet());
-        assertNull(retrieved.getStatusConstraint());
-        assertEquals(agendaActivationGroup, retrieved.getAgendaGroup());
-        assertEquals(agendaActivationGroup, retrieved.getActivationGroup());
-        assertNull(retrieved.getIfBreakField());
-        assertNull(retrieved.getIfBreakOperator());
-        assertNull(retrieved.getIfBreakValue());
-        assertNull(retrieved.getNotConstraints());
+        assertThat(retrieved.getName()).isEqualTo(expectedRule);
+        assertThat(retrieved.getStatusToSet()).isEqualTo(DONE);
+        assertThat(retrieved.getStatusConstraint()).isNull();
+        assertThat(retrieved.getAgendaGroup()).isEqualTo(agendaActivationGroup);
+        assertThat(retrieved.getActivationGroup()).isEqualTo(agendaActivationGroup);
+        assertThat(retrieved.getIfBreakField()).isNull();
+        assertThat(retrieved.getIfBreakOperator()).isNull();
+        assertThat(retrieved.getIfBreakValue()).isNull();
+        assertThat(retrieved.getNotConstraints()).isNull();
         assertThat(retrieved.getAndConstraints()).isNotNull();
-        assertEquals(1, retrieved.getAndConstraints().size());
+        assertThat(retrieved.getAndConstraints()).hasSize(1);
         KiePMMLFieldOperatorValue kiePMMLFieldOperatorValue = retrieved.getAndConstraints().get(0);
-        assertEquals("OUTLOOK", kiePMMLFieldOperatorValue.getName());
-        assertEquals(BOOLEAN_OPERATOR.SURROGATE, kiePMMLFieldOperatorValue.getOperator());
-        assertEquals("value < \"VALUE\"", kiePMMLFieldOperatorValue.getConstraintsAsString());
-        assertEquals(result, retrieved.getResult());
-        assertEquals(ResultCode.OK, retrieved.getResultCode());
+        assertThat(kiePMMLFieldOperatorValue.getName()).isEqualTo("OUTLOOK");
+        assertThat(kiePMMLFieldOperatorValue.getOperator()).isEqualTo(BOOLEAN_OPERATOR.SURROGATE);
+        assertThat(kiePMMLFieldOperatorValue.getConstraintsAsString()).isEqualTo("value < \"VALUE\"");
+        assertThat(retrieved.getResult()).isEqualTo(result);
+        assertThat(retrieved.getResultCode()).isEqualTo(ResultCode.OK);
         // This is the "FALSE" matching rule
         retrieved = rules.get(1);
         assertThat(retrieved).isNotNull();
         expectedRule = baseExpectedRule + "_FALSE";
-        assertEquals(expectedRule, retrieved.getName());
-        assertEquals(parentPath, retrieved.getStatusToSet());
-        assertNull(retrieved.getStatusConstraint());
-        assertEquals(agendaActivationGroup, retrieved.getAgendaGroup());
-        assertEquals(agendaActivationGroup, retrieved.getActivationGroup());
-        assertNull(retrieved.getIfBreakField());
-        assertNull(retrieved.getIfBreakOperator());
-        assertNull(retrieved.getIfBreakValue());
-        assertNull(retrieved.getAndConstraints());
+        assertThat(retrieved.getName()).isEqualTo(expectedRule);
+        assertThat(retrieved.getStatusToSet()).isEqualTo(parentPath);
+        assertThat(retrieved.getStatusConstraint()).isNull();
+        assertThat(retrieved.getAgendaGroup()).isEqualTo(agendaActivationGroup);
+        assertThat(retrieved.getActivationGroup()).isEqualTo(agendaActivationGroup);
+        assertThat(retrieved.getIfBreakField()).isNull();
+        assertThat(retrieved.getIfBreakOperator()).isNull();
+        assertThat(retrieved.getIfBreakValue()).isNull();
+        assertThat(retrieved.getAndConstraints()).isNull();
         assertThat(retrieved.getNotConstraints()).isNotNull();
-        assertEquals(1, retrieved.getNotConstraints().size());
+        assertThat(retrieved.getNotConstraints()).hasSize(1);
         kiePMMLFieldOperatorValue = retrieved.getNotConstraints().get(0);
-        assertEquals("OUTLOOK", kiePMMLFieldOperatorValue.getName());
-        assertEquals(BOOLEAN_OPERATOR.SURROGATE, kiePMMLFieldOperatorValue.getOperator());
-        assertEquals("value < \"VALUE\"", kiePMMLFieldOperatorValue.getConstraintsAsString());
-        assertNull(retrieved.getResult());
-        assertNull(retrieved.getResultCode());
+        assertThat(kiePMMLFieldOperatorValue.getName()).isEqualTo("OUTLOOK");
+        assertThat(kiePMMLFieldOperatorValue.getOperator()).isEqualTo(BOOLEAN_OPERATOR.SURROGATE);
+        assertThat(kiePMMLFieldOperatorValue.getConstraintsAsString()).isEqualTo("value < \"VALUE\"");
+        assertThat(retrieved.getResult()).isNull();
+        assertThat(retrieved.getResultCode()).isNull();
     }
 
     @Test
@@ -129,7 +127,7 @@ public class KiePMMLSimplePredicateASTFactoryTest {
                                                                                      fieldTypeMap);
         KiePMMLSimplePredicateASTFactory.factory(predicateASTFactoryData)
                 .declareRuleFromSimplePredicateSurrogate(agendaActivationGroup, result, false);
-        assertEquals(2, rules.size());
+        assertThat(rules).hasSize(2);
         // This is the "TRUE" matching rule
         KiePMMLDroolsRule retrieved = rules.get(0);
         assertThat(retrieved).isNotNull();
@@ -137,43 +135,43 @@ public class KiePMMLSimplePredicateASTFactoryTest {
                                                 currentRule,
                                                 fieldTypeMap.get(simplePredicate.getField().getValue()).getGeneratedType());
         String expectedRule = baseExpectedRule + "_TRUE";
-        assertEquals(expectedRule, retrieved.getName());
-        assertEquals(currentRule, retrieved.getStatusToSet());
-        assertNull(retrieved.getStatusConstraint());
-        assertEquals(agendaActivationGroup, retrieved.getAgendaGroup());
-        assertEquals(agendaActivationGroup, retrieved.getActivationGroup());
-        assertNull(retrieved.getIfBreakField());
-        assertNull(retrieved.getIfBreakOperator());
-        assertNull(retrieved.getIfBreakValue());
+        assertThat(retrieved.getName()).isEqualTo(expectedRule);
+        assertThat(retrieved.getStatusToSet()).isEqualTo(currentRule);
+        assertThat(retrieved.getStatusConstraint()).isNull();
+        assertThat(retrieved.getAgendaGroup()).isEqualTo(agendaActivationGroup);
+        assertThat(retrieved.getActivationGroup()).isEqualTo(agendaActivationGroup);
+        assertThat(retrieved.getIfBreakField()).isNull();
+        assertThat(retrieved.getIfBreakOperator()).isNull();
+        assertThat(retrieved.getIfBreakValue()).isNull();
         assertThat(retrieved.getAndConstraints()).isNotNull();
-        assertEquals(1, retrieved.getAndConstraints().size());
+        assertThat(retrieved.getAndConstraints()).hasSize(1);
         KiePMMLFieldOperatorValue kiePMMLFieldOperatorValue = retrieved.getAndConstraints().get(0);
-        assertEquals("OUTLOOK", kiePMMLFieldOperatorValue.getName());
-        assertEquals(BOOLEAN_OPERATOR.SURROGATE, kiePMMLFieldOperatorValue.getOperator());
-        assertEquals("value < \"VALUE\"", kiePMMLFieldOperatorValue.getConstraintsAsString());
-        assertNull(retrieved.getResult());
-        assertNull(retrieved.getResultCode());
+        assertThat(kiePMMLFieldOperatorValue.getName()).isEqualTo("OUTLOOK");
+        assertThat(kiePMMLFieldOperatorValue.getOperator()).isEqualTo(BOOLEAN_OPERATOR.SURROGATE);
+        assertThat(kiePMMLFieldOperatorValue.getConstraintsAsString()).isEqualTo("value < \"VALUE\"");
+        assertThat(retrieved.getResult()).isNull();
+        assertThat(retrieved.getResultCode()).isNull();
         // This is the "FALSE" matching rule
         retrieved = rules.get(1);
         assertThat(retrieved).isNotNull();
         expectedRule = baseExpectedRule + "_FALSE";
-        assertEquals(expectedRule, retrieved.getName());
-        assertEquals(parentPath, retrieved.getStatusToSet());
-        assertNull(retrieved.getStatusConstraint());
-        assertEquals(agendaActivationGroup, retrieved.getAgendaGroup());
-        assertEquals(agendaActivationGroup, retrieved.getActivationGroup());
-        assertNull(retrieved.getIfBreakField());
-        assertNull(retrieved.getIfBreakOperator());
-        assertNull(retrieved.getIfBreakValue());
-        assertNull(retrieved.getAndConstraints());
+        assertThat(retrieved.getName()).isEqualTo(expectedRule);
+        assertThat(retrieved.getStatusToSet()).isEqualTo(parentPath);
+        assertThat(retrieved.getStatusConstraint()).isNull();
+        assertThat(retrieved.getAgendaGroup()).isEqualTo(agendaActivationGroup);
+        assertThat(retrieved.getActivationGroup()).isEqualTo(agendaActivationGroup);
+        assertThat(retrieved.getIfBreakField()).isNull();
+        assertThat(retrieved.getIfBreakOperator()).isNull();
+        assertThat(retrieved.getIfBreakValue()).isNull();
+        assertThat(retrieved.getAndConstraints()).isNull();
         assertThat(retrieved.getNotConstraints()).isNotNull();
-        assertEquals(1, retrieved.getNotConstraints().size());
+        assertThat(retrieved.getNotConstraints()).hasSize(1);
         kiePMMLFieldOperatorValue = retrieved.getNotConstraints().get(0);
-        assertEquals("OUTLOOK", kiePMMLFieldOperatorValue.getName());
-        assertEquals(BOOLEAN_OPERATOR.SURROGATE, kiePMMLFieldOperatorValue.getOperator());
-        assertEquals("value < \"VALUE\"", kiePMMLFieldOperatorValue.getConstraintsAsString());
-        assertNull(retrieved.getResult());
-        assertNull(retrieved.getResultCode());
+        assertThat(kiePMMLFieldOperatorValue.getName()).isEqualTo("OUTLOOK");
+        assertThat(kiePMMLFieldOperatorValue.getOperator()).isEqualTo(BOOLEAN_OPERATOR.SURROGATE);
+        assertThat(kiePMMLFieldOperatorValue.getConstraintsAsString()).isEqualTo("value < \"VALUE\"");
+        assertThat(retrieved.getResult()).isNull();
+        assertThat(retrieved.getResultCode()).isNull();
     }
 
     @Test
@@ -195,22 +193,22 @@ public class KiePMMLSimplePredicateASTFactoryTest {
                                                                                      currentRule,
                                                                                      fieldTypeMap);
         KiePMMLSimplePredicateASTFactory.factory(predicateASTFactoryData).declareRuleFromSimplePredicate(result, true);
-        assertEquals(1, rules.size());
+        assertThat(rules).hasSize(1);
         final KiePMMLDroolsRule retrieved = rules.get(0);
         assertThat(retrieved).isNotNull();
-        assertEquals(currentRule, retrieved.getName());
-        assertEquals(DONE, retrieved.getStatusToSet());
-        assertEquals(String.format(KiePMMLAbstractModelASTFactory.STATUS_PATTERN, parentPath), retrieved.getStatusConstraint());
-        assertEquals(ResultCode.OK, retrieved.getResultCode());
-        assertEquals(result, retrieved.getResult());
+        assertThat(retrieved.getName()).isEqualTo(currentRule);
+        assertThat(retrieved.getStatusToSet()).isEqualTo(DONE);
+        assertThat(retrieved.getStatusConstraint()).isEqualTo(String.format(KiePMMLAbstractModelASTFactory.STATUS_PATTERN, parentPath));
+        assertThat(retrieved.getResultCode()).isEqualTo(ResultCode.OK);
+        assertThat(retrieved.getResult()).isEqualTo(result);
         final List<KiePMMLFieldOperatorValue> andConstraints = retrieved.getAndConstraints();
         assertThat(andConstraints).isNotNull();
-        assertEquals(1, andConstraints.size());
+        assertThat(andConstraints).hasSize(1);
         KiePMMLFieldOperatorValue kiePMMLFieldOperatorValue = retrieved.getAndConstraints().get(0);
-        assertEquals(declaredType, kiePMMLFieldOperatorValue.getName());
-        assertEquals(BOOLEAN_OPERATOR.AND, kiePMMLFieldOperatorValue.getOperator());
+        assertThat(kiePMMLFieldOperatorValue.getName()).isEqualTo(declaredType);
+        assertThat(kiePMMLFieldOperatorValue.getOperator()).isEqualTo(BOOLEAN_OPERATOR.AND);
         String expectedValue = "value < \"" + simplePredicate.getValue() + "\"";
-        assertEquals(expectedValue, kiePMMLFieldOperatorValue.getConstraintsAsString());
+        assertThat(kiePMMLFieldOperatorValue.getConstraintsAsString()).isEqualTo(expectedValue);
     }
 
     @Test
@@ -232,21 +230,21 @@ public class KiePMMLSimplePredicateASTFactoryTest {
                                                                                      currentRule,
                                                                                      fieldTypeMap);
         KiePMMLSimplePredicateASTFactory.factory(predicateASTFactoryData).declareRuleFromSimplePredicate(result, false);
-        assertEquals(1, rules.size());
+        assertThat(rules).hasSize(1);
         final KiePMMLDroolsRule retrieved = rules.get(0);
         assertThat(retrieved).isNotNull();
-        assertEquals(currentRule, retrieved.getName());
-        assertEquals(currentRule, retrieved.getStatusToSet());
-        assertEquals(String.format(KiePMMLAbstractModelASTFactory.STATUS_PATTERN, parentPath), retrieved.getStatusConstraint());
-        assertEquals(currentRule, retrieved.getStatusToSet());
+        assertThat(retrieved.getName()).isEqualTo(currentRule);
+        assertThat(retrieved.getStatusToSet()).isEqualTo(currentRule);
+        assertThat(retrieved.getStatusConstraint()).isEqualTo(String.format(KiePMMLAbstractModelASTFactory.STATUS_PATTERN, parentPath));
+        assertThat(retrieved.getStatusToSet()).isEqualTo(currentRule);
         final List<KiePMMLFieldOperatorValue> andConstraints = retrieved.getAndConstraints();
         assertThat(andConstraints).isNotNull();
-        assertEquals(1, andConstraints.size());
+        assertThat(andConstraints).hasSize(1);
         KiePMMLFieldOperatorValue kiePMMLFieldOperatorValue = retrieved.getAndConstraints().get(0);
-        assertEquals(declaredType, kiePMMLFieldOperatorValue.getName());
-        assertEquals(BOOLEAN_OPERATOR.AND, kiePMMLFieldOperatorValue.getOperator());
+        assertThat(kiePMMLFieldOperatorValue.getName()).isEqualTo(declaredType);
+        assertThat(kiePMMLFieldOperatorValue.getOperator()).isEqualTo(BOOLEAN_OPERATOR.AND);
         String expectedValue = "value < \"" + simplePredicate.getValue() + "\"";
-        assertEquals(expectedValue, kiePMMLFieldOperatorValue.getConstraintsAsString());
+        assertThat(kiePMMLFieldOperatorValue.getConstraintsAsString()).isEqualTo(expectedValue);
     }
 
     private SimplePredicate getSimplePredicate(final String predicateName,

--- a/kie-pmml-trusty/kie-pmml-models/kie-pmml-models-drools/kie-pmml-models-drools-common/src/test/java/org/kie/pmml/models/drools/ast/factories/KiePMMLSimpleSetPredicateASTFactoryTest.java
+++ b/kie-pmml-trusty/kie-pmml-models/kie-pmml-models-drools/kie-pmml-models-drools-common/src/test/java/org/kie/pmml/models/drools/ast/factories/KiePMMLSimpleSetPredicateASTFactoryTest.java
@@ -32,9 +32,6 @@ import org.kie.pmml.models.drools.ast.KiePMMLDroolsRule;
 import org.kie.pmml.models.drools.tuples.KiePMMLOriginalTypeGeneratedType;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertTrue;
 import static org.kie.pmml.commons.Constants.DONE;
 import static org.kie.pmml.commons.utils.KiePMMLModelUtils.getSanitizedClassName;
 import static org.kie.pmml.models.drools.ast.factories.KiePMMLAbstractModelASTFactory.STATUS_PATTERN;
@@ -62,23 +59,23 @@ public class KiePMMLSimpleSetPredicateASTFactoryTest {
                                                                                      currentRule,
                                                                                      fieldTypeMap);
         KiePMMLSimpleSetPredicateASTFactory.factory(predicateASTFactoryData).declareRuleFromSimpleSetPredicate(result, true);
-        assertEquals(1, rules.size());
+        assertThat(rules).hasSize(1);
         final KiePMMLDroolsRule retrieved = rules.get(0);
         assertThat(retrieved).isNotNull();
-        assertEquals(currentRule, retrieved.getName());
-        assertEquals(DONE, retrieved.getStatusToSet());
-        assertEquals(String.format(STATUS_PATTERN, parentPath), retrieved.getStatusConstraint());
-        assertEquals(ResultCode.OK, retrieved.getResultCode());
-        assertEquals(result, retrieved.getResult());
+        assertThat(retrieved.getName()).isEqualTo(currentRule);
+        assertThat(retrieved.getStatusToSet()).isEqualTo(DONE);
+        assertThat(retrieved.getStatusConstraint()).isEqualTo(String.format(STATUS_PATTERN, parentPath));
+        assertThat(retrieved.getResultCode()).isEqualTo(ResultCode.OK);
+        assertThat(retrieved.getResult()).isEqualTo(result);
         assertThat(retrieved.getInConstraints()).isNotNull();
         final Map<String, List<Object>> inConstraints = retrieved.getInConstraints();
-        assertEquals(1, inConstraints.size());
-        assertTrue(inConstraints.containsKey(declaredType));
+        assertThat(inConstraints).hasSize(1);
+        assertThat(inConstraints).containsKey(declaredType);
         final List<Object> retrievedValues = inConstraints.get(declaredType);
         List<String> originalPredicateValues = Arrays.asList(((String) simpleSetPredicate.getArray().getValue()).split(" "));
-        assertEquals(originalPredicateValues.size(), retrievedValues.size());
+        assertThat(retrievedValues).hasSameSizeAs(originalPredicateValues);
         retrievedValues.forEach(retrievedValue -> {
-            assertTrue(originalPredicateValues.contains(retrievedValue));
+            assertThat(originalPredicateValues).contains((String) retrievedValue);
         });
     }
 
@@ -102,23 +99,23 @@ public class KiePMMLSimpleSetPredicateASTFactoryTest {
                                                                                      currentRule,
                                                                                      fieldTypeMap);
         KiePMMLSimpleSetPredicateASTFactory.factory(predicateASTFactoryData).declareRuleFromSimpleSetPredicate(result, false);
-        assertEquals(1, rules.size());
+        assertThat(rules).hasSize(1);
         final KiePMMLDroolsRule retrieved = rules.get(0);
         assertThat(retrieved).isNotNull();
-        assertEquals(currentRule, retrieved.getName());
-        assertEquals(currentRule, retrieved.getStatusToSet());
-        assertEquals(String.format(STATUS_PATTERN, parentPath), retrieved.getStatusConstraint());
-        assertNull(retrieved.getResultCode());
-        assertNull(retrieved.getResult());
+        assertThat(retrieved.getName()).isEqualTo(currentRule);
+        assertThat(retrieved.getStatusToSet()).isEqualTo(currentRule);
+        assertThat(retrieved.getStatusConstraint()).isEqualTo(String.format(STATUS_PATTERN, parentPath));
+        assertThat(retrieved.getResultCode()).isNull();
+        assertThat(retrieved.getResult()).isNull();
         assertThat(retrieved.getInConstraints()).isNotNull();
         final Map<String, List<Object>> inConstraints = retrieved.getInConstraints();
-        assertEquals(1, inConstraints.size());
-        assertTrue(inConstraints.containsKey(declaredType));
+        assertThat(inConstraints).hasSize(1);
+        assertThat(inConstraints).containsKey(declaredType);
         final List<Object> retrievedValues = inConstraints.get(declaredType);
         List<String> originalPredicateValues = Arrays.asList(((String) simpleSetPredicate.getArray().getValue()).split(" "));
-        assertEquals(originalPredicateValues.size(), retrievedValues.size());
+        assertThat(retrievedValues).hasSameSizeAs(originalPredicateValues);
         retrievedValues.forEach(retrievedValue -> {
-            assertTrue(originalPredicateValues.contains(retrievedValue));
+            assertThat(originalPredicateValues).contains((String) retrievedValue);
         });
     }
 
@@ -143,23 +140,23 @@ public class KiePMMLSimpleSetPredicateASTFactoryTest {
                                                                                      currentRule,
                                                                                      fieldTypeMap);
         KiePMMLSimpleSetPredicateASTFactory.factory(predicateASTFactoryData).declareRuleFromSimpleSetPredicate(result, true);
-        assertEquals(1, rules.size());
+        assertThat(rules).hasSize(1);
         final KiePMMLDroolsRule retrieved = rules.get(0);
         assertThat(retrieved).isNotNull();
-        assertEquals(currentRule, retrieved.getName());
-        assertEquals(statusToSet, retrieved.getStatusToSet());
-        assertEquals(String.format(STATUS_PATTERN, parentPath), retrieved.getStatusConstraint());
-        assertEquals(ResultCode.OK, retrieved.getResultCode());
-        assertEquals(result, retrieved.getResult());
+        assertThat(retrieved.getName()).isEqualTo(currentRule);
+        assertThat(retrieved.getStatusToSet()).isEqualTo(statusToSet);
+        assertThat(retrieved.getStatusConstraint()).isEqualTo(String.format(STATUS_PATTERN, parentPath));
+        assertThat(retrieved.getResultCode()).isEqualTo(ResultCode.OK);
+        assertThat(retrieved.getResult()).isEqualTo(result);
         assertThat(retrieved.getNotInConstraints()).isNotNull();
         final Map<String, List<Object>> notInConstraints = retrieved.getNotInConstraints();
-        assertEquals(1, notInConstraints.size());
-        assertTrue(notInConstraints.containsKey(declaredType));
+        assertThat(notInConstraints).hasSize(1);
+        assertThat(notInConstraints).containsKey(declaredType);
         final List<Object> retrievedValues = notInConstraints.get(declaredType);
         List<String> originalPredicateValues = Arrays.asList(((String) simpleSetPredicate.getArray().getValue()).split(" "));
-        assertEquals(originalPredicateValues.size(), retrievedValues.size());
+        assertThat(retrievedValues).hasSameSizeAs(originalPredicateValues);
         retrievedValues.forEach(retrievedValue -> {
-            assertTrue(originalPredicateValues.contains(retrievedValue));
+            assertThat(originalPredicateValues).contains((String) retrievedValue);
         });
     }
 
@@ -183,23 +180,23 @@ public class KiePMMLSimpleSetPredicateASTFactoryTest {
                                                                                      currentRule,
                                                                                      fieldTypeMap);
         KiePMMLSimpleSetPredicateASTFactory.factory(predicateASTFactoryData).declareRuleFromSimpleSetPredicate(result, false);
-        assertEquals(1, rules.size());
+        assertThat(rules).hasSize(1);
         final KiePMMLDroolsRule retrieved = rules.get(0);
         assertThat(retrieved).isNotNull();
-        assertEquals(currentRule, retrieved.getName());
-        assertEquals(currentRule, retrieved.getStatusToSet());
-        assertEquals(String.format(STATUS_PATTERN, parentPath), retrieved.getStatusConstraint());
-        assertNull(retrieved.getResultCode());
-        assertNull(retrieved.getResult());
+        assertThat(retrieved.getName()).isEqualTo(currentRule);
+        assertThat(retrieved.getStatusToSet()).isEqualTo(currentRule);
+        assertThat(retrieved.getStatusConstraint()).isEqualTo(String.format(STATUS_PATTERN, parentPath));
+        assertThat(retrieved.getResultCode()).isNull();
+        assertThat(retrieved.getResult()).isNull();
         assertThat(retrieved.getNotInConstraints()).isNotNull();
         final Map<String, List<Object>> notInConstraints = retrieved.getNotInConstraints();
-        assertEquals(1, notInConstraints.size());
-        assertTrue(notInConstraints.containsKey(declaredType));
+        assertThat(notInConstraints).hasSize(1);
+        assertThat(notInConstraints).containsKey(declaredType);
         final List<Object> retrievedValues = notInConstraints.get(declaredType);
         List<String> originalPredicateValues = Arrays.asList(((String) simpleSetPredicate.getArray().getValue()).split(" "));
-        assertEquals(originalPredicateValues.size(), retrievedValues.size());
+        assertThat(retrievedValues).hasSameSizeAs(originalPredicateValues);
         retrievedValues.forEach(retrievedValue -> {
-            assertTrue(originalPredicateValues.contains(retrievedValue));
+            assertThat(originalPredicateValues).contains((String) retrievedValue);
         });
     }
 

--- a/kie-pmml-trusty/kie-pmml-models/kie-pmml-models-drools/kie-pmml-models-drools-common/src/test/java/org/kie/pmml/models/drools/ast/factories/KiePMMLTruePredicateASTFactoryTest.java
+++ b/kie-pmml-trusty/kie-pmml-models/kie-pmml-models-drools/kie-pmml-models-drools-common/src/test/java/org/kie/pmml/models/drools/ast/factories/KiePMMLTruePredicateASTFactoryTest.java
@@ -26,8 +26,6 @@ import org.kie.pmml.api.enums.ResultCode;
 import org.kie.pmml.models.drools.ast.KiePMMLDroolsRule;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNull;
 import static org.kie.pmml.commons.Constants.DONE;
 import static org.kie.pmml.models.drools.ast.factories.KiePMMLAbstractModelASTFactory.STATUS_PATTERN;
 import static org.kie.pmml.models.drools.utils.KiePMMLASTTestUtils.getPredicateASTFactoryData;
@@ -42,14 +40,14 @@ public class KiePMMLTruePredicateASTFactoryTest {
         True truePredicate = new True();
         PredicateASTFactoryData predicateASTFactoryData = getPredicateASTFactoryData(truePredicate, Collections.emptyList(), rules, parentPath, currentRule, Collections.emptyMap());
         KiePMMLTruePredicateASTFactory.factory(predicateASTFactoryData).declareRuleFromTruePredicateWithResult(DONE, false);
-        assertEquals(1, rules.size());
+        assertThat(rules).hasSize(1);
         final KiePMMLDroolsRule retrieved = rules.get(0);
         assertThat(retrieved).isNotNull();
-        assertEquals(currentRule, retrieved.getName());
-        assertEquals(currentRule, retrieved.getStatusToSet());
-        assertEquals(String.format(STATUS_PATTERN, parentPath), retrieved.getStatusConstraint());
-        assertNull(retrieved.getAndConstraints());
-        assertNull(retrieved.getResultCode());
+        assertThat(retrieved.getName()).isEqualTo(currentRule);
+        assertThat(retrieved.getStatusToSet()).isEqualTo(currentRule);
+        assertThat(retrieved.getStatusConstraint()).isEqualTo(String.format(STATUS_PATTERN, parentPath));
+        assertThat(retrieved.getAndConstraints()).isNull();
+        assertThat(retrieved.getResultCode()).isNull();
     }
 
     @Test
@@ -61,14 +59,14 @@ public class KiePMMLTruePredicateASTFactoryTest {
         True truePredicate = new True();
         PredicateASTFactoryData predicateASTFactoryData = getPredicateASTFactoryData(truePredicate, Collections.emptyList(), rules, parentPath, currentRule, Collections.emptyMap());
         KiePMMLTruePredicateASTFactory.factory(predicateASTFactoryData).declareRuleFromTruePredicateWithResult(statusToSet, true);
-        assertEquals(1, rules.size());
+        assertThat(rules).hasSize(1);
         final KiePMMLDroolsRule retrieved = rules.get(0);
         assertThat(retrieved).isNotNull();
-        assertEquals(currentRule, retrieved.getName());
-        assertEquals(statusToSet, retrieved.getStatusToSet());
-        assertEquals(String.format(STATUS_PATTERN, parentPath), retrieved.getStatusConstraint());
-        assertNull(retrieved.getAndConstraints());
-        assertEquals(DONE, retrieved.getResult());
-        assertEquals(ResultCode.OK, retrieved.getResultCode());
+        assertThat(retrieved.getName()).isEqualTo(currentRule);
+        assertThat(retrieved.getStatusToSet()).isEqualTo(statusToSet);
+        assertThat(retrieved.getStatusConstraint()).isEqualTo(String.format(STATUS_PATTERN, parentPath));
+        assertThat(retrieved.getAndConstraints()).isNull();
+        assertThat(retrieved.getResult()).isEqualTo(DONE);
+        assertThat(retrieved.getResultCode()).isEqualTo(ResultCode.OK);
     }
 }

--- a/kie-pmml-trusty/kie-pmml-models/kie-pmml-models-drools/kie-pmml-models-drools-common/src/test/java/org/kie/pmml/models/drools/commons/factories/KiePMMLDescrFactoryTest.java
+++ b/kie-pmml-trusty/kie-pmml-models/kie-pmml-models-drools/kie-pmml-models-drools-common/src/test/java/org/kie/pmml/models/drools/commons/factories/KiePMMLDescrFactoryTest.java
@@ -38,7 +38,6 @@ import org.kie.pmml.models.drools.executor.KiePMMLStatusHolder;
 import org.kie.pmml.models.drools.tuples.KiePMMLOperatorValue;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.Assert.assertEquals;
 import static org.kie.pmml.commons.Constants.PACKAGE_NAME;
 import static org.kie.pmml.models.drools.commons.factories.KiePMMLDescrFactory.OUTPUTFIELDS_MAP;
 import static org.kie.pmml.models.drools.commons.factories.KiePMMLDescrFactory.OUTPUTFIELDS_MAP_IDENTIFIER;
@@ -65,14 +64,14 @@ public class KiePMMLDescrFactoryTest {
         rules.add(rule);
         KiePMMLDroolsAST drooledAST = new KiePMMLDroolsAST(types, rules);
         PackageDescr packageDescr = KiePMMLDescrFactory.getBaseDescr(drooledAST, PACKAGE_NAME);
-        assertEquals(PACKAGE_NAME, packageDescr.getName());
+        assertThat(packageDescr.getName()).isEqualTo(PACKAGE_NAME);
         checkImports(packageDescr.getImports());
         checkGlobals(packageDescr.getGlobals());
         checkRules(packageDescr.getRules());
     }
 
     private void checkImports(List<ImportDescr> toCheck) {
-        assertEquals(4, toCheck.size());
+        assertThat(toCheck).hasSize(4);
         List<String> expectedImports = Arrays.asList(KiePMMLStatusHolder.class.getName(),
                                                      SimplePredicate.class.getName(),
                                                      PMML4Result.class.getName());
@@ -82,18 +81,18 @@ public class KiePMMLDescrFactoryTest {
     }
 
     private void checkGlobals(List<GlobalDescr> toCheck) {
-        assertEquals(2, toCheck.size());
+        assertThat(toCheck).hasSize(2);
         GlobalDescr retrieved = toCheck.get(0);
-        assertEquals(PMML4_RESULT_IDENTIFIER, retrieved.getIdentifier());
-        assertEquals(PMML4_RESULT, retrieved.getType());
+        assertThat(retrieved.getIdentifier()).isEqualTo(PMML4_RESULT_IDENTIFIER);
+        assertThat(retrieved.getType()).isEqualTo(PMML4_RESULT);
         retrieved = toCheck.get(1);
-        assertEquals(OUTPUTFIELDS_MAP_IDENTIFIER, retrieved.getIdentifier());
-        assertEquals(OUTPUTFIELDS_MAP, retrieved.getType());
+        assertThat(retrieved.getIdentifier()).isEqualTo(OUTPUTFIELDS_MAP_IDENTIFIER);
+        assertThat(retrieved.getType()).isEqualTo(OUTPUTFIELDS_MAP);
     }
 
     private void checkRules(List<RuleDescr> toCheck) {
-        assertEquals(1, toCheck.size());
+        assertThat(toCheck).hasSize(1);
         RuleDescr retrieved = toCheck.get(0);
-        assertEquals(RULE_NAME, retrieved.getName());
+        assertThat(retrieved.getName()).isEqualTo(RULE_NAME);
     }
 }

--- a/kie-pmml-trusty/kie-pmml-models/kie-pmml-models-drools/kie-pmml-models-drools-common/src/test/java/org/kie/pmml/models/drools/commons/factories/KiePMMLDescrLhsFactoryTest.java
+++ b/kie-pmml-trusty/kie-pmml-models/kie-pmml-models-drools/kie-pmml-models-drools-common/src/test/java/org/kie/pmml/models/drools/commons/factories/KiePMMLDescrLhsFactoryTest.java
@@ -43,10 +43,6 @@ import org.kie.pmml.models.drools.executor.KiePMMLStatusHolder;
 import org.kie.pmml.models.drools.tuples.KiePMMLOperatorValue;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertTrue;
 import static org.kie.pmml.commons.Constants.PACKAGE_NAME;
 import static org.kie.pmml.models.drools.commons.factories.KiePMMLDescrLhsFactory.INPUT_FIELD;
 import static org.kie.pmml.models.drools.commons.factories.KiePMMLDescrLhsFactory.INPUT_FIELD_CONDITIONAL;
@@ -73,14 +69,14 @@ public class KiePMMLDescrLhsFactoryTest {
         KiePMMLDescrLhsFactory.factory(lhsBuilder).declareLhs(rule);
         assertThat(lhsBuilder.getDescr()).isNotNull();
         assertThat(lhsBuilder.getDescr().getDescrs()).isNotNull();
-        assertEquals(1, lhsBuilder.getDescr().getDescrs().size());
-        assertTrue(lhsBuilder.getDescr().getDescrs().get(0) instanceof PatternDescr);
+        assertThat(lhsBuilder.getDescr().getDescrs()).hasSize(1);
+        assertThat(lhsBuilder.getDescr().getDescrs().get(0)).isInstanceOf(PatternDescr.class);
         PatternDescr patternDescr = (PatternDescr) lhsBuilder.getDescr().getDescrs().get(0);
-        assertEquals(KiePMMLStatusHolder.class.getSimpleName(), patternDescr.getObjectType());
-        assertEquals(STATUS_HOLDER, patternDescr.getIdentifier());
-        assertTrue(patternDescr.getConstraint() instanceof AndDescr);
+        assertThat(patternDescr.getObjectType()).isEqualTo(KiePMMLStatusHolder.class.getSimpleName());
+        assertThat(patternDescr.getIdentifier()).isEqualTo(STATUS_HOLDER);
+        assertThat(patternDescr.getConstraint()).isInstanceOf(AndDescr.class);
         AndDescr andDescr = (AndDescr) patternDescr.getConstraint();
-        assertTrue(andDescr.getDescrs().isEmpty());
+        assertThat(andDescr.getDescrs()).isEmpty();
     }
 
     @Test
@@ -93,40 +89,40 @@ public class KiePMMLDescrLhsFactoryTest {
                                                                               new KiePMMLFieldOperatorValue(humidityField, BOOLEAN_OPERATOR.OR, Collections.singletonList(new KiePMMLOperatorValue(OPERATOR.GREATER_THAN, 85)), null));
         KiePMMLDescrLhsFactory.factory(lhsBuilder).declareConstraintsAndOr(kiePMMLOperatorValues, lhsBuilder.and());
         assertThat(lhsBuilder.getDescr()).isNotNull();
-        assertEquals(1, lhsBuilder.getDescr().getDescrs().size());
-        assertTrue(lhsBuilder.getDescr().getDescrs().get(0) instanceof AndDescr);
+        assertThat(lhsBuilder.getDescr().getDescrs()).hasSize(1);
+        assertThat(lhsBuilder.getDescr().getDescrs().get(0)).isInstanceOf(AndDescr.class);
         AndDescr baseAndDescr = (AndDescr) lhsBuilder.getDescr().getDescrs().get(0);
         final List<BaseDescr> descrs = baseAndDescr.getDescrs();
         assertThat(descrs).isNotNull();
-        assertEquals(2, descrs.size());
+        assertThat(descrs).hasSize(2);
         // First KiePMMLFieldOperatorValue
-        assertTrue(descrs.get(0) instanceof PatternDescr);
+        assertThat(descrs.get(0)).isInstanceOf(PatternDescr.class);
         PatternDescr patternDescr = (PatternDescr) descrs.get(0);
-        assertEquals(temperatureField, patternDescr.getObjectType());
-        assertNull(patternDescr.getIdentifier());
-        assertTrue(patternDescr.getConstraint() instanceof AndDescr);
+        assertThat(patternDescr.getObjectType()).isEqualTo(temperatureField);
+        assertThat(patternDescr.getIdentifier()).isNull();
+        assertThat(patternDescr.getConstraint()).isInstanceOf(AndDescr.class);
         AndDescr andDescr = (AndDescr) patternDescr.getConstraint();
-        assertEquals(1, andDescr.getDescrs().size());
-        assertTrue(andDescr.getDescrs().get(0) instanceof ExprConstraintDescr);
+        assertThat(andDescr.getDescrs()).hasSize(1);
+        assertThat(andDescr.getDescrs().get(0)).isInstanceOf(ExprConstraintDescr.class);
         ExprConstraintDescr exprConstraintDescr = (ExprConstraintDescr) andDescr.getDescrs().get(0);
-        assertFalse(exprConstraintDescr.isNegated());
-        assertEquals(ExprConstraintDescr.Type.NAMED, exprConstraintDescr.getType());
+        assertThat(exprConstraintDescr.isNegated()).isFalse();
+        assertThat(exprConstraintDescr.getType()).isEqualTo(ExprConstraintDescr.Type.NAMED);
         String expected = "value < 35";
-        assertEquals(expected, exprConstraintDescr.getExpression());
+        assertThat(exprConstraintDescr.getExpression()).isEqualTo(expected);
         // Second KiePMMLFieldOperatorValue
-        assertTrue(descrs.get(1) instanceof PatternDescr);
+        assertThat(descrs.get(1)).isInstanceOf(PatternDescr.class);
         patternDescr = (PatternDescr) descrs.get(1);
-        assertEquals(humidityField, patternDescr.getObjectType());
-        assertNull(patternDescr.getIdentifier());
-        assertTrue(patternDescr.getConstraint() instanceof AndDescr);
+        assertThat(patternDescr.getObjectType()).isEqualTo(humidityField);
+        assertThat(patternDescr.getIdentifier()).isNull();
+        assertThat(patternDescr.getConstraint()).isInstanceOf(AndDescr.class);
         andDescr = (AndDescr) patternDescr.getConstraint();
-        assertEquals(1, andDescr.getDescrs().size());
-        assertTrue(andDescr.getDescrs().get(0) instanceof ExprConstraintDescr);
+        assertThat(andDescr.getDescrs()).hasSize(1);
+        assertThat(andDescr.getDescrs().get(0)).isInstanceOf(ExprConstraintDescr.class);
         exprConstraintDescr = (ExprConstraintDescr) andDescr.getDescrs().get(0);
-        assertFalse(exprConstraintDescr.isNegated());
-        assertEquals(ExprConstraintDescr.Type.NAMED, exprConstraintDescr.getType());
+        assertThat(exprConstraintDescr.isNegated()).isFalse();
+        assertThat(exprConstraintDescr.getType()).isEqualTo(ExprConstraintDescr.Type.NAMED);
         expected = "value > 85";
-        assertEquals(expected, exprConstraintDescr.getExpression());
+        assertThat(exprConstraintDescr.getExpression()).isEqualTo(expected);
     }
 
     @Test
@@ -143,59 +139,59 @@ public class KiePMMLDescrLhsFactoryTest {
                                                                         Collections.singletonList(new KiePMMLOperatorValue(OPERATOR.LESS_THAN, 35)), nestedKiePMMLFieldOperatorValues));
         KiePMMLDescrLhsFactory.factory(lhsBuilder).declareConstraintsAndOr(kiePMMLOperatorValues, lhsBuilder.and());
         assertThat(lhsBuilder.getDescr()).isNotNull();
-        assertEquals(1, lhsBuilder.getDescr().getDescrs().size());
-        assertTrue(lhsBuilder.getDescr().getDescrs().get(0) instanceof AndDescr);
+        assertThat(lhsBuilder.getDescr().getDescrs()).hasSize(1);
+        assertThat(lhsBuilder.getDescr().getDescrs().get(0)).isInstanceOf(AndDescr.class);
         AndDescr baseAndDescr = (AndDescr) lhsBuilder.getDescr().getDescrs().get(0);
         final List<BaseDescr> descrs = baseAndDescr.getDescrs();
         assertThat(descrs).isNotNull();
-        assertEquals(2, descrs.size());
+        assertThat(descrs).hasSize(2);
         // First KiePMMLFieldOperatorValue
-        assertTrue(descrs.get(0) instanceof PatternDescr);
+        assertThat(descrs.get(0)).isInstanceOf(PatternDescr.class);
         PatternDescr patternDescr = (PatternDescr) descrs.get(0);
-        assertEquals(temperatureField, patternDescr.getObjectType());
-        assertNull(patternDescr.getIdentifier());
-        assertTrue(patternDescr.getConstraint() instanceof AndDescr);
+        assertThat(patternDescr.getObjectType()).isEqualTo(temperatureField);
+        assertThat(patternDescr.getIdentifier()).isNull();
+        assertThat(patternDescr.getConstraint()).isInstanceOf(AndDescr.class);
         AndDescr andDescr = (AndDescr) patternDescr.getConstraint();
-        assertEquals(1, andDescr.getDescrs().size());
-        assertTrue(andDescr.getDescrs().get(0) instanceof ExprConstraintDescr);
+        assertThat(andDescr.getDescrs()).hasSize(1);
+        assertThat(andDescr.getDescrs().get(0)).isInstanceOf(ExprConstraintDescr.class);
         ExprConstraintDescr exprConstraintDescr = (ExprConstraintDescr) andDescr.getDescrs().get(0);
-        assertFalse(exprConstraintDescr.isNegated());
-        assertEquals(ExprConstraintDescr.Type.NAMED, exprConstraintDescr.getType());
+        assertThat(exprConstraintDescr.isNegated()).isFalse();
+        assertThat(exprConstraintDescr.getType()).isEqualTo(ExprConstraintDescr.Type.NAMED);
         String expected = "value < 35";
-        assertEquals(expected, exprConstraintDescr.getExpression());
+        assertThat(exprConstraintDescr.getExpression()).isEqualTo(expected);
         // Nested KiePMMLFieldOperatorValues
-        assertTrue(descrs.get(1) instanceof AndDescr);
+        assertThat(descrs.get(1)).isInstanceOf(AndDescr.class);
         AndDescr nestedAndDescr = (AndDescr) descrs.get(1);
-        assertEquals(2, nestedAndDescr.getDescrs().size());
+        assertThat(nestedAndDescr.getDescrs()).hasSize(2);
         final List<BaseDescr> nestedDescrs = nestedAndDescr.getDescrs();
         // First nested KiePMMLFieldOperatorValue
-        assertTrue(nestedDescrs.get(0) instanceof PatternDescr);
+        assertThat(nestedDescrs.get(0)).isInstanceOf(PatternDescr.class);
         patternDescr = (PatternDescr) nestedDescrs.get(0);
-        assertEquals(humidityField, patternDescr.getObjectType());
-        assertNull(patternDescr.getIdentifier());
-        assertTrue(patternDescr.getConstraint() instanceof AndDescr);
+        assertThat(patternDescr.getObjectType()).isEqualTo(humidityField);
+        assertThat(patternDescr.getIdentifier()).isNull();
+        assertThat(patternDescr.getConstraint()).isInstanceOf(AndDescr.class);
         andDescr = (AndDescr) patternDescr.getConstraint();
-        assertEquals(1, andDescr.getDescrs().size());
-        assertTrue(andDescr.getDescrs().get(0) instanceof ExprConstraintDescr);
+        assertThat(andDescr.getDescrs()).hasSize(1);
+        assertThat(andDescr.getDescrs().get(0)).isInstanceOf(ExprConstraintDescr.class);
         exprConstraintDescr = (ExprConstraintDescr) andDescr.getDescrs().get(0);
-        assertFalse(exprConstraintDescr.isNegated());
-        assertEquals(ExprConstraintDescr.Type.NAMED, exprConstraintDescr.getType());
+        assertThat(exprConstraintDescr.isNegated()).isFalse();
+        assertThat(exprConstraintDescr.getType()).isEqualTo(ExprConstraintDescr.Type.NAMED);
         expected = "value < 56";
-        assertEquals(expected, exprConstraintDescr.getExpression());
+        assertThat(exprConstraintDescr.getExpression()).isEqualTo(expected);
         // Second nested KiePMMLFieldOperatorValue
-        assertTrue(nestedDescrs.get(1) instanceof PatternDescr);
+        assertThat(nestedDescrs.get(1)).isInstanceOf(PatternDescr.class);
         patternDescr = (PatternDescr) nestedDescrs.get(1);
-        assertEquals(humidityField, patternDescr.getObjectType());
-        assertNull(patternDescr.getIdentifier());
-        assertTrue(patternDescr.getConstraint() instanceof AndDescr);
+        assertThat(patternDescr.getObjectType()).isEqualTo(humidityField);
+        assertThat(patternDescr.getIdentifier()).isNull();
+        assertThat(patternDescr.getConstraint()).isInstanceOf(AndDescr.class);
         andDescr = (AndDescr) patternDescr.getConstraint();
-        assertEquals(1, andDescr.getDescrs().size());
-        assertTrue(andDescr.getDescrs().get(0) instanceof ExprConstraintDescr);
+        assertThat(andDescr.getDescrs()).hasSize(1);
+        assertThat(andDescr.getDescrs().get(0)).isInstanceOf(ExprConstraintDescr.class);
         exprConstraintDescr = (ExprConstraintDescr) andDescr.getDescrs().get(0);
-        assertFalse(exprConstraintDescr.isNegated());
-        assertEquals(ExprConstraintDescr.Type.NAMED, exprConstraintDescr.getType());
+        assertThat(exprConstraintDescr.isNegated()).isFalse();
+        assertThat(exprConstraintDescr.getType()).isEqualTo(ExprConstraintDescr.Type.NAMED);
         expected = "value > 91";
-        assertEquals(expected, exprConstraintDescr.getExpression());
+        assertThat(exprConstraintDescr.getExpression()).isEqualTo(expected);
     }
 
     @Test
@@ -208,40 +204,40 @@ public class KiePMMLDescrLhsFactoryTest {
                                                                               new KiePMMLFieldOperatorValue(humidityField, BOOLEAN_OPERATOR.OR, Collections.singletonList(new KiePMMLOperatorValue(OPERATOR.GREATER_THAN, 85)), null));
         KiePMMLDescrLhsFactory.factory(lhsBuilder).declareConstraintsAndOr(kiePMMLOperatorValues, lhsBuilder.or());
         assertThat(lhsBuilder.getDescr()).isNotNull();
-        assertEquals(1, lhsBuilder.getDescr().getDescrs().size());
-        assertTrue(lhsBuilder.getDescr().getDescrs().get(0) instanceof OrDescr);
+        assertThat(lhsBuilder.getDescr().getDescrs()).hasSize(1);
+        assertThat(lhsBuilder.getDescr().getDescrs().get(0)).isInstanceOf(OrDescr.class);
         OrDescr baseOrDescr = (OrDescr) lhsBuilder.getDescr().getDescrs().get(0);
         final List<BaseDescr> descrs = baseOrDescr.getDescrs();
         assertThat(descrs).isNotNull();
-        assertEquals(2, descrs.size());
+        assertThat(descrs).hasSize(2);
         // First KiePMMLFieldOperatorValue
-        assertTrue(descrs.get(0) instanceof PatternDescr);
+        assertThat(descrs.get(0)).isInstanceOf(PatternDescr.class);
         PatternDescr patternDescr = (PatternDescr) descrs.get(0);
-        assertEquals(temperatureField, patternDescr.getObjectType());
-        assertNull(patternDescr.getIdentifier());
-        assertTrue(patternDescr.getConstraint() instanceof AndDescr);
+        assertThat(patternDescr.getObjectType()).isEqualTo(temperatureField);
+        assertThat(patternDescr.getIdentifier()).isNull();
+        assertThat(patternDescr.getConstraint()).isInstanceOf(AndDescr.class);
         AndDescr andDescr = (AndDescr) patternDescr.getConstraint();
-        assertEquals(1, andDescr.getDescrs().size());
-        assertTrue(andDescr.getDescrs().get(0) instanceof ExprConstraintDescr);
+        assertThat(andDescr.getDescrs()).hasSize(1);
+        assertThat(andDescr.getDescrs().get(0)).isInstanceOf(ExprConstraintDescr.class);
         ExprConstraintDescr exprConstraintDescr = (ExprConstraintDescr) andDescr.getDescrs().get(0);
-        assertFalse(exprConstraintDescr.isNegated());
-        assertEquals(ExprConstraintDescr.Type.NAMED, exprConstraintDescr.getType());
+        assertThat(exprConstraintDescr.isNegated()).isFalse();
+        assertThat(exprConstraintDescr.getType()).isEqualTo(ExprConstraintDescr.Type.NAMED);
         String expected = "value < 35";
-        assertEquals(expected, exprConstraintDescr.getExpression());
+        assertThat(exprConstraintDescr.getExpression()).isEqualTo(expected);
         // Second KiePMMLFieldOperatorValue
-        assertTrue(descrs.get(1) instanceof PatternDescr);
+        assertThat(descrs.get(1)).isInstanceOf(PatternDescr.class);
         patternDescr = (PatternDescr) descrs.get(1);
-        assertEquals(humidityField, patternDescr.getObjectType());
-        assertNull(patternDescr.getIdentifier());
-        assertTrue(patternDescr.getConstraint() instanceof AndDescr);
+        assertThat(patternDescr.getObjectType()).isEqualTo(humidityField);
+        assertThat(patternDescr.getIdentifier()).isNull();
+        assertThat(patternDescr.getConstraint()).isInstanceOf(AndDescr.class);
         andDescr = (AndDescr) patternDescr.getConstraint();
-        assertEquals(1, andDescr.getDescrs().size());
-        assertTrue(andDescr.getDescrs().get(0) instanceof ExprConstraintDescr);
+        assertThat(andDescr.getDescrs()).hasSize(1);
+        assertThat(andDescr.getDescrs().get(0)).isInstanceOf(ExprConstraintDescr.class);
         exprConstraintDescr = (ExprConstraintDescr) andDescr.getDescrs().get(0);
-        assertFalse(exprConstraintDescr.isNegated());
-        assertEquals(ExprConstraintDescr.Type.NAMED, exprConstraintDescr.getType());
+        assertThat(exprConstraintDescr.isNegated()).isFalse();
+        assertThat(exprConstraintDescr.getType()).isEqualTo(ExprConstraintDescr.Type.NAMED);
         expected = "value > 85";
-        assertEquals(expected, exprConstraintDescr.getExpression());
+        assertThat(exprConstraintDescr.getExpression()).isEqualTo(expected);
     }
 
     @Test(expected = KiePMMLException.class)
@@ -271,78 +267,78 @@ public class KiePMMLDescrLhsFactoryTest {
         KiePMMLDescrLhsFactory.factory(lhsBuilder).declareConstraintsXor(xorConstraints);
         assertThat(lhsBuilder.getDescr()).isNotNull();
         assertThat(lhsBuilder.getDescr().getDescrs()).isNotNull();
-        assertEquals(1, lhsBuilder.getDescr().getDescrs().size());
-        assertTrue(lhsBuilder.getDescr().getDescrs().get(0) instanceof AndDescr);
+        assertThat(lhsBuilder.getDescr().getDescrs()).hasSize(1);
+        assertThat(lhsBuilder.getDescr().getDescrs().get(0)).isInstanceOf(AndDescr.class);
         AndDescr rootAndDescr = (AndDescr) lhsBuilder.getDescr().getDescrs().get(0);
-        assertEquals(2, rootAndDescr.getDescrs().size());
-        assertTrue(rootAndDescr.getDescrs().get(0) instanceof NotDescr);
-        assertTrue(rootAndDescr.getDescrs().get(1) instanceof ExistsDescr);
+        assertThat(rootAndDescr.getDescrs()).hasSize(2);
+        assertThat(rootAndDescr.getDescrs().get(0)).isInstanceOf(NotDescr.class);
+        assertThat(rootAndDescr.getDescrs().get(1)).isInstanceOf(ExistsDescr.class);
         // "Not" construct
         NotDescr notDescr = (NotDescr) rootAndDescr.getDescrs().get(0);
-        assertEquals(1, notDescr.getDescrs().size());
-        assertTrue(notDescr.getDescrs().get(0) instanceof AndDescr);
+        assertThat(notDescr.getDescrs()).hasSize(1);
+        assertThat(notDescr.getDescrs().get(0)).isInstanceOf(AndDescr.class);
         AndDescr notAndDescr = (AndDescr) notDescr.getDescrs().get(0);
-        assertTrue(notAndDescr.getDescrs().get(0) instanceof PatternDescr);
-        assertTrue(notAndDescr.getDescrs().get(1) instanceof PatternDescr);
+        assertThat(notAndDescr.getDescrs().get(0)).isInstanceOf(PatternDescr.class);
+        assertThat(notAndDescr.getDescrs().get(1)).isInstanceOf(PatternDescr.class);
         PatternDescr patternDescr = (PatternDescr) notAndDescr.getDescrs().get(0);
-        assertEquals(temperatureField, patternDescr.getObjectType());
-        assertNull(patternDescr.getIdentifier());
-        assertTrue(patternDescr.getConstraint() instanceof AndDescr);
+        assertThat(patternDescr.getObjectType()).isEqualTo(temperatureField);
+        assertThat(patternDescr.getIdentifier()).isNull();
+        assertThat(patternDescr.getConstraint()).isInstanceOf(AndDescr.class);
         AndDescr andDescr = (AndDescr) patternDescr.getConstraint();
-        assertEquals(1, andDescr.getDescrs().size());
-        assertTrue(andDescr.getDescrs().get(0) instanceof ExprConstraintDescr);
+        assertThat(andDescr.getDescrs()).hasSize(1);
+        assertThat(andDescr.getDescrs().get(0)).isInstanceOf(ExprConstraintDescr.class);
         ExprConstraintDescr exprConstraintDescr = (ExprConstraintDescr) andDescr.getDescrs().get(0);
-        assertFalse(exprConstraintDescr.isNegated());
-        assertEquals(ExprConstraintDescr.Type.NAMED, exprConstraintDescr.getType());
+        assertThat(exprConstraintDescr.isNegated()).isFalse();
+        assertThat(exprConstraintDescr.getType()).isEqualTo(ExprConstraintDescr.Type.NAMED);
         String expected = "value < 35";
-        assertEquals(expected, exprConstraintDescr.getExpression());
+        assertThat(exprConstraintDescr.getExpression()).isEqualTo(expected);
         patternDescr = (PatternDescr) notAndDescr.getDescrs().get(1);
-        assertEquals(temperatureField, patternDescr.getObjectType());
-        assertNull(patternDescr.getIdentifier());
-        assertTrue(patternDescr.getConstraint() instanceof AndDescr);
+        assertThat(patternDescr.getObjectType()).isEqualTo(temperatureField);
+        assertThat(patternDescr.getIdentifier()).isNull();
+        assertThat(patternDescr.getConstraint()).isInstanceOf(AndDescr.class);
         andDescr = (AndDescr) patternDescr.getConstraint();
-        assertEquals(1, andDescr.getDescrs().size());
-        assertTrue(andDescr.getDescrs().get(0) instanceof ExprConstraintDescr);
+        assertThat(andDescr.getDescrs()).hasSize(1);
+        assertThat(andDescr.getDescrs().get(0)).isInstanceOf(ExprConstraintDescr.class);
         exprConstraintDescr = (ExprConstraintDescr) andDescr.getDescrs().get(0);
-        assertFalse(exprConstraintDescr.isNegated());
-        assertEquals(ExprConstraintDescr.Type.NAMED, exprConstraintDescr.getType());
+        assertThat(exprConstraintDescr.isNegated()).isFalse();
+        assertThat(exprConstraintDescr.getType()).isEqualTo(ExprConstraintDescr.Type.NAMED);
         expected = "value > 85";
-        assertEquals(expected, exprConstraintDescr.getExpression());
+        assertThat(exprConstraintDescr.getExpression()).isEqualTo(expected);
         // "Exists" construct
         ExistsDescr existsDescr = (ExistsDescr) rootAndDescr.getDescrs().get(1);
-        assertEquals(1, existsDescr.getDescrs().size());
-        assertTrue(existsDescr.getDescrs().get(0) instanceof OrDescr);
+        assertThat(existsDescr.getDescrs()).hasSize(1);
+        assertThat(existsDescr.getDescrs().get(0)).isInstanceOf(OrDescr.class);
         OrDescr existsOrDescr = (OrDescr) existsDescr.getDescrs().get(0);
-        assertEquals(2, existsOrDescr.getDescrs().size());
-        assertTrue(existsOrDescr.getDescrs().get(0) instanceof PatternDescr);
-        assertTrue(existsOrDescr.getDescrs().get(1) instanceof OrDescr);
+        assertThat(existsOrDescr.getDescrs()).hasSize(2);
+        assertThat(existsOrDescr.getDescrs().get(0)).isInstanceOf(PatternDescr.class);
+        assertThat(existsOrDescr.getDescrs().get(1)).isInstanceOf(OrDescr.class);
         patternDescr = (PatternDescr) existsOrDescr.getDescrs().get(0);
-        assertEquals(temperatureField, patternDescr.getObjectType());
-        assertNull(patternDescr.getIdentifier());
-        assertTrue(patternDescr.getConstraint() instanceof AndDescr);
+        assertThat(patternDescr.getObjectType()).isEqualTo(temperatureField);
+        assertThat(patternDescr.getIdentifier()).isNull();
+        assertThat(patternDescr.getConstraint()).isInstanceOf(AndDescr.class);
         andDescr = (AndDescr) patternDescr.getConstraint();
-        assertEquals(1, andDescr.getDescrs().size());
-        assertTrue(andDescr.getDescrs().get(0) instanceof ExprConstraintDescr);
+        assertThat(andDescr.getDescrs()).hasSize(1);
+        assertThat(andDescr.getDescrs().get(0)).isInstanceOf(ExprConstraintDescr.class);
         exprConstraintDescr = (ExprConstraintDescr) andDescr.getDescrs().get(0);
-        assertFalse(exprConstraintDescr.isNegated());
-        assertEquals(ExprConstraintDescr.Type.NAMED, exprConstraintDescr.getType());
+        assertThat(exprConstraintDescr.isNegated()).isFalse();
+        assertThat(exprConstraintDescr.getType()).isEqualTo(ExprConstraintDescr.Type.NAMED);
         expected = "value < 35";
-        assertEquals(expected, exprConstraintDescr.getExpression());
+        assertThat(exprConstraintDescr.getExpression()).isEqualTo(expected);
         OrDescr nestedOrDescr = (OrDescr) existsOrDescr.getDescrs().get(1);
-        assertEquals(1, nestedOrDescr.getDescrs().size());
-        assertTrue(nestedOrDescr.getDescrs().get(0) instanceof PatternDescr);
+        assertThat(nestedOrDescr.getDescrs()).hasSize(1);
+        assertThat(nestedOrDescr.getDescrs().get(0)).isInstanceOf(PatternDescr.class);
         patternDescr = (PatternDescr) nestedOrDescr.getDescrs().get(0);
-        assertEquals(temperatureField, patternDescr.getObjectType());
-        assertNull(patternDescr.getIdentifier());
-        assertTrue(patternDescr.getConstraint() instanceof AndDescr);
+        assertThat(patternDescr.getObjectType()).isEqualTo(temperatureField);
+        assertThat(patternDescr.getIdentifier()).isNull();
+        assertThat(patternDescr.getConstraint()).isInstanceOf(AndDescr.class);
         andDescr = (AndDescr) patternDescr.getConstraint();
-        assertEquals(1, andDescr.getDescrs().size());
-        assertTrue(andDescr.getDescrs().get(0) instanceof ExprConstraintDescr);
+        assertThat(andDescr.getDescrs()).hasSize(1);
+        assertThat(andDescr.getDescrs().get(0)).isInstanceOf(ExprConstraintDescr.class);
         exprConstraintDescr = (ExprConstraintDescr) andDescr.getDescrs().get(0);
-        assertFalse(exprConstraintDescr.isNegated());
-        assertEquals(ExprConstraintDescr.Type.NAMED, exprConstraintDescr.getType());
+        assertThat(exprConstraintDescr.isNegated()).isFalse();
+        assertThat(exprConstraintDescr.getType()).isEqualTo(ExprConstraintDescr.Type.NAMED);
         expected = "value > 85";
-        assertEquals(expected, exprConstraintDescr.getExpression());
+        assertThat(exprConstraintDescr.getExpression()).isEqualTo(expected);
     }
 
     @Test
@@ -355,19 +351,19 @@ public class KiePMMLDescrLhsFactoryTest {
         assertThat(existsBuilder.getDescr()).isNotNull();
         final List<BaseDescr> descrs = existsBuilder.getDescr().getDescrs();
         assertThat(descrs).isNotNull();
-        assertEquals(1, descrs.size());
-        assertTrue(descrs.get(0) instanceof PatternDescr);
+        assertThat(descrs).hasSize(1);
+        assertThat(descrs.get(0)).isInstanceOf(PatternDescr.class);
         PatternDescr patternDescr = (PatternDescr) descrs.get(0);
-        assertEquals(patternType, patternDescr.getObjectType());
-        assertNull(patternDescr.getIdentifier());
-        assertTrue(patternDescr.getConstraint() instanceof AndDescr);
+        assertThat(patternDescr.getObjectType()).isEqualTo(patternType);
+        assertThat(patternDescr.getIdentifier()).isNull();
+        assertThat(patternDescr.getConstraint()).isInstanceOf(AndDescr.class);
         AndDescr andDescr = (AndDescr) patternDescr.getConstraint();
-        assertEquals(1, andDescr.getDescrs().size());
-        assertTrue(andDescr.getDescrs().get(0) instanceof ExprConstraintDescr);
+        assertThat(andDescr.getDescrs()).hasSize(1);
+        assertThat(andDescr.getDescrs().get(0)).isInstanceOf(ExprConstraintDescr.class);
         ExprConstraintDescr exprConstraintDescr = (ExprConstraintDescr) andDescr.getDescrs().get(0);
-        assertFalse(exprConstraintDescr.isNegated());
-        assertEquals(ExprConstraintDescr.Type.NAMED, exprConstraintDescr.getType());
-        assertEquals(constraintsString, exprConstraintDescr.getExpression());
+        assertThat(exprConstraintDescr.isNegated()).isFalse();
+        assertThat(exprConstraintDescr.getType()).isEqualTo(ExprConstraintDescr.Type.NAMED);
+        assertThat(exprConstraintDescr.getExpression()).isEqualTo(constraintsString);
     }
 
     @Test
@@ -377,20 +373,20 @@ public class KiePMMLDescrLhsFactoryTest {
         KiePMMLDescrLhsFactory.factory(lhsBuilder).declareConstraintIn(patternType, values);
         final List<BaseDescr> descrs = lhsBuilder.getDescr().getDescrs();
         assertThat(descrs).isNotNull();
-        assertEquals(1, descrs.size());
-        assertTrue(descrs.get(0) instanceof PatternDescr);
+        assertThat(descrs).hasSize(1);
+        assertThat(descrs.get(0)).isInstanceOf(PatternDescr.class);
         PatternDescr patternDescr = (PatternDescr) descrs.get(0);
-        assertEquals(patternType, patternDescr.getObjectType());
-        assertNull(patternDescr.getIdentifier());
-        assertTrue(patternDescr.getConstraint() instanceof AndDescr);
+        assertThat(patternDescr.getObjectType()).isEqualTo(patternType);
+        assertThat(patternDescr.getIdentifier()).isNull();
+        assertThat(patternDescr.getConstraint()).isInstanceOf(AndDescr.class);
         AndDescr andDescr = (AndDescr) patternDescr.getConstraint();
-        assertEquals(1, andDescr.getDescrs().size());
-        assertTrue(andDescr.getDescrs().get(0) instanceof ExprConstraintDescr);
+        assertThat(andDescr.getDescrs()).hasSize(1);
+        assertThat(andDescr.getDescrs().get(0)).isInstanceOf(ExprConstraintDescr.class);
         ExprConstraintDescr exprConstraintDescr = (ExprConstraintDescr) andDescr.getDescrs().get(0);
-        assertFalse(exprConstraintDescr.isNegated());
-        assertEquals(ExprConstraintDescr.Type.NAMED, exprConstraintDescr.getType());
+        assertThat(exprConstraintDescr.isNegated()).isFalse();
+        assertThat(exprConstraintDescr.getType()).isEqualTo(ExprConstraintDescr.Type.NAMED);
         String expected = "value in (-5, 0.5, 1, 10)";
-        assertEquals(expected, exprConstraintDescr.getExpression());
+        assertThat(exprConstraintDescr.getExpression()).isEqualTo(expected);
     }
 
     @Test
@@ -400,23 +396,23 @@ public class KiePMMLDescrLhsFactoryTest {
         KiePMMLDescrLhsFactory.factory(lhsBuilder).declareConstraintNotIn(patternType, values);
         final List<BaseDescr> descrs = lhsBuilder.getDescr().getDescrs();
         assertThat(descrs).isNotNull();
-        assertEquals(1, descrs.size());
-        assertTrue(descrs.get(0) instanceof NotDescr);
+        assertThat(descrs).hasSize(1);
+        assertThat(descrs.get(0)).isInstanceOf(NotDescr.class);
         NotDescr notDescr = (NotDescr) descrs.get(0);
-        assertEquals(1, notDescr.getDescrs().size());
-        assertTrue(notDescr.getDescrs().get(0) instanceof PatternDescr);
+        assertThat(notDescr.getDescrs()).hasSize(1);
+        assertThat(notDescr.getDescrs().get(0)).isInstanceOf(PatternDescr.class);
         PatternDescr patternDescr = (PatternDescr) notDescr.getDescrs().get(0);
-        assertEquals(patternType, patternDescr.getObjectType());
-        assertNull(patternDescr.getIdentifier());
-        assertTrue(patternDescr.getConstraint() instanceof AndDescr);
+        assertThat(patternDescr.getObjectType()).isEqualTo(patternType);
+        assertThat(patternDescr.getIdentifier()).isNull();
+        assertThat(patternDescr.getConstraint()).isInstanceOf(AndDescr.class);
         AndDescr andDescr = (AndDescr) patternDescr.getConstraint();
-        assertEquals(1, andDescr.getDescrs().size());
-        assertTrue(andDescr.getDescrs().get(0) instanceof ExprConstraintDescr);
+        assertThat(andDescr.getDescrs()).hasSize(1);
+        assertThat(andDescr.getDescrs().get(0)).isInstanceOf(ExprConstraintDescr.class);
         ExprConstraintDescr exprConstraintDescr = (ExprConstraintDescr) andDescr.getDescrs().get(0);
-        assertFalse(exprConstraintDescr.isNegated());
-        assertEquals(ExprConstraintDescr.Type.NAMED, exprConstraintDescr.getType());
+        assertThat(exprConstraintDescr.isNegated()).isFalse();
+        assertThat(exprConstraintDescr.getType()).isEqualTo(ExprConstraintDescr.Type.NAMED);
         String expected = "value in (3, 8.5)";
-        assertEquals(expected, exprConstraintDescr.getExpression());
+        assertThat(exprConstraintDescr.getExpression()).isEqualTo(expected);
     }
 
     @Test
@@ -428,18 +424,18 @@ public class KiePMMLDescrLhsFactoryTest {
         assertThat(lhsBuilder.getDescr()).isNotNull();
         final List<BaseDescr> descrs = lhsBuilder.getDescr().getDescrs();
         assertThat(descrs).isNotNull();
-        assertEquals(2, descrs.size());
-        assertTrue(descrs.get(0) instanceof PatternDescr);
-        assertTrue(descrs.get(1) instanceof ConditionalBranchDescr);
+        assertThat(descrs).hasSize(2);
+        assertThat(descrs.get(0)).isInstanceOf(PatternDescr.class);
+        assertThat(descrs.get(1)).isInstanceOf(ConditionalBranchDescr.class);
         PatternDescr patternDescr = (PatternDescr) descrs.get(0);
-        assertEquals(ifBreakField, patternDescr.getObjectType());
-        assertEquals(INPUT_FIELD, patternDescr.getIdentifier());
-        assertTrue(patternDescr.getConstraint() instanceof AndDescr);
+        assertThat(patternDescr.getObjectType()).isEqualTo(ifBreakField);
+        assertThat(patternDescr.getIdentifier()).isEqualTo(INPUT_FIELD);
+        assertThat(patternDescr.getConstraint()).isInstanceOf(AndDescr.class);
         ConditionalBranchDescr conditionalBranchDescr = (ConditionalBranchDescr) descrs.get(1);
         String expectedCondition = String.format(INPUT_FIELD_CONDITIONAL, ifBreakOperator, ifBreakValue);
-        assertEquals(expectedCondition, conditionalBranchDescr.getCondition().getContent());
-        assertTrue(conditionalBranchDescr.getConsequence().isBreaking());
-        assertEquals(BREAK_LABEL, conditionalBranchDescr.getConsequence().getText());
+        assertThat(conditionalBranchDescr.getCondition().getContent()).isEqualTo(expectedCondition);
+        assertThat(conditionalBranchDescr.getConsequence().isBreaking()).isTrue();
+        assertThat(conditionalBranchDescr.getConsequence().getText()).isEqualTo(BREAK_LABEL);
     }
 
     @Test
@@ -447,6 +443,6 @@ public class KiePMMLDescrLhsFactoryTest {
         List<Object> values = Arrays.asList("-5", "0.5", "1", "10");
         String retrieved = KiePMMLDescrLhsFactory.factory(lhsBuilder).getInNotInConstraint(values);
         String expected = "value in (-5, 0.5, 1, 10)";
-        assertEquals(expected, retrieved);
+        assertThat(retrieved).isEqualTo(expected);
     }
 }

--- a/kie-pmml-trusty/kie-pmml-models/kie-pmml-models-drools/kie-pmml-models-drools-common/src/test/java/org/kie/pmml/models/drools/commons/factories/KiePMMLDescrRhsFactoryTest.java
+++ b/kie-pmml-trusty/kie-pmml-models/kie-pmml-models-drools/kie-pmml-models-drools-common/src/test/java/org/kie/pmml/models/drools/commons/factories/KiePMMLDescrRhsFactoryTest.java
@@ -32,8 +32,6 @@ import org.kie.pmml.api.enums.ResultCode;
 import org.kie.pmml.models.drools.ast.KiePMMLDroolsRule;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
 import static org.kie.pmml.commons.Constants.DONE;
 import static org.kie.pmml.commons.Constants.PACKAGE_NAME;
 import static org.kie.pmml.models.drools.commons.factories.KiePMMLDescrRhsFactory.ADD_PMML4_OUTPUT_FIELD;
@@ -52,7 +50,7 @@ public class KiePMMLDescrRhsFactoryTest {
     public void setUp() throws Exception {
         PackageDescrBuilder builder = DescrFactory.newPackage().name(PACKAGE_NAME);
         ruleBuilder = builder.newRule().name(CURRENT_RULE);
-        assertEquals(CURRENT_RULE, ruleBuilder.getDescr().getName());
+        assertThat(ruleBuilder.getDescr().getName()).isEqualTo(CURRENT_RULE);
     }
 
     @Test
@@ -63,9 +61,9 @@ public class KiePMMLDescrRhsFactoryTest {
         KiePMMLDescrRhsFactory.factory(ruleBuilder).declareRhs(rule);
         assertThat(ruleBuilder.getDescr().getConsequence()).isNotNull();
         String expectedConsequence = String.format(UPDATE_STATUS_HOLDER_STATUS, statusToSet);
-        assertTrue(ruleBuilder.getDescr().getConsequence().toString().contains(expectedConsequence));
+        assertThat(ruleBuilder.getDescr().getConsequence().toString()).contains(expectedConsequence);
         assertThat(ruleBuilder.getDescr().getNamedConsequences()).isNotNull();
-        assertTrue(ruleBuilder.getDescr().getNamedConsequences().isEmpty());
+        assertThat(ruleBuilder.getDescr().getNamedConsequences()).isEmpty();
     }
 
     @Test
@@ -81,9 +79,9 @@ public class KiePMMLDescrRhsFactoryTest {
         KiePMMLDescrRhsFactory.factory(ruleBuilder).declareRhs(rule);
         assertThat(ruleBuilder.getDescr().getConsequence()).isNotNull();
         String expectedConsequence = String.format(UPDATE_STATUS_HOLDER_STATUS, statusToSet);
-        assertTrue(ruleBuilder.getDescr().getConsequence().toString().contains(expectedConsequence));
+        assertThat(ruleBuilder.getDescr().getConsequence().toString()).contains(expectedConsequence);
         assertThat(ruleBuilder.getDescr().getNamedConsequences()).isNotNull();
-        assertEquals(1, ruleBuilder.getDescr().getNamedConsequences().size());
+        assertThat(ruleBuilder.getDescr().getNamedConsequences()).hasSize(1);
         assertThat(ruleBuilder.getDescr().getNamedConsequences().get(BREAK_LABEL)).isNotNull();
     }
 
@@ -95,9 +93,9 @@ public class KiePMMLDescrRhsFactoryTest {
         KiePMMLDescrRhsFactory.factory(ruleBuilder).declareDefaultThen(rule);
         assertThat(ruleBuilder.getDescr().getConsequence()).isNotNull();
         String expectedConsequence = String.format(UPDATE_STATUS_HOLDER_STATUS, statusToSet);
-        assertTrue(ruleBuilder.getDescr().getConsequence().toString().contains(expectedConsequence));
+        assertThat(ruleBuilder.getDescr().getConsequence().toString()).contains(expectedConsequence);
         assertThat(ruleBuilder.getDescr().getNamedConsequences()).isNotNull();
-        assertTrue(ruleBuilder.getDescr().getNamedConsequences().isEmpty());
+        assertThat(ruleBuilder.getDescr().getNamedConsequences()).isEmpty();
     }
 
     @Test
@@ -113,11 +111,11 @@ public class KiePMMLDescrRhsFactoryTest {
         KiePMMLDescrRhsFactory.factory(ruleBuilder).declareDefaultThen(rule);
         assertThat(ruleBuilder.getDescr().getConsequence()).isNotNull();
         String retrievedConsequence = ruleBuilder.getDescr().getConsequence().toString();
-        assertTrue(retrievedConsequence.contains(String.format(UPDATE_STATUS_HOLDER_STATUS, statusToSet)));
-        assertTrue(retrievedConsequence.contains(String.format(SET_PMML4_RESULT_CODE, resultCode)));
-        assertTrue(retrievedConsequence.contains(String.format(ADD_PMML4_RESULT_VARIABLE, result)));
+        assertThat(retrievedConsequence).contains(String.format(UPDATE_STATUS_HOLDER_STATUS, statusToSet));
+        assertThat(retrievedConsequence).contains(String.format(SET_PMML4_RESULT_CODE, resultCode));
+        assertThat(retrievedConsequence).contains(String.format(ADD_PMML4_RESULT_VARIABLE, result));
         assertThat(ruleBuilder.getDescr().getNamedConsequences()).isNotNull();
-        assertTrue(ruleBuilder.getDescr().getNamedConsequences().isEmpty());
+        assertThat(ruleBuilder.getDescr().getNamedConsequences()).isEmpty();
     }
 
     @Test
@@ -128,13 +126,12 @@ public class KiePMMLDescrRhsFactoryTest {
         KiePMMLDescrRhsFactory.factory(ruleBuilder).declareIfThen(rule);
         assertThat(ruleBuilder.getDescr().getConsequence()).isNotNull();
         String expectedConsequence = String.format(UPDATE_STATUS_HOLDER_STATUS, statusToSet);
-        assertEquals(expectedConsequence, ruleBuilder.getDescr().getConsequence());
+        assertThat(ruleBuilder.getDescr().getConsequence()).isEqualTo(expectedConsequence);
         assertThat(ruleBuilder.getDescr().getNamedConsequences()).isNotNull();
-        assertEquals(1, ruleBuilder.getDescr().getNamedConsequences().size());
+        assertThat(ruleBuilder.getDescr().getNamedConsequences()).hasSize(1);
         assertThat(ruleBuilder.getDescr().getNamedConsequences().get(BREAK_LABEL)).isNotNull();
         expectedConsequence = String.format(UPDATE_STATUS_HOLDER_STATUS, DONE);
-        assertTrue(expectedConsequence,
-                   ruleBuilder.getDescr().getNamedConsequences().get(BREAK_LABEL).toString().contains(expectedConsequence));
+        assertThat(ruleBuilder.getDescr().getNamedConsequences().get(BREAK_LABEL).toString()).as(expectedConsequence).contains(expectedConsequence);
     }
 
     @Test
@@ -150,14 +147,14 @@ public class KiePMMLDescrRhsFactoryTest {
         KiePMMLDescrRhsFactory.factory(ruleBuilder).declareIfThen(rule);
         assertThat(ruleBuilder.getDescr().getConsequence()).isNotNull();
         String expectedConsequence = String.format(UPDATE_STATUS_HOLDER_STATUS, statusToSet);
-        assertEquals(expectedConsequence, ruleBuilder.getDescr().getConsequence());
+        assertThat(ruleBuilder.getDescr().getConsequence()).isEqualTo(expectedConsequence);
         assertThat(ruleBuilder.getDescr().getNamedConsequences()).isNotNull();
-        assertEquals(1, ruleBuilder.getDescr().getNamedConsequences().size());
+        assertThat(ruleBuilder.getDescr().getNamedConsequences()).hasSize(1);
         assertThat(ruleBuilder.getDescr().getNamedConsequences().get(BREAK_LABEL)).isNotNull();
         String retrievedConsequence = ruleBuilder.getDescr().getNamedConsequences().get(BREAK_LABEL).toString();
-        assertTrue(retrievedConsequence.contains(String.format(UPDATE_STATUS_HOLDER_STATUS, DONE)));
-        assertTrue(retrievedConsequence.contains(String.format(SET_PMML4_RESULT_CODE, resultCode)));
-        assertTrue(retrievedConsequence.contains(String.format(ADD_PMML4_RESULT_VARIABLE, result)));
+        assertThat(retrievedConsequence).contains(String.format(UPDATE_STATUS_HOLDER_STATUS, DONE));
+        assertThat(retrievedConsequence).contains(String.format(SET_PMML4_RESULT_CODE, resultCode));
+        assertThat(retrievedConsequence).contains(String.format(ADD_PMML4_RESULT_VARIABLE, result));
     }
 
     @Test
@@ -175,7 +172,7 @@ public class KiePMMLDescrRhsFactoryTest {
         StringJoiner joiner = new StringJoiner("");
         KiePMMLDescrRhsFactory.factory(ruleBuilder).commonDeclareThen(rule, joiner);
         String retrieved = joiner.toString();
-        assertTrue(retrieved.isEmpty());
+        assertThat(retrieved).isEmpty();
         //
         ResultCode resultCode = ResultCode.OK;
         builder = builder.withResultCode(resultCode);
@@ -184,7 +181,7 @@ public class KiePMMLDescrRhsFactoryTest {
         KiePMMLDescrRhsFactory.factory(ruleBuilder).commonDeclareThen(rule, joiner);
         retrieved = joiner.toString();
         String expected = String.format(SET_PMML4_RESULT_CODE, resultCode);
-        assertTrue(retrieved.contains(expected));
+        assertThat(retrieved).contains(expected);
         //
         builder = builder.withResult(result);
         rule = builder.build();
@@ -192,9 +189,9 @@ public class KiePMMLDescrRhsFactoryTest {
         KiePMMLDescrRhsFactory.factory(ruleBuilder).commonDeclareThen(rule, joiner);
         retrieved = joiner.toString();
         expected = String.format(ADD_PMML4_RESULT_VARIABLE, result);
-        assertTrue(retrieved.contains(expected));
+        assertThat(retrieved).contains(expected);
         expected = String.format(ADD_PMML4_OUTPUT_FIELD, outputFieldName, result);
-        assertTrue(retrieved.contains(expected));
+        assertThat(retrieved).contains(expected);
         //
         String focusedAgendaGroup = "FOCUSEDAGENDAGROUP";
         builder = builder.withFocusedAgendaGroup(focusedAgendaGroup);
@@ -203,7 +200,7 @@ public class KiePMMLDescrRhsFactoryTest {
         KiePMMLDescrRhsFactory.factory(ruleBuilder).commonDeclareThen(rule, joiner);
         retrieved = joiner.toString();
         expected = String.format(FOCUS_AGENDA_GROUP, focusedAgendaGroup);
-        assertTrue(retrieved.contains(expected));
+        assertThat(retrieved).contains(expected);
         //
     }
 
@@ -219,6 +216,6 @@ public class KiePMMLDescrRhsFactoryTest {
         KiePMMLDescrRhsFactory.factory(ruleBuilder).commonDeclareOutputFields(outputFields, result, joiner);
         String retrieved = joiner.toString();
         String expected = String.format(ADD_PMML4_OUTPUT_FIELD, outputFieldName, result);
-        assertEquals(expected, retrieved);
+        assertThat(retrieved).isEqualTo(expected);
     }
 }

--- a/kie-pmml-trusty/kie-pmml-models/kie-pmml-models-drools/kie-pmml-models-drools-common/src/test/java/org/kie/pmml/models/drools/commons/factories/KiePMMLDescrRulesFactoryTest.java
+++ b/kie-pmml-trusty/kie-pmml-models/kie-pmml-models-drools/kie-pmml-models-drools-common/src/test/java/org/kie/pmml/models/drools/commons/factories/KiePMMLDescrRulesFactoryTest.java
@@ -34,8 +34,6 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
 
 public class KiePMMLDescrRulesFactoryTest {
 
@@ -47,7 +45,7 @@ public class KiePMMLDescrRulesFactoryTest {
     public void setUp() throws Exception {
         builder = DescrFactory.newPackage().name(PACKAGE_NAME);
         assertThat(builder.getDescr()).isNotNull();
-        assertEquals(PACKAGE_NAME, builder.getDescr().getName());
+        assertThat(builder.getDescr().getName()).isEqualTo(PACKAGE_NAME);
     }
 
     @Test
@@ -66,13 +64,13 @@ public class KiePMMLDescrRulesFactoryTest {
                 .build();
         KiePMMLDescrRulesFactory.factory(builder).declareRule(rule);
         assertThat(builder.getDescr().getRules()).isNotNull();
-        assertEquals(1, builder.getDescr().getRules().size());
+        assertThat(builder.getDescr().getRules()).hasSize(1);
         final RuleDescr retrieved = builder.getDescr().getRules().get(0);
-        assertEquals(name, retrieved.getName());
-        assertEquals(2, retrieved.getAttributes().size());
-        assertTrue(retrieved.getAttributes().containsKey("agenda-group"));
-        assertEquals(agendaGroup, retrieved.getAttributes().get("agenda-group").getValue());
-        assertTrue(retrieved.getAttributes().containsKey("activation-group"));
-        assertEquals(activationGroup, retrieved.getAttributes().get("activation-group").getValue());
+        assertThat(retrieved.getName()).isEqualTo(name);
+        assertThat(retrieved.getAttributes()).hasSize(2);
+        assertThat(retrieved.getAttributes()).containsKey("agenda-group");
+        assertThat(retrieved.getAttributes().get("agenda-group").getValue()).isEqualTo(agendaGroup);
+        assertThat(retrieved.getAttributes()).containsKey("activation-group");
+        assertThat(retrieved.getAttributes().get("activation-group").getValue()).isEqualTo(activationGroup);
     }
 }

--- a/kie-pmml-trusty/kie-pmml-models/kie-pmml-models-drools/kie-pmml-models-drools-common/src/test/java/org/kie/pmml/models/drools/commons/factories/KiePMMLDescrTypesFactoryTest.java
+++ b/kie-pmml-trusty/kie-pmml-models/kie-pmml-models-drools/kie-pmml-models-drools-common/src/test/java/org/kie/pmml/models/drools/commons/factories/KiePMMLDescrTypesFactoryTest.java
@@ -28,8 +28,7 @@ import org.junit.Before;
 import org.junit.Test;
 import org.kie.pmml.models.drools.ast.KiePMMLDroolsType;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.kie.pmml.commons.Constants.PACKAGE_NAME;
 
 public class KiePMMLDescrTypesFactoryTest {
@@ -46,9 +45,9 @@ public class KiePMMLDescrTypesFactoryTest {
         List<KiePMMLDroolsType> types = new ArrayList<>();
         types.add(KiePMMLDescrTestUtils.getDroolsType());
         types.add(KiePMMLDescrTestUtils.getDottedDroolsType());
-        assertTrue(builder.getDescr().getTypeDeclarations().isEmpty());
+        assertThat(builder.getDescr().getTypeDeclarations()).isEmpty();
         KiePMMLDescrTypesFactory.factory(builder).declareTypes(types);
-        assertEquals(2, builder.getDescr().getTypeDeclarations().size());
+        assertThat(builder.getDescr().getTypeDeclarations()).hasSize(2);
         IntStream.range(0, types.size())
                 .forEach(i -> commonVerifyTypeDeclarationDescr(Objects.requireNonNull(types.get(i)), builder.getDescr().getTypeDeclarations().get(i)));
     }
@@ -57,16 +56,16 @@ public class KiePMMLDescrTypesFactoryTest {
     public void declareType() {
         KiePMMLDroolsType type = KiePMMLDescrTestUtils.getDroolsType();
         KiePMMLDescrTypesFactory.factory(builder).declareType(type);
-        assertEquals(1, builder.getDescr().getTypeDeclarations().size());
+        assertThat(builder.getDescr().getTypeDeclarations()).hasSize(1);
         commonVerifyTypeDeclarationDescr(type, builder.getDescr().getTypeDeclarations().get(0));
     }
 
     private void commonVerifyTypeDeclarationDescr(KiePMMLDroolsType type, final TypeDeclarationDescr typeDeclarationDescr) {
         String expectedGeneratedType = type.getName();
         String expectedMappedOriginalType = type.getType();
-        assertEquals(expectedGeneratedType, typeDeclarationDescr.getTypeName());
-        assertEquals(1, typeDeclarationDescr.getFields().size());
-        assertTrue(typeDeclarationDescr.getFields().containsKey("value"));
-        assertEquals(expectedMappedOriginalType, typeDeclarationDescr.getFields().get("value").getPattern().getObjectType());
+        assertThat(typeDeclarationDescr.getTypeName()).isEqualTo(expectedGeneratedType);
+        assertThat(typeDeclarationDescr.getFields()).hasSize(1);
+        assertThat(typeDeclarationDescr.getFields()).containsKey("value");
+        assertThat(typeDeclarationDescr.getFields().get("value").getPattern().getObjectType()).isEqualTo(expectedMappedOriginalType);
     }
 }

--- a/kie-pmml-trusty/kie-pmml-models/kie-pmml-models-drools/kie-pmml-models-drools-common/src/test/java/org/kie/pmml/models/drools/commons/model/KiePMMLDroolsModelTest.java
+++ b/kie-pmml-trusty/kie-pmml-models/kie-pmml-models-drools/kie-pmml-models-drools-common/src/test/java/org/kie/pmml/models/drools/commons/model/KiePMMLDroolsModelTest.java
@@ -25,7 +25,7 @@ import org.junit.Test;
 import org.kie.pmml.api.exceptions.KiePMMLException;
 import org.kie.pmml.commons.model.KiePMMLExtension;
 
-import static org.junit.Assert.assertEquals;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.kie.pmml.commons.utils.KiePMMLModelUtils.getSanitizedPackageName;
 
 public class KiePMMLDroolsModelTest {
@@ -42,9 +42,9 @@ public class KiePMMLDroolsModelTest {
 
     @Test
     public void constructor() {
-        assertEquals(MODEL_NAME, kiePMMLDroolsModel.getName());
-        assertEquals(EXTENSIONS, kiePMMLDroolsModel.getExtensions());
-        assertEquals(getSanitizedPackageName(MODEL_NAME), kiePMMLDroolsModel.getKModulePackageName());
+        assertThat(kiePMMLDroolsModel.getName()).isEqualTo(MODEL_NAME);
+        assertThat(kiePMMLDroolsModel.getExtensions()).isEqualTo(EXTENSIONS);
+        assertThat(kiePMMLDroolsModel.getKModulePackageName()).isEqualTo(getSanitizedPackageName(MODEL_NAME));
     }
 
     @Test(expected = KiePMMLException.class)

--- a/kie-pmml-trusty/kie-pmml-models/kie-pmml-models-drools/kie-pmml-models-drools-common/src/test/java/org/kie/pmml/models/drools/provider/DroolsModelProviderTest.java
+++ b/kie-pmml-trusty/kie-pmml-models/kie-pmml-models-drools/kie-pmml-models-drools-common/src/test/java/org/kie/pmml/models/drools/provider/DroolsModelProviderTest.java
@@ -51,8 +51,6 @@ import org.kie.pmml.models.drools.dto.DroolsCompilationDTO;
 import org.kie.pmml.models.drools.tuples.KiePMMLOriginalTypeGeneratedType;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
 import static org.kie.pmml.commons.Constants.PACKAGE_NAME;
 import static org.kie.pmml.commons.utils.KiePMMLModelUtils.getSanitizedClassName;
 import static org.kie.pmml.commons.utils.KiePMMLModelUtils.getSanitizedPackageName;
@@ -115,25 +113,25 @@ public class DroolsModelProviderTest {
                                                                        new HasKnowledgeBuilderMock(knowledgeBuilder));
         KiePMMLDroolsModel retrieved = droolsModelProvider.getKiePMMLModel(compilationDTO);
         assertThat(retrieved).isNotNull();
-        assertTrue(retrieved instanceof KiePMMLDroolsModelTest);
+        assertThat(retrieved).isInstanceOf(KiePMMLDroolsModelTest.class);
         KiePMMLDroolsModelTest retrievedTest = (KiePMMLDroolsModelTest) retrieved;
         final List<DataField> originalDataFields = pmml.getDataDictionary().getDataFields();
         final List<DataField> retrievedDataFields = retrievedTest.dataDictionary.getDataFields();
-        assertEquals(originalDataFields.size(), retrievedTest.dataDictionary.getDataFields().size());
+        assertThat(retrievedTest.dataDictionary.getDataFields()).hasSameSizeAs(originalDataFields);
         originalDataFields.forEach(dataField -> {
             Optional<DataField> optRet = retrievedDataFields.stream()
                     .filter(retrievedDataField -> dataField.getName().equals(retrievedDataField.getName()))
                     .findFirst();
-            assertTrue(optRet.isPresent());
-            assertEquals(dataField.getDataType(), optRet.get().getDataType());
+            assertThat(optRet).isPresent();
+            assertThat(optRet.get().getDataType()).isEqualTo(dataField.getDataType());
         });
-        assertEquals(pmml.getTransformationDictionary(), retrievedTest.transformationDictionary);
-        assertEquals(scorecard, retrievedTest.model);
+        assertThat(retrievedTest.transformationDictionary).isEqualTo(pmml.getTransformationDictionary());
+        assertThat(retrievedTest.model).isEqualTo(scorecard);
         String expectedPackageName = getSanitizedPackageName(PACKAGE_NAME);
-        assertEquals(expectedPackageName, retrievedTest.getKModulePackageName());
-        assertEquals(PACKAGE_NAME, retrievedTest.getName());
+        assertThat(retrievedTest.getKModulePackageName()).isEqualTo(expectedPackageName);
+        assertThat(retrievedTest.getName()).isEqualTo(PACKAGE_NAME);
         PackageDescr packageDescr = knowledgeBuilder.getPackageDescrs("packagename").get(0);
-        assertTrue(packageDescr instanceof CompositePackageDescr);
+        assertThat(packageDescr).isInstanceOf(CompositePackageDescr.class);
     }
 
     @Test(expected = KiePMMLException.class)
@@ -156,10 +154,10 @@ public class DroolsModelProviderTest {
                                                                        new HasKnowledgeBuilderMock(knowledgeBuilder));
         KiePMMLDroolsModelWithSources retrieved = droolsModelProvider.getKiePMMLModelWithSources(compilationDTO);
         assertThat(retrieved).isNotNull();
-        assertEquals(SOURCE_MAP, retrieved.getSourcesMap());
+        assertThat(retrieved.getSourcesMap()).isEqualTo(SOURCE_MAP);
         String expectedPackageName = compilationDTO.getPackageName();
-        assertEquals(expectedPackageName, retrieved.getKModulePackageName());
-        assertEquals(scorecard.getModelName(), retrieved.getName());
+        assertThat(retrieved.getKModulePackageName()).isEqualTo(expectedPackageName);
+        assertThat(retrieved.getName()).isEqualTo(scorecard.getModelName());
         PackageDescr packageDescr = knowledgeBuilder.getPackageDescrs(expectedPackageName).get(0);
         commonVerifyPackageDescr(packageDescr, expectedPackageName);
         assertThat(retrieved).isNotNull();
@@ -233,50 +231,50 @@ public class DroolsModelProviderTest {
         final String rootPath = expectedPackageName.replace('.', '/') + "/";
         packageDescr.getTypeDeclarations().forEach(typeDeclarationDescr -> {
             String expectedPath = rootPath + typeDeclarationDescr.getTypeName() + ".java";
-            assertTrue(retrieved.stream().anyMatch(generatedFile -> generatedFile.getPath().equals(expectedPath)));
+            assertThat(retrieved.stream().anyMatch(generatedFile -> generatedFile.getPath().equals(expectedPath))).isTrue();
         });
         String pkgUUID = packageDescr.getPreferredPkgUUID().get();
         String expectedRule = rootPath + "Rules" + pkgUUID + ".java";
-        assertTrue(retrieved.stream().anyMatch(generatedFile -> generatedFile.getPath().equals(expectedRule)));
+        assertThat(retrieved.stream().anyMatch(generatedFile -> generatedFile.getPath().equals(expectedRule))).isTrue();
         String expectedDomain = rootPath + "DomainClassesMetadata" + pkgUUID + ".java";
-        assertTrue(retrieved.stream().anyMatch(generatedFile -> generatedFile.getPath().equals(expectedDomain)));
+        assertThat(retrieved.stream().anyMatch(generatedFile -> generatedFile.getPath().equals(expectedDomain))).isTrue();
     }
 
     private void commonVerifyRulesSourcesMap(Map<String, String> toVerify, PackageDescr packageDescr, String rootPath) {
         packageDescr.getTypeDeclarations().forEach(typeDeclarationDescr -> {
             String expectedPath = rootPath + typeDeclarationDescr.getTypeName();
-            assertTrue(toVerify.keySet().stream().anyMatch(className -> className.equals(expectedPath)));
+            assertThat(toVerify.keySet().stream().anyMatch(className -> className.equals(expectedPath))).isTrue();
         });
         String pkgUUID = packageDescr.getPreferredPkgUUID().get();
         String expectedRule = rootPath + "Rules" + pkgUUID;
-        assertTrue(toVerify.keySet().stream().anyMatch(className -> className.equals(expectedRule)));
+        assertThat(toVerify.keySet().stream().anyMatch(className -> className.equals(expectedRule))).isTrue();
         String expectedDomain = rootPath + "DomainClassesMetadata" + pkgUUID;
-        assertTrue(toVerify.keySet().stream().anyMatch(className -> className.equals(expectedDomain)));
+        assertThat(toVerify.keySet().stream().anyMatch(className -> className.equals(expectedDomain))).isTrue();
     }
 
     private void commonVerifyPackageDescr(PackageDescr toVerify, String expectedPackageName) {
-        assertEquals(expectedPackageName, toVerify.getName());
+        assertThat(toVerify.getName()).isEqualTo(expectedPackageName);
     }
 
     private void commonVerifyKiePMMLDroolsAST(final KiePMMLDroolsAST toVerify, final Map<String,
             KiePMMLOriginalTypeGeneratedType> fieldTypeMap) {
         assertThat(toVerify).isNotNull();
-        assertTrue(toVerify instanceof KiePMMLDroolsASTTest);
+        assertThat(toVerify).isInstanceOf(KiePMMLDroolsASTTest.class);
         KiePMMLDroolsASTTest toVerifyTest = (KiePMMLDroolsASTTest) toVerify;
 
         final List<DataField> originalDataFields = pmml.getDataDictionary().getDataFields();
         final List<DataField> retrievedDataFields = toVerifyTest.dataDictionary.getDataFields();
-        assertEquals(originalDataFields.size(), toVerifyTest.dataDictionary.getDataFields().size());
+        assertThat(toVerifyTest.dataDictionary.getDataFields()).hasSameSizeAs(originalDataFields);
         originalDataFields.forEach(dataField -> {
             Optional<DataField> optRet = retrievedDataFields.stream()
                     .filter(retrievedDataField -> dataField.getName().equals(retrievedDataField.getName()))
                     .findFirst();
-            assertTrue(optRet.isPresent());
-            assertEquals(dataField.getDataType(), optRet.get().getDataType());
+            assertThat(optRet).isPresent();
+            assertThat(optRet.get().getDataType()).isEqualTo(dataField.getDataType());
         });
-        assertEquals(scorecard, toVerifyTest.model);
+        assertThat(toVerifyTest.model).isEqualTo(scorecard);
         if (fieldTypeMap != null) {
-            assertEquals(fieldTypeMap, toVerifyTest.fieldTypeMap);
+            assertThat(toVerifyTest.fieldTypeMap).isEqualTo(fieldTypeMap);
         }
         commonVerifyTypesList(toVerify.getTypes(),
                               pmml.getDataDictionary().getDataFields(),
@@ -288,14 +286,14 @@ public class DroolsModelProviderTest {
                                        List<DerivedField> transformationsFields,
                                        List<DerivedField> localTransformationsFields) {
         int expectedEntries = dataFields.size() + transformationsFields.size() + localTransformationsFields.size();
-        assertEquals(expectedEntries, toVerify.size());
+        assertThat(toVerify).hasSize(expectedEntries);
         dataFields.forEach(dataField -> commonVerifyTypesList(dataField, toVerify));
         transformationsFields.forEach(derivedField -> commonVerifyTypesList(derivedField, toVerify));
         localTransformationsFields.forEach(derivedField -> commonVerifyTypesList(derivedField, toVerify));
     }
 
     private void commonVerifyTypesList(Field<?> toVerify, final List<KiePMMLDroolsType> types) {
-        assertTrue(types.stream()
+        assertThat(types.stream()
                            .anyMatch(type -> {
                                String expectedName = getSanitizedClassName(toVerify.getName().getValue());
                                if (!type.getName().startsWith(expectedName)) {
@@ -303,16 +301,16 @@ public class DroolsModelProviderTest {
                                }
                                String expectedType =
                                        DATA_TYPE.byName(toVerify.getDataType().value()).getMappedClass().getSimpleName();
-                               assertEquals(expectedType, type.getType());
+                               assertThat(type.getType()).isEqualTo(expectedType);
                                return true;
-                           }));
+                           })).isTrue();
     }
 
     private void commonVerifyFieldTypeMap(final Map<String, KiePMMLOriginalTypeGeneratedType> toVerify,
                                           List<DataField> dataFields, List<DerivedField> transformationsFields,
                                           List<DerivedField> localTransformationsFields) {
         int expectedEntries = dataFields.size() + transformationsFields.size() + localTransformationsFields.size();
-        assertEquals(expectedEntries, toVerify.size());
+        assertThat(toVerify).hasSize(expectedEntries);
         dataFields.forEach(dataField -> commonVerifyFieldTypeMap(dataField, toVerify));
         transformationsFields.forEach(derivedField -> commonVerifyFieldTypeMap(derivedField, toVerify));
         localTransformationsFields.forEach(derivedField -> commonVerifyFieldTypeMap(derivedField, toVerify));
@@ -320,18 +318,18 @@ public class DroolsModelProviderTest {
 
     private void commonVerifyFieldTypeMap(Field<?> toVerify,
                                           final Map<String, KiePMMLOriginalTypeGeneratedType> fieldTypeMap) {
-        assertTrue(fieldTypeMap.entrySet().stream()
+        assertThat(fieldTypeMap.entrySet().stream()
                            .anyMatch(entry -> {
                                if (!entry.getKey().equals(toVerify.getName().getValue())) {
                                    return false;
                                }
                                KiePMMLOriginalTypeGeneratedType value = entry.getValue();
-                               assertEquals(toVerify.getDataType().value(), value.getOriginalType());
+                               assertThat(value.getOriginalType()).isEqualTo(toVerify.getDataType().value());
                                String expectedGeneratedType =
                                        getSanitizedClassName(toVerify.getName().getValue());
-                               assertTrue(value.getGeneratedType().startsWith(expectedGeneratedType));
+                               assertThat(value.getGeneratedType()).startsWith(expectedGeneratedType);
                                return true;
-                           }));
+                           })).isTrue();
     }
 
     //  Needed to avoid Mockito usage

--- a/kie-pmml-trusty/kie-pmml-models/kie-pmml-models-drools/kie-pmml-models-drools-common/src/test/java/org/kie/pmml/models/drools/tuples/KiePMMLOperatorValueTest.java
+++ b/kie-pmml-trusty/kie-pmml-models/kie-pmml-models-drools/kie-pmml-models-drools-common/src/test/java/org/kie/pmml/models/drools/tuples/KiePMMLOperatorValueTest.java
@@ -19,7 +19,7 @@ package org.kie.pmml.models.drools.tuples;
 import org.junit.Test;
 import org.kie.pmml.api.enums.OPERATOR;
 
-import static org.junit.Assert.assertEquals;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.kie.pmml.models.drools.tuples.KiePMMLOperatorValue.VALUE_CONSTRAINT_PATTERN;
 
 public class KiePMMLOperatorValueTest {
@@ -31,7 +31,7 @@ public class KiePMMLOperatorValueTest {
         KiePMMLOperatorValue kiePMMLOperatorValue = new KiePMMLOperatorValue(operator, value);
         String retrieved = kiePMMLOperatorValue.getConstraintsAsString();
         String expected = String.format(VALUE_CONSTRAINT_PATTERN, operator.getOperator(), value);
-        assertEquals(expected, retrieved);
+        assertThat(retrieved).isEqualTo(expected);
     }
 
     @Test
@@ -41,6 +41,6 @@ public class KiePMMLOperatorValueTest {
         KiePMMLOperatorValue kiePMMLOperatorValue = new KiePMMLOperatorValue(operator, value);
         String retrieved = kiePMMLOperatorValue.buildConstraintsString();
         String expected = String.format(VALUE_CONSTRAINT_PATTERN, operator.getOperator(), value);
-        assertEquals(expected, retrieved);
+        assertThat(retrieved).isEqualTo(expected);
     }
 }

--- a/kie-pmml-trusty/kie-pmml-models/kie-pmml-models-drools/kie-pmml-models-drools-common/src/test/java/org/kie/pmml/models/drools/utils/KiePMMLASTFactoryUtilsTest.java
+++ b/kie-pmml-trusty/kie-pmml-models/kie-pmml-models-drools/kie-pmml-models-drools-common/src/test/java/org/kie/pmml/models/drools/utils/KiePMMLASTFactoryUtilsTest.java
@@ -40,9 +40,6 @@ import org.kie.pmml.models.drools.tuples.KiePMMLOriginalTypeGeneratedType;
 
 import static java.util.stream.Collectors.groupingBy;
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
 import static org.kie.pmml.commons.utils.KiePMMLModelUtils.getSanitizedClassName;
 import static org.kie.pmml.compiler.api.testutils.PMMLModelTestUtils.getRandomObject;
 import static org.kie.pmml.compiler.api.testutils.PMMLModelTestUtils.getRandomSimplePredicateOperator;
@@ -89,7 +86,7 @@ public class KiePMMLASTFactoryUtilsTest {
         List<KiePMMLFieldOperatorValue> retrieved = KiePMMLASTFactoryUtils
                 .getConstraintEntriesFromXOrCompoundPredicate(compoundPredicate, fieldTypeMap);
         assertThat(retrieved).isNotNull();
-        assertEquals(predicates.size(), retrieved.size());
+        assertThat(retrieved).hasSameSizeAs(predicates);
         commonVerifyKiePMMLFieldOperatorValueList(retrieved, null);
     }
 
@@ -123,10 +120,10 @@ public class KiePMMLASTFactoryUtilsTest {
                 .collect(Collectors.toList());
         final KiePMMLFieldOperatorValue retrieved = KiePMMLASTFactoryUtils
                 .getConstraintEntryFromSimplePredicates(fieldName, BOOLEAN_OPERATOR.OR, simplePredicates, fieldTypeMap);
-        assertEquals(fieldName, retrieved.getName());
+        assertThat(retrieved.getName()).isEqualTo(fieldName);
         assertThat(retrieved.getConstraintsAsString()).isNotNull();
         String expected = "value < \"VALUE-0\" || value < \"VALUE-1\"";
-        assertEquals(expected, retrieved.getConstraintsAsString());
+        assertThat(retrieved.getConstraintsAsString()).isEqualTo(expected);
     }
 
     @Test
@@ -135,7 +132,7 @@ public class KiePMMLASTFactoryUtilsTest {
         List<KiePMMLFieldOperatorValue> retrieved = KiePMMLASTFactoryUtils
                 .getXORConstraintEntryFromSimplePredicates(predicates, fieldTypeMap);
         assertThat(retrieved).isNotNull();
-        assertEquals(simplePredicates.size(), retrieved.size());
+        assertThat(retrieved).hasSameSizeAs(simplePredicates);
         commonVerifyKiePMMLFieldOperatorValueList(retrieved, null);
     }
 
@@ -147,7 +144,7 @@ public class KiePMMLASTFactoryUtilsTest {
             if (expected instanceof String) {
                 expected = String.format("\"%s\"", expected);
             }
-            assertEquals(expected, retrieved);
+            assertThat(retrieved).isEqualTo(expected);
         });
     }
 
@@ -169,8 +166,8 @@ public class KiePMMLASTFactoryUtilsTest {
         KiePMMLASTFactoryUtils.populateKiePMMLFieldOperatorValueListWithCompoundPredicates(toPopulate,
                                                                                            compoundPredicates,
                                                                                            fieldTypeMap);
-        assertFalse(toPopulate.isEmpty());
-        assertEquals(2, toPopulate.size()); // one entry is for "AND" compounds and the other is for "OR" ones
+        assertThat(toPopulate).isNotEmpty();
+        assertThat(toPopulate).hasSize(2); // one entry is for "AND" compounds and the other is for "OR" ones
         final Map<CompoundPredicate.BooleanOperator, List<CompoundPredicate>> partitionedCompoundPredicates =
                 compoundPredicates.stream()
                 .collect(Collectors.groupingBy(CompoundPredicate::getBooleanOperator));
@@ -184,11 +181,11 @@ public class KiePMMLASTFactoryUtilsTest {
                     operatorValue.getNestedKiePMMLFieldOperatorValues();
             final List<Predicate> nestedPredicates =
                     compoundPredicates.stream().flatMap(compoundPredicate -> compoundPredicate.getPredicates().stream()).collect(Collectors.toList());
-            assertEquals(nestedPredicates.size(), nestedKiePMMLFieldOperatorValues.size());
+            assertThat(nestedKiePMMLFieldOperatorValues).hasSameSizeAs(nestedPredicates);
             nestedKiePMMLFieldOperatorValues.forEach(new Consumer<KiePMMLFieldOperatorValue>() {
                 @Override
                 public void accept(KiePMMLFieldOperatorValue kiePMMLFieldOperatorValue) {
-                    assertEquals(1, kiePMMLFieldOperatorValue.getKiePMMLOperatorValues().size());
+                    assertThat(kiePMMLFieldOperatorValue.getKiePMMLOperatorValues()).hasSize(1);
                     final KiePMMLOperatorValue kiePMMLOperatorValue =
                             kiePMMLFieldOperatorValue.getKiePMMLOperatorValues().get(0);
                     SimplePredicate simplePredicate = nestedPredicates.stream()
@@ -200,7 +197,7 @@ public class KiePMMLASTFactoryUtilsTest {
                     nestedPredicates.remove(simplePredicate);
                 }
             });
-            assertTrue(nestedPredicates.isEmpty());
+            assertThat(nestedPredicates).isEmpty();
         });
     }
 
@@ -212,14 +209,14 @@ public class KiePMMLASTFactoryUtilsTest {
                                                                                          compoundBooleanOperator,
                                                                                          predicatesByField,
                                                                                          fieldTypeMap);
-        assertEquals(simplePredicates.size(), toPopulate.size());
+        assertThat(toPopulate).hasSameSizeAs(simplePredicates);
         commonVerifyKiePMMLFieldOperatorValueList(toPopulate, booleanOperator);
     }
 
     private void commonVerifyKiePMMLFieldOperatorValueList(List<KiePMMLFieldOperatorValue> toVerify,
                                                            BOOLEAN_OPERATOR booleanOperator) {
         toVerify.forEach(kiePMMLFieldOperatorValue -> {
-            assertEquals(booleanOperator, kiePMMLFieldOperatorValue.getOperator());
+            assertThat(kiePMMLFieldOperatorValue.getOperator()).isEqualTo(booleanOperator);
             commonVerifyKiePMMLFieldOperatorValue(kiePMMLFieldOperatorValue);
         });
     }
@@ -231,7 +228,7 @@ public class KiePMMLASTFactoryUtilsTest {
 
     private void commonVerifyKiePMMLFieldOperatorValue(final KiePMMLFieldOperatorValue toVerify,
                                                        final SimplePredicate simplePredicate) {
-        assertEquals(1, toVerify.getKiePMMLOperatorValues().size());
+        assertThat(toVerify.getKiePMMLOperatorValues()).hasSize(1);
         final KiePMMLOperatorValue kiePMMLOperatorValue = toVerify.getKiePMMLOperatorValues().get(0);
         commonVerifyKiePMMLOperatorValue(kiePMMLOperatorValue, simplePredicate);
         Object expectedValue = simplePredicate.getValue();
@@ -240,7 +237,7 @@ public class KiePMMLASTFactoryUtilsTest {
         }
         String expectedOperator = OPERATOR.byName(simplePredicate.getOperator().value()).getOperator();
         String expected = String.format("value %s %s", expectedOperator, expectedValue);
-        assertEquals(expected, toVerify.getConstraintsAsString());
+        assertThat(toVerify.getConstraintsAsString()).isEqualTo(expected);
     }
 
     private void commonVerifyKiePMMLOperatorValue(final KiePMMLOperatorValue toVerify,
@@ -250,7 +247,7 @@ public class KiePMMLASTFactoryUtilsTest {
         if (expectedValue instanceof String) {
             expectedValue = String.format("\"%s\"", expectedValue);
         }
-        assertEquals(expectedValue, toVerify.getValue());
+        assertThat(toVerify.getValue()).isEqualTo(expectedValue);
     }
 
     private SimplePredicate getSimplePredicate(String generatedType) {

--- a/kie-pmml-trusty/kie-pmml-models/kie-pmml-models-drools/kie-pmml-models-drools-common/src/test/java/org/kie/pmml/models/drools/utils/KiePMMLDroolsModelFactoryUtilsTest.java
+++ b/kie-pmml-trusty/kie-pmml-models/kie-pmml-models-drools/kie-pmml-models-drools-common/src/test/java/org/kie/pmml/models/drools/utils/KiePMMLDroolsModelFactoryUtilsTest.java
@@ -59,8 +59,7 @@ import org.kie.pmml.compiler.commons.mocks.HasClassLoaderMock;
 import org.kie.pmml.models.drools.dto.DroolsCompilationDTO;
 import org.kie.pmml.models.drools.tuples.KiePMMLOriginalTypeGeneratedType;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.kie.pmml.commons.utils.KiePMMLModelUtils.getSanitizedClassName;
 import static org.kie.pmml.commons.utils.KiePMMLModelUtils.getSanitizedPackageName;
 import static org.kie.pmml.compiler.commons.testutils.CodegenTestUtils.commonEvaluateAssignExpr;
@@ -113,7 +112,7 @@ public class KiePMMLDroolsModelFactoryUtilsTest {
         CompilationUnit retrieved =
                 KiePMMLDroolsModelFactoryUtils.getKiePMMLModelCompilationUnit(droolsCompilationDTO, TEMPLATE_SOURCE,
                                                                               TEMPLATE_CLASS_NAME);
-        assertEquals(droolsCompilationDTO.getPackageName(), retrieved.getPackageDeclaration().get().getNameAsString());
+        assertThat(retrieved.getPackageDeclaration().get().getNameAsString()).isEqualTo(droolsCompilationDTO.getPackageName());
         ConstructorDeclaration constructorDeclaration =
                 retrieved.getClassByName(modelName).get().getDefaultConstructor().get();
         MINING_FUNCTION miningFunction = MINING_FUNCTION.CLASSIFICATION;
@@ -125,7 +124,7 @@ public class KiePMMLDroolsModelFactoryUtilsTest {
         assignExpressionMap.put("pmmlMODEL", new NameExpr(pmmlModel.getClass().getName() + "." + pmmlModel.name()));
         String expectedKModulePackageName = getSanitizedPackageName(packageName + "." + modelName);
         assignExpressionMap.put("kModulePackageName", new StringLiteralExpr(expectedKModulePackageName));
-        assertTrue(commonEvaluateAssignExpr(constructorDeclaration.getBody(), assignExpressionMap));
+        assertThat(commonEvaluateAssignExpr(constructorDeclaration.getBody(), assignExpressionMap)).isTrue();
         int expectedMethodCallExprs = assignExpressionMap.size() + fieldTypeMap.size() + 1; // The last "1" is for
         // the super invocation
         commonEvaluateFieldTypeMap(constructorDeclaration.getBody(), fieldTypeMap, expectedMethodCallExprs);
@@ -150,9 +149,9 @@ public class KiePMMLDroolsModelFactoryUtilsTest {
                                 new NameExpr(miningFunction.getClass().getName() + "." + miningFunction.name()));
         assignExpressionMap.put("pmmlMODEL", new NameExpr(pmmlModel.getClass().getName() + "." + pmmlModel.name()));
         assignExpressionMap.put("kModulePackageName", new StringLiteralExpr(kModulePackageName));
-        assertTrue(commonEvaluateConstructor(constructorDeclaration, tableName.asString(),
+        assertThat(commonEvaluateConstructor(constructorDeclaration, tableName.asString(),
                                              superInvocationExpressionsMap,
-                                             assignExpressionMap));
+                                             assignExpressionMap)).isTrue();
     }
 
     @Test
@@ -175,9 +174,9 @@ public class KiePMMLDroolsModelFactoryUtilsTest {
         List<MethodCallExpr> retrieved = getMethodCallExprList(blockStmt, expectedMethodCallSize, "fieldTypeMap",
                                                                "put");
         for (Map.Entry<String, KiePMMLOriginalTypeGeneratedType> entry : fieldTypeMap.entrySet()) {
-            assertTrue(retrieved.stream()
+            assertThat(retrieved.stream()
                                .map(MethodCallExpr::getArguments)
-                               .anyMatch(arguments -> evaluateFieldTypeMapPopulation(entry, arguments)));
+                               .anyMatch(arguments -> evaluateFieldTypeMapPopulation(entry, arguments))).isTrue();
         }
     }
 
@@ -233,7 +232,7 @@ public class KiePMMLDroolsModelFactoryUtilsTest {
 
     private Stream<Statement> getStatementStream(BlockStmt blockStmt, int expectedSize) {
         final NodeList<Statement> statements = blockStmt.getStatements();
-        assertEquals(expectedSize, statements.size());
+        assertThat(statements).hasSize(expectedSize);
         return StreamSupport.stream(
                 Spliterators.spliteratorUnknownSize(
                         statements.iterator(),

--- a/kie-pmml-trusty/kie-pmml-models/kie-pmml-models-drools/kie-pmml-models-drools-common/src/test/java/org/kie/pmml/models/drools/utils/KiePMMLSessionUtilsTest.java
+++ b/kie-pmml-trusty/kie-pmml-models/kie-pmml-models-drools/kie-pmml-models-drools-common/src/test/java/org/kie/pmml/models/drools/utils/KiePMMLSessionUtilsTest.java
@@ -18,6 +18,7 @@ package org.kie.pmml.models.drools.utils;
 
 import java.util.List;
 
+import org.assertj.core.data.Offset;
 import org.drools.core.command.runtime.SetGlobalCommand;
 import org.drools.core.command.runtime.rule.InsertObjectCommand;
 import org.drools.core.impl.KnowledgeBaseImpl;
@@ -30,9 +31,6 @@ import org.kie.api.runtime.StatelessKieSession;
 import org.kie.pmml.models.drools.executor.KiePMMLStatusHolder;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertTrue;
 import static org.kie.pmml.commons.Constants.PACKAGE_NAME;
 
 public class KiePMMLSessionUtilsTest {
@@ -59,26 +57,26 @@ public class KiePMMLSessionUtilsTest {
     public void kiePMMLSessionUtils() {
         List<Command> retrieved = kiePMMLSessionUtils.commands;
         assertThat(retrieved).isNotNull();
-        assertEquals(3, retrieved.size());
-        assertTrue(retrieved.get(0) instanceof InsertObjectCommand);
+        assertThat(retrieved).hasSize(3);
+        assertThat(retrieved.get(0)).isInstanceOf(InsertObjectCommand.class);
         InsertObjectCommand insertObjectCommand = (InsertObjectCommand) retrieved.get(0);
-        assertEquals("DEFAULT", insertObjectCommand.getEntryPoint());
+        assertThat(insertObjectCommand.getEntryPoint()).isEqualTo("DEFAULT");
         assertThat(insertObjectCommand.getObject()).isNotNull();
-        assertTrue(insertObjectCommand.getObject() instanceof KiePMMLStatusHolder);
+        assertThat(insertObjectCommand.getObject()).isInstanceOf(KiePMMLStatusHolder.class);
         KiePMMLStatusHolder kiePMMLStatusHolder = (KiePMMLStatusHolder) insertObjectCommand.getObject();
-        assertEquals(0.0, kiePMMLStatusHolder.getAccumulator(), 0.0);
-        assertNull(kiePMMLStatusHolder.getStatus());
-        assertTrue(retrieved.get(1) instanceof InsertObjectCommand);
+        assertThat(kiePMMLStatusHolder.getAccumulator()).isCloseTo(0.0, Offset.offset(0.0));
+        assertThat(kiePMMLStatusHolder.getStatus()).isNull();
+        assertThat(retrieved.get(1)).isInstanceOf(InsertObjectCommand.class);
         insertObjectCommand = (InsertObjectCommand) retrieved.get(1);
-        assertEquals("DEFAULT", insertObjectCommand.getEntryPoint());
+        assertThat(insertObjectCommand.getEntryPoint()).isEqualTo("DEFAULT");
         assertThat(insertObjectCommand.getObject()).isNotNull();
-        assertTrue(insertObjectCommand.getObject() instanceof PMML4Result);
-        assertEquals(PMML4_RESULT, insertObjectCommand.getObject());
-        assertTrue(retrieved.get(2) instanceof SetGlobalCommand);
+        assertThat(insertObjectCommand.getObject()).isInstanceOf(PMML4Result.class);
+        assertThat(insertObjectCommand.getObject()).isEqualTo(PMML4_RESULT);
+        assertThat(retrieved.get(2)).isInstanceOf(SetGlobalCommand.class);
         SetGlobalCommand setGlobalCommand = (SetGlobalCommand) retrieved.get(2);
-        assertEquals("$pmml4Result", setGlobalCommand.getIdentifier());
-        assertTrue(setGlobalCommand.getObject() instanceof PMML4Result);
-        assertEquals(PMML4_RESULT, setGlobalCommand.getObject());
+        assertThat(setGlobalCommand.getIdentifier()).isEqualTo("$pmml4Result");
+        assertThat(setGlobalCommand.getObject()).isInstanceOf(PMML4Result.class);
+        assertThat(setGlobalCommand.getObject()).isEqualTo(PMML4_RESULT);
     }
 
     @Test
@@ -91,19 +89,19 @@ public class KiePMMLSessionUtilsTest {
     public void insertObjectInSession() {
         final List<Command> retrieved = kiePMMLSessionUtils.commands;
         assertThat(retrieved).isNotNull();
-        assertEquals(3, retrieved.size());
+        assertThat(retrieved).hasSize(3);
         final Object toInsert = "TO_INSERT";
         final String globalName = "GLOBAL_NAME";
         kiePMMLSessionUtils.insertObjectInSession(toInsert, globalName);
-        assertEquals(5, retrieved.size());
-        assertTrue(retrieved.get(3) instanceof InsertObjectCommand);
+        assertThat(retrieved).hasSize(5);
+        assertThat(retrieved.get(3)).isInstanceOf(InsertObjectCommand.class);
         InsertObjectCommand insertObjectCommand = (InsertObjectCommand) retrieved.get(3);
-        assertEquals("DEFAULT", insertObjectCommand.getEntryPoint());
+        assertThat(insertObjectCommand.getEntryPoint()).isEqualTo("DEFAULT");
         assertThat(insertObjectCommand.getObject()).isNotNull();
-        assertEquals(toInsert, insertObjectCommand.getObject());
-        assertTrue(retrieved.get(4) instanceof SetGlobalCommand);
+        assertThat(insertObjectCommand.getObject()).isEqualTo(toInsert);
+        assertThat(retrieved.get(4)).isInstanceOf(SetGlobalCommand.class);
         SetGlobalCommand setGlobalCommand = (SetGlobalCommand) retrieved.get(4);
-        assertEquals(globalName, setGlobalCommand.getIdentifier());
-        assertEquals(toInsert, setGlobalCommand.getObject());
+        assertThat(setGlobalCommand.getIdentifier()).isEqualTo(globalName);
+        assertThat(setGlobalCommand.getObject()).isEqualTo(toInsert);
     }
 }

--- a/kie-pmml-trusty/kie-pmml-models/kie-pmml-models-drools/kie-pmml-models-drools-scorecard/kie-pmml-models-drools-scorecard-compiler/src/test/java/org/kie/pmml/models/drools/scorecard/compiler/executor/ScorecardModelImplementationProviderTest.java
+++ b/kie-pmml-trusty/kie-pmml-models/kie-pmml-models-drools/kie-pmml-models-drools-scorecard/kie-pmml-models-drools-scorecard-compiler/src/test/java/org/kie/pmml/models/drools/scorecard/compiler/executor/ScorecardModelImplementationProviderTest.java
@@ -34,8 +34,6 @@ import org.kie.pmml.models.drools.scorecard.model.KiePMMLScorecardModel;
 import org.kie.test.util.filesystem.FileUtils;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
 
 public class ScorecardModelImplementationProviderTest {
 
@@ -45,7 +43,7 @@ public class ScorecardModelImplementationProviderTest {
 
     @Test
     public void getPMMLModelType() {
-        assertEquals(PMML_MODEL.SCORECARD_MODEL, PROVIDER.getPMMLModelType());
+        assertThat(PROVIDER.getPMMLModelType()).isEqualTo(PMML_MODEL.SCORECARD_MODEL);
     }
 
     @Test
@@ -80,13 +78,13 @@ public class ScorecardModelImplementationProviderTest {
         final FileInputStream fis = FileUtils.getFileInputStream(source);
         final PMML toReturn = KiePMMLUtil.load(fis, source);
         assertThat(toReturn).isNotNull();
-        assertEquals(1, toReturn.getModels().size());
-        assertTrue(toReturn.getModels().get(0) instanceof Scorecard);
+        assertThat(toReturn.getModels()).hasSize(1);
+        assertThat(toReturn.getModels().get(0)).isInstanceOf(Scorecard.class);
         return toReturn;
     }
 
     private void commonVerifyIsDeepCloneable(AbstractKiePMMLComponent toVerify) {
-        assertTrue(toVerify instanceof Serializable);
+        assertThat(toVerify).isInstanceOf(Serializable.class);
         ExternalizableMock externalizableMock = new ExternalizableMock();
         externalizableMock.setKiePMMLComponent(toVerify);
         ClassUtils.deepClone(externalizableMock);

--- a/kie-pmml-trusty/kie-pmml-models/kie-pmml-models-drools/kie-pmml-models-drools-scorecard/kie-pmml-models-drools-scorecard-compiler/src/test/java/org/kie/pmml/models/drools/scorecard/compiler/factories/KiePMMLScorecardModelASTFactoryTest.java
+++ b/kie-pmml-trusty/kie-pmml-models/kie-pmml-models-drools/kie-pmml-models-drools-scorecard/kie-pmml-models-drools-scorecard-compiler/src/test/java/org/kie/pmml/models/drools/scorecard/compiler/factories/KiePMMLScorecardModelASTFactoryTest.java
@@ -30,9 +30,6 @@ import org.kie.pmml.models.drools.ast.KiePMMLDroolsType;
 import org.kie.pmml.models.drools.tuples.KiePMMLOriginalTypeGeneratedType;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
 import static org.kie.pmml.compiler.api.CommonTestingUtils.getFieldsFromDataDictionary;
 import static org.kie.pmml.models.drools.utils.KiePMMLASTTestUtils.getFieldTypeMap;
 
@@ -46,8 +43,8 @@ public class KiePMMLScorecardModelASTFactoryTest {
     public void setUp() throws Exception {
         samplePmml = TestUtils.loadFromFile(SOURCE_SAMPLE);
         assertThat(samplePmml).isNotNull();
-        assertEquals(1, samplePmml.getModels().size());
-        assertTrue(samplePmml.getModels().get(0) instanceof Scorecard);
+        assertThat(samplePmml.getModels()).hasSize(1);
+        assertThat(samplePmml.getModels().get(0)).isInstanceOf(Scorecard.class);
         scorecardModel = ((Scorecard) samplePmml.getModels().get(0));
     }
 
@@ -57,8 +54,8 @@ public class KiePMMLScorecardModelASTFactoryTest {
         List<KiePMMLDroolsType> types = Collections.emptyList();
         KiePMMLDroolsAST retrieved = KiePMMLScorecardModelASTFactory.getKiePMMLDroolsAST(getFieldsFromDataDictionary(samplePmml.getDataDictionary()), scorecardModel, fieldTypeMap, types);
         assertThat(retrieved).isNotNull();
-        assertEquals(types, retrieved.getTypes());
-        assertFalse(retrieved.getRules().isEmpty());
+        assertThat(retrieved.getTypes()).isEqualTo(types);
+        assertThat(retrieved.getRules()).isNotEmpty();
     }
 
 }

--- a/kie-pmml-trusty/kie-pmml-models/kie-pmml-models-drools/kie-pmml-models-drools-scorecard/kie-pmml-models-drools-scorecard-compiler/src/test/java/org/kie/pmml/models/drools/scorecard/compiler/factories/KiePMMLScorecardModelCharacteristicASTFactoryTest.java
+++ b/kie-pmml-trusty/kie-pmml-models/kie-pmml-models-drools/kie-pmml-models-drools-scorecard/kie-pmml-models-drools-scorecard-compiler/src/test/java/org/kie/pmml/models/drools/scorecard/compiler/factories/KiePMMLScorecardModelCharacteristicASTFactoryTest.java
@@ -372,7 +372,7 @@ public class KiePMMLScorecardModelCharacteristicASTFactoryTest {
     }
 
     private void commonValidateObjectValues(List<Object> toValidate, SimpleSetPredicate simpleSetPredicate) {
-        assertThat(simpleSetPredicate.getArray().getN().intValue()).isEqualTo(toValidate.size());
+        assertThat(toValidate).hasSize(simpleSetPredicate.getArray().getN().intValue());
         String[] retrieved = ((String) simpleSetPredicate.getArray().getValue()).split(" ");
         for (int i = 0; i < toValidate.size(); i++) {
             assertThat(toValidate.get(i)).isEqualTo("\"" + retrieved[i] + "\"");

--- a/kie-pmml-trusty/kie-pmml-models/kie-pmml-models-drools/kie-pmml-models-drools-scorecard/kie-pmml-models-drools-scorecard-compiler/src/test/java/org/kie/pmml/models/drools/scorecard/compiler/factories/KiePMMLScorecardModelCharacteristicASTFactoryTest.java
+++ b/kie-pmml-trusty/kie-pmml-models/kie-pmml-models-drools/kie-pmml-models-drools-scorecard/kie-pmml-models-drools-scorecard-compiler/src/test/java/org/kie/pmml/models/drools/scorecard/compiler/factories/KiePMMLScorecardModelCharacteristicASTFactoryTest.java
@@ -24,6 +24,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.concurrent.atomic.AtomicInteger;
 
+import org.assertj.core.data.Offset;
 import org.dmg.pmml.Array;
 import org.dmg.pmml.CompoundPredicate;
 import org.dmg.pmml.DataDictionary;
@@ -54,10 +55,6 @@ import org.kie.pmml.models.drools.tuples.KiePMMLOriginalTypeGeneratedType;
 import org.kie.pmml.models.drools.tuples.KiePMMLReasonCodeAndValue;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertTrue;
 import static org.kie.pmml.commons.Constants.DONE;
 import static org.kie.pmml.commons.utils.KiePMMLModelUtils.getSanitizedClassName;
 import static org.kie.pmml.compiler.api.CommonTestingUtils.getFieldsFromDataDictionary;
@@ -78,8 +75,8 @@ public class KiePMMLScorecardModelCharacteristicASTFactoryTest {
     public void setUp() throws Exception {
         samplePmml = TestUtils.loadFromFile(SOURCE_SAMPLE);
         assertThat(samplePmml).isNotNull();
-        assertEquals(1, samplePmml.getModels().size());
-        assertTrue(samplePmml.getModels().get(0) instanceof Scorecard);
+        assertThat(samplePmml.getModels()).hasSize(1);
+        assertThat(samplePmml.getModels().get(0)).isInstanceOf(Scorecard.class);
         scorecardModel = ((Scorecard) samplePmml.getModels().get(0));
         dataDictionary = samplePmml.getDataDictionary();
     }
@@ -128,7 +125,7 @@ public class KiePMMLScorecardModelCharacteristicASTFactoryTest {
                                    expectedOperatorValuesSize);
             }
         }
-        assertEquals(attributes.size() + 1, retrieved.size());
+        assertThat(attributes).hasSize(retrieved.size() -1);
     }
 
     @Test
@@ -146,7 +143,7 @@ public class KiePMMLScorecardModelCharacteristicASTFactoryTest {
                                                rules,
                                                statusToSet,
                                                isLastCharacteristic);
-        assertEquals(characteristic.getAttributes().size(), rules.size());
+        assertThat(rules).hasSameSizeAs(characteristic.getAttributes());
         for (int i = 0; i < rules.size(); i++) {
             commonValidateRule(rules.get(i),
                                characteristic.getAttributes().get(i),
@@ -175,7 +172,7 @@ public class KiePMMLScorecardModelCharacteristicASTFactoryTest {
         final boolean isLastCharacteristic = false;
         getKiePMMLScorecardModelCharacteristicASTFactory()
                 .declareRuleFromAttribute(attribute, parentPath, attributeIndex, rules, statusToSet, characteristicReasonCode, characteristicBaselineScore, isLastCharacteristic);
-        assertEquals(1, rules.size());
+        assertThat(rules).hasSize(1);
         commonValidateRule(rules.get(0),
                            attribute,
                            statusToSet,
@@ -202,7 +199,7 @@ public class KiePMMLScorecardModelCharacteristicASTFactoryTest {
         getKiePMMLScorecardModelCharacteristicASTFactory()
                 .withReasonCodes(null, REASONCODE_ALGORITHM.POINTS_ABOVE)
                 .declareRuleFromAttribute(attribute, parentPath, attributeIndex, rules, statusToSet, characteristicReasonCode, characteristicBaselineScore, isLastCharacteristic);
-        assertEquals(1, rules.size());
+        assertThat(rules).hasSize(1);
         KiePMMLDroolsRule toValidate = rules.get(0);
         commonValidateRule(toValidate,
                            attribute,
@@ -217,9 +214,9 @@ public class KiePMMLScorecardModelCharacteristicASTFactoryTest {
                            1);
         KiePMMLReasonCodeAndValue retrieved = toValidate.getReasonCodeAndValue();
         assertThat(retrieved).isNotNull();
-        assertEquals(characteristicReasonCode, retrieved.getReasonCode());
+        assertThat(retrieved.getReasonCode()).isEqualTo(characteristicReasonCode);
         double expected = attribute.getPartialScore().doubleValue() - characteristicBaselineScore;
-        assertEquals(expected, retrieved.getValue(), 0);
+        assertThat(expected).isCloseTo(retrieved.getValue(), Offset.offset(0.0));
     }
 
     @Test
@@ -234,7 +231,7 @@ public class KiePMMLScorecardModelCharacteristicASTFactoryTest {
         final boolean isLastCharacteristic = true;
         getKiePMMLScorecardModelCharacteristicASTFactory()
                 .declareRuleFromAttribute(attribute, parentPath, attributeIndex, rules, statusToSet, characteristicReasonCode, characteristicBaselineScore, isLastCharacteristic);
-        assertEquals(1, rules.size());
+        assertThat(rules).hasSize(1);
         commonValidateRule(rules.get(0),
                            attribute,
                            statusToSet,
@@ -260,7 +257,7 @@ public class KiePMMLScorecardModelCharacteristicASTFactoryTest {
         final boolean isLastCharacteristic = false;
         getKiePMMLScorecardModelCharacteristicASTFactory()
                 .declareRuleFromAttribute(attribute, parentPath, attributeIndex, rules, statusToSet, characteristicReasonCode, characteristicBaselineScore, isLastCharacteristic);
-        assertEquals(1, rules.size());
+        assertThat(rules).hasSize(1);
         commonValidateRule(rules.get(0),
                            attribute,
                            statusToSet,
@@ -286,7 +283,7 @@ public class KiePMMLScorecardModelCharacteristicASTFactoryTest {
         final boolean isLastCharacteristic = false;
         getKiePMMLScorecardModelCharacteristicASTFactory()
                 .declareRuleFromAttribute(attribute, parentPath, attributeIndex, rules, statusToSet, characteristicReasonCode, characteristicBaselineScore, isLastCharacteristic);
-        assertEquals(1, rules.size());
+        assertThat(rules).hasSize(1);
         commonValidateRule(rules.get(0),
                            attribute,
                            statusToSet,
@@ -311,24 +308,24 @@ public class KiePMMLScorecardModelCharacteristicASTFactoryTest {
                                     BOOLEAN_OPERATOR expectedOperator,
                                     String expectedConstraints,
                                     Integer expectedOperatorValuesSize) {
-        assertEquals(String.format(PATH_PATTERN, parentPath, attributeIndex), toValidate.getName());
-        assertEquals(statusToSet, toValidate.getStatusToSet());
-        assertEquals(String.format(STATUS_PATTERN, parentPath), toValidate.getStatusConstraint());
-        assertEquals(attribute.getPartialScore().doubleValue(), toValidate.getToAccumulate(), 0.0);
+        assertThat(toValidate.getName()).isEqualTo(String.format(PATH_PATTERN, parentPath, attributeIndex));
+        assertThat(toValidate.getStatusToSet()).isEqualTo(statusToSet);
+        assertThat(toValidate.getStatusConstraint()).isEqualTo(String.format(STATUS_PATTERN, parentPath));
+        assertThat(toValidate.getToAccumulate()).isCloseTo(attribute.getPartialScore().doubleValue(), Offset.offset(0.0));
         if (isLastCharacteristic) {
-            assertTrue(toValidate.isAccumulationResult());
-            assertEquals(ResultCode.OK, toValidate.getResultCode());
+            assertThat(toValidate.isAccumulationResult()).isTrue();
+            assertThat(toValidate.getResultCode()).isEqualTo(ResultCode.OK);
         } else {
-            assertFalse(toValidate.isAccumulationResult());
-            assertNull(toValidate.getResultCode());
+            assertThat(toValidate.isAccumulationResult()).isFalse();
+            assertThat(toValidate.getResultCode()).isNull();
         }
-        assertNull(toValidate.getResult());
+        assertThat(toValidate.getResult()).isNull();
         if (expectedAndConstraints != null) {
-            assertEquals(expectedAndConstraints.intValue(), toValidate.getAndConstraints().size());
+            assertThat(toValidate.getAndConstraints()).hasSize(expectedAndConstraints.intValue());
             commonValidateAndConstraint(toValidate.getAndConstraints().get(0), attribute, expectedOperator, expectedConstraints, expectedOperatorValuesSize);
         }
         if (expectedInConstraints != null) {
-            assertEquals(expectedInConstraints.intValue(), toValidate.getInConstraints().size());
+            assertThat(toValidate.getInConstraints()).hasSize(expectedInConstraints.intValue());
             commonValidateInConstraint(toValidate.getInConstraints(), attribute);
         }
     }
@@ -338,12 +335,12 @@ public class KiePMMLScorecardModelCharacteristicASTFactoryTest {
                                              BOOLEAN_OPERATOR expectedOperator,
                                              String expectedConstraints,
                                              int expectedOperatorValuesSize) {
-        assertEquals(expectedOperator, toValidate.getOperator());
+        assertThat(toValidate.getOperator()).isEqualTo(expectedOperator);
         if (expectedConstraints != null) {
-            assertEquals(expectedConstraints, toValidate.getConstraintsAsString());
+            assertThat(toValidate.getConstraintsAsString()).isEqualTo(expectedConstraints);
         }
         final List<KiePMMLOperatorValue> operatorValues = toValidate.getKiePMMLOperatorValues();
-        assertEquals(expectedOperatorValuesSize, operatorValues.size());
+        assertThat(operatorValues).hasSize(expectedOperatorValuesSize);
         if (attribute.getPredicate() instanceof SimplePredicate) {
             commonValidateKiePMMLOperatorValue(operatorValues.get(0),
                                                (SimplePredicate) attribute.getPredicate());
@@ -361,9 +358,9 @@ public class KiePMMLScorecardModelCharacteristicASTFactoryTest {
 
     private void commonValidateKiePMMLOperatorValue(KiePMMLOperatorValue toValidate, SimplePredicate simplePredicate) {
         OPERATOR expectedOperator = OPERATOR.byName(simplePredicate.getOperator().value());
-        assertEquals(expectedOperator, toValidate.getOperator());
+        assertThat(toValidate.getOperator()).isEqualTo(expectedOperator);
         Object expectedValue = getExpectedValue(simplePredicate);
-        assertEquals(expectedValue, toValidate.getValue());
+        assertThat(toValidate.getValue()).isEqualTo(expectedValue);
     }
 
     private Object getExpectedValue(SimplePredicate simplePredicate) throws RuntimeException {
@@ -375,15 +372,15 @@ public class KiePMMLScorecardModelCharacteristicASTFactoryTest {
     }
 
     private void commonValidateObjectValues(List<Object> toValidate, SimpleSetPredicate simpleSetPredicate) {
-        assertEquals(toValidate.size(), simpleSetPredicate.getArray().getN().intValue());
+        assertThat(simpleSetPredicate.getArray().getN().intValue()).isEqualTo(toValidate.size());
         String[] retrieved = ((String) simpleSetPredicate.getArray().getValue()).split(" ");
         for (int i = 0; i < toValidate.size(); i++) {
-            assertEquals(toValidate.get(i), "\"" + retrieved[i] + "\"");
+            assertThat(toValidate.get(i)).isEqualTo("\"" + retrieved[i] + "\"");
         }
     }
 
     private void commonValidateKiePMMLOperatorValues(List<KiePMMLOperatorValue> toValidate, CompoundPredicate compoundPredicate) {
-        assertEquals(toValidate.size(), compoundPredicate.getPredicates().size());
+        assertThat(compoundPredicate.getPredicates()).hasSameSizeAs(toValidate);
         for (int i = 0; i < toValidate.size(); i++) {
             commonValidateKiePMMLOperatorValue(toValidate.get(i),
                                                (SimplePredicate) compoundPredicate.getPredicates().get(i));
@@ -448,8 +445,8 @@ public class KiePMMLScorecardModelCharacteristicASTFactoryTest {
 
     @Test
     public void getKiePMMLReasonCodeAndValueUseReasonCodesFalse() {
-        assertNull(getKiePMMLScorecardModelCharacteristicASTFactory().getKiePMMLReasonCodeAndValue(new Attribute(),
-                                                                                                   "", 0));
+        assertThat(getKiePMMLScorecardModelCharacteristicASTFactory().getKiePMMLReasonCodeAndValue(new Attribute(),
+                                                                                                   "", 0)).isNull();
     }
 
     @Test(expected = KiePMMLException.class)
@@ -490,25 +487,25 @@ public class KiePMMLScorecardModelCharacteristicASTFactoryTest {
                 .getKiePMMLReasonCodeAndValue(attribute,
                                               characteristicReasonCode, null);
         assertThat(retrieved).isNotNull();
-        assertEquals(characteristicReasonCode, retrieved.getReasonCode());
+        assertThat(retrieved.getReasonCode()).isEqualTo(characteristicReasonCode);
         double expected = attributePartialScore - baselineScore;
-        assertEquals(expected, retrieved.getValue(), 0);
+        assertThat(retrieved.getValue()).isCloseTo(expected, Offset.offset(0.0));
         retrieved = getKiePMMLScorecardModelCharacteristicASTFactory()
                 .withReasonCodes(baselineScore, REASONCODE_ALGORITHM.POINTS_ABOVE)
                 .getKiePMMLReasonCodeAndValue(attribute,
                                               characteristicReasonCode, characteristicBaselineScore);
         assertThat(retrieved).isNotNull();
-        assertEquals(characteristicReasonCode, retrieved.getReasonCode());
+        assertThat(retrieved.getReasonCode()).isEqualTo(characteristicReasonCode);
         expected = attributePartialScore - characteristicBaselineScore;
-        assertEquals(expected, retrieved.getValue(), 0);
+        assertThat(retrieved.getValue()).isCloseTo(expected, Offset.offset(0.0));
         attribute.setReasonCode(attributeReasonCode);
         retrieved = getKiePMMLScorecardModelCharacteristicASTFactory()
                 .withReasonCodes(baselineScore, REASONCODE_ALGORITHM.POINTS_ABOVE)
                 .getKiePMMLReasonCodeAndValue(attribute,
                                               characteristicReasonCode, characteristicBaselineScore);
         assertThat(retrieved).isNotNull();
-        assertEquals(attributeReasonCode, retrieved.getReasonCode());
-        assertEquals(expected, retrieved.getValue(), 0);
+        assertThat(retrieved.getReasonCode()).isEqualTo(attributeReasonCode);
+        assertThat(retrieved.getValue()).isCloseTo(expected, Offset.offset(0.0));
     }
 
     private KiePMMLScorecardModelCharacteristicASTFactory getKiePMMLScorecardModelCharacteristicASTFactory() {
@@ -516,7 +513,7 @@ public class KiePMMLScorecardModelCharacteristicASTFactoryTest {
         final List<Field<?>> fields = getFieldsFromDataDictionary(samplePmml.getDataDictionary());
         DATA_TYPE targetType = getTargetFieldType(fields, scorecardModel);
         KiePMMLDataDictionaryASTFactory.factory(fieldTypeMap).declareTypes(fields);
-        assertFalse(fieldTypeMap.isEmpty());
+        assertThat(fieldTypeMap).isNotEmpty();
         return KiePMMLScorecardModelCharacteristicASTFactory.factory(fieldTypeMap, Collections.emptyList(), targetType);
     }
 

--- a/kie-pmml-trusty/kie-pmml-models/kie-pmml-models-drools/kie-pmml-models-drools-scorecard/kie-pmml-models-drools-scorecard-compiler/src/test/java/org/kie/pmml/models/drools/scorecard/compiler/factories/KiePMMLScorecardModelFactoryTest.java
+++ b/kie-pmml-trusty/kie-pmml-models/kie-pmml-models-drools/kie-pmml-models-drools-scorecard/kie-pmml-models-drools-scorecard-compiler/src/test/java/org/kie/pmml/models/drools/scorecard/compiler/factories/KiePMMLScorecardModelFactoryTest.java
@@ -43,8 +43,6 @@ import org.kie.pmml.models.drools.scorecard.model.KiePMMLScorecardModel;
 import org.kie.pmml.models.drools.tuples.KiePMMLOriginalTypeGeneratedType;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
 import static org.kie.pmml.commons.Constants.PACKAGE_NAME;
 import static org.kie.pmml.commons.utils.KiePMMLModelUtils.getSanitizedClassName;
 import static org.kie.pmml.compiler.api.CommonTestingUtils.getFieldsFromDataDictionary;
@@ -66,8 +64,8 @@ public class KiePMMLScorecardModelFactoryTest {
     public static void setUp() throws Exception {
         pmml = TestUtils.loadFromFile(SOURCE_1);
         assertThat(pmml).isNotNull();
-        assertEquals(1, pmml.getModels().size());
-        assertTrue(pmml.getModels().get(0) instanceof Scorecard);
+        assertThat(pmml.getModels().size()).isEqualTo(1);
+        assertThat(pmml.getModels().get(0)).isInstanceOf(Scorecard.class);
         scorecardModel = (Scorecard) pmml.getModels().get(0);
         assertThat(scorecardModel).isNotNull();
         CompilationUnit templateCU = getFromFileName(KIE_PMML_SCORECARD_MODEL_TEMPLATE_JAVA);
@@ -92,8 +90,8 @@ public class KiePMMLScorecardModelFactoryTest {
                                                         fieldTypeMap);
         KiePMMLScorecardModel retrieved = KiePMMLScorecardModelFactory.getKiePMMLScorecardModel(droolsCompilationDTO);
         assertThat(retrieved).isNotNull();
-        assertEquals(scorecardModel.getModelName(), retrieved.getName());
-        assertEquals(TARGET_FIELD, retrieved.getTargetField());
+        assertThat(retrieved.getName()).isEqualTo(scorecardModel.getModelName());
+        assertThat(retrieved.getTargetField()).isEqualTo(TARGET_FIELD);
     }
 
     @Test
@@ -115,7 +113,7 @@ public class KiePMMLScorecardModelFactoryTest {
         Map<String, String> retrieved =
                 KiePMMLScorecardModelFactory.getKiePMMLScorecardModelSourcesMap(droolsCompilationDTO);
         assertThat(retrieved).isNotNull();
-        assertEquals(1, retrieved.size());
+        assertThat(retrieved).hasSize(1);
     }
 
     @Test
@@ -155,8 +153,8 @@ public class KiePMMLScorecardModelFactoryTest {
                                 new NameExpr(miningFunction.getClass().getName() + "." + miningFunction.name()));
         assignExpressionMap.put("pmmlMODEL", new NameExpr(pmmlModel.getClass().getName() + "." + pmmlModel.name()));
         ConstructorDeclaration constructorDeclaration = modelTemplate.getDefaultConstructor().get();
-        assertTrue(commonEvaluateConstructor(constructorDeclaration,
+        assertThat(commonEvaluateConstructor(constructorDeclaration,
                                              getSanitizedClassName(scorecardModel.getModelName()),
-                                             superInvocationExpressionsMap, assignExpressionMap));
+                                             superInvocationExpressionsMap, assignExpressionMap)).isTrue();
     }
 }

--- a/kie-pmml-trusty/kie-pmml-models/kie-pmml-models-drools/kie-pmml-models-drools-scorecard/kie-pmml-models-drools-scorecard-compiler/src/test/java/org/kie/pmml/models/drools/scorecard/compiler/factories/KiePMMLScorecardModelFactoryTest.java
+++ b/kie-pmml-trusty/kie-pmml-models/kie-pmml-models-drools/kie-pmml-models-drools-scorecard/kie-pmml-models-drools-scorecard-compiler/src/test/java/org/kie/pmml/models/drools/scorecard/compiler/factories/KiePMMLScorecardModelFactoryTest.java
@@ -64,7 +64,7 @@ public class KiePMMLScorecardModelFactoryTest {
     public static void setUp() throws Exception {
         pmml = TestUtils.loadFromFile(SOURCE_1);
         assertThat(pmml).isNotNull();
-        assertThat(pmml.getModels().size()).isEqualTo(1);
+        assertThat(pmml.getModels()).hasSize(1);
         assertThat(pmml.getModels().get(0)).isInstanceOf(Scorecard.class);
         scorecardModel = (Scorecard) pmml.getModels().get(0);
         assertThat(scorecardModel).isNotNull();

--- a/kie-pmml-trusty/kie-pmml-models/kie-pmml-models-drools/kie-pmml-models-drools-scorecard/kie-pmml-models-drools-scorecard-evaluator/src/test/java/org/kie/pmml/models/drools/scorecard/evaluator/PMMLScorecardModelEvaluatorTest.java
+++ b/kie-pmml-trusty/kie-pmml-models/kie-pmml-models-drools/kie-pmml-models-drools-scorecard/kie-pmml-models-drools-scorecard-evaluator/src/test/java/org/kie/pmml/models/drools/scorecard/evaluator/PMMLScorecardModelEvaluatorTest.java
@@ -48,9 +48,6 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
 
 @RunWith(Parameterized.class)
 public class PMMLScorecardModelEvaluatorTest {
@@ -89,8 +86,8 @@ public class PMMLScorecardModelEvaluatorTest {
         evaluator = new PMMLScorecardModelEvaluator();
         final PMML pmml = TestUtils.loadFromFile(SOURCE_1);
         assertThat(pmml).isNotNull();
-        assertEquals(1, pmml.getModels().size());
-        assertTrue(pmml.getModels().get(0) instanceof Scorecard);
+        assertThat(pmml.getModels()).hasSize(1);
+        assertThat(pmml.getModels().get(0)).isInstanceOf(Scorecard.class);
         KnowledgeBuilderImpl knowledgeBuilder = new KnowledgeBuilderImpl();
         final CommonCompilationDTO<Scorecard> compilationDTO =
                 CommonCompilationDTO.fromGeneratedPackageNameAndFields(PACKAGE_NAME,
@@ -294,7 +291,7 @@ public class PMMLScorecardModelEvaluatorTest {
 
     @Test
     public void getPMMLModelType() {
-        assertEquals(PMML_MODEL.SCORECARD_MODEL, evaluator.getPMMLModelType());
+        assertThat(evaluator.getPMMLModelType()).isEqualTo(PMML_MODEL.SCORECARD_MODEL);
     }
 
     @Test
@@ -317,13 +314,13 @@ public class PMMLScorecardModelEvaluatorTest {
         PMML4Result retrieved = evaluator.evaluate(kieBase, kiePMMLModel, pmmlContext);
         assertThat(retrieved).isNotNull();
         logger.trace(retrieved.toString());
-        assertEquals(TARGET_FIELD, retrieved.getResultObjectName());
+        assertThat(retrieved.getResultObjectName()).isEqualTo(TARGET_FIELD);
         final Map<String, Object> resultVariables = retrieved.getResultVariables();
         assertThat(resultVariables).isNotNull();
-        assertEquals(ResultCode.OK.getName(), retrieved.getResultCode());
-        assertFalse(resultVariables.isEmpty());
-        assertTrue(resultVariables.containsKey(TARGET_FIELD));
-        assertEquals(expectedResult, resultVariables.get(TARGET_FIELD));
+        assertThat(retrieved.getResultCode()).isEqualTo(ResultCode.OK.getName());
+        assertThat(resultVariables).isNotEmpty();
+        assertThat(resultVariables).containsKey(TARGET_FIELD);
+        assertThat(resultVariables.get(TARGET_FIELD)).isEqualTo(expectedResult);
     }
 
     private PMMLRequestData getPMMLRequestData(String modelName, Map<String, Object> parameters) {

--- a/kie-pmml-trusty/kie-pmml-models/kie-pmml-models-drools/kie-pmml-models-drools-scorecard/kie-pmml-models-drools-scorecard-tests/src/test/java/org/kie/pmml/models/drools/scorecard/tests/SimpleScorecardCategoricalTest.java
+++ b/kie-pmml-trusty/kie-pmml-models/kie-pmml-models-drools/kie-pmml-models-drools-scorecard/kie-pmml-models-drools-scorecard-tests/src/test/java/org/kie/pmml/models/drools/scorecard/tests/SimpleScorecardCategoricalTest.java
@@ -33,7 +33,6 @@ import org.kie.pmml.api.runtime.PMMLRuntime;
 import org.kie.pmml.models.tests.AbstractPMMLTest;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.Assert.assertFalse;
 
 @RunWith(Parameterized.class)
 public class SimpleScorecardCategoricalTest extends AbstractPMMLTest {
@@ -99,8 +98,8 @@ public class SimpleScorecardCategoricalTest extends AbstractPMMLTest {
         getSamples().stream().map(sample -> evaluate(pmmlRuntime, sample, MODEL_NAME))
                 .filter(pmml4Result -> pmml4Result.getResultVariables().get(TARGET_FIELD) == null)
                 .forEach(pmml4Result -> {
-                    assertFalse(pmml4Result.getResultVariables().containsKey(REASON_CODE1_FIELD));
-                    assertFalse(pmml4Result.getResultVariables().containsKey(REASON_CODE2_FIELD));
+                    assertThat(pmml4Result.getResultVariables()).doesNotContainKey(REASON_CODE1_FIELD);
+                    assertThat(pmml4Result.getResultVariables()).doesNotContainKey(REASON_CODE2_FIELD);
                 });
     }
 

--- a/kie-pmml-trusty/kie-pmml-models/kie-pmml-models-drools/kie-pmml-models-drools-tree/kie-pmml-models-drools-tree-compiler/src/test/java/org/kie/pmml/models/drools/tree/compiler/executor/TreeModelImplementationProviderTest.java
+++ b/kie-pmml-trusty/kie-pmml-models/kie-pmml-models-drools/kie-pmml-models-drools-tree/kie-pmml-models-drools-tree-compiler/src/test/java/org/kie/pmml/models/drools/tree/compiler/executor/TreeModelImplementationProviderTest.java
@@ -34,8 +34,6 @@ import org.kie.pmml.models.drools.tree.model.KiePMMLTreeModel;
 import org.kie.test.util.filesystem.FileUtils;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
 import static org.kie.pmml.commons.Constants.PACKAGE_NAME;
 
 public class TreeModelImplementationProviderTest {
@@ -45,7 +43,7 @@ public class TreeModelImplementationProviderTest {
 
     @Test
     public void getPMMLModelType() {
-        assertEquals(PMML_MODEL.TREE_MODEL, PROVIDER.getPMMLModelType());
+        assertThat(PROVIDER.getPMMLModelType()).isEqualTo(PMML_MODEL.TREE_MODEL);
     }
 
     @Test
@@ -80,13 +78,13 @@ public class TreeModelImplementationProviderTest {
         final FileInputStream fis = FileUtils.getFileInputStream(source);
         final PMML toReturn = KiePMMLUtil.load(fis, source);
         assertThat(toReturn).isNotNull();
-        assertEquals(1, toReturn.getModels().size());
-        assertTrue(toReturn.getModels().get(0) instanceof TreeModel);
+        assertThat(toReturn.getModels()).hasSize(1);
+        assertThat(toReturn.getModels().get(0)).isInstanceOf(TreeModel.class);
         return toReturn;
     }
 
     private void commonVerifyIsDeepCloneable(AbstractKiePMMLComponent toVerify) {
-        assertTrue(toVerify instanceof Serializable);
+        assertThat(toVerify).isInstanceOf(Serializable.class);
         ExternalizableMock externalizableMock = new ExternalizableMock();
         externalizableMock.setKiePMMLComponent(toVerify);
         ClassUtils.deepClone(externalizableMock);

--- a/kie-pmml-trusty/kie-pmml-models/kie-pmml-models-drools/kie-pmml-models-drools-tree/kie-pmml-models-drools-tree-compiler/src/test/java/org/kie/pmml/models/drools/tree/compiler/factories/KiePMMLTreeModelASTFactoryTest.java
+++ b/kie-pmml-trusty/kie-pmml-models/kie-pmml-models-drools/kie-pmml-models-drools-tree/kie-pmml-models-drools-tree-compiler/src/test/java/org/kie/pmml/models/drools/tree/compiler/factories/KiePMMLTreeModelASTFactoryTest.java
@@ -30,9 +30,6 @@ import org.kie.pmml.models.drools.ast.KiePMMLDroolsType;
 import org.kie.pmml.models.drools.tuples.KiePMMLOriginalTypeGeneratedType;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
 import static org.kie.pmml.compiler.api.CommonTestingUtils.getFieldsFromDataDictionary;
 import static org.kie.pmml.models.drools.utils.KiePMMLASTTestUtils.getFieldTypeMap;
 
@@ -52,20 +49,20 @@ public class KiePMMLTreeModelASTFactoryTest {
     public void setUp() throws Exception {
         golfingPmml = TestUtils.loadFromFile(SOURCE_GOLFING);
         assertThat(golfingPmml).isNotNull();
-        assertEquals(1, golfingPmml.getModels().size());
-        assertTrue(golfingPmml.getModels().get(0) instanceof TreeModel);
+        assertThat(golfingPmml.getModels()).hasSize(1);
+        assertThat(golfingPmml.getModels().get(0)).isInstanceOf(TreeModel.class);
         golfingModel = ((TreeModel) golfingPmml.getModels().get(0));
         //
         irisPmml = TestUtils.loadFromFile(SOURCE_IRIS);
         assertThat(irisPmml).isNotNull();
-        assertEquals(1, irisPmml.getModels().size());
-        assertTrue(irisPmml.getModels().get(0) instanceof TreeModel);
+        assertThat(irisPmml.getModels()).hasSize(1);
+        assertThat(irisPmml.getModels().get(0)).isInstanceOf(TreeModel.class);
         irisModel = ((TreeModel) irisPmml.getModels().get(0));
         //
         simpleSetPmml = TestUtils.loadFromFile(SOURCE_SIMPLESET);
         assertThat(simpleSetPmml).isNotNull();
-        assertEquals(1, simpleSetPmml.getModels().size());
-        assertTrue(simpleSetPmml.getModels().get(0) instanceof TreeModel);
+        assertThat(simpleSetPmml.getModels()).hasSize(1);
+        assertThat(simpleSetPmml.getModels().get(0)).isInstanceOf(TreeModel.class);
         simpleSetModel = ((TreeModel) simpleSetPmml.getModels().get(0));
     }
 
@@ -75,8 +72,8 @@ public class KiePMMLTreeModelASTFactoryTest {
         List<KiePMMLDroolsType> types = Collections.emptyList();
         KiePMMLDroolsAST retrieved = KiePMMLTreeModelASTFactory.getKiePMMLDroolsAST(getFieldsFromDataDictionary(golfingPmml.getDataDictionary()), golfingModel, fieldTypeMap, types);
         assertThat(retrieved).isNotNull();
-        assertEquals(types, retrieved.getTypes());
-        assertFalse(retrieved.getRules().isEmpty());
+        assertThat(retrieved.getTypes()).isEqualTo(types);
+        assertThat(retrieved.getRules()).isNotEmpty();
     }
 
     @Test
@@ -85,8 +82,8 @@ public class KiePMMLTreeModelASTFactoryTest {
         List<KiePMMLDroolsType> types = Collections.emptyList();
         KiePMMLDroolsAST retrieved = KiePMMLTreeModelASTFactory.getKiePMMLDroolsAST(getFieldsFromDataDictionary(irisPmml.getDataDictionary()), irisModel, fieldTypeMap, types);
         assertThat(retrieved).isNotNull();
-        assertEquals(types, retrieved.getTypes());
-        assertFalse(retrieved.getRules().isEmpty());
+        assertThat(retrieved.getTypes()).isEqualTo(types);
+        assertThat(retrieved.getRules()).isNotEmpty();
     }
 
     @Test
@@ -95,7 +92,7 @@ public class KiePMMLTreeModelASTFactoryTest {
         List<KiePMMLDroolsType> types = Collections.emptyList();
         KiePMMLDroolsAST retrieved = KiePMMLTreeModelASTFactory.getKiePMMLDroolsAST(getFieldsFromDataDictionary(simpleSetPmml.getDataDictionary()), simpleSetModel, fieldTypeMap, types);
         assertThat(retrieved).isNotNull();
-        assertEquals(types, retrieved.getTypes());
-        assertFalse(retrieved.getRules().isEmpty());
+        assertThat(retrieved.getTypes()).isEqualTo(types);
+        assertThat(retrieved.getRules()).isNotEmpty();
     }
 }

--- a/kie-pmml-trusty/kie-pmml-models/kie-pmml-models-drools/kie-pmml-models-drools-tree/kie-pmml-models-drools-tree-compiler/src/test/java/org/kie/pmml/models/drools/tree/compiler/factories/KiePMMLTreeModelFactoryTest.java
+++ b/kie-pmml-trusty/kie-pmml-models/kie-pmml-models-drools/kie-pmml-models-drools-tree/kie-pmml-models-drools-tree-compiler/src/test/java/org/kie/pmml/models/drools/tree/compiler/factories/KiePMMLTreeModelFactoryTest.java
@@ -45,8 +45,6 @@ import org.kie.pmml.models.drools.tree.model.KiePMMLTreeModel;
 import org.kie.pmml.models.drools.tuples.KiePMMLOriginalTypeGeneratedType;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
 import static org.kie.pmml.commons.Constants.PACKAGE_NAME;
 import static org.kie.pmml.commons.utils.KiePMMLModelUtils.getSanitizedClassName;
 import static org.kie.pmml.compiler.api.CommonTestingUtils.getFieldsFromDataDictionary;
@@ -68,8 +66,8 @@ public class KiePMMLTreeModelFactoryTest {
     public static void setUp() throws Exception {
         pmml = TestUtils.loadFromFile(SOURCE_1);
         assertThat(pmml).isNotNull();
-        assertEquals(1, pmml.getModels().size());
-        assertTrue(pmml.getModels().get(0) instanceof TreeModel);
+        assertThat(pmml.getModels()).hasSize(1);
+        assertThat(pmml.getModels().get(0)).isInstanceOf(TreeModel.class);
         treeModel = (TreeModel) pmml.getModels().get(0);
         CompilationUnit templateCU = getFromFileName(KIE_PMML_TREE_MODEL_TEMPLATE_JAVA);
         classOrInterfaceDeclaration = templateCU
@@ -92,8 +90,8 @@ public class KiePMMLTreeModelFactoryTest {
                                                         fieldTypeMap);
         KiePMMLTreeModel retrieved = KiePMMLTreeModelFactory.getKiePMMLTreeModel(droolsCompilationDTO);
         assertThat(retrieved).isNotNull();
-        assertEquals(treeModel.getModelName(), retrieved.getName());
-        assertEquals(TARGET_FIELD, retrieved.getTargetField());
+        assertThat(retrieved.getName()).isEqualTo(treeModel.getModelName());
+        assertThat(retrieved.getTargetField()).isEqualTo(TARGET_FIELD);
     }
 
     @Test
@@ -112,7 +110,7 @@ public class KiePMMLTreeModelFactoryTest {
                                                         fieldTypeMap);
         Map<String, String> retrieved = KiePMMLTreeModelFactory.getKiePMMLTreeModelSourcesMap(droolsCompilationDTO);
         assertThat(retrieved).isNotNull();
-        assertEquals(1, retrieved.size());
+        assertThat(retrieved).hasSize(1);
     }
 
     @Test
@@ -126,8 +124,8 @@ public class KiePMMLTreeModelFactoryTest {
                                                             fieldTypeMap, Collections.emptyList());
         assertThat(retrieved).isNotNull();
         List<DataField> dataFields = dataDictionary.getDataFields();
-        assertEquals(dataFields.size(), fieldTypeMap.size());
-        dataFields.forEach(dataField -> assertTrue(fieldTypeMap.containsKey(dataField.getName().getValue())));
+        assertThat(fieldTypeMap).hasSameSizeAs(dataFields);
+        dataFields.forEach(dataField -> assertThat(fieldTypeMap).containsKey(dataField.getName().getValue()));
     }
 
     @Test
@@ -155,7 +153,7 @@ public class KiePMMLTreeModelFactoryTest {
                                 new NameExpr(miningFunction.getClass().getName() + "." + miningFunction.name()));
         assignExpressionMap.put("pmmlMODEL", new NameExpr(pmmlModel.getClass().getName() + "." + pmmlModel.name()));
         ConstructorDeclaration constructorDeclaration = modelTemplate.getDefaultConstructor().get();
-        assertTrue(commonEvaluateConstructor(constructorDeclaration, getSanitizedClassName(treeModel.getModelName()),
-                                             superInvocationExpressionsMap, assignExpressionMap));
+        assertThat(commonEvaluateConstructor(constructorDeclaration, getSanitizedClassName(treeModel.getModelName()),
+                                             superInvocationExpressionsMap, assignExpressionMap)).isTrue();
     }
 }

--- a/kie-pmml-trusty/kie-pmml-models/kie-pmml-models-drools/kie-pmml-models-drools-tree/kie-pmml-models-drools-tree-compiler/src/test/java/org/kie/pmml/models/drools/tree/compiler/factories/KiePMMLTreeModelNodeASTFactoryTest.java
+++ b/kie-pmml-trusty/kie-pmml-models/kie-pmml-models-drools/kie-pmml-models-drools-tree/kie-pmml-models-drools-tree-compiler/src/test/java/org/kie/pmml/models/drools/tree/compiler/factories/KiePMMLTreeModelNodeASTFactoryTest.java
@@ -53,12 +53,12 @@ public class KiePMMLTreeModelNodeASTFactoryTest {
     public void setUp() throws Exception {
         golfingPmml = TestUtils.loadFromFile(SOURCE_GOLFING);
         assertThat(golfingPmml).isNotNull();
-        assertThat(golfingPmml.getModels().size()).isEqualTo(1);
+        assertThat(golfingPmml.getModels()).hasSize(1);
         assertThat(golfingPmml.getModels().get(0)).isInstanceOf(TreeModel.class);
         golfingModel = ((TreeModel) golfingPmml.getModels().get(0));
         irisPmml = TestUtils.loadFromFile(SOURCE_IRIS);
         assertThat(irisPmml).isNotNull();
-        assertThat(irisPmml.getModels().size()).isEqualTo(1);
+        assertThat(irisPmml.getModels()).hasSize(1);
         assertThat(irisPmml.getModels().get(0)).isInstanceOf(TreeModel.class);
         irisModel = ((TreeModel) irisPmml.getModels().get(0));
     }

--- a/kie-pmml-trusty/kie-pmml-models/kie-pmml-models-drools/kie-pmml-models-drools-tree/kie-pmml-models-drools-tree-compiler/src/test/java/org/kie/pmml/models/drools/tree/compiler/factories/KiePMMLTreeModelNodeASTFactoryTest.java
+++ b/kie-pmml-trusty/kie-pmml-models/kie-pmml-models-drools/kie-pmml-models-drools-tree/kie-pmml-models-drools-tree-compiler/src/test/java/org/kie/pmml/models/drools/tree/compiler/factories/KiePMMLTreeModelNodeASTFactoryTest.java
@@ -37,9 +37,6 @@ import org.kie.pmml.models.drools.ast.factories.KiePMMLDataDictionaryASTFactory;
 import org.kie.pmml.models.drools.tuples.KiePMMLOriginalTypeGeneratedType;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
 import static org.kie.pmml.compiler.api.CommonTestingUtils.getFieldsFromDataDictionary;
 import static org.kie.pmml.compiler.api.utils.ModelUtils.getTargetFieldType;
 
@@ -56,66 +53,66 @@ public class KiePMMLTreeModelNodeASTFactoryTest {
     public void setUp() throws Exception {
         golfingPmml = TestUtils.loadFromFile(SOURCE_GOLFING);
         assertThat(golfingPmml).isNotNull();
-        assertEquals(1, golfingPmml.getModels().size());
-        assertTrue(golfingPmml.getModels().get(0) instanceof TreeModel);
+        assertThat(golfingPmml.getModels().size()).isEqualTo(1);
+        assertThat(golfingPmml.getModels().get(0)).isInstanceOf(TreeModel.class);
         golfingModel = ((TreeModel) golfingPmml.getModels().get(0));
         irisPmml = TestUtils.loadFromFile(SOURCE_IRIS);
         assertThat(irisPmml).isNotNull();
-        assertEquals(1, irisPmml.getModels().size());
-        assertTrue(irisPmml.getModels().get(0) instanceof TreeModel);
+        assertThat(irisPmml.getModels().size()).isEqualTo(1);
+        assertThat(irisPmml.getModels().get(0)).isInstanceOf(TreeModel.class);
         irisModel = ((TreeModel) irisPmml.getModels().get(0));
     }
 
     @Test
     public void declareRulesFromRootGolfingNode() {
         Node rootNode = golfingModel.getNode();
-        assertEquals("will play", rootNode.getScore());
+        assertThat(rootNode.getScore()).isEqualTo("will play");
         final Map<String, KiePMMLOriginalTypeGeneratedType> fieldTypeMap = new HashMap<>();
         final List<Field<?>> fields = getFieldsFromDataDictionary(golfingPmml.getDataDictionary());
         DATA_TYPE targetType = getTargetFieldType(fields, golfingModel);
         KiePMMLDataDictionaryASTFactory.factory(fieldTypeMap).declareTypes(fields);
         KiePMMLTreeModelNodeASTFactory.factory(fieldTypeMap, Collections.emptyList(), TreeModel.NoTrueChildStrategy.RETURN_NULL_PREDICTION, targetType).declareRulesFromRootNode(rootNode, "_will");
-        assertFalse(fieldTypeMap.isEmpty());
+        assertThat(fieldTypeMap).isNotEmpty();
     }
 
     @Test
     public void declareRulesFromRootIrisNode() {
         Node rootNode = irisModel.getNode();
-        assertEquals("setosa", rootNode.getScore());
+        assertThat(rootNode.getScore()).isEqualTo("setosa");
         final Map<String, KiePMMLOriginalTypeGeneratedType> fieldTypeMap = new HashMap<>();
         final List<Field<?>> fields = getFieldsFromDataDictionary(irisPmml.getDataDictionary());
         DATA_TYPE targetType = getTargetFieldType(fields, irisModel);
         KiePMMLDataDictionaryASTFactory.factory(fieldTypeMap).declareTypes(fields);
         KiePMMLTreeModelNodeASTFactory.factory(fieldTypeMap, Collections.emptyList(), TreeModel.NoTrueChildStrategy.RETURN_NULL_PREDICTION, targetType).declareRulesFromRootNode(rootNode, "_setosa");
-        assertFalse(fieldTypeMap.isEmpty());
+        assertThat(fieldTypeMap).isNotEmpty();
     }
 
     @Test
     public void declareIntermediateRuleFromGolfingNode() {
         Node finalNode = golfingModel.getNode()
                 .getNodes().get(0);
-        assertEquals("will play", finalNode.getScore());
+        assertThat(finalNode.getScore()).isEqualTo("will play");
         final Map<String, KiePMMLOriginalTypeGeneratedType> fieldTypeMap = new HashMap<>();
         final List<Field<?>> fields = getFieldsFromDataDictionary(golfingPmml.getDataDictionary());
         DATA_TYPE targetType = getTargetFieldType(fields, golfingModel);
         KiePMMLDataDictionaryASTFactory.factory(fieldTypeMap).declareTypes(fields);
         final List<KiePMMLDroolsRule> rules = new ArrayList<>();
         KiePMMLTreeModelNodeASTFactory.factory(fieldTypeMap, Collections.emptyList(), TreeModel.NoTrueChildStrategy.RETURN_NULL_PREDICTION, targetType).declareIntermediateRuleFromNode(finalNode, "_will play", rules);
-        assertFalse(rules.isEmpty());
+        assertThat(rules).isNotEmpty();
     }
 
     @Test
     public void declareIntermediateRuleFromIrisNode() {
         Node finalNode = irisModel.getNode()
                 .getNodes().get(1);
-        assertEquals("versicolor", finalNode.getScore());
+        assertThat(finalNode.getScore()).isEqualTo("versicolor");
         final Map<String, KiePMMLOriginalTypeGeneratedType> fieldTypeMap = new HashMap<>();
         final List<Field<?>> fields = getFieldsFromDataDictionary(irisPmml.getDataDictionary());
         DATA_TYPE targetType = getTargetFieldType(fields, irisModel);
         KiePMMLDataDictionaryASTFactory.factory(fieldTypeMap).declareTypes(fields);
         final List<KiePMMLDroolsRule> rules = new ArrayList<>();
         KiePMMLTreeModelNodeASTFactory.factory(fieldTypeMap, Collections.emptyList(), TreeModel.NoTrueChildStrategy.RETURN_NULL_PREDICTION, targetType).declareIntermediateRuleFromNode(finalNode, "_setosa", rules);
-        assertFalse(rules.isEmpty());
+        assertThat(rules).isNotEmpty();
     }
 
     @Test
@@ -123,10 +120,10 @@ public class KiePMMLTreeModelNodeASTFactoryTest {
         Node node = new LeafNode();
         DATA_TYPE targetType = DATA_TYPE.STRING;
         KiePMMLTreeModelNodeASTFactory.factory(new HashMap<>(), Collections.emptyList(), TreeModel.NoTrueChildStrategy.RETURN_NULL_PREDICTION, targetType).isFinalLeaf(node);
-        assertTrue(KiePMMLTreeModelNodeASTFactory.factory(new HashMap<>(), Collections.emptyList(), TreeModel.NoTrueChildStrategy.RETURN_NULL_PREDICTION, targetType).isFinalLeaf(node));
+        assertThat(KiePMMLTreeModelNodeASTFactory.factory(new HashMap<>(), Collections.emptyList(), TreeModel.NoTrueChildStrategy.RETURN_NULL_PREDICTION, targetType).isFinalLeaf(node)).isTrue();
         node = new ClassifierNode();
-        assertTrue(KiePMMLTreeModelNodeASTFactory.factory(new HashMap<>(), Collections.emptyList(), TreeModel.NoTrueChildStrategy.RETURN_NULL_PREDICTION, targetType).isFinalLeaf(node));
+        assertThat(KiePMMLTreeModelNodeASTFactory.factory(new HashMap<>(), Collections.emptyList(), TreeModel.NoTrueChildStrategy.RETURN_NULL_PREDICTION, targetType).isFinalLeaf(node)).isTrue();
         node.addNodes(new LeafNode());
-        assertFalse(KiePMMLTreeModelNodeASTFactory.factory(new HashMap<>(), Collections.emptyList(), TreeModel.NoTrueChildStrategy.RETURN_NULL_PREDICTION, targetType).isFinalLeaf(node));
+        assertThat(KiePMMLTreeModelNodeASTFactory.factory(new HashMap<>(), Collections.emptyList(), TreeModel.NoTrueChildStrategy.RETURN_NULL_PREDICTION, targetType).isFinalLeaf(node)).isFalse();
     }
 }

--- a/kie-pmml-trusty/kie-pmml-models/kie-pmml-models-drools/kie-pmml-models-drools-tree/kie-pmml-models-drools-tree-evaluator/src/test/java/org/kie/pmml/models/drools/tree/evaluator/PMMLTreeModelEvaluatorTest.java
+++ b/kie-pmml-trusty/kie-pmml-models/kie-pmml-models-drools/kie-pmml-models-drools-tree/kie-pmml-models-drools-tree-evaluator/src/test/java/org/kie/pmml/models/drools/tree/evaluator/PMMLTreeModelEvaluatorTest.java
@@ -44,9 +44,6 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
 import static org.kie.pmml.commons.Constants.PACKAGE_NAME;
 
 public class PMMLTreeModelEvaluatorTest {
@@ -78,8 +75,8 @@ public class PMMLTreeModelEvaluatorTest {
         evaluator = new PMMLTreeModelEvaluator();
         final PMML pmml = TestUtils.loadFromFile(SOURCE_1);
         assertThat(pmml).isNotNull();
-        assertEquals(1, pmml.getModels().size());
-        assertTrue(pmml.getModels().get(0) instanceof TreeModel);
+        assertThat(pmml.getModels()).hasSize(1);
+        assertThat(pmml.getModels().get(0)).isInstanceOf(TreeModel.class);
         KnowledgeBuilderImpl knowledgeBuilder = new KnowledgeBuilderImpl();
         final CommonCompilationDTO<TreeModel> compilationDTO =
                 CommonCompilationDTO.fromGeneratedPackageNameAndFields(PACKAGE_NAME,
@@ -97,7 +94,7 @@ public class PMMLTreeModelEvaluatorTest {
 
     @Test
     public void getPMMLModelType() {
-        assertEquals(PMML_MODEL.TREE_MODEL, evaluator.getPMMLModelType());
+        assertThat(evaluator.getPMMLModelType()).isEqualTo(PMML_MODEL.TREE_MODEL);
     }
 
     @Test
@@ -190,17 +187,17 @@ public class PMMLTreeModelEvaluatorTest {
         PMML4Result retrieved = evaluator.evaluate(kieBase, kiePMMLModel, pmmlContext);
         assertThat(retrieved).isNotNull();
         logger.trace(retrieved.toString());
-        assertEquals(TARGET_FIELD, retrieved.getResultObjectName());
+        assertThat(retrieved.getResultObjectName()).isEqualTo(TARGET_FIELD);
         final Map<String, Object> resultVariables = retrieved.getResultVariables();
         assertThat(resultVariables).isNotNull();
         if (expectedScore != null) {
-            assertEquals(ResultCode.OK.getName(), retrieved.getResultCode());
-            assertFalse(resultVariables.isEmpty());
-            assertTrue(resultVariables.containsKey(TARGET_FIELD));
-            assertEquals(expectedScore, resultVariables.get(TARGET_FIELD));
+            assertThat(retrieved.getResultCode()).isEqualTo(ResultCode.OK.getName());
+            assertThat(resultVariables).isNotEmpty();
+            assertThat(resultVariables).containsKey(TARGET_FIELD);
+            assertThat(resultVariables.get(TARGET_FIELD)).isEqualTo(expectedScore);
         } else {
-            assertEquals(ResultCode.FAIL.getName(), retrieved.getResultCode());
-            assertFalse(resultVariables.containsKey(TARGET_FIELD));
+        	assertThat(retrieved.getResultCode()).isEqualTo(ResultCode.FAIL.getName());
+        	assertThat(resultVariables).doesNotContainKey(TARGET_FIELD);
         }
     }
 

--- a/kie-pmml-trusty/kie-pmml-models/kie-pmml-models-mining/kie-pmml-models-mining-compiler/src/test/java/org/kie/pmml/models/mining/compiler/executor/MiningModelImplementationProviderTest.java
+++ b/kie-pmml-trusty/kie-pmml-models/kie-pmml-models-mining/kie-pmml-models-mining-compiler/src/test/java/org/kie/pmml/models/mining/compiler/executor/MiningModelImplementationProviderTest.java
@@ -40,10 +40,7 @@ import org.kie.pmml.models.mining.model.KiePMMLMiningModelWithSources;
 import org.kie.test.util.filesystem.FileUtils;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
+import static org.assertj.core.api.Assertions.fail;
 import static org.kie.pmml.commons.Constants.PACKAGE_NAME;
 
 public class MiningModelImplementationProviderTest {
@@ -58,7 +55,7 @@ public class MiningModelImplementationProviderTest {
 
     @Test
     public void getPMMLModelType() {
-        assertEquals(PMML_MODEL.MINING_MODEL, PROVIDER.getPMMLModelType());
+        assertThat(PROVIDER.getPMMLModelType()).isEqualTo(PMML_MODEL.MINING_MODEL);
     }
 
     @Test
@@ -134,7 +131,7 @@ public class MiningModelImplementationProviderTest {
                                                                        new HasKnowledgeBuilderMock(knowledgeBuilder));
         final KiePMMLMiningModel retrieved = PROVIDER.getKiePMMLModel(compilationDTO);
         assertThat(retrieved).isNotNull();
-        assertTrue(retrieved instanceof Serializable);
+        assertThat(retrieved).isInstanceOf(Serializable.class);
         commonVerifyIsDeepCloneable(retrieved);
     }
 
@@ -152,9 +149,9 @@ public class MiningModelImplementationProviderTest {
         assertThat(retrieved).isNotNull();
         commonVerifyIsDeepCloneable(retrieved);
         assertThat(retrieved.getNestedModels()).isNotNull();
-        assertFalse(retrieved.getNestedModels().isEmpty());
+        assertThat(retrieved.getNestedModels()).isNotEmpty();
         final Map<String, String> sourcesMap = new HashMap<>(retrieved.getSourcesMap());
-        assertFalse(sourcesMap.isEmpty());
+        assertThat(sourcesMap).isNotEmpty();
         try {
             KieMemoryCompiler.compile(sourcesMap, Thread.currentThread().getContextClassLoader());
             fail("Expecting compilation error without nested models sources");
@@ -173,13 +170,13 @@ public class MiningModelImplementationProviderTest {
         final FileInputStream fis = FileUtils.getFileInputStream(source);
         final PMML toReturn = KiePMMLUtil.load(fis, source);
         assertThat(toReturn).isNotNull();
-        assertEquals(1, toReturn.getModels().size());
-        assertTrue(toReturn.getModels().get(0) instanceof MiningModel);
+        assertThat(toReturn.getModels()).hasSize(1);
+        assertThat(toReturn.getModels().get(0)).isInstanceOf(MiningModel.class);
         return toReturn;
     }
 
     private void commonVerifyIsDeepCloneable(AbstractKiePMMLComponent toVerify) {
-        assertTrue(toVerify instanceof Serializable);
+        assertThat(toVerify).isInstanceOf(Serializable.class);
         ExternalizableMock externalizableMock = new ExternalizableMock();
         externalizableMock.setKiePMMLComponent(toVerify);
         ClassUtils.deepClone(externalizableMock);

--- a/kie-pmml-trusty/kie-pmml-models/kie-pmml-models-mining/kie-pmml-models-mining-compiler/src/test/java/org/kie/pmml/models/mining/compiler/factories/AbstractKiePMMLFactoryTest.java
+++ b/kie-pmml-trusty/kie-pmml-models/kie-pmml-models-mining/kie-pmml-models-mining-compiler/src/test/java/org/kie/pmml/models/mining/compiler/factories/AbstractKiePMMLFactoryTest.java
@@ -36,7 +36,6 @@ import org.kie.test.util.filesystem.FileUtils;
 import org.xml.sax.SAXException;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.Assert.assertTrue;
 import static org.kie.pmml.commons.Constants.PACKAGE_CLASS_TEMPLATE;
 import static org.kie.pmml.commons.Constants.PACKAGE_NAME;
 import static org.kie.pmml.commons.utils.KiePMMLModelUtils.getSanitizedClassName;
@@ -65,7 +64,7 @@ public abstract class AbstractKiePMMLFactoryTest {
         DATA_DICTIONARY = pmml.getDataDictionary();
         assertThat(DATA_DICTIONARY).isNotNull();
         TRANSFORMATION_DICTIONARY = pmml.getTransformationDictionary();
-        assertTrue(pmml.getModels().get(0) instanceof MiningModel);
+        assertThat(pmml.getModels().get(0)).isInstanceOf(MiningModel.class);
         MINING_MODEL = (MiningModel) pmml.getModels().get(0);
         assertThat(MINING_MODEL).isNotNull();
         populateMissingIds(MINING_MODEL);

--- a/kie-pmml-trusty/kie-pmml-models/kie-pmml-models-mining/kie-pmml-models-mining-compiler/src/test/java/org/kie/pmml/models/mining/compiler/factories/KiePMMLMiningModelFactoryTest.java
+++ b/kie-pmml-trusty/kie-pmml-models/kie-pmml-models-mining/kie-pmml-models-mining-compiler/src/test/java/org/kie/pmml/models/mining/compiler/factories/KiePMMLMiningModelFactoryTest.java
@@ -46,11 +46,9 @@ import org.kie.pmml.models.mining.compiler.dto.MiningModelCompilationDTO;
 import org.kie.pmml.models.mining.model.KiePMMLMiningModel;
 import org.xml.sax.SAXException;
 
-import static org.assertj.core.api.Assertions.assertThat;
 import static com.github.javaparser.StaticJavaParser.parseClassOrInterfaceType;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.fail;
 import static org.kie.pmml.commons.Constants.PACKAGE_CLASS_TEMPLATE;
 import static org.kie.pmml.commons.Constants.PACKAGE_NAME;
 import static org.kie.pmml.commons.utils.KiePMMLModelUtils.getSanitizedClassName;
@@ -84,9 +82,9 @@ public class KiePMMLMiningModelFactoryTest extends AbstractKiePMMLFactoryTest {
                 MiningModelCompilationDTO.fromCompilationDTO(source);
         final KiePMMLMiningModel retrieved = KiePMMLMiningModelFactory.getKiePMMLMiningModel(compilationDTO);
         assertThat(retrieved).isNotNull();
-        assertEquals(MINING_MODEL.getAlgorithmName(), retrieved.getAlgorithmName());
-        assertEquals(MINING_MODEL.isScorable(), retrieved.isScorable());
-        assertEquals(targetFieldName, retrieved.getTargetField());
+        assertThat(retrieved.getAlgorithmName()).isEqualTo(MINING_MODEL.getAlgorithmName());
+        assertThat(retrieved.isScorable()).isEqualTo(MINING_MODEL.isScorable());
+        assertThat(retrieved.getTargetField()).isEqualTo(targetFieldName);
     }
 
     @Test
@@ -103,7 +101,7 @@ public class KiePMMLMiningModelFactoryTest extends AbstractKiePMMLFactoryTest {
                 KiePMMLMiningModelFactory.getKiePMMLMiningModelSourcesMap(compilationDTO, nestedModels);
         assertThat(retrieved).isNotNull();
         int expectedNestedModels = MINING_MODEL.getSegmentation().getSegments().size();
-        assertEquals(expectedNestedModels, nestedModels.size());
+        assertThat(nestedModels).hasSize(expectedNestedModels);
     }
 
     @Test
@@ -132,14 +130,14 @@ public class KiePMMLMiningModelFactoryTest extends AbstractKiePMMLFactoryTest {
                 hasKnowledgeBuilderMock.getClassLoader().loadClass(expectedGeneratedClass);
                 fail("Expecting class not found: " + expectedGeneratedClass);
             } catch (Exception e) {
-                assertTrue(e instanceof ClassNotFoundException);
+                assertThat(e).isInstanceOf(ClassNotFoundException.class);
             }
         });
         final Map<String, String> retrieved =
                 KiePMMLMiningModelFactory.getKiePMMLMiningModelSourcesMapCompiled(compilationDTO, nestedModels);
         assertThat(retrieved).isNotNull();
         int expectedNestedModels = MINING_MODEL.getSegmentation().getSegments().size();
-        assertEquals(expectedNestedModels, nestedModels.size());
+        assertThat(nestedModels).hasSize(expectedNestedModels);
         expectedGeneratedClasses.forEach(expectedGeneratedClass -> {
             try {
                 hasKnowledgeBuilderMock.getClassLoader().loadClass(expectedGeneratedClass);
@@ -177,7 +175,7 @@ public class KiePMMLMiningModelFactoryTest extends AbstractKiePMMLFactoryTest {
         objectCreationExpr.setType(kiePMMLSegmentationClass);
         assignExpressionMap.put("segmentation", objectCreationExpr);
         ConstructorDeclaration constructorDeclaration = modelTemplate.getDefaultConstructor().get();
-        assertTrue(commonEvaluateConstructor(constructorDeclaration, getSanitizedClassName(MINING_MODEL.getModelName()),
-                                             superInvocationExpressionsMap, assignExpressionMap));
+        assertThat(commonEvaluateConstructor(constructorDeclaration, getSanitizedClassName(MINING_MODEL.getModelName()),
+                                             superInvocationExpressionsMap, assignExpressionMap)).isTrue();
     }
 }

--- a/kie-pmml-trusty/kie-pmml-models/kie-pmml-models-mining/kie-pmml-models-mining-compiler/src/test/java/org/kie/pmml/models/mining/compiler/factories/KiePMMLSegmentFactoryTest.java
+++ b/kie-pmml-trusty/kie-pmml-models/kie-pmml-models-mining/kie-pmml-models-mining-compiler/src/test/java/org/kie/pmml/models/mining/compiler/factories/KiePMMLSegmentFactoryTest.java
@@ -48,11 +48,9 @@ import org.kie.pmml.models.mining.compiler.dto.MiningModelCompilationDTO;
 import org.kie.pmml.models.mining.compiler.dto.SegmentCompilationDTO;
 import org.xml.sax.SAXException;
 
-import static org.assertj.core.api.Assertions.assertThat;
 import static com.github.javaparser.StaticJavaParser.parseClassOrInterfaceType;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.fail;
 import static org.kie.pmml.commons.Constants.PACKAGE_NAME;
 import static org.kie.pmml.compiler.commons.testutils.CodegenTestUtils.commonEvaluateConstructor;
 import static org.kie.pmml.compiler.commons.utils.JavaParserUtils.getFromFileName;
@@ -132,7 +130,7 @@ public class KiePMMLSegmentFactoryTest extends AbstractKiePMMLFactoryTest {
             hasKnowledgeBuilderMock.getClassLoader().loadClass(expectedNestedModelGeneratedClass);
             fail("Expecting class not found: " + expectedNestedModelGeneratedClass);
         } catch (Exception e) {
-            assertTrue(e instanceof ClassNotFoundException);
+            assertThat(e).isInstanceOf(ClassNotFoundException.class);
         }
         final CommonCompilationDTO<MiningModel> source =
                 CommonCompilationDTO.fromGeneratedPackageNameAndFields(PACKAGE_NAME,
@@ -194,8 +192,8 @@ public class KiePMMLSegmentFactoryTest extends AbstractKiePMMLFactoryTest {
         Map<String, Expression> assignExpressionMap = new HashMap<>();
         assignExpressionMap.put("weight", new DoubleLiteralExpr(weight));
         assignExpressionMap.put("id", new StringLiteralExpr(segmentName));
-        assertTrue(commonEvaluateConstructor(constructorDeclaration, generatedClassName,
-                                             superInvocationExpressionsMap, assignExpressionMap));
+        assertThat(commonEvaluateConstructor(constructorDeclaration, generatedClassName,
+                                             superInvocationExpressionsMap, assignExpressionMap)).isTrue();
     }
 
     @Test
@@ -222,7 +220,7 @@ public class KiePMMLSegmentFactoryTest extends AbstractKiePMMLFactoryTest {
         assignExpressionMap.put("id", new StringLiteralExpr(segmentName));
         String text = getFileContent(TEST_01_SOURCE);
         BlockStmt expected = JavaParserUtils.parseConstructorBlock(text);
-        assertTrue(JavaParserUtils.equalsNode(expected, constructorDeclaration.getBody()));
+        assertThat(JavaParserUtils.equalsNode(expected, constructorDeclaration.getBody())).isTrue();
     }
 
     private void commonEvaluateMap(final Map<String, String> toEvaluate, final Segment segment) {
@@ -230,7 +228,7 @@ public class KiePMMLSegmentFactoryTest extends AbstractKiePMMLFactoryTest {
     }
 
     private void commonEvaluateNestedModels(final List<KiePMMLModel> toEvaluate) {
-        assertFalse(toEvaluate.isEmpty());
-        toEvaluate.forEach(kiePMMLModel -> assertTrue(kiePMMLModel instanceof HasSourcesMap));
+        assertThat(toEvaluate).isNotEmpty();
+        toEvaluate.forEach(kiePMMLModel -> assertThat(kiePMMLModel instanceof HasSourcesMap).isTrue());
     }
 }

--- a/kie-pmml-trusty/kie-pmml-models/kie-pmml-models-mining/kie-pmml-models-mining-compiler/src/test/java/org/kie/pmml/models/mining/compiler/factories/KiePMMLSegmentationFactoryTest.java
+++ b/kie-pmml-trusty/kie-pmml-models/kie-pmml-models-mining/kie-pmml-models-mining-compiler/src/test/java/org/kie/pmml/models/mining/compiler/factories/KiePMMLSegmentationFactoryTest.java
@@ -34,9 +34,7 @@ import org.kie.pmml.models.mining.compiler.dto.MiningModelCompilationDTO;
 import org.xml.sax.SAXException;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
+import static org.assertj.core.api.Assertions.fail;
 import static org.kie.pmml.commons.Constants.PACKAGE_NAME;
 
 public class KiePMMLSegmentationFactoryTest extends AbstractKiePMMLFactoryTest {
@@ -60,7 +58,7 @@ public class KiePMMLSegmentationFactoryTest extends AbstractKiePMMLFactoryTest {
                                                                                                    nestedModels);
         assertThat(retrieved).isNotNull();
         int expectedNestedModels = MINING_MODEL.getSegmentation().getSegments().size();
-        assertEquals(expectedNestedModels, nestedModels.size());
+        assertThat(nestedModels).hasSize(expectedNestedModels);
     }
 
     @Test
@@ -81,14 +79,14 @@ public class KiePMMLSegmentationFactoryTest extends AbstractKiePMMLFactoryTest {
                 hasKnowledgeBuilderMock.getClassLoader().loadClass(expectedGeneratedClass);
                 fail("Expecting class not found: " + expectedGeneratedClass);
             } catch (Exception e) {
-                assertTrue(e instanceof ClassNotFoundException);
+                assertThat(e).isInstanceOf(ClassNotFoundException.class);
             }
         });
         final Map<String, String> retrieved =
                 KiePMMLSegmentationFactory.getSegmentationSourcesMapCompiled(compilationDTO, nestedModels);
         assertThat(retrieved).isNotNull();
         int expectedNestedModels = MINING_MODEL.getSegmentation().getSegments().size();
-        assertEquals(expectedNestedModels, nestedModels.size());
+        assertThat(nestedModels).hasSize(expectedNestedModels);
         expectedGeneratedClasses.forEach(expectedGeneratedClass -> {
             try {
                 hasKnowledgeBuilderMock.getClassLoader().loadClass(expectedGeneratedClass);

--- a/kie-pmml-trusty/kie-pmml-models/kie-pmml-models-mining/kie-pmml-models-mining-evaluator/src/test/java/org/kie/pmml/models/mining/evaluator/PMMLMiningModelEvaluatorTest.java
+++ b/kie-pmml-trusty/kie-pmml-models/kie-pmml-models-mining/kie-pmml-models-mining-evaluator/src/test/java/org/kie/pmml/models/mining/evaluator/PMMLMiningModelEvaluatorTest.java
@@ -25,6 +25,7 @@ import java.util.Set;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 
+import org.assertj.core.data.Offset;
 import org.junit.Before;
 import org.junit.Test;
 import org.kie.api.KieBase;
@@ -53,12 +54,7 @@ import org.kie.pmml.models.mining.model.segmentation.KiePMMLSegment;
 import org.kie.pmml.models.mining.model.segmentation.KiePMMLSegmentation;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNotEquals;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
+import static org.assertj.core.api.Assertions.fail;
 import static org.kie.pmml.api.enums.ResultCode.FAIL;
 import static org.kie.pmml.api.enums.ResultCode.OK;
 import static org.kie.pmml.models.mining.model.enums.MULTIPLE_MODEL_METHOD.AVERAGE;
@@ -100,7 +96,7 @@ public class PMMLMiningModelEvaluatorTest {
 
     @Test
     public void getPMMLModelType() {
-        assertEquals(PMML_MODEL.MINING_MODEL, evaluator.getPMMLModelType());
+        assertThat(evaluator.getPMMLModelType()).isEqualTo(PMML_MODEL.MINING_MODEL);
     }
 
     @Test
@@ -119,11 +115,11 @@ public class PMMLMiningModelEvaluatorTest {
         inputData.put("SECOND_KEY", new PMMLMiningModelEvaluator.KiePMMLNameValueProbabilityMapTuple(new KiePMMLNameValue("SECOND_NAME", "SECOND_VALUE"), new ArrayList<>()));
         PMML4Result retrieved = evaluator.getPMML4Result(kiePMMLMiningModel, inputData, new PMMLContextTest());
         assertThat(retrieved).isNotNull();
-        assertEquals(OK.getName(), retrieved.getResultCode());
-        assertEquals(targetField, retrieved.getResultObjectName());
+        assertThat(retrieved.getResultCode()).isEqualTo(OK.getName());
+        assertThat(retrieved.getResultObjectName()).isEqualTo(targetField);
         final Map<String, Object> resultVariables = retrieved.getResultVariables();
-        assertTrue(resultVariables.containsKey(targetField));
-        assertEquals(prediction, resultVariables.get(targetField));
+        assertThat(resultVariables).containsKey(targetField);
+        assertThat(resultVariables.get(targetField)).isEqualTo(prediction);
     }
 
     @Test
@@ -141,11 +137,11 @@ public class PMMLMiningModelEvaluatorTest {
         inputData.put("SECOND_KEY", new PMMLMiningModelEvaluator.KiePMMLNameValueProbabilityMapTuple(new KiePMMLNameValue("SECOND_NAME", "SECOND_VALUE"), new ArrayList<>()));
         PMML4Result retrieved = evaluator.getPMML4Result(kiePMMLMiningModel, inputData, new PMMLContextTest());
         assertThat(retrieved).isNotNull();
-        assertEquals(FAIL.getName(), retrieved.getResultCode());
-        assertEquals(targetField, retrieved.getResultObjectName());
+        assertThat(retrieved.getResultCode()).isEqualTo(FAIL.getName());
+        assertThat(retrieved.getResultObjectName()).isEqualTo(targetField);
         final Map<String, Object> resultVariables = retrieved.getResultVariables();
-        assertTrue(resultVariables.containsKey(targetField));
-        assertNull(resultVariables.get(targetField));
+        assertThat(resultVariables).containsKey(targetField);
+        assertThat(resultVariables.get(targetField)).isNull();
     }
 
     @Test
@@ -157,19 +153,19 @@ public class PMMLMiningModelEvaluatorTest {
         String containerModelName = "containerModelNameA";
         PMMLRuntime firstRetrieved = evaluator.getPMMLRuntime(kModulePackageName, kieBase, containerModelName);
         assertThat(firstRetrieved).isNotNull();
-        assertTrue(firstRetrieved instanceof PMMLRuntimeInternal);
+        assertThat(firstRetrieved).isInstanceOf(PMMLRuntimeInternal.class);
         PMMLRuntimeInternal firstPMMLRuntimeInternal = (PMMLRuntimeInternal) firstRetrieved;
         PMMLRuntime secondRetrieved = evaluator.getPMMLRuntime(kModulePackageName, kieBase, containerModelName);
-        assertTrue(secondRetrieved instanceof PMMLRuntimeInternal);
+        assertThat(secondRetrieved).isInstanceOf(PMMLRuntimeInternal.class);
         PMMLRuntimeInternal secondPMMLRuntimeInternal = (PMMLRuntimeInternal) secondRetrieved;
-        assertEquals(firstPMMLRuntimeInternal.getKnowledgeBase(), secondPMMLRuntimeInternal.getKnowledgeBase());
+        assertThat(secondPMMLRuntimeInternal.getKnowledgeBase()).isEqualTo(firstPMMLRuntimeInternal.getKnowledgeBase());
         kModulePackageName = "kModulePackageNameB";
         containerModelName = "containerModelNameB";
         PMMLRuntime thirdRetrieved = evaluator.getPMMLRuntime(kModulePackageName, kieBase, containerModelName);
         assertThat(thirdRetrieved).isNotNull();
-        assertTrue(thirdRetrieved instanceof PMMLRuntimeInternal);
+        assertThat(thirdRetrieved).isInstanceOf(PMMLRuntimeInternal.class);
         PMMLRuntimeInternal thirdPMMLRuntimeInternal = (PMMLRuntimeInternal) thirdRetrieved;
-        assertNotEquals(firstPMMLRuntimeInternal.getKnowledgeBase(), thirdPMMLRuntimeInternal.getKnowledgeBase());
+        assertThat(firstPMMLRuntimeInternal.getKnowledgeBase()).isNotEqualTo(thirdPMMLRuntimeInternal.getKnowledgeBase());
     }
 
     @Test
@@ -178,9 +174,9 @@ public class PMMLMiningModelEvaluatorTest {
         final PMML4Result pmml4Result = getPMML4Result(rawObject);
         RAW_OBJECT_METHODS.forEach(multipleModelMethod -> {
             KiePMMLNameValue retrieved = evaluator.getKiePMMLNameValue(pmml4Result, multipleModelMethod, 34.2);
-            assertEquals(pmml4Result.getResultObjectName(), retrieved.getName());
+            assertThat(retrieved.getName()).isEqualTo(pmml4Result.getResultObjectName());
             assertThat(retrieved.getValue()).isNotNull();
-            assertEquals(rawObject, retrieved.getValue());
+            assertThat(retrieved.getValue()).isEqualTo(rawObject);
         });
     }
 
@@ -193,12 +189,12 @@ public class PMMLMiningModelEvaluatorTest {
         VALUE_WEIGHT_METHODS.forEach(multipleModelMethod -> {
             KiePMMLNameValue retrieved = evaluator.getKiePMMLNameValue(pmml4Result, multipleModelMethod, weight);
             assertThat(retrieved).isNotNull();
-            assertEquals(pmml4Result.getResultObjectName(), retrieved.getName());
+            assertThat(retrieved.getName()).isEqualTo(pmml4Result.getResultObjectName());
             assertThat(retrieved.getValue()).isNotNull();
-            assertTrue(retrieved.getValue() instanceof KiePMMLValueWeight);
+            assertThat(retrieved.getValue()).isInstanceOf(KiePMMLValueWeight.class);
             KiePMMLValueWeight kiePMMLValueWeight = (KiePMMLValueWeight) retrieved.getValue();
-            assertEquals(expected, kiePMMLValueWeight.getValue(), 0.0);
-            assertEquals(weight, kiePMMLValueWeight.getWeight(), 0.0);
+            assertThat(kiePMMLValueWeight.getValue()).isCloseTo(expected, Offset.offset(0.0));
+            assertThat(kiePMMLValueWeight.getWeight()).isCloseTo(weight, Offset.offset(0.0));
         });
     }
 
@@ -234,7 +230,7 @@ public class PMMLMiningModelEvaluatorTest {
         RAW_OBJECT_METHODS.forEach(multipleModelMethod -> {
             Object retrieved = evaluator.getEventuallyWeightedResult(rawObject, multipleModelMethod, 34.2);
             assertThat(retrieved).isNotNull();
-            assertEquals(rawObject, retrieved);
+            assertThat(retrieved).isEqualTo(rawObject);
         });
     }
 
@@ -245,10 +241,10 @@ public class PMMLMiningModelEvaluatorTest {
         VALUE_WEIGHT_METHODS.forEach(multipleModelMethod -> {
             Object retrieved = evaluator.getEventuallyWeightedResult(rawObject, multipleModelMethod, weight);
             assertThat(retrieved).isNotNull();
-            assertTrue(retrieved instanceof KiePMMLValueWeight);
+            assertThat(retrieved).isInstanceOf(KiePMMLValueWeight.class);
             KiePMMLValueWeight kiePMMLValueWeight = (KiePMMLValueWeight) retrieved;
-            assertEquals(rawObject.doubleValue(), kiePMMLValueWeight.getValue(), 0.0);
-            assertEquals(weight, kiePMMLValueWeight.getWeight(), 0.0);
+            assertThat(kiePMMLValueWeight.getValue()).isCloseTo(rawObject.doubleValue(), Offset.offset(0.0));
+            assertThat(kiePMMLValueWeight.getWeight()).isCloseTo(weight, Offset.offset(0.0));
         });
     }
 
@@ -349,26 +345,26 @@ public class PMMLMiningModelEvaluatorTest {
         pmml4Result.getResultVariables().put(resultObjectName, resultObjectValue);
         PMMLStep retrieved = evaluator.getStep(segmentMock, pmml4Result);
         assertThat(retrieved).isNotNull();
-        assertTrue(retrieved instanceof PMMLMiningModelStep);
+        assertThat(retrieved).isInstanceOf(PMMLMiningModelStep.class);
         Map<String, Object> retrievedInfo = retrieved.getInfo();
         assertThat(retrievedInfo).isNotNull();
-        assertEquals(segmentName, retrievedInfo.get("SEGMENT"));
-        assertEquals(modelName, retrievedInfo.get("MODEL"));
-        assertEquals(resultCode.getName(), retrievedInfo.get("RESULT CODE"));
-        assertEquals(resultObjectValue, retrievedInfo.get("RESULT"));
+        assertThat(retrievedInfo.get("SEGMENT")).isEqualTo(segmentName);
+        assertThat(retrievedInfo.get("MODEL")).isEqualTo(modelName);
+        assertThat(retrievedInfo.get("RESULT CODE")).isEqualTo(resultCode.getName());
+        assertThat(retrievedInfo.get("RESULT")).isEqualTo(resultObjectValue);
 
         resultCode = FAIL;
         pmml4Result = new PMML4Result();
         pmml4Result.setResultCode(resultCode.getName());
         retrieved = evaluator.getStep(segmentMock, pmml4Result);
         assertThat(retrieved).isNotNull();
-        assertTrue(retrieved instanceof PMMLMiningModelStep);
+        assertThat(retrieved).isInstanceOf(PMMLMiningModelStep.class);
         retrievedInfo = retrieved.getInfo();
         assertThat(retrievedInfo).isNotNull();
-        assertEquals(segmentName, retrievedInfo.get("SEGMENT"));
-        assertEquals(modelName, retrievedInfo.get("MODEL"));
-        assertEquals(resultCode.getName(), retrievedInfo.get("RESULT CODE"));
-        assertFalse(retrievedInfo.containsKey("RESULT"));
+        assertThat(retrievedInfo.get("SEGMENT")).isEqualTo(segmentName);
+        assertThat(retrievedInfo.get("MODEL")).isEqualTo(modelName);
+        assertThat(retrievedInfo.get("RESULT CODE")).isEqualTo(resultCode.getName());
+        assertThat(retrievedInfo).doesNotContainKey("RESULT");
     }
 
     private PMML4Result getPMML4Result(Object rawObject) {

--- a/kie-pmml-trusty/kie-pmml-models/kie-pmml-models-mining/kie-pmml-models-mining-model/src/test/java/org/kie/pmml/models/mining/model/KiePMMLMiningModelTest.java
+++ b/kie-pmml-trusty/kie-pmml-models/kie-pmml-models-mining/kie-pmml-models-mining-model/src/test/java/org/kie/pmml/models/mining/model/KiePMMLMiningModelTest.java
@@ -26,10 +26,6 @@ import org.kie.pmml.commons.testingutility.PMMLContextTest;
 import org.kie.pmml.models.mining.model.segmentation.KiePMMLSegmentation;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertTrue;
 import static org.kie.pmml.models.mining.model.AbstractKiePMMLMiningModelTest.getKiePMMLSegmentation;
 
 public class KiePMMLMiningModelTest {
@@ -54,24 +50,24 @@ public class KiePMMLMiningModelTest {
 
     @Test
     public void getAlgorithmName() {
-        assertNull(KIE_PMML_MINING_MODEL.getAlgorithmName());
+        assertThat(KIE_PMML_MINING_MODEL.getAlgorithmName()).isNull();
         String algorithmName = "algorithmName";
         KIE_PMML_MINING_MODEL = BUILDER.withAlgorithmName(algorithmName).build();
-        assertEquals(algorithmName, KIE_PMML_MINING_MODEL.getAlgorithmName());
+        assertThat(KIE_PMML_MINING_MODEL.getAlgorithmName()).isEqualTo(algorithmName);
     }
 
     @Test
     public void isScorable() {
-        assertTrue(KIE_PMML_MINING_MODEL.isScorable());
+    	assertThat(KIE_PMML_MINING_MODEL.isScorable()).isTrue();
         KIE_PMML_MINING_MODEL = BUILDER.withScorable(false).build();
-        assertFalse(KIE_PMML_MINING_MODEL.isScorable());
+        assertThat(KIE_PMML_MINING_MODEL.isScorable()).isFalse();
     }
 
     @Test
     public void getSegmentation() {
-        assertNull(KIE_PMML_MINING_MODEL.getSegmentation());
+        assertThat(KIE_PMML_MINING_MODEL.getSegmentation()).isNull();
         final KiePMMLSegmentation segmentation = getKiePMMLSegmentation("SEGMENTATION_NAME");
         KIE_PMML_MINING_MODEL = BUILDER.withSegmentation(segmentation).build();
-        assertEquals(segmentation, KIE_PMML_MINING_MODEL.getSegmentation());
+        assertThat(KIE_PMML_MINING_MODEL.getSegmentation()).isEqualTo(segmentation);
     }
 }

--- a/kie-pmml-trusty/kie-pmml-models/kie-pmml-models-mining/kie-pmml-models-mining-model/src/test/java/org/kie/pmml/models/mining/model/enums/MULTIPLE_MODEL_METHODTest.java
+++ b/kie-pmml-trusty/kie-pmml-models/kie-pmml-models-mining/kie-pmml-models-mining-model/src/test/java/org/kie/pmml/models/mining/model/enums/MULTIPLE_MODEL_METHODTest.java
@@ -29,14 +29,13 @@ import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 import java.util.stream.Stream;
 
+import org.assertj.core.data.Offset;
 import org.junit.Test;
 import org.kie.pmml.api.exceptions.KieEnumException;
 import org.kie.pmml.commons.model.tuples.KiePMMLNameValue;
 import org.kie.pmml.commons.model.tuples.KiePMMLValueWeight;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
 import static org.kie.pmml.models.mining.model.enums.MULTIPLE_MODEL_METHOD.AVERAGE;
 import static org.kie.pmml.models.mining.model.enums.MULTIPLE_MODEL_METHOD.MAJORITY_VOTE;
 import static org.kie.pmml.models.mining.model.enums.MULTIPLE_MODEL_METHOD.MAX;
@@ -85,7 +84,7 @@ public class MULTIPLE_MODEL_METHODTest {
 
     @Test
     public void getName() {
-        EXISTING_VALUES.forEach((multipleModelMethod, s) -> assertEquals(s, multipleModelMethod.getName()));
+        EXISTING_VALUES.forEach((multipleModelMethod, s) -> assertThat(multipleModelMethod.getName()).isEqualTo(s));
     }
 
     @Test
@@ -98,7 +97,7 @@ public class MULTIPLE_MODEL_METHODTest {
         inputData.put("ValueD", new KiePMMLNameValue("valuex", EXPECTED));
         inputData.put("ValueE", new KiePMMLNameValue("valueb", 1));
         Object retrieved = MAJORITY_VOTE.applyPrediction(inputData);
-        assertEquals(EXPECTED, retrieved);
+        assertThat(retrieved).isEqualTo(EXPECTED);
         inputData = new LinkedHashMap<>();
         EXPECTED = "EXPECTED";
         inputData.put("ValueA", new KiePMMLNameValue("valuea", "dvsdv"));
@@ -107,7 +106,7 @@ public class MULTIPLE_MODEL_METHODTest {
         inputData.put("ValueD", new KiePMMLNameValue("valuex", EXPECTED));
         inputData.put("ValueE", new KiePMMLNameValue("valueb", "vsd"));
         retrieved = MAJORITY_VOTE.applyPrediction(inputData);
-        assertEquals(EXPECTED, retrieved);
+        assertThat(retrieved).isEqualTo(EXPECTED);
     }
 
     @Test(expected = KieEnumException.class)
@@ -129,13 +128,13 @@ public class MULTIPLE_MODEL_METHODTest {
         LinkedHashMap<String, KiePMMLNameValue> inputData =
                 (LinkedHashMap<String, KiePMMLNameValue>) expectedKiePMMLValueWeightMap.get("inputData");
         double retrieved = (Double) AVERAGE.applyPrediction(inputData);
-        assertEquals(average, retrieved,0.0000000000001);
+        assertThat(retrieved).isCloseTo(average, Offset.offset(0.0000000000001));
         expectedKiePMMLValueWeightMap = getExpectedKiePMMLValueWeightMap(false);
         average = (Double) expectedKiePMMLValueWeightMap.get("average");
         inputData =
                 (LinkedHashMap<String, KiePMMLNameValue>) expectedKiePMMLValueWeightMap.get("inputData");
         retrieved = (Double) AVERAGE.applyPrediction(inputData);
-        assertEquals(average, retrieved,0.0000000000001);
+        assertThat(retrieved).isCloseTo(average, Offset.offset(0.0000000000001));
     }
 
     @Test(expected = KieEnumException.class)
@@ -157,13 +156,13 @@ public class MULTIPLE_MODEL_METHODTest {
         LinkedHashMap<String, KiePMMLNameValue> inputData =
                 (LinkedHashMap<String, KiePMMLNameValue>) expectedKiePMMLValueWeightMap.get("inputData");
         double retrieved = (Double) WEIGHTED_AVERAGE.applyPrediction(inputData);
-        assertEquals(weightedAverage, retrieved,0.0000000000001);
+        assertThat(retrieved).isCloseTo(weightedAverage, Offset.offset(0.0000000000001));
         expectedKiePMMLValueWeightMap = getExpectedKiePMMLValueWeightMap(false);
         weightedAverage = (Double) expectedKiePMMLValueWeightMap.get("weightedAverage");
         inputData =
                 (LinkedHashMap<String, KiePMMLNameValue>) expectedKiePMMLValueWeightMap.get("inputData");
         retrieved = (Double) WEIGHTED_AVERAGE.applyPrediction(inputData);
-        assertEquals(weightedAverage, retrieved,0.0000000000001);
+        assertThat(retrieved).isCloseTo(weightedAverage, Offset.offset(0.0000000000001));
     }
 
     @Test(expected = KieEnumException.class)
@@ -185,13 +184,13 @@ public class MULTIPLE_MODEL_METHODTest {
         LinkedHashMap<String, KiePMMLNameValue> inputData =
                 (LinkedHashMap<String, KiePMMLNameValue>) expectedKiePMMLValueWeightMap.get("inputData");
         double retrieved = (Double) MEDIAN.applyPrediction(inputData);
-        assertEquals(median, retrieved,0.0000000000001);
+        assertThat(retrieved).isCloseTo(median, Offset.offset(0.0000000000001));
         expectedKiePMMLValueWeightMap = getExpectedKiePMMLValueWeightMap(false);
         median = (Double) expectedKiePMMLValueWeightMap.get("median");
         inputData =
                 (LinkedHashMap<String, KiePMMLNameValue>) expectedKiePMMLValueWeightMap.get("inputData");
         retrieved = (Double) MEDIAN.applyPrediction(inputData);
-        assertEquals(median, retrieved,0.0000000000001);
+        assertThat(retrieved).isCloseTo(median, Offset.offset(0.0000000000001));
     }
 
     @Test(expected = KieEnumException.class)
@@ -213,13 +212,13 @@ public class MULTIPLE_MODEL_METHODTest {
         LinkedHashMap<String, KiePMMLNameValue> inputData =
                 (LinkedHashMap<String, KiePMMLNameValue>) expectedKiePMMLValueWeightMap.get("inputData");
         double retrieved = (Double) WEIGHTED_MEDIAN.applyPrediction(inputData);
-        assertEquals(weightedMedian, retrieved,0.0000000000001);
+        assertThat(retrieved).isCloseTo(weightedMedian, Offset.offset(0.0000000000001));
         expectedKiePMMLValueWeightMap = getExpectedKiePMMLValueWeightMap(false);
         weightedMedian = (Double) expectedKiePMMLValueWeightMap.get("weightedMedian");
         inputData =
                 (LinkedHashMap<String, KiePMMLNameValue>) expectedKiePMMLValueWeightMap.get("inputData");
         retrieved = (Double)  WEIGHTED_MEDIAN.applyPrediction(inputData);
-        assertEquals(weightedMedian, retrieved,0.0000000000001);
+        assertThat(retrieved).isCloseTo(weightedMedian, Offset.offset(0.0000000000001));
     }
 
     @Test(expected = KieEnumException.class)
@@ -241,13 +240,13 @@ public class MULTIPLE_MODEL_METHODTest {
         LinkedHashMap<String, KiePMMLNameValue> inputData =
                 (LinkedHashMap<String, KiePMMLNameValue>) expectedKiePMMLValueWeightMap.get("inputData");
         double retrieved = (Double) MAX.applyPrediction(inputData);
-        assertEquals(max, retrieved,0.0000000000001);
+        assertThat(retrieved).isCloseTo(max, Offset.offset(0.0000000000001));
         expectedKiePMMLValueWeightMap = getExpectedKiePMMLValueWeightMap(false);
         max = (Double) expectedKiePMMLValueWeightMap.get("max");
         inputData =
                 (LinkedHashMap<String, KiePMMLNameValue>) expectedKiePMMLValueWeightMap.get("inputData");
         retrieved = (Double)  MAX.applyPrediction(inputData);
-        assertEquals(max, retrieved,0.0000000000001);
+        assertThat(retrieved).isCloseTo(max, Offset.offset(0.0000000000001));
     }
 
     @Test(expected = KieEnumException.class)
@@ -269,13 +268,13 @@ public class MULTIPLE_MODEL_METHODTest {
         LinkedHashMap<String, KiePMMLNameValue> inputData =
                 (LinkedHashMap<String, KiePMMLNameValue>) expectedKiePMMLValueWeightMap.get("inputData");
         double retrieved = (Double) SUM.applyPrediction(inputData);
-        assertEquals(sum, retrieved,0.0000000000001);
+        assertThat(retrieved).isCloseTo(sum, Offset.offset(0.0000000000001));
         expectedKiePMMLValueWeightMap = getExpectedKiePMMLValueWeightMap(false);
         sum = (Double) expectedKiePMMLValueWeightMap.get("sum");
         inputData =
                 (LinkedHashMap<String, KiePMMLNameValue>) expectedKiePMMLValueWeightMap.get("inputData");
         retrieved = (Double)  SUM.applyPrediction(inputData);
-        assertEquals(sum, retrieved,0.0000000000001);
+        assertThat(retrieved).isCloseTo(sum, Offset.offset(0.0000000000001));
     }
 
     @Test(expected = KieEnumException.class)
@@ -297,13 +296,13 @@ public class MULTIPLE_MODEL_METHODTest {
         LinkedHashMap<String, KiePMMLNameValue> inputData =
                 (LinkedHashMap<String, KiePMMLNameValue>) expectedKiePMMLValueWeightMap.get("inputData");
         double retrieved = (Double) WEIGHTED_SUM.applyPrediction(inputData);
-        assertEquals(weightsSum, retrieved,0.0000000000001);
+        assertThat(retrieved).isCloseTo(weightsSum, Offset.offset(0.0000000000001));
         expectedKiePMMLValueWeightMap = getExpectedKiePMMLValueWeightMap(false);
         weightsSum = (Double) expectedKiePMMLValueWeightMap.get("weightedSum");
         inputData =
                 (LinkedHashMap<String, KiePMMLNameValue>) expectedKiePMMLValueWeightMap.get("inputData");
         retrieved = (Double)  WEIGHTED_SUM.applyPrediction(inputData);
-        assertEquals(weightsSum, retrieved,0.0000000000001);
+        assertThat(retrieved).isCloseTo(weightsSum, Offset.offset(0.0000000000001));
     }
 
     @Test(expected = KieEnumException.class)
@@ -325,13 +324,13 @@ public class MULTIPLE_MODEL_METHODTest {
                 (LinkedHashMap<String, KiePMMLNameValue>) expectedKiePMMLValueWeightMap.get("inputData");
         double first = ((KiePMMLValueWeight) inputData.entrySet().iterator().next().getValue().getValue()).getValue();
         double retrieved = (Double) SELECT_FIRST.applyPrediction(inputData);
-        assertEquals(first, retrieved,0.0000000000001);
+        assertThat(retrieved).isCloseTo(first, Offset.offset(0.0000000000001));
         expectedKiePMMLValueWeightMap = getExpectedKiePMMLValueWeightMap(false);
         inputData =
                 (LinkedHashMap<String, KiePMMLNameValue>) expectedKiePMMLValueWeightMap.get("inputData");
         first = ((KiePMMLValueWeight) inputData.entrySet().iterator().next().getValue().getValue()).getValue();
         retrieved = (Double)  SELECT_FIRST.applyPrediction(inputData);
-        assertEquals(first, retrieved,0.0000000000001);
+        assertThat(retrieved).isCloseTo(first, Offset.offset(0.0000000000001));
     }
 
     @Test
@@ -344,7 +343,7 @@ public class MULTIPLE_MODEL_METHODTest {
         inputData.put("ValueD", new KiePMMLNameValue("valuex", "vfdsvsdeeee"));
         inputData.put("ValueE", new KiePMMLNameValue("valueb", "vsd"));
         Object retrieved =  SELECT_FIRST.applyPrediction(inputData);
-        assertEquals(EXPECTED, retrieved);
+        assertThat(retrieved).isEqualTo(EXPECTED);
     }
 
     @Test
@@ -357,9 +356,9 @@ public class MULTIPLE_MODEL_METHODTest {
                 .map(kiePMMLNameValue -> ((KiePMMLValueWeight)kiePMMLNameValue.getValue()).getValue())
                 .collect(Collectors.toList());
         List retrieved = (List) SELECT_ALL.applyPrediction(inputData);
-        assertEquals(expected.size(), retrieved.size());
+        assertThat(retrieved).hasSameSizeAs(expected);
         for (Double expDouble : expected) {
-            assertTrue(retrieved.contains(expDouble));
+            assertThat(retrieved).contains(expDouble);
         }
         expectedKiePMMLValueWeightMap = getExpectedKiePMMLValueWeightMap(false);
         inputData =
@@ -369,9 +368,9 @@ public class MULTIPLE_MODEL_METHODTest {
                 .map(kiePMMLNameValue -> ((KiePMMLValueWeight)kiePMMLNameValue.getValue()).getValue())
                 .collect(Collectors.toList());
         retrieved = (List) SELECT_ALL.applyPrediction(inputData);
-        assertEquals(expected.size(), retrieved.size());
+        assertThat(retrieved).hasSameSizeAs(expected);
         for (Double expDouble : expected) {
-            assertTrue(retrieved.contains(expDouble));
+            assertThat(retrieved).contains(expDouble);
         }
     }
 
@@ -385,8 +384,8 @@ public class MULTIPLE_MODEL_METHODTest {
         inputData.put("ValueE", new KiePMMLNameValue("valueb", "vsd"));
         List expected = inputData.values().stream().map(KiePMMLNameValue::getValue).collect(Collectors.toList());
         List retrieved = (List) SELECT_ALL.applyPrediction(inputData);
-        assertEquals(expected.size(), retrieved.size());
-        expected.forEach(expString -> assertTrue(retrieved.contains(expString)));
+        assertThat(retrieved).hasSameSizeAs(expected);
+        expected.forEach(expString -> assertThat(retrieved).contains(expString));
     }
 
     @Test(expected = KieEnumException.class)

--- a/kie-pmml-trusty/kie-pmml-models/kie-pmml-models-mining/kie-pmml-models-mining-model/src/test/java/org/kie/pmml/models/mining/model/segmentation/KiePMMLSegmentTest.java
+++ b/kie-pmml-trusty/kie-pmml-models/kie-pmml-models-mining/kie-pmml-models-mining-model/src/test/java/org/kie/pmml/models/mining/model/segmentation/KiePMMLSegmentTest.java
@@ -18,13 +18,13 @@ package org.kie.pmml.models.mining.model.segmentation;
 
 import java.util.Collections;
 
+import org.assertj.core.data.Offset;
 import org.junit.BeforeClass;
 import org.junit.Test;
 import org.kie.pmml.commons.model.KiePMMLModel;
 import org.kie.pmml.commons.model.predicates.KiePMMLPredicate;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.Assert.assertEquals;
 import static org.kie.pmml.models.mining.model.AbstractKiePMMLMiningModelTest.getKiePMMLModel;
 import static org.kie.pmml.models.mining.model.AbstractKiePMMLMiningModelTest.getKiePMMLSimplePredicate;
 
@@ -50,19 +50,19 @@ public class KiePMMLSegmentTest {
     @Test
     public void getWeight() {
         final double weight = 33.45;
-        assertEquals(1.0, KIE_PMML_SEGMENT.getWeight(), 0.0);
+        assertThat(KIE_PMML_SEGMENT.getWeight()).isCloseTo(1.0, Offset.offset(0.0));
         KIE_PMML_SEGMENT = BUILDER.withWeight(weight).build();
-        assertEquals(weight, KIE_PMML_SEGMENT.getWeight(), 0.0);
+        assertThat(KIE_PMML_SEGMENT.getWeight()).isCloseTo(weight, Offset.offset(0.0));
     }
 
     @Test
     public void getKiePMMLPredicate() {
-        assertEquals(KIE_PMML_PREDICATE, KIE_PMML_SEGMENT.getKiePMMLPredicate());
+        assertThat(KIE_PMML_SEGMENT.getKiePMMLPredicate()).isEqualTo(KIE_PMML_PREDICATE);
     }
 
     @Test
     public void getModel() {
-        assertEquals(KIE_PMML_MODEL, KIE_PMML_SEGMENT.getModel());
+        assertThat(KIE_PMML_SEGMENT.getModel()).isEqualTo(KIE_PMML_MODEL);
     }
 
 

--- a/kie-pmml-trusty/kie-pmml-models/kie-pmml-models-mining/kie-pmml-models-mining-model/src/test/java/org/kie/pmml/models/mining/model/segmentation/KiePMMLSegmentationTest.java
+++ b/kie-pmml-trusty/kie-pmml-models/kie-pmml-models-mining/kie-pmml-models-mining-model/src/test/java/org/kie/pmml/models/mining/model/segmentation/KiePMMLSegmentationTest.java
@@ -24,8 +24,6 @@ import org.junit.Test;
 import org.kie.pmml.models.mining.model.enums.MULTIPLE_MODEL_METHOD;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNull;
 import static org.kie.pmml.models.mining.model.AbstractKiePMMLMiningModelTest.getKiePMMLSegments;
 
 public class KiePMMLSegmentationTest {
@@ -46,15 +44,15 @@ public class KiePMMLSegmentationTest {
 
     @Test
     public void getMultipleModelMethod() {
-        assertEquals(MULTIPLE_MODELMETHOD, KIE_PMML_SEGMENTATION.getMultipleModelMethod());
+        assertThat(KIE_PMML_SEGMENTATION.getMultipleModelMethod()).isEqualTo(MULTIPLE_MODELMETHOD);
     }
 
     @Test
     public void getSegments() {
-        assertNull(KIE_PMML_SEGMENTATION.getSegments());
+        assertThat(KIE_PMML_SEGMENTATION.getSegments()).isNull();
         final List<KiePMMLSegment> segments = getKiePMMLSegments();
         KIE_PMML_SEGMENTATION = BUILDER.withSegments(segments).build();
-        assertEquals(segments, KIE_PMML_SEGMENTATION.getSegments());
+        assertThat(KIE_PMML_SEGMENTATION.getSegments()).isEqualTo(segments);
     }
 
 

--- a/kie-pmml-trusty/kie-pmml-models/kie-pmml-models-mining/kie-pmml-models-mining-tests/src/test/java/org/kie/pmml/mining/tests/MiningListenerTest.java
+++ b/kie-pmml-trusty/kie-pmml-models/kie-pmml-models-mining/kie-pmml-models-mining-tests/src/test/java/org/kie/pmml/mining/tests/MiningListenerTest.java
@@ -35,8 +35,7 @@ import org.kie.pmml.api.runtime.PMMLRuntime;
 import org.kie.pmml.evaluator.core.implementations.PMMLRuntimeStep;
 import org.kie.pmml.models.tests.AbstractPMMLTest;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
+import static org.assertj.core.api.Assertions.assertThat;
 
 @RunWith(Parameterized.class)
 public class MiningListenerTest extends AbstractPMMLTest {
@@ -107,9 +106,9 @@ public class MiningListenerTest extends AbstractPMMLTest {
 
     private void commonValidateStep(final PMMLStep toValidate) {
         Map<String, Object> retrieved = toValidate.getInfo();
-        assertTrue(retrieved.containsKey("SEGMENT"));
-        assertTrue(retrieved.containsKey("RESULT CODE"));
-        assertTrue(retrieved.containsKey("MODEL"));
-        assertTrue(retrieved.containsKey("RESULT"));
+        assertThat(retrieved.containsKey("SEGMENT")).isTrue();
+        assertThat(retrieved.containsKey("RESULT CODE")).isTrue();
+        assertThat(retrieved.containsKey("MODEL")).isTrue();
+        assertThat(retrieved.containsKey("RESULT")).isTrue();
     }
 }

--- a/kie-pmml-trusty/kie-pmml-models/kie-pmml-models-regression/kie-pmml-models-regression-compiler/src/test/java/org/kie/pmml/models/regression/compiler/executor/RegressionModelImplementationProviderTest.java
+++ b/kie-pmml-trusty/kie-pmml-models/kie-pmml-models-regression/kie-pmml-models-regression-compiler/src/test/java/org/kie/pmml/models/regression/compiler/executor/RegressionModelImplementationProviderTest.java
@@ -35,6 +35,7 @@ import org.kie.pmml.compiler.commons.mocks.HasClassLoaderMock;
 import org.kie.pmml.models.regression.model.KiePMMLRegressionModel;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.fail;
 import static org.dmg.pmml.regression.RegressionModel.NormalizationMethod.CAUCHIT;
 import static org.dmg.pmml.regression.RegressionModel.NormalizationMethod.CLOGLOG;
 import static org.dmg.pmml.regression.RegressionModel.NormalizationMethod.EXP;
@@ -43,10 +44,6 @@ import static org.dmg.pmml.regression.RegressionModel.NormalizationMethod.LOGLOG
 import static org.dmg.pmml.regression.RegressionModel.NormalizationMethod.NONE;
 import static org.dmg.pmml.regression.RegressionModel.NormalizationMethod.PROBIT;
 import static org.dmg.pmml.regression.RegressionModel.NormalizationMethod.SOFTMAX;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
 import static org.kie.pmml.compiler.api.CommonTestingUtils.getFieldsFromDataDictionary;
 
 public class RegressionModelImplementationProviderTest {
@@ -68,15 +65,15 @@ public class RegressionModelImplementationProviderTest {
 
     @Test
     public void getPMMLModelType() {
-        assertEquals(PMML_MODEL.REGRESSION_MODEL, PROVIDER.getPMMLModelType());
+        assertThat(PROVIDER.getPMMLModelType()).isEqualTo(PMML_MODEL.REGRESSION_MODEL);
     }
 
     @Test
     public void getKiePMMLModel() throws Exception {
         final PMML pmml = TestUtils.loadFromFile(SOURCE_1);
         assertThat(pmml).isNotNull();
-        assertEquals(1, pmml.getModels().size());
-        assertTrue(pmml.getModels().get(0) instanceof RegressionModel);
+        assertThat(pmml.getModels()).hasSize(1);
+        assertThat(pmml.getModels().get(0)).isInstanceOf(RegressionModel.class);
         RegressionModel regressionModel = (RegressionModel) pmml.getModels().get(0);
         final CommonCompilationDTO<RegressionModel> compilationDTO =
                 CommonCompilationDTO.fromGeneratedPackageNameAndFields(PACKAGE_NAME,
@@ -85,15 +82,15 @@ public class RegressionModelImplementationProviderTest {
                                                                        new HasClassLoaderMock());
         final KiePMMLRegressionModel retrieved = PROVIDER.getKiePMMLModel(compilationDTO);
         assertThat(retrieved).isNotNull();
-        assertTrue(retrieved instanceof Serializable);
+        assertThat(retrieved).isInstanceOf(Serializable.class);
     }
 
     @Test
     public void getKiePMMLModelWithSources() throws Exception {
         final PMML pmml = TestUtils.loadFromFile(SOURCE_1);
         assertThat(pmml).isNotNull();
-        assertEquals(1, pmml.getModels().size());
-        assertTrue(pmml.getModels().get(0) instanceof RegressionModel);
+        assertThat(pmml.getModels()).hasSize(1);
+        assertThat(pmml.getModels().get(0)).isInstanceOf(RegressionModel.class);
         RegressionModel regressionModel = (RegressionModel) pmml.getModels().get(0);
         final CommonCompilationDTO<RegressionModel> compilationDTO =
                 CommonCompilationDTO.fromGeneratedPackageNameAndFields(PACKAGE_NAME,
@@ -104,11 +101,11 @@ public class RegressionModelImplementationProviderTest {
         assertThat(retrieved).isNotNull();
         final Map<String, String> sourcesMap = retrieved.getSourcesMap();
         assertThat(sourcesMap).isNotNull();
-        assertFalse(sourcesMap.isEmpty());
+        assertThat(sourcesMap).isNotEmpty();
         ClassLoader classLoader = Thread.currentThread().getContextClassLoader();
         final Map<String, Class<?>> compiled = KieMemoryCompiler.compile(sourcesMap, classLoader);
         for (Class<?> clazz : compiled.values()) {
-            assertTrue(clazz instanceof Serializable);
+            assertThat(clazz).isInstanceOf(Serializable.class);
         }
     }
 
@@ -145,8 +142,8 @@ public class RegressionModelImplementationProviderTest {
     public void validateNoRegressionTables() throws Exception {
         final PMML pmml = TestUtils.loadFromFile(SOURCE_1);
         assertThat(pmml).isNotNull();
-        assertEquals(1, pmml.getModels().size());
-        assertTrue(pmml.getModels().get(0) instanceof RegressionModel);
+        assertThat(pmml.getModels()).hasSize(1);
+        assertThat(pmml.getModels().get(0)).isInstanceOf(RegressionModel.class);
         RegressionModel regressionModel = (RegressionModel) pmml.getModels().get(0);
         regressionModel.getRegressionTables().clear();
         final List<Field<?>> fields = getFieldsFromDataDictionary(pmml.getDataDictionary());
@@ -169,8 +166,8 @@ public class RegressionModelImplementationProviderTest {
     private void commonValidateSource(String sourceFile) throws Exception {
         final PMML pmml = TestUtils.loadFromFile(sourceFile);
         assertThat(pmml).isNotNull();
-        assertEquals(1, pmml.getModels().size());
-        assertTrue(pmml.getModels().get(0) instanceof RegressionModel);
+        assertThat(pmml.getModels()).hasSize(1);
+        assertThat(pmml.getModels().get(0)).isInstanceOf(RegressionModel.class);
         PROVIDER.validate(getFieldsFromDataDictionary(pmml.getDataDictionary()), (RegressionModel) pmml.getModels().get(0));
     }
 }

--- a/kie-pmml-trusty/kie-pmml-models/kie-pmml-models-regression/kie-pmml-models-regression-compiler/src/test/java/org/kie/pmml/models/regression/compiler/factories/AbstractKiePMMLRegressionTableRegressionFactoryTest.java
+++ b/kie-pmml-trusty/kie-pmml-models/kie-pmml-models-regression/kie-pmml-models-regression-compiler/src/test/java/org/kie/pmml/models/regression/compiler/factories/AbstractKiePMMLRegressionTableRegressionFactoryTest.java
@@ -23,15 +23,15 @@ import java.util.stream.IntStream;
 
 import com.github.javaparser.StaticJavaParser;
 import com.github.javaparser.ast.CompilationUnit;
-import com.github.javaparser.ast.validator.language_level_validations.Java8Validator;
 import com.github.javaparser.ast.validator.ProblemReporter;
+import com.github.javaparser.ast.validator.language_level_validations.Java8Validator;
 import org.dmg.pmml.regression.CategoricalPredictor;
 import org.dmg.pmml.regression.NumericPredictor;
 import org.dmg.pmml.regression.PredictorTerm;
 import org.dmg.pmml.regression.RegressionTable;
 import org.kie.pmml.compiler.api.testutils.PMMLModelTestUtils;
 
-import static org.junit.Assert.fail;
+import static org.assertj.core.api.Assertions.fail;
 import static org.kie.pmml.compiler.api.testutils.PMMLModelTestUtils.getCategoricalPredictor;
 import static org.kie.pmml.compiler.api.testutils.PMMLModelTestUtils.getNumericPredictor;
 import static org.kie.pmml.compiler.api.testutils.PMMLModelTestUtils.getPredictorTerm;

--- a/kie-pmml-trusty/kie-pmml-models/kie-pmml-models-regression/kie-pmml-models-regression-compiler/src/test/java/org/kie/pmml/models/regression/compiler/factories/KiePMMLClassificationTableFactoryTest.java
+++ b/kie-pmml-trusty/kie-pmml-models/kie-pmml-models-regression/kie-pmml-models-regression-compiler/src/test/java/org/kie/pmml/models/regression/compiler/factories/KiePMMLClassificationTableFactoryTest.java
@@ -120,7 +120,7 @@ public class KiePMMLClassificationTableFactoryTest extends AbstractKiePMMLRegres
         KiePMMLClassificationTable retrieved =
                 KiePMMLClassificationTableFactory.getClassificationTable(compilationDTO);
         assertThat(retrieved).isNotNull();
-        assertThat(retrieved.getCategoryTableMap().size()).isEqualTo(regressionModel.getRegressionTables().size());
+        assertThat(retrieved.getCategoryTableMap()).hasSameSizeAs(regressionModel.getRegressionTables());
         regressionModel.getRegressionTables().forEach(regressionTable ->
                                                               assertThat(retrieved.getCategoryTableMap()).containsKey(regressionTable.getTargetCategory().toString()));
         assertThat(retrieved.getRegressionNormalizationMethod().getName()).isEqualTo(regressionModel.getNormalizationMethod().value());

--- a/kie-pmml-trusty/kie-pmml-models/kie-pmml-models-regression/kie-pmml-models-regression-compiler/src/test/java/org/kie/pmml/models/regression/compiler/factories/KiePMMLClassificationTableFactoryTest.java
+++ b/kie-pmml-trusty/kie-pmml-models/kie-pmml-models-regression/kie-pmml-models-regression-compiler/src/test/java/org/kie/pmml/models/regression/compiler/factories/KiePMMLClassificationTableFactoryTest.java
@@ -50,9 +50,7 @@ import org.kie.pmml.models.regression.model.KiePMMLClassificationTable;
 import org.kie.pmml.models.regression.model.tuples.KiePMMLTableSourceCategory;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
+import static org.assertj.core.api.Assertions.fail;
 import static org.kie.pmml.commons.Constants.PACKAGE_NAME;
 import static org.kie.pmml.commons.utils.KiePMMLModelUtils.getGeneratedClassName;
 import static org.kie.pmml.compiler.commons.testutils.CodegenTestUtils.commonValidateCompilation;
@@ -122,16 +120,15 @@ public class KiePMMLClassificationTableFactoryTest extends AbstractKiePMMLRegres
         KiePMMLClassificationTable retrieved =
                 KiePMMLClassificationTableFactory.getClassificationTable(compilationDTO);
         assertThat(retrieved).isNotNull();
-        assertEquals(regressionModel.getRegressionTables().size(), retrieved.getCategoryTableMap().size());
+        assertThat(retrieved.getCategoryTableMap().size()).isEqualTo(regressionModel.getRegressionTables().size());
         regressionModel.getRegressionTables().forEach(regressionTable ->
-                                                              assertTrue(retrieved.getCategoryTableMap().containsKey(regressionTable.getTargetCategory().toString())));
-        assertEquals(regressionModel.getNormalizationMethod().value(),
-                     retrieved.getRegressionNormalizationMethod().getName());
-        assertEquals(OP_TYPE.CATEGORICAL, retrieved.getOpType());
+                                                              assertThat(retrieved.getCategoryTableMap()).containsKey(regressionTable.getTargetCategory().toString()));
+        assertThat(retrieved.getRegressionNormalizationMethod().getName()).isEqualTo(regressionModel.getNormalizationMethod().value());
+        assertThat(retrieved.getOpType()).isEqualTo(OP_TYPE.CATEGORICAL);
         boolean isBinary = regressionModel.getRegressionTables().size() == 2;
-        assertEquals(isBinary, retrieved.isBinary());
-        assertEquals(isBinary, retrieved.isBinary());
-        assertEquals(targetMiningField.getName().getValue(), retrieved.getTargetField());
+        assertThat(retrieved.isBinary()).isEqualTo(isBinary);
+        assertThat(retrieved.isBinary()).isEqualTo(isBinary);
+        assertThat(retrieved.getTargetField()).isEqualTo(targetMiningField.getName().getValue());
     }
 
     @Test
@@ -176,7 +173,7 @@ public class KiePMMLClassificationTableFactoryTest extends AbstractKiePMMLRegres
         Map<String, KiePMMLTableSourceCategory> retrieved =
                 KiePMMLClassificationTableFactory.getClassificationTableBuilders(compilationDTO);
         assertThat(retrieved).isNotNull();
-        assertEquals(3, retrieved.size());
+        assertThat(retrieved).hasSize(3);
         retrieved.values().forEach(kiePMMLTableSourceCategory -> commonValidateKiePMMLRegressionTable(kiePMMLTableSourceCategory.getSource()));
 
         Map<String, String> sources = retrieved.entrySet().stream().collect(Collectors.toMap(Map.Entry::getKey,
@@ -244,18 +241,18 @@ public class KiePMMLClassificationTableFactoryTest extends AbstractKiePMMLRegres
             try {
                 KiePMMLClassificationTableFactory.getProbabilityMapFunction(normalizationMethod, false);
             } catch (Throwable t) {
-                assertTrue(t instanceof KiePMMLInternalException);
+                assertThat(t).isInstanceOf(KiePMMLInternalException.class);
                 String expected = String.format("Unsupported NormalizationMethod %s",
                                                 normalizationMethod);
-                assertEquals(expected, t.getMessage());
+                assertThat(t.getMessage()).isEqualTo(expected);
             }
             try {
                 KiePMMLClassificationTableFactory.getProbabilityMapFunction(normalizationMethod, true);
             } catch (Throwable t) {
-                assertTrue(t instanceof KiePMMLInternalException);
+                assertThat(t).isInstanceOf(KiePMMLInternalException.class);
                 String expected = String.format("Unsupported NormalizationMethod %s",
                                                 normalizationMethod);
-                assertEquals(expected, t.getMessage());
+                assertThat(t.getMessage()).isEqualTo(expected);
             }
         });
     }
@@ -325,7 +322,7 @@ public class KiePMMLClassificationTableFactoryTest extends AbstractKiePMMLRegres
                                                           variableName);
         String text = getFileContent(TEST_02_SOURCE);
         MethodDeclaration expected = JavaParserUtils.parseMethod(text);
-        assertTrue(JavaParserUtils.equalsNode(expected, staticGetterMethod));
+        assertThat(JavaParserUtils.equalsNode(expected, staticGetterMethod)).isTrue();
     }
 
     @Test
@@ -338,7 +335,7 @@ public class KiePMMLClassificationTableFactoryTest extends AbstractKiePMMLRegres
                 String text = getFileContent(TEST_01_SOURCE);
                 Expression expected = JavaParserUtils.parseExpression(String.format(text,
                                                                                     normalizationMethod.name()));
-                assertTrue(JavaParserUtils.equalsNode(expected, retrieved));
+                assertThat(JavaParserUtils.equalsNode(expected, retrieved)).isTrue();
             } catch (IOException e) {
                 fail(e.getMessage());
             }
@@ -353,7 +350,7 @@ public class KiePMMLClassificationTableFactoryTest extends AbstractKiePMMLRegres
                                                                                       false);
                 fail("Expecting KiePMMLInternalException with normalizationMethod " + normalizationMethod);
             } catch (Exception e) {
-                assertTrue(e instanceof KiePMMLInternalException);
+                assertThat(e).isInstanceOf(KiePMMLInternalException.class);
             }
         });
     }
@@ -365,7 +362,7 @@ public class KiePMMLClassificationTableFactoryTest extends AbstractKiePMMLRegres
         String text = getFileContent(TEST_01_SOURCE);
         Expression expected = JavaParserUtils.parseExpression(String.format(text,
                                                                             RegressionModel.NormalizationMethod.CAUCHIT.name()));
-        assertTrue(JavaParserUtils.equalsNode(expected, retrieved));
+        assertThat(JavaParserUtils.equalsNode(expected, retrieved)).isTrue();
     }
 
     private OutputField getOutputField(String name, ResultFeature resultFeature, String targetField) {

--- a/kie-pmml-trusty/kie-pmml-models/kie-pmml-models-regression/kie-pmml-models-regression-compiler/src/test/java/org/kie/pmml/models/regression/compiler/factories/KiePMMLRegressionModelFactoryTest.java
+++ b/kie-pmml-trusty/kie-pmml-models/kie-pmml-models-regression/kie-pmml-models-regression-compiler/src/test/java/org/kie/pmml/models/regression/compiler/factories/KiePMMLRegressionModelFactoryTest.java
@@ -69,8 +69,6 @@ import org.kie.pmml.models.regression.model.enums.REGRESSION_NORMALIZATION_METHO
 import org.kie.pmml.models.regression.model.tuples.KiePMMLTableSourceCategory;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
 import static org.kie.pmml.commons.Constants.GET_MODEL;
 import static org.kie.pmml.commons.Constants.PACKAGE_NAME;
 import static org.kie.pmml.compiler.api.testutils.PMMLModelTestUtils.getCategoricalPredictor;
@@ -163,13 +161,12 @@ public class KiePMMLRegressionModelFactoryTest {
         KiePMMLRegressionModel retrieved =
                 KiePMMLRegressionModelFactory.getKiePMMLRegressionModelClasses(RegressionCompilationDTO.fromCompilationDTO(compilationDTO));
         assertThat(retrieved).isNotNull();
-        assertEquals(regressionModel.getModelName(), retrieved.getName());
-        assertEquals(MINING_FUNCTION.byName(regressionModel.getMiningFunction().value()),
-                     retrieved.getMiningFunction());
-        assertEquals(miningFields.get(0).getName().getValue(), retrieved.getTargetField());
+        assertThat(retrieved.getName()).isEqualTo(regressionModel.getModelName());
+        assertThat(retrieved.getMiningFunction()).isEqualTo(MINING_FUNCTION.byName(regressionModel.getMiningFunction().value()));
+        assertThat(retrieved.getTargetField()).isEqualTo(miningFields.get(0).getName().getValue());
         final AbstractKiePMMLTable regressionTable = retrieved.getRegressionTable();
         assertThat(regressionTable).isNotNull();
-        assertTrue(regressionTable instanceof KiePMMLClassificationTable);
+        assertThat(regressionTable).isInstanceOf(KiePMMLClassificationTable.class);
         evaluateCategoricalRegressionTable((KiePMMLClassificationTable) regressionTable);
     }
 
@@ -185,7 +182,7 @@ public class KiePMMLRegressionModelFactoryTest {
         assertThat(retrieved).isNotNull();
         int expectedSize = regressionTables.size()
                 + 2; // One for classification and one for the whole model
-        assertEquals(expectedSize, retrieved.size());
+        assertThat(retrieved).hasSize(expectedSize);
     }
 
     @Test
@@ -198,10 +195,10 @@ public class KiePMMLRegressionModelFactoryTest {
         Map<String, KiePMMLTableSourceCategory> retrieved = KiePMMLRegressionModelFactory
                 .getRegressionTablesMap(RegressionCompilationDTO.fromCompilationDTO(compilationDTO));
         int expectedSize = regressionTables.size() + 1; // One for classification
-        assertEquals(expectedSize, retrieved.size());
+        assertThat(retrieved).hasSize(expectedSize);
         final Collection<KiePMMLTableSourceCategory> values = retrieved.values();
         regressionTables.forEach(regressionTable ->
-                                         assertTrue(values.stream().anyMatch(kiePMMLTableSourceCategory -> kiePMMLTableSourceCategory.getCategory().equals(regressionTable.getTargetCategory()))));
+                                         assertThat(values.stream().anyMatch(kiePMMLTableSourceCategory -> kiePMMLTableSourceCategory.getCategory().equals(regressionTable.getTargetCategory()))).isTrue());
     }
 
     @Test
@@ -236,16 +233,15 @@ public class KiePMMLRegressionModelFactoryTest {
         MethodDeclaration retrieved = modelTemplate.getMethodsByName(GET_MODEL).get(0);
         String text = getFileContent(TEST_01_SOURCE);
         MethodDeclaration expected = JavaParserUtils.parseMethod(text);
-        assertTrue(JavaParserUtils.equalsNode(expected, retrieved));
+        assertThat(JavaParserUtils.equalsNode(expected, retrieved)).isTrue();
     }
 
     private void evaluateCategoricalRegressionTable(KiePMMLClassificationTable regressionTable) {
-        assertEquals(REGRESSION_NORMALIZATION_METHOD.byName(regressionModel.getNormalizationMethod().value()),
-                     regressionTable.getRegressionNormalizationMethod());
-        assertEquals(OP_TYPE.CATEGORICAL, regressionTable.getOpType());
+        assertThat(regressionTable.getRegressionNormalizationMethod()).isEqualTo(REGRESSION_NORMALIZATION_METHOD.byName(regressionModel.getNormalizationMethod().value()));
+        assertThat(regressionTable.getOpType()).isEqualTo(OP_TYPE.CATEGORICAL);
         final Map<String, KiePMMLRegressionTable> categoryTableMap = regressionTable.getCategoryTableMap();
         for (RegressionTable originalRegressionTable : regressionTables) {
-            assertTrue(categoryTableMap.containsKey(originalRegressionTable.getTargetCategory().toString()));
+            assertThat(categoryTableMap).containsKey(originalRegressionTable.getTargetCategory().toString());
             evaluateRegressionTable(categoryTableMap.get(originalRegressionTable.getTargetCategory().toString()),
                                     originalRegressionTable);
         }
@@ -253,21 +249,21 @@ public class KiePMMLRegressionModelFactoryTest {
 
     private void evaluateRegressionTable(KiePMMLRegressionTable regressionTable,
                                          RegressionTable originalRegressionTable) {
-        assertEquals(originalRegressionTable.getIntercept(), regressionTable.getIntercept());
+        assertThat(regressionTable.getIntercept()).isEqualTo(originalRegressionTable.getIntercept());
         final Map<String, SerializableFunction<Double, Double>> numericFunctionMap =
                 regressionTable.getNumericFunctionMap();
         for (NumericPredictor numericPredictor : originalRegressionTable.getNumericPredictors()) {
-            assertTrue(numericFunctionMap.containsKey(numericPredictor.getName().getValue()));
+            assertThat(numericFunctionMap).containsKey(numericPredictor.getName().getValue());
         }
         final Map<String, SerializableFunction<String, Double>> categoricalFunctionMap =
                 regressionTable.getCategoricalFunctionMap();
         for (CategoricalPredictor categoricalPredictor : originalRegressionTable.getCategoricalPredictors()) {
-            assertTrue(categoricalFunctionMap.containsKey(categoricalPredictor.getName().getValue()));
+        	assertThat(categoricalFunctionMap).containsKey(categoricalPredictor.getName().getValue());
         }
         final Map<String, SerializableFunction<Map<String, Object>, Double>> predictorTermsFunctionMap =
                 regressionTable.getPredictorTermsFunctionMap();
         for (PredictorTerm predictorTerm : originalRegressionTable.getPredictorTerms()) {
-            assertTrue(predictorTermsFunctionMap.containsKey(predictorTerm.getName().getValue()));
+        	assertThat(predictorTermsFunctionMap).containsKey(predictorTerm.getName().getValue());
         }
     }
 }

--- a/kie-pmml-trusty/kie-pmml-models/kie-pmml-models-regression/kie-pmml-models-regression-compiler/src/test/java/org/kie/pmml/models/regression/compiler/factories/KiePMMLRegressionTableFactoryTest.java
+++ b/kie-pmml-trusty/kie-pmml-models/kie-pmml-models-regression/kie-pmml-models-regression-compiler/src/test/java/org/kie/pmml/models/regression/compiler/factories/KiePMMLRegressionTableFactoryTest.java
@@ -38,6 +38,7 @@ import com.github.javaparser.ast.expr.MethodReferenceExpr;
 import com.github.javaparser.ast.expr.NullLiteralExpr;
 import com.github.javaparser.ast.stmt.BlockStmt;
 import com.github.javaparser.ast.stmt.ExpressionStmt;
+import org.assertj.core.data.Offset;
 import org.dmg.pmml.DataDictionary;
 import org.dmg.pmml.DataField;
 import org.dmg.pmml.FieldName;
@@ -65,10 +66,7 @@ import org.kie.pmml.models.regression.model.tuples.KiePMMLTableSourceCategory;
 
 import static java.util.stream.Collectors.groupingBy;
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
+import static org.assertj.core.api.Assertions.fail;
 import static org.kie.pmml.commons.utils.KiePMMLModelUtils.getGeneratedClassName;
 import static org.kie.pmml.commons.utils.KiePMMLModelUtils.getSanitizedVariableName;
 import static org.kie.pmml.compiler.commons.testutils.CodegenTestUtils.commonValidateCompilation;
@@ -139,9 +137,9 @@ public class KiePMMLRegressionTableFactoryTest extends AbstractKiePMMLRegression
         Map<String, KiePMMLRegressionTable> retrieved =
                 KiePMMLRegressionTableFactory.getRegressionTables(compilationDTO);
         assertThat(retrieved).isNotNull();
-        assertEquals(regressionModel.getRegressionTables().size(), retrieved.size());
+        assertThat(retrieved).hasSize(regressionModel.getRegressionTables().size());
         regressionModel.getRegressionTables().forEach(regrTabl -> {
-            assertTrue(retrieved.containsKey(regrTabl.getTargetCategory().toString()));
+            assertThat(retrieved).containsKey(regrTabl.getTargetCategory().toString());
             commonEvaluateRegressionTable(retrieved.get(regrTabl.getTargetCategory().toString()), regrTabl);
         });
     }
@@ -269,7 +267,7 @@ public class KiePMMLRegressionTableFactoryTest extends AbstractKiePMMLRegression
         }).collect(Collectors.toList());
         Map<String, SerializableFunction<Double, Double>> retrieved =
                 KiePMMLRegressionTableFactory.getNumericPredictorsMap(numericPredictors);
-        assertEquals(numericPredictors.size(), retrieved.size());
+        assertThat(retrieved).hasSameSizeAs(numericPredictors);
     }
 
     @Test
@@ -315,8 +313,8 @@ public class KiePMMLRegressionTableFactoryTest extends AbstractKiePMMLRegression
                 KiePMMLRegressionTableFactory.getCategoricalPredictorsMap(categoricalPredictors);
         final Map<String, List<CategoricalPredictor>> groupedCollectors = categoricalPredictors.stream()
                 .collect(groupingBy(categoricalPredictor -> categoricalPredictor.getField().getValue()));
-        assertEquals(groupedCollectors.size(), retrieved.size());
-        groupedCollectors.keySet().forEach(predictName -> assertTrue(retrieved.containsKey(predictName)));
+        assertThat(retrieved).hasSameSizeAs(groupedCollectors);
+        groupedCollectors.keySet().forEach(predictName -> assertThat(retrieved).containsKey(predictName));
     }
 
     @Test
@@ -330,13 +328,12 @@ public class KiePMMLRegressionTableFactoryTest extends AbstractKiePMMLRegression
         Map<String, Double> retrieved =
                 KiePMMLRegressionTableFactory.getGroupedCategoricalPredictorMap(categoricalPredictors);
         assertThat(retrieved).isNotNull();
-        assertEquals(categoricalPredictors.size(), retrieved.size());
+        assertThat(retrieved).hasSameSizeAs(categoricalPredictors);
         categoricalPredictors.forEach(categoricalPredictor ->
                                       {
                                           String key = categoricalPredictor.getValue().toString();
-                                          assertTrue(retrieved.containsKey(key));
-                                          assertEquals(categoricalPredictor.getCoefficient().doubleValue(),
-                                                       retrieved.get(key), 0.0);
+                                          assertThat(retrieved).containsKey(key);
+                                          assertThat(retrieved.get(key)).isCloseTo(categoricalPredictor.getCoefficient().doubleValue(), Offset.offset(0.0));
                                       });
     }
 
@@ -351,10 +348,10 @@ public class KiePMMLRegressionTableFactoryTest extends AbstractKiePMMLRegression
         }).collect(Collectors.toList());
         Map<String, SerializableFunction<Map<String, Object>, Double>> retrieved =
                 KiePMMLRegressionTableFactory.getPredictorTermsMap(predictorTerms);
-        assertEquals(predictorTerms.size(), retrieved.size());
+        assertThat(retrieved).hasSameSizeAs(predictorTerms);
         IntStream.range(0, predictorTerms.size()).forEach(index -> {
             PredictorTerm predictorTerm = predictorTerms.get(index);
-            assertTrue(retrieved.containsKey(predictorTerm.getName().getValue()));
+            assertThat(retrieved).containsKey(predictorTerm.getName().getValue());
         });
     }
 
@@ -373,7 +370,7 @@ public class KiePMMLRegressionTableFactoryTest extends AbstractKiePMMLRegression
     @Test
     public void getResultUpdaterUnsupportedFunction() {
         UNSUPPORTED_NORMALIZATION_METHODS.forEach(normalizationMethod ->
-                                                          assertNull(KiePMMLRegressionTableFactory.getResultUpdaterFunction(normalizationMethod)));
+                                                          assertThat(KiePMMLRegressionTableFactory.getResultUpdaterFunction(normalizationMethod)).isNull());
     }
 
     @Test
@@ -422,8 +419,8 @@ public class KiePMMLRegressionTableFactoryTest extends AbstractKiePMMLRegression
                                                       variableName);
         String text = getFileContent(TEST_06_SOURCE);
         MethodDeclaration expected = JavaParserUtils.parseMethod(text);
-        assertEquals(expected.toString(), staticGetterMethod.toString());
-        assertTrue(JavaParserUtils.equalsNode(expected, staticGetterMethod));
+        assertThat(staticGetterMethod.toString()).isEqualTo(expected.toString());
+        assertThat(JavaParserUtils.equalsNode(expected, staticGetterMethod)).isTrue();
         List<Class<?>> imports = Arrays.asList(AtomicReference.class,
                                                Collections.class,
                                                Arrays.class,
@@ -443,7 +440,7 @@ public class KiePMMLRegressionTableFactoryTest extends AbstractKiePMMLRegression
                 String text = getFileContent(TEST_03_SOURCE);
                 Expression expected = JavaParserUtils.parseExpression(String.format(text,
                                                                                     normalizationMethod.name()));
-                assertTrue(JavaParserUtils.equalsNode(expected, retrieved));
+                assertThat(JavaParserUtils.equalsNode(expected, retrieved)).isTrue();
             } catch (IOException e) {
                 fail(e.getMessage());
             }
@@ -455,7 +452,7 @@ public class KiePMMLRegressionTableFactoryTest extends AbstractKiePMMLRegression
         UNSUPPORTED_NORMALIZATION_METHODS.forEach(normalizationMethod -> {
             Expression retrieved =
                     KiePMMLRegressionTableFactory.getResultUpdaterExpression(normalizationMethod);
-            assertTrue(retrieved instanceof NullLiteralExpr);
+            assertThat(retrieved).isInstanceOf(NullLiteralExpr.class);
         });
     }
 
@@ -466,7 +463,7 @@ public class KiePMMLRegressionTableFactoryTest extends AbstractKiePMMLRegression
         String text = getFileContent(TEST_03_SOURCE);
         Expression expected = JavaParserUtils.parseExpression(String.format(text,
                                                                             RegressionModel.NormalizationMethod.CAUCHIT.name()));
-        assertTrue(JavaParserUtils.equalsNode(expected, retrieved));
+        assertThat(JavaParserUtils.equalsNode(expected, retrieved)).isTrue();
     }
 
     @Test
@@ -478,7 +475,7 @@ public class KiePMMLRegressionTableFactoryTest extends AbstractKiePMMLRegression
         }).collect(Collectors.toList());
         Map<String, Expression> retrieved =
                 KiePMMLRegressionTableFactory.getNumericPredictorsExpressions(numericPredictors);
-        assertEquals(numericPredictors.size(), retrieved.size());
+        assertThat(retrieved).hasSameSizeAs(numericPredictors);
     }
 
     @Test
@@ -491,7 +488,7 @@ public class KiePMMLRegressionTableFactoryTest extends AbstractKiePMMLRegression
         CastExpr retrieved = KiePMMLRegressionTableFactory.getNumericPredictorExpression(numericPredictor);
         String text = getFileContent(TEST_01_SOURCE);
         Expression expected = JavaParserUtils.parseExpression(String.format(text, coefficient, exponent));
-        assertTrue(JavaParserUtils.equalsNode(expected, retrieved));
+        assertThat(retrieved).isEqualTo(expected);
     }
 
     @Test
@@ -504,7 +501,7 @@ public class KiePMMLRegressionTableFactoryTest extends AbstractKiePMMLRegression
         CastExpr retrieved = KiePMMLRegressionTableFactory.getNumericPredictorExpression(numericPredictor);
         String text = getFileContent(TEST_02_SOURCE);
         Expression expected = JavaParserUtils.parseExpression(String.format(text, coefficient));
-        assertTrue(JavaParserUtils.equalsNode(expected, retrieved));
+        assertThat(retrieved).isEqualTo(expected);
     }
 
     @Test
@@ -527,7 +524,7 @@ public class KiePMMLRegressionTableFactoryTest extends AbstractKiePMMLRegression
                 KiePMMLRegressionTableFactory.getCategoricalPredictorsExpressions(categoricalPredictors,
                                                                                   body,
                                                                                   "variableName");
-        assertEquals(3, retrieved.size());
+        assertThat(retrieved).hasSize(3);
         final Map<String, List<CategoricalPredictor>> groupedCollectors = categoricalPredictors.stream()
                 .collect(groupingBy(categoricalPredictor -> categoricalPredictor.getField().getValue()));
 
@@ -557,7 +554,7 @@ public class KiePMMLRegressionTableFactoryTest extends AbstractKiePMMLRegression
                                                                       categoricalPredictors.get(1).getCoefficient(),
                                                                       categoricalPredictors.get(2).getValue(),
                                                                       categoricalPredictors.get(2).getCoefficient()));
-        assertTrue(JavaParserUtils.equalsNode(expected, toPopulate));
+        assertThat(JavaParserUtils.equalsNode(expected, toPopulate)).isTrue();
     }
 
     @Test
@@ -567,7 +564,7 @@ public class KiePMMLRegressionTableFactoryTest extends AbstractKiePMMLRegression
                 KiePMMLRegressionTableFactory.getCategoricalPredictorExpression(categoricalPredictorMapName);
         String text = getFileContent(TEST_05_SOURCE);
         Expression expected = JavaParserUtils.parseExpression(String.format(text, categoricalPredictorMapName));
-        assertTrue(JavaParserUtils.equalsNode(expected, retrieved));
+        assertThat(retrieved).isEqualTo(expected);
     }
 
     @Test
@@ -581,10 +578,10 @@ public class KiePMMLRegressionTableFactoryTest extends AbstractKiePMMLRegression
         }).collect(Collectors.toList());
         Map<String, Expression> retrieved =
                 KiePMMLRegressionTableFactory.getPredictorTermFunctions(predictorTerms);
-        assertEquals(predictorTerms.size(), retrieved.size());
+        assertThat(retrieved).hasSameSizeAs(predictorTerms);
         IntStream.range(0, predictorTerms.size()).forEach(index -> {
             PredictorTerm predictorTerm = predictorTerms.get(index);
-            assertTrue(retrieved.containsKey(predictorTerm.getName().getValue()));
+            assertThat(retrieved).containsKey(predictorTerm.getName().getValue());
         });
     }
 
@@ -599,7 +596,7 @@ public class KiePMMLRegressionTableFactoryTest extends AbstractKiePMMLRegression
 
         String text = getFileContent(TEST_07_SOURCE);
         Expression expected = JavaParserUtils.parseExpression(String.format(text, fieldRef, coefficient));
-        assertTrue(JavaParserUtils.equalsNode(expected, retrieved));
+        assertThat(JavaParserUtils.equalsNode(expected, retrieved)).isTrue();
     }
 
     @Test
@@ -613,21 +610,20 @@ public class KiePMMLRegressionTableFactoryTest extends AbstractKiePMMLRegression
                 .collect(Collectors.toList());
         outputFields.addAll(probabilityOutputFields);
     }
-
     private void commonEvaluateRegressionTable(KiePMMLRegressionTable retrieved, RegressionTable source) {
         Map<String, SerializableFunction<Double, Double>> numericFunctionMap = retrieved.getNumericFunctionMap();
-        assertEquals(source.getNumericPredictors().size(), numericFunctionMap.size());
-        source.getNumericPredictors().forEach(numericPredictor -> assertTrue(numericFunctionMap.containsKey(numericPredictor.getName().getValue())));
+        assertThat(numericFunctionMap).hasSize(source.getNumericPredictors().size());
+        source.getNumericPredictors().forEach(numericPredictor -> assertThat(numericFunctionMap).containsKey(numericPredictor.getName().getValue()));
         Map<String, SerializableFunction<String, Double>> categoricalFunctionMap =
                 retrieved.getCategoricalFunctionMap();
         Map<String, List<CategoricalPredictor>> groupedCollectors = categoricalPredictors.stream()
                 .collect(groupingBy(categoricalPredictor -> categoricalPredictor.getField().getValue()));
-        assertEquals(groupedCollectors.size(), categoricalFunctionMap.size());
-        groupedCollectors.keySet().forEach(categorical -> assertTrue(categoricalFunctionMap.containsKey(categorical)));
+        assertThat(categoricalFunctionMap).hasSameSizeAs(groupedCollectors);
+        groupedCollectors.keySet().forEach(categorical -> assertThat(categoricalFunctionMap).containsKey(categorical));
         Map<String, SerializableFunction<Map<String, Object>, Double>> predictorTermsFunctionMap =
                 retrieved.getPredictorTermsFunctionMap();
-        assertEquals(source.getPredictorTerms().size(), predictorTermsFunctionMap.size());
-        source.getPredictorTerms().forEach(predictorTerm -> assertTrue(predictorTermsFunctionMap.containsKey(predictorTerm.getName().getValue())));
+        assertThat(predictorTermsFunctionMap).hasSize(source.getPredictorTerms().size());
+        source.getPredictorTerms().forEach(predictorTerm -> assertThat(predictorTermsFunctionMap).containsKey(predictorTerm.getName().getValue()));
     }
 
     private void commonEvaluateCategoryPredictors(final BlockStmt toVerify,
@@ -637,7 +633,7 @@ public class KiePMMLRegressionTableFactoryTest extends AbstractKiePMMLRegression
             CategoricalPredictor categoricalPredictor = categoricalPredictors.get(i);
             String expectedVariableName =
                     getSanitizedVariableName(String.format("%sMap", variableName)) + "_" + i;
-            assertTrue(toVerify.getStatements()
+            assertThat(toVerify.getStatements()
                                .stream()
                                .anyMatch(statement -> {
                                    String expected = String.format(
@@ -648,7 +644,7 @@ public class KiePMMLRegressionTableFactoryTest extends AbstractKiePMMLRegression
                                    return statement instanceof ExpressionStmt &&
                                            ((ExpressionStmt) statement).getExpression() instanceof MethodCallExpr &&
                                            statement.toString().equals(expected);
-                               }));
+                               })).isTrue();
         }
     }
 

--- a/kie-pmml-trusty/kie-pmml-models/kie-pmml-models-regression/kie-pmml-models-regression-compiler/src/test/java/org/kie/pmml/models/regression/compiler/factories/KiePMMLRegressionTableFactoryTest.java
+++ b/kie-pmml-trusty/kie-pmml-models/kie-pmml-models-regression/kie-pmml-models-regression-compiler/src/test/java/org/kie/pmml/models/regression/compiler/factories/KiePMMLRegressionTableFactoryTest.java
@@ -137,7 +137,7 @@ public class KiePMMLRegressionTableFactoryTest extends AbstractKiePMMLRegression
         Map<String, KiePMMLRegressionTable> retrieved =
                 KiePMMLRegressionTableFactory.getRegressionTables(compilationDTO);
         assertThat(retrieved).isNotNull();
-        assertThat(retrieved).hasSize(regressionModel.getRegressionTables().size());
+        assertThat(retrieved).hasSameSizeAs(regressionModel.getRegressionTables());
         regressionModel.getRegressionTables().forEach(regrTabl -> {
             assertThat(retrieved).containsKey(regrTabl.getTargetCategory().toString());
             commonEvaluateRegressionTable(retrieved.get(regrTabl.getTargetCategory().toString()), regrTabl);
@@ -612,7 +612,7 @@ public class KiePMMLRegressionTableFactoryTest extends AbstractKiePMMLRegression
     }
     private void commonEvaluateRegressionTable(KiePMMLRegressionTable retrieved, RegressionTable source) {
         Map<String, SerializableFunction<Double, Double>> numericFunctionMap = retrieved.getNumericFunctionMap();
-        assertThat(numericFunctionMap).hasSize(source.getNumericPredictors().size());
+        assertThat(numericFunctionMap).hasSameSizeAs(source.getNumericPredictors());
         source.getNumericPredictors().forEach(numericPredictor -> assertThat(numericFunctionMap).containsKey(numericPredictor.getName().getValue()));
         Map<String, SerializableFunction<String, Double>> categoricalFunctionMap =
                 retrieved.getCategoricalFunctionMap();
@@ -622,7 +622,7 @@ public class KiePMMLRegressionTableFactoryTest extends AbstractKiePMMLRegression
         groupedCollectors.keySet().forEach(categorical -> assertThat(categoricalFunctionMap).containsKey(categorical));
         Map<String, SerializableFunction<Map<String, Object>, Double>> predictorTermsFunctionMap =
                 retrieved.getPredictorTermsFunctionMap();
-        assertThat(predictorTermsFunctionMap).hasSize(source.getPredictorTerms().size());
+        assertThat(predictorTermsFunctionMap).hasSameSizeAs(source.getPredictorTerms());
         source.getPredictorTerms().forEach(predictorTerm -> assertThat(predictorTermsFunctionMap).containsKey(predictorTerm.getName().getValue()));
     }
 

--- a/kie-pmml-trusty/kie-pmml-models/kie-pmml-models-regression/kie-pmml-models-regression-evaluator/src/test/java/org/kie/pmml/models/regression/evaluator/PMMLRegressionModelEvaluatorTest.java
+++ b/kie-pmml-trusty/kie-pmml-models/kie-pmml-models-regression/kie-pmml-models-regression-evaluator/src/test/java/org/kie/pmml/models/regression/evaluator/PMMLRegressionModelEvaluatorTest.java
@@ -4,7 +4,7 @@ import org.junit.Before;
 import org.junit.Test;
 import org.kie.pmml.api.enums.PMML_MODEL;
 
-import static org.junit.Assert.assertEquals;
+import static org.assertj.core.api.Assertions.assertThat;
 
 public class PMMLRegressionModelEvaluatorTest {
 
@@ -17,6 +17,6 @@ public class PMMLRegressionModelEvaluatorTest {
 
     @Test
     public void getPMMLModelType() {
-        assertEquals(PMML_MODEL.REGRESSION_MODEL, executor.getPMMLModelType());
+        assertThat(executor.getPMMLModelType()).isEqualTo(PMML_MODEL.REGRESSION_MODEL);
     }
 }

--- a/kie-pmml-trusty/kie-pmml-models/kie-pmml-models-regression/kie-pmml-models-regression-model/src/test/java/org/kie/pmml/models/regression/model/KiePMMLClassificationTableTest.java
+++ b/kie-pmml-trusty/kie-pmml-models/kie-pmml-models-regression/kie-pmml-models-regression-model/src/test/java/org/kie/pmml/models/regression/model/KiePMMLClassificationTableTest.java
@@ -24,13 +24,14 @@ import java.util.LinkedHashMap;
 import java.util.Map;
 import java.util.function.DoubleUnaryOperator;
 
+import org.assertj.core.data.Offset;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
 import org.kie.pmml.api.exceptions.KiePMMLException;
 import org.kie.pmml.commons.testingutility.PMMLContextTest;
 
-import static org.junit.Assert.assertEquals;
+import static org.assertj.core.api.Assertions.assertThat;
 
 @RunWith(Parameterized.class)
 public class KiePMMLClassificationTableTest {
@@ -78,10 +79,10 @@ public class KiePMMLClassificationTableTest {
         input.put(CASE_A, firstTableResult);
         input.put(CASE_B, secondTableResult);
         Object retrieved = classificationTable.evaluateRegression(input, pmmlContextTest);
-        assertEquals(expectedResult, retrieved);
+        assertThat(retrieved).isEqualTo(expectedResult);
         final Map<String, Double> probabilityResultMap = pmmlContextTest.getProbabilityResultMap();
-        assertEquals(firstExpectedValue, probabilityResultMap.get(CASE_A), 0);
-        assertEquals(secondExpectedValue, probabilityResultMap.get(CASE_B), 0);
+        assertThat(probabilityResultMap.get(CASE_A)).isCloseTo(firstExpectedValue, Offset.offset(0.0));
+        assertThat(probabilityResultMap.get(CASE_B)).isCloseTo(secondExpectedValue, Offset.offset(0.0));
     }
 
     @Test
@@ -93,9 +94,10 @@ public class KiePMMLClassificationTableTest {
                                                                                                FIRST_ITEM_OPERATOR,
                                                                                                SECOND_ITEM_OPERATOR);
         double expectedDouble = FIRST_ITEM_OPERATOR.applyAsDouble(firstTableResult);
-        assertEquals(expectedDouble, retrieved.get(CASE_B), 0.0);
+
+        assertThat(retrieved.get(CASE_B)).isCloseTo(expectedDouble, Offset.offset(0.0));      
         expectedDouble = SECOND_ITEM_OPERATOR.applyAsDouble(expectedDouble);
-        assertEquals(expectedDouble, retrieved.get(CASE_A), 0.0);
+        assertThat(retrieved.get(CASE_A)).isCloseTo(expectedDouble, Offset.offset(0.0));      
     }
 
     @Test(expected = KiePMMLException.class)

--- a/kie-pmml-trusty/kie-pmml-models/kie-pmml-models-regression/kie-pmml-models-regression-model/src/test/java/org/kie/pmml/models/regression/model/KiePMMLRegressionTableTest.java
+++ b/kie-pmml-trusty/kie-pmml-models/kie-pmml-models-regression/kie-pmml-models-regression-model/src/test/java/org/kie/pmml/models/regression/model/KiePMMLRegressionTableTest.java
@@ -28,7 +28,7 @@ import org.junit.runners.Parameterized;
 import org.kie.pmml.api.iinterfaces.SerializableFunction;
 import org.kie.pmml.api.runtime.PMMLContext;
 
-import static org.junit.Assert.assertEquals;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.mock;
 
 @RunWith(Parameterized.class)
@@ -78,7 +78,7 @@ public class KiePMMLRegressionTableTest {
         input.put(FIRST_CATEGORICAL_INPUT, "unused");
         input.put(SECOND_CATEGORICAL_INPUT, "unused");
         Object retrieved = regressionTable.evaluateRegression(input, mock(PMMLContext.class));
-        assertEquals(expectedResult, retrieved);
+        assertThat(retrieved).isEqualTo(expectedResult);
     }
 
     private KiePMMLRegressionTable getKiePMMLRegressionTable() {

--- a/kie-pmml-trusty/kie-pmml-models/kie-pmml-models-scorecard/kie-pmml-models-scorecard-compiler/src/test/java/org/kie/pmml/models/scorecard/compiler/executor/ScorecardModelImplementationProviderTest.java
+++ b/kie-pmml-trusty/kie-pmml-models/kie-pmml-models-scorecard/kie-pmml-models-scorecard-compiler/src/test/java/org/kie/pmml/models/scorecard/compiler/executor/ScorecardModelImplementationProviderTest.java
@@ -31,8 +31,6 @@ import org.kie.pmml.compiler.commons.mocks.HasClassLoaderMock;
 import org.kie.pmml.models.scorecard.model.KiePMMLScorecardModel;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
 
 public class ScorecardModelImplementationProviderTest {
 
@@ -55,7 +53,7 @@ public class ScorecardModelImplementationProviderTest {
 
     @Test
     public void getPMMLModelType() {
-        assertEquals(PMML_MODEL.SCORECARD_MODEL, PROVIDER.getPMMLModelType());
+        assertThat(PROVIDER.getPMMLModelType()).isEqualTo(PMML_MODEL.SCORECARD_MODEL);
     }
 
     @Test
@@ -80,6 +78,6 @@ public class ScorecardModelImplementationProviderTest {
         assertThat(retrieved).isNotNull();
         Map<String, String> retrievedSourcesMap = retrieved.getSourcesMap();
         assertThat(retrievedSourcesMap).isNotNull();
-        assertFalse(retrievedSourcesMap.isEmpty());
+        assertThat(retrievedSourcesMap).isNotEmpty();
     }
 }

--- a/kie-pmml-trusty/kie-pmml-models/kie-pmml-models-scorecard/kie-pmml-models-scorecard-compiler/src/test/java/org/kie/pmml/models/scorecard/compiler/factories/KiePMMLAttributeFactoryTest.java
+++ b/kie-pmml-trusty/kie-pmml-models/kie-pmml-models-scorecard/kie-pmml-models-scorecard-compiler/src/test/java/org/kie/pmml/models/scorecard/compiler/factories/KiePMMLAttributeFactoryTest.java
@@ -44,7 +44,7 @@ import org.kie.pmml.compiler.commons.utils.JavaParserUtils;
 import org.kie.pmml.models.scorecard.model.KiePMMLAttribute;
 import org.kie.pmml.models.scorecard.model.KiePMMLComplexPartialScore;
 
-import static org.junit.Assert.assertTrue;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.kie.pmml.compiler.api.CommonTestingUtils.getFieldsFromDataDictionary;
 import static org.kie.pmml.compiler.api.testutils.PMMLModelTestUtils.getSimplePredicate;
 import static org.kie.pmml.compiler.api.testutils.PMMLModelTestUtils.getStringObjects;
@@ -97,7 +97,7 @@ public class KiePMMLAttributeFactoryTest {
                                                                                       getFieldsFromDataDictionary(dataDictionary));
         String text = getFileContent(TEST_01_SOURCE);
         Statement expected = JavaParserUtils.parseBlock(String.format(text, variableName, valuesString));
-        assertTrue(JavaParserUtils.equalsNode(expected, retrieved));
+        assertThat(JavaParserUtils.equalsNode(expected, retrieved)).isTrue();
         List<Class<?>> imports = Arrays.asList(KiePMMLAttribute.class,
                                                KiePMMLComplexPartialScore.class,
                                                KiePMMLCompoundPredicate.class,

--- a/kie-pmml-trusty/kie-pmml-models/kie-pmml-models-scorecard/kie-pmml-models-scorecard-compiler/src/test/java/org/kie/pmml/models/scorecard/compiler/factories/KiePMMLCharacteristicFactoryTest.java
+++ b/kie-pmml-trusty/kie-pmml-models/kie-pmml-models-scorecard/kie-pmml-models-scorecard-compiler/src/test/java/org/kie/pmml/models/scorecard/compiler/factories/KiePMMLCharacteristicFactoryTest.java
@@ -46,7 +46,7 @@ import org.kie.pmml.models.scorecard.model.KiePMMLAttribute;
 import org.kie.pmml.models.scorecard.model.KiePMMLCharacteristic;
 import org.kie.pmml.models.scorecard.model.KiePMMLComplexPartialScore;
 
-import static org.junit.Assert.assertTrue;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.kie.pmml.compiler.api.CommonTestingUtils.getFieldsFromDataDictionary;
 import static org.kie.pmml.compiler.api.testutils.PMMLModelTestUtils.getSimplePredicate;
 import static org.kie.pmml.compiler.api.testutils.PMMLModelTestUtils.getStringObjects;
@@ -128,7 +128,7 @@ public class KiePMMLCharacteristicFactoryTest {
                                                                       valuesString2,
                                                                       characteristic.getBaselineScore(),
                                                                       characteristic.getReasonCode()));
-        assertTrue(JavaParserUtils.equalsNode(expected, retrieved));
+        assertThat(JavaParserUtils.equalsNode(expected, retrieved)).isTrue();
         List<Class<?>> imports = Arrays.asList(KiePMMLAttribute.class,
                                                KiePMMLCharacteristic.class,
                                                KiePMMLComplexPartialScore.class,

--- a/kie-pmml-trusty/kie-pmml-models/kie-pmml-models-scorecard/kie-pmml-models-scorecard-compiler/src/test/java/org/kie/pmml/models/scorecard/compiler/factories/KiePMMLCharacteristicsFactoryTest.java
+++ b/kie-pmml-trusty/kie-pmml-models/kie-pmml-models-scorecard/kie-pmml-models-scorecard-compiler/src/test/java/org/kie/pmml/models/scorecard/compiler/factories/KiePMMLCharacteristicsFactoryTest.java
@@ -56,9 +56,7 @@ import org.kie.pmml.models.scorecard.model.KiePMMLCharacteristics;
 import org.kie.pmml.models.scorecard.model.KiePMMLComplexPartialScore;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
+import static org.assertj.core.api.Assertions.fail;
 import static org.kie.pmml.commons.Constants.PACKAGE_NAME;
 import static org.kie.pmml.compiler.api.CommonTestingUtils.getFieldsFromDataDictionary;
 import static org.kie.pmml.compiler.api.utils.ModelUtils.getDerivedFields;
@@ -130,9 +128,9 @@ public class KiePMMLCharacteristicsFactoryTest {
         final Map<String, String> retrieved =
                 KiePMMLCharacteristicsFactory.getKiePMMLCharacteristicsSourcesMap(compilationDTO);
         assertThat(retrieved).isNotNull();
-        assertEquals(1, retrieved.size());
+        assertThat(retrieved).hasSize(1);
         String expected = compilationDTO.getPackageCanonicalCharacteristicsClassName();
-        assertTrue(retrieved.containsKey(expected));
+        assertThat(retrieved).containsKey(expected);
         try {
             KieMemoryCompiler.compile(retrieved, Thread.currentThread().getContextClassLoader());
         } catch (Exception e) {
@@ -166,17 +164,17 @@ public class KiePMMLCharacteristicsFactoryTest {
     public void addGetCharacteristicMethod() throws IOException {
         final String characteristicName = "CharacteristicName";
         String expectedMethod = "get" + characteristicName;
-        assertTrue(characteristicsTemplate.getMethodsByName(expectedMethod).isEmpty());
+        assertThat(characteristicsTemplate.getMethodsByName(expectedMethod)).isEmpty();
         KiePMMLCharacteristicsFactory.addGetCharacteristicMethod(characteristicName,
                                                                  basicComplexPartialScoreFirstCharacteristic,
                                                                  getFieldsFromDataDictionary(basicComplexPartialScoreDataDictionary),
                                                                  characteristicsTemplate);
-        assertEquals(1, characteristicsTemplate.getMethodsByName(expectedMethod).size());
+        assertThat(characteristicsTemplate.getMethodsByName(expectedMethod)).hasSize(1);
         MethodDeclaration retrieved = characteristicsTemplate.getMethodsByName(expectedMethod).get(0);
         String text = getFileContent(TEST_01_SOURCE);
         MethodDeclaration expected = JavaParserUtils
                 .parseMethod(String.format(text, characteristicName));
-        assertTrue(JavaParserUtils.equalsNode(expected, retrieved));
+        assertThat(JavaParserUtils.equalsNode(expected, retrieved)).isTrue();
         List<Class<?>> imports = Arrays.asList(KiePMMLApply.class,
                                                KiePMMLAttribute.class,
                                                KiePMMLCharacteristic.class,

--- a/kie-pmml-trusty/kie-pmml-models/kie-pmml-models-scorecard/kie-pmml-models-scorecard-compiler/src/test/java/org/kie/pmml/models/scorecard/compiler/factories/KiePMMLComplexPartialScoreFactoryTest.java
+++ b/kie-pmml-trusty/kie-pmml-models/kie-pmml-models-scorecard/kie-pmml-models-scorecard-compiler/src/test/java/org/kie/pmml/models/scorecard/compiler/factories/KiePMMLComplexPartialScoreFactoryTest.java
@@ -34,7 +34,7 @@ import org.kie.pmml.commons.model.expressions.KiePMMLFieldRef;
 import org.kie.pmml.compiler.commons.utils.JavaParserUtils;
 import org.kie.pmml.models.scorecard.model.KiePMMLComplexPartialScore;
 
-import static org.junit.Assert.assertTrue;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.kie.pmml.compiler.commons.testutils.CodegenTestUtils.commonValidateCompilationWithImports;
 import static org.kie.test.util.filesystem.FileUtils.getFileContent;
 
@@ -58,7 +58,7 @@ public class KiePMMLComplexPartialScoreFactoryTest {
         String text = getFileContent(TEST_01_SOURCE);
         Statement expected = JavaParserUtils.parseBlock(String.format(text, constant.getValue(),
                                                                       variableName));
-        assertTrue(JavaParserUtils.equalsNode(expected, retrieved));
+        assertThat(retrieved).isEqualTo(expected);
         List<Class<?>> imports = Arrays.asList(KiePMMLConstant.class,
                                                KiePMMLComplexPartialScore.class,
                                                Collections.class);
@@ -78,7 +78,7 @@ public class KiePMMLComplexPartialScoreFactoryTest {
         String text = getFileContent(TEST_02_SOURCE);
         Statement expected = JavaParserUtils.parseBlock(String.format(text, fieldRef.getField().getValue(),
                                                                       variableName));
-        assertTrue(JavaParserUtils.equalsNode(expected, retrieved));
+        assertThat(retrieved).isEqualTo(expected);
         List<Class<?>> imports = Arrays.asList(KiePMMLFieldRef.class,
                                                KiePMMLComplexPartialScore.class,
                                                Collections.class);
@@ -107,7 +107,7 @@ public class KiePMMLComplexPartialScoreFactoryTest {
                                                                       apply.getFunction(),
                                                                       apply.getInvalidValueTreatment().value(),
                                                                       variableName));
-        assertTrue(JavaParserUtils.equalsNode(expected, retrieved));
+        assertThat(retrieved).isEqualTo(expected);
         List<Class<?>> imports = Arrays.asList(KiePMMLConstant.class,
                                                KiePMMLFieldRef.class,
                                                KiePMMLApply.class,

--- a/kie-pmml-trusty/kie-pmml-models/kie-pmml-models-scorecard/kie-pmml-models-scorecard-compiler/src/test/java/org/kie/pmml/models/scorecard/compiler/factories/KiePMMLScorecardModelFactoryTest.java
+++ b/kie-pmml-trusty/kie-pmml-models/kie-pmml-models-scorecard/kie-pmml-models-scorecard-compiler/src/test/java/org/kie/pmml/models/scorecard/compiler/factories/KiePMMLScorecardModelFactoryTest.java
@@ -45,9 +45,7 @@ import org.kie.pmml.models.scorecard.compiler.ScorecardCompilationDTO;
 import org.kie.pmml.models.scorecard.model.KiePMMLScorecardModel;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
+import static org.assertj.core.api.Assertions.fail;
 import static org.kie.pmml.commons.Constants.MISSING_CONSTRUCTOR_IN_BODY;
 import static org.kie.pmml.commons.Constants.MISSING_DEFAULT_CONSTRUCTOR;
 import static org.kie.pmml.commons.utils.KiePMMLModelUtils.getSanitizedClassName;
@@ -110,9 +108,9 @@ public class KiePMMLScorecardModelFactoryTest {
         final Map<String, String> retrieved =
                 KiePMMLScorecardModelFactory.getKiePMMLScorecardModelSourcesMap(compilationDTO);
         assertThat(retrieved).isNotNull();
-        assertEquals(2, retrieved.size());
-        assertTrue(retrieved.containsKey(compilationDTO.getPackageCanonicalClassName()));
-        assertTrue(retrieved.containsKey(compilationDTO.getPackageCanonicalCharacteristicsClassName()));
+        assertThat(retrieved).hasSize(2);
+        assertThat(retrieved).containsKey(compilationDTO.getPackageCanonicalClassName());
+        assertThat(retrieved).containsKey(compilationDTO.getPackageCanonicalCharacteristicsClassName());
         try {
             KieMemoryCompiler.compile(retrieved, Thread.currentThread().getContextClassLoader());
         } catch (Exception e) {
@@ -148,6 +146,6 @@ public class KiePMMLScorecardModelFactoryTest {
                                               REASONCODE_ALGORITHM.class.getName() + "." + REASONCODE_ALGORITHM.byName(basicComplexPartialScore.getReasonCodeAlgorithm().value()),
                                               basicComplexPartialScore.getBaselineScore()
                 ));
-        assertTrue(JavaParserUtils.equalsNode(expected, retrieved));
+        assertThat(JavaParserUtils.equalsNode(expected, retrieved)).isTrue();
     }
 }

--- a/kie-pmml-trusty/kie-pmml-models/kie-pmml-models-scorecard/kie-pmml-models-scorecard-evaluator/src/test/java/org/kie/pmml/models/scorecard/evaluator/PMMLScorecardModelEvaluatorTest.java
+++ b/kie-pmml-trusty/kie-pmml-models/kie-pmml-models-scorecard/kie-pmml-models-scorecard-evaluator/src/test/java/org/kie/pmml/models/scorecard/evaluator/PMMLScorecardModelEvaluatorTest.java
@@ -19,7 +19,7 @@ import org.junit.Before;
 import org.junit.Test;
 import org.kie.pmml.api.enums.PMML_MODEL;
 
-import static org.junit.Assert.assertEquals;
+import static org.assertj.core.api.Assertions.assertThat;
 
 public class PMMLScorecardModelEvaluatorTest {
 
@@ -32,7 +32,7 @@ public class PMMLScorecardModelEvaluatorTest {
 
     @Test
     public void getPMMLModelType(){
-        assertEquals(PMML_MODEL.SCORECARD_MODEL, evaluator.getPMMLModelType());
+        assertThat(evaluator.getPMMLModelType()).isEqualTo(PMML_MODEL.SCORECARD_MODEL);
     }
 
 }

--- a/kie-pmml-trusty/kie-pmml-models/kie-pmml-models-scorecard/kie-pmml-models-scorecard-model/src/test/java/org/kie/pmml/models/scorecard/model/KiePMMLAttributeTest.java
+++ b/kie-pmml-trusty/kie-pmml-models/kie-pmml-models-scorecard/kie-pmml-models-scorecard-model/src/test/java/org/kie/pmml/models/scorecard/model/KiePMMLAttributeTest.java
@@ -30,8 +30,7 @@ import org.kie.pmml.commons.model.predicates.KiePMMLFalsePredicate;
 import org.kie.pmml.commons.model.predicates.KiePMMLTruePredicate;
 import org.kie.pmml.commons.transformations.KiePMMLDerivedField;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNull;
+import static org.assertj.core.api.Assertions.assertThat;
 
 public class KiePMMLAttributeTest {
 
@@ -48,8 +47,8 @@ public class KiePMMLAttributeTest {
         KiePMMLAttribute attribute = KiePMMLAttribute.builder(ATTRIBUTE, Collections.emptyList(), KiePMMLFalsePredicate.builder(Collections.emptyList()).build())
                 .withPartialScore(value1)
                 .build();
-        assertNull(attribute.evaluate(Collections.emptyList(), Collections.emptyList(), Collections.emptyList(),
-                                      Collections.emptyMap()));
+        assertThat(attribute.evaluate(Collections.emptyList(), Collections.emptyList(), Collections.emptyList(),
+                                      Collections.emptyMap())).isNull();
     }
 
     @Test
@@ -57,8 +56,8 @@ public class KiePMMLAttributeTest {
         KiePMMLAttribute attribute = KiePMMLAttribute.builder(ATTRIBUTE, Collections.emptyList(), KiePMMLTruePredicate.builder(Collections.emptyList()).build())
                 .withPartialScore(value1)
                 .build();
-        assertEquals(value1, attribute.evaluate(Collections.emptyList(), Collections.emptyList(), Collections.emptyList(),
-                                      Collections.emptyMap()));
+        assertThat(attribute.evaluate(Collections.emptyList(), Collections.emptyList(), Collections.emptyList(),
+                                      Collections.emptyMap())).isEqualTo(value1);
     }
 
     @Test
@@ -67,8 +66,8 @@ public class KiePMMLAttributeTest {
                 .withComplexPartialScore(getKiePMMLComplexPartialScore())
                 .build();
         Object expected = value1 / value2;
-        assertEquals(expected, attribute.evaluate(Collections.emptyList(), getDerivedFields(), Collections.emptyList(),
-                                                Collections.emptyMap()));
+        assertThat(attribute.evaluate(Collections.emptyList(), getDerivedFields(), Collections.emptyList(),
+                                                Collections.emptyMap())).isEqualTo(expected);
     }
 
     @Test
@@ -78,8 +77,8 @@ public class KiePMMLAttributeTest {
                 .withComplexPartialScore(getKiePMMLComplexPartialScore())
                 .build();
         Object expected = value1 / value2;
-        assertEquals(expected, attribute.evaluate(Collections.emptyList(), getDerivedFields(), Collections.emptyList(),
-                                                  Collections.emptyMap()));
+        assertThat(attribute.evaluate(Collections.emptyList(), getDerivedFields(), Collections.emptyList(),
+                                                  Collections.emptyMap())).isEqualTo(expected);
     }
 
     private KiePMMLComplexPartialScore getKiePMMLComplexPartialScore() {

--- a/kie-pmml-trusty/kie-pmml-models/kie-pmml-models-scorecard/kie-pmml-models-scorecard-model/src/test/java/org/kie/pmml/models/scorecard/model/KiePMMLCharacteristicTest.java
+++ b/kie-pmml-trusty/kie-pmml-models/kie-pmml-models-scorecard/kie-pmml-models-scorecard-model/src/test/java/org/kie/pmml/models/scorecard/model/KiePMMLCharacteristicTest.java
@@ -24,8 +24,6 @@ import org.kie.pmml.commons.model.predicates.KiePMMLFalsePredicate;
 import org.kie.pmml.commons.model.predicates.KiePMMLTruePredicate;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNull;
 
 public class KiePMMLCharacteristicTest {
 
@@ -51,8 +49,8 @@ public class KiePMMLCharacteristicTest {
                 .withBaselineScore(baselineScore)
                 .withReasonCode(REASON_CODE)
                 .build();
-        assertNull(kiePMMLCharacteristic.evaluate(Collections.emptyList(), Collections.emptyList(), Collections.emptyList(),
-                                      Collections.emptyMap()));
+        assertThat(kiePMMLCharacteristic.evaluate(Collections.emptyList(), Collections.emptyList(), Collections.emptyList(),
+                                      Collections.emptyMap())).isNull();
     }
 
     @Test
@@ -69,8 +67,8 @@ public class KiePMMLCharacteristicTest {
                 .build();
         KiePMMLCharacteristic.ReasonCodeValue retrieved = kiePMMLCharacteristic.evaluate(Collections.emptyList(), Collections.emptyList(), Collections.emptyList(), Collections.emptyMap());
         assertThat(retrieved).isNotNull();
-        assertEquals(REASON_CODE, retrieved.getReasonCode());
-        assertEquals(value1, retrieved.getScore());
+        assertThat(retrieved.getReasonCode()).isEqualTo(REASON_CODE);
+        assertThat(retrieved.getScore()).isEqualTo(value1);
     }
 
     @Test
@@ -87,8 +85,8 @@ public class KiePMMLCharacteristicTest {
                 .build();
         KiePMMLCharacteristic.ReasonCodeValue retrieved = kiePMMLCharacteristic.evaluate(Collections.emptyList(), Collections.emptyList(), Collections.emptyList(), Collections.emptyMap());
         assertThat(retrieved).isNotNull();
-        assertEquals(REASON_CODE, retrieved.getReasonCode());
-        assertEquals(value2, retrieved.getScore());
+        assertThat(retrieved.getReasonCode()).isEqualTo(REASON_CODE);
+        assertThat(retrieved.getScore()).isEqualTo(value2);
     }
 
     @Test
@@ -107,8 +105,8 @@ public class KiePMMLCharacteristicTest {
                 .build();
         KiePMMLCharacteristic.ReasonCodeValue retrieved = kiePMMLCharacteristic.evaluate(Collections.emptyList(), Collections.emptyList(), Collections.emptyList(), Collections.emptyMap());
         assertThat(retrieved).isNotNull();
-        assertEquals(REASON_CODE_1, retrieved.getReasonCode());
-        assertEquals(value1, retrieved.getScore());
+        assertThat(retrieved.getReasonCode()).isEqualTo(REASON_CODE_1);
+        assertThat(retrieved.getScore()).isEqualTo(value1);
     }
 
     @Test
@@ -127,7 +125,7 @@ public class KiePMMLCharacteristicTest {
                 .build();
         KiePMMLCharacteristic.ReasonCodeValue retrieved = kiePMMLCharacteristic.evaluate(Collections.emptyList(), Collections.emptyList(), Collections.emptyList(), Collections.emptyMap());
         assertThat(retrieved).isNotNull();
-        assertEquals(REASON_CODE_2, retrieved.getReasonCode());
-        assertEquals(value2, retrieved.getScore());
+        assertThat(retrieved.getReasonCode()).isEqualTo(REASON_CODE_2);
+        assertThat(retrieved.getScore()).isEqualTo(value2);
     }
 }

--- a/kie-pmml-trusty/kie-pmml-models/kie-pmml-models-scorecard/kie-pmml-models-scorecard-model/src/test/java/org/kie/pmml/models/scorecard/model/KiePMMLCharacteristicsTest.java
+++ b/kie-pmml-trusty/kie-pmml-models/kie-pmml-models-scorecard/kie-pmml-models-scorecard-model/src/test/java/org/kie/pmml/models/scorecard/model/KiePMMLCharacteristicsTest.java
@@ -30,8 +30,6 @@ import org.kie.pmml.commons.model.predicates.KiePMMLTruePredicate;
 import org.kie.pmml.commons.testingutility.PMMLContextTest;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
 
 public class KiePMMLCharacteristicsTest {
 
@@ -59,17 +57,17 @@ public class KiePMMLCharacteristicsTest {
                                                                      true,
                                                                      0);
         assertThat(retrieved).isNotNull();
-        assertTrue(retrieved.isPresent());
+        assertThat(retrieved).isPresent();
         Double EVALUATION_20 = baselineScore - value2;
         Double EVALUATION_11 = baselineScore - value1;
         Double expected = initialScore + value2 + value1 + 1;
-        assertEquals(expected, retrieved.get());
+        assertThat(retrieved.get()).isEqualTo(expected);
         final Map<String, Object> outputFieldsMap = pmmlContextTest.getOutputFieldsMap();
-        assertEquals(2, outputFieldsMap.size());
-        assertTrue(outputFieldsMap.containsKey("REASON_CODE_20"));
-        assertEquals(EVALUATION_20, outputFieldsMap.get("REASON_CODE_20"));
-        assertTrue(outputFieldsMap.containsKey("REASON_CODE_11"));
-        assertEquals(EVALUATION_11, outputFieldsMap.get("REASON_CODE_11"));
+        assertThat(outputFieldsMap).hasSize(2);
+        assertThat(outputFieldsMap).containsKey("REASON_CODE_20");
+        assertThat(outputFieldsMap.get("REASON_CODE_20")).isEqualTo(EVALUATION_20);
+        assertThat(outputFieldsMap).containsKey("REASON_CODE_11");
+        assertThat(outputFieldsMap.get("REASON_CODE_11")).isEqualTo(EVALUATION_11);
     }
 
     private List<KiePMMLCharacteristic> getKiePMMLCharacteristicList() {

--- a/kie-pmml-trusty/kie-pmml-models/kie-pmml-models-scorecard/kie-pmml-models-scorecard-model/src/test/java/org/kie/pmml/models/scorecard/model/KiePMMLComplexPartialScoreTest.java
+++ b/kie-pmml-trusty/kie-pmml-models/kie-pmml-models-scorecard/kie-pmml-models-scorecard-model/src/test/java/org/kie/pmml/models/scorecard/model/KiePMMLComplexPartialScoreTest.java
@@ -29,7 +29,7 @@ import org.kie.pmml.commons.model.expressions.KiePMMLConstant;
 import org.kie.pmml.commons.model.expressions.KiePMMLFieldRef;
 import org.kie.pmml.commons.transformations.KiePMMLDerivedField;
 
-import static org.junit.Assert.assertEquals;
+import static org.assertj.core.api.Assertions.assertThat;
 
 public class KiePMMLComplexPartialScoreTest {
 
@@ -49,7 +49,7 @@ public class KiePMMLComplexPartialScoreTest {
                                                                                        kiePMMLConstant1);
         Object retrieved = complexPartialScore.evaluate(Collections.emptyList(), Collections.emptyList(), Collections.emptyList(),
                                                  Collections.emptyMap());
-        assertEquals(value1, retrieved);
+        assertThat(retrieved).isEqualTo(value1);
     }
 
     @Test
@@ -64,7 +64,7 @@ public class KiePMMLComplexPartialScoreTest {
         inputData.put(PARAM_1, value1);
         Object retrieved = complexPartialScore.evaluate(Collections.emptyList(), Collections.emptyList(), Collections.emptyList(),
                                                  inputData);
-        assertEquals(value1, retrieved);
+        assertThat(retrieved).isEqualTo(value1);
     }
 
     @Test
@@ -85,7 +85,7 @@ public class KiePMMLComplexPartialScoreTest {
         Object retrieved = complexPartialScore.evaluate(Collections.emptyList(), Collections.emptyList(), Collections.emptyList(),
                                                  getInputData());
         Object expected = value1 / value2;
-        assertEquals(expected, retrieved);
+        assertThat(retrieved).isEqualTo(expected);
     }
 
     @Test
@@ -106,7 +106,7 @@ public class KiePMMLComplexPartialScoreTest {
         Object retrieved = complexPartialScore.evaluate(Collections.emptyList(), getDerivedFields(), Collections.emptyList(),
                                                  Collections.emptyMap());
         Object expected = value1 / value2;
-        assertEquals(expected, retrieved);
+        assertThat(retrieved).isEqualTo(expected);
     }
 
     private Map<String, Object> getInputData() {

--- a/kie-pmml-trusty/kie-pmml-models/kie-pmml-models-scorecard/kie-pmml-models-scorecard-model/src/test/java/org/kie/pmml/models/scorecard/model/KiePMMLScorecardModelTest.java
+++ b/kie-pmml-trusty/kie-pmml-models/kie-pmml-models-scorecard/kie-pmml-models-scorecard-model/src/test/java/org/kie/pmml/models/scorecard/model/KiePMMLScorecardModelTest.java
@@ -29,8 +29,6 @@ import org.kie.pmml.commons.model.predicates.KiePMMLTruePredicate;
 import org.kie.pmml.commons.testingutility.PMMLContextTest;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
 
 public class KiePMMLScorecardModelTest {
 
@@ -62,13 +60,13 @@ public class KiePMMLScorecardModelTest {
         Double EVALUATION_20 = baselineScore - value2;
         Double EVALUATION_11 = baselineScore - value1;
         Double expected = initialScore + value2 + value1 + 1;
-        assertEquals(expected, retrieved);
+        assertThat(retrieved).isEqualTo(expected);
         final Map<String, Object> outputFieldsMap = pmmlContextTest.getOutputFieldsMap();
-        assertEquals(2, outputFieldsMap.size());
-        assertTrue(outputFieldsMap.containsKey("REASON_CODE_20"));
-        assertEquals(EVALUATION_20, outputFieldsMap.get("REASON_CODE_20"));
-        assertTrue(outputFieldsMap.containsKey("REASON_CODE_11"));
-        assertEquals(EVALUATION_11, outputFieldsMap.get("REASON_CODE_11"));
+        assertThat(outputFieldsMap).hasSize(2);
+        assertThat(outputFieldsMap).containsKey("REASON_CODE_20");
+        assertThat(outputFieldsMap.get("REASON_CODE_20")).isEqualTo(EVALUATION_20);
+        assertThat(outputFieldsMap).containsKey("REASON_CODE_11");
+        assertThat(outputFieldsMap.get("REASON_CODE_11")).isEqualTo(EVALUATION_11);
     }
 
     private KiePMMLCharacteristics getKiePMMLCharacteristics() {

--- a/kie-pmml-trusty/kie-pmml-models/kie-pmml-models-scorecard/kie-pmml-models-scorecard-tests/src/test/java/org/kie/pmml/models/scorecard/tests/SimpleScorecardCategoricalTest.java
+++ b/kie-pmml-trusty/kie-pmml-models/kie-pmml-models-scorecard/kie-pmml-models-scorecard-tests/src/test/java/org/kie/pmml/models/scorecard/tests/SimpleScorecardCategoricalTest.java
@@ -33,7 +33,6 @@ import org.kie.pmml.api.runtime.PMMLRuntime;
 import org.kie.pmml.models.tests.AbstractPMMLTest;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.Assert.assertFalse;
 
 @RunWith(Parameterized.class)
 public class SimpleScorecardCategoricalTest extends AbstractPMMLTest {
@@ -101,8 +100,8 @@ public class SimpleScorecardCategoricalTest extends AbstractPMMLTest {
         getSamples().stream().map(sample -> evaluate(pmmlRuntime, sample, MODEL_NAME))
                 .filter(pmml4Result -> pmml4Result.getResultVariables().get(TARGET_FIELD) == null)
                 .forEach(pmml4Result -> {
-                    assertFalse(pmml4Result.getResultVariables().containsKey(REASON_CODE1_FIELD));
-                    assertFalse(pmml4Result.getResultVariables().containsKey(REASON_CODE2_FIELD));
+                    assertThat(pmml4Result.getResultVariables()).doesNotContainKey(REASON_CODE1_FIELD);
+                    assertThat(pmml4Result.getResultVariables()).doesNotContainKey(REASON_CODE2_FIELD);
                 });
     }
 

--- a/kie-pmml-trusty/kie-pmml-models/kie-pmml-models-tests/src/main/java/org/kie/pmml/models/tests/AbstractPMMLTest.java
+++ b/kie-pmml-trusty/kie-pmml-models/kie-pmml-models-tests/src/main/java/org/kie/pmml/models/tests/AbstractPMMLTest.java
@@ -31,7 +31,7 @@ import org.kie.pmml.evaluator.assembler.factories.PMMLRuntimeFactoryImpl;
 import org.kie.pmml.evaluator.core.PMMLContextImpl;
 import org.kie.pmml.evaluator.core.utils.PMMLRequestDataBuilder;
 
-import static org.junit.Assert.assertEquals;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.kie.test.util.filesystem.FileUtils.getFile;
 
 public class AbstractPMMLTest {
@@ -78,7 +78,7 @@ public class AbstractPMMLTest {
     }
 
     private void commonValidateListener(final PMMLListenerTest toValidate, final List<PMMLStep> expectedSteps) {
-        assertEquals(expectedSteps, toValidate.getSteps());
+        assertThat(toValidate.getSteps()).isEqualTo(expectedSteps);
     }
 
     protected static class PMMLListenerTest implements PMMLListener {

--- a/kie-pmml-trusty/kie-pmml-models/kie-pmml-models-tree/kie-pmml-models-tree-compiler/src/test/java/org/kie/pmml/models/tree/compiler/executor/TreeModelImplementationProviderTest.java
+++ b/kie-pmml-trusty/kie-pmml-models/kie-pmml-models-tree/kie-pmml-models-tree-compiler/src/test/java/org/kie/pmml/models/tree/compiler/executor/TreeModelImplementationProviderTest.java
@@ -31,10 +31,7 @@ import org.kie.pmml.compiler.commons.mocks.HasClassLoaderMock;
 import org.kie.pmml.models.tree.model.KiePMMLTreeModel;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
+import static org.assertj.core.api.Assertions.fail;
 import static org.kie.pmml.commons.Constants.PACKAGE_NAME;
 
 public class TreeModelImplementationProviderTest {
@@ -50,7 +47,7 @@ public class TreeModelImplementationProviderTest {
 
     @Test
     public void getPMMLModelType() {
-        assertEquals(PMML_MODEL.TREE_MODEL, PROVIDER.getPMMLModelType());
+        assertThat(PROVIDER.getPMMLModelType()).isEqualTo(PMML_MODEL.TREE_MODEL);
     }
 
     @Test
@@ -63,7 +60,7 @@ public class TreeModelImplementationProviderTest {
                                                                        new HasClassLoaderMock());
         final KiePMMLTreeModel retrieved = PROVIDER.getKiePMMLModel(compilationDTO);
         assertThat(retrieved).isNotNull();
-        assertTrue(retrieved instanceof Serializable);
+        assertThat(retrieved).isInstanceOf(Serializable.class);
     }
 
     @Test
@@ -78,12 +75,12 @@ public class TreeModelImplementationProviderTest {
         assertThat(retrieved).isNotNull();
         final Map<String, String> sourcesMap = retrieved.getSourcesMap();
         assertThat(sourcesMap).isNotNull();
-        assertFalse(sourcesMap.isEmpty());
+        assertThat(sourcesMap).isNotEmpty();
         ClassLoader classLoader = Thread.currentThread().getContextClassLoader();
         try {
             final Map<String, Class<?>> compiled = KieMemoryCompiler.compile(sourcesMap, classLoader);
             for (Class<?> clazz : compiled.values()) {
-                assertTrue(clazz instanceof Serializable);
+                assertThat(clazz).isInstanceOf(Serializable.class);
             }
         } catch (Throwable t) {
             fail(t.getMessage());

--- a/kie-pmml-trusty/kie-pmml-models/kie-pmml-models-tree/kie-pmml-models-tree-compiler/src/test/java/org/kie/pmml/models/tree/compiler/factories/KiePMMLNodeFactoryTest.java
+++ b/kie-pmml-trusty/kie-pmml-models/kie-pmml-models-tree/kie-pmml-models-tree-compiler/src/test/java/org/kie/pmml/models/tree/compiler/factories/KiePMMLNodeFactoryTest.java
@@ -42,6 +42,7 @@ import com.github.javaparser.ast.expr.TypeExpr;
 import com.github.javaparser.ast.expr.VariableDeclarationExpr;
 import com.github.javaparser.ast.stmt.BlockStmt;
 import com.github.javaparser.ast.stmt.Statement;
+import org.assertj.core.data.Offset;
 import org.dmg.pmml.DataDictionary;
 import org.dmg.pmml.DerivedField;
 import org.dmg.pmml.PMML;
@@ -58,9 +59,6 @@ import org.kie.pmml.models.tree.model.KiePMMLNode;
 
 import static com.github.javaparser.StaticJavaParser.parseClassOrInterfaceType;
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
 import static org.kie.pmml.commons.Constants.PACKAGE_CLASS_TEMPLATE;
 import static org.kie.pmml.commons.Constants.PACKAGE_NAME;
 import static org.kie.pmml.compiler.api.CommonTestingUtils.getFieldsFromDataDictionaryAndDerivedFields;
@@ -176,9 +174,9 @@ public class KiePMMLNodeFactoryTest {
 
         MethodReferenceExpr retrieved = evaluateNodeInitializer.getArguments().get(0).asMethodReferenceExpr();
         String expected = toPopulate.nodeClassName;
-        assertEquals(expected, retrieved.getScope().asNameExpr().toString());
+        assertThat(retrieved.getScope().asNameExpr().toString()).isEqualTo(expected);
         expected = EVALUATE_NODE + nestedNodeClassName;
-        assertEquals(expected, retrieved.getIdentifier());
+        assertThat(retrieved.getIdentifier()).isEqualTo(expected);
     }
 
     @Test
@@ -217,7 +215,7 @@ public class KiePMMLNodeFactoryTest {
         variableDeclarator.setType("Object");
         variableDeclarator.setName(NODE_FUNCTIONS);
         toPopulate.addStatement(new VariableDeclarationExpr(variableDeclarator));
-        assertFalse(variableDeclarator.getInitializer().isPresent());
+        assertThat(variableDeclarator.getInitializer()).isNotPresent();
         // empty list
         List<String> nestedNodesFullClasses = Collections.emptyList();
         KiePMMLNodeFactory.populateEvaluateNodeWithNodeFunctions(toPopulate, nestedNodesFullClasses);
@@ -235,8 +233,8 @@ public class KiePMMLNodeFactoryTest {
     public void getEvaluateNodeMethodReference() {
         String fullNodeClassName = "full.node.NodeClassName";
         MethodReferenceExpr retrieved = KiePMMLNodeFactory.getEvaluateNodeMethodReference(fullNodeClassName);
-        assertEquals(fullNodeClassName, retrieved.getScope().toString());
-        assertEquals(EVALUATE_NODE, retrieved.getIdentifier());
+        assertThat(retrieved.getScope().toString()).isEqualTo(fullNodeClassName);
+        assertThat(retrieved.getIdentifier()).isEqualTo(EVALUATE_NODE);
     }
 
     @Test
@@ -246,7 +244,7 @@ public class KiePMMLNodeFactoryTest {
         variableDeclarator.setType("Object");
         variableDeclarator.setName(SCORE);
         toPopulate.addStatement(new VariableDeclarationExpr(variableDeclarator));
-        assertFalse(variableDeclarator.getInitializer().isPresent());
+        assertThat(variableDeclarator.getInitializer()).isNotPresent();
         // null score
         Object score = null;
         KiePMMLNodeFactory.populateEvaluateNodeWithScore(toPopulate, score);
@@ -268,7 +266,7 @@ public class KiePMMLNodeFactoryTest {
         variableDeclarator.setType("List");
         variableDeclarator.setName(SCORE_DISTRIBUTIONS);
         toPopulate.addStatement(new VariableDeclarationExpr(variableDeclarator));
-        assertFalse(variableDeclarator.getInitializer().isPresent());
+        assertThat(variableDeclarator.getInitializer()).isNotPresent();
         // Without probability
         List<ScoreDistribution> scoreDistributions = getRandomPMMLScoreDistributions(false);
         KiePMMLNodeFactory.populateEvaluateNodeWithScoreDistributions(toPopulate, scoreDistributions);
@@ -286,14 +284,14 @@ public class KiePMMLNodeFactoryTest {
         variableDeclarator.setType("double");
         variableDeclarator.setName(MISSING_VALUE_PENALTY);
         toPopulate.addStatement(new VariableDeclarationExpr(variableDeclarator));
-        assertFalse(variableDeclarator.getInitializer().isPresent());
+        assertThat(variableDeclarator.getInitializer()).isNotPresent();
         final double missingValuePenalty = new Random().nextDouble();
         KiePMMLNodeFactory.populateEvaluateNodeWithMissingValuePenalty(toPopulate, missingValuePenalty);
-        assertTrue(variableDeclarator.getInitializer().isPresent());
+        assertThat(variableDeclarator.getInitializer()).isPresent();
         Expression expression = variableDeclarator.getInitializer().get();
-        assertTrue(expression instanceof DoubleLiteralExpr);
+        assertThat(expression).isInstanceOf(DoubleLiteralExpr.class);
         DoubleLiteralExpr doubleLiteralExpr = (DoubleLiteralExpr) expression;
-        assertEquals(missingValuePenalty, doubleLiteralExpr.asDouble(), 0.0);
+        assertThat(doubleLiteralExpr.asDouble()).isCloseTo(missingValuePenalty, Offset.offset(0.0));
     }
 
     @Test
@@ -304,14 +302,14 @@ public class KiePMMLNodeFactoryTest {
                                                              getFieldsFromDataDictionaryAndDerivedFields(dataDictionary2, derivedFields2));
         String text = getFileContent(TEST_01_SOURCE);
         Statement expected = JavaParserUtils.parseBlock(text);
-        assertTrue(JavaParserUtils.equalsNode(expected, toPopulate));
+        assertThat(JavaParserUtils.equalsNode(expected, toPopulate)).isTrue();
     }
 
     @Test
     public void nodeNamesDTO() {
         KiePMMLNodeFactory.NodeNamesDTO retrieved = new KiePMMLNodeFactory.NodeNamesDTO(nodeRoot, createNodeClassName(),
                                                                                         PACKAGE_NAME, 1.0);
-        assertEquals(nodeRoot.getNodes().size(), retrieved.childrenNodes.size());
+        assertThat(retrieved.childrenNodes.size()).isEqualTo(nodeRoot.getNodes().size());
     }
 
     private void commonVerifyEvaluateNode(final KiePMMLNodeFactory.JavaParserDTO toPopulate,
@@ -334,46 +332,46 @@ public class KiePMMLNodeFactoryTest {
 
     private void commonVerifyEvaluateNodeWithNodeFunctions(final VariableDeclarator variableDeclarator,
                                                            final List<String> nestedNodesFullClasses) {
-        assertTrue(variableDeclarator.getInitializer().isPresent());
+        assertThat(variableDeclarator.getInitializer()).isPresent();
         Expression expression = variableDeclarator.getInitializer().get();
-        assertTrue(expression instanceof MethodCallExpr);
+        assertThat(expression).isInstanceOf(MethodCallExpr.class);
         MethodCallExpr methodCallExpr = (MethodCallExpr) expression;
         Expression scope = methodCallExpr.getScope().orElseThrow(() -> new RuntimeException("No scope in generated " +
                                                                                                     "methodCallExpr"));
         if (nestedNodesFullClasses.isEmpty()) {
-            assertEquals(Collections.class.getName(), scope.toString());
-            assertEquals(EMPTY_LIST, methodCallExpr.getName().asString());
-            assertTrue(methodCallExpr.getArguments().isEmpty());
+            assertThat(scope.toString()).isEqualTo(Collections.class.getName());
+            assertThat(methodCallExpr.getName().asString()).isEqualTo(EMPTY_LIST);
+            assertThat(methodCallExpr.getArguments()).isEmpty();
         } else {
-            assertEquals(Arrays.class.getName(), scope.toString());
-            assertEquals(AS_LIST, methodCallExpr.getName().asString());
-            assertEquals(nestedNodesFullClasses.size(), methodCallExpr.getArguments().size());
+            assertThat(scope.toString()).isEqualTo(Arrays.class.getName());
+            assertThat(methodCallExpr.getName().asString()).isEqualTo(AS_LIST);
+            assertThat(methodCallExpr.getArguments().size()).isEqualTo(nestedNodesFullClasses.size());
         }
     }
 
     private void commonVerifyEvaluateNodeWithScore(final VariableDeclarator variableDeclarator, final Object score) {
-        assertTrue(variableDeclarator.getInitializer().isPresent());
+        assertThat(variableDeclarator.getInitializer()).isPresent();
         Expression expression = variableDeclarator.getInitializer().get();
         if (score == null) {
-            assertTrue(expression instanceof NullLiteralExpr);
+            assertThat(expression).isInstanceOf(NullLiteralExpr.class);
         } else {
-            assertTrue(expression instanceof NameExpr);
+            assertThat(expression).isInstanceOf(NameExpr.class);
             String toFormat = score instanceof String ? "\"%s\"" : "%s";
-            assertEquals(String.format(toFormat, score), expression.toString());
+            assertThat(expression.toString()).isEqualTo(String.format(toFormat, score));
         }
     }
 
     private void commonVerifyEvaluateNodeWithScoreDistributions(final VariableDeclarator variableDeclarator,
                                                                 final List<ScoreDistribution> scoreDistributions) {
-        assertTrue(variableDeclarator.getInitializer().isPresent());
+        assertThat(variableDeclarator.getInitializer()).isPresent();
         Expression expression = variableDeclarator.getInitializer().get();
-        assertTrue(expression instanceof MethodCallExpr);
+        assertThat(expression).isInstanceOf(MethodCallExpr.class);
         MethodCallExpr methodCallExpr = (MethodCallExpr) expression;
-        assertEquals("Arrays", methodCallExpr.getScope().get().toString());
-        assertEquals("asList", methodCallExpr.getName().toString());
+        assertThat(methodCallExpr.getScope().get().toString()).isEqualTo("Arrays");
+        assertThat(methodCallExpr.getName().toString()).isEqualTo("asList");
         NodeList<Expression> arguments = methodCallExpr.getArguments();
-        assertEquals(scoreDistributions.size(), arguments.size());
-        arguments.forEach(argument -> assertTrue(argument instanceof ObjectCreationExpr));
+        assertThat(arguments).hasSameSizeAs(scoreDistributions);
+        arguments.forEach(argument -> assertThat(argument).isInstanceOf(ObjectCreationExpr.class));
         List<ObjectCreationExpr> objectCreationExprs = arguments.stream()
                 .map(ObjectCreationExpr.class::cast)
                 .collect(Collectors.toList());
@@ -381,27 +379,27 @@ public class KiePMMLNodeFactoryTest {
             Optional<ObjectCreationExpr> retrieved = objectCreationExprs.stream()
                     .filter(objectCreationExpr -> scoreDistribution.getValue().equals(objectCreationExpr.getArgument(2).asStringLiteralExpr().asString()))
                     .findFirst();
-            assertTrue(retrieved.isPresent());
+            assertThat(retrieved).isPresent();
             Expression recordCountExpected = getExpressionForObject(scoreDistribution.getRecordCount().intValue());
             Expression confidenceExpected = getExpressionForObject(scoreDistribution.getConfidence().doubleValue());
             Expression probabilityExpected = scoreDistribution.getProbability() != null ?
                     getExpressionForObject(scoreDistribution.getProbability().doubleValue()) : new NullLiteralExpr();
             retrieved.ifPresent(objectCreationExpr -> {
-                assertEquals(recordCountExpected, objectCreationExpr.getArgument(3));
-                assertEquals(confidenceExpected, objectCreationExpr.getArgument(4));
-                assertEquals(probabilityExpected, objectCreationExpr.getArgument(5));
+                assertThat(objectCreationExpr.getArgument(3)).isEqualTo(recordCountExpected);
+                assertThat(objectCreationExpr.getArgument(4)).isEqualTo(confidenceExpected);
+                assertThat(objectCreationExpr.getArgument(5)).isEqualTo(probabilityExpected);
             });
         });
     }
 
     private void commonVerifyNode(KiePMMLNode toVerify, Node original) {
-        assertEquals(original.getId(), toVerify.getName());
+        assertThat(toVerify.getName()).isEqualTo(original.getId());
     }
 
     private void commonVerifyNodeSource(final Map<String, String> retrieved, final String packageName) {
-        assertEquals(1, retrieved.size());
+        assertThat(retrieved).hasSize(1);
         String toVerify = retrieved.values().iterator().next();
         CompilationUnit nodeCompilationUnit = getFromSource(toVerify);
-        assertEquals(packageName, nodeCompilationUnit.getPackageDeclaration().get().getName().asString());
+        assertThat(nodeCompilationUnit.getPackageDeclaration().get().getName().asString()).isEqualTo(packageName);
     }
 }

--- a/kie-pmml-trusty/kie-pmml-models/kie-pmml-models-tree/kie-pmml-models-tree-compiler/src/test/java/org/kie/pmml/models/tree/compiler/factories/KiePMMLNodeFactoryTest.java
+++ b/kie-pmml-trusty/kie-pmml-models/kie-pmml-models-tree/kie-pmml-models-tree-compiler/src/test/java/org/kie/pmml/models/tree/compiler/factories/KiePMMLNodeFactoryTest.java
@@ -309,7 +309,7 @@ public class KiePMMLNodeFactoryTest {
     public void nodeNamesDTO() {
         KiePMMLNodeFactory.NodeNamesDTO retrieved = new KiePMMLNodeFactory.NodeNamesDTO(nodeRoot, createNodeClassName(),
                                                                                         PACKAGE_NAME, 1.0);
-        assertThat(retrieved.childrenNodes.size()).isEqualTo(nodeRoot.getNodes().size());
+        assertThat(retrieved.childrenNodes).hasSameSizeAs(nodeRoot.getNodes());
     }
 
     private void commonVerifyEvaluateNode(final KiePMMLNodeFactory.JavaParserDTO toPopulate,
@@ -345,7 +345,7 @@ public class KiePMMLNodeFactoryTest {
         } else {
             assertThat(scope.toString()).isEqualTo(Arrays.class.getName());
             assertThat(methodCallExpr.getName().asString()).isEqualTo(AS_LIST);
-            assertThat(methodCallExpr.getArguments().size()).isEqualTo(nestedNodesFullClasses.size());
+            assertThat(methodCallExpr.getArguments()).hasSameSizeAs(nestedNodesFullClasses);
         }
     }
 

--- a/kie-pmml-trusty/kie-pmml-models/kie-pmml-models-tree/kie-pmml-models-tree-compiler/src/test/java/org/kie/pmml/models/tree/compiler/factories/KiePMMLTreeModelFactoryTest.java
+++ b/kie-pmml-trusty/kie-pmml-models/kie-pmml-models-tree/kie-pmml-models-tree-compiler/src/test/java/org/kie/pmml/models/tree/compiler/factories/KiePMMLTreeModelFactoryTest.java
@@ -47,8 +47,6 @@ import org.kie.pmml.models.tree.compiler.dto.TreeCompilationDTO;
 import org.kie.pmml.models.tree.model.KiePMMLTreeModel;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
 import static org.kie.pmml.commons.Constants.MISSING_DEFAULT_CONSTRUCTOR;
 import static org.kie.pmml.commons.Constants.PACKAGE_NAME;
 import static org.kie.pmml.commons.utils.KiePMMLModelUtils.getSanitizedClassName;
@@ -142,38 +140,38 @@ public class KiePMMLTreeModelFactoryTest {
         BlockStmt body = constructorDeclaration.getBody();
         // targetField
         Optional<AssignExpr> optRetrieved = CommonCodegenUtils.getAssignExpression(body, "targetField");
-        assertTrue(optRetrieved.isPresent());
+        assertThat(optRetrieved).isPresent();
         AssignExpr retrieved = optRetrieved.get();
         Expression initializer = retrieved.getValue();
-        assertTrue(initializer instanceof StringLiteralExpr);
+        assertThat(initializer).isInstanceOf(StringLiteralExpr.class);
         String expected = String.format("\"%s\"", targetField);
-        assertEquals(expected, initializer.toString());
+        assertThat(initializer.toString()).isEqualTo(expected);
         // miningFunction
         optRetrieved = CommonCodegenUtils.getAssignExpression(body, "miningFunction");
-        assertTrue(optRetrieved.isPresent());
+        assertThat(optRetrieved).isPresent();
         retrieved = optRetrieved.get();
         initializer = retrieved.getValue();
-        assertTrue(initializer instanceof NameExpr);
+        assertThat(initializer).isInstanceOf(NameExpr.class);
         MINING_FUNCTION miningFunction = MINING_FUNCTION.byName(treeModel1.getMiningFunction().value());
         expected = miningFunction.getClass().getName() + "." + miningFunction.name();
-        assertEquals(expected, initializer.toString());
+        assertThat(initializer.toString()).isEqualTo(expected);
         // pmmlMODEL
         optRetrieved = CommonCodegenUtils.getAssignExpression(body, "pmmlMODEL");
-        assertTrue(optRetrieved.isPresent());
+        assertThat(optRetrieved).isPresent();
         retrieved = optRetrieved.get();
         initializer = retrieved.getValue();
-        assertTrue(initializer instanceof NameExpr);
+        assertThat(initializer).isInstanceOf(NameExpr.class);
         expected = PMML_MODEL.TREE_MODEL.getClass().getName() + "." + PMML_MODEL.TREE_MODEL.name();
-        assertEquals(expected, initializer.toString());
+        assertThat(initializer.toString()).isEqualTo(expected);
         // nodeFunction
         optRetrieved = CommonCodegenUtils.getAssignExpression(body, "nodeFunction");
-        assertTrue(optRetrieved.isPresent());
+        assertThat(optRetrieved).isPresent();
         retrieved = optRetrieved.get();
         initializer = retrieved.getValue();
-        assertTrue(initializer instanceof MethodReferenceExpr);
+        assertThat(initializer).isInstanceOf(MethodReferenceExpr.class);
         expected = fullNodeClassName;
-        assertEquals(expected, ((MethodReferenceExpr) initializer).getScope().toString());
+        assertThat(((MethodReferenceExpr) initializer).getScope().toString()).isEqualTo(expected);
         expected = "evaluateNode";
-        assertEquals(expected, ((MethodReferenceExpr) initializer).getIdentifier());
+        assertThat(((MethodReferenceExpr) initializer).getIdentifier()).isEqualTo(expected);
     }
 }

--- a/kie-pmml-trusty/kie-pmml-models/kie-pmml-models-tree/kie-pmml-models-tree-evaluator/src/test/java/org/kie/pmml/models/tree/evaluator/PMMLTreeModelEvaluatorTest.java
+++ b/kie-pmml-trusty/kie-pmml-models/kie-pmml-models-tree/kie-pmml-models-tree-evaluator/src/test/java/org/kie/pmml/models/tree/evaluator/PMMLTreeModelEvaluatorTest.java
@@ -19,7 +19,7 @@ import org.junit.Before;
 import org.junit.Test;
 import org.kie.pmml.api.enums.PMML_MODEL;
 
-import static org.junit.Assert.assertEquals;
+import static org.assertj.core.api.Assertions.assertThat;
 
 public class PMMLTreeModelEvaluatorTest {
 
@@ -32,7 +32,7 @@ public class PMMLTreeModelEvaluatorTest {
 
     @Test
     public void getPMMLModelType(){
-        assertEquals(PMML_MODEL.TREE_MODEL, evaluator.getPMMLModelType());
+        assertThat(evaluator.getPMMLModelType()).isEqualTo(PMML_MODEL.TREE_MODEL);
     }
 
 

--- a/kie-pmml-trusty/kie-pmml-models/kie-pmml-models-tree/kie-pmml-models-tree-model/src/test/java/org/kie/pmml/models/tree/model/KiePMMLNodeTest.java
+++ b/kie-pmml-trusty/kie-pmml-models/kie-pmml-models-tree/kie-pmml-models-tree-model/src/test/java/org/kie/pmml/models/tree/model/KiePMMLNodeTest.java
@@ -21,12 +21,11 @@ import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Random;
 
+import org.assertj.core.data.Offset;
 import org.junit.Test;
 import org.kie.pmml.commons.model.tuples.KiePMMLProbabilityConfidence;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
 import static org.kie.pmml.models.tree.model.KiePMMLTreeTestUtils.getRandomKiePMMLScoreDistributions;
 
 public class KiePMMLNodeTest {
@@ -35,14 +34,14 @@ public class KiePMMLNodeTest {
     public void getProbabilityConfidenceMap() {
         LinkedHashMap<String, KiePMMLProbabilityConfidence> retrieved = KiePMMLNode.getProbabilityConfidenceMap(null, 1.0);
         assertThat(retrieved).isNotNull();
-        assertTrue(retrieved.isEmpty());
+        assertThat(retrieved).isEmpty();
         retrieved = KiePMMLNode.getProbabilityConfidenceMap(Collections.emptyList(), 1.0);
         assertThat(retrieved).isNotNull();
-        assertTrue(retrieved.isEmpty());
+        assertThat(retrieved).isEmpty();
         List<KiePMMLScoreDistribution> kiePMMLScoreDistributions = getRandomKiePMMLScoreDistributions(false);
         retrieved = KiePMMLNode.getProbabilityConfidenceMap(kiePMMLScoreDistributions, 1.0);
         assertThat(retrieved).isNotNull();
-        assertEquals(kiePMMLScoreDistributions.size(), retrieved.size());
+        assertThat(retrieved).hasSameSizeAs(kiePMMLScoreDistributions);
     }
 
     @Test
@@ -55,26 +54,26 @@ public class KiePMMLNodeTest {
         LinkedHashMap<String, KiePMMLProbabilityConfidence> retrievedNoProbability = KiePMMLNode.getProbabilityConfidenceMap(kiePMMLScoreDistributions, missingValuePenalty);
         assertThat(retrievedNoProbability).isNotNull();
         kiePMMLScoreDistributions.forEach(kiePMMLScoreDistribution -> {
-            assertTrue(retrievedNoProbability.containsKey(kiePMMLScoreDistribution.getValue()));
+            assertThat(retrievedNoProbability).containsKey(kiePMMLScoreDistribution.getValue());
             KiePMMLProbabilityConfidence kiePMMLProbabilityConfidence = retrievedNoProbability.get(kiePMMLScoreDistribution.getValue());
             assertThat(kiePMMLProbabilityConfidence).isNotNull();
             double probabilityExpected = (double) kiePMMLScoreDistribution.getRecordCount() / (double) totalRecordCount;
             double confidenceExpected = kiePMMLScoreDistribution.getConfidence() * missingValuePenalty;
-            assertEquals(probabilityExpected, kiePMMLProbabilityConfidence.getProbability(), 0.000000001);
-            assertEquals(confidenceExpected, kiePMMLProbabilityConfidence.getConfidence(), 0.000000001);
+            assertThat(kiePMMLProbabilityConfidence.getProbability()).isCloseTo(probabilityExpected, Offset.offset(0.000000001));
+            assertThat(kiePMMLProbabilityConfidence.getConfidence()).isCloseTo(confidenceExpected, Offset.offset(0.000000001));
         });
         //
         kiePMMLScoreDistributions = getRandomKiePMMLScoreDistributions(true);
         LinkedHashMap<String, KiePMMLProbabilityConfidence> retrievedProbability = KiePMMLNode.getProbabilityConfidenceMap(kiePMMLScoreDistributions, missingValuePenalty);
         assertThat(retrievedNoProbability).isNotNull();
         kiePMMLScoreDistributions.forEach(kiePMMLScoreDistribution -> {
-            assertTrue(retrievedProbability.containsKey(kiePMMLScoreDistribution.getValue()));
+        	assertThat(retrievedProbability).containsKey(kiePMMLScoreDistribution.getValue());
             KiePMMLProbabilityConfidence kiePMMLProbabilityConfidence = retrievedProbability.get(kiePMMLScoreDistribution.getValue());
             assertThat(kiePMMLProbabilityConfidence).isNotNull();
             double probabilityExpected = kiePMMLScoreDistribution.getProbability();
             double confidenceExpected = kiePMMLScoreDistribution.getConfidence() * missingValuePenalty;
-            assertEquals(probabilityExpected, kiePMMLProbabilityConfidence.getProbability(), 0.000000001);
-            assertEquals(confidenceExpected, kiePMMLProbabilityConfidence.getConfidence(), 0.000000001);
+            assertThat(kiePMMLProbabilityConfidence.getProbability()).isCloseTo(probabilityExpected, Offset.offset(0.000000001));
+            assertThat(kiePMMLProbabilityConfidence.getConfidence()).isCloseTo(confidenceExpected, Offset.offset(0.000000001));
         });
     }
 }


### PR DESCRIPTION
This is the backport of [4390](https://github.com/kiegroup/drools/pull/4390)

**JIRA**:  [DROOLS-6931](https://issues.redhat.com/browse/DROOLS-6931)

<details>
<summary>
How to replicate CI configuration locally?
</summary>

Build Chain tool does "simple" maven build(s), the builds are just Maven commands, but because the repositories relates and depends on each other and any change in API or class method could affect several of those repositories there is a need to use [build-chain tool](https://github.com/kiegroup/github-action-build-chain) to handle cross repository builds and be sure that we always use latest version of the code for each repository.
 
[build-chain tool](https://github.com/kiegroup/github-action-build-chain) is a build tool which can be used on command line locally or in Github Actions workflow(s), in case you need to change multiple repositories and send multiple dependent pull requests related with a change you can easily reproduce the same build by executing it on Github hosted environment or locally in your development environment. See [local execution](https://github.com/kiegroup/github-action-build-chain#local-execution) details to get more information about it.
</details>

<details>
<summary>
How to retest this PR or trigger a specific build:
</summary>

- for <b>pull request checks</b>  
  Please add comment: <b>Jenkins retest this</b>

- for a <b>specific pull request check</b>  
  Please add comment: <b>Jenkins (re)run [drools|kogito-runtimes|optaplanner|kogito-apps|kogito-examples|optaplanner-quickstarts|optaweb-employee-rostering|optaweb-vehicle-routing] tests</b>

- for a <b>full downstream build</b> 
  - for <b>jenkins</b> job: please add comment: <b>Jenkins run fdb</b>
  - for <b>github actions</b> job: add the label `run_fdb`

- <b>a compile downstream build</b> please  add comment: <b>Jenkins run cdb</b>

- <b>a full production downstream build</b> please add comment: <b>Jenkins execute product fdb</b>

- <b>an upstream build</b> please add comment: <b>Jenkins run upstream</b>

- for <b>quarkus branch checks</b>  
  Run checks against Quarkus current used branch  
  Please add comment: <b>Jenkins run quarkus-branch</b>

- for a <b>quarkus branch specific check</b>  
  Run checks against Quarkus current used branch  
  Please add comment: <b>Jenkins (re)run [drools|kogito-runtimes|optaplanner|kogito-apps|kogito-examples|optaplanner-quickstarts|optaweb-employee-rostering|optaweb-vehicle-routing] quarkus-branch</b>

- for <b>quarkus main checks</b>  
  Run checks against Quarkus main branch  
  Please add comment: <b>Jenkins run quarkus-main</b>

- for a <b>specific quarkus main check</b>  
  Run checks against Quarkus main branch  
  Please add comment: <b>Jenkins (re)run [drools|kogito-runtimes|optaplanner|kogito-apps|kogito-examples|optaplanner-quickstarts|optaweb-employee-rostering|optaweb-vehicle-routing] quarkus-branch</b>

- for <b>native checks</b>  
  Run native checks  
  Please add comment: <b>Jenkins run native</b>

- for a <b>specific native check</b>  
  Run native checks 
  Please add comment: <b>Jenkins (re)run [drools|kogito-runtimes|optaplanner|kogito-apps|kogito-examples|optaplanner-quickstarts|optaweb-employee-rostering|optaweb-vehicle-routing] native</b>

- for <b>mandrel checks</b>  
  Run native checks against Mandrel image
  Please add comment: <b>Jenkins run mandrel</b>

- for a <b>specific mandrel check</b>  
  Run native checks against Mandrel image  
  Please add comment: <b>Jenkins (re)run [drools|kogito-runtimes|optaplanner|kogito-apps|kogito-examples|optaplanner-quickstarts|optaweb-employee-rostering|optaweb-vehicle-routing] mandrel</b>
</details>
