### PR TITLE
DROOLS-6956 DMN DTAnalysis and "allow null"s interactions

### DIFF
--- a/kie-dmn/kie-dmn-core/src/test/java/org/kie/dmn/core/DMNRuntimeTest.java
+++ b/kie-dmn/kie-dmn-core/src/test/java/org/kie/dmn/core/DMNRuntimeTest.java
@@ -30,7 +30,6 @@ import java.time.temporal.ChronoUnit;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
-import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -3125,5 +3124,37 @@ public class DMNRuntimeTest extends BaseInterpretedVsCompiledTest {
          * input[Value>0].Primary-Key is filtering, then projecting
          */
         assertThat((Map<String, Object>)dmnResult.getDecisionResultByName("decision").getResult()).containsExactly(entry("correct", Arrays.asList("k1", "k2", "k3")),entry("incorrect", Arrays.asList("k1", "k3")));
+    }
+    
+    @Test
+    public void testSoundLevelAllowNull() {
+        final DMNRuntime runtime = DMNRuntimeUtil.createRuntime("RecommenderHitPolicy1_allowNull.dmn", this.getClass());
+        final DMNModel dmnModel = runtime.getModel("http://www.trisotech.com/definitions/_50aea0bb-4482-48f6-acfe-4abc1a1bd0d6", "Drawing 1");
+        assertThat(dmnModel).isNotNull();
+        assertThat(dmnModel.hasErrors()).as(DMNRuntimeUtil.formatMessages(dmnModel.getMessages())).isFalse();
+
+        final DMNContext contextWithNullValueForKey = DMNFactory.newContext();
+        contextWithNullValueForKey.set("Level", null);
+        
+        final DMNResult dmnResult = runtime.evaluateAll(dmnModel, contextWithNullValueForKey);
+        LOG.debug("{}", dmnResult);
+        assertThat(dmnResult.hasErrors()).as(DMNRuntimeUtil.formatMessages(dmnResult.getMessages())).isFalse();
+        assertThat(dmnResult.getDecisionResultByName("Evaluation").getResult()).isEqualTo("Unknown");
+    }
+    
+    @Test
+    public void testSoundLevelAllowNullItemDef() {
+        final DMNRuntime runtime = DMNRuntimeUtil.createRuntime("RecommenderHitPolicy1_allowNull_itemDef.dmn", this.getClass());
+        final DMNModel dmnModel = runtime.getModel("http://www.trisotech.com/definitions/_50aea0bb-4482-48f6-acfe-4abc1a1bd0d6", "Drawing 1");
+        assertThat(dmnModel).isNotNull();
+        assertThat(dmnModel.hasErrors()).as(DMNRuntimeUtil.formatMessages(dmnModel.getMessages())).isFalse();
+
+        final DMNContext contextWithNullValueForKey = DMNFactory.newContext();
+        contextWithNullValueForKey.set("Level", null);
+        
+        final DMNResult dmnResult = runtime.evaluateAll(dmnModel, contextWithNullValueForKey);
+        LOG.debug("{}", dmnResult);
+        assertThat(dmnResult.hasErrors()).as(DMNRuntimeUtil.formatMessages(dmnResult.getMessages())).isFalse();
+        assertThat(dmnResult.getDecisionResultByName("Evaluation").getResult()).isEqualTo("Unknown");
     }
 }

--- a/kie-dmn/kie-dmn-core/src/test/resources/org/kie/dmn/core/RecommenderHitPolicy1_allowNull.dmn
+++ b/kie-dmn/kie-dmn-core/src/test/resources/org/kie/dmn/core/RecommenderHitPolicy1_allowNull.dmn
@@ -1,0 +1,53 @@
+<?xml version="1.0" encoding="utf-8" standalone="yes"?>
+<semantic:definitions xmlns:semantic="http://www.omg.org/spec/DMN/20180521/MODEL/"  xmlns:triso="http://www.trisotech.com/2015/triso/modeling"  xmlns:dmndi="http://www.omg.org/spec/DMN/20180521/DMNDI/"  xmlns:di="http://www.omg.org/spec/DMN/20180521/DI/"  xmlns:dc="http://www.omg.org/spec/DMN/20180521/DC/"  xmlns:trisodmn="http://www.trisotech.com/2016/triso/dmn"  xmlns:feel="http://www.omg.org/spec/DMN/20180521/FEEL/"  xmlns:tc="http://www.omg.org/spec/DMN/20160719/testcase"  xmlns:drools="http://www.drools.org/kie/dmn/1.1"  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"  xmlns:rss="http://purl.org/rss/2.0/"  xmlns:openapi="https://openapis.org/omg/extension/1.0"  xmlns:xsd="http://www.w3.org/2001/XMLSchema"  xmlns="http://www.trisotech.com/definitions/_50aea0bb-4482-48f6-acfe-4abc1a1bd0d6" id="_50aea0bb-4482-48f6-acfe-4abc1a1bd0d6" name="Drawing 1" namespace="http://www.trisotech.com/definitions/_50aea0bb-4482-48f6-acfe-4abc1a1bd0d6" exporter="DMN Modeler" exporterVersion="6.7.1" triso:logoChoice="Default">
+    <semantic:inputData id="_3aad4dbe-ad99-4dc3-8fad-cba91d4a7c15" name="Level">
+        <semantic:variable name="Level" id="_09a643aa-0f89-4216-ab5a-58179fa86b33" typeRef="number"/>
+    </semantic:inputData>
+    <semantic:decision id="_0cd2bcb7-1882-4e26-8d7f-3dd35b04c2d4" name="Evaluation">
+        <semantic:variable name="Evaluation" id="_4d97f0f6-9bf8-4693-b049-dadd34243900" typeRef="string"/>
+        <semantic:informationRequirement id="_e3435805-4eed-4fcc-83d0-7a26c50a82a6">
+            <semantic:requiredInput href="#_3aad4dbe-ad99-4dc3-8fad-cba91d4a7c15"/>
+        </semantic:informationRequirement>
+        <semantic:decisionTable id="_3aa68aee-6314-482f-a0be-84c2411d65d7" hitPolicy="UNIQUE" outputLabel="Evaluation" typeRef="string" triso:expressionId="_7af1784f-15c3-406c-b908-8fa9c8a3766b">
+            <semantic:input id="_de33d278-570e-4065-9d68-9f8ba6f4d1e6" label="Level">
+                <semantic:inputExpression typeRef="number">
+                    <semantic:text>Level</semantic:text>
+                </semantic:inputExpression>
+                <semantic:inputValues triso:constraintsType="expression">
+                    <semantic:text>&gt;=0,null</semantic:text> <!-- entering Level=null with lov only defined as `>=0` won't match as null is not gte zero. -->
+                </semantic:inputValues>
+            </semantic:input>
+            <semantic:output id="_26189690-cdb6-466d-b2d7-289380c47e83" triso:allowNull="true">
+                <semantic:outputValues>
+                    <semantic:text>"No risk","Danger","Unknown",null</semantic:text>
+                </semantic:outputValues>
+                <semantic:defaultOutputEntry>
+                    <semantic:text>"Unknown"</semantic:text>
+                </semantic:defaultOutputEntry>
+            </semantic:output>
+            <semantic:annotation name="Description"/>
+            <semantic:rule id="_663e0683-f440-4031-bdb9-0acd121d4651">
+                <semantic:inputEntry id="_b544eee7-d7b9-491d-83a4-e4916029e7f6">
+                    <semantic:text>[0..80)</semantic:text>
+                </semantic:inputEntry>
+                <semantic:outputEntry id="_6a5f720b-5063-4b3e-8062-c06fd6903e90">
+                    <semantic:text>"No risk"</semantic:text>
+                </semantic:outputEntry>
+                <semantic:annotationEntry>
+                    <semantic:text/>
+                </semantic:annotationEntry>
+            </semantic:rule>
+            <semantic:rule id="_9ad17ef0-3226-4c07-9a83-bd72ef71612d">
+                <semantic:inputEntry id="_c04cae1e-a7e8-46d6-8cdc-2cfa4f6adcb9">
+                    <semantic:text>&gt;=120</semantic:text>
+                </semantic:inputEntry>
+                <semantic:outputEntry id="_e08a897c-9c66-4ee0-89b0-d3c74996c9cf">
+                    <semantic:text>"Danger"</semantic:text>
+                </semantic:outputEntry>
+                <semantic:annotationEntry>
+                    <semantic:text>"Seconds of exposure may cause irreversible damage"</semantic:text>
+                </semantic:annotationEntry>
+            </semantic:rule>
+        </semantic:decisionTable>
+    </semantic:decision>
+</semantic:definitions>

--- a/kie-dmn/kie-dmn-core/src/test/resources/org/kie/dmn/core/RecommenderHitPolicy1_allowNull_itemDef.dmn
+++ b/kie-dmn/kie-dmn-core/src/test/resources/org/kie/dmn/core/RecommenderHitPolicy1_allowNull_itemDef.dmn
@@ -1,0 +1,98 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<dmn:definitions xmlns:dmn="http://www.omg.org/spec/DMN/20180521/MODEL/" xmlns="http://www.trisotech.com/definitions/_50aea0bb-4482-48f6-acfe-4abc1a1bd0d6" xmlns:triso="http://www.trisotech.com/2015/triso/modeling" xmlns:dmndi="http://www.omg.org/spec/DMN/20180521/DMNDI/" xmlns:di="http://www.omg.org/spec/DMN/20180521/DI/" xmlns:dc="http://www.omg.org/spec/DMN/20180521/DC/" xmlns:trisodmn="http://www.trisotech.com/2016/triso/dmn" xmlns:feel="http://www.omg.org/spec/DMN/20180521/FEEL/" xmlns:tc="http://www.omg.org/spec/DMN/20160719/testcase" xmlns:drools="http://www.drools.org/kie/dmn/1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:rss="http://purl.org/rss/2.0/" xmlns:openapi="https://openapis.org/omg/extension/1.0" xmlns:xsd="http://www.w3.org/2001/XMLSchema" id="_50aea0bb-4482-48f6-acfe-4abc1a1bd0d6" name="Drawing 1" typeLanguage="http://www.omg.org/spec/DMN/20180521/FEEL/" namespace="http://www.trisotech.com/definitions/_50aea0bb-4482-48f6-acfe-4abc1a1bd0d6">
+  <dmn:extensionElements/>
+  <dmn:itemDefinition id="_BA87A52A-0481-4921-A1EA-A6FD0E5FB435" name="tLevel" isCollection="false">
+    <dmn:typeRef>number</dmn:typeRef>
+    <dmn:allowedValues drools:constraintType="expression" id="_26755E8C-D3E6-494A-899F-730951CFEAA7">
+      <dmn:text>&gt;=0,null</dmn:text> <!-- a number GTE than zero, or null (explicitly) -->
+    </dmn:allowedValues>
+  </dmn:itemDefinition>
+  <dmn:inputData id="_3aad4dbe-ad99-4dc3-8fad-cba91d4a7c15" name="Level">
+    <dmn:extensionElements/>
+    <dmn:variable id="_09a643aa-0f89-4216-ab5a-58179fa86b33" name="Level" typeRef="tLevel"/>
+  </dmn:inputData>
+  <dmn:decision id="_0cd2bcb7-1882-4e26-8d7f-3dd35b04c2d4" name="Evaluation">
+    <dmn:extensionElements/>
+    <dmn:variable id="_4d97f0f6-9bf8-4693-b049-dadd34243900" name="Evaluation" typeRef="string"/>
+    <dmn:informationRequirement id="_07EB7C45-FE70-41ED-AED0-9203763ABB29">
+      <dmn:requiredInput href="#_3aad4dbe-ad99-4dc3-8fad-cba91d4a7c15"/>
+    </dmn:informationRequirement>
+    <dmn:decisionTable id="_3aa68aee-6314-482f-a0be-84c2411d65d7" typeRef="string" hitPolicy="UNIQUE" preferredOrientation="Rule-as-Row" outputLabel="Evaluation">
+      <dmn:input id="_de33d278-570e-4065-9d68-9f8ba6f4d1e6">
+        <dmn:inputExpression id="_68C50455-07C9-47CF-931B-BE06DAB066FC" typeRef="tLevel">
+          <dmn:text>Level</dmn:text>
+        </dmn:inputExpression>
+        <dmn:inputValues id="_51A9733A-4497-40B4-B708-0BF54C55E340">
+          <dmn:text>&gt;=0,null</dmn:text>
+        </dmn:inputValues>
+      </dmn:input>
+      <dmn:output id="_26189690-cdb6-466d-b2d7-289380c47e83">
+        <dmn:outputValues id="_84D161ED-E100-493A-A673-372CE254B66A">
+          <dmn:text>"No risk","Danger","Unknown",null</dmn:text>
+        </dmn:outputValues>
+        <dmn:defaultOutputEntry id="_D213CB99-E3F6-4EBC-AC8F-98106792109B">
+          <dmn:text>"Unknown"</dmn:text>
+        </dmn:defaultOutputEntry>
+      </dmn:output>
+      <dmn:annotation name="Description"/>
+      <dmn:rule id="_663e0683-f440-4031-bdb9-0acd121d4651">
+        <dmn:inputEntry id="_b544eee7-d7b9-491d-83a4-e4916029e7f6">
+          <dmn:text>[0..80)</dmn:text>
+        </dmn:inputEntry>
+        <dmn:outputEntry id="_6a5f720b-5063-4b3e-8062-c06fd6903e90">
+          <dmn:text>"No risk"</dmn:text>
+        </dmn:outputEntry>
+        <dmn:annotationEntry>
+          <dmn:text/>
+        </dmn:annotationEntry>
+      </dmn:rule>
+      <dmn:rule id="_9ad17ef0-3226-4c07-9a83-bd72ef71612d">
+        <dmn:inputEntry id="_c04cae1e-a7e8-46d6-8cdc-2cfa4f6adcb9">
+          <dmn:text>&gt;=120</dmn:text>
+        </dmn:inputEntry>
+        <dmn:outputEntry id="_e08a897c-9c66-4ee0-89b0-d3c74996c9cf">
+          <dmn:text>"Danger"</dmn:text>
+        </dmn:outputEntry>
+        <dmn:annotationEntry>
+          <dmn:text>"Seconds of exposure may cause irreversible damage"</dmn:text>
+        </dmn:annotationEntry>
+      </dmn:rule>
+    </dmn:decisionTable>
+  </dmn:decision>
+  <dmndi:DMNDI>
+    <dmndi:DMNDiagram id="_433EAC15-27FE-4380-9CCE-A7E8F1E7ACE0" name="DRG">
+      <di:extension>
+        <kie:ComponentsWidthsExtension xmlns:kie="http://www.drools.org/kie/dmn/1.2">
+          <kie:ComponentWidths dmnElementRef="_3aa68aee-6314-482f-a0be-84c2411d65d7">
+            <kie:width>50</kie:width>
+            <kie:width>100</kie:width>
+            <kie:width>100</kie:width>
+            <kie:width>100</kie:width>
+          </kie:ComponentWidths>
+        </kie:ComponentsWidthsExtension>
+      </di:extension>
+      <dmndi:DMNShape id="dmnshape-drg-_3aad4dbe-ad99-4dc3-8fad-cba91d4a7c15" dmnElementRef="_3aad4dbe-ad99-4dc3-8fad-cba91d4a7c15" isCollapsed="false">
+        <dmndi:DMNStyle>
+          <dmndi:FillColor red="255" green="255" blue="255"/>
+          <dmndi:StrokeColor red="0" green="0" blue="0"/>
+          <dmndi:FontColor red="0" green="0" blue="0"/>
+        </dmndi:DMNStyle>
+        <dc:Bounds x="50" y="225" width="100" height="50"/>
+        <dmndi:DMNLabel/>
+      </dmndi:DMNShape>
+      <dmndi:DMNShape id="dmnshape-drg-_0cd2bcb7-1882-4e26-8d7f-3dd35b04c2d4" dmnElementRef="_0cd2bcb7-1882-4e26-8d7f-3dd35b04c2d4" isCollapsed="false">
+        <dmndi:DMNStyle>
+          <dmndi:FillColor red="255" green="255" blue="255"/>
+          <dmndi:StrokeColor red="0" green="0" blue="0"/>
+          <dmndi:FontColor red="0" green="0" blue="0"/>
+        </dmndi:DMNStyle>
+        <dc:Bounds x="339" y="142" width="100" height="50"/>
+        <dmndi:DMNLabel/>
+      </dmndi:DMNShape>
+      <dmndi:DMNEdge id="dmnedge-drg-_07EB7C45-FE70-41ED-AED0-9203763ABB29" dmnElementRef="_07EB7C45-FE70-41ED-AED0-9203763ABB29">
+        <di:waypoint x="100" y="250"/>
+        <di:waypoint x="389" y="167"/>
+      </dmndi:DMNEdge>
+    </dmndi:DMNDiagram>
+  </dmndi:DMNDI>
+</dmn:definitions>

--- a/kie-dmn/kie-dmn-openapi/src/test/java/org/kie/dmn/openapi/AllowNullTest.java
+++ b/kie-dmn/kie-dmn-openapi/src/test/java/org/kie/dmn/openapi/AllowNullTest.java
@@ -1,0 +1,76 @@
+/*
+ * Copyright 2022 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.kie.dmn.openapi;
+
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import com.networknt.schema.JsonSchema;
+import org.junit.Test;
+import org.kie.dmn.api.core.DMNModel;
+import org.kie.dmn.api.core.DMNRuntime;
+import org.kie.dmn.core.DMNRuntimeTest;
+import org.kie.dmn.openapi.model.DMNOASResult;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class AllowNullTest extends BaseDMNOASTest {
+
+    @Test
+    public void testVowels() throws Exception {
+        final DMNRuntime runtime = createRuntime("vowels.dmn", this.getClass());
+        DMNOASResult result = DMNOASGeneratorFactory.generator(runtime.getModels()).build();
+
+        DMNModel modelUnderTest = runtime.getModel("https://kiegroup.org/dmn/_0885BF04-027C-4743-9427-2668DA3AD472", "vowels");
+        ObjectNode syntheticJSONSchema = synthesizeSchema(result, modelUnderTest);
+        JsonSchema validator = getJSONSchema(syntheticJSONSchema);
+
+        assertThat(validateUsing(validator, "{ \"an order\":123 }")).isNotEmpty();
+        assertThat(validateUsing(validator, "{ \"my input\": \"#FF0000\" }")).isNotEmpty();
+        assertThat(validateUsing(validator, "{ \"my input\": null }")).isNotEmpty();
+        assertThat(validateUsing(validator, "{ \"my input\": \"a\"}")).isEmpty();
+    }
+    
+    @Test
+    public void testVowelsAllowNull() throws Exception {
+        final DMNRuntime runtime = createRuntime("vowelsAllowNull.dmn", this.getClass());
+        DMNOASResult result = DMNOASGeneratorFactory.generator(runtime.getModels()).build();
+
+        DMNModel modelUnderTest = runtime.getModel("https://kiegroup.org/dmn/_0885BF04-027C-4743-9427-2668DA3AD472", "vowels");
+        ObjectNode syntheticJSONSchema = synthesizeSchema(result, modelUnderTest);
+        JsonSchema validator = getJSONSchema(syntheticJSONSchema);
+
+        assertThat(validateUsing(validator, "{ \"an order\":123 }")).isNotEmpty();
+        assertThat(validateUsing(validator, "{ \"my input\": \"#FF0000\" }")).isNotEmpty();
+        assertThat(validateUsing(validator, "{ \"my input\": null }")).isEmpty();
+        assertThat(validateUsing(validator, "{ \"my input\": \"a\" }")).isEmpty();
+    }
+    
+    @Test
+    public void testSoundItemDefAllowNull() throws Exception {
+        final DMNRuntime runtime = createRuntime("RecommenderHitPolicy1_allowNull_itemDef.dmn", DMNRuntimeTest.class);
+        DMNOASResult result = DMNOASGeneratorFactory.generator(runtime.getModels()).build();
+
+        DMNModel modelUnderTest = runtime.getModel("http://www.trisotech.com/definitions/_50aea0bb-4482-48f6-acfe-4abc1a1bd0d6", "Drawing 1");
+        ObjectNode syntheticJSONSchema = synthesizeSchema(result, modelUnderTest);
+        JsonSchema validator = getJSONSchema(syntheticJSONSchema);
+
+        assertThat(validateUsing(validator, "{ \"an order\":123 }")).isNotEmpty();
+        assertThat(validateUsing(validator, "{ \"Level\": \"#FF0000\" }")).isNotEmpty();
+        assertThat(validateUsing(validator, "{ \"Level\": null }")).isEmpty();
+        assertThat(validateUsing(validator, "{ \"Level\": 47 }")).isEmpty();
+        assertThat(validateUsing(validator, "{ \"Level\": -999 }")).isNotEmpty();
+    }
+}

--- a/kie-dmn/kie-dmn-openapi/src/test/resources/org/kie/dmn/openapi/vowels.dmn
+++ b/kie-dmn/kie-dmn-openapi/src/test/resources/org/kie/dmn/openapi/vowels.dmn
@@ -1,0 +1,57 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<dmn:definitions xmlns:dmn="http://www.omg.org/spec/DMN/20180521/MODEL/" xmlns="https://kiegroup.org/dmn/_0885BF04-027C-4743-9427-2668DA3AD472" xmlns:feel="http://www.omg.org/spec/DMN/20180521/FEEL/" xmlns:kie="http://www.drools.org/kie/dmn/1.2" xmlns:dmndi="http://www.omg.org/spec/DMN/20180521/DMNDI/" xmlns:di="http://www.omg.org/spec/DMN/20180521/DI/" xmlns:dc="http://www.omg.org/spec/DMN/20180521/DC/" id="_B58ED4DB-D990-487B-BA54-F5FE28298C6B" name="vowels" typeLanguage="http://www.omg.org/spec/DMN/20180521/FEEL/" namespace="https://kiegroup.org/dmn/_0885BF04-027C-4743-9427-2668DA3AD472">
+  <dmn:extensionElements/>
+  <dmn:itemDefinition id="_0D99B3FC-04A7-449A-9FD9-91A440984EBF" name="tVowel" isCollection="false">
+    <dmn:typeRef>string</dmn:typeRef>
+    <dmn:allowedValues kie:constraintType="expression" id="_F9994677-B82E-4E55-ACE7-B276EA56A5F9">
+      <dmn:text>"a","e","i","o","u"</dmn:text>
+    </dmn:allowedValues>
+  </dmn:itemDefinition>
+  <dmn:inputData id="_4D4E82CC-C73E-4FF1-83EB-E2CC3E5B2701" name="my input">
+    <dmn:extensionElements/>
+    <dmn:variable id="_1AD4A266-E3EB-46CB-BB24-6A3A3946CD4B" name="my input" typeRef="tVowel"/>
+  </dmn:inputData>
+  <dmn:decision id="_9D919B3A-D84E-43E8-8631-5C17277FD8C2" name="my decision">
+    <dmn:extensionElements/>
+    <dmn:variable id="_65AF7151-2AC1-451F-A795-2E7C9B034E1F" name="my decision" typeRef="Any"/>
+    <dmn:informationRequirement id="_4B05AA07-6DB3-43AB-B4EE-F206D9413E4D">
+      <dmn:requiredInput href="#_4D4E82CC-C73E-4FF1-83EB-E2CC3E5B2701"/>
+    </dmn:informationRequirement>
+    <dmn:literalExpression id="_F6A980CC-71B8-4975-B293-1E9ABDDB155D">
+      <dmn:text>"the input was: "+my input</dmn:text>
+    </dmn:literalExpression>
+  </dmn:decision>
+  <dmndi:DMNDI>
+    <dmndi:DMNDiagram id="_790DD48A-65E4-49C6-92EB-FE7B8C49E6C6" name="DRG">
+      <di:extension>
+        <kie:ComponentsWidthsExtension>
+          <kie:ComponentWidths dmnElementRef="_F6A980CC-71B8-4975-B293-1E9ABDDB155D">
+            <kie:width>300</kie:width>
+          </kie:ComponentWidths>
+        </kie:ComponentsWidthsExtension>
+      </di:extension>
+      <dmndi:DMNShape id="dmnshape-drg-_4D4E82CC-C73E-4FF1-83EB-E2CC3E5B2701" dmnElementRef="_4D4E82CC-C73E-4FF1-83EB-E2CC3E5B2701" isCollapsed="false">
+        <dmndi:DMNStyle>
+          <dmndi:FillColor red="255" green="255" blue="255"/>
+          <dmndi:StrokeColor red="0" green="0" blue="0"/>
+          <dmndi:FontColor red="0" green="0" blue="0"/>
+        </dmndi:DMNStyle>
+        <dc:Bounds x="239" y="294" width="100" height="50"/>
+        <dmndi:DMNLabel/>
+      </dmndi:DMNShape>
+      <dmndi:DMNShape id="dmnshape-drg-_9D919B3A-D84E-43E8-8631-5C17277FD8C2" dmnElementRef="_9D919B3A-D84E-43E8-8631-5C17277FD8C2" isCollapsed="false">
+        <dmndi:DMNStyle>
+          <dmndi:FillColor red="255" green="255" blue="255"/>
+          <dmndi:StrokeColor red="0" green="0" blue="0"/>
+          <dmndi:FontColor red="0" green="0" blue="0"/>
+        </dmndi:DMNStyle>
+        <dc:Bounds x="461" y="294" width="100" height="50"/>
+        <dmndi:DMNLabel/>
+      </dmndi:DMNShape>
+      <dmndi:DMNEdge id="dmnedge-drg-_4B05AA07-6DB3-43AB-B4EE-F206D9413E4D-AUTO-SOURCE-AUTO-TARGET" dmnElementRef="_4B05AA07-6DB3-43AB-B4EE-F206D9413E4D">
+        <di:waypoint x="289" y="294"/>
+        <di:waypoint x="511" y="344"/>
+      </dmndi:DMNEdge>
+    </dmndi:DMNDiagram>
+  </dmndi:DMNDI>
+</dmn:definitions>

--- a/kie-dmn/kie-dmn-openapi/src/test/resources/org/kie/dmn/openapi/vowelsAllowNull.dmn
+++ b/kie-dmn/kie-dmn-openapi/src/test/resources/org/kie/dmn/openapi/vowelsAllowNull.dmn
@@ -1,0 +1,57 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<dmn:definitions xmlns:dmn="http://www.omg.org/spec/DMN/20180521/MODEL/" xmlns="https://kiegroup.org/dmn/_0885BF04-027C-4743-9427-2668DA3AD472" xmlns:feel="http://www.omg.org/spec/DMN/20180521/FEEL/" xmlns:kie="http://www.drools.org/kie/dmn/1.2" xmlns:dmndi="http://www.omg.org/spec/DMN/20180521/DMNDI/" xmlns:di="http://www.omg.org/spec/DMN/20180521/DI/" xmlns:dc="http://www.omg.org/spec/DMN/20180521/DC/" id="_B58ED4DB-D990-487B-BA54-F5FE28298C6B" name="vowels" typeLanguage="http://www.omg.org/spec/DMN/20180521/FEEL/" namespace="https://kiegroup.org/dmn/_0885BF04-027C-4743-9427-2668DA3AD472">
+  <dmn:extensionElements/>
+  <dmn:itemDefinition id="_0D99B3FC-04A7-449A-9FD9-91A440984EBF" name="tVowel" isCollection="false">
+    <dmn:typeRef>string</dmn:typeRef>
+    <dmn:allowedValues kie:constraintType="expression" id="_F9994677-B82E-4E55-ACE7-B276EA56A5F9">
+      <dmn:text>"a","e","i","o","u",null</dmn:text> <!-- a string which is a vowel, or null explicitly in the lov -->
+    </dmn:allowedValues>
+  </dmn:itemDefinition>
+  <dmn:inputData id="_4D4E82CC-C73E-4FF1-83EB-E2CC3E5B2701" name="my input">
+    <dmn:extensionElements/>
+    <dmn:variable id="_1AD4A266-E3EB-46CB-BB24-6A3A3946CD4B" name="my input" typeRef="tVowel"/>
+  </dmn:inputData>
+  <dmn:decision id="_9D919B3A-D84E-43E8-8631-5C17277FD8C2" name="my decision">
+    <dmn:extensionElements/>
+    <dmn:variable id="_65AF7151-2AC1-451F-A795-2E7C9B034E1F" name="my decision" typeRef="Any"/>
+    <dmn:informationRequirement id="_4B05AA07-6DB3-43AB-B4EE-F206D9413E4D">
+      <dmn:requiredInput href="#_4D4E82CC-C73E-4FF1-83EB-E2CC3E5B2701"/>
+    </dmn:informationRequirement>
+    <dmn:literalExpression id="_F6A980CC-71B8-4975-B293-1E9ABDDB155D">
+      <dmn:text>"the input was: "+my input</dmn:text>
+    </dmn:literalExpression>
+  </dmn:decision>
+  <dmndi:DMNDI>
+    <dmndi:DMNDiagram id="_790DD48A-65E4-49C6-92EB-FE7B8C49E6C6" name="DRG">
+      <di:extension>
+        <kie:ComponentsWidthsExtension>
+          <kie:ComponentWidths dmnElementRef="_F6A980CC-71B8-4975-B293-1E9ABDDB155D">
+            <kie:width>300</kie:width>
+          </kie:ComponentWidths>
+        </kie:ComponentsWidthsExtension>
+      </di:extension>
+      <dmndi:DMNShape id="dmnshape-drg-_4D4E82CC-C73E-4FF1-83EB-E2CC3E5B2701" dmnElementRef="_4D4E82CC-C73E-4FF1-83EB-E2CC3E5B2701" isCollapsed="false">
+        <dmndi:DMNStyle>
+          <dmndi:FillColor red="255" green="255" blue="255"/>
+          <dmndi:StrokeColor red="0" green="0" blue="0"/>
+          <dmndi:FontColor red="0" green="0" blue="0"/>
+        </dmndi:DMNStyle>
+        <dc:Bounds x="239" y="294" width="100" height="50"/>
+        <dmndi:DMNLabel/>
+      </dmndi:DMNShape>
+      <dmndi:DMNShape id="dmnshape-drg-_9D919B3A-D84E-43E8-8631-5C17277FD8C2" dmnElementRef="_9D919B3A-D84E-43E8-8631-5C17277FD8C2" isCollapsed="false">
+        <dmndi:DMNStyle>
+          <dmndi:FillColor red="255" green="255" blue="255"/>
+          <dmndi:StrokeColor red="0" green="0" blue="0"/>
+          <dmndi:FontColor red="0" green="0" blue="0"/>
+        </dmndi:DMNStyle>
+        <dc:Bounds x="461" y="294" width="100" height="50"/>
+        <dmndi:DMNLabel/>
+      </dmndi:DMNShape>
+      <dmndi:DMNEdge id="dmnedge-drg-_4B05AA07-6DB3-43AB-B4EE-F206D9413E4D-AUTO-SOURCE-AUTO-TARGET" dmnElementRef="_4B05AA07-6DB3-43AB-B4EE-F206D9413E4D">
+        <di:waypoint x="289" y="294"/>
+        <di:waypoint x="511" y="344"/>
+      </dmndi:DMNEdge>
+    </dmndi:DMNDiagram>
+  </dmndi:DMNDI>
+</dmn:definitions>

--- a/kie-dmn/kie-dmn-validation/src/main/java/org/kie/dmn/validation/dtanalysis/model/DDTAInputClause.java
+++ b/kie-dmn/kie-dmn-validation/src/main/java/org/kie/dmn/validation/dtanalysis/model/DDTAInputClause.java
@@ -24,17 +24,20 @@ public class DDTAInputClause implements Domain {
     private final Interval domainMinMax;
     private final List discreteValues;
     private final List<Comparable<?>> discreteDMNOrder;
+    private final boolean allowNull;
 
-    public DDTAInputClause(Interval domainMinMax) {
+    public DDTAInputClause(Interval domainMinMax, boolean allowNull) {
         this.domainMinMax = domainMinMax;
         this.discreteValues = Collections.emptyList();
         this.discreteDMNOrder = Collections.emptyList();
+        this.allowNull = allowNull;
     }
 
-    public DDTAInputClause(Interval domainMinMax, List discreteValues, List<Comparable<?>> discreteDMNOrder) {
+    public DDTAInputClause(Interval domainMinMax, boolean allowNull, List discreteValues, List<Comparable<?>> discreteDMNOrder) {
         this.domainMinMax = domainMinMax;
         this.discreteValues = discreteValues;
         this.discreteDMNOrder = discreteDMNOrder;
+        this.allowNull = allowNull;
     }
 
     @Override
@@ -70,4 +73,10 @@ public class DDTAInputClause implements Domain {
         return discreteDMNOrder;
     }
 
+    /**
+     * the null was explicitly specified in lov
+     */
+    public boolean isAllowNull() {
+        return allowNull;
+    }
 }

--- a/kie-dmn/kie-dmn-validation/src/test/java/org/kie/dmn/validation/dtanalysis/RecommenderHitPolicyTest.java
+++ b/kie-dmn/kie-dmn-validation/src/test/java/org/kie/dmn/validation/dtanalysis/RecommenderHitPolicyTest.java
@@ -45,6 +45,17 @@ public class RecommenderHitPolicyTest extends AbstractDTAnalysisTest {
         assertThat(analysis.getGaps()).hasSize(1);
         assertTrue(validate.stream().noneMatch(m -> m.getMessageType() == DMNMessageType.DECISION_TABLE_HITPOLICY_RECOMMENDER));
     }
+    
+    @Test
+    public void testGapsAllowNull() {
+        Definitions definitions = getDefinitions("RecommenderHitPolicy1_allowNull.dmn", "http://www.trisotech.com/definitions/_50aea0bb-4482-48f6-acfe-4abc1a1bd0d6", "Drawing 1");
+        List<DMNMessage> validate = validator.validate(definitions, VALIDATE_COMPILATION, ANALYZE_DECISION_TABLE);
+        DTAnalysis analysis = getAnalysis(validate, "_3aa68aee-6314-482f-a0be-84c2411d65d7");
+
+        debugValidatorMsg(validate);
+        assertThat(analysis.getGaps()).hasSize(1);
+        assertThat(validate.stream().noneMatch(m -> m.getMessageType() == DMNMessageType.DECISION_TABLE_HITPOLICY_RECOMMENDER)).isTrue();
+    }
 
     @Test
     public void testNoGapsNoOverlaps() {

--- a/kie-dmn/kie-dmn-validation/src/test/resources/org/kie/dmn/validation/dtanalysis/RecommenderHitPolicy1_allowNull.dmn
+++ b/kie-dmn/kie-dmn-validation/src/test/resources/org/kie/dmn/validation/dtanalysis/RecommenderHitPolicy1_allowNull.dmn
@@ -1,0 +1,53 @@
+<?xml version="1.0" encoding="utf-8" standalone="yes"?>
+<semantic:definitions xmlns:semantic="http://www.omg.org/spec/DMN/20180521/MODEL/"  xmlns:triso="http://www.trisotech.com/2015/triso/modeling"  xmlns:dmndi="http://www.omg.org/spec/DMN/20180521/DMNDI/"  xmlns:di="http://www.omg.org/spec/DMN/20180521/DI/"  xmlns:dc="http://www.omg.org/spec/DMN/20180521/DC/"  xmlns:trisodmn="http://www.trisotech.com/2016/triso/dmn"  xmlns:feel="http://www.omg.org/spec/DMN/20180521/FEEL/"  xmlns:tc="http://www.omg.org/spec/DMN/20160719/testcase"  xmlns:drools="http://www.drools.org/kie/dmn/1.1"  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"  xmlns:rss="http://purl.org/rss/2.0/"  xmlns:openapi="https://openapis.org/omg/extension/1.0"  xmlns:xsd="http://www.w3.org/2001/XMLSchema"  xmlns="http://www.trisotech.com/definitions/_50aea0bb-4482-48f6-acfe-4abc1a1bd0d6" id="_50aea0bb-4482-48f6-acfe-4abc1a1bd0d6" name="Drawing 1" namespace="http://www.trisotech.com/definitions/_50aea0bb-4482-48f6-acfe-4abc1a1bd0d6" exporter="DMN Modeler" exporterVersion="6.7.1" triso:logoChoice="Default">
+    <semantic:inputData id="_3aad4dbe-ad99-4dc3-8fad-cba91d4a7c15" name="Level">
+        <semantic:variable name="Level" id="_09a643aa-0f89-4216-ab5a-58179fa86b33" typeRef="number"/>
+    </semantic:inputData>
+    <semantic:decision id="_0cd2bcb7-1882-4e26-8d7f-3dd35b04c2d4" name="Evaluation">
+        <semantic:variable name="Evaluation" id="_4d97f0f6-9bf8-4693-b049-dadd34243900" typeRef="string"/>
+        <semantic:informationRequirement id="_e3435805-4eed-4fcc-83d0-7a26c50a82a6">
+            <semantic:requiredInput href="#_3aad4dbe-ad99-4dc3-8fad-cba91d4a7c15"/>
+        </semantic:informationRequirement>
+        <semantic:decisionTable id="_3aa68aee-6314-482f-a0be-84c2411d65d7" hitPolicy="UNIQUE" outputLabel="Evaluation" typeRef="string" triso:expressionId="_7af1784f-15c3-406c-b908-8fa9c8a3766b">
+            <semantic:input id="_de33d278-570e-4065-9d68-9f8ba6f4d1e6" label="Level">
+                <semantic:inputExpression typeRef="number">
+                    <semantic:text>Level</semantic:text>
+                </semantic:inputExpression>
+                <semantic:inputValues triso:constraintsType="expression">
+                    <semantic:text>&gt;=0,null</semantic:text> <!-- entering Level=null with lov only defined as `>=0` won't match as null is not gte zero. -->
+                </semantic:inputValues>
+            </semantic:input>
+            <semantic:output id="_26189690-cdb6-466d-b2d7-289380c47e83" triso:allowNull="true">
+                <semantic:outputValues>
+                    <semantic:text>"No risk","Danger","Unknown",null</semantic:text>
+                </semantic:outputValues>
+                <semantic:defaultOutputEntry>
+                    <semantic:text>"Unknown"</semantic:text>
+                </semantic:defaultOutputEntry>
+            </semantic:output>
+            <semantic:annotation name="Description"/>
+            <semantic:rule id="_663e0683-f440-4031-bdb9-0acd121d4651">
+                <semantic:inputEntry id="_b544eee7-d7b9-491d-83a4-e4916029e7f6">
+                    <semantic:text>[0..80)</semantic:text>
+                </semantic:inputEntry>
+                <semantic:outputEntry id="_6a5f720b-5063-4b3e-8062-c06fd6903e90">
+                    <semantic:text>"No risk"</semantic:text>
+                </semantic:outputEntry>
+                <semantic:annotationEntry>
+                    <semantic:text/>
+                </semantic:annotationEntry>
+            </semantic:rule>
+            <semantic:rule id="_9ad17ef0-3226-4c07-9a83-bd72ef71612d">
+                <semantic:inputEntry id="_c04cae1e-a7e8-46d6-8cdc-2cfa4f6adcb9">
+                    <semantic:text>&gt;=120</semantic:text>
+                </semantic:inputEntry>
+                <semantic:outputEntry id="_e08a897c-9c66-4ee0-89b0-d3c74996c9cf">
+                    <semantic:text>"Danger"</semantic:text>
+                </semantic:outputEntry>
+                <semantic:annotationEntry>
+                    <semantic:text>"Seconds of exposure may cause irreversible damage"</semantic:text>
+                </semantic:annotationEntry>
+            </semantic:rule>
+        </semantic:decisionTable>
+    </semantic:decision>
+</semantic:definitions>


### PR DESCRIPTION
7.x backport of https://github.com/kiegroup/drools/pull/4414

<details>
<summary>
How to replicate CI configuration locally?
</summary>

Build Chain tool does "simple" maven build(s), the builds are just Maven commands, but because the repositories relates and depends on each other and any change in API or class method could affect several of those repositories there is a need to use [build-chain tool](https://github.com/kiegroup/github-action-build-chain) to handle cross repository builds and be sure that we always use latest version of the code for each repository.
 
[build-chain tool](https://github.com/kiegroup/github-action-build-chain) is a build tool which can be used on command line locally or in Github Actions workflow(s), in case you need to change multiple repositories and send multiple dependent pull requests related with a change you can easily reproduce the same build by executing it on Github hosted environment or locally in your development environment. See [local execution](https://github.com/kiegroup/github-action-build-chain#local-execution) details to get more information about it.
</details>

<details>
<summary>
How to retest this PR or trigger a specific build:
</summary>

- for <b>pull request checks</b>  
  Please add comment: <b>Jenkins retest this</b>

- for a <b>specific pull request check</b>  
  Please add comment: <b>Jenkins (re)run [drools|kogito-runtimes|optaplanner|kogito-apps|kogito-examples|optaplanner-quickstarts|optaweb-employee-rostering|optaweb-vehicle-routing] tests</b>

- for a <b>full downstream build</b> 
  - for <b>jenkins</b> job: please add comment: <b>Jenkins run fdb</b>
  - for <b>github actions</b> job: add the label `run_fdb`

- <b>a compile downstream build</b> please  add comment: <b>Jenkins run cdb</b>

- <b>a full production downstream build</b> please add comment: <b>Jenkins execute product fdb</b>

- <b>an upstream build</b> please add comment: <b>Jenkins run upstream</b>

- for <b>quarkus branch checks</b>  
  Run checks against Quarkus current used branch  
  Please add comment: <b>Jenkins run quarkus-branch</b>

- for a <b>quarkus branch specific check</b>  
  Run checks against Quarkus current used branch  
  Please add comment: <b>Jenkins (re)run [drools|kogito-runtimes|optaplanner|kogito-apps|kogito-examples|optaplanner-quickstarts|optaweb-employee-rostering|optaweb-vehicle-routing] quarkus-branch</b>

- for <b>quarkus main checks</b>  
  Run checks against Quarkus main branch  
  Please add comment: <b>Jenkins run quarkus-main</b>

- for a <b>specific quarkus main check</b>  
  Run checks against Quarkus main branch  
  Please add comment: <b>Jenkins (re)run [drools|kogito-runtimes|optaplanner|kogito-apps|kogito-examples|optaplanner-quickstarts|optaweb-employee-rostering|optaweb-vehicle-routing] quarkus-branch</b>

- for <b>native checks</b>  
  Run native checks  
  Please add comment: <b>Jenkins run native</b>

- for a <b>specific native check</b>  
  Run native checks 
  Please add comment: <b>Jenkins (re)run [drools|kogito-runtimes|optaplanner|kogito-apps|kogito-examples|optaplanner-quickstarts|optaweb-employee-rostering|optaweb-vehicle-routing] native</b>

- for <b>mandrel checks</b>  
  Run native checks against Mandrel image
  Please add comment: <b>Jenkins run mandrel</b>

- for a <b>specific mandrel check</b>  
  Run native checks against Mandrel image  
  Please add comment: <b>Jenkins (re)run [drools|kogito-runtimes|optaplanner|kogito-apps|kogito-examples|optaplanner-quickstarts|optaweb-employee-rostering|optaweb-vehicle-routing] mandrel</b>
</details>
