### PR TITLE
DROOLS-6921

### DIFF
--- a/drools-tms/src/main/java/org/drools/tms/TruthMaintenanceSystemImpl.java
+++ b/drools-tms/src/main/java/org/drools/tms/TruthMaintenanceSystemImpl.java
@@ -39,6 +39,8 @@ import org.drools.tms.beliefsystem.BeliefSystem;
 import org.drools.tms.beliefsystem.BeliefSystemMode;
 import org.drools.tms.beliefsystem.ModedAssertion;
 import org.drools.tms.beliefsystem.jtms.JTMSBeliefSetImpl;
+import org.drools.tms.beliefsystem.newbs.NewSimpleBeliefSystem;
+import org.drools.tms.beliefsystem.newbs.NewSimpleBeliefSystemEP;
 import org.kie.api.runtime.rule.FactHandle;
 
 public class TruthMaintenanceSystemImpl implements TruthMaintenanceSystem {
@@ -65,7 +67,10 @@ public class TruthMaintenanceSystemImpl implements TruthMaintenanceSystem {
         this.equalityKeyMap = new ObjectHashMap();
         this.equalityKeyMap.setComparator( EqualityKeyComparator.getInstance() );
 
-        defaultBeliefSystem = BeliefSystemFactory.createBeliefSystem(ep.getReteEvaluator().getSessionConfiguration().getBeliefSystemType(), ep, this);
+        //defaultBeliefSystem = BeliefSystemFactory.createBeliefSystem(ep.getReteEvaluator().getSessionConfiguration().getBeliefSystemType(), ep, this);
+        NewSimpleBeliefSystemEP newBsEP = new NewSimpleBeliefSystemEP(ep,this);
+        defaultBeliefSystem = new NewSimpleBeliefSystem(newBsEP,ep.getObjectTypeConfigurationRegistry(),ep.getEntryPoint());
+
     }
 
     @Override

--- a/drools-tms/src/main/java/org/drools/tms/beliefsystem/BeliefSystemC.java
+++ b/drools-tms/src/main/java/org/drools/tms/beliefsystem/BeliefSystemC.java
@@ -1,0 +1,31 @@
+/*
+ * Copyright 2015 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.drools.tms.beliefsystem;
+
+import org.drools.core.common.InternalFactHandle;
+import org.drools.core.common.TruthMaintenanceSystem;
+import org.drools.core.definitions.rule.impl.RuleImpl;
+import org.drools.core.reteoo.ObjectTypeConf;
+import org.drools.core.rule.consequence.Activation;
+import org.drools.core.common.PropagationContext;
+import org.drools.tms.LogicalDependency;
+import org.drools.tms.agenda.TruthMaintenanceSystemActivation;
+
+public interface BeliefSystemC<M extends ModedAssertion<M>> extends BeliefSystem<M> {
+
+    void setNextBSInChain(BeliefSystemC nextBSInChain);
+
+}

--- a/drools-tms/src/main/java/org/drools/tms/beliefsystem/newbs/NewSimpleBeliefSet.java
+++ b/drools-tms/src/main/java/org/drools/tms/beliefsystem/newbs/NewSimpleBeliefSet.java
@@ -1,0 +1,109 @@
+/*
+ * Copyright 2015 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.drools.tms.beliefsystem.newbs;
+
+import org.drools.tms.beliefsystem.BeliefSet;
+import org.drools.tms.beliefsystem.BeliefSystem;
+import org.drools.tms.SimpleMode;
+import org.drools.core.common.InternalFactHandle;
+import org.drools.tms.LogicalDependency;
+import org.drools.core.common.WorkingMemoryAction;
+import org.drools.core.common.PropagationContext;
+import org.drools.core.util.LinkedList;
+import org.drools.core.util.LinkedListEntry;
+import org.drools.tms.beliefsystem.BeliefSystemC;
+
+public class NewSimpleBeliefSet extends LinkedList<SimpleMode> implements BeliefSet<SimpleMode> {
+    protected BeliefSystemC beliefSystem;
+
+    protected InternalFactHandle fh;
+
+    protected WorkingMemoryAction wmAction;
+
+    public NewSimpleBeliefSet(BeliefSystemC beliefSystem, InternalFactHandle fh) {
+        this.beliefSystem = beliefSystem;
+        this.fh = fh;
+    }
+
+    public NewSimpleBeliefSet() {
+    }
+
+
+    public BeliefSystem getBeliefSystem() {
+        return (BeliefSystem) beliefSystem;
+    }
+
+    public InternalFactHandle getFactHandle() {
+        return this.fh;
+    }
+
+    public void cancel(PropagationContext context) {
+        // get all but last, as that we'll do via the BeliefSystem, for cleanup
+        SimpleMode entry = getFirst();
+        while (entry != getLast()) {
+            SimpleMode temp = entry.getNext(); // get next, as we are about to remove it
+            final LogicalDependency<SimpleMode> node = entry.getObject();
+            node.getJustifier().getLogicalDependencies().remove( node );
+            remove( entry );
+            entry = temp;
+        }
+
+        LinkedListEntry last = getFirst();
+        final LogicalDependency<SimpleMode> node = (LogicalDependency) last.getObject();
+        node.getJustifier().getLogicalDependencies().remove( node );
+        beliefSystem.delete( node, this, context );
+    }
+
+    public void clear(PropagationContext context) {
+        // remove all, but don't allow the BeliefSystem to clean up, the FH is most likely going to be used else where
+        SimpleMode entry = getFirst();
+        while (entry != null) {
+            SimpleMode temp = entry.getNext(); // get next, as we are about to remove it
+            final LogicalDependency<SimpleMode> node = entry.getObject();
+            node.getJustifier().getLogicalDependencies().remove( node );
+            remove( entry );
+            entry = temp;
+        }
+    }
+
+    public WorkingMemoryAction getWorkingMemoryAction() {
+        return wmAction;
+    }
+
+    public void setWorkingMemoryAction(WorkingMemoryAction wmAction) {
+        this.wmAction = wmAction;
+    }
+
+    @Override
+    public boolean isNegated() {
+        return false;
+    }
+
+    @Override
+    public boolean isDecided() {
+        return true;
+    }
+
+    @Override
+    public boolean isConflicting() {
+        return false;
+    }
+
+    @Override
+    public boolean isPositive() {
+        return ! isEmpty();
+    }
+}

--- a/drools-tms/src/main/java/org/drools/tms/beliefsystem/newbs/NewSimpleBeliefSystem.java
+++ b/drools-tms/src/main/java/org/drools/tms/beliefsystem/newbs/NewSimpleBeliefSystem.java
@@ -1,0 +1,222 @@
+/*
+ * Copyright 2015 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.drools.tms.beliefsystem.newbs;
+
+import org.drools.core.WorkingMemoryEntryPoint;
+import org.drools.core.common.EqualityKey;
+import org.drools.core.common.InternalFactHandle;
+import org.drools.core.common.InternalWorkingMemoryEntryPoint;
+import org.drools.core.common.ObjectTypeConfigurationRegistry;
+import org.drools.core.common.PropagationContext;
+import org.drools.core.common.TruthMaintenanceSystem;
+import org.drools.core.definitions.rule.impl.RuleImpl;
+import org.drools.core.reteoo.ObjectTypeConf;
+import org.drools.core.rule.EntryPointId;
+import org.drools.core.rule.consequence.Activation;
+import org.drools.kiesession.entrypoints.NamedEntryPoint;
+import org.drools.tms.LogicalDependency;
+import org.drools.tms.SimpleMode;
+import org.drools.tms.TruthMaintenanceSystemEqualityKey;
+import org.drools.tms.agenda.TruthMaintenanceSystemActivation;
+import org.drools.tms.beliefsystem.BeliefSet;
+import org.drools.tms.beliefsystem.BeliefSystem;
+import org.drools.tms.beliefsystem.BeliefSystemC;
+import org.drools.tms.beliefsystem.simple.SimpleBeliefSet;
+import org.drools.tms.beliefsystem.simple.SimpleLogicalDependency;
+
+import static org.drools.core.reteoo.PropertySpecificUtil.allSetButTraitBitMask;
+
+public class NewSimpleBeliefSystem implements BeliefSystemC<SimpleMode> {
+
+    private BeliefSystemC nextBSInChain;
+    private ObjectTypeConfigurationRegistry reg;
+    private EntryPointId entrypoint;
+
+    public NewSimpleBeliefSystem(BeliefSystemC nextBSInChain,ObjectTypeConfigurationRegistry reg, EntryPointId entrypoint) {
+        super();
+        this.nextBSInChain = nextBSInChain;
+        this.reg = reg;
+        this.entrypoint = entrypoint;
+    }
+
+    @Override
+    public SimpleMode asMode( Object value ) {
+        return new SimpleMode();
+    }
+
+    @Override
+    public void setNextBSInChain(BeliefSystemC nextBSInChain) {
+        this.nextBSInChain = nextBSInChain;
+    }
+
+    public BeliefSet<SimpleMode> insert(LogicalDependency<SimpleMode> node,
+                                        BeliefSet<SimpleMode> beliefSet,
+                                        PropagationContext context,
+                                        ObjectTypeConf typeConf) {
+
+        return this.nextBSInChain.insert(node, beliefSet, context, typeConf);
+
+        /*
+        boolean empty = beliefSet.isEmpty();
+
+        beliefSet.add( node.getMode() );
+
+        InternalFactHandle bfh = beliefSet.getFactHandle();
+        if ( empty && bfh.getEqualityKey().getStatus() == EqualityKey.JUSTIFIED ) {
+            ep.insert( bfh,
+                    bfh.getObject(),
+                    node.getJustifier().getRule(),
+                    node.getJustifier().getTuple().getTupleSink(),
+                    typeConf );
+        }
+        return beliefSet;
+        */
+    }
+
+    public BeliefSet<SimpleMode> insert( SimpleMode mode,
+                                         RuleImpl rule,
+                                         TruthMaintenanceSystemActivation activation,
+                                         Object payload,
+                                         BeliefSet<SimpleMode> beliefSet,
+                                         PropagationContext context,
+                                         ObjectTypeConf typeConf) {
+        return this.nextBSInChain.insert(mode, rule,activation,payload,beliefSet,context,typeConf);
+        /*
+        boolean empty = beliefSet.isEmpty();
+
+        beliefSet.add( mode );
+
+        InternalFactHandle bfh = beliefSet.getFactHandle();
+        if ( empty && bfh.getEqualityKey().getStatus() == EqualityKey.JUSTIFIED ) {
+            ep.insert( bfh,
+                    bfh.getObject(),
+                    rule,
+                    activation != null ? activation.getTuple().getTupleSink() : null,
+                    typeConf );
+        }
+        return beliefSet;
+        */
+    }
+
+    public void read(LogicalDependency<SimpleMode> node,
+                     BeliefSet<SimpleMode> beliefSet,
+                     PropagationContext context,
+                     ObjectTypeConf typeConf) {
+        //insert(node, beliefSet, context, typeConf );
+        beliefSet.add( node.getMode() );
+    }
+
+    public void delete(LogicalDependency<SimpleMode> node,
+                       BeliefSet<SimpleMode> beliefSet,
+                       PropagationContext context) {
+        delete( node.getMode(), node.getJustifier().getRule(), node.getJustifier(), node.getObject(), beliefSet, context );
+    }
+
+    @Override
+    public void delete( SimpleMode mode, RuleImpl rule, Activation activation, Object payload, BeliefSet<SimpleMode> beliefSet, PropagationContext context ) {
+
+        this.nextBSInChain.delete(mode, rule, activation, payload, beliefSet, context);
+        /*
+        beliefSet.remove( mode );
+
+        InternalFactHandle bfh = beliefSet.getFactHandle();
+
+        if ( beliefSet.isEmpty() && bfh.getEqualityKey() != null && bfh.getEqualityKey().getStatus() == EqualityKey.JUSTIFIED ) {
+            ep.delete(bfh, bfh.getObject(), getObjectTypeConf(beliefSet), context.getRuleOrigin(),
+                    null, activation != null ? activation.getTuple().getTupleSink() : null);
+        } else if ( !beliefSet.isEmpty() && bfh.getObject() == payload && payload != bfh.getObject() ) {
+            // prime has changed, to update new object
+            // Equality might have changed on the object, so remove (which uses the handle id) and add back in
+            WorkingMemoryEntryPoint ep = bfh.getEntryPoint(this.ep.getReteEvaluator());
+            ep.getObjectStore().updateHandle(bfh, beliefSet.getFirst().getObject().getObject());
+            ep.update( bfh, bfh.getObject(), allSetButTraitBitMask(), Object.class, null );
+        }
+
+        if ( beliefSet.isEmpty() && bfh.getEqualityKey() != null ) {
+            // if the beliefSet is empty, we must null the logical handle
+            EqualityKey key = bfh.getEqualityKey();
+            key.setLogicalFactHandle( null );
+            ((TruthMaintenanceSystemEqualityKey)key).setBeliefSet( null );
+
+            if ( key.getStatus() == EqualityKey.JUSTIFIED ) {
+                // if it's stated, there will be other handles, so leave it in the TMS
+                tms.remove( key );
+            }
+        }*/
+    }
+
+    public void stage(PropagationContext context,
+                      BeliefSet<SimpleMode> beliefSet) {
+        this.nextBSInChain.stage(context, beliefSet);
+        /*
+        InternalFactHandle bfh = beliefSet.getFactHandle();
+        // Remove the FH from the network
+        ep.delete(bfh, bfh.getObject(), getObjectTypeConf(beliefSet), context.getRuleOrigin(), null);
+
+        bfh.getEqualityKey().setStatus( EqualityKey.STATED ); // revert to stated
+        */
+    }
+
+    public void unstage(PropagationContext context,
+                        BeliefSet<SimpleMode> beliefSet) {
+        this.nextBSInChain.unstage(context,beliefSet);
+        /*
+        InternalFactHandle bfh = beliefSet.getFactHandle();
+        bfh.getEqualityKey().setStatus( EqualityKey.JUSTIFIED ); // revert to justified
+
+        // Add the FH back into the network
+        ep.insert(bfh, bfh.getObject(), context.getRuleOrigin(), null, getObjectTypeConf(beliefSet) );
+        */
+    }
+
+    @Override
+    public TruthMaintenanceSystem getTruthMaintenanceSystem() {
+        return null;
+    }
+
+
+    private ObjectTypeConf getObjectTypeConf(BeliefSet beliefSet) {
+        InternalFactHandle fh = beliefSet.getFactHandle();
+        //ObjectTypeConfigurationRegistry reg;
+        ObjectTypeConf typeConf;
+        //reg = ep.getObjectTypeConfigurationRegistry();
+        typeConf = this.reg.getOrCreateObjectTypeConf( this.entrypoint, fh.getObject() ); //p.getEntryPoint()
+        return typeConf;
+    }
+
+    public BeliefSet newBeliefSet(InternalFactHandle fh) {
+        return new NewSimpleBeliefSet( this, fh );
+    }
+
+    public LogicalDependency newLogicalDependency(TruthMaintenanceSystemActivation activation,
+                                                  BeliefSet beliefSet,
+                                                  Object object,
+                                                  Object value) {
+        SimpleMode mode = new SimpleMode();
+        SimpleLogicalDependency dep =  new SimpleLogicalDependency( activation, beliefSet, object, mode );
+        mode.setObject( dep );
+        return dep;
+    }
+
+    public BeliefSystemC getNextBSInChain() {
+        return this.nextBSInChain;
+    }
+
+    public void setEp( BeliefSystemC nextBSInChain ) {
+        this.nextBSInChain = nextBSInChain;
+    }
+
+}

--- a/drools-tms/src/main/java/org/drools/tms/beliefsystem/newbs/NewSimpleBeliefSystemEP.java
+++ b/drools-tms/src/main/java/org/drools/tms/beliefsystem/newbs/NewSimpleBeliefSystemEP.java
@@ -1,0 +1,208 @@
+/*
+ * Copyright 2015 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.drools.tms.beliefsystem.newbs;
+
+import org.drools.core.WorkingMemoryEntryPoint;
+import org.drools.core.common.EqualityKey;
+import org.drools.core.common.InternalFactHandle;
+import org.drools.core.common.InternalWorkingMemoryEntryPoint;
+import org.drools.core.common.ObjectTypeConfigurationRegistry;
+import org.drools.core.common.PropagationContext;
+import org.drools.core.common.TruthMaintenanceSystem;
+import org.drools.core.definitions.rule.impl.RuleImpl;
+import org.drools.core.reteoo.ObjectTypeConf;
+import org.drools.core.rule.consequence.Activation;
+import org.drools.kiesession.entrypoints.NamedEntryPoint;
+import org.drools.tms.LogicalDependency;
+import org.drools.tms.SimpleMode;
+import org.drools.tms.TruthMaintenanceSystemEqualityKey;
+import org.drools.tms.agenda.TruthMaintenanceSystemActivation;
+import org.drools.tms.beliefsystem.BeliefSet;
+import org.drools.tms.beliefsystem.BeliefSystemC;
+import org.drools.tms.beliefsystem.simple.SimpleLogicalDependency;
+
+import static org.drools.core.reteoo.PropertySpecificUtil.allSetButTraitBitMask;
+
+public class NewSimpleBeliefSystemEP implements BeliefSystemC<SimpleMode> {
+
+    private InternalWorkingMemoryEntryPoint ep;
+    private BeliefSystemC nextBSInChain;
+    private TruthMaintenanceSystem tms;
+
+    public NewSimpleBeliefSystemEP(InternalWorkingMemoryEntryPoint ep, TruthMaintenanceSystem tms){
+        super();
+        this.ep = ep;
+        this.tms = tms;
+    }
+
+    @Override
+    public void setNextBSInChain(BeliefSystemC nextBSInChain) {
+        this.nextBSInChain = nextBSInChain;
+    }
+
+    @Override
+    public SimpleMode asMode( Object value ) {
+        return new SimpleMode();
+    }
+
+    public BeliefSet<SimpleMode> insert(LogicalDependency<SimpleMode> node,
+                                        BeliefSet<SimpleMode> beliefSet,
+                                        PropagationContext context,
+                                        ObjectTypeConf typeConf) {
+        boolean empty = beliefSet.isEmpty();
+
+        beliefSet.add( node.getMode() );
+
+        InternalFactHandle bfh = beliefSet.getFactHandle();
+        if ( empty && bfh.getEqualityKey().getStatus() == EqualityKey.JUSTIFIED ) {
+            ep.insert( bfh,
+                    bfh.getObject(),
+                    node.getJustifier().getRule(),
+                    node.getJustifier().getTuple().getTupleSink(),
+                    typeConf );
+        }
+        return beliefSet;
+    }
+
+    public BeliefSet<SimpleMode> insert( SimpleMode mode,
+                                         RuleImpl rule,
+                                         TruthMaintenanceSystemActivation activation,
+                                         Object payload,
+                                         BeliefSet<SimpleMode> beliefSet,
+                                         PropagationContext context,
+                                         ObjectTypeConf typeConf) {
+        boolean empty = beliefSet.isEmpty();
+
+        beliefSet.add( mode );
+
+        InternalFactHandle bfh = beliefSet.getFactHandle();
+        if ( empty && bfh.getEqualityKey().getStatus() == EqualityKey.JUSTIFIED ) {
+            ep.insert( bfh,
+                    bfh.getObject(),
+                    rule,
+                    activation != null ? activation.getTuple().getTupleSink() : null,
+                    typeConf );
+        }
+        return beliefSet;
+    }
+
+    public void read(LogicalDependency<SimpleMode> node,
+                     BeliefSet<SimpleMode> beliefSet,
+                     PropagationContext context,
+                     ObjectTypeConf typeConf) {
+        //insert(node, beliefSet, context, typeConf );
+        beliefSet.add( node.getMode() );
+    }
+
+    public void delete(LogicalDependency<SimpleMode> node,
+                       BeliefSet<SimpleMode> beliefSet,
+                       PropagationContext context) {
+        delete( node.getMode(), node.getJustifier().getRule(), node.getJustifier(), node.getObject(), beliefSet, context );
+    }
+
+    @Override
+    public void delete( SimpleMode mode, RuleImpl rule, Activation activation, Object payload, BeliefSet<SimpleMode> beliefSet, PropagationContext context ) {
+
+        beliefSet.remove( mode );
+
+        InternalFactHandle bfh = beliefSet.getFactHandle();
+
+        if ( beliefSet.isEmpty() && bfh.getEqualityKey() != null && bfh.getEqualityKey().getStatus() == EqualityKey.JUSTIFIED ) {
+            ep.delete(bfh, bfh.getObject(), getObjectTypeConf(beliefSet), context.getRuleOrigin(),
+                    null, activation != null ? activation.getTuple().getTupleSink() : null);
+        } else if ( !beliefSet.isEmpty() && bfh.getObject() == payload && payload != bfh.getObject() ) {
+            // prime has changed, to update new object
+            // Equality might have changed on the object, so remove (which uses the handle id) and add back in
+            WorkingMemoryEntryPoint ep = bfh.getEntryPoint(this.ep.getReteEvaluator());
+            ep.getObjectStore().updateHandle(bfh, beliefSet.getFirst().getObject().getObject());
+            ep.update( bfh, bfh.getObject(), allSetButTraitBitMask(), Object.class, null );
+        }
+
+        if ( beliefSet.isEmpty() && bfh.getEqualityKey() != null ) {
+            // if the beliefSet is empty, we must null the logical handle
+            EqualityKey key = bfh.getEqualityKey();
+            key.setLogicalFactHandle( null );
+            ((TruthMaintenanceSystemEqualityKey)key).setBeliefSet( null );
+
+            if ( key.getStatus() == EqualityKey.JUSTIFIED ) {
+                // if it's stated, there will be other handles, so leave it in the TMS
+                tms.remove( key );
+            }
+        }
+    }
+
+    public void stage(PropagationContext context,
+                      BeliefSet<SimpleMode> beliefSet) {
+        InternalFactHandle bfh = beliefSet.getFactHandle();
+        // Remove the FH from the network
+        ep.delete(bfh, bfh.getObject(), getObjectTypeConf(beliefSet), context.getRuleOrigin(), null);
+
+        bfh.getEqualityKey().setStatus( EqualityKey.STATED ); // revert to stated
+    }
+
+    public void unstage(PropagationContext context,
+                        BeliefSet<SimpleMode> beliefSet) {
+        InternalFactHandle bfh = beliefSet.getFactHandle();
+        bfh.getEqualityKey().setStatus( EqualityKey.JUSTIFIED ); // revert to justified
+
+        // Add the FH back into the network
+        ep.insert(bfh, bfh.getObject(), context.getRuleOrigin(), null, getObjectTypeConf(beliefSet) );
+    }
+
+    @Override
+    public TruthMaintenanceSystem getTruthMaintenanceSystem() {
+        return null;
+    }
+
+    private ObjectTypeConf getObjectTypeConf(BeliefSet beliefSet) {
+        InternalFactHandle fh = beliefSet.getFactHandle();
+        ObjectTypeConfigurationRegistry reg;
+        ObjectTypeConf typeConf;
+        reg = ep.getObjectTypeConfigurationRegistry();
+        typeConf = reg.getOrCreateObjectTypeConf( ep.getEntryPoint(), fh.getObject() );
+        return typeConf;
+    }
+
+    public BeliefSet newBeliefSet(InternalFactHandle fh) {
+        return new NewSimpleBeliefSet( this, fh );
+    }
+
+    public LogicalDependency newLogicalDependency(TruthMaintenanceSystemActivation activation,
+                                                  BeliefSet beliefSet,
+                                                  Object object,
+                                                  Object value) {
+        SimpleMode mode = new SimpleMode();
+        SimpleLogicalDependency dep =  new SimpleLogicalDependency( activation, beliefSet, object, mode );
+        mode.setObject( dep );
+        return dep;
+    }
+
+    public InternalWorkingMemoryEntryPoint getEp() {
+        return ep;
+    }
+
+    public void setEp( NamedEntryPoint ep ) {
+        this.ep = ep;
+    }
+
+    public TruthMaintenanceSystem getTms() {
+        return tms;
+    }
+
+    public void setTms( TruthMaintenanceSystem tms ) {
+        this.tms = tms;
+    }
+}


### PR DESCRIPTION
DROOLS-6921
[initial implementation/testing of the concept of chaining of belief systems]

code changes: 
- new BeliefSystemC interface
- NewSimpleBeliefSystem: the belief system that now delegates to the next in chain 
- NewSimpleBeliefSystemEP: the belief system that delegates to the entry point (working memory)

To test the above functionality you can find hard coded changes in the TruthMaintenanceSystemImpl class: defaultBeliefSystem is instantiated as a NewSimpleBeliefSystem, which points to a NewSystemBeliefSystemEP as the next BS in the chain.
You can run JTMSTest.testPrimeJustificationWithEqualityMode() to see this in action.