### PR TITLE
[DROOLS-6984] Drools8 docs : getting started / how to

### DIFF
--- a/drools-docs/.gitignore
+++ b/drools-docs/.gitignore
@@ -4,7 +4,6 @@
 /build
 /node
 /node_modules
-.index.adoc
 
 # Eclipse, Netbeans and IntelliJ files
 /.*
@@ -18,3 +17,6 @@
 
 # Repository wide ignore mac DS_Store files
 .DS_Store
+
+# Doc generation
+!.index.adoc

--- a/drools-docs/antora-playbook-author.yml
+++ b/drools-docs/antora-playbook-author.yml
@@ -2,7 +2,7 @@
 site:
   title: Drools Documentation
   url: https://www.drools.org/docs
-  start_page: drools::rule-engine/index.adoc
+  start_page: drools::getting-started/index.adoc
   robots: allow
 content:
   edit_url: '{web_url}/edit/main/{path}'

--- a/drools-docs/antora-playbook.yml
+++ b/drools-docs/antora-playbook.yml
@@ -3,7 +3,7 @@
 site:
   title: Drools Documentation
   url: https://www.drools.org/docs
-  start_page: drools::rule-engine/index.adoc
+  start_page: drools::getting-started/index.adoc
   robots: allow
 content:
   edit_url: '{web_url}/edit/main/{path}'
@@ -16,6 +16,7 @@ ui:
   bundle:
     url: ./ui-bundle/ui-bundle.zip
     snapshot: true
+  supplemental_files: ./supplemental-ui
 antora:
   extensions:
     - '@antora/lunr-extension'

--- a/drools-docs/pom.xml
+++ b/drools-docs/pom.xml
@@ -42,6 +42,7 @@
             </resource>
           </resources>
           <attributes>
+            <drools-repo-dir>${basedir}/..</drools-repo-dir>
             <drools-version>${project.version}</drools-version>
             <java-version>${maven.compiler.release}</java-version>
             <maven-version>${maven.min.version}</maven-version>

--- a/drools-docs/src/antora.yml
+++ b/drools-docs/src/antora.yml
@@ -5,11 +5,11 @@
 # The goal is to have the antora.yml containing correct attributes available in the release branch before
 # the drools-website is refreshed.
 name: drools
-title: Drools User Guide 8.23.0-SNAPSHOT
+title: Drools User Guide 8.24.0-SNAPSHOT
 version: latest
 asciidoc:
   attributes:
-    drools-version: 8.23.0-SNAPSHOT
+    drools-version: 8.24.0-SNAPSHOT
     java-version: 8
     maven-version: 3.8.1
     quarkus-version: 2.9.2.Final

--- a/drools-docs/src/modules/ROOT/nav.adoc
+++ b/drools-docs/src/modules/ROOT/nav.adoc
@@ -1,3 +1,4 @@
+* xref:getting-started/index.adoc[leveloffset=+1]
 * xref:rule-engine/index.adoc[leveloffset=+1]
 * xref:language-reference/index.adoc[leveloffset=+1]
 

--- a/drools-docs/src/modules/ROOT/pages/.index.adoc
+++ b/drools-docs/src/modules/ROOT/pages/.index.adoc
@@ -18,5 +18,6 @@ ifndef::backend-pdf[]
 image::shared/droolsExpertLogo.png[align="center"]
 endif::[]
 
+include::getting-started/index.adoc[leveloffset=+1]
 include::rule-engine/index.adoc[leveloffset=+1]
 include::language-reference/index.adoc[leveloffset=+1]

--- a/drools-docs/src/modules/ROOT/pages/getting-started/first-rule-project.adoc
+++ b/drools-docs/src/modules/ROOT/pages/getting-started/first-rule-project.adoc
@@ -1,0 +1,145 @@
+[id='first-rule-project_{context}']
+= First Rule Project
+
+This guide walks you through the process of creating a simple Drools application project.
+
+== Prerequisites
+
+* https://adoptopenjdk.net/[JDK] {java-version}+ with `JAVA_HOME` configured appropriately
+* https://maven.apache.org/download.html[Apache Maven] {maven-version}+ 
+* Optionally, an IDE, such as IntelliJ IDEA, VSCode or Eclipse
+
+== Creating a project with maven archetype
+
+Create a project with the following command.
+
+[source,shell,subs=attributes+]
+----
+mvn archetype:generate -DarchetypeGroupId=org.kie -DarchetypeArtifactId=kie-drools-exec-model-ruleunit-archetype -DarchetypeVersion={drools-version}
+----
+
+During the command execution, input property values interactively. 
+[source,subs=attributes+]
+----
+Define value for property 'groupId': org.example
+Define value for property 'artifactId': my-project
+Define value for property 'version' 1.0-SNAPSHOT: : 
+Define value for property 'package' org.example: : 
+...
+ Y: : Y
+...
+[INFO] BUILD SUCCESS
+----
+
+Now your first rule project is created. Let's look into the project.
+
+Firstly, `pom.xml`.
+[source,xml]
+----
+    <dependency>
+      <groupId>org.drools</groupId>
+      <artifactId>drools-engine</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.drools</groupId>
+      <artifactId>drools-ruleunits-impl</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.drools</groupId>
+      <artifactId>drools-model-compiler</artifactId>
+    </dependency>
+----
+They are required dependencies for executable model with rule unit use cases.
+
+[NOTE]
+====
+You can still use traditional Drools 7 style rules without rule unit. In this case, use `kie-drools-exec-model-archetype`.
+====
+
+The archetype contains one DRL file as an example `src/main/resources/org/example/rules.drl`.
+
+[source]
+----
+package org.example;
+
+unit MeasurementUnit;
+
+rule "will execute per each Measurement having ID color"
+when
+	/measurements[ id == "color", $colorVal : val ]
+then
+	controlSet.add($colorVal);
+end
+
+query FindColor
+    $m: /measurements[ id == "color" ]
+end
+----
+This rule checks incoming `Measurement` data and stores its value in a global variable `controlSet` when it's color information.
+
+`when` part implements the pattern matching and `then` part implements the action when the conditions are met.
+
+Next, find `src/main/java/org/example/MeasurementUnit.java` that is specified as `unit MeasurementUnit` in the rule. It is called `rule unit` that groups data sources, global variables and DRL rules.
+
+[source,java]
+----
+public class MeasurementUnit implements RuleUnitData {
+
+    private final DataStore<Measurement> measurements;
+    private final Set<String> controlSet = new HashSet<>();
+
+    ...
+----
+
+`/measurements` in `rules.drl` is bound to the `measurements` field in `MeasurementUnit`. So you know that the inserted data type is `Measurement`. This class also defines a global variable `controlSet`.
+
+Then, `src/main/java/org/example/Measurement.java` is a Java bean class used in the rule. Such an object is called `Fact`.
+
+Finally, `src/test/java/org/example/RuleTest.java` is the test case that executes the rule. You can learn the basic API usage that is used in your own applications.
+
+[source,java]
+----
+        MeasurementUnit measurementUnit = new MeasurementUnit();
+
+        RuleUnitInstance<MeasurementUnit> instance = RuleUnitInstanceFactory.instance(measurementUnit);
+----
+Create a `MeasurementUnit` instance. Then create a `RuleUnitInstance` with the `MeasurementUnit` instance using `RuleUnitInstanceFactory`.
+
+[source,java]
+----
+        measurementUnit.getMeasurements().add(new Measurement("color", "red"));
+        measurementUnit.getMeasurements().add(new Measurement("color", "green"));
+        measurementUnit.getMeasurements().add(new Measurement("color", "blue"));
+----
+Add `Measurement` facts into `measurementUnit.measurements`. It means the facts are inserted into {RULE_ENGINE}.
+
+[source,java]
+----
+        List<Measurement> queryResult = instance.executeQuery("FindColor").stream().map(tuple -> (Measurement) tuple.get("$m")).collect(toList());
+----
+Execute a query named `FindColor`. When you execute a query, rules that are matched with inserted facts are automatically fired. If you want to only fire rules without a query, you can call `instance.fire()` instead.
+
+[source,java]
+----
+        instance.dispose();
+----
+At the end, call `dispose()` to release resources retained by the `RuleUnitInstance`.
+
+Let's run the test with `mvn clean test`.
+----
+[INFO] -------------------------------------------------------
+[INFO]  T E S T S
+[INFO] -------------------------------------------------------
+[INFO] Running org.example.RuleTest
+2022-06-13 12:49:56,499 [main] INFO  Creating RuleUnit
+2022-06-13 12:49:56,696 [main] INFO  Insert data
+2022-06-13 12:49:56,700 [main] INFO  Run query. Rules are also fired
+[INFO] Tests run: 1, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.411 s - in org.example.RuleTest
+----
+
+Now you can add your own rules and facts to this project!
+
+[NOTE]
+====
+The rule project requires code generation that is triggered by mvn compile phase. If you directly run `RuleTest.java` in IDE, you may need to run `mvn compile` first.
+====

--- a/drools-docs/src/modules/ROOT/pages/getting-started/index.adoc
+++ b/drools-docs/src/modules/ROOT/pages/getting-started/index.adoc
@@ -1,0 +1,8 @@
+:DROOLS:
+include::../_artifacts/document-attributes.adoc[]
+
+[[gettingStarted]]
+= Getting Started
+:context: getting-started
+
+include::first-rule-project.adoc[leveloffset=+1]

--- a/kie-archetypes/kie-drools-exec-model-ruleunit-archetype/src/main/resources/archetype-resources/src/test/java/RuleTest.java
+++ b/kie-archetypes/kie-drools-exec-model-ruleunit-archetype/src/main/resources/archetype-resources/src/test/java/RuleTest.java
@@ -40,18 +40,21 @@ public class RuleTest {
         MeasurementUnit measurementUnit = new MeasurementUnit();
 
         RuleUnitInstance<MeasurementUnit> instance = RuleUnitInstanceFactory.instance(measurementUnit);
+        try {
+            LOG.info("Insert data");
+            measurementUnit.getMeasurements().add(new Measurement("color", "red"));
+            measurementUnit.getMeasurements().add(new Measurement("color", "green"));
+            measurementUnit.getMeasurements().add(new Measurement("color", "blue"));
 
-        LOG.info("Insert data");
-        measurementUnit.getMeasurements().add(new Measurement("color", "red"));
-        measurementUnit.getMeasurements().add(new Measurement("color", "green"));
-        measurementUnit.getMeasurements().add(new Measurement("color", "blue"));
+            LOG.info("Run query. Rules are also fired");
+            List<Measurement> queryResult = instance.executeQuery("FindColor").stream().map(tuple -> (Measurement) tuple.get("$m")).collect(toList());
 
-        LOG.info("Run query. Rules are also fired");
-        List<Measurement> queryResult = instance.executeQuery("FindColor").stream().map(tuple -> (Measurement) tuple.get("$m")).collect(toList());
-
-        assertEquals(3, queryResult.size());
-        assertTrue("contains red", measurementUnit.getControlSet().contains("red"));
-        assertTrue("contains green", measurementUnit.getControlSet().contains("green"));
-        assertTrue("contains blue", measurementUnit.getControlSet().contains("blue"));
+            assertEquals(3, queryResult.size());
+            assertTrue("contains red", measurementUnit.getControlSet().contains("red"));
+            assertTrue("contains green", measurementUnit.getControlSet().contains("green"));
+            assertTrue("contains blue", measurementUnit.getControlSet().contains("blue"));
+        } finally {
+            instance.dispose();
+        }
     }
 }

--- a/kie-archetypes/kie-drools-exec-model-ruleunit-archetype/src/test/resources/projects/integrationtestDefaults/reference/src/test/java/it/pkg/RuleTest.java
+++ b/kie-archetypes/kie-drools-exec-model-ruleunit-archetype/src/test/resources/projects/integrationtestDefaults/reference/src/test/java/it/pkg/RuleTest.java
@@ -37,18 +37,21 @@ public class RuleTest {
         MeasurementUnit measurementUnit = new MeasurementUnit();
 
         RuleUnitInstance<MeasurementUnit> instance = RuleUnitInstanceFactory.instance(measurementUnit);
+        try {
+            LOG.info("Insert data");
+            measurementUnit.getMeasurements().add(new Measurement("color", "red"));
+            measurementUnit.getMeasurements().add(new Measurement("color", "green"));
+            measurementUnit.getMeasurements().add(new Measurement("color", "blue"));
 
-        LOG.info("Insert data");
-        measurementUnit.getMeasurements().add(new Measurement("color", "red"));
-        measurementUnit.getMeasurements().add(new Measurement("color", "green"));
-        measurementUnit.getMeasurements().add(new Measurement("color", "blue"));
+            LOG.info("Run query. Rules are also fired");
+            List<Measurement> queryResult = instance.executeQuery("FindColor").stream().map(tuple -> (Measurement) tuple.get("$m")).collect(toList());
 
-        LOG.info("Run query. Rules are also fired");
-        List<Measurement> queryResult = instance.executeQuery("FindColor").stream().map(tuple -> (Measurement) tuple.get("$m")).collect(toList());
-
-        assertEquals(3, queryResult.size());
-        assertTrue("contains red", measurementUnit.getControlSet().contains("red"));
-        assertTrue("contains green", measurementUnit.getControlSet().contains("green"));
-        assertTrue("contains blue", measurementUnit.getControlSet().contains("blue"));
+            assertEquals(3, queryResult.size());
+            assertTrue("contains red", measurementUnit.getControlSet().contains("red"));
+            assertTrue("contains green", measurementUnit.getControlSet().contains("green"));
+            assertTrue("contains blue", measurementUnit.getControlSet().contains("blue"));
+        } finally {
+            instance.dispose();
+        }
     }
 }


### PR DESCRIPTION
**JIRA**: 
https://issues.redhat.com/browse/DROOLS-6984

<details>
<summary>
How to replicate CI configuration locally?
</summary>

Build Chain tool does "simple" maven build(s), the builds are just Maven commands, but because the repositories relates and depends on each other and any change in API or class method could affect several of those repositories there is a need to use [build-chain tool](https://github.com/kiegroup/github-action-build-chain) to handle cross repository builds and be sure that we always use latest version of the code for each repository.
 
[build-chain tool](https://github.com/kiegroup/github-action-build-chain) is a build tool which can be used on command line locally or in Github Actions workflow(s), in case you need to change multiple repositories and send multiple dependent pull requests related with a change you can easily reproduce the same build by executing it on Github hosted environment or locally in your development environment. See [local execution](https://github.com/kiegroup/github-action-build-chain#local-execution) details to get more information about it.
</details>

<details>
<summary>
How to retest this PR or trigger a specific build:
</summary>

- for <b>pull request checks</b>  
  Please add comment: <b>Jenkins retest this</b>

- for a <b>specific pull request check</b>  
  Please add comment: <b>Jenkins (re)run [drools|kogito-runtimes|optaplanner|kogito-apps|kogito-examples|optaplanner-quickstarts|optaweb-employee-rostering|optaweb-vehicle-routing] tests</b>

- for a <b>full downstream build</b> 
  - for <b>jenkins</b> job: please add comment: <b>Jenkins run fdb</b>
  - for <b>github actions</b> job: add the label `run_fdb`

- <b>a compile downstream build</b> please  add comment: <b>Jenkins run cdb</b>

- <b>a full production downstream build</b> please add comment: <b>Jenkins execute product fdb</b>

- <b>an upstream build</b> please add comment: <b>Jenkins run upstream</b>

- for <b>quarkus branch checks</b>  
  Run checks against Quarkus current used branch  
  Please add comment: <b>Jenkins run quarkus-branch</b>

- for a <b>quarkus branch specific check</b>  
  Run checks against Quarkus current used branch  
  Please add comment: <b>Jenkins (re)run [drools|kogito-runtimes|optaplanner|kogito-apps|kogito-examples|optaplanner-quickstarts|optaweb-employee-rostering|optaweb-vehicle-routing] quarkus-branch</b>

- for <b>quarkus main checks</b>  
  Run checks against Quarkus main branch  
  Please add comment: <b>Jenkins run quarkus-main</b>

- for a <b>specific quarkus main check</b>  
  Run checks against Quarkus main branch  
  Please add comment: <b>Jenkins (re)run [drools|kogito-runtimes|optaplanner|kogito-apps|kogito-examples|optaplanner-quickstarts|optaweb-employee-rostering|optaweb-vehicle-routing] quarkus-branch</b>

- for <b>native checks</b>  
  Run native checks  
  Please add comment: <b>Jenkins run native</b>

- for a <b>specific native check</b>  
  Run native checks 
  Please add comment: <b>Jenkins (re)run [drools|kogito-runtimes|optaplanner|kogito-apps|kogito-examples|optaplanner-quickstarts|optaweb-employee-rostering|optaweb-vehicle-routing] native</b>

- for <b>mandrel checks</b>  
  Run native checks against Mandrel image
  Please add comment: <b>Jenkins run mandrel</b>

- for a <b>specific mandrel check</b>  
  Run native checks against Mandrel image  
  Please add comment: <b>Jenkins (re)run [drools|kogito-runtimes|optaplanner|kogito-apps|kogito-examples|optaplanner-quickstarts|optaweb-employee-rostering|optaweb-vehicle-routing] mandrel</b>
</details>
