### PR TITLE
DROOLS-7012 Remove resource field from KnowledgeBuilder

### DIFF
--- a/drools-compiler/src/main/java/org/drools/compiler/builder/impl/KnowledgeBuilderImpl.java
+++ b/drools-compiler/src/main/java/org/drools/compiler/builder/impl/KnowledgeBuilderImpl.java
@@ -598,7 +598,7 @@ public class KnowledgeBuilderImpl implements InternalKnowledgeBuilder, TypeDecla
      * and the generation of the corresponding rete/phreak network
      */
     @Override
-    public void addPackage(final PackageDescr packageDescr) {
+    public final void addPackage(final PackageDescr packageDescr) {
         addPackageWithResource(packageDescr, null);
     }
 

--- a/drools-compiler/src/main/java/org/drools/compiler/builder/impl/KnowledgeBuilderImpl.java
+++ b/drools-compiler/src/main/java/org/drools/compiler/builder/impl/KnowledgeBuilderImpl.java
@@ -140,7 +140,7 @@ public class KnowledgeBuilderImpl implements InternalKnowledgeBuilder, TypeDecla
 
     private final GlobalVariableContext globals = new GlobalVariableContextImpl();
 
-    private Resource resource;
+//    private Resource resource;
 
     private List<DSLTokenizedMappingFile> dslFiles;
 
@@ -290,7 +290,8 @@ public class KnowledgeBuilderImpl implements InternalKnowledgeBuilder, TypeDecla
     }
 
     public Resource getCurrentResource() {
-        return resource;
+//        return resource;
+        throw new UnsupportedOperationException("deprecated");
     }
 
     public InternalKnowledgeBase getKnowledgeBase() {
@@ -322,7 +323,6 @@ public class KnowledgeBuilderImpl implements InternalKnowledgeBuilder, TypeDecla
      */
     public void addPackageFromDrl(final Reader reader,
                                   final Resource sourceResource) throws DroolsParserException, IOException {
-        this.resource = sourceResource;
         final DrlParser parser = new DrlParser(configuration.getLanguageLevel());
         final PackageDescr pkg = parser.parse(sourceResource, reader);
         this.results.addAll(parser.getErrors());
@@ -331,17 +331,14 @@ public class KnowledgeBuilderImpl implements InternalKnowledgeBuilder, TypeDecla
         }
 
         if (!parser.hasErrors()) {
-            addPackage(pkg);
+            addPackageWithResource(pkg, sourceResource);
         }
-        this.resource = null;
     }
 
     public void addPackageFromDecisionTable(Resource resource,
                                             ResourceConfiguration configuration) throws DroolsParserException,
             IOException {
-        this.resource = resource;
-        addPackage(decisionTableToPackageDescr(resource, configuration));
-        this.resource = null;
+        addPackageWithResource(decisionTableToPackageDescr(resource, configuration), resource);
     }
 
     PackageDescr decisionTableToPackageDescr(Resource resource,
@@ -417,9 +414,7 @@ public class KnowledgeBuilderImpl implements InternalKnowledgeBuilder, TypeDecla
 
     public void addPackageFromTemplate(Resource resource) throws DroolsParserException,
             IOException {
-        this.resource = resource;
-        addPackage(templateToPackageDescr(resource));
-        this.resource = null;
+        addPackageWithResource(templateToPackageDescr(resource), resource);
     }
 
     PackageDescr templateToPackageDescr(Resource resource) throws DroolsParserException, IOException {
@@ -445,16 +440,12 @@ public class KnowledgeBuilderImpl implements InternalKnowledgeBuilder, TypeDecla
 
     public void addPackageFromDrl(Resource resource) throws DroolsParserException,
             IOException {
-        this.resource = resource;
-        addPackage(new DrlResourceHandler(configuration).process(resource));
-        this.resource = null;
+        addPackageWithResource(new DrlResourceHandler(configuration).process(resource), resource);
     }
 
     public void addPackageFromDslr(final Resource resource) throws DroolsParserException,
             IOException {
-        this.resource = resource;
-        addPackage(dslrToPackageDescr(resource));
-        this.resource = null;
+        addPackageWithResource(dslrToPackageDescr(resource), resource);
     }
 
     PackageDescr dslrToPackageDescr(Resource resource) throws DroolsParserException,
@@ -497,7 +488,7 @@ public class KnowledgeBuilderImpl implements InternalKnowledgeBuilder, TypeDecla
     }
 
     public void addDsl(Resource resource) throws IOException {
-        this.resource = resource;
+//        this.resource = resource;
         DSLTokenizedMappingFile file = new DSLTokenizedMappingFile();
 
         try (Reader reader = resource.getReader()) {
@@ -509,7 +500,7 @@ public class KnowledgeBuilderImpl implements InternalKnowledgeBuilder, TypeDecla
             }
             this.dslFiles.add(file);
         } finally {
-            this.resource = null;
+//            this.resource = null;
         }
     }
 
@@ -608,7 +599,11 @@ public class KnowledgeBuilderImpl implements InternalKnowledgeBuilder, TypeDecla
      */
     @Override
     public void addPackage(final PackageDescr packageDescr) {
-        PackageRegistry pkgRegistry = getOrCreatePackageRegistry( packageDescr );
+        addPackageWithResource(packageDescr, null);
+    }
+
+    private void addPackageWithResource(PackageDescr packageDescr, Resource resource) {
+        PackageRegistry pkgRegistry = getOrCreatePackageRegistry(packageDescr);
         if (pkgRegistry == null) {
             return;
         }
@@ -621,16 +616,17 @@ public class KnowledgeBuilderImpl implements InternalKnowledgeBuilder, TypeDecla
                         typeDeclarationManager.getTypeDeclarationBuilder(),
                         assetFilter,
                         pkgRegistry,
-                        packageDescr);
+                        packageDescr,
+                        resource);
         packageProcessor.process();
         this.results.addAll(packageProcessor.getResults());
 
-        compileKnowledgePackages( packageDescr, pkgRegistry);
+        compileKnowledgePackages(packageDescr, pkgRegistry, resource);
         wireAllRules();
         compileRete(pkgRegistry, packageDescr);
     }
 
-    private void compileKnowledgePackages(PackageDescr packageDescr, PackageRegistry pkgRegistry) {
+    private void compileKnowledgePackages(PackageDescr packageDescr, PackageRegistry pkgRegistry, Resource resource) {
         pkgRegistry.setDialect(getPackageDialect(packageDescr));
         PackageRegistry packageRegistry = this.pkgRegistryManager.getPackageRegistry(packageDescr.getNamespace());
         Map<String, AttributeDescr> packageAttributes = this.pkgRegistryManager.getPackageAttributes().get(packageDescr.getNamespace());
@@ -660,7 +656,7 @@ public class KnowledgeBuilderImpl implements InternalKnowledgeBuilder, TypeDecla
         }
     }
 
-    protected void compileRete(PackageRegistry pkgRegistry, PackageDescr packageDescr) {
+    private void compileRete(PackageRegistry pkgRegistry, PackageDescr packageDescr) {
         if (!hasErrors() && this.kBase != null) {
             ReteCompiler reteCompiler = new ReteCompiler(pkgRegistry, packageDescr, kBase, assetFilter);
             reteCompiler.process();
@@ -762,7 +758,8 @@ public class KnowledgeBuilderImpl implements InternalKnowledgeBuilder, TypeDecla
                             typeDeclarationManager.getTypeDeclarationBuilder(),
                             assetFilter,
                             this.pkgRegistryManager.getPackageRegistry(packageDescr.getNamespace()),
-                            packageDescr);
+                            packageDescr,
+                            null);
             packageProcessor.process();
             this.results.addAll(packageProcessor.getResults());
             pkg = pkgRegistry.getPackage();
@@ -1208,7 +1205,7 @@ public class KnowledgeBuilderImpl implements InternalKnowledgeBuilder, TypeDecla
         for (CompositePackageDescr packageDescr : packages) {
             setAssetFilter(packageDescr.getFilter());
             PackageRegistry pkgRegistry = getPackageRegistry(packageDescr.getNamespace());
-            compileKnowledgePackages(packageDescr, pkgRegistry);
+            compileKnowledgePackages(packageDescr, pkgRegistry, null);
             setAssetFilter(null);
         }
 

--- a/drools-compiler/src/main/java/org/drools/compiler/builder/impl/KnowledgeBuilderImpl.java
+++ b/drools-compiler/src/main/java/org/drools/compiler/builder/impl/KnowledgeBuilderImpl.java
@@ -602,7 +602,8 @@ public class KnowledgeBuilderImpl implements InternalKnowledgeBuilder, TypeDecla
         addPackageWithResource(packageDescr, null);
     }
 
-    private void addPackageWithResource(PackageDescr packageDescr, Resource resource) {
+    // this is only overridden by org.drools.verifier.builder.VerifierPackageBuilder.InnerBuilder
+    protected void addPackageWithResource(PackageDescr packageDescr, Resource resource) {
         PackageRegistry pkgRegistry = getOrCreatePackageRegistry(packageDescr);
         if (pkgRegistry == null) {
             return;

--- a/drools-compiler/src/main/java/org/drools/compiler/builder/impl/TypeDeclarationBuilder.java
+++ b/drools-compiler/src/main/java/org/drools/compiler/builder/impl/TypeDeclarationBuilder.java
@@ -101,7 +101,7 @@ public class TypeDeclarationBuilder {
                                          Map<String,AbstractClassTypeDeclarationDescr> unprocesseableDescrs ) {
 
         packageDescrs.forEach( context::getOrCreatePackageRegistry );
-        packageDescrs.forEach( this::setResourcesInDescriptors );
+        packageDescrs.forEach(packageDescr -> setResourcesInDescriptors(packageDescr, null));
 
         // ensure all names are fully qualified before continuing
         typeDeclarationNameResolver.resolveTypes( packageDescrs, unresolvedTypes );
@@ -114,11 +114,12 @@ public class TypeDeclarationBuilder {
 
     public void processTypeDeclarations( PackageDescr packageDescr,
                                          PackageRegistry pkgRegistry,
+                                         Resource currentResource,
                                          Collection<AbstractClassTypeDeclarationDescr> unsortedDescrs,
                                          List<TypeDefinition> unresolvedTypes,
                                          Map<String,AbstractClassTypeDeclarationDescr> unprocesseableDescrs ) {
 
-        setResourcesInDescriptors( packageDescr );
+        setResourcesInDescriptors( packageDescr, currentResource );
 
         // ensure all names are fully qualified before continuing
         typeDeclarationNameResolver.resolveTypes( packageDescr, unresolvedTypes, pkgRegistry.getTypeResolver() );
@@ -219,10 +220,11 @@ public class TypeDeclarationBuilder {
         return ! prev.getFields().isEmpty();
     }
 
-    private void setResourcesInDescriptors( PackageDescr packageDescr ) {
+    private void setResourcesInDescriptors( PackageDescr packageDescr, Resource currentResource ) {
+        if (currentResource == null) return;
         for ( AbstractClassTypeDeclarationDescr typeDescr : packageDescr.getClassAndEnumDeclarationDescrs() ) {
             if ( typeDescr.getResource() == null ) {
-                typeDescr.setResource( context.getCurrentResource() );
+                typeDescr.setResource( currentResource );
             }
         }
     }

--- a/drools-compiler/src/main/java/org/drools/compiler/builder/impl/TypeDeclarationContext.java
+++ b/drools-compiler/src/main/java/org/drools/compiler/builder/impl/TypeDeclarationContext.java
@@ -43,9 +43,6 @@ public interface TypeDeclarationContext extends
 
     TypeDeclarationBuilder getTypeBuilder();
 
-    // this is currently only invoked in org.drools.compiler.builder.impl.TypeDeclarationBuilder#setResourcesInDescriptors
-    Resource getCurrentResource();
-
     boolean filterAccepts(ResourceChange.Type declaration, String namespace, String typeName);
 
     List<PackageDescr> getPackageDescrs(String namespace);

--- a/drools-compiler/src/main/java/org/drools/compiler/builder/impl/TypeDeclarationContextImpl.java
+++ b/drools-compiler/src/main/java/org/drools/compiler/builder/impl/TypeDeclarationContextImpl.java
@@ -56,11 +56,6 @@ public class TypeDeclarationContextImpl implements TypeDeclarationContext {
     }
 
     @Override
-    public Resource getCurrentResource() {
-        throw new UnsupportedOperationException("not yet implemented");
-    }
-
-    @Override
     public boolean filterAccepts(ResourceChange.Type declaration, String namespace, String typeName) {
         return false;
     }

--- a/drools-compiler/src/main/java/org/drools/compiler/builder/impl/processors/PackageCompilationPhase.java
+++ b/drools-compiler/src/main/java/org/drools/compiler/builder/impl/processors/PackageCompilationPhase.java
@@ -6,6 +6,7 @@ import org.drools.compiler.builder.impl.TypeDeclarationBuilder;
 import org.drools.compiler.compiler.PackageRegistry;
 import org.drools.drl.ast.descr.PackageDescr;
 import org.drools.kiesession.rulebase.InternalKnowledgeBase;
+import org.kie.api.io.Resource;
 
 import java.util.List;
 
@@ -17,6 +18,7 @@ public final class PackageCompilationPhase extends AbstractPackageCompilationPha
     private final KnowledgeBuilderConfigurationImpl configuration;
     private final TypeDeclarationBuilder typeBuilder;
     private final KnowledgeBuilderImpl.AssetFilter filterCondition;
+    private final Resource currentResource;
 
     public PackageCompilationPhase(
             KnowledgeBuilderImpl knowledgeBuilder,
@@ -25,13 +27,15 @@ public final class PackageCompilationPhase extends AbstractPackageCompilationPha
             TypeDeclarationBuilder typeBuilder,
             KnowledgeBuilderImpl.AssetFilter filterCondition,
             PackageRegistry pkgRegistry,
-            PackageDescr packageDescr) {
+            PackageDescr packageDescr,
+            Resource currentResource) {
         super(pkgRegistry, packageDescr);
         this.knowledgeBuilder = knowledgeBuilder;
         this.kBase = kBase;
         this.configuration = configuration;
         this.typeBuilder = typeBuilder;
         this.filterCondition = filterCondition;
+        this.currentResource = currentResource;
     }
 
     public void process() {
@@ -45,7 +49,7 @@ public final class PackageCompilationPhase extends AbstractPackageCompilationPha
                 new TypeDeclarationAnnotationNormalizer(annotationNormalizer, packageDescr),
                 new EntryPointDeclarationCompilationPhase(pkgRegistry, packageDescr),
                 new AccumulateFunctionCompilationPhase(pkgRegistry, packageDescr),
-                new TypeDeclarationCompilationPhase(packageDescr, typeBuilder, pkgRegistry),
+                new TypeDeclarationCompilationPhase(packageDescr, typeBuilder, pkgRegistry, currentResource),
                 new WindowDeclarationCompilationPhase(pkgRegistry, packageDescr, knowledgeBuilder),
                 new FunctionCompilationPhase(pkgRegistry, packageDescr, configuration),
                 new GlobalCompilationPhase(pkgRegistry, packageDescr, kBase, knowledgeBuilder, filterCondition),

--- a/drools-compiler/src/main/java/org/drools/compiler/builder/impl/processors/TypeDeclarationCompilationPhase.java
+++ b/drools-compiler/src/main/java/org/drools/compiler/builder/impl/processors/TypeDeclarationCompilationPhase.java
@@ -23,6 +23,8 @@ import org.drools.compiler.compiler.PackageRegistry;
 import org.drools.compiler.compiler.TypeDeclarationError;
 import org.drools.drl.ast.descr.AbstractClassTypeDeclarationDescr;
 import org.drools.drl.ast.descr.PackageDescr;
+import org.kie.api.io.Resource;
+import org.kie.api.io.ResourceType;
 
 import java.util.ArrayList;
 import java.util.HashMap;
@@ -31,10 +33,12 @@ import java.util.Map;
 
 public class TypeDeclarationCompilationPhase extends AbstractPackageCompilationPhase {
     private final TypeDeclarationBuilder typeBuilder;
+    private final Resource currentResource;
 
-    public TypeDeclarationCompilationPhase(PackageDescr packageDescr, TypeDeclarationBuilder typeBuilder, PackageRegistry pkgRegistry) {
+    public TypeDeclarationCompilationPhase(PackageDescr packageDescr, TypeDeclarationBuilder typeBuilder, PackageRegistry pkgRegistry, Resource resource) {
         super(pkgRegistry, packageDescr);
         this.typeBuilder = typeBuilder;
+        this.currentResource = resource;
     }
 
     public void process() {
@@ -43,7 +47,7 @@ public class TypeDeclarationCompilationPhase extends AbstractPackageCompilationP
         List<AbstractClassTypeDeclarationDescr> unsortedDescrs = new ArrayList<>();
         unsortedDescrs.addAll(packageDescr.getTypeDeclarations());
         unsortedDescrs.addAll(packageDescr.getEnumDeclarations());
-        typeBuilder.processTypeDeclarations(packageDescr, pkgRegistry, unsortedDescrs, unresolvedTypes, unprocesseableDescrs);
+        typeBuilder.processTypeDeclarations(packageDescr, pkgRegistry, currentResource, unsortedDescrs, unresolvedTypes, unprocesseableDescrs);
         for (AbstractClassTypeDeclarationDescr descr : unprocesseableDescrs.values()) {
             this.results.add(new TypeDeclarationError(descr, "Unable to process type " + descr.getTypeName()));
         }

--- a/drools-impact-analysis/drools-impact-analysis-parser/src/main/java/org/drools/impact/analysis/parser/internal/ImpactModelBuilderImpl.java
+++ b/drools-impact-analysis/drools-impact-analysis-parser/src/main/java/org/drools/impact/analysis/parser/internal/ImpactModelBuilderImpl.java
@@ -39,6 +39,7 @@ import org.drools.impact.analysis.parser.impl.PackageParser;
 import org.drools.modelcompiler.builder.PackageModel;
 import org.drools.modelcompiler.builder.generator.DRLIdGenerator;
 import org.kie.api.builder.ReleaseId;
+import org.kie.api.io.Resource;
 
 import static java.util.Collections.emptyList;
 import static org.drools.compiler.builder.impl.ClassDefinitionFactory.createClassDefinition;
@@ -68,7 +69,7 @@ public class ImpactModelBuilderImpl extends KnowledgeBuilderImpl {
     }
 
     @Override
-    public void addPackage(final PackageDescr packageDescr) {
+    protected void addPackageWithResource(final PackageDescr packageDescr, final Resource resource) {
         if (compositePackagesMap == null) {
             compositePackagesMap = new HashMap<>();
             if(compositePackages != null) {

--- a/drools-model/drools-model-compiler/src/main/java/org/drools/modelcompiler/builder/ModelBuilderImpl.java
+++ b/drools-model/drools-model-compiler/src/main/java/org/drools/modelcompiler/builder/ModelBuilderImpl.java
@@ -34,6 +34,7 @@ import org.drools.modelcompiler.builder.processors.ModelGeneratorPhase;
 import org.drools.modelcompiler.builder.processors.ModelMainCompilationPhase;
 import org.drools.modelcompiler.builder.processors.SourceCodeGenerationPhase;
 import org.kie.api.builder.ReleaseId;
+import org.kie.api.io.Resource;
 import org.kie.internal.builder.KnowledgeBuilderResult;
 
 import java.util.Collection;
@@ -67,7 +68,7 @@ public class ModelBuilderImpl<T extends PackageSources> extends KnowledgeBuilder
     }
 
     @Override
-    public void addPackage(final PackageDescr packageDescr) {
+    protected void addPackageWithResource(final PackageDescr packageDescr, Resource resource) {
         compositePackagesManager.register(packageDescr);
         PackageRegistry pkgRegistry = getOrCreatePackageRegistry(packageDescr);
         InternalKnowledgePackage pkg = pkgRegistry.getPackage();

--- a/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/compiler/integrationtests/phases/ExplicitCompilerTest.java
+++ b/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/compiler/integrationtests/phases/ExplicitCompilerTest.java
@@ -116,7 +116,7 @@ public class ExplicitCompilerTest {
                 new TypeDeclarationAnnotationNormalizer(annotationNormalizer, packageDescr),
                 new EntryPointDeclarationCompilationPhase(packageRegistry, packageDescr),
                 new AccumulateFunctionCompilationPhase(packageRegistry, packageDescr),
-                new TypeDeclarationCompilationPhase(packageDescr, typeBuilder, packageRegistry),
+                new TypeDeclarationCompilationPhase(packageDescr, typeBuilder, packageRegistry, null),
                 new WindowDeclarationCompilationPhase(packageRegistry, packageDescr, typeDeclarationContext),
                 new FunctionCompilationPhase(packageRegistry, packageDescr, configuration),
                 new GlobalCompilationPhase(packageRegistry, packageDescr, kBase, globalVariableContext, null),

--- a/drools-verifier/drools-verifier-drl/src/main/java/org/drools/verifier/builder/VerifierPackageBuilder.java
+++ b/drools-verifier/drools-verifier-drl/src/main/java/org/drools/verifier/builder/VerifierPackageBuilder.java
@@ -60,7 +60,7 @@ class VerifierPackageBuilder {
         }
 
         @Override
-        public void addPackage(PackageDescr pDescr) {
+        protected void addPackageWithResource(PackageDescr pDescr, Resource unused) {
             packageDescr = pDescr;
         }
     }


### PR DESCRIPTION
KnowledgeBulderImpl contains a `resource` field that is really used only in a few places for better error reporting. However this makes it add like a big fat global variable that makes it harder to track; I am removing this field and instead trickle down the Resource variable to all the relevant usages.