### PR TITLE
[KOGITO-7165] Drools release pipeline: Antora documentation handling …

### DIFF
--- a/drools-docs/.gitignore
+++ b/drools-docs/.gitignore
@@ -1,0 +1,1 @@
+!.index.adoc

--- a/drools-docs/pom.xml
+++ b/drools-docs/pom.xml
@@ -7,7 +7,7 @@
   <parent>
     <groupId>org.kie</groupId>
     <artifactId>drools-build-parent</artifactId>
-    <version>8.21.0-SNAPSHOT</version>
+    <version>8.23.0-SNAPSHOT</version>
     <relativePath>../build-parent/pom.xml</relativePath>
   </parent>
 

--- a/drools-docs/pom.xml
+++ b/drools-docs/pom.xml
@@ -42,7 +42,6 @@
             <java-version>${maven.compiler.release}</java-version>
             <maven-version>${maven.min.version}</maven-version>
             <quarkus-version>${version.io.quarkus}</quarkus-version>
-            <spring-boot-version>${version.org.springframework.boot}</spring-boot-version>
           </attributes>
         </configuration>
         <executions>

--- a/drools-docs/src/antora-template.yml
+++ b/drools-docs/src/antora-template.yml
@@ -13,6 +13,5 @@ asciidoc:
     java-version: ${maven.compiler.release}
     maven-version: ${maven.min.version}
     quarkus-version: ${version.io.quarkus}
-    spring-boot-version: ${version.org.springframework.boot}
 nav:
   - modules/ROOT/nav.adoc

--- a/drools-docs/src/antora-template.yml
+++ b/drools-docs/src/antora-template.yml
@@ -9,7 +9,7 @@ title: Drools User Guide ${project.version}
 version: latest
 asciidoc:
   attributes:
-    optaplanner-version: ${project.version}
+    drools-version: ${project.version}
     java-version: ${maven.compiler.release}
     maven-version: ${maven.min.version}
     quarkus-version: ${version.io.quarkus}

--- a/drools-docs/src/antora.yml
+++ b/drools-docs/src/antora.yml
@@ -5,14 +5,14 @@
 # The goal is to have the antora.yml containing correct attributes available in the release branch before
 # the drools-website is refreshed.
 name: drools
-title: Drools User Guide 8.21.0-SNAPSHOT
+title: Drools User Guide 8.23.0-SNAPSHOT
 version: latest
 asciidoc:
   attributes:
-    drools-version: 8.21.0-SNAPSHOT
-    java-version: 11
+    drools-version: 8.23.0-SNAPSHOT
+    java-version: 8
     maven-version: 3.8.1
-    quarkus-version: 2.7.3.Final
-    spring-boot-version: 2.4.5
+    quarkus-version: 2.9.0.Final
+    spring-boot-version: ${version.org.springframework.boot}
 nav:
   - modules/ROOT/nav.adoc

--- a/drools-docs/src/antora.yml
+++ b/drools-docs/src/antora.yml
@@ -13,6 +13,5 @@ asciidoc:
     java-version: 8
     maven-version: 3.8.1
     quarkus-version: 2.9.0.Final
-    spring-boot-version: ${version.org.springframework.boot}
 nav:
   - modules/ROOT/nav.adoc

--- a/drools-docs/src/modules/ROOT/pages/.index.adoc
+++ b/drools-docs/src/modules/ROOT/pages/.index.adoc
@@ -1,0 +1,22 @@
+= Drools User Guide
+The Drools Team <https://www.drools.org/community/team.html>
+:doctype: book
+:imagesdir: .
+:title-logo-image: image:shared/droolsExpertLogo.png[align="center"]
+:toc: left
+:toclevels: 3
+:sectnums:
+:sectanchors:
+:sectlinks:
+:sectnumlevels: 5
+:icons: font
+:docinfo:
+
+
+// PDF uses :title-logo-image: on first page, no need to repeat image later on
+ifndef::backend-pdf[]
+image::shared/droolsExpertLogo.png[align="center"]
+endif::[]
+
+include::rule-engine/index.adoc[leveloffset=+1]
+include::language-reference/index.adoc[leveloffset=+1]

--- a/pom.xml
+++ b/pom.xml
@@ -199,6 +199,7 @@
         </property>
       </activation>
       <modules>
+        <module>drools-docs</module>
         <module>drools-distribution</module>
       </modules>
     </profile>


### PR DESCRIPTION
…in release pipeline is not working

**JIRA**: 
https://issues.redhat.com/browse/KOGITO-7165

<details>
<summary>
How to replicate CI configuration locally?
</summary>

Build Chain tool does "simple" maven build(s), the builds are just Maven commands, but because the repositories relates and depends on each other and any change in API or class method could affect several of those repositories there is a need to use [build-chain tool](https://github.com/kiegroup/github-action-build-chain) to handle cross repository builds and be sure that we always use latest version of the code for each repository.
 
[build-chain tool](https://github.com/kiegroup/github-action-build-chain) is a build tool which can be used on command line locally or in Github Actions workflow(s), in case you need to change multiple repositories and send multiple dependent pull requests related with a change you can easily reproduce the same build by executing it on Github hosted environment or locally in your development environment. See [local execution](https://github.com/kiegroup/github-action-build-chain#local-execution) details to get more information about it.
</details>

<details>
<summary>
How to retest this PR or trigger a specific build:
</summary>

- for <b>pull request checks</b>  
  Please add comment: <b>Jenkins retest this</b>

- for a <b>specific pull request check</b>  
  Please add comment: <b>Jenkins (re)run [drools|kogito-runtimes|optaplanner|kogito-apps|kogito-examples|optaplanner-quickstarts|optaweb-employee-rostering|optaweb-vehicle-routing] tests</b>

- for a <b>full downstream build</b> 
  - for <b>jenkins</b> job: please add comment: <b>Jenkins run fdb</b>
  - for <b>github actions</b> job: add the label `run_fdb`

- <b>a compile downstream build</b> please  add comment: <b>Jenkins run cdb</b>

- <b>a full production downstream build</b> please add comment: <b>Jenkins execute product fdb</b>

- <b>an upstream build</b> please add comment: <b>Jenkins run upstream</b>

- for <b>quarkus branch checks</b>  
  Run checks against Quarkus current used branch  
  Please add comment: <b>Jenkins run quarkus-branch</b>

- for a <b>quarkus branch specific check</b>  
  Run checks against Quarkus current used branch  
  Please add comment: <b>Jenkins (re)run [drools|kogito-runtimes|optaplanner|kogito-apps|kogito-examples|optaplanner-quickstarts|optaweb-employee-rostering|optaweb-vehicle-routing] quarkus-branch</b>

- for <b>quarkus main checks</b>  
  Run checks against Quarkus main branch  
  Please add comment: <b>Jenkins run quarkus-main</b>

- for a <b>specific quarkus main check</b>  
  Run checks against Quarkus main branch  
  Please add comment: <b>Jenkins (re)run [drools|kogito-runtimes|optaplanner|kogito-apps|kogito-examples|optaplanner-quickstarts|optaweb-employee-rostering|optaweb-vehicle-routing] quarkus-branch</b>

- for <b>native checks</b>  
  Run native checks  
  Please add comment: <b>Jenkins run native</b>

- for a <b>specific native check</b>  
  Run native checks 
  Please add comment: <b>Jenkins (re)run [drools|kogito-runtimes|optaplanner|kogito-apps|kogito-examples|optaplanner-quickstarts|optaweb-employee-rostering|optaweb-vehicle-routing] native</b>

- for <b>mandrel checks</b>  
  Run native checks against Mandrel image
  Please add comment: <b>Jenkins run mandrel</b>

- for a <b>specific mandrel check</b>  
  Run native checks against Mandrel image  
  Please add comment: <b>Jenkins (re)run [drools|kogito-runtimes|optaplanner|kogito-apps|kogito-examples|optaplanner-quickstarts|optaweb-employee-rostering|optaweb-vehicle-routing] mandrel</b>
</details>
