### PR TITLE
[8.22.x] Bump Quarkus version to 2.9.2.Final

### DIFF
--- a/build-parent/pom.xml
+++ b/build-parent/pom.xml
@@ -35,9 +35,9 @@
     <version.commons-logging>1.1.1</version.commons-logging>
     <version.commons-io>2.11.0</version.commons-io>
     <version.common-text>1.9</version.common-text>
-    <version.com.fasterxml.jackson>2.13.2</version.com.fasterxml.jackson>
-    <version.com.fasterxml.jackson.databind>2.13.2.2</version.com.fasterxml.jackson.databind>
-    <version.com.fasterxml.jackson.annotations>2.13.2</version.com.fasterxml.jackson.annotations>
+    <version.com.fasterxml.jackson>2.13.3</version.com.fasterxml.jackson>
+    <version.com.fasterxml.jackson.databind>2.13.3</version.com.fasterxml.jackson.databind>
+    <version.com.fasterxml.jackson.annotations>2.13.3</version.com.fasterxml.jackson.annotations>
     <!-- DROOLS-6678: only used in one drools-examples -->
     <version.com.google.code.gson>2.9.0</version.com.google.code.gson>
     <version.org.jresearch.gwt.time>2.0.3</version.org.jresearch.gwt.time>
@@ -58,7 +58,7 @@
     <version.guru.nidi>0.18.0</version.guru.nidi>
     <version.info.picocli>4.6.3</version.info.picocli>
     <version.io.micrometer>1.8.6</version.io.micrometer>
-    <version.io.quarkus>2.9.1.Final</version.io.quarkus>
+    <version.io.quarkus>2.9.2.Final</version.io.quarkus>
     <version.io.smallrye.openapi.core>2.1.22</version.io.smallrye.openapi.core>
     <version.junit>4.13.1</version.junit>
     <version.net.java.dev.glazedlists>1.8.0</version.net.java.dev.glazedlists>


### PR DESCRIPTION
Assembly:
- https://github.com/kiegroup/drools/pull/4418
- https://github.com/kiegroup/optaplanner/pull/2002
- https://github.com/kiegroup/optaplanner-quickstarts/pull/346
- https://github.com/kiegroup/kogito-examples/pull/1270
- https://github.com/kiegroup/kogito-runtimes/pull/2226