### PR TITLE
[DROOLS-6990] Add dispose in archetypes example codes

### DIFF
--- a/kie-archetypes/kie-drools-archetype/src/main/resources/archetype-resources/src/test/java/RuleTest.java
+++ b/kie-archetypes/kie-drools-archetype/src/main/resources/archetype-resources/src/test/java/RuleTest.java
@@ -76,52 +76,58 @@ public class RuleTest {
         KieSessionConfiguration config = kieServices.newKieSessionConfiguration();
         config.setOption( ClockTypeOption.get("pseudo") );
         KieSession session = kieBase.newKieSession(config, null);
-        SessionPseudoClock clock = session.getSessionClock();
+
+        try {
+            SessionPseudoClock clock = session.getSessionClock();
+
 #else
         LOG.info("Creating kieSession");
         KieSession session = kieBase.newKieSession();
+
+        try {
 #end
+            LOG.info("Populating globals");
+            Set<String> check = new HashSet<String>();
+            session.setGlobal("controlSet", check);
 
-        LOG.info("Populating globals");
-        Set<String> check = new HashSet<String>();
-        session.setGlobal("controlSet", check);
-
-        LOG.info("Now running data");
+            LOG.info("Now running data");
 
 #if( $exampleWithCEP=="true" || $exampleWithCEP == "y" ||  $exampleWithCEP == "yes" )
-        clock.advanceTime(1, TimeUnit.MINUTES);
+            clock.advanceTime(1, TimeUnit.MINUTES);
 #end
-        Measurement mRed= new Measurement("color", "red");
-        session.insert(mRed);
-        session.fireAllRules();
+            Measurement mRed = new Measurement("color", "red");
+            session.insert(mRed);
+            session.fireAllRules();
 
 #if( $exampleWithCEP=="true" || $exampleWithCEP == "y" ||  $exampleWithCEP == "yes" )
-        clock.advanceTime(1, TimeUnit.MINUTES);
+            clock.advanceTime(1, TimeUnit.MINUTES);
 #end
-        Measurement mGreen= new Measurement("color", "green");
-        session.insert(mGreen);
-        session.fireAllRules();
+            Measurement mGreen = new Measurement("color", "green");
+            session.insert(mGreen);
+            session.fireAllRules();
 
 #if( $exampleWithCEP=="true" || $exampleWithCEP == "y" ||  $exampleWithCEP == "yes" )
-        clock.advanceTime(1, TimeUnit.MINUTES);
+            clock.advanceTime(1, TimeUnit.MINUTES);
 #end
-        Measurement mBlue= new Measurement("color", "blue");
-        session.insert(mBlue);
-        session.fireAllRules();
+            Measurement mBlue = new Measurement("color", "blue");
+            session.insert(mBlue);
+            session.fireAllRules();
 
-        LOG.info("Final checks");
+            LOG.info("Final checks");
 
 #if( $exampleWithCEP=="true" || $exampleWithCEP == "y" ||  $exampleWithCEP == "yes" )
-        assertEquals("Size of object in Working Memory is 2 for the last 2", 2, session.getObjects().size());
-        assertFalse("contains red", check.contains("red"));
-        assertTrue("contains green", check.contains("green"));
-        assertTrue("contains blue", check.contains("blue"));
+            assertEquals("Size of object in Working Memory is 2 for the last 2", 2, session.getObjects().size());
+            assertFalse("contains red", check.contains("red"));
+            assertTrue("contains green", check.contains("green"));
+            assertTrue("contains blue", check.contains("blue"));
 #else
-        assertEquals("Size of object in Working Memory is 3", 3, session.getObjects().size());
-        assertTrue("contains red", check.contains("red"));
-        assertTrue("contains green", check.contains("green"));
-        assertTrue("contains blue", check.contains("blue"));
+            assertEquals("Size of object in Working Memory is 3", 3, session.getObjects().size());
+            assertTrue("contains red", check.contains("red"));
+            assertTrue("contains green", check.contains("green"));
+            assertTrue("contains blue", check.contains("blue"));
 #end
-
+        } finally {
+            session.dispose();
+        }
     }
 }

--- a/kie-archetypes/kie-drools-archetype/src/test/resources/projects/integrationtestDefaults/reference/src/test/java/it/pkg/RuleTest.java
+++ b/kie-archetypes/kie-drools-archetype/src/test/resources/projects/integrationtestDefaults/reference/src/test/java/it/pkg/RuleTest.java
@@ -64,30 +64,33 @@ public class RuleTest {
         LOG.info("Creating kieSession");
         KieSession session = kieBase.newKieSession();
 
-        LOG.info("Populating globals");
-        Set<String> check = new HashSet<String>();
-        session.setGlobal("controlSet", check);
+        try {
+            LOG.info("Populating globals");
+            Set<String> check = new HashSet<String>();
+            session.setGlobal("controlSet", check);
 
-        LOG.info("Now running data");
+            LOG.info("Now running data");
 
-        Measurement mRed= new Measurement("color", "red");
-        session.insert(mRed);
-        session.fireAllRules();
+            Measurement mRed = new Measurement("color", "red");
+            session.insert(mRed);
+            session.fireAllRules();
 
-        Measurement mGreen= new Measurement("color", "green");
-        session.insert(mGreen);
-        session.fireAllRules();
+            Measurement mGreen = new Measurement("color", "green");
+            session.insert(mGreen);
+            session.fireAllRules();
 
-        Measurement mBlue= new Measurement("color", "blue");
-        session.insert(mBlue);
-        session.fireAllRules();
+            Measurement mBlue = new Measurement("color", "blue");
+            session.insert(mBlue);
+            session.fireAllRules();
 
-        LOG.info("Final checks");
+            LOG.info("Final checks");
 
-        assertEquals("Size of object in Working Memory is 3", 3, session.getObjects().size());
-        assertTrue("contains red", check.contains("red"));
-        assertTrue("contains green", check.contains("green"));
-        assertTrue("contains blue", check.contains("blue"));
-
+            assertEquals("Size of object in Working Memory is 3", 3, session.getObjects().size());
+            assertTrue("contains red", check.contains("red"));
+            assertTrue("contains green", check.contains("green"));
+            assertTrue("contains blue", check.contains("blue"));
+        } finally {
+            session.dispose();
+        }
     }
 }

--- a/kie-archetypes/kie-drools-archetype/src/test/resources/projects/integrationtestWithCEP/reference/src/test/java/it/pkg/RuleTest.java
+++ b/kie-archetypes/kie-drools-archetype/src/test/resources/projects/integrationtestWithCEP/reference/src/test/java/it/pkg/RuleTest.java
@@ -67,35 +67,39 @@ public class RuleTest {
         KieSessionConfiguration config = kieServices.newKieSessionConfiguration();
         config.setOption( ClockTypeOption.get("pseudo") );
         KieSession session = kieBase.newKieSession(config, null);
-        SessionPseudoClock clock = session.getSessionClock();
 
-        LOG.info("Populating globals");
-        Set<String> check = new HashSet<String>();
-        session.setGlobal("controlSet", check);
+        try {
+            SessionPseudoClock clock = session.getSessionClock();
 
-        LOG.info("Now running data");
+            LOG.info("Populating globals");
+            Set<String> check = new HashSet<String>();
+            session.setGlobal("controlSet", check);
 
-        clock.advanceTime(1, TimeUnit.MINUTES);
-        Measurement mRed= new Measurement("color", "red");
-        session.insert(mRed);
-        session.fireAllRules();
+            LOG.info("Now running data");
 
-        clock.advanceTime(1, TimeUnit.MINUTES);
-        Measurement mGreen= new Measurement("color", "green");
-        session.insert(mGreen);
-        session.fireAllRules();
+            clock.advanceTime(1, TimeUnit.MINUTES);
+            Measurement mRed = new Measurement("color", "red");
+            session.insert(mRed);
+            session.fireAllRules();
 
-        clock.advanceTime(1, TimeUnit.MINUTES);
-        Measurement mBlue= new Measurement("color", "blue");
-        session.insert(mBlue);
-        session.fireAllRules();
+            clock.advanceTime(1, TimeUnit.MINUTES);
+            Measurement mGreen = new Measurement("color", "green");
+            session.insert(mGreen);
+            session.fireAllRules();
 
-        LOG.info("Final checks");
+            clock.advanceTime(1, TimeUnit.MINUTES);
+            Measurement mBlue = new Measurement("color", "blue");
+            session.insert(mBlue);
+            session.fireAllRules();
 
-        assertEquals("Size of object in Working Memory is 2 for the last 2", 2, session.getObjects().size());
-        assertFalse("contains red", check.contains("red"));
-        assertTrue("contains green", check.contains("green"));
-        assertTrue("contains blue", check.contains("blue"));
+            LOG.info("Final checks");
 
+            assertEquals("Size of object in Working Memory is 2 for the last 2", 2, session.getObjects().size());
+            assertFalse("contains red", check.contains("red"));
+            assertTrue("contains green", check.contains("green"));
+            assertTrue("contains blue", check.contains("blue"));
+        } finally {
+            session.dispose();
+        }
     }
 }

--- a/kie-archetypes/kie-drools-archetype/src/test/resources/projects/integrationtestWithEclipse/reference/src/test/java/it/pkg/RuleTest.java
+++ b/kie-archetypes/kie-drools-archetype/src/test/resources/projects/integrationtestWithEclipse/reference/src/test/java/it/pkg/RuleTest.java
@@ -64,30 +64,33 @@ public class RuleTest {
         LOG.info("Creating kieSession");
         KieSession session = kieBase.newKieSession();
 
-        LOG.info("Populating globals");
-        Set<String> check = new HashSet<String>();
-        session.setGlobal("controlSet", check);
+        try {
+            LOG.info("Populating globals");
+            Set<String> check = new HashSet<String>();
+            session.setGlobal("controlSet", check);
 
-        LOG.info("Now running data");
+            LOG.info("Now running data");
 
-        Measurement mRed= new Measurement("color", "red");
-        session.insert(mRed);
-        session.fireAllRules();
+            Measurement mRed = new Measurement("color", "red");
+            session.insert(mRed);
+            session.fireAllRules();
 
-        Measurement mGreen= new Measurement("color", "green");
-        session.insert(mGreen);
-        session.fireAllRules();
+            Measurement mGreen = new Measurement("color", "green");
+            session.insert(mGreen);
+            session.fireAllRules();
 
-        Measurement mBlue= new Measurement("color", "blue");
-        session.insert(mBlue);
-        session.fireAllRules();
+            Measurement mBlue = new Measurement("color", "blue");
+            session.insert(mBlue);
+            session.fireAllRules();
 
-        LOG.info("Final checks");
+            LOG.info("Final checks");
 
-        assertEquals("Size of object in Working Memory is 3", 3, session.getObjects().size());
-        assertTrue("contains red", check.contains("red"));
-        assertTrue("contains green", check.contains("green"));
-        assertTrue("contains blue", check.contains("blue"));
-
+            assertEquals("Size of object in Working Memory is 3", 3, session.getObjects().size());
+            assertTrue("contains red", check.contains("red"));
+            assertTrue("contains green", check.contains("green"));
+            assertTrue("contains blue", check.contains("blue"));
+        } finally {
+            session.dispose();
+        }
     }
 }


### PR DESCRIPTION
**Ports**
This PR is for main.
for 7.x -> https://github.com/kiegroup/droolsjbpm-knowledge/pull/600

**JIRA**: 
https://issues.redhat.com/browse/DROOLS-6990

<details>
<summary>
How to replicate CI configuration locally?
</summary>

Build Chain tool does "simple" maven build(s), the builds are just Maven commands, but because the repositories relates and depends on each other and any change in API or class method could affect several of those repositories there is a need to use [build-chain tool](https://github.com/kiegroup/github-action-build-chain) to handle cross repository builds and be sure that we always use latest version of the code for each repository.
 
[build-chain tool](https://github.com/kiegroup/github-action-build-chain) is a build tool which can be used on command line locally or in Github Actions workflow(s), in case you need to change multiple repositories and send multiple dependent pull requests related with a change you can easily reproduce the same build by executing it on Github hosted environment or locally in your development environment. See [local execution](https://github.com/kiegroup/github-action-build-chain#local-execution) details to get more information about it.
</details>

<details>
<summary>
How to retest this PR or trigger a specific build:
</summary>

- for <b>pull request checks</b>  
  Please add comment: <b>Jenkins retest this</b>

- for a <b>specific pull request check</b>  
  Please add comment: <b>Jenkins (re)run [drools|kogito-runtimes|optaplanner|kogito-apps|kogito-examples|optaplanner-quickstarts|optaweb-employee-rostering|optaweb-vehicle-routing] tests</b>

- for a <b>full downstream build</b> 
  - for <b>jenkins</b> job: please add comment: <b>Jenkins run fdb</b>
  - for <b>github actions</b> job: add the label `run_fdb`

- <b>a compile downstream build</b> please  add comment: <b>Jenkins run cdb</b>

- <b>a full production downstream build</b> please add comment: <b>Jenkins execute product fdb</b>

- <b>an upstream build</b> please add comment: <b>Jenkins run upstream</b>

- for <b>quarkus branch checks</b>  
  Run checks against Quarkus current used branch  
  Please add comment: <b>Jenkins run quarkus-branch</b>

- for a <b>quarkus branch specific check</b>  
  Run checks against Quarkus current used branch  
  Please add comment: <b>Jenkins (re)run [drools|kogito-runtimes|optaplanner|kogito-apps|kogito-examples|optaplanner-quickstarts|optaweb-employee-rostering|optaweb-vehicle-routing] quarkus-branch</b>

- for <b>quarkus main checks</b>  
  Run checks against Quarkus main branch  
  Please add comment: <b>Jenkins run quarkus-main</b>

- for a <b>specific quarkus main check</b>  
  Run checks against Quarkus main branch  
  Please add comment: <b>Jenkins (re)run [drools|kogito-runtimes|optaplanner|kogito-apps|kogito-examples|optaplanner-quickstarts|optaweb-employee-rostering|optaweb-vehicle-routing] quarkus-branch</b>

- for <b>native checks</b>  
  Run native checks  
  Please add comment: <b>Jenkins run native</b>

- for a <b>specific native check</b>  
  Run native checks 
  Please add comment: <b>Jenkins (re)run [drools|kogito-runtimes|optaplanner|kogito-apps|kogito-examples|optaplanner-quickstarts|optaweb-employee-rostering|optaweb-vehicle-routing] native</b>

- for <b>mandrel checks</b>  
  Run native checks against Mandrel image
  Please add comment: <b>Jenkins run mandrel</b>

- for a <b>specific mandrel check</b>  
  Run native checks against Mandrel image  
  Please add comment: <b>Jenkins (re)run [drools|kogito-runtimes|optaplanner|kogito-apps|kogito-examples|optaplanner-quickstarts|optaweb-employee-rostering|optaweb-vehicle-routing] mandrel</b>
</details>
