### PR TITLE
[7.x][DROOLS-6932] Migrate assertions in kie-dmn tests to assertj 

### DIFF
--- a/kie-dmn/kie-dmn-backend/src/test/java/org/kie/dmn/backend/marshalling/v1_1/UnmarshalMarshalTest.java
+++ b/kie-dmn/kie-dmn-backend/src/test/java/org/kie/dmn/backend/marshalling/v1_1/UnmarshalMarshalTest.java
@@ -52,9 +52,8 @@ import org.xmlunit.validation.ValidationProblem;
 import org.xmlunit.validation.ValidationResult;
 import org.xmlunit.validation.Validator;
 
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.fail;
 
 public class UnmarshalMarshalTest {
 
@@ -181,7 +180,7 @@ public class UnmarshalMarshalTest {
                 LOG.error("{}", p);
             }
         }
-        assertTrue(validateInputResult.isValid());
+        assertThat(validateInputResult.isValid()).isTrue();
 
         final File subdirFile = new File(baseOutputDir, subdir);
         if (!subdirFile.mkdirs()) {
@@ -208,7 +207,7 @@ public class UnmarshalMarshalTest {
                 LOG.error("{}", p);
             }
         }
-        assertTrue(validateOutputResult.isValid());
+        assertThat(validateOutputResult.isValid()).isTrue();
 
         LOG.debug("\n---\nDefault XMLUnit comparison:");
         Source control = Input.fromFile(inputXMLFile).build();
@@ -282,7 +281,7 @@ public class UnmarshalMarshalTest {
         if (!checkSimilar.getDifferences().iterator().hasNext()) {
             LOG.info("[ EMPTY - no diffs using customized similarity ]");
         }
-        assertFalse("XML are NOT similar: " + checkSimilar.toString(), checkSimilar.hasDifferences());
+        assertThat(checkSimilar.hasDifferences()).as("XML are NOT similar: " + checkSimilar.toString()).isFalse();
     }
 
     private String safeStripDMNPRefix(Node target) {

--- a/kie-dmn/kie-dmn-backend/src/test/java/org/kie/dmn/backend/marshalling/v1_2/UnmarshalMarshalTest.java
+++ b/kie-dmn/kie-dmn-backend/src/test/java/org/kie/dmn/backend/marshalling/v1_2/UnmarshalMarshalTest.java
@@ -52,9 +52,8 @@ import org.xmlunit.validation.ValidationProblem;
 import org.xmlunit.validation.ValidationResult;
 import org.xmlunit.validation.Validator;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.within;
 
 public class UnmarshalMarshalTest {
 
@@ -110,8 +109,8 @@ public class UnmarshalMarshalTest {
         Definitions definitions = MARSHALLER.unmarshal(new InputStreamReader(this.getClass().getResourceAsStream("test-FontSize-sharedStyle.dmn")));
         DMNShape shape0 = (DMNShape) definitions.getDMNDI().getDMNDiagram().get(0).getDMNDiagramElement().get(0);
         DMNStyle shape0sharedStyle = (DMNStyle) shape0.getDMNLabel().getSharedStyle();
-        assertEquals("LS_4d396200-362f-4939-830d-32d2b4c87042_0", shape0sharedStyle.getId());
-        assertEquals(21d, shape0sharedStyle.getFontSize(), 0.0d);
+        assertThat(shape0sharedStyle.getId()).isEqualTo("LS_4d396200-362f-4939-830d-32d2b4c87042_0");
+        assertThat(shape0sharedStyle.getFontSize()).isCloseTo(21d, within(0.0d));
     }
 
     @Test
@@ -147,7 +146,7 @@ public class UnmarshalMarshalTest {
                 LOG.error("{}", p);
             }
         }
-        assertTrue(validateInputResult.isValid());
+        assertThat(validateInputResult.isValid()).isTrue();
 
         final File subdirFile = new File(baseOutputDir, subdir);
         if (!subdirFile.mkdirs()) {
@@ -174,7 +173,7 @@ public class UnmarshalMarshalTest {
                 LOG.error("{}", p);
             }
         }
-        assertTrue(validateOutputResult.isValid());
+        assertThat(validateOutputResult.isValid()).isTrue();
 
         LOG.debug("\n---\nDefault XMLUnit comparison:");
         Source control = Input.fromFile(inputXMLFile).build();
@@ -265,7 +264,7 @@ DMNDIv1.2:
         if (!checkSimilar.getDifferences().iterator().hasNext()) {
             LOG.info("[ EMPTY - no diffs using customized similarity ]");
         }
-        assertFalse("XML are NOT similar: " + checkSimilar.toString(), checkSimilar.hasDifferences());
+        assertThat(checkSimilar.hasDifferences()).as("XML are NOT similar: " + checkSimilar.toString()).isFalse();
     }
 
     private String safeStripDMNPRefix(Node target) {

--- a/kie-dmn/kie-dmn-backend/src/test/java/org/kie/dmn/backend/marshalling/v1_3/UnmarshalMarshalTest.java
+++ b/kie-dmn/kie-dmn-backend/src/test/java/org/kie/dmn/backend/marshalling/v1_3/UnmarshalMarshalTest.java
@@ -50,8 +50,7 @@ import org.xmlunit.validation.ValidationProblem;
 import org.xmlunit.validation.ValidationResult;
 import org.xmlunit.validation.Validator;
 
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
+import static org.assertj.core.api.Assertions.assertThat;
 
 public class UnmarshalMarshalTest {
 
@@ -128,7 +127,7 @@ public class UnmarshalMarshalTest {
                 LOG.error("{}", p);
             }
         }
-        assertTrue(validateInputResult.isValid());
+        assertThat(validateInputResult.isValid()).isTrue();
 
         final File subdirFile = new File(baseOutputDir, subdir);
         if (!subdirFile.mkdirs()) {
@@ -155,7 +154,7 @@ public class UnmarshalMarshalTest {
                 LOG.error("{}", p);
             }
         }
-        assertTrue(validateOutputResult.isValid());
+        assertThat(validateOutputResult.isValid()).isTrue();
 
         LOG.debug("\n---\nDefault XMLUnit comparison:");
         Source control = Input.fromFile(inputXMLFile).build();
@@ -246,7 +245,7 @@ DMNDIv1.2:
         if (!checkSimilar.getDifferences().iterator().hasNext()) {
             LOG.info("[ EMPTY - no diffs using customized similarity ]");
         }
-        assertFalse("XML are NOT similar: " + checkSimilar.toString(), checkSimilar.hasDifferences());
+        assertThat(checkSimilar.hasDifferences()).as("XML are NOT similar: " + checkSimilar.toString()).isFalse();
     }
 
     private String safeStripDMNPRefix(Node target) {

--- a/kie-dmn/kie-dmn-backend/src/test/java/org/kie/dmn/backend/marshalling/v1_4/UnmarshalMarshalTest.java
+++ b/kie-dmn/kie-dmn-backend/src/test/java/org/kie/dmn/backend/marshalling/v1_4/UnmarshalMarshalTest.java
@@ -50,8 +50,7 @@ import org.xmlunit.validation.ValidationProblem;
 import org.xmlunit.validation.ValidationResult;
 import org.xmlunit.validation.Validator;
 
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
+import static org.assertj.core.api.Assertions.assertThat;
 
 public class UnmarshalMarshalTest {
 
@@ -128,7 +127,7 @@ public class UnmarshalMarshalTest {
                 LOG.error("{}", p);
             }
         }
-        assertTrue(validateInputResult.isValid());
+        assertThat(validateInputResult.isValid()).isTrue();
 
         final File subdirFile = new File(baseOutputDir, subdir);
         if (!subdirFile.mkdirs()) {
@@ -155,7 +154,7 @@ public class UnmarshalMarshalTest {
                 LOG.error("{}", p);
             }
         }
-        assertTrue(validateOutputResult.isValid());
+        assertThat(validateOutputResult.isValid()).isTrue();
 
         LOG.debug("\n---\nDefault XMLUnit comparison:");
         Source control = Input.fromFile(inputXMLFile).build();
@@ -246,7 +245,7 @@ DMNDIv1.2:
         if (!checkSimilar.getDifferences().iterator().hasNext()) {
             LOG.info("[ EMPTY - no diffs using customized similarity ]");
         }
-        assertFalse("XML are NOT similar: " + checkSimilar.toString(), checkSimilar.hasDifferences());
+        assertThat(checkSimilar.hasDifferences()).as("XML are NOT similar: " + checkSimilar.toString()).isFalse();
     }
 
     private String safeStripDMNPRefix(Node target) {

--- a/kie-dmn/kie-dmn-core/src/test/java/org/kie/dmn/core/BaseDMNContextTest.java
+++ b/kie-dmn/kie-dmn-core/src/test/java/org/kie/dmn/core/BaseDMNContextTest.java
@@ -26,9 +26,6 @@ import org.kie.dmn.api.core.DMNContext;
 import org.kie.dmn.api.core.DMNMetadata;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
 
 public abstract class BaseDMNContextTest {
 
@@ -142,14 +139,14 @@ public abstract class BaseDMNContextTest {
         Map<String, Object> currentEntries = container.getAll();
 
         assertThat(currentEntries).isNotNull();
-        assertEquals(expectedEntries.size(), currentEntries.size());
+        assertThat(currentEntries).hasSameSizeAs(expectedEntries);
 
         for (Map.Entry<String, Object> entry : expectedEntries.entrySet()) {
-            assertTrue(currentEntries.containsKey(entry.getKey()));
-            assertEquals(entry.getValue(), currentEntries.get(entry.getKey()));
+            assertThat(currentEntries).containsKey(entry.getKey());
+            assertThat(currentEntries.get(entry.getKey())).isEqualTo(entry.getValue());
 
-            assertTrue(container.isDefined(entry.getKey()));
-            assertEquals(entry.getValue(), container.get(entry.getKey()));
+            assertThat(container.isDefined(entry.getKey())).isTrue();
+            assertThat(container.get(entry.getKey())).isEqualTo(entry.getValue());
         }
     }
 
@@ -165,14 +162,14 @@ public abstract class BaseDMNContextTest {
     public static void assertNamespaceIsAbsent(DMNContext ctx) {
         Optional<String> optNamespace = ctx.scopeNamespace();
         assertThat(optNamespace).isNotNull();
-        assertFalse(optNamespace.isPresent());
+        assertThat(optNamespace).isNotPresent();
     }
 
     public static void assertNamespaceEquals(String expectedName, DMNContext ctx) {
         Optional<String> optNamespace = ctx.scopeNamespace();
         assertThat(optNamespace).isNotNull();
-        assertTrue(optNamespace.isPresent());
-        assertEquals(expectedName, optNamespace.get());
+        assertThat(optNamespace).isPresent();
+        assertThat(optNamespace.get()).isEqualTo(expectedName);
     }
 
     public static void assertNamespaceEquals(DMNContext expectedCtx, DMNContext testCtx) {
@@ -182,10 +179,10 @@ public abstract class BaseDMNContextTest {
         assertThat(optTestNamespace).isNotNull();
 
         if (optExpectedNamespace.isPresent()) {
-            assertTrue(optTestNamespace.isPresent());
-            assertEquals(optExpectedNamespace.get(), optTestNamespace.get());
+            assertThat(optTestNamespace).isPresent();
+            assertThat(optTestNamespace.get()).isEqualTo(optExpectedNamespace.get());
         } else {
-            assertFalse(optTestNamespace.isPresent());
+            assertThat(optTestNamespace).isNotPresent();
         }
     }
 

--- a/kie-dmn/kie-dmn-core/src/test/java/org/kie/dmn/core/DMNAssemblerTest.java
+++ b/kie-dmn/kie-dmn-core/src/test/java/org/kie/dmn/core/DMNAssemblerTest.java
@@ -19,9 +19,7 @@ import org.kie.dmn.core.util.DMNRuntimeUtil;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertTrue;
+import static org.assertj.core.api.Assertions.assertThat;
 
 public class DMNAssemblerTest extends BaseInterpretedVsCompiledTest {
     public static final Logger LOG = LoggerFactory.getLogger(DMNAssemblerTest.class);
@@ -42,8 +40,8 @@ public class DMNAssemblerTest extends BaseInterpretedVsCompiledTest {
         
         LOG.info("buildAll() completed.");
         results.getMessages(Level.ERROR).forEach( e -> LOG.error("{}", e));
-        
-        assertTrue( results.getMessages(Level.ERROR).size() > 0 );
+
+        assertThat(results.getMessages(Level.ERROR)).hasSizeGreaterThan(0);
     }
 
     @Test
@@ -53,7 +51,7 @@ public class DMNAssemblerTest extends BaseInterpretedVsCompiledTest {
         final DMNContext ctx = runtime.newContext();
         ctx.set( "timestring", "2016-12-20T14:30:22z" );
         final DMNResult result = runtime.evaluateAll(model, ctx);
-        assertEquals( DateTimeFormatter.ISO_TIME.parse( "14:30:22z", OffsetTime::from ), result.getDecisionResultByName( "time" ).getResult() );
+        assertThat(result.getDecisionResultByName("time").getResult()).isEqualTo(DateTimeFormatter.ISO_TIME.parse("14:30:22z", OffsetTime::from));
     }
 
     @Test
@@ -64,7 +62,7 @@ public class DMNAssemblerTest extends BaseInterpretedVsCompiledTest {
         final DMNContext ctx = runtime.newContext();
         ctx.set( "timestring", "2016-12-20T14:30:22z" );
         final DMNResult result = runtime.evaluateAll(model, ctx);
-        assertNull( result.getDecisionResultByName("time").getResult() );
+        assertThat(result.getDecisionResultByName("time").getResult()).isNull();
     }
 
     @Test
@@ -82,7 +80,7 @@ public class DMNAssemblerTest extends BaseInterpretedVsCompiledTest {
         final DMNContext ctx = runtime.newContext();
         ctx.set( "timestring", "2016-12-20T14:30:22z" );
         final DMNResult result = runtime.evaluateAll(model, ctx);
-        assertNull( result.getDecisionResultByName("time").getResult() );
+        assertThat(result.getDecisionResultByName("time").getResult()).isNull();
     }
 
     @After

--- a/kie-dmn/kie-dmn-core/src/test/java/org/kie/dmn/core/DMNCompilerTest.java
+++ b/kie-dmn/kie-dmn-core/src/test/java/org/kie/dmn/core/DMNCompilerTest.java
@@ -44,8 +44,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.fail;
+import static org.assertj.core.api.Assertions.fail;
 import static org.kie.dmn.core.util.DynamicTypeUtils.entry;
 import static org.kie.dmn.core.util.DynamicTypeUtils.mapOf;
 
@@ -231,7 +230,7 @@ public class DMNCompilerTest extends BaseVariantTest {
         final DMNRuntime runtime = createRuntime("Recursive.dmn", this.getClass());
         final DMNModel dmnModel = runtime.getModel("https://github.com/kiegroup/kie-dmn", "Recursive" );
         assertThat(dmnModel).isNotNull();
-        assertFalse( evaluateModel(runtime, dmnModel, DMNFactory.newContext() ).hasErrors() );
+        assertThat(evaluateModel(runtime, dmnModel, DMNFactory.newContext()).hasErrors()).isFalse();
     }
 
     @Test

--- a/kie-dmn/kie-dmn-core/src/test/java/org/kie/dmn/core/DMNDecisionTableHitPolicyTest.java
+++ b/kie-dmn/kie-dmn-core/src/test/java/org/kie/dmn/core/DMNDecisionTableHitPolicyTest.java
@@ -34,8 +34,6 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
 
 public class DMNDecisionTableHitPolicyTest extends BaseInterpretedVsCompiledTest {
 
@@ -68,9 +66,9 @@ public class DMNDecisionTableHitPolicyTest extends BaseInterpretedVsCompiledTest
         final DMNContext result = dmnResult.getContext();
 
         assertThat(result.get("Approval Status")).isNull();
-        assertTrue(dmnResult.getMessages().size() > 0);
+        assertThat(dmnResult.getMessages()).hasSizeGreaterThan(0);
         DMNMessage message = dmnResult.getMessages().iterator().next();
-        assertEquals(message.getText(), "DMN: RiskCategory='ASD' does not match any of the valid values \"High\", \"Low\", \"Medium\" for decision table '_0004-simpletable-U'. (DMN id: _0004-simpletable-U, FEEL expression evaluation error) ");
+        assertThat("DMN: RiskCategory='ASD' does not match any of the valid values \"High\", \"Low\", \"Medium\" for decision table '_0004-simpletable-U'. (DMN id: _0004-simpletable-U, FEEL expression evaluation error) ").isEqualTo(message.getText());
     }
 
     @Test
@@ -88,8 +86,8 @@ public class DMNDecisionTableHitPolicyTest extends BaseInterpretedVsCompiledTest
         final DMNContext result = dmnResult.getContext();
 
         assertThat(result.get("Approval Status")).isNull();
-        assertTrue(dmnResult.getMessages().size() > 0);
-        assertTrue(dmnResult.getMessages().stream().anyMatch(dm -> dm.getSeverity().equals(DMNMessage.Severity.WARN) && dm.getFeelEvent() instanceof HitPolicyViolationEvent && dm.getFeelEvent().getSeverity().equals(FEELEvent.Severity.WARN)));
+        assertThat(dmnResult.getMessages()).hasSizeGreaterThan(0);
+        assertThat(dmnResult.getMessages().stream().anyMatch(dm -> dm.getSeverity().equals(DMNMessage.Severity.WARN) && dm.getFeelEvent() instanceof HitPolicyViolationEvent && dm.getFeelEvent().getSeverity().equals(FEELEvent.Severity.WARN))).isTrue();
     }
 
     @Test
@@ -359,8 +357,8 @@ public class DMNDecisionTableHitPolicyTest extends BaseInterpretedVsCompiledTest
     public void testDecisionTableHitPolicyAnyWithOverlap_DoOverlap() {
         final DMNResult dmnResult = executeHitPolicyAnyWithOverlap(20);
         assertThat(dmnResult.hasErrors()).isTrue();
-        assertTrue(dmnResult.getMessages().size() > 0);
-        assertTrue(dmnResult.getMessages().stream().anyMatch(dm -> dm.getFeelEvent() instanceof HitPolicyViolationEvent && dm.getFeelEvent().getSeverity().equals(FEELEvent.Severity.ERROR)));
+        assertThat(dmnResult.getMessages()).hasSizeGreaterThan(0);
+        assertThat(dmnResult.getMessages().stream().anyMatch(dm -> dm.getFeelEvent() instanceof HitPolicyViolationEvent && dm.getFeelEvent().getSeverity().equals(FEELEvent.Severity.ERROR))).isTrue();
         assertThat(dmnResult.getDecisionResultByName("a decision").getResult()).isNull();
     }
 

--- a/kie-dmn/kie-dmn-core/src/test/java/org/kie/dmn/core/DMNDecisionTableHitPolicyTest.java
+++ b/kie-dmn/kie-dmn-core/src/test/java/org/kie/dmn/core/DMNDecisionTableHitPolicyTest.java
@@ -68,7 +68,7 @@ public class DMNDecisionTableHitPolicyTest extends BaseInterpretedVsCompiledTest
         assertThat(result.get("Approval Status")).isNull();
         assertThat(dmnResult.getMessages()).hasSizeGreaterThan(0);
         DMNMessage message = dmnResult.getMessages().iterator().next();
-        assertThat("DMN: RiskCategory='ASD' does not match any of the valid values \"High\", \"Low\", \"Medium\" for decision table '_0004-simpletable-U'. (DMN id: _0004-simpletable-U, FEEL expression evaluation error) ").isEqualTo(message.getText());
+        assertThat(message.getText()).isEqualTo("DMN: RiskCategory='ASD' does not match any of the valid values \"High\", \"Low\", \"Medium\" for decision table '_0004-simpletable-U'. (DMN id: _0004-simpletable-U, FEEL expression evaluation error) ");
     }
 
     @Test

--- a/kie-dmn/kie-dmn-core/src/test/java/org/kie/dmn/core/DMNDecisionTableRuntimeTest.java
+++ b/kie-dmn/kie-dmn-core/src/test/java/org/kie/dmn/core/DMNDecisionTableRuntimeTest.java
@@ -65,10 +65,6 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertTrue;
 import static org.mockito.Mockito.verify;
 import static org.mockito.internal.verification.VerificationModeFactory.times;
 
@@ -362,7 +358,7 @@ public class DMNDecisionTableRuntimeTest extends BaseInterpretedVsCompiledTest {
         final DMNResult dmnResult = runtime.evaluateAll( dmnModel, context );
         LOG.debug("{}", dmnResult);
         assertThat(dmnResult.hasErrors()).isFalse();
-        assertNull( dmnResult.getContext().get("Logique de décision 1") );
+        assertThat(dmnResult.getContext().get("Logique de décision 1")).isNull();
     }
 
     @Test
@@ -584,9 +580,9 @@ public class DMNDecisionTableRuntimeTest extends BaseInterpretedVsCompiledTest {
         final DMNContext context = DMNFactory.newContext();
         final DMNDecisionResult result = runtime.evaluateByName(model, context, "Result").getDecisionResultByName("Result");
 
-        assertEquals(expectedStatus, result.getEvaluationStatus());
-        assertFalse(result.hasErrors());
-        assertEquals(expectedResult, result.getResult());
+        assertThat(result.getEvaluationStatus()).isEqualTo(expectedStatus);
+        assertThat(result.hasErrors()).isFalse();
+        assertThat(result.getResult()).isEqualTo(expectedResult);
     }
 
     @Test
@@ -682,7 +678,7 @@ public class DMNDecisionTableRuntimeTest extends BaseInterpretedVsCompiledTest {
         kfs.write("src/main/resources/multipleOutputsCollectDT.dmn", dmnXml);
         kfs.generateAndWritePomXML(kjarReleaseId);
         final KieBuilder kieBuilder = ks.newKieBuilder(kfs).buildAll();
-        assertTrue(kieBuilder.getResults().getMessages().toString(), kieBuilder.getResults().getMessages().isEmpty());
+        assertThat(kieBuilder.getResults().getMessages()).as(kieBuilder.getResults().getMessages().toString()).isEmpty();
 
         final KieContainer container = ks.newKieContainer(kjarReleaseId);
         final DMNRuntime runtime = KieRuntimeFactory.of(container.getKieBase()).get(DMNRuntime.class);

--- a/kie-dmn/kie-dmn-core/src/test/java/org/kie/dmn/core/DMNInputRuntimeTest.java
+++ b/kie-dmn/kie-dmn-core/src/test/java/org/kie/dmn/core/DMNInputRuntimeTest.java
@@ -39,7 +39,6 @@ import org.kie.dmn.core.api.DMNFactory;
 import org.kie.dmn.core.util.DMNRuntimeUtil;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.Assert.assertTrue;
 import static org.kie.dmn.core.util.DynamicTypeUtils.entry;
 import static org.kie.dmn.core.util.DynamicTypeUtils.prototype;
 
@@ -298,7 +297,7 @@ public class DMNInputRuntimeTest extends BaseInterpretedVsCompiledTest {
         assertThat(idnMembershipLevels.getType().getBaseType().getName()).isEqualTo("tMembershipLevel");
         assertThat(idnMembershipLevels.getType().isCollection()).isTrue();
         assertThat(idnMembershipLevels.getType().isComposite()).isFalse();
-        assertThat(idnMembershipLevels.getType().getAllowedValues().isEmpty()).isTrue();
+        assertThat(idnMembershipLevels.getType().getAllowedValues()).isEmpty();
 
         final InputDataNode idnPercent = dmnModel.getInputs().stream().filter(idn -> idn.getName().equals("Percent")).findFirst().get();
         assertThat(idnPercent.getType().getBaseType().getNamespace()).isEqualTo(FEEL_NAMESPACE);
@@ -361,27 +360,27 @@ public class DMNInputRuntimeTest extends BaseInterpretedVsCompiledTest {
 
         int index = 1;
         for (InputDataNode node : dmnModel.getInputs()) {
-            assertTrue(node.getName().endsWith("" + index++));
+            assertThat(node.getName().endsWith("" + index++)).isTrue();
         }
 
         index = 1;
         for (DecisionNode node : dmnModel.getDecisions()) {
-            assertTrue(node.getName().endsWith("" + index++));
+            assertThat(node.getName().endsWith("" + index++)).isTrue();
         }
 
         index = 1;
         for (BusinessKnowledgeModelNode node : dmnModel.getBusinessKnowledgeModels()) {
-            assertTrue(node.getName().endsWith("" + index++));
+            assertThat(node.getName().endsWith("" + index++)).isTrue();
         }
 
         index = 1;
         for (ItemDefNode node : dmnModel.getItemDefinitions()) {
-            assertTrue(node.getName().endsWith("" + index++));
+            assertThat(node.getName().endsWith("" + index++)).isTrue();
         }
 
         index = 1;
         for (DecisionServiceNode node : dmnModel.getDecisionServices()) {
-            assertTrue(node.getName().endsWith("" + index++));
+            assertThat(node.getName().endsWith("" + index++)).isTrue();
         }
     }
 }

--- a/kie-dmn/kie-dmn-core/src/test/java/org/kie/dmn/core/DMNRuntimeTest.java
+++ b/kie-dmn/kie-dmn-core/src/test/java/org/kie/dmn/core/DMNRuntimeTest.java
@@ -79,9 +79,6 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
 import static org.kie.dmn.core.util.DMNTestUtil.getAndAssertModelNoErrors;
 import static org.kie.dmn.core.util.DynamicTypeUtils.entry;
 import static org.kie.dmn.core.util.DynamicTypeUtils.mapOf;
@@ -1117,9 +1114,9 @@ public class DMNRuntimeTest extends BaseInterpretedVsCompiledTest {
     @Test
     public void testUnknownVariable1() {
         final List<DMNMessage> messages = DMNRuntimeUtil.createExpectingDMNMessages("unknown_variable1.dmn", this.getClass());
-        assertEquals(1, messages.stream().filter(m -> m.getMessageType().equals(DMNMessageType.ERR_COMPILING_FEEL))
-                                .filter(m -> m.getMessage().contains("Unknown variable 'NonSalaryPct'"))
-                                .count());
+        assertThat(messages.stream().filter(m -> m.getMessageType().equals(DMNMessageType.ERR_COMPILING_FEEL))
+                .filter(m -> m.getMessage().contains("Unknown variable 'NonSalaryPct'"))
+                .count()).isEqualTo(1);
     }
 
     @Test
@@ -1238,7 +1235,7 @@ public class DMNRuntimeTest extends BaseInterpretedVsCompiledTest {
         final List<String> sourceIDs = messages.stream().map(DMNMessage::getSourceId).collect(Collectors.toList());
         // notice the other BKM in the DMN model is a LiteralExpression, would have failed only at runtime accordingly as expected:
         // FEEL FuncDefNode not checked at compile time: assertTrue( sourceIDs.contains( "_a72a7aff-48c3-4806-83ca-fc1f1fe34320") );
-        assertTrue( sourceIDs.contains( "_a72a7aff-48c3-4806-83ca-fc1f1fe34321" ) );
+        assertThat(sourceIDs).contains("_a72a7aff-48c3-4806-83ca-fc1f1fe34321");
         assertThat(messages).anyMatch(m -> m.getText().contains("java.lang.Mathhh"));
     }
     
@@ -1248,7 +1245,7 @@ public class DMNRuntimeTest extends BaseInterpretedVsCompiledTest {
         assertThat(messages).hasSize(1);
 
         final List<String> sourceIDs = messages.stream().map(DMNMessage::getSourceId).collect(Collectors.toList());
-        assertTrue( sourceIDs.contains( "_a72a7aff-48c3-4806-83ca-fc1f1fe34321" ) );
+        assertThat(sourceIDs).contains("_a72a7aff-48c3-4806-83ca-fc1f1fe34321");
         assertThat(messages).anyMatch(m -> m.getText().contains("max(int,int)") && m.getText().contains("max(long,long)"));
     }
 
@@ -1586,7 +1583,7 @@ public class DMNRuntimeTest extends BaseInterpretedVsCompiledTest {
         model.addDecision(b);
         final DMNRuntime runtime = DMNRuntimeUtil.createRuntime(this.getClass());
         final DMNResult result = runtime.evaluateAll(model, DMNFactory.newContext());
-        assertTrue(result.hasErrors());
+        assertThat(result.hasErrors()).isTrue();
     }
 
     @Test
@@ -1599,7 +1596,7 @@ public class DMNRuntimeTest extends BaseInterpretedVsCompiledTest {
         model.addDecision(decision);
         final DMNRuntime runtime = DMNRuntimeUtil.createRuntime(this.getClass());
         final DMNResult result = runtime.evaluateAll(model, DMNFactory.newContext());
-        assertTrue(result.hasErrors());
+        assertThat(result.hasErrors()).isTrue();
     }
 
     @Test
@@ -1617,7 +1614,7 @@ public class DMNRuntimeTest extends BaseInterpretedVsCompiledTest {
         model.addDecision(c);
         final DMNRuntime runtime = DMNRuntimeUtil.createRuntime(this.getClass());
         final DMNResult result = runtime.evaluateAll(model, DMNFactory.newContext());
-        assertFalse(result.hasErrors());
+        assertThat(result.hasErrors()).isFalse();
     }
 
     @Test
@@ -1639,7 +1636,7 @@ public class DMNRuntimeTest extends BaseInterpretedVsCompiledTest {
         model.addDecision(d);
         final DMNRuntime runtime = DMNRuntimeUtil.createRuntime(this.getClass());
         final DMNResult result = runtime.evaluateAll(model, DMNFactory.newContext());
-        assertFalse(result.hasErrors());
+        assertThat(result.hasErrors()).isFalse();
     }
 
     @Test
@@ -1722,12 +1719,12 @@ public class DMNRuntimeTest extends BaseInterpretedVsCompiledTest {
         final List people = (List) resultContext.get("People");
         final List peopleGroups = (List) resultContext.get("People groups");
 
-        assertEquals(6, people.size());
+        assertThat(people).hasSize(6);
 
-        assertEquals(3, peopleGroups.size());
-        assertEquals(2, ((List) peopleGroups.get(0)).size());
-        assertEquals(2, ((List) peopleGroups.get(1)).size());
-        assertEquals(2, ((List) peopleGroups.get(2)).size());
+        assertThat(peopleGroups).hasSize(3);
+        assertThat(((List) peopleGroups.get(0))).hasSize(2);
+        assertThat(((List) peopleGroups.get(1))).hasSize(2);
+        assertThat(((List) peopleGroups.get(2))).hasSize(2);
     }
 
     @Test
@@ -1894,7 +1891,7 @@ public class DMNRuntimeTest extends BaseInterpretedVsCompiledTest {
         final DMNResult result = runtime.evaluateAll(model, context);
         final List<?> resultObject = (ArrayList<?>) result.getDecisionResultByName("PickAllJohns").getResult();
 
-        assertEquals(2, resultObject.size());
+        assertThat(resultObject).hasSize(2);
     }
 
     @Test
@@ -2123,8 +2120,8 @@ public class DMNRuntimeTest extends BaseInterpretedVsCompiledTest {
             put("type", 1);
         }});
         final DMNDecisionResult result = runtime.evaluateAll(model, context).getDecisionResultByName("TestDecision");
-        assertFalse(result.hasErrors());
-        assertEquals("This is product 1", result.getResult());
+        assertThat(result.hasErrors()).isFalse();
+        assertThat(result.getResult()).isEqualTo("This is product 1");
     }
 
     @Test
@@ -2172,29 +2169,29 @@ public class DMNRuntimeTest extends BaseInterpretedVsCompiledTest {
         assertThat(result.get("Bruce")).isInstanceOf(Map.class);
         final Map<String, Object> bruce = (Map<String, Object>) result.get("Bruce");
 
-        assertEquals(2, ((List) bruce.get("one")).size());
-        assertTrue(((List) bruce.get("one")).stream().anyMatch(e -> ((Map<String, Object>) e).get("Title").equals("55")));
-        assertTrue(((List) bruce.get("one")).stream().anyMatch(e -> ((Map<String, Object>) e).get("Title").equals("510")));
+        assertThat(((List) bruce.get("one"))).hasSize(2);
+        assertThat(((List) bruce.get("one")).stream().anyMatch(e -> ((Map<String, Object>) e).get("Title").equals("55"))).isTrue();
+        assertThat(((List) bruce.get("one")).stream().anyMatch(e -> ((Map<String, Object>) e).get("Title").equals("510"))).isTrue();
 
-        assertEquals(3, ((List) bruce.get("two")).size());
-        assertTrue(((List) bruce.get("two")).stream().anyMatch(e -> ((Map<String, Object>) e).get("Title").equals("810")));
-        assertTrue(((List) bruce.get("two")).stream().anyMatch(e -> ((Map<String, Object>) e).get("Title").equals("85")));
-        assertTrue(((List) bruce.get("two")).stream().anyMatch(e -> ((Map<String, Object>) e).get("Title").equals("66")));
+        assertThat(((List) bruce.get("two"))).hasSize(3);
+        assertThat(((List) bruce.get("two")).stream().anyMatch(e -> ((Map<String, Object>) e).get("Title").equals("810"))).isTrue();
+        assertThat(((List) bruce.get("two")).stream().anyMatch(e -> ((Map<String, Object>) e).get("Title").equals("85"))).isTrue();
+        assertThat(((List) bruce.get("two")).stream().anyMatch(e -> ((Map<String, Object>) e).get("Title").equals("66"))).isTrue();
 
-        assertEquals(1, ((List) bruce.get("three")).size());
-        assertTrue(((List) bruce.get("three")).stream().anyMatch(e -> ((Map<String, Object>) e).get("Title").equals("510")));
+        assertThat(((List) bruce.get("three"))).hasSize(1);
+        assertThat(((List) bruce.get("three")).stream().anyMatch(e -> ((Map<String, Object>) e).get("Title").equals("510"))).isTrue();
 
-        assertEquals(2, ((List) bruce.get("Four")).size());
-        assertTrue(((List) bruce.get("Four")).stream().anyMatch(e -> ((Map<String, Object>) e).get("Title").equals("85")));
-        assertTrue(((List) bruce.get("Four")).stream().anyMatch(e -> ((Map<String, Object>) e).get("Title").equals("66")));
+        assertThat(((List) bruce.get("Four"))).hasSize(2);
+        assertThat(((List) bruce.get("Four")).stream().anyMatch(e -> ((Map<String, Object>) e).get("Title").equals("85"))).isTrue();
+        assertThat(((List) bruce.get("Four")).stream().anyMatch(e -> ((Map<String, Object>) e).get("Title").equals("66"))).isTrue();
 
-        assertEquals(2, ((List) bruce.get("Five")).size());
-        assertTrue(((List) bruce.get("Five")).stream().anyMatch(e -> ((Map<String, Object>) e).get("Title").equals("85")));
-        assertTrue(((List) bruce.get("Five")).stream().anyMatch(e -> ((Map<String, Object>) e).get("Title").equals("66")));
+        assertThat(((List) bruce.get("Five"))).hasSize(2);
+        assertThat(((List) bruce.get("Five")).stream().anyMatch(e -> ((Map<String, Object>) e).get("Title").equals("85"))).isTrue();
+        assertThat(((List) bruce.get("Five")).stream().anyMatch(e -> ((Map<String, Object>) e).get("Title").equals("66"))).isTrue();
 
-        assertEquals(2, ((List) bruce.get("six")).size());
-        assertTrue(((List) bruce.get("six")).stream().anyMatch(e -> ((Map<String, Object>) e).get("Title").equals("85")));
-        assertTrue(((List) bruce.get("six")).stream().anyMatch(e -> ((Map<String, Object>) e).get("Title").equals("66")));
+        assertThat(((List) bruce.get("six"))).hasSize(2);
+        assertThat(((List) bruce.get("six")).stream().anyMatch(e -> ((Map<String, Object>) e).get("Title").equals("85"))).isTrue();
+        assertThat(((List) bruce.get("six")).stream().anyMatch(e -> ((Map<String, Object>) e).get("Title").equals("66"))).isTrue();
     }
     
     @Test
@@ -2275,7 +2272,7 @@ public class DMNRuntimeTest extends BaseInterpretedVsCompiledTest {
         // DROOLS-2813 DMN boxed invocation missing expression NPE and Validator issue
         final List<DMNMessage> messages = DMNRuntimeUtil.createExpectingDMNMessages("DROOLS-2813-NPE-BoxedInvocationMissingExpression.dmn", this.getClass());
 
-        assertTrue(messages.stream().anyMatch(p -> p.getMessageType().equals(DMNMessageType.MISSING_EXPRESSION) && p.getSourceId().equals("_a111c4df-c5b5-4d84-81e7-3ec735b50d06")));
+        assertThat(messages.stream().anyMatch(p -> p.getMessageType().equals(DMNMessageType.MISSING_EXPRESSION) && p.getSourceId().equals("_a111c4df-c5b5-4d84-81e7-3ec735b50d06"))).isTrue();
     }
 
     @Test

--- a/kie-dmn/kie-dmn-core/src/test/java/org/kie/dmn/core/DMNRuntimeTypeCheckTest.java
+++ b/kie-dmn/kie-dmn-core/src/test/java/org/kie/dmn/core/DMNRuntimeTypeCheckTest.java
@@ -44,8 +44,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
+import static org.assertj.core.api.Assertions.fail;
 
 public class DMNRuntimeTypeCheckTest extends BaseInterpretedVsCompiledTest {
 
@@ -205,7 +204,7 @@ public class DMNRuntimeTypeCheckTest extends BaseInterpretedVsCompiledTest {
 
             fail("");
         } catch (final Exception e) {
-            assertTrue(e.getMessage().contains("'model'"));
+            assertThat(e.getMessage()).contains("'model'");
             /* java.lang.NullPointerException: Kie DMN API parameter 'model' cannot be null.
                 at java.util.Objects.requireNonNull(Objects.java:290)
                 at org.kie.dmn.core.impl.DMNRuntimeImpl.evaluateAll(DMNRuntimeImpl.java:123)

--- a/kie-dmn/kie-dmn-core/src/test/java/org/kie/dmn/core/DMNStronglyTypedSupportTest.java
+++ b/kie-dmn/kie-dmn-core/src/test/java/org/kie/dmn/core/DMNStronglyTypedSupportTest.java
@@ -44,8 +44,6 @@ import org.kie.dmn.core.util.DMNRuntimeUtil;
 import org.kie.dmn.feel.lang.types.impl.ComparablePeriod;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
 import static org.kie.dmn.core.BaseVariantTest.VariantTestConf.BUILDER_DEFAULT_NOCL_TYPECHECK;
 import static org.kie.dmn.core.BaseVariantTest.VariantTestConf.BUILDER_DEFAULT_NOCL_TYPECHECK_TYPESAFE;
 import static org.kie.dmn.core.BaseVariantTest.VariantTestConf.KIE_API_TYPECHECK;
@@ -90,7 +88,7 @@ public class DMNStronglyTypedSupportTest extends BaseVariantTest {
         assertThat(idnMembershipLevels.getType().getBaseType().getName()).isEqualTo("tMembershipLevel");
         assertThat(idnMembershipLevels.getType().isCollection()).isTrue();
         assertThat(idnMembershipLevels.getType().isComposite()).isFalse();
-        assertThat(idnMembershipLevels.getType().getAllowedValues().isEmpty()).isTrue();
+        assertThat(idnMembershipLevels.getType().getAllowedValues()).isEmpty();
 
         final InputDataNode idnPercent = dmnModel.getInputs().stream().filter(idn -> idn.getName().equals("Percent")).findFirst().get();
         assertThat(idnPercent.getType().getBaseType().getNamespace()).isEqualTo(FEEL_NAMESPACE);
@@ -310,28 +308,28 @@ public class DMNStronglyTypedSupportTest extends BaseVariantTest {
         assertThat(result.get("Bruce")).isInstanceOf(Map.class);
         final Map<String, Object> bruce = (Map<String, Object>) result.get("Bruce");
 
-        assertEquals(2, ((List) bruce.get("one")).size());
-        assertTrue(((List) bruce.get("one")).stream().anyMatch(e -> ((Map<String, Object>) e).get("Title").equals("55")));
-        assertTrue(((List) bruce.get("one")).stream().anyMatch(e -> ((Map<String, Object>) e).get("Title").equals("510")));
+        assertThat(((List) bruce.get("one"))).hasSize(2);
+        assertThat(((List) bruce.get("one")).stream().anyMatch(e -> ((Map<String, Object>) e).get("Title").equals("55"))).isTrue();
+        assertThat(((List) bruce.get("one")).stream().anyMatch(e -> ((Map<String, Object>) e).get("Title").equals("510"))).isTrue();
 
-        assertEquals(3, ((List) bruce.get("two")).size());
-        assertTrue(((List) bruce.get("two")).stream().anyMatch(e -> ((Map<String, Object>) e).get("Title").equals("810")));
-        assertTrue(((List) bruce.get("two")).stream().anyMatch(e -> ((Map<String, Object>) e).get("Title").equals("85")));
-        assertTrue(((List) bruce.get("two")).stream().anyMatch(e -> ((Map<String, Object>) e).get("Title").equals("66")));
+        assertThat(((List) bruce.get("two"))).hasSize(3);
+        assertThat(((List) bruce.get("two")).stream().anyMatch(e -> ((Map<String, Object>) e).get("Title").equals("810"))).isTrue();
+        assertThat(((List) bruce.get("two")).stream().anyMatch(e -> ((Map<String, Object>) e).get("Title").equals("85"))).isTrue();
+        assertThat(((List) bruce.get("two")).stream().anyMatch(e -> ((Map<String, Object>) e).get("Title").equals("66"))).isTrue();
 
-        assertEquals(1, ((List) bruce.get("three")).size());
-        assertTrue(((List) bruce.get("three")).stream().anyMatch(e -> ((Map<String, Object>) e).get("Title").equals("510")));
+        assertThat(((List) bruce.get("three"))).hasSize(1);
+        assertThat(((List) bruce.get("three")).stream().anyMatch(e -> ((Map<String, Object>) e).get("Title").equals("510"))).isTrue();
 
-        assertEquals(2, ((List) bruce.get("Four")).size());
-        assertTrue(((List) bruce.get("Four")).stream().anyMatch(e -> ((Map<String, Object>) e).get("Title").equals("85")));
-        assertTrue(((List) bruce.get("Four")).stream().anyMatch(e -> ((Map<String, Object>) e).get("Title").equals("66")));
+        assertThat(((List) bruce.get("Four"))).hasSize(2);
+        assertThat(((List) bruce.get("Four")).stream().anyMatch(e -> ((Map<String, Object>) e).get("Title").equals("85"))).isTrue();
+        assertThat(((List) bruce.get("Four")).stream().anyMatch(e -> ((Map<String, Object>) e).get("Title").equals("66"))).isTrue();
 
-        assertEquals(2, ((List) bruce.get("Five")).size());
-        assertTrue(((List) bruce.get("Five")).stream().anyMatch(e -> ((Map<String, Object>) e).get("Title").equals("85")));
-        assertTrue(((List) bruce.get("Five")).stream().anyMatch(e -> ((Map<String, Object>) e).get("Title").equals("66")));
+        assertThat(((List) bruce.get("Five"))).hasSize(2);
+        assertThat(((List) bruce.get("Five")).stream().anyMatch(e -> ((Map<String, Object>) e).get("Title").equals("85"))).isTrue();
+        assertThat(((List) bruce.get("Five")).stream().anyMatch(e -> ((Map<String, Object>) e).get("Title").equals("66"))).isTrue();
 
-        assertEquals(2, ((List) bruce.get("six")).size());
-        assertTrue(((List) bruce.get("six")).stream().anyMatch(e -> ((Map<String, Object>) e).get("Title").equals("85")));
-        assertTrue(((List) bruce.get("six")).stream().anyMatch(e -> ((Map<String, Object>) e).get("Title").equals("66")));
+        assertThat(((List) bruce.get("six"))).hasSize(2);
+        assertThat(((List) bruce.get("six")).stream().anyMatch(e -> ((Map<String, Object>) e).get("Title").equals("85"))).isTrue();
+        assertThat(((List) bruce.get("six")).stream().anyMatch(e -> ((Map<String, Object>) e).get("Title").equals("66"))).isTrue();
     }
 }

--- a/kie-dmn/kie-dmn-core/src/test/java/org/kie/dmn/core/DMNTypeTest.java
+++ b/kie-dmn/kie-dmn-core/src/test/java/org/kie/dmn/core/DMNTypeTest.java
@@ -31,8 +31,7 @@ import org.kie.dmn.feel.FEEL;
 import org.kie.dmn.feel.lang.types.BuiltInType;
 import org.kie.dmn.model.v1_1.KieDMNModelInstrumentedBase;
 
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.kie.dmn.core.util.DynamicTypeUtils.entry;
 import static org.kie.dmn.core.util.DynamicTypeUtils.prototype;
 
@@ -58,32 +57,32 @@ public class DMNTypeTest {
 
         final Map<String, Object> instanceNOTaPerson = prototype(entry("name", "NOTAPERSON"));
 
-        assertTrue(dmnPerson.isAssignableValue(instanceBob));
-        assertTrue(dmnPerson.isAssignableValue(instanceJohn));
+        assertThat(dmnPerson.isAssignableValue(instanceBob)).isTrue();
+        assertThat(dmnPerson.isAssignableValue(instanceJohn)).isTrue();
 
-        assertFalse(dmnPerson.isAssignableValue(instanceNOTaPerson));
+        assertThat(dmnPerson.isAssignableValue(instanceNOTaPerson)).isFalse();
 
         final List<Map<String, Object>> onlyBob = Collections.singletonList(instanceBob);
         final List<Map<String, Object>> bobANDjohn = Arrays.asList(instanceBob, instanceJohn);
         final List<Map<String, Object>> johnANDnotAPerson = Arrays.asList(instanceJohn, instanceNOTaPerson);
 
-        assertTrue(dmnPersonList.isAssignableValue(onlyBob));
-        assertTrue(dmnPersonList.isAssignableValue(bobANDjohn));
-        assertFalse(dmnPersonList.isAssignableValue(johnANDnotAPerson));
-        assertTrue(dmnPersonList.isAssignableValue(instanceBob)); // because accordingly to FEEL spec, bob=[bob]
+        assertThat(dmnPersonList.isAssignableValue(onlyBob)).isTrue();
+        assertThat(dmnPersonList.isAssignableValue(bobANDjohn)).isTrue();
+        assertThat(dmnPersonList.isAssignableValue(johnANDnotAPerson)).isFalse();
+        assertThat(dmnPersonList.isAssignableValue(instanceBob)).isTrue(); // because accordingly to FEEL spec, bob=[bob]
         
         final List<List<Map<String, Object>>> the2ListsThatContainBob = Arrays.asList(onlyBob, bobANDjohn);
-        assertTrue(dmnListOfPersonsGrouped.isAssignableValue(the2ListsThatContainBob));
+        assertThat(dmnListOfPersonsGrouped.isAssignableValue(the2ListsThatContainBob)).isTrue();
 
         final List<List<Map<String, Object>>> the3Lists = Arrays.asList(onlyBob, bobANDjohn, johnANDnotAPerson);
-        assertFalse(dmnListOfPersonsGrouped.isAssignableValue(the3Lists));
+        assertThat(dmnListOfPersonsGrouped.isAssignableValue(the3Lists)).isFalse();
 
         final List<Object> groupsOfBobAndBobHimself = Arrays.asList(instanceBob, onlyBob, bobANDjohn);
-        assertTrue(dmnListOfPersonsGrouped.isAssignableValue(groupsOfBobAndBobHimself)); // [bob, [bob], [bob, john]] because for the property of FEEL spec a=[a] is equivalent to [[bob], [bob], [bob, john]]
+        assertThat(dmnListOfPersonsGrouped.isAssignableValue(groupsOfBobAndBobHimself)).isTrue(); // [bob, [bob], [bob, john]] because for the property of FEEL spec a=[a] is equivalent to [[bob], [bob], [bob, john]]
 
         final DMNType listOfGroups = typeRegistry.registerType(new CompositeTypeImpl(testNS, "listOfGroups", null, true, null, dmnListOfPersonsGrouped, null));
         final List<Object> groupsContainingBobPartitionedBySize = Arrays.asList(the2ListsThatContainBob, Collections.singletonList(bobANDjohn));
-        assertTrue(listOfGroups.isAssignableValue(groupsContainingBobPartitionedBySize)); // [ [[B], [B, J]], [[B, J]] ]
+        assertThat(listOfGroups.isAssignableValue(groupsContainingBobPartitionedBySize)).isTrue(); // [ [[B], [B, J]], [[B, J]] ]
     }
 
     @Test
@@ -94,14 +93,14 @@ public class DMNTypeTest {
         final FEEL feel = FEEL.newInstance();
         final DMNType tDecision1 = typeRegistry.registerType(new SimpleTypeImpl(testNS, "tListOfVowels", null, true, feel.evaluateUnaryTests("\"a\",\"e\",\"i\",\"o\",\"u\""), FEEL_STRING, BuiltInType.STRING));
 
-        assertTrue(tDecision1.isAssignableValue("a"));
-        assertTrue(tDecision1.isAssignableValue(Collections.singletonList("a")));
+        assertThat(tDecision1.isAssignableValue("a")).isTrue();
+        assertThat(tDecision1.isAssignableValue(Collections.singletonList("a"))).isTrue();
 
-        assertFalse(tDecision1.isAssignableValue("z"));
+        assertThat(tDecision1.isAssignableValue("z")).isFalse();
 
-        assertTrue(tDecision1.isAssignableValue(Arrays.asList("a", "e")));
+        assertThat(tDecision1.isAssignableValue(Arrays.asList("a", "e"))).isTrue();
 
-        assertFalse(tDecision1.isAssignableValue(Arrays.asList("a", "e", "zzz")));
+        assertThat(tDecision1.isAssignableValue(Arrays.asList("a", "e", "zzz"))).isFalse();
     }
 
 }

--- a/kie-dmn/kie-dmn-core/src/test/java/org/kie/dmn/core/alphanetwork/AlphaNetworkSupportInLargeDecisionTableTest.java
+++ b/kie-dmn/kie-dmn-core/src/test/java/org/kie/dmn/core/alphanetwork/AlphaNetworkSupportInLargeDecisionTableTest.java
@@ -38,8 +38,6 @@ import org.kie.dmn.api.core.DMNRuntime;
 import org.kie.dmn.core.compiler.AlphaNetworkOption;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
 import static org.kie.dmn.core.classloader.DMNClassloaderTest.getPom;
 
 @RunWith(Parameterized.class)
@@ -76,7 +74,7 @@ public class AlphaNetworkSupportInLargeDecisionTableTest {
         kfs.writePomXML(getPom(releaseId));
 
         final KieBuilder kieBuilder = ks.newKieBuilder(kfs).buildAll();
-        assertTrue(kieBuilder.getResults().getMessages().toString(), kieBuilder.getResults().getMessages().isEmpty());
+        assertThat(kieBuilder.getResults().getMessages()).as(kieBuilder.getResults().getMessages().toString()).isEmpty();
 
         final KieContainer container = ks.newKieContainer(releaseId);
         DMNRuntime dmnRuntime = KieRuntimeFactory.of(container.getKieBase()).get(DMNRuntime.class);
@@ -89,7 +87,7 @@ public class AlphaNetworkSupportInLargeDecisionTableTest {
         dmnContext.set("isAffordable", true);
 
         DMNResult dmnResult = dmnRuntime.evaluateAll(dmnModel, dmnContext);
-        assertFalse(dmnResult.hasErrors());
+        assertThat(dmnResult.hasErrors()).isFalse();
         assertThat(dmnResult.getDecisionResultById("decision-table").getResult()).isEqualTo("Declined");
     }
 

--- a/kie-dmn/kie-dmn-core/src/test/java/org/kie/dmn/core/classloader/DMNClassloaderTest.java
+++ b/kie-dmn/kie-dmn-core/src/test/java/org/kie/dmn/core/classloader/DMNClassloaderTest.java
@@ -37,7 +37,6 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.Assert.assertTrue;
 
 public class DMNClassloaderTest extends BaseInterpretedVsCompiledTest {
     public static final Logger LOG = LoggerFactory.getLogger(DMNClassloaderTest.class);
@@ -80,7 +79,7 @@ public class DMNClassloaderTest extends BaseInterpretedVsCompiledTest {
         kfs.writePomXML(getPom(kjarReleaseId, commonsMathGAV));
 
         final KieBuilder kieBuilder = ks.newKieBuilder(kfs).buildAll();
-        assertTrue(kieBuilder.getResults().getMessages().toString(), kieBuilder.getResults().getMessages().isEmpty());
+        assertThat(kieBuilder.getResults().getMessages()).as(kieBuilder.getResults().getMessages().toString()).isEmpty();
 
         final KieContainer container = ks.newKieContainer(kjarReleaseId);
         final DMNRuntime runtime = container.newKieSession().getKieRuntime(DMNRuntime.class);
@@ -152,7 +151,7 @@ public class DMNClassloaderTest extends BaseInterpretedVsCompiledTest {
         kfs.writePomXML(getPom(kjarReleaseId));
 
         final KieBuilder kieBuilder = ks.newKieBuilder(kfs).buildAll();
-        assertTrue(kieBuilder.getResults().getMessages().toString(), kieBuilder.getResults().getMessages().isEmpty());
+        assertThat(kieBuilder.getResults().getMessages()).as(kieBuilder.getResults().getMessages().toString()).isEmpty();
 
         final KieContainer container = ks.newKieContainer(kjarReleaseId);
         final DMNRuntime runtime = container.newKieSession().getKieRuntime(DMNRuntime.class);

--- a/kie-dmn/kie-dmn-core/src/test/java/org/kie/dmn/core/classloader/DMNEvalHelperAccessorCacheTest.java
+++ b/kie-dmn/kie-dmn-core/src/test/java/org/kie/dmn/core/classloader/DMNEvalHelperAccessorCacheTest.java
@@ -36,7 +36,6 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.Assert.assertTrue;
 
 public class DMNEvalHelperAccessorCacheTest extends BaseInterpretedVsCompiledTest {
     public static final Logger LOG = LoggerFactory.getLogger(DMNEvalHelperAccessorCacheTest.class);
@@ -167,7 +166,7 @@ public class DMNEvalHelperAccessorCacheTest extends BaseInterpretedVsCompiledTes
         kfs2.generateAndWritePomXML(kjarReleaseId2);
 
         final KieBuilder kieBuilder2 = ks.newKieBuilder(kfs2).buildAll();
-        assertTrue(kieBuilder2.getResults().getMessages().toString(), kieBuilder2.getResults().getMessages().isEmpty());
+        assertThat(kieBuilder2.getResults().getMessages()).as(kieBuilder2.getResults().getMessages().toString()).isEmpty();
 
         final KieContainer container2 = ks.newKieContainer(kjarReleaseId2);
         return container2;

--- a/kie-dmn/kie-dmn-core/src/test/java/org/kie/dmn/core/classloader/DMNRuntimeListenerPropertyTest.java
+++ b/kie-dmn/kie-dmn-core/src/test/java/org/kie/dmn/core/classloader/DMNRuntimeListenerPropertyTest.java
@@ -35,7 +35,6 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.Assert.assertTrue;
 
 public class DMNRuntimeListenerPropertyTest {
 
@@ -67,7 +66,7 @@ public class DMNRuntimeListenerPropertyTest {
         kfs.generateAndWritePomXML(releaseId);
 
         final KieBuilder kieBuilder = ks.newKieBuilder(kfs).buildAll();
-        assertTrue(kieBuilder.getResults().getMessages().toString(), kieBuilder.getResults().getMessages().isEmpty());
+        assertThat(kieBuilder.getResults().getMessages()).as(kieBuilder.getResults().getMessages().toString()).isEmpty();
 
         final KieContainer kieContainer = ks.newKieContainer(releaseId);
 

--- a/kie-dmn/kie-dmn-core/src/test/java/org/kie/dmn/core/classloader/DMNRuntimeListenerTest.java
+++ b/kie-dmn/kie-dmn-core/src/test/java/org/kie/dmn/core/classloader/DMNRuntimeListenerTest.java
@@ -52,8 +52,6 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
 
 public class DMNRuntimeListenerTest extends BaseInterpretedVsCompiledTest {
 
@@ -111,7 +109,7 @@ public class DMNRuntimeListenerTest extends BaseInterpretedVsCompiledTest {
                                                   )
                         );
         final KieBuilder kieBuilder = ks.newKieBuilder(kfs).buildAll();
-        assertTrue(kieBuilder.getResults().getMessages().toString(), kieBuilder.getResults().getMessages().isEmpty());
+        assertThat(kieBuilder.getResults().getMessages()).as(kieBuilder.getResults().getMessages().toString()).isEmpty();
 
         final KieContainer kieContainer = ks.newKieContainer(releaseId);
 
@@ -264,14 +262,14 @@ public class DMNRuntimeListenerTest extends BaseInterpretedVsCompiledTest {
         runtime.evaluateAll(dmnModel, emptyContext);
 
         assertThat(listener.beforeEvent).isNotNull();
-        assertEquals(listener.beforeEvent.getModelNamespace(), modelNamespace);
-        assertEquals(listener.beforeEvent.getModelName(), modelName);
+        assertThat(modelNamespace).isEqualTo(listener.beforeEvent.getModelNamespace());
+        assertThat(modelName).isEqualTo(listener.beforeEvent.getModelName());
         assertThat(listener.beforeEvent.getResult()).isNotNull();
         assertThat(listener.beforeEvent.getResult().getContext().getMetadata().asMap()).isEqualTo(TEST_METADATA);
 
         assertThat(listener.afterEvent).isNotNull();
-        assertEquals(listener.afterEvent.getModelNamespace(), modelNamespace);
-        assertEquals(listener.afterEvent.getModelName(), modelName);
+        assertThat(modelNamespace).isEqualTo(listener.afterEvent.getModelNamespace());
+        assertThat(modelName).isEqualTo(listener.afterEvent.getModelName());
         assertThat(listener.afterEvent.getResult()).isNotNull();
         assertThat(listener.afterEvent.getResult().getContext().getMetadata().asMap()).isEqualTo(TEST_METADATA);
     }

--- a/kie-dmn/kie-dmn-core/src/test/java/org/kie/dmn/core/compiler/ImportDMNResolverUtilTest.java
+++ b/kie-dmn/kie-dmn-core/src/test/java/org/kie/dmn/core/compiler/ImportDMNResolverUtilTest.java
@@ -13,8 +13,7 @@ import org.kie.dmn.feel.util.Either;
 import org.kie.dmn.model.api.Import;
 import org.kie.dmn.model.v1_1.TImport;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
+import static org.assertj.core.api.Assertions.assertThat;
 
 public class ImportDMNResolverUtilTest {
 
@@ -25,8 +24,8 @@ public class ImportDMNResolverUtilTest {
                                                     new QName("ns2", "m2"),
                                                     new QName("ns3", "m3"));
         final Either<String, QName> result = ImportDMNResolverUtil.resolveImportDMN(i, available, Function.identity());
-        assertTrue(result.isRight());
-        assertEquals(new QName("ns1", "m1"), result.getOrElse(null));
+        assertThat(result.isRight()).isTrue();
+        assertThat(result.getOrElse(null)).isEqualTo(new QName("ns1", "m1"));
     }
 
     @Test
@@ -36,8 +35,8 @@ public class ImportDMNResolverUtilTest {
                                                     new QName("ns2", "m2"),
                                                     new QName("ns3", "m3"));
         final Either<String, QName> result = ImportDMNResolverUtil.resolveImportDMN(i, available, Function.identity());
-        assertTrue(result.isRight());
-        assertEquals(new QName("ns1", "m1"), result.getOrElse(null));
+        assertThat(result.isRight()).isTrue();
+        assertThat(result.getOrElse(null)).isEqualTo(new QName("ns1", "m1"));
     }
 
     @Test
@@ -47,8 +46,8 @@ public class ImportDMNResolverUtilTest {
                                                     new QName("ns2", "m2"),
                                                     new QName("ns3", "m3"));
         final Either<String, QName> result = ImportDMNResolverUtil.resolveImportDMN(i, available, Function.identity());
-        assertTrue(result.isRight());
-        assertEquals(new QName("ns1", "m1"), result.getOrElse(null));
+        assertThat(result.isRight()).isTrue();
+        assertThat(result.getOrElse(null)).isEqualTo(new QName("ns1", "m1"));
     }
 
     @Test
@@ -58,8 +57,8 @@ public class ImportDMNResolverUtilTest {
                                                     new QName("ns2", "m2"),
                                                     new QName("ns3", "m3"));
         final Either<String, QName> result = ImportDMNResolverUtil.resolveImportDMN(i, available, Function.identity());
-        assertTrue(result.isRight());
-        assertEquals(new QName("ns1", "m1"), result.getOrElse(null));
+        assertThat(result.isRight()).isTrue();
+        assertThat(result.getOrElse(null)).isEqualTo(new QName("ns1", "m1"));
     }
 
     @Test
@@ -69,7 +68,7 @@ public class ImportDMNResolverUtilTest {
                                                     new QName("ns2", "m2"),
                                                     new QName("ns3", "m3"));
         final Either<String, QName> result = ImportDMNResolverUtil.resolveImportDMN(i, available, Function.identity());
-        assertTrue(result.isLeft());
+        assertThat(result.isLeft()).isTrue();
     }
 
     @Test
@@ -79,8 +78,8 @@ public class ImportDMNResolverUtilTest {
                                                     new QName("ns2", "m2"),
                                                     new QName("ns3", "m3"));
         final Either<String, QName> result = ImportDMNResolverUtil.resolveImportDMN(i, available, Function.identity());
-        assertTrue(result.isRight());
-        assertEquals(new QName("ns1", "m1"), result.getOrElse(null));
+        assertThat(result.isRight()).isTrue();
+        assertThat(result.getOrElse(null)).isEqualTo(new QName("ns1", "m1"));
     }
 
     @Test
@@ -90,8 +89,8 @@ public class ImportDMNResolverUtilTest {
                                                     new QName("nsA", "m2"),
                                                     new QName("nsB", "m3"));
         final Either<String, QName> result = ImportDMNResolverUtil.resolveImportDMN(i, available, Function.identity());
-        assertTrue(result.isRight());
-        assertEquals(new QName("nsA", "m1"), result.getOrElse(null));
+        assertThat(result.isRight()).isTrue();
+        assertThat(result.getOrElse(null)).isEqualTo(new QName("nsA", "m1"));
     }
 
     @Test
@@ -101,7 +100,7 @@ public class ImportDMNResolverUtilTest {
                                                     new QName("nsA", "m2"),
                                                     new QName("nsB", "m3"));
         final Either<String, QName> result = ImportDMNResolverUtil.resolveImportDMN(i, available, Function.identity());
-        assertTrue(result.isLeft());
+        assertThat(result.isLeft()).isTrue();
     }
 
     @Test
@@ -111,8 +110,8 @@ public class ImportDMNResolverUtilTest {
                                                     new QName("nsA", "m2"),
                                                     new QName("nsB", "m3"));
         final Either<String, QName> result = ImportDMNResolverUtil.resolveImportDMN(i, available, Function.identity());
-        assertTrue(result.isRight());
-        assertEquals(new QName("nsA", "m1"), result.getOrElse(null));
+        assertThat(result.isRight()).isTrue();
+        assertThat(result.getOrElse(null)).isEqualTo(new QName("nsA", "m1"));
     }
 
     @Test
@@ -122,7 +121,7 @@ public class ImportDMNResolverUtilTest {
                                                     new QName("nsA", "m2"),
                                                     new QName("nsB", "m3"));
         final Either<String, QName> result = ImportDMNResolverUtil.resolveImportDMN(i, available, Function.identity());
-        assertTrue(result.isLeft());
+        assertThat(result.isLeft()).isTrue();
     }
 
     @Test
@@ -132,7 +131,7 @@ public class ImportDMNResolverUtilTest {
                                                     new QName("nsA", "m2"),
                                                     new QName("nsB", "m3"));
         final Either<String, QName> result = ImportDMNResolverUtil.resolveImportDMN(i, available, Function.identity());
-        assertTrue(result.isLeft());
+        assertThat(result.isLeft()).isTrue();
     }
 
     @Test
@@ -143,7 +142,7 @@ public class ImportDMNResolverUtilTest {
                                                     new QName("nsA", "mA"),
                                                     new QName("nsB", "m3"));
         final Either<String, QName> result = ImportDMNResolverUtil.resolveImportDMN(i, available, Function.identity());
-        assertTrue(result.isLeft());
+        assertThat(result.isLeft()).isTrue();
     }
 
     private Import makeImport(final String namespace, final String name, final String modelName) {

--- a/kie-dmn/kie-dmn-core/src/test/java/org/kie/dmn/core/compiler/ItemDefinitionDependenciesGeneratedTest.java
+++ b/kie-dmn/kie-dmn-core/src/test/java/org/kie/dmn/core/compiler/ItemDefinitionDependenciesGeneratedTest.java
@@ -33,7 +33,7 @@ import org.kie.dmn.model.v1_1.TItemDefinition;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import static org.junit.Assert.assertTrue;
+import static org.assertj.core.api.Assertions.assertThat;
 
 @RunWith(Parameterized.class)
 public class ItemDefinitionDependenciesGeneratedTest {
@@ -197,10 +197,8 @@ public class ItemDefinitionDependenciesGeneratedTest {
         for (final ItemDefinition dependency : itemDefinition.getItemComponent()) {
             final String dependencyName = dependency.getTypeRef().getLocalPart();
             final int indexOfDependency = indexOfItemDefinitionByName(dependencyName, orderedList);
-            assertTrue("Cannot find dependency " + dependencyName + " in the ordered list!",
-                       indexOfDependency > -1);
-            assertTrue("Index of " + itemDefinition.getName() + " < " + dependency.getTypeRef().getLocalPart(),
-                       orderedList.indexOf(itemDefinition) > indexOfDependency);
+            assertThat(indexOfDependency > -1).as("Cannot find dependency " + dependencyName + " in the ordered list!").isTrue();
+            assertThat(orderedList.indexOf(itemDefinition) > indexOfDependency).as("Index of " + itemDefinition.getName() + " < " + dependency.getTypeRef().getLocalPart()).isTrue();
             if (dependency.getItemComponent() != null && !dependency.getItemComponent().isEmpty()) {
                 assertOrdering(dependency, orderedList);
             }

--- a/kie-dmn/kie-dmn-core/src/test/java/org/kie/dmn/core/compiler/ItemDefinitionDependenciesTest.java
+++ b/kie-dmn/kie-dmn-core/src/test/java/org/kie/dmn/core/compiler/ItemDefinitionDependenciesTest.java
@@ -26,7 +26,6 @@ import org.kie.dmn.model.api.ItemDefinition;
 import org.kie.dmn.model.v1_1.TItemDefinition;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.Assert.assertTrue;
 
 
 public class ItemDefinitionDependenciesTest {
@@ -83,7 +82,7 @@ public class ItemDefinitionDependenciesTest {
         
         final List<ItemDefinition> orderedList = orderingStrategy(originalList);
 
-        assertTrue("Index of z < a", orderedList.indexOf(z) < orderedList.indexOf(a));
+        assertThat(orderedList.indexOf(z) < orderedList.indexOf(a)).as("Index of z < a").isTrue();
     }
     
     @Test
@@ -115,9 +114,9 @@ public class ItemDefinitionDependenciesTest {
                                                                 tPrequalification);
         
         final List<ItemDefinition> orderedList = orderingStrategy(originalList);
-        
-        assertTrue("Index of tAge < tBorrowe", orderedList.indexOf(tAge) < orderedList.indexOf(tBorrowe));
-        assertTrue("Index of temploementStatus < tBorrowe", orderedList.indexOf(temploementStatus) < orderedList.indexOf(tBorrowe));
+
+        assertThat(orderedList.indexOf(tAge) < orderedList.indexOf(tBorrowe)).as("Index of tAge < tBorrowe").isTrue();
+        assertThat(orderedList.indexOf(temploementStatus) < orderedList.indexOf(tBorrowe)).as("Index of temploementStatus < tBorrowe").isTrue();
     }
     
     @Test
@@ -139,14 +138,14 @@ public class ItemDefinitionDependenciesTest {
                                                                 tLoanTypes);
         
         final List<ItemDefinition> orderedList = orderingStrategy(originalList);
-        
-        assertTrue("Index of tMortgageType < tRequested", orderedList.indexOf(tMortgageType) < orderedList.indexOf(tRequested));
-        assertTrue("Index of tObjective < tRequested", orderedList.indexOf(tObjective) < orderedList.indexOf(tRequested));
 
-        assertTrue("Index of tProduct < tProductCollection", orderedList.indexOf(tProduct) < orderedList.indexOf(tProductCollection));
-        
-        assertTrue("Index of tMortgageType < tLoanTypes", orderedList.indexOf(tMortgageType) < orderedList.indexOf(tLoanTypes));
-        assertTrue("Index of tConformanceType < tLoanTypes", orderedList.indexOf(tConformanceType) < orderedList.indexOf(tLoanTypes));
+        assertThat(orderedList.indexOf(tMortgageType) < orderedList.indexOf(tRequested)).as("Index of tMortgageType < tRequested").isTrue();
+        assertThat(orderedList.indexOf(tObjective) < orderedList.indexOf(tRequested)).as("Index of tObjective < tRequested").isTrue();
+
+        assertThat(orderedList.indexOf(tProduct) < orderedList.indexOf(tProductCollection)).as("Index of tProduct < tProductCollection").isTrue();
+
+        assertThat(orderedList.indexOf(tMortgageType) < orderedList.indexOf(tLoanTypes)).as("Index of tMortgageType < tLoanTypes").isTrue();
+        assertThat(orderedList.indexOf(tConformanceType) < orderedList.indexOf(tLoanTypes)).as("Index of tConformanceType < tLoanTypes").isTrue();
     }
     
     @Test
@@ -170,12 +169,12 @@ public class ItemDefinitionDependenciesTest {
                                                                 tTaxList);
         
         final List<ItemDefinition> orderedList = orderingStrategy(originalList);
-        
-        assertTrue("Index of tCategory < tItem", orderedList.indexOf(tCategory) < orderedList.indexOf(tItem));
-        assertTrue("Index of tItem < tItemList", orderedList.indexOf(tItem) < orderedList.indexOf(tItemList));
-        assertTrue("Index of tItemList < tOrder", orderedList.indexOf(tItemList) < orderedList.indexOf(tOrder));
-        
-        assertTrue("Index of tTax < tTaxList", orderedList.indexOf(tTax) < orderedList.indexOf(tTaxList));
+
+        assertThat(orderedList.indexOf(tCategory) < orderedList.indexOf(tItem)).as("Index of tCategory < tItem").isTrue();
+        assertThat(orderedList.indexOf(tItem) < orderedList.indexOf(tItemList)).as("Index of tItem < tItemList").isTrue();
+        assertThat(orderedList.indexOf(tItemList) < orderedList.indexOf(tOrder)).as("Index of tItemList < tOrder").isTrue();
+
+        assertThat(orderedList.indexOf(tTax) < orderedList.indexOf(tTaxList)).as("Index of tTax < tTaxList").isTrue();
     }
 
     @Test
@@ -200,14 +199,14 @@ public class ItemDefinitionDependenciesTest {
 
         final List<ItemDefinition> orderedList = orderingStrategy(originalList);
 
-        assertTrue("Index of _TypeDecisionA1 < _TypeDecisionA2_x", orderedList.indexOf(_TypeDecisionA1) < orderedList.indexOf(_TypeDecisionA2_x));
-        assertTrue("Index of _TypeDecisionA2_x < _TypeDecisionA3", orderedList.indexOf(_TypeDecisionA2_x) < orderedList.indexOf(_TypeDecisionA3));
-        assertTrue("Index of _TypeDecisionA3 < _TypeDecisionB3", orderedList.indexOf(_TypeDecisionA3) < orderedList.indexOf(_TypeDecisionB3));
-        assertTrue("Index of _TypeDecisionA3 < _TypeDecisionC1", orderedList.indexOf(_TypeDecisionA3) < orderedList.indexOf(_TypeDecisionC1));
+        assertThat(orderedList.indexOf(_TypeDecisionA1) < orderedList.indexOf(_TypeDecisionA2_x)).as("Index of _TypeDecisionA1 < _TypeDecisionA2_x").isTrue();
+        assertThat(orderedList.indexOf(_TypeDecisionA2_x) < orderedList.indexOf(_TypeDecisionA3)).as("Index of _TypeDecisionA2_x < _TypeDecisionA3").isTrue();
+        assertThat(orderedList.indexOf(_TypeDecisionA3) < orderedList.indexOf(_TypeDecisionB3)).as("Index of _TypeDecisionA3 < _TypeDecisionB3").isTrue();
+        assertThat(orderedList.indexOf(_TypeDecisionA3) < orderedList.indexOf(_TypeDecisionC1)).as("Index of _TypeDecisionA3 < _TypeDecisionC1").isTrue();
 
-        assertTrue("Index of _TypeDecisionB1 < _TypeDecisionB2_x", orderedList.indexOf(_TypeDecisionB1) < orderedList.indexOf(_TypeDecisionB2_x));
-        assertTrue("Index of _TypeDecisionB2_x < _TypeDecisionB3", orderedList.indexOf(_TypeDecisionB2_x) < orderedList.indexOf(_TypeDecisionB3));
-        assertTrue("Index of _TypeDecisionB3 < _TypeDecisionC1", orderedList.indexOf(_TypeDecisionB3) < orderedList.indexOf(_TypeDecisionC1));
+        assertThat(orderedList.indexOf(_TypeDecisionB1) < orderedList.indexOf(_TypeDecisionB2_x)).as("Index of _TypeDecisionB1 < _TypeDecisionB2_x").isTrue();
+        assertThat(orderedList.indexOf(_TypeDecisionB2_x) < orderedList.indexOf(_TypeDecisionB3)).as("Index of _TypeDecisionB2_x < _TypeDecisionB3").isTrue();
+        assertThat(orderedList.indexOf(_TypeDecisionB3) < orderedList.indexOf(_TypeDecisionC1)).as("Index of _TypeDecisionB3 < _TypeDecisionC1").isTrue();
     }
 
     @Test

--- a/kie-dmn/kie-dmn-core/src/test/java/org/kie/dmn/core/compiler/extensions/DMNExtensionRegisterTest.java
+++ b/kie-dmn/kie-dmn-core/src/test/java/org/kie/dmn/core/compiler/extensions/DMNExtensionRegisterTest.java
@@ -37,9 +37,6 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertTrue;
 
 public class DMNExtensionRegisterTest {
     private static final Logger LOG = LoggerFactory.getLogger(DMNExtensionRegisterTest.class);
@@ -48,36 +45,36 @@ public class DMNExtensionRegisterTest {
     public void testUsingSystemProperty() {
         try {
             System.setProperty("org.kie.dmn.profiles.FirstNameLastNameProfile", FirstNameLastNameProfile.class.getCanonicalName());
-            assertEquals(FirstNameLastNameProfile.class.getCanonicalName(), System.getProperty("org.kie.dmn.profiles.FirstNameLastNameProfile"));
+            assertThat(System.getProperty("org.kie.dmn.profiles.FirstNameLastNameProfile")).isEqualTo(FirstNameLastNameProfile.class.getCanonicalName());
             
             final DMNRuntime runtime = DMNRuntimeUtil.createRuntime("0001-input-data-string-with-extensions.dmn", this.getClass() );
             final DMNModel dmnModel = runtime.getModel("https://github.com/kiegroup/kie-dmn", "0001-input-data-string" );
             assertThat(dmnModel).isNotNull();
             assertThat(dmnModel.hasErrors()).as(DMNRuntimeUtil.formatMessages(dmnModel.getMessages())).isFalse();
-            
-            assertEquals(3, dmnModel.getDefinitions().getDrgElement().size());
+
+            assertThat(dmnModel.getDefinitions().getDrgElement()).hasSize(3);
             
             final InputData inputData1 = (InputData) dmnModel.getDefinitions().getDrgElement().get(1);
-            assertEquals("First Name", inputData1.getName());
+            assertThat(inputData1.getName()).isEqualTo("First Name");
             final DMNElement.ExtensionElements id1elements = inputData1.getExtensionElements();
             assertThat(id1elements).isNotNull();
-            assertEquals(1, id1elements.getAny().size());
+            assertThat(id1elements.getAny()).hasSize(1);
             final FirstNameDescription firstNameDescription = (FirstNameDescription) id1elements.getAny().get(0);
-            assertEquals("First name in latin characters", firstNameDescription.getContent());
+            assertThat(firstNameDescription.getContent()).isEqualTo("First name in latin characters");
             
             final InputData inputData2 = (InputData) dmnModel.getDefinitions().getDrgElement().get(2);
-            assertEquals("Last Name", inputData2.getName());
+            assertThat(inputData2.getName()).isEqualTo("Last Name");
             final DMNElement.ExtensionElements id2elements = inputData2.getExtensionElements();
             assertThat(id2elements).isNotNull();
-            assertEquals(1, id2elements.getAny().size());
+            assertThat(id2elements.getAny()).hasSize(1);
             final LastNameDescription lastNameDescription = (LastNameDescription) id2elements.getAny().get(0);
-            assertEquals("Last name in latin characters", lastNameDescription.getContent());
+            assertThat(lastNameDescription.getContent()).isEqualTo("Last name in latin characters");
         } catch (final Exception e) {
             LOG.error("{}", e.getLocalizedMessage(), e);
             throw e;
         } finally {
             System.clearProperty("org.kie.dmn.profiles.FirstNameLastNameProfile");
-            assertNull(System.getProperty("org.kie.dmn.profiles.FirstNameLastNameProfile"));
+            assertThat(System.getProperty("org.kie.dmn.profiles.FirstNameLastNameProfile")).isNull();
         }
     }
 
@@ -98,7 +95,7 @@ public class DMNExtensionRegisterTest {
         
         LOG.info("buildAll() completed.");
         results.getMessages(Level.WARNING).forEach( e -> LOG.warn("{}", e));
-        assertEquals(0, results.getMessages(Level.WARNING).size());
+        assertThat(results.getMessages(Level.WARNING)).hasSize(0);
 
         final KieContainer kieContainer = ks.newKieContainer(ks.getRepository().getDefaultReleaseId());
         
@@ -106,24 +103,24 @@ public class DMNExtensionRegisterTest {
         final DMNModel dmnModel = runtime.getModel("https://github.com/kiegroup/kie-dmn", "0001-input-data-string" );
         assertThat(dmnModel).isNotNull();
         assertThat(dmnModel.hasErrors()).as(DMNRuntimeUtil.formatMessages(dmnModel.getMessages())).isFalse();
-        
-        assertEquals(3, dmnModel.getDefinitions().getDrgElement().size());
+
+        assertThat(dmnModel.getDefinitions().getDrgElement()).hasSize(3);
         
         final InputData inputData1 = (InputData) dmnModel.getDefinitions().getDrgElement().get(1);
-        assertEquals("First Name", inputData1.getName());
+        assertThat(inputData1.getName()).isEqualTo("First Name");
         final DMNElement.ExtensionElements id1elements = inputData1.getExtensionElements();
         assertThat(id1elements).isNotNull();
-        assertEquals(1, id1elements.getAny().size());
+        assertThat(id1elements.getAny()).hasSize(1);
         final FirstNameDescription firstNameDescription = (FirstNameDescription) id1elements.getAny().get(0);
-        assertEquals("First name in latin characters", firstNameDescription.getContent());
+        assertThat(firstNameDescription.getContent()).isEqualTo("First name in latin characters");
         
         final InputData inputData2 = (InputData) dmnModel.getDefinitions().getDrgElement().get(2);
-        assertEquals("Last Name", inputData2.getName());
+        assertThat(inputData2.getName()).isEqualTo("Last Name");
         final DMNElement.ExtensionElements id2elements = inputData2.getExtensionElements();
         assertThat(id2elements).isNotNull();
-        assertEquals(1, id2elements.getAny().size());
+        assertThat(id2elements.getAny()).hasSize(1);
         final LastNameDescription lastNameDescription = (LastNameDescription) id2elements.getAny().get(0);
-        assertEquals("Last name in latin characters", lastNameDescription.getContent());
+        assertThat(lastNameDescription.getContent()).isEqualTo("Last name in latin characters");
     }
 
     @Test
@@ -143,7 +140,7 @@ public class DMNExtensionRegisterTest {
         
         LOG.info("buildAll() completed.");
         results.getMessages(Level.WARNING).forEach( e -> LOG.warn("{}", e));
-        assertTrue( results.getMessages(Level.WARNING).size() > 0 );
+        assertThat(results.getMessages(Level.WARNING)).hasSizeGreaterThan(0);
 
         final KieContainer kieContainer = ks.newKieContainer(ks.getRepository().getDefaultReleaseId());
         
@@ -151,19 +148,19 @@ public class DMNExtensionRegisterTest {
         final DMNModel dmnModel = runtime.getModel("https://github.com/kiegroup/kie-dmn", "0001-input-data-string" );
         assertThat(dmnModel).isNotNull();
         assertThat(dmnModel.hasErrors()).as(DMNRuntimeUtil.formatMessages(dmnModel.getMessages())).isFalse();
-        
-        assertEquals(3, dmnModel.getDefinitions().getDrgElement().size());
+
+        assertThat(dmnModel.getDefinitions().getDrgElement()).hasSize(3);
         final InputData inputData1 = (InputData) dmnModel.getDefinitions().getDrgElement().get(1);
-        assertEquals("First Name", inputData1.getName());
+        assertThat(inputData1.getName()).isEqualTo("First Name");
         final DMNElement.ExtensionElements id1elements = inputData1.getExtensionElements();
         assertThat(id1elements).isNotNull();
-        assertEquals(0, id1elements.getAny().size());
+        assertThat(id1elements.getAny()).hasSize(0);
         
         final InputData inputData2 = (InputData) dmnModel.getDefinitions().getDrgElement().get(2);
-        assertEquals("Last Name", inputData2.getName());
+        assertThat(inputData2.getName()).isEqualTo("Last Name");
         final DMNElement.ExtensionElements id2elements = inputData2.getExtensionElements();
         assertThat(id2elements).isNotNull();
-        assertEquals(0, id2elements.getAny().size());
+        assertThat(id2elements.getAny()).hasSize(0);
     }
 
     private String formatMessages(final List<DMNMessage> messages) {

--- a/kie-dmn/kie-dmn-core/src/test/java/org/kie/dmn/core/compiler/profiles/ExtendedDMNProfileTest.java
+++ b/kie-dmn/kie-dmn-core/src/test/java/org/kie/dmn/core/compiler/profiles/ExtendedDMNProfileTest.java
@@ -24,7 +24,6 @@ import java.time.format.DateTimeFormatter;
 import java.util.Arrays;
 import java.util.Collections;
 
-import org.junit.Assert;
 import org.junit.Test;
 import org.kie.dmn.feel.runtime.functions.AbsFunction;
 import org.kie.dmn.feel.runtime.functions.EvenFunction;
@@ -44,7 +43,6 @@ import org.kie.dmn.feel.runtime.functions.extended.TimeFunction;
 
 import static java.math.BigDecimal.valueOf;
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.Assert.assertTrue;
 
 public class ExtendedDMNProfileTest {
     private final DateFunction dateFunction = DateFunction.INSTANCE;
@@ -163,16 +161,16 @@ public class ExtendedDMNProfileTest {
     }
 
     private static <T> void assertResult(final FEELFnResult<T> result, final T val) {
-        assertTrue(result.isRight());
+        assertThat(result.isRight()).isTrue();
         assertThat(result.getOrElse(null)).isEqualTo(val);
     }
 
     private static void assertResultDoublePrecision(final FEELFnResult<BigDecimal> result, final BigDecimal val) {
-        assertTrue(result.isRight());
+        assertThat(result.isRight()).isTrue();
         assertThat(Double.compare(result.getOrElse(null).doubleValue(), val.doubleValue())).isEqualTo(0);
     }
 
     private static void assertNull(final FEELFnResult<?> result) {
-        Assert.assertNull(result.getOrElse(null));
+        assertThat(result.getOrElse(null)).isNull();
     }
 }

--- a/kie-dmn/kie-dmn-core/src/test/java/org/kie/dmn/core/incrementalcompilation/WBCompilationTest.java
+++ b/kie-dmn/kie-dmn-core/src/test/java/org/kie/dmn/core/incrementalcompilation/WBCompilationTest.java
@@ -30,7 +30,7 @@ import org.kie.internal.builder.IncrementalResults;
 import org.kie.internal.builder.InternalKieBuilder;
 import org.kie.internal.services.KieAssemblersImpl;
 
-import static org.junit.Assert.assertEquals;
+import static org.assertj.core.api.Assertions.assertThat;
 
 public class WBCompilationTest {
 
@@ -91,16 +91,16 @@ public class WBCompilationTest {
 
         kfs.write("src/main/resources/org/kie/scanner/dmn1.dmn", DMN_1);
         KieBuilder kieBuilder = ks.newKieBuilder(kfs).buildAll(DrlProject.class);
-        assertEquals(0, kieBuilder.getResults().getMessages(org.kie.api.builder.Message.Level.ERROR).size());
+        assertThat(kieBuilder.getResults().getMessages(org.kie.api.builder.Message.Level.ERROR)).hasSize(0);
 
         kfs.write("src/main/resources/org/kie/scanner/dmn2.dmn", DMN_2);
         IncrementalResults addResults = ((InternalKieBuilder) kieBuilder).createFileSet("src/main/resources/org/kie/scanner/dmn2.dmn").build();
-        assertEquals(0, addResults.getAddedMessages().size());
-        assertEquals(0, addResults.getRemovedMessages().size());
+        assertThat(addResults.getAddedMessages()).hasSize(0);
+        assertThat(addResults.getRemovedMessages()).hasSize(0);
 
         KieContainer kieContainer = ks.newKieContainer(id);
         DMNRuntime runtime = kieContainer.newKieSession().getKieRuntime(DMNRuntime.class);
-        assertEquals(2, runtime.getModels().size());
+        assertThat(runtime.getModels()).hasSize(2);
     }
 
     @Test
@@ -116,20 +116,20 @@ public class WBCompilationTest {
         kfs.generateAndWritePomXML(id);
 
         KieBuilder kieBuilder = ks.newKieBuilder(kfs).buildAll(DrlProject.class);
-        assertEquals(0, kieBuilder.getResults().getMessages(org.kie.api.builder.Message.Level.ERROR).size());
+        assertThat(kieBuilder.getResults().getMessages(org.kie.api.builder.Message.Level.ERROR)).hasSize(0);
 
         kfs.write("src/main/resources/org/kie/scanner/dmn1.dmn", DMN_1);
         IncrementalResults addResults = ((InternalKieBuilder) kieBuilder).createFileSet("src/main/resources/org/kie/scanner/dmn1.dmn").build();
-        assertEquals(0, addResults.getAddedMessages().size());
-        assertEquals(0, addResults.getRemovedMessages().size());
+        assertThat(addResults.getAddedMessages()).hasSize(0);
+        assertThat(addResults.getRemovedMessages()).hasSize(0);
 
         kfs.write("src/main/resources/org/kie/scanner/dmn2.dmn", DMN_2);
         addResults = ((InternalKieBuilder) kieBuilder).createFileSet("src/main/resources/org/kie/scanner/dmn2.dmn").build();
-        assertEquals(0, addResults.getAddedMessages().size());
-        assertEquals(0, addResults.getRemovedMessages().size());
+        assertThat(addResults.getAddedMessages()).hasSize(0);
+        assertThat(addResults.getRemovedMessages()).hasSize(0);
 
         KieContainer kieContainer = ks.newKieContainer(id);
         DMNRuntime runtime = kieContainer.newKieSession().getKieRuntime(DMNRuntime.class);
-        assertEquals(2, runtime.getModels().size());
+        assertThat(runtime.getModels()).hasSize(2);
     }
 }

--- a/kie-dmn/kie-dmn-core/src/test/java/org/kie/dmn/core/internal/utils/DMNRuntimeBuilderTest.java
+++ b/kie-dmn/kie-dmn-core/src/test/java/org/kie/dmn/core/internal/utils/DMNRuntimeBuilderTest.java
@@ -27,7 +27,6 @@ import org.kie.api.runtime.KieRuntimeFactory;
 import org.kie.dmn.core.impl.DMNRuntimeImpl;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.Assert.assertEquals;
 
 public class DMNRuntimeBuilderTest {
 
@@ -50,6 +49,6 @@ public class DMNRuntimeBuilderTest {
                 .fromResources(Collections.emptyList()).getOrElseThrow(RuntimeException::new);
         assertThat(retrieved).isNotNull();
         KieRuntimeFactory kieRuntimeFactory = retrieved.getKieRuntimeFactory("TEST");
-        assertEquals(toReturn, kieRuntimeFactory);
+        assertThat(kieRuntimeFactory).isEqualTo(toReturn);
     }
 }

--- a/kie-dmn/kie-dmn-core/src/test/java/org/kie/dmn/core/stronglytyped/DMNTypeSafeTest.java
+++ b/kie-dmn/kie-dmn-core/src/test/java/org/kie/dmn/core/stronglytyped/DMNTypeSafeTest.java
@@ -41,7 +41,6 @@ import org.slf4j.LoggerFactory;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static java.util.Arrays.asList;
-import static org.junit.Assert.assertEquals;
 import static org.kie.dmn.core.BaseVariantTest.VariantTestConf.KIE_API_TYPECHECK_TYPESAFE;
 import static org.kie.dmn.core.util.DynamicTypeUtils.entry;
 import static org.kie.dmn.core.util.DynamicTypeUtils.mapOf;
@@ -186,8 +185,8 @@ public class DMNTypeSafeTest extends BaseVariantTest {
         DMNContext context = new DMNContextFPAImpl(feelPropertyAccessibleContext);
         context.getMetadata().set(metadataKey, metadataValue);
 
-        assertEquals(metadataValue, context.getMetadata().get(metadataKey));
-        assertEquals(metadataValue, context.clone().getMetadata().get(metadataKey));
+        assertThat(context.getMetadata().get(metadataKey)).isEqualTo(metadataValue);
+        assertThat(context.clone().getMetadata().get(metadataKey)).isEqualTo(metadataValue);
     }
 
     private void assertValidDmnModel(DMNModel dmnModel){

--- a/kie-dmn/kie-dmn-core/src/test/java/org/kie/dmn/core/stronglytyped/JavadocTest.java
+++ b/kie-dmn/kie-dmn-core/src/test/java/org/kie/dmn/core/stronglytyped/JavadocTest.java
@@ -36,7 +36,6 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.Assert.assertTrue;
 import static org.kie.dmn.core.BaseVariantTest.VariantTestConf.BUILDER_DEFAULT_NOCL_TYPECHECK_TYPESAFE;
 import static org.kie.dmn.core.BaseVariantTest.VariantTestConf.KIE_API_TYPECHECK_TYPESAFE;
 
@@ -134,9 +133,9 @@ public class JavadocTest extends BaseVariantTest {
     private void assertJavadoc(CompilationUnit cu, String field, String expectedJavadocComment) {
         String lcField = StringUtils.lcFirst(field);
         Optional<FieldDeclaration> opt = cu.findFirst(FieldDeclaration.class, fd -> fd.asFieldDeclaration().getVariable(0).getNameAsString().equals(lcField));
-        assertTrue(opt.isPresent());
+        assertThat(opt).isPresent();
         Optional<JavadocComment> actual = opt.get().getJavadocComment();
-        assertTrue(actual.isPresent());
+        assertThat(actual).isPresent();
         assertThat(actual.get().getContent()).contains(expectedJavadocComment);
     }
 }

--- a/kie-dmn/kie-dmn-core/src/test/java/org/kie/dmn/core/v1_4/DMN14ExpressionsTest.java
+++ b/kie-dmn/kie-dmn-core/src/test/java/org/kie/dmn/core/v1_4/DMN14ExpressionsTest.java
@@ -34,9 +34,6 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
 import static org.kie.dmn.core.BaseVariantTest.VariantTestConf.BUILDER_DEFAULT_NOCL_TYPECHECK;
 import static org.kie.dmn.core.BaseVariantTest.VariantTestConf.KIE_API_TYPECHECK;
 
@@ -68,105 +65,105 @@ public class DMN14ExpressionsTest extends BaseVariantTest {
     @Test
     public void testConditionalWithInput() throws Throwable {
         DMNResult results = runtime.evaluateByName(model, new DMNContextImpl(Collections.singletonMap("Boolean Input", true)), "Conditional");
-        assertEquals("Conditional evaluated to TRUE", results.getDecisionResultByName("Conditional").getResult());
+        assertThat(results.getDecisionResultByName("Conditional").getResult()).isEqualTo("Conditional evaluated to TRUE");
 
         results = runtime.evaluateByName(model, new DMNContextImpl(Collections.singletonMap("Boolean Input", false)), "Conditional");
-        assertEquals("Conditional evaluated to FALSE", results.getDecisionResultByName("Conditional").getResult());
+        assertThat(results.getDecisionResultByName("Conditional").getResult()).isEqualTo("Conditional evaluated to FALSE");
 
         results = runtime.evaluateByName(model, new DMNContextImpl(Collections.singletonMap("Boolean Input", null)), "Conditional");
-        assertEquals("Conditional evaluated to FALSE", results.getDecisionResultByName("Conditional").getResult());
+        assertThat(results.getDecisionResultByName("Conditional").getResult()).isEqualTo("Conditional evaluated to FALSE");
 
     }
 
     @Test
     public void testConditionalNonBooleanIf() throws Throwable {
         DMNResult results = runtime.evaluateByName(model, new DMNContextImpl(), "Non boolean");
-        assertEquals(1, results.getMessages().size());
-        assertEquals(DMNMessageType.ERROR_EVAL_NODE, results.getMessages().iterator().next().getMessageType());
+        assertThat(results.getMessages()).hasSize(1);
+        assertThat(results.getMessages().iterator().next().getMessageType()).isEqualTo(DMNMessageType.ERROR_EVAL_NODE);
 
     }
 
     @Test
     public void testIteratorFor() throws Throwable {
         DMNResult results = runtime.evaluateByName(model, new DMNContextImpl(Collections.singletonMap("Number Input", 1)), "Addition");
-        assertEquals(Arrays.asList(2, 3, 4, 5).toString(), results.getDecisionResultByName("Addition").getResult().toString());
+        assertThat(results.getDecisionResultByName("Addition").getResult().toString()).isEqualTo(Arrays.asList(2, 3, 4, 5).toString());
 
         results = runtime.evaluateByName(model, new DMNContextImpl(Collections.singletonMap("Number Input", 2)), "Addition");
-        assertEquals(Arrays.asList(3, 4, 5, 6).toString(), results.getDecisionResultByName("Addition").getResult().toString());
+        assertThat(results.getDecisionResultByName("Addition").getResult().toString()).isEqualTo(Arrays.asList(3, 4, 5, 6).toString());
     }
 
     @Test
     public void testIteratorForPartial() throws Throwable {
         DMNResult results = runtime.evaluateByName(model, new DMNContextImpl(Collections.singletonMap("Number Input", 0)), "Addition Partial");
-        assertEquals(Arrays.asList(1, 3, 6, 10).toString(), results.getDecisionResultByName("Addition Partial").getResult().toString());
+        assertThat(results.getDecisionResultByName("Addition Partial").getResult().toString()).isEqualTo(Arrays.asList(1, 3, 6, 10).toString());
 
         results = runtime.evaluateByName(model, new DMNContextImpl(Collections.singletonMap("Number Input", 5)), "Addition Partial");
-        assertEquals(Arrays.asList(1, 8, 16, 25).toString(), results.getDecisionResultByName("Addition Partial").getResult().toString());
+        assertThat(results.getDecisionResultByName("Addition Partial").getResult().toString()).isEqualTo(Arrays.asList(1, 8, 16, 25).toString());
     }
     
     @Test
     public void testIteratorForInRangeClose() throws Throwable {
         DMNResult results = runtime.evaluateByName(model, new DMNContextImpl(Collections.singletonMap("Number Input", 1)), "Addition Range Close");
-        assertEquals(Arrays.asList(3, 4).toString(), results.getDecisionResultByName("Addition Range Close").getResult().toString());
+        assertThat(results.getDecisionResultByName("Addition Range Close").getResult().toString()).isEqualTo(Arrays.asList(3, 4).toString());
 
         results = runtime.evaluateByName(model, new DMNContextImpl(Collections.singletonMap("Number Input", 2)), "Addition Range Close");
-        assertEquals(Arrays.asList(4, 5).toString(), results.getDecisionResultByName("Addition Range Close").getResult().toString());
+        assertThat(results.getDecisionResultByName("Addition Range Close").getResult().toString()).isEqualTo(Arrays.asList(4, 5).toString());
     } 
 
     @Test
     public void testIteratorForInRangeOpen() throws Throwable {
         DMNResult results = runtime.evaluateByName(model, new DMNContextImpl(Collections.singletonMap("Number Input", 1)), "Addition Range Open");
-        assertEquals(Arrays.asList(2, 3, 4, 5).toString(), results.getDecisionResultByName("Addition Range Open").getResult().toString());
+        assertThat(results.getDecisionResultByName("Addition Range Open").getResult().toString()).isEqualTo(Arrays.asList(2, 3, 4, 5).toString());
 
         results = runtime.evaluateByName(model, new DMNContextImpl(Collections.singletonMap("Number Input", 2)), "Addition Range Open");
-        assertEquals(Arrays.asList(3, 4, 5, 6).toString(), results.getDecisionResultByName("Addition Range Open").getResult().toString());
+        assertThat(results.getDecisionResultByName("Addition Range Open").getResult().toString()).isEqualTo(Arrays.asList(3, 4, 5, 6).toString());
     } 
 
     
     @Test
     public void testIteratorSome() throws Throwable {
         DMNResult results = runtime.evaluateByName(model, new DMNContextImpl(Collections.singletonMap("Number Input", 5)), "Number Greater Exists");
-        assertTrue(((Boolean) results.getDecisionResultByName("Number Greater Exists").getResult()).booleanValue());
+        assertThat(((Boolean) results.getDecisionResultByName("Number Greater Exists").getResult()).booleanValue()).isTrue();
 
         results = runtime.evaluateByName(model, new DMNContextImpl(Collections.singletonMap("Number Input", -1)), "Number Greater Exists");
-        assertTrue(((Boolean) results.getDecisionResultByName("Number Greater Exists").getResult()).booleanValue());
+        assertThat(((Boolean) results.getDecisionResultByName("Number Greater Exists").getResult()).booleanValue()).isTrue();
 
         results = runtime.evaluateByName(model, new DMNContextImpl(Collections.singletonMap("Number Input", 11)), "Number Greater Exists");
-        assertFalse(((Boolean) results.getDecisionResultByName("Number Greater Exists").getResult()).booleanValue());
+        assertThat(((Boolean) results.getDecisionResultByName("Number Greater Exists").getResult()).booleanValue()).isFalse();
     }
 
     @Test
     public void testIteratorEvery() throws Throwable {
         DMNResult results = runtime.evaluateByName(model, new DMNContextImpl(Collections.singletonMap("Number Input", 5)), "All Greater");
-        assertFalse(((Boolean) results.getDecisionResultByName("All Greater").getResult()).booleanValue());
+        assertThat(((Boolean) results.getDecisionResultByName("All Greater").getResult()).booleanValue()).isFalse();
 
         results = runtime.evaluateByName(model, new DMNContextImpl(Collections.singletonMap("Number Input", -1)), "All Greater");
-        assertTrue(((Boolean) results.getDecisionResultByName("All Greater").getResult()).booleanValue());
+        assertThat(((Boolean) results.getDecisionResultByName("All Greater").getResult()).booleanValue()).isTrue();
 
         results = runtime.evaluateByName(model, new DMNContextImpl(Collections.singletonMap("Number Input", 11)), "All Greater");
-        assertFalse(((Boolean) results.getDecisionResultByName("All Greater").getResult()).booleanValue());
+        assertThat(((Boolean) results.getDecisionResultByName("All Greater").getResult()).booleanValue()).isFalse();
     }
 
     @Test
     public void testFilterIndex() throws Throwable {
         DMNResult results = runtime.evaluateByName(model, new DMNContextImpl(Collections.singletonMap("Number Input", 5)), "Match by index");
-        assertEquals(new BigDecimal(5), results.getDecisionResultByName("Match by index").getResult());
+        assertThat(results.getDecisionResultByName("Match by index").getResult()).isEqualTo(new BigDecimal(5));
 
         results = runtime.evaluateByName(model, new DMNContextImpl(Collections.singletonMap("Number Input", -2)), "Match by index");
-        assertEquals(new BigDecimal(9), results.getDecisionResultByName("Match by index").getResult());
+        assertThat(results.getDecisionResultByName("Match by index").getResult()).isEqualTo(new BigDecimal(9));
 
         results = runtime.evaluateByName(model, new DMNContextImpl(Collections.singletonMap("Number Input", 0)), "Match by index");
-        assertTrue(results.getMessages().size() > 0);
+        assertThat(results.getMessages()).hasSizeGreaterThan(0);
 
     }
 
     @Test
     public void testFilterExpression() throws Throwable {
         DMNResult results = runtime.evaluateByName(model, new DMNContextImpl(Collections.singletonMap("Number Input", 5)), "Match by Fnct");
-        assertEquals(Arrays.asList(6, 7, 8, 9, 10).toString(), results.getDecisionResultByName("Match by Fnct").getResult().toString());
+        assertThat(results.getDecisionResultByName("Match by Fnct").getResult().toString()).isEqualTo(Arrays.asList(6, 7, 8, 9, 10).toString());
 
         results = runtime.evaluateByName(model, new DMNContextImpl(Collections.singletonMap("Number Input", 11)), "Match by Fnct");
-        assertEquals(Arrays.asList().toString(), results.getDecisionResultByName("Match by Fnct").getResult().toString());
+        assertThat(results.getDecisionResultByName("Match by Fnct").getResult().toString()).isEqualTo(Arrays.asList().toString());
 
     }
 }

--- a/kie-dmn/kie-dmn-core/src/test/java/org/kie/dmn/core/v1_4/DMN14GenericSynthTest.java
+++ b/kie-dmn/kie-dmn-core/src/test/java/org/kie/dmn/core/v1_4/DMN14GenericSynthTest.java
@@ -32,7 +32,6 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.Assert.assertEquals;
 import static org.kie.dmn.core.BaseVariantTest.VariantTestConf.BUILDER_DEFAULT_NOCL_TYPECHECK;
 import static org.kie.dmn.core.BaseVariantTest.VariantTestConf.KIE_API_TYPECHECK;
 import static org.kie.dmn.core.util.DynamicTypeUtils.entry;
@@ -68,7 +67,7 @@ public class DMN14GenericSynthTest extends BaseVariantTest {
         DMNContext context = runtime.newContext();
         context.set("Input", Arrays.asList(tc1, tc2, tc3));
         DMNResult results = runtime.evaluateAll(model, context);
-        assertEquals(Arrays.asList(tc1, tc3), results.getDecisionResultByName("Decision").getResult());
+        assertThat(results.getDecisionResultByName("Decision").getResult()).isEqualTo(Arrays.asList(tc1, tc3));
     }
 
     @Test
@@ -98,7 +97,7 @@ public class DMN14GenericSynthTest extends BaseVariantTest {
         DMNContext context = runtime.newContext();
         context.set("Input", Arrays.asList(tc1, tc2, tc3));
         DMNResult results = runtime.evaluateAll(model, context);
-        assertEquals(Arrays.asList("x", "y", "z"), results.getDecisionResultByName("Decision").getResult());
+        assertThat(results.getDecisionResultByName("Decision").getResult()).isEqualTo(Arrays.asList("x", "y", "z"));
     }
 
     @Test

--- a/kie-dmn/kie-dmn-feel-gwt-functions/pom.xml
+++ b/kie-dmn/kie-dmn-feel-gwt-functions/pom.xml
@@ -44,6 +44,11 @@
       <scope>test</scope>
     </dependency>
     <dependency>
+      <groupId>org.assertj</groupId>
+      <artifactId>assertj-core</artifactId>
+      <scope>test</scope>
+    </dependency>    
+    <dependency>
       <groupId>org.mockito</groupId>
       <artifactId>mockito-core</artifactId>
       <scope>test</scope>

--- a/kie-dmn/kie-dmn-feel-gwt-functions/src/test/java/org/kie/dmn/feel/gwt/functions/api/FunctionOverrideVariationTest.java
+++ b/kie-dmn/kie-dmn-feel-gwt-functions/src/test/java/org/kie/dmn/feel/gwt/functions/api/FunctionOverrideVariationTest.java
@@ -19,7 +19,7 @@ package org.kie.dmn.feel.gwt.functions.api;
 import org.junit.Before;
 import org.junit.Test;
 
-import static org.junit.Assert.assertEquals;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.kie.dmn.feel.lang.types.BuiltInType.STRING;
 
 public class FunctionOverrideVariationTest {
@@ -39,13 +39,13 @@ public class FunctionOverrideVariationTest {
 
     @Test
     public void testToHumanReadableString() {
-        assertEquals("string, string, string, string", functionOverrideVariation.toHumanReadableString());
+        assertThat(functionOverrideVariation.toHumanReadableString()).isEqualTo("string, string, string, string");
     }
 
     @Test
     public void testToHumanReadableStrings() {
         final FunctionDefinitionStrings functionDefinitionStrings = functionOverrideVariation.toHumanReadableStrings();
-        assertEquals("replace(string, string, string, string)", functionDefinitionStrings.getHumanReadable());
-        assertEquals("replace($1, $2, $3, $4)", functionDefinitionStrings.getTemplate());
+        assertThat(functionDefinitionStrings.getHumanReadable()).isEqualTo("replace(string, string, string, string)");
+        assertThat(functionDefinitionStrings.getTemplate()).isEqualTo("replace($1, $2, $3, $4)");
     }
 }

--- a/kie-dmn/kie-dmn-feel-gwt-functions/src/test/java/org/kie/dmn/feel/gwt/functions/rebind/FileCreatorTest.java
+++ b/kie-dmn/kie-dmn-feel-gwt-functions/src/test/java/org/kie/dmn/feel/gwt/functions/rebind/FileCreatorTest.java
@@ -36,8 +36,7 @@ import org.kie.dmn.feel.lang.types.BuiltInType;
 import org.mockito.Mock;
 import org.mockito.junit.MockitoJUnitRunner;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertSame;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.kie.dmn.feel.gwt.functions.rebind.FileCreator.GENERATED_CLASS_FQCN;
 import static org.kie.dmn.feel.gwt.functions.rebind.FileCreator.PACKAGE_NAME;
 import static org.mockito.Mockito.doReturn;
@@ -100,13 +99,13 @@ public class FileCreatorTest {
         verify(composerFactory).addImport(Type.class.getCanonicalName());
         verify(composerFactory).addImplementedInterface(FEELFunctionProvider.class.getName());
 
-        assertSame(composerFactory, actualFactory);
+        assertThat(actualFactory).isSameAs(composerFactory);
     }
 
     @Test
     public void testMakeComposerFactory() {
         final ClassSourceFileComposerFactory factory = fileCreator.makeComposerFactory();
-        assertEquals(PACKAGE_NAME, factory.getCreatedPackage());
-        assertEquals(GENERATED_CLASS_FQCN, factory.getCreatedClassShortName());
+        assertThat(factory.getCreatedPackage()).isEqualTo(PACKAGE_NAME);
+        assertThat(factory.getCreatedClassShortName()).isEqualTo(GENERATED_CLASS_FQCN);
     }
 }

--- a/kie-dmn/kie-dmn-feel-gwt-functions/src/test/java/org/kie/dmn/feel/gwt/functions/rebind/FunctionProviderGeneratorTest.java
+++ b/kie-dmn/kie-dmn-feel-gwt-functions/src/test/java/org/kie/dmn/feel/gwt/functions/rebind/FunctionProviderGeneratorTest.java
@@ -25,8 +25,7 @@ import org.junit.runner.RunWith;
 import org.mockito.Mock;
 import org.mockito.junit.MockitoJUnitRunner;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNull;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.doNothing;
 import static org.mockito.Mockito.doReturn;
@@ -72,7 +71,7 @@ public class FunctionProviderGeneratorTest {
         final String actualGenerate = generator.generate(logger, context, requestedClass);
 
         verify(fileCreator).write();
-        assertEquals(expectedGenerate, actualGenerate);
+        assertThat(actualGenerate).isEqualTo(expectedGenerate);
     }
 
     @Test
@@ -85,6 +84,6 @@ public class FunctionProviderGeneratorTest {
         final String actualGenerate = generator.generate(logger, context, requestedClass);
 
         verify(fileCreator, never()).write();
-        assertNull(actualGenerate);
+        assertThat(actualGenerate).isNull();
     }
 }

--- a/kie-dmn/kie-dmn-feel-gwt-functions/src/test/java/org/kie/dmn/feel/gwt/functions/rebind/MethodTemplatesTest.java
+++ b/kie-dmn/kie-dmn-feel-gwt-functions/src/test/java/org/kie/dmn/feel/gwt/functions/rebind/MethodTemplatesTest.java
@@ -28,8 +28,7 @@ import org.kie.dmn.feel.runtime.functions.BuiltInFunctions;
 import org.kie.dmn.feel.runtime.functions.extended.KieExtendedDMNFunctions;
 
 import static java.util.Arrays.asList;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
+import static org.assertj.core.api.Assertions.assertThat;
 
 public class MethodTemplatesTest {
 
@@ -45,11 +44,11 @@ public class MethodTemplatesTest {
         final String template = MethodTemplates.getTemplate();
         final String[] templateLines = template.split("\n");
 
-        assertEquals("public List<FunctionOverrideVariation> getDefinitions() {", templateLines[0]);
-        assertEquals("    ArrayList definitions = new ArrayList();", templateLines[1]);
+        assertThat(templateLines[0]).isEqualTo("public List<FunctionOverrideVariation> getDefinitions() {");
+        assertThat(templateLines[1]).isEqualTo("    ArrayList definitions = new ArrayList();");
         assertTemplateBody(templateLines);
-        assertEquals("    return definitions;", templateLines[templateLines.length - 2]);
-        assertEquals("}", templateLines[templateLines.length - 1]);
+        assertThat(templateLines[templateLines.length - 2]).isEqualTo("    return definitions;");
+        assertThat(templateLines[templateLines.length - 1]).isEqualTo("}");
     }
 
     @Test
@@ -57,15 +56,15 @@ public class MethodTemplatesTest {
         final FEEL feel = FEEL.newInstance(profiles);
 
         final List<FEELFunction> templatedFunctions = MethodTemplates.getFeelFunctions();
-        assertTrue(templatedFunctions.stream().allMatch(fn -> feel.evaluate(fn.getName()) instanceof FEELFunction));
+        assertThat(templatedFunctions.stream().allMatch(fn -> feel.evaluate(fn.getName()) instanceof FEELFunction)).isTrue();
     }
 
     @Test
     public void testTemplatedFunctionsIncludeBuiltInAndKieExtendedFunctions() {
         final List<FEELFunction> templatedFunctions = MethodTemplates.getFeelFunctions();
 
-        assertTrue(templatedFunctions.containsAll(asList(BuiltInFunctions.getFunctions())));
-        assertTrue(templatedFunctions.containsAll(asList(KieExtendedDMNFunctions.getFunctions())));
+        assertThat(templatedFunctions).containsAll(asList(BuiltInFunctions.getFunctions()));
+        assertThat(templatedFunctions).containsAll(asList(KieExtendedDMNFunctions.getFunctions()));
     }
 
     private void assertTemplateBody(final String[] templateLines) {
@@ -240,6 +239,6 @@ public class MethodTemplatesTest {
 
     private void assertLine(final List<String> lines,
                             final String line) {
-        assertTrue(lines.contains(String.format("definitions.add( new FunctionOverrideVariation( %s );", line)));
+        assertThat(lines).contains(String.format("definitions.add( new FunctionOverrideVariation( %s );", line));
     }
 }

--- a/kie-dmn/kie-dmn-feel-gwt-showcase/pom.xml
+++ b/kie-dmn/kie-dmn-feel-gwt-showcase/pom.xml
@@ -96,6 +96,11 @@
       <artifactId>junit</artifactId>
       <scope>test</scope>
     </dependency>
+    <dependency>
+      <groupId>org.assertj</groupId>
+      <artifactId>assertj-core</artifactId>
+      <scope>test</scope>
+    </dependency>    
 
     <!-- GWT -->
     <dependency>

--- a/kie-dmn/kie-dmn-feel-gwt-showcase/src/test/java/org/kie/dmn/feel/client/showcase/FEELShowcaseIT.java
+++ b/kie-dmn/kie-dmn-feel-gwt-showcase/src/test/java/org/kie/dmn/feel/client/showcase/FEELShowcaseIT.java
@@ -32,7 +32,8 @@ import org.openqa.selenium.firefox.FirefoxOptions;
 import org.openqa.selenium.firefox.FirefoxProfile;
 import org.openqa.selenium.support.ui.WebDriverWait;
 
-import static org.junit.Assert.assertEquals;
+import static org.assertj.core.api.Assertions.assertThat;
+
 
 public class FEELShowcaseIT {
 
@@ -91,7 +92,7 @@ public class FEELShowcaseIT {
         feelExpressionTextBox.clear();
         feelExpressionTextBox.sendKeys(feelExpression);
 
-        assertEquals(expectedEvaluation, feelEvaluation.getAttribute("value"));
+        assertThat(feelEvaluation.getAttribute("value")).isEqualTo(expectedEvaluation);
     }
 
     private FirefoxOptions getFirefoxOptions() {

--- a/kie-dmn/kie-dmn-feel-gwt/pom.xml
+++ b/kie-dmn/kie-dmn-feel-gwt/pom.xml
@@ -84,6 +84,11 @@
       <artifactId>junit</artifactId>
       <scope>test</scope>
     </dependency>
+    <dependency>
+      <groupId>org.assertj</groupId>
+      <artifactId>assertj-core</artifactId>
+      <scope>test</scope>
+    </dependency>     
   </dependencies>
 
   <build>

--- a/kie-dmn/kie-dmn-feel-gwt/src/test/java/org/kie/dmn/feel/util/AssignableFromUtilTest.java
+++ b/kie-dmn/kie-dmn-feel-gwt/src/test/java/org/kie/dmn/feel/util/AssignableFromUtilTest.java
@@ -18,19 +18,18 @@ package org.kie.dmn.feel.util;
 
 import org.junit.Test;
 
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
+import static org.assertj.core.api.Assertions.assertThat;
 
 public class AssignableFromUtilTest {
 
     @Test
     public void testIsAssignableFromWhenItIsAssignable() {
-        assertTrue(AssignableFromUtil.isAssignableFrom(A.class, B.class));
+        assertThat(AssignableFromUtil.isAssignableFrom(A.class, B.class)).isTrue();
     }
 
     @Test
     public void testIsAssignableFromWhenItIsNotAssignable() {
-        assertFalse(AssignableFromUtil.isAssignableFrom(A.class, C.class));
+        assertThat(AssignableFromUtil.isAssignableFrom(A.class, C.class)).isFalse();
     }
 
     static class A {

--- a/kie-dmn/kie-dmn-feel/src/test/java/org/kie/dmn/feel/lang/examples/CompileEvaluateTest.java
+++ b/kie-dmn/kie-dmn-feel/src/test/java/org/kie/dmn/feel/lang/examples/CompileEvaluateTest.java
@@ -38,7 +38,6 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.Assert.assertTrue;
 import static org.kie.dmn.feel.util.DynamicTypeUtils.entry;
 import static org.kie.dmn.feel.util.DynamicTypeUtils.prototype;
 
@@ -141,13 +140,13 @@ public class CompileEvaluateTest {
         CompilerContext ctx = feel.newCompilerContext();
         ctx.addInputVariableType( "input", new MapBackedType().addField( "Primary-Key", BuiltInType.STRING ).addField( "Value", BuiltInType.STRING ) );
         CompiledExpression compiledExpression = feel.compile( "input.Primary-Key", ctx );
-        assertTrue(errors.isEmpty());
+        assertThat(errors).isEmpty();
         
         Map<String, Object> inputs = new HashMap<>();
         inputs.put( "input", prototype(entry("Primary-Key", "k987")) );
         Object result = feel.evaluate(compiledExpression, inputs);
         assertThat(result).isEqualTo("k987");
-        assertTrue(errors.isEmpty());
+        assertThat(errors).isEmpty();
     }
     
     @Test
@@ -156,13 +155,13 @@ public class CompileEvaluateTest {
         CompilerContext ctx = feel.newCompilerContext();
         ctx.addInputVariableType( "input", new GenListType(compositeType) );
         CompiledExpression compiledExpression = feel.compile( "input.Primary-Key", ctx );
-        assertTrue(errors.isEmpty());
+        assertThat(errors).isEmpty();
         
         Map<String, Object> inputs = new HashMap<>();
         inputs.put( "input", Arrays.asList(prototype(entry("Primary-Key", "k987"))) );
         Object result = feel.evaluate(compiledExpression, inputs);
         assertThat(result).asList().containsExactly("k987");
-        assertTrue(errors.isEmpty());
+        assertThat(errors).isEmpty();
     }
     
     @Test
@@ -171,13 +170,13 @@ public class CompileEvaluateTest {
         CompilerContext ctx = feel.newCompilerContext();
         ctx.addInputVariableType( "my input", new GenListType(compositeType) );
         CompiledExpression compiledExpression = feel.compile( "my input[1].Primary-Key", ctx );
-        assertTrue(errors.isEmpty());
+        assertThat(errors).isEmpty();
         
         Map<String, Object> inputs = new HashMap<>();
         inputs.put( "my input", Arrays.asList(prototype(entry("Primary-Key", "k987"))) );
         Object result = feel.evaluate(compiledExpression, inputs);
         assertThat(result).isEqualTo("k987");
-        assertTrue(errors.isEmpty());
+        assertThat(errors).isEmpty();
     }
     
     @Test

--- a/kie-dmn/kie-dmn-feel/src/test/java/org/kie/dmn/feel/lang/examples/ExamplesBaseTest.java
+++ b/kie-dmn/kie-dmn-feel/src/test/java/org/kie/dmn/feel/lang/examples/ExamplesBaseTest.java
@@ -16,13 +16,14 @@
 
 package org.kie.dmn.feel.lang.examples;
 
-import org.junit.Assert;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.nio.file.Files;
 import java.nio.file.Paths;
 import java.util.Map;
+
+import static org.assertj.core.api.Assertions.fail;
 
 public abstract class ExamplesBaseTest {
     public static final  String DEFAULT_IDENT = "    ";
@@ -34,7 +35,7 @@ public abstract class ExamplesBaseTest {
             return new String( Files.readAllBytes( Paths.get( ExamplesTest.class.getResource( fileName ).toURI() ) ) );
         } catch ( Exception e ) {
             logger.error( "Error reading file " + fileName, e );
-            Assert.fail( "Error reading file " + fileName);
+            fail( "Error reading file " + fileName);
         }
         return null;
     }

--- a/kie-dmn/kie-dmn-feel/src/test/java/org/kie/dmn/feel/lang/impl/MapBackedTypeTest.java
+++ b/kie-dmn/kie-dmn-feel/src/test/java/org/kie/dmn/feel/lang/impl/MapBackedTypeTest.java
@@ -1,11 +1,12 @@
 package org.kie.dmn.feel.lang.impl;
 
-import static org.junit.Assert.*;
 import static org.kie.dmn.feel.util.DynamicTypeUtils.*;
 
 import java.util.Map;
 
 import org.junit.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
 import org.kie.dmn.feel.lang.types.BuiltInType;
 
 public class MapBackedTypeTest {
@@ -14,35 +15,35 @@ public class MapBackedTypeTest {
         MapBackedType personType = new MapBackedType( "Person" , mapOf( entry("First Name", BuiltInType.STRING), entry("Last Name", BuiltInType.STRING) ));
         
         Map<?, ?> aPerson = prototype( entry("First Name", "John"), entry("Last Name", "Doe") );
-        assertTrue( personType.isAssignableValue(aPerson) );
-        assertTrue( personType.isInstanceOf(aPerson) );
+        assertThat(personType.isAssignableValue(aPerson)).isTrue();
+        assertThat(personType.isInstanceOf(aPerson)).isTrue();
         
         Map<?, ?> aCompletePerson = prototype( entry("First Name", "John"), entry("Last Name", "Doe"), entry("Address", "100 East Davie Street"));
-        assertTrue( personType.isAssignableValue(aCompletePerson) );
-        assertTrue( personType.isInstanceOf(aCompletePerson) );
+        assertThat(personType.isAssignableValue(aCompletePerson)).isTrue();
+        assertThat(personType.isInstanceOf(aCompletePerson)).isTrue();
         
         Map<?, ?> notAPerson = prototype( entry("First Name", "John") );
-        assertFalse( personType.isAssignableValue(notAPerson) );
-        assertFalse( personType.isInstanceOf(notAPerson) );
+        assertThat(personType.isAssignableValue(notAPerson)).isFalse();
+        assertThat(personType.isInstanceOf(notAPerson)).isFalse();
         
         Map<?, ?> anonymousPerson1 = prototype( entry("First Name", null), entry("Last Name", "Doe") );
-        assertTrue( personType.isAssignableValue(anonymousPerson1) );
-        assertTrue( personType.isInstanceOf(anonymousPerson1) );
+        assertThat(personType.isAssignableValue(anonymousPerson1)).isTrue();
+        assertThat(personType.isInstanceOf(anonymousPerson1)).isTrue();
         
         Map<?, ?> anonymousPerson2 = prototype( entry("First Name", "John"), entry("Last Name", null) );
-        assertTrue( personType.isAssignableValue(anonymousPerson2) );
-        assertTrue( personType.isInstanceOf(anonymousPerson2) );
+        assertThat(personType.isAssignableValue(anonymousPerson2)).isTrue();
+        assertThat(personType.isInstanceOf(anonymousPerson2)).isTrue();
         
         Map<?, ?> anonymousPerson3 = prototype( entry("First Name", null), entry("Last Name", null) );
-        assertTrue( personType.isAssignableValue(anonymousPerson3) );
-        assertTrue( personType.isInstanceOf(anonymousPerson3) );
+        assertThat(personType.isAssignableValue(anonymousPerson3)).isTrue();
+        assertThat(personType.isInstanceOf(anonymousPerson3)).isTrue();
         
         Map<?, ?> anonymousCompletePerson = prototype( entry("First Name", null), entry("Last Name", null), entry("Address", "100 East Davie Street"));
-        assertTrue( personType.isAssignableValue(anonymousCompletePerson) );
-        assertTrue( personType.isInstanceOf(anonymousCompletePerson) );
+        assertThat(personType.isAssignableValue(anonymousCompletePerson)).isTrue();
+        assertThat(personType.isInstanceOf(anonymousCompletePerson)).isTrue();
         
         Map<?, ?> nullPerson = null;
-        assertTrue( personType.isAssignableValue(nullPerson) );
-        assertFalse( personType.isInstanceOf(nullPerson) );
+        assertThat(personType.isAssignableValue(nullPerson)).isTrue();
+        assertThat(personType.isInstanceOf(nullPerson)).isFalse();
     }
 }

--- a/kie-dmn/kie-dmn-feel/src/test/java/org/kie/dmn/feel/parser/feel11/FEELParserTest.java
+++ b/kie-dmn/kie-dmn-feel/src/test/java/org/kie/dmn/feel/parser/feel11/FEELParserTest.java
@@ -692,7 +692,7 @@ public class FEELParserTest {
         assertThat( list.getText()).isEqualTo( "10, foo * bar, true");
 
         ListNode ln = (ListNode) list;
-        assertThat( ln.getElements().size()).isEqualTo(3);
+        assertThat( ln.getElements()).hasSize(3);
         assertThat( ln.getElements().get( 0 )).isInstanceOf(NumberNode.class);
         assertThat( ln.getElements().get( 1 )).isInstanceOf(InfixOpNode.class);
         assertThat( ln.getElements().get( 2 )).isInstanceOf(BooleanNode.class);
@@ -721,7 +721,7 @@ public class FEELParserTest {
         assertThat( ctxbase.getText()).isEqualTo(inputExpression);
 
         ContextNode ctx = (ContextNode) ctxbase;
-        assertThat( ctx.getEntries().size()).isEqualTo(3);
+        assertThat( ctx.getEntries()).hasSize(3);
 
         ContextEntryNode entry = ctx.getEntries().get( 0 );
         assertThat(entry.getName()).isInstanceOf(StringNode.class);
@@ -736,7 +736,7 @@ public class FEELParserTest {
         assertThat( entry.getName()).isInstanceOf(NameDefNode.class);
         NameDefNode name = (NameDefNode) entry.getName();
         assertThat( name.getParts()).isNotNull();
-        assertThat( name.getParts().size()).isEqualTo(5);
+        assertThat( name.getParts()).hasSize(5);
         assertThat( entry.getName().getText()).isEqualTo("a non-string key");
         assertThat( entry.getValue()).isInstanceOf(InfixOpNode.class);
         assertThat( entry.getResultType()).isEqualTo(BuiltInType.NUMBER);
@@ -746,7 +746,7 @@ public class FEELParserTest {
         assertThat( entry.getName()).isInstanceOf(NameDefNode.class);
         name = (NameDefNode) entry.getName();
         assertThat( name.getParts()).isNotNull();
-        assertThat( name.getParts().size()).isEqualTo(9);
+        assertThat( name.getParts()).hasSize(9);
         assertThat( entry.getName().getText()).isEqualTo("a key.with + /' odd chars");
         assertThat( entry.getValue()).isInstanceOf(RangeNode.class);
         assertThat( entry.getResultType()).isEqualTo(BuiltInType.RANGE);
@@ -764,13 +764,13 @@ public class FEELParserTest {
         assertThat( ctxbase.getText()).isEqualTo(inputExpression);
 
         ContextNode ctx = (ContextNode) ctxbase;
-        assertThat( ctx.getEntries().size()).isEqualTo(3);
+        assertThat( ctx.getEntries()).hasSize(3);
 
         ContextEntryNode entry = ctx.getEntries().get( 0 );
         assertThat( entry.getName()).isInstanceOf(NameDefNode.class);
         NameDefNode name = (NameDefNode) entry.getName();
         assertThat( name.getParts()).isNotNull();
-        assertThat( name.getParts().size()).isEqualTo(5);
+        assertThat( name.getParts()).hasSize(5);
         assertThat( entry.getName().getText()).isEqualTo("a variable with in keyword");
         assertThat( entry.getValue()).isInstanceOf(NumberNode.class);
         assertThat( entry.getResultType()).isEqualTo(BuiltInType.NUMBER);
@@ -780,7 +780,7 @@ public class FEELParserTest {
         assertThat( entry.getName()).isInstanceOf(NameDefNode.class);
         name = (NameDefNode) entry.getName();
         assertThat( name.getParts()).isNotNull();
-        assertThat( name.getParts().size()).isEqualTo(2);
+        assertThat( name.getParts()).hasSize(2);
         assertThat( entry.getName().getText()).isEqualTo("another variable");
         assertThat( entry.getValue()).isInstanceOf(InfixOpNode.class);
         assertThat( entry.getResultType()).isEqualTo(BuiltInType.NUMBER);
@@ -790,7 +790,7 @@ public class FEELParserTest {
         assertThat( entry.getName()).isInstanceOf(NameDefNode.class);
         name = (NameDefNode) entry.getName();
         assertThat( name.getParts()).isNotNull();
-        assertThat( name.getParts().size()).isEqualTo(3);
+        assertThat( name.getParts()).hasSize(3);
         assertThat( entry.getName().getText()).isEqualTo("another in variable");
         assertThat( entry.getValue()).isInstanceOf(InfixOpNode.class);
         assertThat( entry.getResultType()).isEqualTo(BuiltInType.NUMBER);
@@ -817,7 +817,7 @@ public class FEELParserTest {
         assertThat( ctxbase.getText()).isEqualTo(inputExpression);
 
         ContextNode ctx = (ContextNode) ctxbase;
-        assertThat( ctx.getEntries().size()).isEqualTo(2);
+        assertThat( ctx.getEntries()).hasSize(2);
 
         ContextEntryNode entry = ctx.getEntries().get( 0 );
         assertThat( entry.getName()).isInstanceOf(NameDefNode.class);
@@ -834,7 +834,7 @@ public class FEELParserTest {
         assertThat( entry.getValue()).isInstanceOf(ContextNode.class);
 
         ContextNode applicant = (ContextNode) entry.getValue();
-        assertThat( applicant.getEntries().size()).isEqualTo(5);
+        assertThat( applicant.getEntries()).hasSize(5);
         assertThat( applicant.getEntries().get( 0 ).getName().getText()).isEqualTo("first name");
         assertThat( applicant.getEntries().get( 0 ).getResultType()).isEqualTo(BuiltInType.STRING);
         assertThat( applicant.getEntries().get( 1 ).getName().getText()).isEqualTo("last + name");
@@ -845,7 +845,7 @@ public class FEELParserTest {
         assertThat( applicant.getEntries().get( 3 ).getValue()).isInstanceOf(ContextNode.class);
 
         ContextNode address = (ContextNode) applicant.getEntries().get( 3 ).getValue();
-        assertThat( address.getEntries().size()).isEqualTo(2);
+        assertThat( address.getEntries()).hasSize(2);
         assertThat( address.getEntries().get( 0 ).getName().getText()).isEqualTo("street");
         assertThat( address.getEntries().get( 0 ).getResultType()).isEqualTo(BuiltInType.STRING);
         assertThat( address.getEntries().get( 1 ).getName().getText()).isEqualTo("city");
@@ -868,7 +868,7 @@ public class FEELParserTest {
         assertThat( ctxbase.getText()).isEqualTo(inputExpression);
 
         ContextNode ctx = (ContextNode) ctxbase;
-        assertThat( ctx.getEntries().size()).isEqualTo(2);
+        assertThat( ctx.getEntries()).hasSize(2);
 
         ContextEntryNode entry = ctx.getEntries().get( 1 );
         assertThat( entry.getName()).isInstanceOf(NameDefNode.class);
@@ -891,7 +891,7 @@ public class FEELParserTest {
         assertThat( ctxbase.getText()).isEqualTo(inputExpression);
 
         ContextNode ctx = (ContextNode) ctxbase;
-        assertThat( ctx.getEntries().size()).isEqualTo(1);
+        assertThat( ctx.getEntries()).hasSize(1);
 
         ContextEntryNode entry = ctx.getEntries().get( 0 );
         assertThat( entry.getName()).isInstanceOf(NameDefNode.class);
@@ -901,7 +901,7 @@ public class FEELParserTest {
         assertThat( entry.getValue().getText()).isEqualTo("function( person's age ) person's age < 21");
 
         FunctionDefNode isMinorFunc = (FunctionDefNode) entry.getValue();
-        assertThat( isMinorFunc.getFormalParameters().size()).isEqualTo(1);
+        assertThat( isMinorFunc.getFormalParameters()).hasSize(1);
         assertThat( isMinorFunc.getFormalParameters().get( 0 ).getText()).isEqualTo( "person's age");
         assertThat( isMinorFunc.isExternal()).isEqualTo(false);
         assertThat( isMinorFunc.getBody()).isInstanceOf(InfixOpNode.class);
@@ -921,7 +921,7 @@ public class FEELParserTest {
         assertThat( ctxbase.getText()).isEqualTo(inputExpression);
 
         ContextNode ctx = (ContextNode) ctxbase;
-        assertThat( ctx.getEntries().size()).isEqualTo(1);
+        assertThat( ctx.getEntries()).hasSize(1);
 
         ContextEntryNode entry = ctx.getEntries().get( 0 );
         assertThat( entry.getName()).isInstanceOf(NameDefNode.class);
@@ -936,19 +936,19 @@ public class FEELParserTest {
                                                  + "}");
 
         FunctionDefNode cos = (FunctionDefNode) entry.getValue();
-        assertThat( cos.getFormalParameters().size()).isEqualTo(1);
+        assertThat( cos.getFormalParameters()).hasSize(1);
         assertThat( cos.getFormalParameters().get( 0 ).getText()).isEqualTo("angle");
         assertThat( cos.isExternal()).isEqualTo(true);
         assertThat( cos.getBody()).isInstanceOf(ContextNode.class);
 
         ContextNode body = (ContextNode) cos.getBody();
-        assertThat( body.getEntries().size()).isEqualTo(1);
+        assertThat( body.getEntries()).hasSize(1);
         ContextEntryNode java = body.getEntries().get( 0 );
         assertThat( java.getName().getText()).isEqualTo("java");
         assertThat( java.getValue()).isInstanceOf(ContextNode.class);
 
         ContextNode def = (ContextNode) java.getValue();
-        assertThat( def.getEntries().size()).isEqualTo(2);
+        assertThat( def.getEntries()).hasSize(2);
         assertThat( def.getEntries().get( 0 ).getName().getText()).isEqualTo("class");
         assertThat( def.getEntries().get( 0 ).getValue()).isInstanceOf(StringNode.class);
         assertThat( def.getEntries().get( 0 ).getValue().getText()).isEqualTo( "\"java.lang.Math\"");
@@ -967,7 +967,7 @@ public class FEELParserTest {
         assertThat( forbase.getResultType()).isEqualTo(BuiltInType.LIST);
 
         ForExpressionNode forExpr = (ForExpressionNode) forbase;
-        assertThat( forExpr.getIterationContexts().size()).isEqualTo(1);
+        assertThat( forExpr.getIterationContexts()).hasSize(1);
         assertThat( forExpr.getExpression()).isInstanceOf(InfixOpNode.class);
         assertThat( forExpr.getExpression().getText()).isEqualTo( "item.price * item.quantity");
 
@@ -1003,7 +1003,7 @@ public class FEELParserTest {
 
         QuantifiedExpressionNode someExpr = (QuantifiedExpressionNode) someBase;
         assertThat( someExpr.getQuantifier()).isEqualTo(QuantifiedExpressionNode.Quantifier.SOME);
-        assertThat( someExpr.getIterationContexts().size()).isEqualTo(1);
+        assertThat( someExpr.getIterationContexts()).hasSize(1);
         assertThat( someExpr.getIterationContexts().get( 0 ).getText()).isEqualTo( "item in order.items");
         assertThat( someExpr.getExpression().getText()).isEqualTo( "item.price > 100");
     }
@@ -1019,7 +1019,7 @@ public class FEELParserTest {
 
         QuantifiedExpressionNode everyExpr = (QuantifiedExpressionNode) everyBase;
         assertThat( everyExpr.getQuantifier()).isEqualTo(QuantifiedExpressionNode.Quantifier.EVERY);
-        assertThat( everyExpr.getIterationContexts().size()).isEqualTo(1);
+        assertThat( everyExpr.getIterationContexts()).hasSize(1);
         assertThat( everyExpr.getIterationContexts().get( 0 ).getText()).isEqualTo( "item in order.items");
         assertThat( everyExpr.getExpression().getText()).isEqualTo( "item.price > 100");
     }
@@ -1129,7 +1129,7 @@ public class FEELParserTest {
         assertThat( function.getName()).isInstanceOf(QualifiedNameNode.class);
         assertThat( function.getName().getText()).isEqualTo("my.test.Function");
         assertThat( function.getParams()).isInstanceOf(ListNode.class);
-        assertThat( function.getParams().getElements().size()).isEqualTo(2);
+        assertThat( function.getParams().getElements()).hasSize(2);
         assertThat( function.getParams().getElements().get( 0 )).isInstanceOf(NamedParameterNode.class);
         assertThat( function.getParams().getElements().get( 1 )).isInstanceOf(NamedParameterNode.class);
 
@@ -1158,7 +1158,7 @@ public class FEELParserTest {
         assertThat( function.getName()).isInstanceOf(QualifiedNameNode.class);
         assertThat( function.getName().getText()).isEqualTo("my.test.Function");
         assertThat( function.getParams()).isInstanceOf(ListNode.class);
-        assertThat( function.getParams().getElements().size()).isEqualTo(2);
+        assertThat( function.getParams().getElements()).hasSize(2);
         assertThat( function.getParams().getElements().get( 0 )).isInstanceOf(InfixOpNode.class);
         assertThat( function.getParams().getElements().get( 1 )).isInstanceOf(StringNode.class);
     }
@@ -1175,7 +1175,7 @@ public class FEELParserTest {
         assertThat( function.getName()).isInstanceOf(NameRefNode.class);
         assertThat( function.getName().getText()).isEqualTo( "date and time");
         assertThat( function.getParams()).isInstanceOf(ListNode.class);
-        assertThat( function.getParams().getElements().size()).isEqualTo(1);
+        assertThat( function.getParams().getElements()).hasSize(1);
         assertThat( function.getParams().getElements().get( 0 )).isInstanceOf(StringNode.class);
     }
 
@@ -1191,7 +1191,7 @@ public class FEELParserTest {
         assertThat( function.getName()).isInstanceOf(NameRefNode.class);
         assertThat( function.getName().getText()).isEqualTo( "date and time");
         assertThat( function.getParams()).isInstanceOf(ListNode.class);
-        assertThat( function.getParams().getElements().size()).isEqualTo(2);
+        assertThat( function.getParams().getElements()).hasSize(2);
         assertThat( function.getParams().getElements().get( 0 )).isInstanceOf(FunctionInvocationNode.class);
         assertThat( function.getParams().getElements().get( 1 )).isInstanceOf(FunctionInvocationNode.class);
     }
@@ -1234,7 +1234,7 @@ public class FEELParserTest {
         assertThat( function.getName()).isInstanceOf(NameRefNode.class);
         assertThat( function.getName().getText()).isEqualTo( "decision table");
         assertThat( function.getParams()).isInstanceOf(ListNode.class);
-        assertThat( function.getParams().getElements().size()).isEqualTo(4);
+        assertThat( function.getParams().getElements()).hasSize(4);
         assertThat( function.getParams().getElements().get( 0 )).isInstanceOf(NamedParameterNode.class);
         assertThat( function.getParams().getElements().get( 1 )).isInstanceOf(NamedParameterNode.class);
         assertThat( function.getParams().getElements().get( 2 )).isInstanceOf(NamedParameterNode.class);
@@ -1251,7 +1251,7 @@ public class FEELParserTest {
         assertThat( named.getExpression()).isInstanceOf(ListNode.class);
 
         ListNode list = (ListNode) named.getExpression();
-        assertThat( list.getElements().size()).isEqualTo(2);
+        assertThat( list.getElements()).hasSize(2);
         assertThat( list.getElements().get( 0 )).isInstanceOf(StringNode.class);
         assertThat( list.getElements().get( 0 ).getText()).isEqualTo( "\"Applicant Age\"");
         assertThat( list.getElements().get( 1 )).isInstanceOf(StringNode.class);
@@ -1262,11 +1262,11 @@ public class FEELParserTest {
         assertThat( named.getExpression()).isInstanceOf(ListNode.class);
 
         list = (ListNode) named.getExpression();
-        assertThat(list.getElements().size()).isEqualTo(5); // this assert on the 5 rows but third row contains the - operation which is not allowed in expression.
+        assertThat(list.getElements()).hasSize(5); // this assert on the 5 rows but third row contains the - operation which is not allowed in expression.
         assertThat( list.getElements().get( 0 )).isInstanceOf(ListNode.class);
 
         ListNode rule = (ListNode) list.getElements().get( 0 );
-        assertThat( rule.getElements().size()).isEqualTo(3);
+        assertThat( rule.getElements()).hasSize(3);
         assertThat( rule.getElements().get( 0 )).isInstanceOf(RangeNode.class);
         assertThat( rule.getElements().get( 0 ).getText()).isEqualTo( ">60");
         assertThat( rule.getElements().get( 1 )).isInstanceOf(StringNode.class);

--- a/kie-dmn/kie-dmn-feel/src/test/java/org/kie/dmn/feel/runtime/functions/ComposingDifferentFunctionsTest.java
+++ b/kie-dmn/kie-dmn-feel/src/test/java/org/kie/dmn/feel/runtime/functions/ComposingDifferentFunctionsTest.java
@@ -29,7 +29,6 @@ import org.junit.Before;
 import org.junit.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.Assert.assertEquals;
 
 public class ComposingDifferentFunctionsTest {
 
@@ -83,8 +82,8 @@ public class ComposingDifferentFunctionsTest {
 
         final TemporalAccessor p2TA = p2.getOrElse(null);
         assertThat(p2TA).isNotNull();
-        assertEquals(LocalTime.of(23, 59, 1), p2TA.query(TemporalQueries.localTime()));
-        assertEquals(ZoneId.of("Europe/Paris"), p2TA.query(TemporalQueries.zone()));
+        assertThat(p2TA.query(TemporalQueries.localTime())).isEqualTo(LocalTime.of(23, 59, 1));
+        assertThat(p2TA.query(TemporalQueries.zone())).isEqualTo(ZoneId.of("Europe/Paris"));
 
         final FEELFnResult<TemporalAccessor> result = dateTimeFunction.invoke(p1.getOrElse(null), p2.getOrElse(null));
         FunctionTestUtil.assertResult(result, ZonedDateTime.of(2017, 1, 1, 23, 59, 1, 0, ZoneId.of("Europe/Paris")));
@@ -97,8 +96,8 @@ public class ComposingDifferentFunctionsTest {
 
         final TemporalAccessor timeOnDateTime = timeFunction.invoke(p1.getOrElse(null)).getOrElse(null);
         assertThat(timeOnDateTime).isNotNull();
-        assertEquals(LocalTime.of(10, 20, 0), timeOnDateTime.query(TemporalQueries.localTime()));
-        assertEquals(ZoneId.of("Europe/Paris"), timeOnDateTime.query(TemporalQueries.zone()));
+        assertThat(timeOnDateTime.query(TemporalQueries.localTime())).isEqualTo(LocalTime.of(10, 20, 0));
+        assertThat(timeOnDateTime.query(TemporalQueries.zone())).isEqualTo(ZoneId.of("Europe/Paris"));
 
         FunctionTestUtil.assertResult(stringFunction.invoke(timeOnDateTime), "10:20:00@Europe/Paris");
     }

--- a/kie-dmn/kie-dmn-feel/src/test/java/org/kie/dmn/feel/runtime/functions/FunctionTestUtil.java
+++ b/kie-dmn/kie-dmn-feel/src/test/java/org/kie/dmn/feel/runtime/functions/FunctionTestUtil.java
@@ -47,7 +47,7 @@ public final class FunctionTestUtil {
     public static <T> void assertResultList(final FEELFnResult<List<T>> result, final List<Object> expectedResult) {
         assertResultNotError(result);
         final List<T> resultList = result.cata(left -> null, right -> right);
-        assertThat(resultList).hasSize(expectedResult.size());
+        assertThat(resultList).hasSameSizeAs(expectedResult);
         if (expectedResult.isEmpty()) {
             assertThat(resultList).isEmpty();
         } else {

--- a/kie-dmn/kie-dmn-feel/src/test/java/org/kie/dmn/feel/runtime/functions/TimeFunctionTest.java
+++ b/kie-dmn/kie-dmn-feel/src/test/java/org/kie/dmn/feel/runtime/functions/TimeFunctionTest.java
@@ -16,8 +16,6 @@
 
 package org.kie.dmn.feel.runtime.functions;
 
-import static org.junit.Assert.assertEquals;
-
 import java.math.BigDecimal;
 import java.time.DayOfWeek;
 import java.time.Duration;
@@ -31,6 +29,8 @@ import java.time.temporal.TemporalAccessor;
 import java.time.temporal.TemporalQueries;
 
 import org.junit.Before;
+
+import static org.assertj.core.api.Assertions.assertThat;
 import org.junit.Test;
 import org.kie.dmn.feel.runtime.events.InvalidParametersEvent;
 
@@ -72,15 +72,15 @@ public class TimeFunctionTest {
     @Test
     public void parseWithZone() {
         final TemporalAccessor parsedResult = timeFunction.invoke("00:01:00@Etc/UTC").getOrElse(null);
-        assertEquals(LocalTime.of(0, 1, 0), parsedResult.query(TemporalQueries.localTime()));
-        assertEquals(ZoneId.of("Etc/UTC"), parsedResult.query(TemporalQueries.zone()));
+        assertThat(parsedResult.query(TemporalQueries.localTime())).isEqualTo(LocalTime.of(0, 1, 0));
+        assertThat(parsedResult.query(TemporalQueries.zone())).isEqualTo(ZoneId.of("Etc/UTC"));
     }
 
     @Test
     public void parseWithZoneIANA() {
         final TemporalAccessor parsedResult = timeFunction.invoke("00:01:00@Europe/Paris").getOrElse(null);
-        assertEquals(LocalTime.of(0, 1, 0), parsedResult.query(TemporalQueries.localTime()));
-        assertEquals(ZoneId.of("Europe/Paris"), parsedResult.query(TemporalQueries.zone()));
+        assertThat(parsedResult.query(TemporalQueries.localTime())).isEqualTo(LocalTime.of(0, 1, 0));
+        assertThat(parsedResult.query(TemporalQueries.zone())).isEqualTo(ZoneId.of("Europe/Paris"));
     }
 
     @Test

--- a/kie-dmn/kie-dmn-feel/src/test/java/org/kie/dmn/feel/runtime/impl/RangeImplTest.java
+++ b/kie-dmn/kie-dmn-feel/src/test/java/org/kie/dmn/feel/runtime/impl/RangeImplTest.java
@@ -16,9 +16,10 @@
 
 package org.kie.dmn.feel.runtime.impl;
 
-import org.junit.Assert;
 import org.junit.Test;
 import org.kie.dmn.feel.runtime.Range;
+
+import static org.assertj.core.api.Assertions.assertThat;
 
 public class RangeImplTest {
 
@@ -26,96 +27,96 @@ public class RangeImplTest {
     public void getLowBoundary() {
         final Range.RangeBoundary lowBoundary = Range.RangeBoundary.CLOSED;
         final RangeImpl rangeImpl = new RangeImpl(lowBoundary, 10, 15, Range.RangeBoundary.OPEN);
-        Assert.assertEquals(lowBoundary, rangeImpl.getLowBoundary());
+        assertThat(rangeImpl.getLowBoundary()).isEqualTo(lowBoundary);
     }
 
     @Test
     public void getLowEndPoint() {
         final Integer lowEndPoint = 1;
         final RangeImpl rangeImpl = new RangeImpl(Range.RangeBoundary.OPEN, lowEndPoint, 15, Range.RangeBoundary.CLOSED);
-        Assert.assertEquals(lowEndPoint, rangeImpl.getLowEndPoint());
+        assertThat(rangeImpl.getLowEndPoint()).isEqualTo(lowEndPoint);
     }
 
     @Test
     public void getHighEndPoint() {
         final Integer highEndPoint = 15;
         final RangeImpl rangeImpl = new RangeImpl(Range.RangeBoundary.OPEN, 1, highEndPoint, Range.RangeBoundary.CLOSED);
-        Assert.assertEquals(highEndPoint, rangeImpl.getHighEndPoint());
+        assertThat(rangeImpl.getHighEndPoint()).isEqualTo(highEndPoint);
     }
 
     @Test
     public void getHighBoundary() {
         final Range.RangeBoundary highBoundary = Range.RangeBoundary.CLOSED;
         final RangeImpl rangeImpl = new RangeImpl(Range.RangeBoundary.OPEN, 10, 15, highBoundary);
-        Assert.assertEquals(highBoundary, rangeImpl.getHighBoundary());
+        assertThat(rangeImpl.getHighBoundary()).isEqualTo(highBoundary);
     }
 
     @Test
     public void includes() {
         RangeImpl rangeImpl = new RangeImpl(Range.RangeBoundary.OPEN, 10, 15, Range.RangeBoundary.OPEN);
-        Assert.assertFalse(rangeImpl.includes(-15));
-        Assert.assertFalse(rangeImpl.includes(5));
-        Assert.assertFalse(rangeImpl.includes(10));
-        Assert.assertTrue(rangeImpl.includes(12));
-        Assert.assertFalse(rangeImpl.includes(15));
-        Assert.assertFalse(rangeImpl.includes(156));
+        assertThat(rangeImpl.includes(-15)).isFalse();
+        assertThat(rangeImpl.includes(5)).isFalse();
+        assertThat(rangeImpl.includes(10)).isFalse();
+        assertThat(rangeImpl.includes(12)).isTrue();
+        assertThat(rangeImpl.includes(15)).isFalse();
+        assertThat(rangeImpl.includes(156)).isFalse();
 
         rangeImpl = new RangeImpl(Range.RangeBoundary.CLOSED, 10, 15, Range.RangeBoundary.OPEN);
-        Assert.assertTrue(rangeImpl.includes(10));
-        Assert.assertTrue(rangeImpl.includes(12));
-        Assert.assertFalse(rangeImpl.includes(15));
+        assertThat(rangeImpl.includes(10)).isTrue();
+        assertThat(rangeImpl.includes(12)).isTrue();
+        assertThat(rangeImpl.includes(15)).isFalse();
 
         rangeImpl = new RangeImpl(Range.RangeBoundary.OPEN, 10, 15, Range.RangeBoundary.CLOSED);
-        Assert.assertFalse(rangeImpl.includes(10));
-        Assert.assertTrue(rangeImpl.includes(12));
-        Assert.assertTrue(rangeImpl.includes(15));
+        assertThat(rangeImpl.includes(10)).isFalse();
+        assertThat(rangeImpl.includes(12)).isTrue();
+        assertThat(rangeImpl.includes(15)).isTrue();
 
         rangeImpl = new RangeImpl(Range.RangeBoundary.CLOSED, 10, 15, Range.RangeBoundary.CLOSED);
-        Assert.assertTrue(rangeImpl.includes(10));
-        Assert.assertTrue(rangeImpl.includes(12));
-        Assert.assertTrue(rangeImpl.includes(15));
+        assertThat(rangeImpl.includes(10)).isTrue();
+        assertThat(rangeImpl.includes(12)).isTrue();
+        assertThat(rangeImpl.includes(15)).isTrue();
     }
 
     @Test
     public void equals() {
         RangeImpl rangeImpl = new RangeImpl(Range.RangeBoundary.OPEN, 10, 15, Range.RangeBoundary.OPEN);
-        Assert.assertEquals(rangeImpl, rangeImpl);
+        assertThat(rangeImpl).isEqualTo(rangeImpl);
 
         RangeImpl rangeImpl2 = new RangeImpl(Range.RangeBoundary.OPEN, 10, 15, Range.RangeBoundary.OPEN);
-        Assert.assertEquals(rangeImpl, rangeImpl2);
+        assertThat(rangeImpl2).isEqualTo(rangeImpl);
 
         rangeImpl2 = new RangeImpl(Range.RangeBoundary.OPEN, 10, 15, Range.RangeBoundary.CLOSED);
-        Assert.assertNotEquals(rangeImpl, rangeImpl2);
+        assertThat(rangeImpl2).isNotEqualTo(rangeImpl);
         rangeImpl2 = new RangeImpl(Range.RangeBoundary.CLOSED, 10, 15, Range.RangeBoundary.OPEN);
-        Assert.assertNotEquals(rangeImpl, rangeImpl2);
+        assertThat(rangeImpl2).isNotEqualTo(rangeImpl);
         rangeImpl2 = new RangeImpl(Range.RangeBoundary.CLOSED, 10, 15, Range.RangeBoundary.CLOSED);
-        Assert.assertNotEquals(rangeImpl, rangeImpl2);
+        assertThat(rangeImpl2).isNotEqualTo(rangeImpl);
         rangeImpl2 = new RangeImpl(Range.RangeBoundary.CLOSED, 12, 15, Range.RangeBoundary.CLOSED);
-        Assert.assertNotEquals(rangeImpl, rangeImpl2);
+        assertThat(rangeImpl2).isNotEqualTo(rangeImpl);
         rangeImpl2 = new RangeImpl(Range.RangeBoundary.CLOSED, 12, 17, Range.RangeBoundary.CLOSED);
-        Assert.assertNotEquals(rangeImpl, rangeImpl2);
+        assertThat(rangeImpl2).isNotEqualTo(rangeImpl);
 
         rangeImpl = new RangeImpl();
-        Assert.assertEquals(rangeImpl, rangeImpl);
+        assertThat(rangeImpl).isEqualTo(rangeImpl);
     }
 
     @Test
     public void hashCodeTest() {
         final RangeImpl rangeImpl = new RangeImpl(Range.RangeBoundary.OPEN, 10, 15, Range.RangeBoundary.OPEN);
-        Assert.assertEquals(rangeImpl.hashCode(), rangeImpl.hashCode());
+        assertThat(rangeImpl.hashCode()).isEqualTo(rangeImpl.hashCode());
 
         RangeImpl rangeImpl2 = new RangeImpl(Range.RangeBoundary.OPEN, 10, 15, Range.RangeBoundary.OPEN);
-        Assert.assertEquals(rangeImpl.hashCode(), rangeImpl2.hashCode());
+        assertThat(rangeImpl2.hashCode()).isEqualTo(rangeImpl.hashCode());
 
         rangeImpl2 = new RangeImpl(Range.RangeBoundary.OPEN, 10, 15, Range.RangeBoundary.CLOSED);
-        Assert.assertNotEquals(rangeImpl.hashCode(), rangeImpl2.hashCode());
+        assertThat(rangeImpl2).doesNotHaveSameHashCodeAs(rangeImpl);
         rangeImpl2 = new RangeImpl(Range.RangeBoundary.CLOSED, 10, 15, Range.RangeBoundary.OPEN);
-        Assert.assertNotEquals(rangeImpl.hashCode(), rangeImpl2.hashCode());
+        assertThat(rangeImpl2).doesNotHaveSameHashCodeAs(rangeImpl);
         rangeImpl2 = new RangeImpl(Range.RangeBoundary.CLOSED, 10, 15, Range.RangeBoundary.CLOSED);
-        Assert.assertNotEquals(rangeImpl.hashCode(), rangeImpl2.hashCode());
+        assertThat(rangeImpl2).doesNotHaveSameHashCodeAs(rangeImpl);
         rangeImpl2 = new RangeImpl(Range.RangeBoundary.CLOSED, 12, 15, Range.RangeBoundary.CLOSED);
-        Assert.assertNotEquals(rangeImpl.hashCode(), rangeImpl2.hashCode());
+        assertThat(rangeImpl2).doesNotHaveSameHashCodeAs(rangeImpl);
         rangeImpl2 = new RangeImpl(Range.RangeBoundary.CLOSED, 12, 17, Range.RangeBoundary.CLOSED);
-        Assert.assertNotEquals(rangeImpl.hashCode(), rangeImpl2.hashCode());
+        assertThat(rangeImpl2).doesNotHaveSameHashCodeAs(rangeImpl);
     }
 }

--- a/kie-dmn/kie-dmn-feel/src/test/java/org/kie/dmn/feel/runtime/impl/RangeImplTest.java
+++ b/kie-dmn/kie-dmn-feel/src/test/java/org/kie/dmn/feel/runtime/impl/RangeImplTest.java
@@ -109,14 +109,14 @@ public class RangeImplTest {
         assertThat(rangeImpl2.hashCode()).isEqualTo(rangeImpl.hashCode());
 
         rangeImpl2 = new RangeImpl(Range.RangeBoundary.OPEN, 10, 15, Range.RangeBoundary.CLOSED);
-        assertThat(rangeImpl2).doesNotHaveSameHashCodeAs(rangeImpl);
+        assertThat(rangeImpl2.hashCode()).isNotEqualTo(rangeImpl.hashCode());
         rangeImpl2 = new RangeImpl(Range.RangeBoundary.CLOSED, 10, 15, Range.RangeBoundary.OPEN);
-        assertThat(rangeImpl2).doesNotHaveSameHashCodeAs(rangeImpl);
+        assertThat(rangeImpl2.hashCode()).isNotEqualTo(rangeImpl.hashCode());
         rangeImpl2 = new RangeImpl(Range.RangeBoundary.CLOSED, 10, 15, Range.RangeBoundary.CLOSED);
-        assertThat(rangeImpl2).doesNotHaveSameHashCodeAs(rangeImpl);
+        assertThat(rangeImpl2.hashCode()).isNotEqualTo(rangeImpl.hashCode());
         rangeImpl2 = new RangeImpl(Range.RangeBoundary.CLOSED, 12, 15, Range.RangeBoundary.CLOSED);
-        assertThat(rangeImpl2).doesNotHaveSameHashCodeAs(rangeImpl);
+        assertThat(rangeImpl2.hashCode()).isNotEqualTo(rangeImpl.hashCode());
         rangeImpl2 = new RangeImpl(Range.RangeBoundary.CLOSED, 12, 17, Range.RangeBoundary.CLOSED);
-        assertThat(rangeImpl2).doesNotHaveSameHashCodeAs(rangeImpl);
+        assertThat(rangeImpl2.hashCode()).isNotEqualTo(rangeImpl.hashCode());
     }
 }

--- a/kie-dmn/kie-dmn-feel/src/test/java/org/kie/dmn/feel/util/EvalHelperTest.java
+++ b/kie-dmn/kie-dmn-feel/src/test/java/org/kie/dmn/feel/util/EvalHelperTest.java
@@ -22,8 +22,7 @@ import java.math.BigDecimal;
 import org.junit.Test;
 import org.kie.dmn.feel.lang.FEELProperty;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNull;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.kie.dmn.feel.util.EvalHelper.getBigDecimalOrNull;
 import static org.kie.dmn.feel.util.EvalHelper.normalizeVariableName;
 
@@ -31,48 +30,44 @@ public class EvalHelperTest {
 
     @Test
     public void testNormalizeSpace() {
-        assertNull(normalizeVariableName(null));
-        assertEquals("", normalizeVariableName(""));
-        assertEquals("", normalizeVariableName(" "));
-        assertEquals("", normalizeVariableName("\t"));
-        assertEquals("", normalizeVariableName("\n"));
-        assertEquals("", normalizeVariableName("\u0009"));
-        assertEquals("", normalizeVariableName("\u000B"));
-        assertEquals("", normalizeVariableName("\u000C"));
-        assertEquals("", normalizeVariableName("\u001C"));
-        assertEquals("", normalizeVariableName("\u001D"));
-        assertEquals("", normalizeVariableName("\u001E"));
-        assertEquals("", normalizeVariableName("\u001F"));
-        assertEquals("", normalizeVariableName("\f"));
-        assertEquals("", normalizeVariableName("\r"));
-        assertEquals("a", normalizeVariableName("  a  "));
-        assertEquals("a b c", normalizeVariableName("  a  b   c  "));
-        assertEquals("a b c", normalizeVariableName("a\t\f\r  b\u000B   c\n"));
-        assertEquals("a b c", normalizeVariableName("a\t\f\r  \u00A0\u00A0b\u000B   c\n"));
-        assertEquals("b", normalizeVariableName(" b"));
-        assertEquals("b", normalizeVariableName("b "));
-        assertEquals("ab c", normalizeVariableName("ab c  "));
-        assertEquals("a b", normalizeVariableName("a\u00A0b"));
+        assertThat(normalizeVariableName(null)).isNull();
+        assertThat(normalizeVariableName("")).isEqualTo("");
+        assertThat(normalizeVariableName(" ")).isEqualTo("");
+        assertThat(normalizeVariableName("\t")).isEqualTo("");
+        assertThat(normalizeVariableName("\n")).isEqualTo("");
+        assertThat(normalizeVariableName("\u0009")).isEqualTo("");
+        assertThat(normalizeVariableName("\u000B")).isEqualTo("");
+        assertThat(normalizeVariableName("\u000C")).isEqualTo("");
+        assertThat(normalizeVariableName("\u001C")).isEqualTo("");
+        assertThat(normalizeVariableName("\u001D")).isEqualTo("");
+        assertThat(normalizeVariableName("\u001E")).isEqualTo("");
+        assertThat(normalizeVariableName("\u001F")).isEqualTo("");
+        assertThat(normalizeVariableName("\f")).isEqualTo("");
+        assertThat(normalizeVariableName("\r")).isEqualTo("");
+        assertThat(normalizeVariableName("  a  ")).isEqualTo("a");
+        assertThat(normalizeVariableName("  a  b   c  ")).isEqualTo("a b c");
+        assertThat(normalizeVariableName("a\t\f\r  b\u000B   c\n")).isEqualTo("a b c");
+        assertThat(normalizeVariableName("a\t\f\r  \u00A0\u00A0b\u000B   c\n")).isEqualTo("a b c");
+        assertThat(normalizeVariableName(" b")).isEqualTo("b");
+        assertThat(normalizeVariableName("b ")).isEqualTo("b");
+        assertThat(normalizeVariableName("ab c  ")).isEqualTo("ab c");
+        assertThat(normalizeVariableName("a\u00A0b")).isEqualTo("a b");
     }
 
     @Test
     public void testGetBigDecimalOrNull() {
-        assertEquals(new BigDecimal("10"), getBigDecimalOrNull(10d));
-        assertEquals(new BigDecimal("10"), getBigDecimalOrNull(10.00000000D));
-        assertEquals(new BigDecimal("10000000000.5"), getBigDecimalOrNull(10000000000.5D));
+        assertThat(getBigDecimalOrNull(10d)).isEqualTo(new BigDecimal("10"));
+        assertThat(getBigDecimalOrNull(10.00000000D)).isEqualTo(new BigDecimal("10"));
+        assertThat(getBigDecimalOrNull(10000000000.5D)).isEqualTo(new BigDecimal("10000000000.5"));
     }
 
     @Test
     public void testGetGenericAccessor() throws NoSuchMethodException {
         Method expectedAccessor = TestPojo.class.getMethod("getAProperty");
 
-        assertEquals("getGenericAccessor should work on Java bean accessors.",
-                     expectedAccessor,
-                     EvalHelper.getGenericAccessor(TestPojo.class, "aProperty"));
+        assertThat(EvalHelper.getGenericAccessor(TestPojo.class, "aProperty")).as("getGenericAccessor should work on Java bean accessors.").isEqualTo(expectedAccessor);
 
-        assertEquals("getGenericAccessor should work for methods annotated with '@FEELProperty'.",
-                     expectedAccessor,
-                     EvalHelper.getGenericAccessor(TestPojo.class, "feelPropertyIdentifier"));
+        assertThat(EvalHelper.getGenericAccessor(TestPojo.class, "feelPropertyIdentifier")).as("getGenericAccessor should work for methods annotated with '@FEELProperty'.").isEqualTo(expectedAccessor);
     }
 
     private static class TestPojo {

--- a/kie-dmn/kie-dmn-legacy-tests/src/test/java/org/kie/dmn/legacy/tests/core/v1_1/DMNAssemblerTest.java
+++ b/kie-dmn/kie-dmn-legacy-tests/src/test/java/org/kie/dmn/legacy/tests/core/v1_1/DMNAssemblerTest.java
@@ -35,9 +35,7 @@ import org.kie.dmn.core.util.DMNRuntimeUtil;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertTrue;
+import static org.assertj.core.api.Assertions.assertThat;
 
 public class DMNAssemblerTest extends BaseDMN1_1VariantTest {
     public static final Logger LOG = LoggerFactory.getLogger(DMNAssemblerTest.class);
@@ -58,8 +56,8 @@ public class DMNAssemblerTest extends BaseDMN1_1VariantTest {
         
         LOG.info("buildAll() completed.");
         results.getMessages(Level.ERROR).forEach( e -> LOG.error("{}", e));
-        
-        assertTrue( results.getMessages(Level.ERROR).size() > 0 );
+
+        assertThat(results.getMessages(Level.ERROR)).hasSizeGreaterThan(0);
     }
 
     @Test
@@ -69,7 +67,7 @@ public class DMNAssemblerTest extends BaseDMN1_1VariantTest {
         final DMNContext ctx = runtime.newContext();
         ctx.set( "timestring", "2016-12-20T14:30:22z" );
         final DMNResult result = runtime.evaluateAll(model, ctx);
-        assertEquals( DateTimeFormatter.ISO_TIME.parse( "14:30:22z", OffsetTime::from ), result.getDecisionResultByName( "time" ).getResult() );
+        assertThat(result.getDecisionResultByName("time").getResult()).isEqualTo(DateTimeFormatter.ISO_TIME.parse("14:30:22z", OffsetTime::from));
     }
 
     @Test
@@ -80,7 +78,7 @@ public class DMNAssemblerTest extends BaseDMN1_1VariantTest {
         final DMNContext ctx = runtime.newContext();
         ctx.set( "timestring", "2016-12-20T14:30:22z" );
         final DMNResult result = runtime.evaluateAll(model, ctx);
-        assertNull( result.getDecisionResultByName("time").getResult() );
+        assertThat(result.getDecisionResultByName("time").getResult()).isNull();
     }
 
     @Test
@@ -98,7 +96,7 @@ public class DMNAssemblerTest extends BaseDMN1_1VariantTest {
         final DMNContext ctx = runtime.newContext();
         ctx.set( "timestring", "2016-12-20T14:30:22z" );
         final DMNResult result = runtime.evaluateAll(model, ctx);
-        assertNull( result.getDecisionResultByName("time").getResult() );
+        assertThat(result.getDecisionResultByName("time").getResult()).isNull();
     }
 
     @After

--- a/kie-dmn/kie-dmn-legacy-tests/src/test/java/org/kie/dmn/legacy/tests/core/v1_1/DMNCompilerTest.java
+++ b/kie-dmn/kie-dmn-legacy-tests/src/test/java/org/kie/dmn/legacy/tests/core/v1_1/DMNCompilerTest.java
@@ -36,8 +36,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.fail;
+import static org.assertj.core.api.Assertions.fail;
 import static org.kie.dmn.core.util.DynamicTypeUtils.entry;
 import static org.kie.dmn.core.util.DynamicTypeUtils.mapOf;
 
@@ -132,7 +131,7 @@ public class DMNCompilerTest extends BaseDMN1_1VariantTest {
         final DMNRuntime runtime = createRuntime("Recursive.dmn", this.getClass());
         final DMNModel dmnModel = runtime.getModel("https://github.com/kiegroup/kie-dmn", "Recursive" );
         assertThat(dmnModel).isNotNull();
-        assertFalse( evaluateModel(runtime, dmnModel, DMNFactory.newContext() ).hasErrors() );
+        assertThat(evaluateModel(runtime, dmnModel, DMNFactory.newContext()).hasErrors()).isFalse();
     }
 
     @Test

--- a/kie-dmn/kie-dmn-legacy-tests/src/test/java/org/kie/dmn/legacy/tests/core/v1_1/DMNDecisionTableHitPolicyTest.java
+++ b/kie-dmn/kie-dmn-legacy-tests/src/test/java/org/kie/dmn/legacy/tests/core/v1_1/DMNDecisionTableHitPolicyTest.java
@@ -34,7 +34,6 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.Assert.assertTrue;
 
 public class DMNDecisionTableHitPolicyTest extends BaseDMN1_1VariantTest {
 
@@ -66,7 +65,7 @@ public class DMNDecisionTableHitPolicyTest extends BaseDMN1_1VariantTest {
         final DMNContext result = dmnResult.getContext();
 
         assertThat(result.get("Approval Status")).isNull();
-        assertTrue(dmnResult.getMessages().size() > 0);
+        assertThat(dmnResult.getMessages()).hasSizeGreaterThan(0);
     }
 
     @Test
@@ -84,8 +83,8 @@ public class DMNDecisionTableHitPolicyTest extends BaseDMN1_1VariantTest {
         final DMNContext result = dmnResult.getContext();
 
         assertThat(result.get("Approval Status")).isNull();
-        assertTrue(dmnResult.getMessages().size() > 0);
-        assertTrue(dmnResult.getMessages().stream().anyMatch(dm -> dm.getSeverity().equals(DMNMessage.Severity.WARN) && dm.getFeelEvent() instanceof HitPolicyViolationEvent && dm.getFeelEvent().getSeverity().equals(FEELEvent.Severity.WARN)));
+        assertThat(dmnResult.getMessages()).hasSizeGreaterThan(0);
+        assertThat(dmnResult.getMessages().stream().anyMatch(dm -> dm.getSeverity().equals(DMNMessage.Severity.WARN) && dm.getFeelEvent() instanceof HitPolicyViolationEvent && dm.getFeelEvent().getSeverity().equals(FEELEvent.Severity.WARN))).isTrue();
     }
 
     @Test

--- a/kie-dmn/kie-dmn-legacy-tests/src/test/java/org/kie/dmn/legacy/tests/core/v1_1/DMNDecisionTableRuntimeTest.java
+++ b/kie-dmn/kie-dmn-legacy-tests/src/test/java/org/kie/dmn/legacy/tests/core/v1_1/DMNDecisionTableRuntimeTest.java
@@ -44,7 +44,6 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.Assert.assertNull;
 import static org.mockito.Mockito.verify;
 import static org.mockito.internal.verification.VerificationModeFactory.times;
 
@@ -338,7 +337,7 @@ public class DMNDecisionTableRuntimeTest extends BaseDMN1_1VariantTest {
         final DMNResult dmnResult = runtime.evaluateAll( dmnModel, context );
         LOG.debug("{}", dmnResult);
         assertThat(dmnResult.hasErrors()).isFalse();
-        assertNull( dmnResult.getContext().get("Logique de décision 1") );
+        assertThat(dmnResult.getContext().get("Logique de décision 1")).isNull();
     }
 
     @Test

--- a/kie-dmn/kie-dmn-legacy-tests/src/test/java/org/kie/dmn/legacy/tests/core/v1_1/DMNInputRuntimeTest.java
+++ b/kie-dmn/kie-dmn-legacy-tests/src/test/java/org/kie/dmn/legacy/tests/core/v1_1/DMNInputRuntimeTest.java
@@ -293,7 +293,7 @@ public class DMNInputRuntimeTest extends BaseDMN1_1VariantTest {
         assertThat(idnMembershipLevels.getType().getBaseType().getName()).isEqualTo("tMembershipLevel");
         assertThat(idnMembershipLevels.getType().isCollection()).isTrue();
         assertThat(idnMembershipLevels.getType().isComposite()).isFalse();
-        assertThat(idnMembershipLevels.getType().getAllowedValues().isEmpty()).isTrue();
+        assertThat(idnMembershipLevels.getType().getAllowedValues()).isEmpty();
 
         final InputDataNode idnPercent = dmnModel.getInputs().stream().filter(idn -> idn.getName().equals("Percent")).findFirst().get();
         assertThat(idnPercent.getType().getBaseType().getNamespace()).isEqualTo(FEEL_NAMESPACE);

--- a/kie-dmn/kie-dmn-legacy-tests/src/test/java/org/kie/dmn/legacy/tests/core/v1_1/DMNRuntimeTest.java
+++ b/kie-dmn/kie-dmn-legacy-tests/src/test/java/org/kie/dmn/legacy/tests/core/v1_1/DMNRuntimeTest.java
@@ -74,9 +74,6 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
 import static org.kie.dmn.core.util.DMNTestUtil.getAndAssertModelNoErrors;
 import static org.kie.dmn.core.util.DynamicTypeUtils.entry;
 import static org.kie.dmn.core.util.DynamicTypeUtils.mapOf;
@@ -1096,9 +1093,9 @@ public class DMNRuntimeTest extends BaseDMN1_1VariantTest {
     @Test
     public void testUnknownVariable1() {
         final List<DMNMessage> messages = DMNRuntimeUtil.createExpectingDMNMessages("unknown_variable1.dmn", this.getClass());
-        assertEquals(1, messages.stream().filter(m -> m.getMessageType().equals(DMNMessageType.ERR_COMPILING_FEEL))
-                                .filter(m -> m.getMessage().contains("Unknown variable 'NonSalaryPct'"))
-                                .count());
+        assertThat(messages.stream().filter(m -> m.getMessageType().equals(DMNMessageType.ERR_COMPILING_FEEL))
+                .filter(m -> m.getMessage().contains("Unknown variable 'NonSalaryPct'"))
+                .count()).isEqualTo(1);
     }
 
     @Test
@@ -1216,7 +1213,7 @@ public class DMNRuntimeTest extends BaseDMN1_1VariantTest {
 
         final List<String> sourceIDs = messages.stream().map(DMNMessage::getSourceId).collect(Collectors.toList());
         // FEEL FuncDefNode not checked at compile time: assertTrue( sourceIDs.contains( "_a72a7aff-48c3-4806-83ca-fc1f1fe34320") );
-        assertTrue( sourceIDs.contains( "_a72a7aff-48c3-4806-83ca-fc1f1fe34321" ) );
+        assertThat(sourceIDs).contains("_a72a7aff-48c3-4806-83ca-fc1f1fe34321");
     }
     
     @Test
@@ -1488,7 +1485,7 @@ public class DMNRuntimeTest extends BaseDMN1_1VariantTest {
         model.addDecision(b);
         final DMNRuntime runtime = DMNRuntimeUtil.createRuntime(this.getClass());
         final DMNResult result = runtime.evaluateAll(model, DMNFactory.newContext());
-        assertTrue(result.hasErrors());
+        assertThat(result.hasErrors()).isTrue();
     }
 
     @Test
@@ -1501,7 +1498,7 @@ public class DMNRuntimeTest extends BaseDMN1_1VariantTest {
         model.addDecision(decision);
         final DMNRuntime runtime = DMNRuntimeUtil.createRuntime(this.getClass());
         final DMNResult result = runtime.evaluateAll(model, DMNFactory.newContext());
-        assertTrue(result.hasErrors());
+        assertThat(result.hasErrors()).isTrue();
     }
 
     @Test
@@ -1519,7 +1516,7 @@ public class DMNRuntimeTest extends BaseDMN1_1VariantTest {
         model.addDecision(c);
         final DMNRuntime runtime = DMNRuntimeUtil.createRuntime(this.getClass());
         final DMNResult result = runtime.evaluateAll(model, DMNFactory.newContext());
-        assertFalse(result.hasErrors());
+        assertThat(result.hasErrors()).isFalse();
     }
 
     @Test
@@ -1541,7 +1538,7 @@ public class DMNRuntimeTest extends BaseDMN1_1VariantTest {
         model.addDecision(d);
         final DMNRuntime runtime = DMNRuntimeUtil.createRuntime(this.getClass());
         final DMNResult result = runtime.evaluateAll(model, DMNFactory.newContext());
-        assertFalse(result.hasErrors());
+        assertThat(result.hasErrors()).isFalse();
     }
 
     @Test
@@ -1624,12 +1621,12 @@ public class DMNRuntimeTest extends BaseDMN1_1VariantTest {
         final List people = (List) resultContext.get("People");
         final List peopleGroups = (List) resultContext.get("People groups");
 
-        assertEquals(6, people.size());
+        assertThat(people).hasSize(6);
 
-        assertEquals(3, peopleGroups.size());
-        assertEquals(2, ((List) peopleGroups.get(0)).size());
-        assertEquals(2, ((List) peopleGroups.get(1)).size());
-        assertEquals(2, ((List) peopleGroups.get(2)).size());
+        assertThat(peopleGroups).hasSize(3);
+        assertThat(((List) peopleGroups.get(0))).hasSize(2);
+        assertThat(((List) peopleGroups.get(1))).hasSize(2);
+        assertThat(((List) peopleGroups.get(2))).hasSize(2);
     }
 
     @Test
@@ -1796,7 +1793,7 @@ public class DMNRuntimeTest extends BaseDMN1_1VariantTest {
         final DMNResult result = runtime.evaluateAll(model, context);
         final List<?> resultObject = (ArrayList<?>) result.getDecisionResultByName("PickAllJohns").getResult();
 
-        assertEquals(2, resultObject.size());
+        assertThat(resultObject).hasSize(2);
     }
 
     @Test
@@ -1987,8 +1984,8 @@ public class DMNRuntimeTest extends BaseDMN1_1VariantTest {
             put("type", 1);
         }});
         final DMNDecisionResult result = runtime.evaluateAll(model, context).getDecisionResultByName("TestDecision");
-        assertFalse(result.hasErrors());
-        assertEquals("This is product 1", result.getResult());
+        assertThat(result.hasErrors()).isFalse();
+        assertThat(result.getResult()).isEqualTo("This is product 1");
     }
 
     @Test
@@ -2036,29 +2033,29 @@ public class DMNRuntimeTest extends BaseDMN1_1VariantTest {
         assertThat(result.get("Bruce")).isInstanceOf(Map.class);
         final Map<String, Object> bruce = (Map<String, Object>) result.get("Bruce");
 
-        assertEquals(2, ((List) bruce.get("one")).size());
-        assertTrue(((List) bruce.get("one")).stream().anyMatch(e -> ((Map<String, Object>) e).get("Title").equals("55")));
-        assertTrue(((List) bruce.get("one")).stream().anyMatch(e -> ((Map<String, Object>) e).get("Title").equals("510")));
+        assertThat(((List) bruce.get("one"))).hasSize(2);
+        assertThat(((List) bruce.get("one")).stream().anyMatch(e -> ((Map<String, Object>) e).get("Title").equals("55"))).isTrue();
+        assertThat(((List) bruce.get("one")).stream().anyMatch(e -> ((Map<String, Object>) e).get("Title").equals("510"))).isTrue();
 
-        assertEquals(3, ((List) bruce.get("two")).size());
-        assertTrue(((List) bruce.get("two")).stream().anyMatch(e -> ((Map<String, Object>) e).get("Title").equals("810")));
-        assertTrue(((List) bruce.get("two")).stream().anyMatch(e -> ((Map<String, Object>) e).get("Title").equals("85")));
-        assertTrue(((List) bruce.get("two")).stream().anyMatch(e -> ((Map<String, Object>) e).get("Title").equals("66")));
+        assertThat(((List) bruce.get("two"))).hasSize(3);
+        assertThat(((List) bruce.get("two")).stream().anyMatch(e -> ((Map<String, Object>) e).get("Title").equals("810"))).isTrue();
+        assertThat(((List) bruce.get("two")).stream().anyMatch(e -> ((Map<String, Object>) e).get("Title").equals("85"))).isTrue();
+        assertThat(((List) bruce.get("two")).stream().anyMatch(e -> ((Map<String, Object>) e).get("Title").equals("66"))).isTrue();
 
-        assertEquals(1, ((List) bruce.get("three")).size());
-        assertTrue(((List) bruce.get("three")).stream().anyMatch(e -> ((Map<String, Object>) e).get("Title").equals("510")));
+        assertThat(((List) bruce.get("three"))).hasSize(1);
+        assertThat(((List) bruce.get("three")).stream().anyMatch(e -> ((Map<String, Object>) e).get("Title").equals("510"))).isTrue();
 
-        assertEquals(2, ((List) bruce.get("Four")).size());
-        assertTrue(((List) bruce.get("Four")).stream().anyMatch(e -> ((Map<String, Object>) e).get("Title").equals("85")));
-        assertTrue(((List) bruce.get("Four")).stream().anyMatch(e -> ((Map<String, Object>) e).get("Title").equals("66")));
+        assertThat(((List) bruce.get("Four"))).hasSize(2);
+        assertThat(((List) bruce.get("Four")).stream().anyMatch(e -> ((Map<String, Object>) e).get("Title").equals("85"))).isTrue();
+        assertThat(((List) bruce.get("Four")).stream().anyMatch(e -> ((Map<String, Object>) e).get("Title").equals("66"))).isTrue();
 
-        assertEquals(2, ((List) bruce.get("Five")).size());
-        assertTrue(((List) bruce.get("Five")).stream().anyMatch(e -> ((Map<String, Object>) e).get("Title").equals("85")));
-        assertTrue(((List) bruce.get("Five")).stream().anyMatch(e -> ((Map<String, Object>) e).get("Title").equals("66")));
+        assertThat(((List) bruce.get("Five"))).hasSize(2);
+        assertThat(((List) bruce.get("Five")).stream().anyMatch(e -> ((Map<String, Object>) e).get("Title").equals("85"))).isTrue();
+        assertThat(((List) bruce.get("Five")).stream().anyMatch(e -> ((Map<String, Object>) e).get("Title").equals("66"))).isTrue();
 
-        assertEquals(2, ((List) bruce.get("six")).size());
-        assertTrue(((List) bruce.get("six")).stream().anyMatch(e -> ((Map<String, Object>) e).get("Title").equals("85")));
-        assertTrue(((List) bruce.get("six")).stream().anyMatch(e -> ((Map<String, Object>) e).get("Title").equals("66")));
+        assertThat(((List) bruce.get("six"))).hasSize(2);
+        assertThat(((List) bruce.get("six")).stream().anyMatch(e -> ((Map<String, Object>) e).get("Title").equals("85"))).isTrue();
+        assertThat(((List) bruce.get("six")).stream().anyMatch(e -> ((Map<String, Object>) e).get("Title").equals("66"))).isTrue();
     }
     
     @Test
@@ -2139,7 +2136,7 @@ public class DMNRuntimeTest extends BaseDMN1_1VariantTest {
         // DROOLS-2813 DMN boxed invocation missing expression NPE and Validator issue
         final List<DMNMessage> messages = DMNRuntimeUtil.createExpectingDMNMessages("DROOLS-2813-NPE-BoxedInvocationMissingExpression.dmn", this.getClass());
 
-        assertTrue(messages.stream().anyMatch(p -> p.getMessageType().equals(DMNMessageType.MISSING_EXPRESSION) && p.getSourceId().equals("_a111c4df-c5b5-4d84-81e7-3ec735b50d06")));
+        assertThat(messages.stream().anyMatch(p -> p.getMessageType().equals(DMNMessageType.MISSING_EXPRESSION) && p.getSourceId().equals("_a111c4df-c5b5-4d84-81e7-3ec735b50d06"))).isTrue();
     }
 
     @Test

--- a/kie-dmn/kie-dmn-legacy-tests/src/test/java/org/kie/dmn/legacy/tests/core/v1_1/decisionservices/DMNDecisionServicesTest.java
+++ b/kie-dmn/kie-dmn-legacy-tests/src/test/java/org/kie/dmn/legacy/tests/core/v1_1/decisionservices/DMNDecisionServicesTest.java
@@ -33,7 +33,6 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.Assert.assertNull;
 
 public class DMNDecisionServicesTest extends BaseDMN1_1VariantTest {
 
@@ -425,7 +424,7 @@ public class DMNDecisionServicesTest extends BaseDMN1_1VariantTest {
             throw e;
         } finally {
             System.clearProperty(CoerceDecisionServiceSingletonOutputOption.PROPERTY_NAME);
-            assertNull(System.getProperty(CoerceDecisionServiceSingletonOutputOption.PROPERTY_NAME));
+            assertThat(System.getProperty(CoerceDecisionServiceSingletonOutputOption.PROPERTY_NAME)).isNull();
         }
     }
 

--- a/kie-dmn/kie-dmn-legacy-tests/src/test/java/org/kie/dmn/legacy/tests/validation/v1_1/ValidatorArtifactTest.java
+++ b/kie-dmn/kie-dmn-legacy-tests/src/test/java/org/kie/dmn/legacy/tests/validation/v1_1/ValidatorArtifactTest.java
@@ -27,7 +27,6 @@ import org.kie.dmn.validation.AbstractValidatorTest;
 import org.kie.dmn.validation.ValidatorUtil;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.Assert.assertTrue;
 import static org.kie.dmn.validation.DMNValidator.Validation.VALIDATE_COMPILATION;
 import static org.kie.dmn.validation.DMNValidator.Validation.VALIDATE_MODEL;
 import static org.kie.dmn.validation.DMNValidator.Validation.VALIDATE_SCHEMA;
@@ -41,7 +40,7 @@ public class ValidatorArtifactTest extends AbstractValidatorTest {
                     reader,
                     VALIDATE_SCHEMA, VALIDATE_MODEL, VALIDATE_COMPILATION);
             assertThat(validate).as(ValidatorUtil.formatMessages(validate)).hasSize(2);
-            assertTrue( validate.stream().anyMatch( p -> p.getMessageType().equals( DMNMessageType.REQ_NOT_FOUND ) ) );
+            assertThat(validate.stream().anyMatch(p -> p.getMessageType().equals(DMNMessageType.REQ_NOT_FOUND))).isTrue();
         }
     }
 
@@ -51,7 +50,7 @@ public class ValidatorArtifactTest extends AbstractValidatorTest {
                 getFile( "artifact/ASSOC_REFERENCES_NOT_EMPTY.dmn" ),
                 VALIDATE_SCHEMA, VALIDATE_MODEL, VALIDATE_COMPILATION);
         assertThat(validate).as(ValidatorUtil.formatMessages(validate)).hasSize(2);
-        assertTrue( validate.stream().anyMatch( p -> p.getMessageType().equals( DMNMessageType.REQ_NOT_FOUND ) ) );
+        assertThat(validate.stream().anyMatch(p -> p.getMessageType().equals(DMNMessageType.REQ_NOT_FOUND))).isTrue();
     }
 
     @Test
@@ -62,6 +61,6 @@ public class ValidatorArtifactTest extends AbstractValidatorTest {
                                 "ASSOC_REFERENCES_NOT_EMPTY"),
                 VALIDATE_MODEL, VALIDATE_COMPILATION);
         assertThat(validate).as(ValidatorUtil.formatMessages(validate)).hasSize(2);
-        assertTrue( validate.stream().anyMatch( p -> p.getMessageType().equals( DMNMessageType.REQ_NOT_FOUND ) ) );
+        assertThat(validate.stream().anyMatch(p -> p.getMessageType().equals(DMNMessageType.REQ_NOT_FOUND))).isTrue();
     }
 }

--- a/kie-dmn/kie-dmn-legacy-tests/src/test/java/org/kie/dmn/legacy/tests/validation/v1_1/ValidatorAuthorityRequirementTest.java
+++ b/kie-dmn/kie-dmn-legacy-tests/src/test/java/org/kie/dmn/legacy/tests/validation/v1_1/ValidatorAuthorityRequirementTest.java
@@ -27,7 +27,6 @@ import org.kie.dmn.validation.AbstractValidatorTest;
 import org.kie.dmn.validation.ValidatorUtil;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.Assert.assertTrue;
 import static org.kie.dmn.validation.DMNValidator.Validation.VALIDATE_COMPILATION;
 import static org.kie.dmn.validation.DMNValidator.Validation.VALIDATE_MODEL;
 import static org.kie.dmn.validation.DMNValidator.Validation.VALIDATE_SCHEMA;
@@ -41,7 +40,7 @@ public class ValidatorAuthorityRequirementTest extends AbstractValidatorTest {
                     reader,
                     VALIDATE_SCHEMA, VALIDATE_MODEL, VALIDATE_COMPILATION);
              assertThat(validate).as(ValidatorUtil.formatMessages(validate)).hasSize(3);
-            assertTrue(validate.stream().anyMatch(p -> p.getMessageType().equals(DMNMessageType.REQ_NOT_FOUND)));
+            assertThat(validate.stream().anyMatch(p -> p.getMessageType().equals(DMNMessageType.REQ_NOT_FOUND))).isTrue();
         }
     }
 
@@ -51,7 +50,7 @@ public class ValidatorAuthorityRequirementTest extends AbstractValidatorTest {
                 getFile("authorityrequirement/AUTHREQ_MISSING_DEPENDENCY_REQ_AUTH.dmn"),
                 VALIDATE_SCHEMA, VALIDATE_MODEL, VALIDATE_COMPILATION);
          assertThat(validate).as(ValidatorUtil.formatMessages(validate)).hasSize(3);
-        assertTrue(validate.stream().anyMatch(p -> p.getMessageType().equals(DMNMessageType.REQ_NOT_FOUND)));
+        assertThat(validate.stream().anyMatch(p -> p.getMessageType().equals(DMNMessageType.REQ_NOT_FOUND))).isTrue();
     }
 
     @Test
@@ -62,7 +61,7 @@ public class ValidatorAuthorityRequirementTest extends AbstractValidatorTest {
                                "AUTHREQ_MISSING_DEPENDENCY_REQ_AUTH"),
                 VALIDATE_MODEL, VALIDATE_COMPILATION);
          assertThat(validate).as(ValidatorUtil.formatMessages(validate)).hasSize(3);
-        assertTrue(validate.stream().anyMatch(p -> p.getMessageType().equals(DMNMessageType.REQ_NOT_FOUND)));
+        assertThat(validate.stream().anyMatch(p -> p.getMessageType().equals(DMNMessageType.REQ_NOT_FOUND))).isTrue();
     }
 
     @Test
@@ -72,7 +71,7 @@ public class ValidatorAuthorityRequirementTest extends AbstractValidatorTest {
                     reader,
                     VALIDATE_SCHEMA, VALIDATE_MODEL, VALIDATE_COMPILATION);
              assertThat(validate).as(ValidatorUtil.formatMessages(validate)).hasSize(3);
-            assertTrue(validate.stream().anyMatch(p -> p.getMessageType().equals(DMNMessageType.REQ_NOT_FOUND)));
+            assertThat(validate.stream().anyMatch(p -> p.getMessageType().equals(DMNMessageType.REQ_NOT_FOUND))).isTrue();
         }
     }
 
@@ -82,7 +81,7 @@ public class ValidatorAuthorityRequirementTest extends AbstractValidatorTest {
                 getFile("authorityrequirement/AUTHREQ_MISSING_DEPENDENCY_REQ_DEC.dmn"),
                 VALIDATE_SCHEMA, VALIDATE_MODEL, VALIDATE_COMPILATION);
          assertThat(validate).as(ValidatorUtil.formatMessages(validate)).hasSize(3);
-        assertTrue(validate.stream().anyMatch(p -> p.getMessageType().equals(DMNMessageType.REQ_NOT_FOUND)));
+        assertThat(validate.stream().anyMatch(p -> p.getMessageType().equals(DMNMessageType.REQ_NOT_FOUND))).isTrue();
     }
 
     @Test
@@ -93,7 +92,7 @@ public class ValidatorAuthorityRequirementTest extends AbstractValidatorTest {
                                "AUTHREQ_MISSING_DEPENDENCY_REQ_DEC"),
                 VALIDATE_MODEL, VALIDATE_COMPILATION);
          assertThat(validate).as(ValidatorUtil.formatMessages(validate)).hasSize(3);
-        assertTrue(validate.stream().anyMatch(p -> p.getMessageType().equals(DMNMessageType.REQ_NOT_FOUND)));
+        assertThat(validate.stream().anyMatch(p -> p.getMessageType().equals(DMNMessageType.REQ_NOT_FOUND))).isTrue();
     }
 
     @Test
@@ -103,7 +102,7 @@ public class ValidatorAuthorityRequirementTest extends AbstractValidatorTest {
                     reader,
                     VALIDATE_SCHEMA, VALIDATE_MODEL, VALIDATE_COMPILATION);
              assertThat(validate).as(ValidatorUtil.formatMessages(validate)).hasSize(3);
-            assertTrue(validate.stream().anyMatch(p -> p.getMessageType().equals(DMNMessageType.REQ_NOT_FOUND)));
+            assertThat(validate.stream().anyMatch(p -> p.getMessageType().equals(DMNMessageType.REQ_NOT_FOUND))).isTrue();
         }
     }
 
@@ -113,7 +112,7 @@ public class ValidatorAuthorityRequirementTest extends AbstractValidatorTest {
                 getFile("authorityrequirement/AUTHREQ_MISSING_DEPENDENCY_REQ_INPUT.dmn"),
                 VALIDATE_SCHEMA, VALIDATE_MODEL, VALIDATE_COMPILATION);
          assertThat(validate).as(ValidatorUtil.formatMessages(validate)).hasSize(3);
-        assertTrue(validate.stream().anyMatch(p -> p.getMessageType().equals(DMNMessageType.REQ_NOT_FOUND)));
+        assertThat(validate.stream().anyMatch(p -> p.getMessageType().equals(DMNMessageType.REQ_NOT_FOUND))).isTrue();
     }
 
     @Test
@@ -124,7 +123,7 @@ public class ValidatorAuthorityRequirementTest extends AbstractValidatorTest {
                                "AUTHREQ_MISSING_DEPENDENCY_REQ_INPUT"),
                 VALIDATE_MODEL, VALIDATE_COMPILATION);
          assertThat(validate).as(ValidatorUtil.formatMessages(validate)).hasSize(3);
-        assertTrue(validate.stream().anyMatch(p -> p.getMessageType().equals(DMNMessageType.REQ_NOT_FOUND)));
+        assertThat(validate.stream().anyMatch(p -> p.getMessageType().equals(DMNMessageType.REQ_NOT_FOUND))).isTrue();
     }
 
     @Test
@@ -134,7 +133,7 @@ public class ValidatorAuthorityRequirementTest extends AbstractValidatorTest {
                     reader,
                     VALIDATE_SCHEMA, VALIDATE_MODEL, VALIDATE_COMPILATION);
              assertThat(validate).as(ValidatorUtil.formatMessages(validate)).hasSize(3);
-            assertTrue(validate.stream().anyMatch(p -> p.getMessageType().equals(DMNMessageType.REQ_NOT_FOUND)));
+            assertThat(validate.stream().anyMatch(p -> p.getMessageType().equals(DMNMessageType.REQ_NOT_FOUND))).isTrue();
         }
     }
 
@@ -144,7 +143,7 @@ public class ValidatorAuthorityRequirementTest extends AbstractValidatorTest {
                 getFile("authorityrequirement/AUTHREQ_DEP_REQ_AUTH_NOT_KNOWLEDGESOURCE.dmn"),
                 VALIDATE_SCHEMA, VALIDATE_MODEL, VALIDATE_COMPILATION);
          assertThat(validate).as(ValidatorUtil.formatMessages(validate)).hasSize(3);
-        assertTrue(validate.stream().anyMatch(p -> p.getMessageType().equals(DMNMessageType.REQ_NOT_FOUND)));
+        assertThat(validate.stream().anyMatch(p -> p.getMessageType().equals(DMNMessageType.REQ_NOT_FOUND))).isTrue();
     }
 
     @Test
@@ -155,7 +154,7 @@ public class ValidatorAuthorityRequirementTest extends AbstractValidatorTest {
                                "AUTHREQ_DEP_REQ_AUTH_NOT_KNOWLEDGESOURCE"),
                 VALIDATE_MODEL, VALIDATE_COMPILATION);
          assertThat(validate).as(ValidatorUtil.formatMessages(validate)).hasSize(3);
-        assertTrue(validate.stream().anyMatch(p -> p.getMessageType().equals(DMNMessageType.REQ_NOT_FOUND)));
+        assertThat(validate.stream().anyMatch(p -> p.getMessageType().equals(DMNMessageType.REQ_NOT_FOUND))).isTrue();
     }
 
     @Test
@@ -165,7 +164,7 @@ public class ValidatorAuthorityRequirementTest extends AbstractValidatorTest {
                     reader,
                     VALIDATE_SCHEMA, VALIDATE_MODEL, VALIDATE_COMPILATION);
              assertThat(validate).as(ValidatorUtil.formatMessages(validate)).hasSize(3);
-            assertTrue(validate.stream().anyMatch(p -> p.getMessageType().equals(DMNMessageType.REQ_NOT_FOUND)));
+            assertThat(validate.stream().anyMatch(p -> p.getMessageType().equals(DMNMessageType.REQ_NOT_FOUND))).isTrue();
         }
     }
 
@@ -175,7 +174,7 @@ public class ValidatorAuthorityRequirementTest extends AbstractValidatorTest {
                 getFile("authorityrequirement/AUTHREQ_DEP_REQ_DEC_NOT_DECISION.dmn"),
                 VALIDATE_SCHEMA, VALIDATE_MODEL, VALIDATE_COMPILATION);
          assertThat(validate).as(ValidatorUtil.formatMessages(validate)).hasSize(3);
-        assertTrue(validate.stream().anyMatch(p -> p.getMessageType().equals(DMNMessageType.REQ_NOT_FOUND)));
+        assertThat(validate.stream().anyMatch(p -> p.getMessageType().equals(DMNMessageType.REQ_NOT_FOUND))).isTrue();
     }
 
     @Test
@@ -186,7 +185,7 @@ public class ValidatorAuthorityRequirementTest extends AbstractValidatorTest {
                                "AUTHREQ_DEP_REQ_DEC_NOT_DECISION"),
                 VALIDATE_MODEL, VALIDATE_COMPILATION);
          assertThat(validate).as(ValidatorUtil.formatMessages(validate)).hasSize(3);
-        assertTrue(validate.stream().anyMatch(p -> p.getMessageType().equals(DMNMessageType.REQ_NOT_FOUND)));
+        assertThat(validate.stream().anyMatch(p -> p.getMessageType().equals(DMNMessageType.REQ_NOT_FOUND))).isTrue();
     }
 
     @Test
@@ -196,7 +195,7 @@ public class ValidatorAuthorityRequirementTest extends AbstractValidatorTest {
                     reader,
                     VALIDATE_SCHEMA, VALIDATE_MODEL, VALIDATE_COMPILATION);
              assertThat(validate).as(ValidatorUtil.formatMessages(validate)).hasSize(3);
-            assertTrue(validate.stream().anyMatch(p -> p.getMessageType().equals(DMNMessageType.REQ_NOT_FOUND)));
+            assertThat(validate.stream().anyMatch(p -> p.getMessageType().equals(DMNMessageType.REQ_NOT_FOUND))).isTrue();
         }
     }
 
@@ -206,7 +205,7 @@ public class ValidatorAuthorityRequirementTest extends AbstractValidatorTest {
                 getFile("authorityrequirement/AUTHREQ_DEP_REQ_INPUT_NOT_INPUT.dmn"),
                 VALIDATE_SCHEMA, VALIDATE_MODEL, VALIDATE_COMPILATION);
          assertThat(validate).as(ValidatorUtil.formatMessages(validate)).hasSize(3);
-        assertTrue(validate.stream().anyMatch(p -> p.getMessageType().equals(DMNMessageType.REQ_NOT_FOUND)));
+        assertThat(validate.stream().anyMatch(p -> p.getMessageType().equals(DMNMessageType.REQ_NOT_FOUND))).isTrue();
     }
 
     @Test
@@ -217,6 +216,6 @@ public class ValidatorAuthorityRequirementTest extends AbstractValidatorTest {
                                "AUTHREQ_DEP_REQ_INPUT_NOT_INPUT"),
                 VALIDATE_MODEL, VALIDATE_COMPILATION);
          assertThat(validate).as(ValidatorUtil.formatMessages(validate)).hasSize(3);
-        assertTrue(validate.stream().anyMatch(p -> p.getMessageType().equals(DMNMessageType.REQ_NOT_FOUND)));
+        assertThat(validate.stream().anyMatch(p -> p.getMessageType().equals(DMNMessageType.REQ_NOT_FOUND))).isTrue();
     }
 }

--- a/kie-dmn/kie-dmn-legacy-tests/src/test/java/org/kie/dmn/legacy/tests/validation/v1_1/ValidatorBusinessContextTest.java
+++ b/kie-dmn/kie-dmn-legacy-tests/src/test/java/org/kie/dmn/legacy/tests/validation/v1_1/ValidatorBusinessContextTest.java
@@ -27,7 +27,6 @@ import org.kie.dmn.validation.AbstractValidatorTest;
 import org.kie.dmn.validation.ValidatorUtil;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.Assert.assertTrue;
 import static org.kie.dmn.validation.DMNValidator.Validation.VALIDATE_COMPILATION;
 import static org.kie.dmn.validation.DMNValidator.Validation.VALIDATE_MODEL;
 import static org.kie.dmn.validation.DMNValidator.Validation.VALIDATE_SCHEMA;
@@ -41,7 +40,7 @@ public class ValidatorBusinessContextTest extends AbstractValidatorTest {
                     reader,
                     VALIDATE_SCHEMA, VALIDATE_MODEL, VALIDATE_COMPILATION);
              assertThat(validate).as(ValidatorUtil.formatMessages(validate)).hasSize(2);
-            assertTrue(validate.stream().anyMatch(p -> p.getMessageType().equals(DMNMessageType.REQ_NOT_FOUND)));
+            assertThat(validate.stream().anyMatch(p -> p.getMessageType().equals(DMNMessageType.REQ_NOT_FOUND))).isTrue();
         }
     }
 
@@ -51,7 +50,7 @@ public class ValidatorBusinessContextTest extends AbstractValidatorTest {
                 getFile("businesscontext/ORG_UNIT_DECISION_MADE_WRONG_TYPE.dmn"),
                 VALIDATE_SCHEMA, VALIDATE_MODEL, VALIDATE_COMPILATION);
          assertThat(validate).as(ValidatorUtil.formatMessages(validate)).hasSize(2);
-        assertTrue(validate.stream().anyMatch(p -> p.getMessageType().equals(DMNMessageType.REQ_NOT_FOUND)));
+        assertThat(validate.stream().anyMatch(p -> p.getMessageType().equals(DMNMessageType.REQ_NOT_FOUND))).isTrue();
     }
 
     @Test
@@ -62,7 +61,7 @@ public class ValidatorBusinessContextTest extends AbstractValidatorTest {
                                "ORG_UNIT_DECISION_MADE_WRONG_TYPE"),
                 VALIDATE_MODEL, VALIDATE_COMPILATION);
          assertThat(validate).as(ValidatorUtil.formatMessages(validate)).hasSize(2);
-        assertTrue(validate.stream().anyMatch(p -> p.getMessageType().equals(DMNMessageType.REQ_NOT_FOUND)));
+        assertThat(validate.stream().anyMatch(p -> p.getMessageType().equals(DMNMessageType.REQ_NOT_FOUND))).isTrue();
     }
 
     @Test
@@ -72,7 +71,7 @@ public class ValidatorBusinessContextTest extends AbstractValidatorTest {
                     reader,
                     VALIDATE_SCHEMA, VALIDATE_MODEL, VALIDATE_COMPILATION);
              assertThat(validate).as(ValidatorUtil.formatMessages(validate)).hasSize(2);
-            assertTrue(validate.stream().anyMatch(p -> p.getMessageType().equals(DMNMessageType.REQ_NOT_FOUND)));
+            assertThat(validate.stream().anyMatch(p -> p.getMessageType().equals(DMNMessageType.REQ_NOT_FOUND))).isTrue();
         }
     }
 
@@ -82,7 +81,7 @@ public class ValidatorBusinessContextTest extends AbstractValidatorTest {
                 getFile("businesscontext/ORG_UNIT_DECISION_OWNED_WRONG_TYPE.dmn"),
                 VALIDATE_SCHEMA, VALIDATE_MODEL, VALIDATE_COMPILATION);
          assertThat(validate).as(ValidatorUtil.formatMessages(validate)).hasSize(2);
-        assertTrue(validate.stream().anyMatch(p -> p.getMessageType().equals(DMNMessageType.REQ_NOT_FOUND)));
+        assertThat(validate.stream().anyMatch(p -> p.getMessageType().equals(DMNMessageType.REQ_NOT_FOUND))).isTrue();
     }
 
     @Test
@@ -93,7 +92,7 @@ public class ValidatorBusinessContextTest extends AbstractValidatorTest {
                                "ORG_UNIT_DECISION_OWNED_WRONG_TYPE"),
                 VALIDATE_MODEL, VALIDATE_COMPILATION);
          assertThat(validate).as(ValidatorUtil.formatMessages(validate)).hasSize(2);
-        assertTrue(validate.stream().anyMatch(p -> p.getMessageType().equals(DMNMessageType.REQ_NOT_FOUND)));
+        assertThat(validate.stream().anyMatch(p -> p.getMessageType().equals(DMNMessageType.REQ_NOT_FOUND))).isTrue();
     }
 
     @Test
@@ -103,7 +102,7 @@ public class ValidatorBusinessContextTest extends AbstractValidatorTest {
                     reader,
                     VALIDATE_SCHEMA, VALIDATE_MODEL, VALIDATE_COMPILATION);
              assertThat(validate).as(ValidatorUtil.formatMessages(validate)).hasSize(2);
-            assertTrue(validate.stream().anyMatch(p -> p.getMessageType().equals(DMNMessageType.REQ_NOT_FOUND)));
+            assertThat(validate.stream().anyMatch(p -> p.getMessageType().equals(DMNMessageType.REQ_NOT_FOUND))).isTrue();
         }
     }
 
@@ -113,7 +112,7 @@ public class ValidatorBusinessContextTest extends AbstractValidatorTest {
                 getFile("businesscontext/PERF_INDICATOR_IMP_DECISION_WRONG_TYPE.dmn"),
                 VALIDATE_SCHEMA, VALIDATE_MODEL, VALIDATE_COMPILATION);
          assertThat(validate).as(ValidatorUtil.formatMessages(validate)).hasSize(2);
-        assertTrue(validate.stream().anyMatch(p -> p.getMessageType().equals(DMNMessageType.REQ_NOT_FOUND)));
+        assertThat(validate.stream().anyMatch(p -> p.getMessageType().equals(DMNMessageType.REQ_NOT_FOUND))).isTrue();
     }
 
     @Test
@@ -124,6 +123,6 @@ public class ValidatorBusinessContextTest extends AbstractValidatorTest {
                                "PERF_INDICATOR_IMP_DECISION_WRONG_TYPE"),
                 VALIDATE_MODEL, VALIDATE_COMPILATION);
          assertThat(validate).as(ValidatorUtil.formatMessages(validate)).hasSize(2);
-        assertTrue(validate.stream().anyMatch(p -> p.getMessageType().equals(DMNMessageType.REQ_NOT_FOUND)));
+        assertThat(validate.stream().anyMatch(p -> p.getMessageType().equals(DMNMessageType.REQ_NOT_FOUND))).isTrue();
     }
 }

--- a/kie-dmn/kie-dmn-legacy-tests/src/test/java/org/kie/dmn/legacy/tests/validation/v1_1/ValidatorBusinessKnowledgeModelTest.java
+++ b/kie-dmn/kie-dmn-legacy-tests/src/test/java/org/kie/dmn/legacy/tests/validation/v1_1/ValidatorBusinessKnowledgeModelTest.java
@@ -27,7 +27,6 @@ import org.kie.dmn.validation.AbstractValidatorTest;
 import org.kie.dmn.validation.ValidatorUtil;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.Assert.assertTrue;
 import static org.kie.dmn.validation.DMNValidator.Validation.VALIDATE_COMPILATION;
 import static org.kie.dmn.validation.DMNValidator.Validation.VALIDATE_MODEL;
 import static org.kie.dmn.validation.DMNValidator.Validation.VALIDATE_SCHEMA;
@@ -41,7 +40,7 @@ public class ValidatorBusinessKnowledgeModelTest extends AbstractValidatorTest {
                     reader,
                     VALIDATE_SCHEMA, VALIDATE_MODEL, VALIDATE_COMPILATION);
             assertThat(validate).as(ValidatorUtil.formatMessages(validate)).hasSize(1);
-            assertTrue(validate.stream().anyMatch(p -> p.getMessageType().equals(DMNMessageType.MISSING_VARIABLE)));
+            assertThat(validate.stream().anyMatch(p -> p.getMessageType().equals(DMNMessageType.MISSING_VARIABLE))).isTrue();
         }
     }
 
@@ -51,7 +50,7 @@ public class ValidatorBusinessKnowledgeModelTest extends AbstractValidatorTest {
                 getFile("businessknowledgemodel/BKM_MISSING_VAR.dmn"),
                 VALIDATE_SCHEMA, VALIDATE_MODEL, VALIDATE_COMPILATION);
         assertThat(validate).as(ValidatorUtil.formatMessages(validate)).hasSize(1);
-        assertTrue(validate.stream().anyMatch(p -> p.getMessageType().equals(DMNMessageType.MISSING_VARIABLE)));
+        assertThat(validate.stream().anyMatch(p -> p.getMessageType().equals(DMNMessageType.MISSING_VARIABLE))).isTrue();
     }
 
     @Test
@@ -62,7 +61,7 @@ public class ValidatorBusinessKnowledgeModelTest extends AbstractValidatorTest {
                                "BKM_MISSING_VAR"),
                 VALIDATE_MODEL, VALIDATE_COMPILATION);
         assertThat(validate).as(ValidatorUtil.formatMessages(validate)).hasSize(1);
-        assertTrue(validate.stream().anyMatch(p -> p.getMessageType().equals(DMNMessageType.MISSING_VARIABLE)));
+        assertThat(validate.stream().anyMatch(p -> p.getMessageType().equals(DMNMessageType.MISSING_VARIABLE))).isTrue();
     }
 
     @Test
@@ -72,7 +71,7 @@ public class ValidatorBusinessKnowledgeModelTest extends AbstractValidatorTest {
                     reader,
                     VALIDATE_SCHEMA, VALIDATE_MODEL, VALIDATE_COMPILATION);
             assertThat(validate).as(ValidatorUtil.formatMessages(validate)).hasSize(1);
-            assertTrue(validate.stream().anyMatch(p -> p.getMessageType().equals(DMNMessageType.VARIABLE_NAME_MISMATCH)));
+            assertThat(validate.stream().anyMatch(p -> p.getMessageType().equals(DMNMessageType.VARIABLE_NAME_MISMATCH))).isTrue();
         }
     }
 
@@ -82,7 +81,7 @@ public class ValidatorBusinessKnowledgeModelTest extends AbstractValidatorTest {
                 getFile("businessknowledgemodel/BKM_MISMATCH_VAR.dmn"),
                 VALIDATE_SCHEMA, VALIDATE_MODEL, VALIDATE_COMPILATION);
         assertThat(validate).as(ValidatorUtil.formatMessages(validate)).hasSize(1);
-        assertTrue(validate.stream().anyMatch(p -> p.getMessageType().equals(DMNMessageType.VARIABLE_NAME_MISMATCH)));
+        assertThat(validate.stream().anyMatch(p -> p.getMessageType().equals(DMNMessageType.VARIABLE_NAME_MISMATCH))).isTrue();
     }
 
     @Test
@@ -93,7 +92,7 @@ public class ValidatorBusinessKnowledgeModelTest extends AbstractValidatorTest {
                                "BKM_MISSING_VAR"),
                 VALIDATE_MODEL, VALIDATE_COMPILATION);
         assertThat(validate).as(ValidatorUtil.formatMessages(validate)).hasSize(1);
-        assertTrue(validate.stream().anyMatch(p -> p.getMessageType().equals(DMNMessageType.VARIABLE_NAME_MISMATCH)));
+        assertThat(validate.stream().anyMatch(p -> p.getMessageType().equals(DMNMessageType.VARIABLE_NAME_MISMATCH))).isTrue();
     }
 
     @Test

--- a/kie-dmn/kie-dmn-legacy-tests/src/test/java/org/kie/dmn/legacy/tests/validation/v1_1/ValidatorContextTest.java
+++ b/kie-dmn/kie-dmn-legacy-tests/src/test/java/org/kie/dmn/legacy/tests/validation/v1_1/ValidatorContextTest.java
@@ -29,7 +29,6 @@ import org.kie.dmn.validation.AbstractValidatorTest;
 import org.kie.dmn.validation.ValidatorUtil;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.Assert.assertTrue;
 import static org.kie.dmn.validation.DMNValidator.Validation.VALIDATE_COMPILATION;
 import static org.kie.dmn.validation.DMNValidator.Validation.VALIDATE_MODEL;
 import static org.kie.dmn.validation.DMNValidator.Validation.VALIDATE_SCHEMA;
@@ -43,8 +42,8 @@ public class ValidatorContextTest extends AbstractValidatorTest {
                     reader,
                     VALIDATE_SCHEMA, VALIDATE_MODEL, VALIDATE_COMPILATION);
             assertThat(validate).as(ValidatorUtil.formatMessages(validate)).hasSize(2);
-            assertTrue(validate.stream().anyMatch(p -> p.getMessageType().equals(DMNMessageType.FAILED_XML_VALIDATION))); // this is schema validation
-            assertTrue(validate.stream().anyMatch(p -> p.getMessageType().equals(DMNMessageType.MISSING_EXPRESSION)));
+            assertThat(validate.stream().anyMatch(p -> p.getMessageType().equals(DMNMessageType.FAILED_XML_VALIDATION))).isTrue(); // this is schema validation
+            assertThat(validate.stream().anyMatch(p -> p.getMessageType().equals(DMNMessageType.MISSING_EXPRESSION))).isTrue();
         }
     }
 
@@ -54,8 +53,8 @@ public class ValidatorContextTest extends AbstractValidatorTest {
                 getFile("context/CONTEXT_MISSING_EXPR.dmn"),
                 VALIDATE_SCHEMA, VALIDATE_MODEL, VALIDATE_COMPILATION);
         assertThat(validate).as(ValidatorUtil.formatMessages(validate)).hasSize(2);
-        assertTrue(validate.stream().anyMatch(p -> p.getMessageType().equals(DMNMessageType.FAILED_XML_VALIDATION))); // this is schema validation
-        assertTrue(validate.stream().anyMatch(p -> p.getMessageType().equals(DMNMessageType.MISSING_EXPRESSION)));
+        assertThat(validate.stream().anyMatch(p -> p.getMessageType().equals(DMNMessageType.FAILED_XML_VALIDATION))).isTrue(); // this is schema validation
+        assertThat(validate.stream().anyMatch(p -> p.getMessageType().equals(DMNMessageType.MISSING_EXPRESSION))).isTrue();
     }
 
     @Test
@@ -66,7 +65,7 @@ public class ValidatorContextTest extends AbstractValidatorTest {
                                "CONTEXT_MISSING_EXPR"),
                 VALIDATE_MODEL, VALIDATE_COMPILATION);
         assertThat(validate).as(ValidatorUtil.formatMessages(validate)).hasSize(1);
-        assertTrue(validate.stream().anyMatch(p -> p.getMessageType().equals(DMNMessageType.MISSING_EXPRESSION)));
+        assertThat(validate.stream().anyMatch(p -> p.getMessageType().equals(DMNMessageType.MISSING_EXPRESSION))).isTrue();
     }
 
     @Test
@@ -76,7 +75,7 @@ public class ValidatorContextTest extends AbstractValidatorTest {
                     reader,
                     VALIDATE_SCHEMA, VALIDATE_MODEL, VALIDATE_COMPILATION);
             assertThat(validate).as(ValidatorUtil.formatMessages(validate)).hasSize(1);
-            assertTrue(validate.stream().anyMatch(p -> p.getMessageType().equals(DMNMessageType.MISSING_EXPRESSION)));
+            assertThat(validate.stream().anyMatch(p -> p.getMessageType().equals(DMNMessageType.MISSING_EXPRESSION))).isTrue();
         }
     }
 
@@ -86,7 +85,7 @@ public class ValidatorContextTest extends AbstractValidatorTest {
                 getFile("context/CONTEXT_MISSING_ENTRIES.dmn"),
                 VALIDATE_SCHEMA, VALIDATE_MODEL, VALIDATE_COMPILATION);
         assertThat(validate).as(ValidatorUtil.formatMessages(validate)).hasSize(1);
-        assertTrue(validate.stream().anyMatch(p -> p.getMessageType().equals(DMNMessageType.MISSING_EXPRESSION)));
+        assertThat(validate.stream().anyMatch(p -> p.getMessageType().equals(DMNMessageType.MISSING_EXPRESSION))).isTrue();
     }
 
     @Test
@@ -97,7 +96,7 @@ public class ValidatorContextTest extends AbstractValidatorTest {
                                "CONTEXT_MISSING_EXPR"),
                 VALIDATE_MODEL, VALIDATE_COMPILATION);
         assertThat(validate).as(ValidatorUtil.formatMessages(validate)).hasSize(1);
-        assertTrue(validate.stream().anyMatch(p -> p.getMessageType().equals(DMNMessageType.MISSING_EXPRESSION)));
+        assertThat(validate.stream().anyMatch(p -> p.getMessageType().equals(DMNMessageType.MISSING_EXPRESSION))).isTrue();
     }
 
     @Test
@@ -107,7 +106,7 @@ public class ValidatorContextTest extends AbstractValidatorTest {
                     reader,
                     VALIDATE_SCHEMA, VALIDATE_MODEL, VALIDATE_COMPILATION);
             assertThat(validate).as(ValidatorUtil.formatMessages(validate)).hasSize(1);
-            assertTrue(validate.stream().anyMatch(p -> p.getMessageType().equals(DMNMessageType.MISSING_VARIABLE)));
+            assertThat(validate.stream().anyMatch(p -> p.getMessageType().equals(DMNMessageType.MISSING_VARIABLE))).isTrue();
             // check that it reports and error for the second context entry, but not for the last one
             final ContextEntry ce = (ContextEntry) validate.get(0).getSourceReference();
             assertThat(((Context) ce.getParent()).getContextEntry().indexOf(ce)).isEqualTo(1);
@@ -120,7 +119,7 @@ public class ValidatorContextTest extends AbstractValidatorTest {
                 getFile("context/CONTEXT_ENTRY_MISSING_VARIABLE.dmn"),
                 VALIDATE_SCHEMA, VALIDATE_MODEL, VALIDATE_COMPILATION);
         assertThat(validate).as(ValidatorUtil.formatMessages(validate)).hasSize(1);
-        assertTrue(validate.stream().anyMatch(p -> p.getMessageType().equals(DMNMessageType.MISSING_VARIABLE)));
+        assertThat(validate.stream().anyMatch(p -> p.getMessageType().equals(DMNMessageType.MISSING_VARIABLE))).isTrue();
         // check that it reports and error for the second context entry, but not for the last one
         final ContextEntry ce = (ContextEntry) validate.get(0).getSourceReference();
         assertThat(((Context) ce.getParent()).getContextEntry().indexOf(ce)).isEqualTo(1);
@@ -134,7 +133,7 @@ public class ValidatorContextTest extends AbstractValidatorTest {
                                "CONTEXT_MISSING_EXPR"),
                 VALIDATE_MODEL, VALIDATE_COMPILATION);
         assertThat(validate).as(ValidatorUtil.formatMessages(validate)).hasSize(1);
-        assertTrue(validate.stream().anyMatch(p -> p.getMessageType().equals(DMNMessageType.MISSING_VARIABLE)));
+        assertThat(validate.stream().anyMatch(p -> p.getMessageType().equals(DMNMessageType.MISSING_VARIABLE))).isTrue();
         // check that it reports and error for the second context entry, but not for the last one
         final ContextEntry ce = (ContextEntry) validate.get(0).getSourceReference();
         assertThat(((Context) ce.getParent()).getContextEntry().indexOf(ce)).isEqualTo(1);
@@ -147,7 +146,7 @@ public class ValidatorContextTest extends AbstractValidatorTest {
                     reader,
                     VALIDATE_SCHEMA, VALIDATE_MODEL, VALIDATE_COMPILATION);
             assertThat(validate).as(ValidatorUtil.formatMessages(validate)).hasSize(2);
-            assertTrue(validate.stream().anyMatch(p -> p.getMessageType().equals(DMNMessageType.DUPLICATE_NAME)));
+            assertThat(validate.stream().anyMatch(p -> p.getMessageType().equals(DMNMessageType.DUPLICATE_NAME))).isTrue();
         }
     }
 
@@ -157,7 +156,7 @@ public class ValidatorContextTest extends AbstractValidatorTest {
                 getFile("context/CONTEXT_DUP_ENTRY.dmn"),
                 VALIDATE_SCHEMA, VALIDATE_MODEL, VALIDATE_COMPILATION);
         assertThat(validate).as(ValidatorUtil.formatMessages(validate)).hasSize(2);
-        assertTrue(validate.stream().anyMatch(p -> p.getMessageType().equals(DMNMessageType.DUPLICATE_NAME)));
+        assertThat(validate.stream().anyMatch(p -> p.getMessageType().equals(DMNMessageType.DUPLICATE_NAME))).isTrue();
     }
 
     @Test
@@ -168,7 +167,7 @@ public class ValidatorContextTest extends AbstractValidatorTest {
                                "CONTEXT_DUP_ENTRY"),
                 VALIDATE_MODEL, VALIDATE_COMPILATION);
         assertThat(validate).as(ValidatorUtil.formatMessages(validate)).hasSize(2);
-        assertTrue(validate.stream().anyMatch(p -> p.getMessageType().equals(DMNMessageType.DUPLICATE_NAME)));
+        assertThat(validate.stream().anyMatch(p -> p.getMessageType().equals(DMNMessageType.DUPLICATE_NAME))).isTrue();
     }
 
     @Test
@@ -178,7 +177,7 @@ public class ValidatorContextTest extends AbstractValidatorTest {
                     reader,
                     VALIDATE_SCHEMA, VALIDATE_MODEL, VALIDATE_COMPILATION);
             assertThat(validate).as(ValidatorUtil.formatMessages(validate)).hasSize(2);
-            assertTrue(validate.stream().anyMatch(p -> p.getMessageType().equals(DMNMessageType.MISSING_TYPE_REF)));
+            assertThat(validate.stream().anyMatch(p -> p.getMessageType().equals(DMNMessageType.MISSING_TYPE_REF))).isTrue();
         }
     }
 
@@ -188,7 +187,7 @@ public class ValidatorContextTest extends AbstractValidatorTest {
                 getFile("context/CONTEXT_ENTRY_NOTYPEREF.dmn"),
                 VALIDATE_SCHEMA, VALIDATE_MODEL, VALIDATE_COMPILATION);
         assertThat(validate).as(ValidatorUtil.formatMessages(validate)).hasSize(2);
-        assertTrue(validate.stream().anyMatch(p -> p.getMessageType().equals(DMNMessageType.MISSING_TYPE_REF)));
+        assertThat(validate.stream().anyMatch(p -> p.getMessageType().equals(DMNMessageType.MISSING_TYPE_REF))).isTrue();
     }
 
     @Test
@@ -199,6 +198,6 @@ public class ValidatorContextTest extends AbstractValidatorTest {
                                "CONTEXT_ENTRY_NOTYPEREF"),
                 VALIDATE_MODEL, VALIDATE_COMPILATION);
         assertThat(validate).as(ValidatorUtil.formatMessages(validate)).hasSize(2);
-        assertTrue(validate.stream().anyMatch(p -> p.getMessageType().equals(DMNMessageType.MISSING_TYPE_REF)));
+        assertThat(validate.stream().anyMatch(p -> p.getMessageType().equals(DMNMessageType.MISSING_TYPE_REF))).isTrue();
     }
 }

--- a/kie-dmn/kie-dmn-legacy-tests/src/test/java/org/kie/dmn/legacy/tests/validation/v1_1/ValidatorDMNElementReferenceTest.java
+++ b/kie-dmn/kie-dmn-legacy-tests/src/test/java/org/kie/dmn/legacy/tests/validation/v1_1/ValidatorDMNElementReferenceTest.java
@@ -27,7 +27,6 @@ import org.kie.dmn.validation.AbstractValidatorTest;
 import org.kie.dmn.validation.ValidatorUtil;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.Assert.assertTrue;
 import static org.kie.dmn.validation.DMNValidator.Validation.VALIDATE_COMPILATION;
 import static org.kie.dmn.validation.DMNValidator.Validation.VALIDATE_MODEL;
 import static org.kie.dmn.validation.DMNValidator.Validation.VALIDATE_SCHEMA;
@@ -64,9 +63,9 @@ public class ValidatorDMNElementReferenceTest extends AbstractValidatorTest {
 
     private void assertValiadationResult(List<DMNMessage> validationMessages) {
     	assertThat(validationMessages).as(ValidatorUtil.formatMessages(validationMessages)).hasSize(3);
-        assertTrue(validationMessages.stream().anyMatch(p -> p.getMessageType().equals(DMNMessageType.MISSING_EXPRESSION)));
-        assertTrue(validationMessages.stream().anyMatch(p -> p.getMessageType().equals(DMNMessageType.INVALID_HREF_SYNTAX)));
-        assertTrue(validationMessages.stream().anyMatch(p -> p.getMessageType().equals(DMNMessageType.REQ_NOT_FOUND)));
+        assertThat(validationMessages.stream().anyMatch(p -> p.getMessageType().equals(DMNMessageType.MISSING_EXPRESSION))).isTrue();
+        assertThat(validationMessages.stream().anyMatch(p -> p.getMessageType().equals(DMNMessageType.INVALID_HREF_SYNTAX))).isTrue();
+        assertThat(validationMessages.stream().anyMatch(p -> p.getMessageType().equals(DMNMessageType.REQ_NOT_FOUND))).isTrue();
     }
 
 }

--- a/kie-dmn/kie-dmn-legacy-tests/src/test/java/org/kie/dmn/legacy/tests/validation/v1_1/ValidatorDecisionTableTest.java
+++ b/kie-dmn/kie-dmn-legacy-tests/src/test/java/org/kie/dmn/legacy/tests/validation/v1_1/ValidatorDecisionTableTest.java
@@ -27,7 +27,6 @@ import org.kie.dmn.validation.AbstractValidatorTest;
 import org.kie.dmn.validation.ValidatorUtil;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.Assert.assertTrue;
 import static org.kie.dmn.validation.DMNValidator.Validation.VALIDATE_COMPILATION;
 import static org.kie.dmn.validation.DMNValidator.Validation.VALIDATE_MODEL;
 import static org.kie.dmn.validation.DMNValidator.Validation.VALIDATE_SCHEMA;
@@ -42,7 +41,7 @@ public class ValidatorDecisionTableTest
                     reader,
                     VALIDATE_MODEL, VALIDATE_COMPILATION);
             assertThat(validate).as(ValidatorUtil.formatMessages(validate)).hasSize(2);
-            assertTrue(validate.stream().anyMatch(p -> p.getMessageType().equals(DMNMessageType.MISSING_EXPRESSION)));
+            assertThat(validate.stream().anyMatch(p -> p.getMessageType().equals(DMNMessageType.MISSING_EXPRESSION))).isTrue();
         }
     }
 
@@ -52,7 +51,7 @@ public class ValidatorDecisionTableTest
                 getFile("DTABLE_EMPTY_ENTRY.dmn"),
                 VALIDATE_MODEL, VALIDATE_COMPILATION);
         assertThat(validate).as(ValidatorUtil.formatMessages(validate)).hasSize(2);
-        assertTrue(validate.stream().anyMatch(p -> p.getMessageType().equals(DMNMessageType.MISSING_EXPRESSION)));
+        assertThat(validate.stream().anyMatch(p -> p.getMessageType().equals(DMNMessageType.MISSING_EXPRESSION))).isTrue();
     }
 
     @Test
@@ -63,7 +62,7 @@ public class ValidatorDecisionTableTest
                                "DTABLE_PRIORITY_MISSING_OUTVALS"),
                 VALIDATE_MODEL, VALIDATE_COMPILATION);
         assertThat(validate).as(ValidatorUtil.formatMessages(validate)).hasSize(2);
-        assertTrue(validate.stream().anyMatch(p -> p.getMessageType().equals(DMNMessageType.MISSING_EXPRESSION)));
+        assertThat(validate.stream().anyMatch(p -> p.getMessageType().equals(DMNMessageType.MISSING_EXPRESSION))).isTrue();
     }
 
     @Test
@@ -71,9 +70,9 @@ public class ValidatorDecisionTableTest
         try (final Reader reader = getReader( "DTABLE_MULTIPLEOUTPUT_WRONG_OUTPUT.dmn" )) {
             List<DMNMessage> validate = validator.validate( reader, VALIDATE_SCHEMA, VALIDATE_MODEL, VALIDATE_COMPILATION);
             assertThat(validate).as(ValidatorUtil.formatMessages(validate)).hasSize(5);
-            assertTrue( validate.stream().anyMatch( p -> p.getMessageType().equals( DMNMessageType.MISSING_NAME ) ) );
-            assertTrue( validate.stream().anyMatch( p -> p.getMessageType().equals( DMNMessageType.MISSING_TYPE_REF ) ) );
-            assertTrue( validate.stream().anyMatch( p -> p.getMessageType().equals( DMNMessageType.INVALID_NAME ) ) );
+            assertThat(validate.stream().anyMatch(p -> p.getMessageType().equals(DMNMessageType.MISSING_NAME))).isTrue();
+            assertThat(validate.stream().anyMatch(p -> p.getMessageType().equals(DMNMessageType.MISSING_TYPE_REF))).isTrue();
+            assertThat(validate.stream().anyMatch(p -> p.getMessageType().equals(DMNMessageType.INVALID_NAME))).isTrue();
         }
     }
 
@@ -81,9 +80,9 @@ public class ValidatorDecisionTableTest
     public void testDTABLE_MULTIPLEOUT_NAME_FileInput() {
         List<DMNMessage> validate = validator.validate( getFile( "DTABLE_MULTIPLEOUTPUT_WRONG_OUTPUT.dmn" ), VALIDATE_SCHEMA, VALIDATE_MODEL, VALIDATE_COMPILATION);
         assertThat(validate).as(ValidatorUtil.formatMessages(validate)).hasSize(5);
-        assertTrue( validate.stream().anyMatch( p -> p.getMessageType().equals( DMNMessageType.MISSING_NAME ) ) );
-        assertTrue( validate.stream().anyMatch( p -> p.getMessageType().equals( DMNMessageType.MISSING_TYPE_REF ) ) );
-        assertTrue( validate.stream().anyMatch( p -> p.getMessageType().equals( DMNMessageType.INVALID_NAME ) ) );
+        assertThat(validate.stream().anyMatch(p -> p.getMessageType().equals(DMNMessageType.MISSING_NAME))).isTrue();
+        assertThat(validate.stream().anyMatch(p -> p.getMessageType().equals(DMNMessageType.MISSING_TYPE_REF))).isTrue();
+        assertThat(validate.stream().anyMatch(p -> p.getMessageType().equals(DMNMessageType.INVALID_NAME))).isTrue();
     }
 
     @Test
@@ -94,25 +93,25 @@ public class ValidatorDecisionTableTest
                                 "DTABLE_MULTIPLEOUTPUT_WRONG_OUTPUT"),
                 VALIDATE_MODEL, VALIDATE_COMPILATION);
         assertThat(validate).as(ValidatorUtil.formatMessages(validate)).hasSize(5);
-        assertTrue( validate.stream().anyMatch( p -> p.getMessageType().equals( DMNMessageType.MISSING_NAME ) ) );
-        assertTrue( validate.stream().anyMatch( p -> p.getMessageType().equals( DMNMessageType.MISSING_TYPE_REF ) ) );
-        assertTrue( validate.stream().anyMatch( p -> p.getMessageType().equals( DMNMessageType.INVALID_NAME ) ) );
+        assertThat(validate.stream().anyMatch(p -> p.getMessageType().equals(DMNMessageType.MISSING_NAME))).isTrue();
+        assertThat(validate.stream().anyMatch(p -> p.getMessageType().equals(DMNMessageType.MISSING_TYPE_REF))).isTrue();
+        assertThat(validate.stream().anyMatch(p -> p.getMessageType().equals(DMNMessageType.INVALID_NAME))).isTrue();
     }
 
     @Test
     public void testDTABLE_PRIORITY_MISSING_OUTVALS_ReaderInput() throws IOException {
         try (final Reader reader = getReader( "DTABLE_PRIORITY_MISSING_OUTVALS.dmn" )) {
             List<DMNMessage> validate = validator.validate( reader, VALIDATE_SCHEMA, VALIDATE_MODEL, VALIDATE_COMPILATION);
-            assertThat(validate.isEmpty()).as(ValidatorUtil.formatMessages(validate)).isFalse();
-            assertTrue( validate.stream().anyMatch( p -> p.getMessageType().equals( DMNMessageType.MISSING_OUTPUT_VALUES ) ) );
+            assertThat(validate).as(ValidatorUtil.formatMessages(validate)).isNotEmpty();
+            assertThat(validate.stream().anyMatch(p -> p.getMessageType().equals(DMNMessageType.MISSING_OUTPUT_VALUES))).isTrue();
         }
     }
 
     @Test
     public void testDTABLE_PRIORITY_MISSING_OUTVALS_FileInput() {
         List<DMNMessage> validate = validator.validate( getFile( "DTABLE_PRIORITY_MISSING_OUTVALS.dmn" ), VALIDATE_SCHEMA, VALIDATE_MODEL, VALIDATE_COMPILATION);
-        assertThat(validate.isEmpty()).as(ValidatorUtil.formatMessages(validate)).isFalse();
-        assertTrue( validate.stream().anyMatch( p -> p.getMessageType().equals( DMNMessageType.MISSING_OUTPUT_VALUES ) ) );
+        assertThat(validate).as(ValidatorUtil.formatMessages(validate)).isNotEmpty();
+        assertThat(validate.stream().anyMatch(p -> p.getMessageType().equals(DMNMessageType.MISSING_OUTPUT_VALUES))).isTrue();
     }
 
     @Test
@@ -122,8 +121,8 @@ public class ValidatorDecisionTableTest
                                 "https://github.com/kiegroup/kie-dmn",
                                 "DTABLE_PRIORITY_MISSING_OUTVALS"),
                 VALIDATE_MODEL, VALIDATE_COMPILATION);
-        assertThat(validate.isEmpty()).as(ValidatorUtil.formatMessages(validate)).isFalse();
-        assertTrue( validate.stream().anyMatch( p -> p.getMessageType().equals( DMNMessageType.MISSING_OUTPUT_VALUES ) ) );
+        assertThat(validate).as(ValidatorUtil.formatMessages(validate)).isNotEmpty();
+        assertThat(validate.stream().anyMatch(p -> p.getMessageType().equals(DMNMessageType.MISSING_OUTPUT_VALUES))).isTrue();
     }
 
     @Test
@@ -131,8 +130,8 @@ public class ValidatorDecisionTableTest
         try (final Reader reader = getReader( "DTABLE_SINGLEOUTPUT_WRONG_OUTPUT.dmn" )) {
             List<DMNMessage> validate = validator.validate( reader, VALIDATE_SCHEMA, VALIDATE_MODEL, VALIDATE_COMPILATION);
             assertThat(validate).as(ValidatorUtil.formatMessages(validate)).hasSize(2);
-            assertTrue( validate.stream().anyMatch( p -> p.getMessageType().equals( DMNMessageType.ILLEGAL_USE_OF_NAME ) ) );
-            assertTrue( validate.stream().anyMatch( p -> p.getMessageType().equals( DMNMessageType.ILLEGAL_USE_OF_TYPEREF ) ) );
+            assertThat(validate.stream().anyMatch(p -> p.getMessageType().equals(DMNMessageType.ILLEGAL_USE_OF_NAME))).isTrue();
+            assertThat(validate.stream().anyMatch(p -> p.getMessageType().equals(DMNMessageType.ILLEGAL_USE_OF_TYPEREF))).isTrue();
         }
     }
 
@@ -140,8 +139,8 @@ public class ValidatorDecisionTableTest
     public void testDTABLE_SINGLEOUT_NONAME_FileInput() {
         List<DMNMessage> validate = validator.validate( getFile( "DTABLE_SINGLEOUTPUT_WRONG_OUTPUT.dmn" ), VALIDATE_SCHEMA, VALIDATE_MODEL, VALIDATE_COMPILATION);
         assertThat(validate).as(ValidatorUtil.formatMessages(validate)).hasSize(2);
-        assertTrue( validate.stream().anyMatch( p -> p.getMessageType().equals( DMNMessageType.ILLEGAL_USE_OF_NAME ) ) );
-        assertTrue( validate.stream().anyMatch( p -> p.getMessageType().equals( DMNMessageType.ILLEGAL_USE_OF_TYPEREF ) ) );
+        assertThat(validate.stream().anyMatch(p -> p.getMessageType().equals(DMNMessageType.ILLEGAL_USE_OF_NAME))).isTrue();
+        assertThat(validate.stream().anyMatch(p -> p.getMessageType().equals(DMNMessageType.ILLEGAL_USE_OF_TYPEREF))).isTrue();
     }
 
     @Test
@@ -152,7 +151,7 @@ public class ValidatorDecisionTableTest
                                "DTABLE_SINGLEOUTPUT_WRONG_OUTPUT"),
                 VALIDATE_MODEL, VALIDATE_COMPILATION);
         assertThat(validate).as(ValidatorUtil.formatMessages(validate)).hasSize(2);
-        assertTrue( validate.stream().anyMatch( p -> p.getMessageType().equals( DMNMessageType.ILLEGAL_USE_OF_NAME ) ) );
-        assertTrue( validate.stream().anyMatch( p -> p.getMessageType().equals( DMNMessageType.ILLEGAL_USE_OF_TYPEREF ) ) );
+        assertThat(validate.stream().anyMatch(p -> p.getMessageType().equals(DMNMessageType.ILLEGAL_USE_OF_NAME))).isTrue();
+        assertThat(validate.stream().anyMatch(p -> p.getMessageType().equals(DMNMessageType.ILLEGAL_USE_OF_TYPEREF))).isTrue();
     }
 }

--- a/kie-dmn/kie-dmn-legacy-tests/src/test/java/org/kie/dmn/legacy/tests/validation/v1_1/ValidatorDecisionTest.java
+++ b/kie-dmn/kie-dmn-legacy-tests/src/test/java/org/kie/dmn/legacy/tests/validation/v1_1/ValidatorDecisionTest.java
@@ -27,7 +27,6 @@ import org.kie.dmn.validation.AbstractValidatorTest;
 import org.kie.dmn.validation.ValidatorUtil;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.Assert.assertTrue;
 import static org.kie.dmn.validation.DMNValidator.Validation.VALIDATE_COMPILATION;
 import static org.kie.dmn.validation.DMNValidator.Validation.VALIDATE_MODEL;
 import static org.kie.dmn.validation.DMNValidator.Validation.VALIDATE_SCHEMA;
@@ -72,7 +71,7 @@ public class ValidatorDecisionTest extends AbstractValidatorTest {
                     reader,
                     VALIDATE_SCHEMA, VALIDATE_MODEL, VALIDATE_COMPILATION);
             assertThat(validate).as(ValidatorUtil.formatMessages(validate)).hasSize(1);
-            assertTrue(validate.stream().anyMatch(p -> p.getMessageType().equals(DMNMessageType.MISSING_VARIABLE)));
+            assertThat(validate.stream().anyMatch(p -> p.getMessageType().equals(DMNMessageType.MISSING_VARIABLE))).isTrue();
         }
     }
 
@@ -82,7 +81,7 @@ public class ValidatorDecisionTest extends AbstractValidatorTest {
                 getFile("decision/DECISION_MISSING_VAR.dmn"),
                 VALIDATE_SCHEMA, VALIDATE_MODEL, VALIDATE_COMPILATION);
         assertThat(validate).as(ValidatorUtil.formatMessages(validate)).hasSize(1);
-        assertTrue(validate.stream().anyMatch(p -> p.getMessageType().equals(DMNMessageType.MISSING_VARIABLE)));
+        assertThat(validate.stream().anyMatch(p -> p.getMessageType().equals(DMNMessageType.MISSING_VARIABLE))).isTrue();
     }
 
     @Test
@@ -93,7 +92,7 @@ public class ValidatorDecisionTest extends AbstractValidatorTest {
                                "DECISION_MISSING_VAR"),
                 VALIDATE_MODEL, VALIDATE_COMPILATION);
         assertThat(validate).as(ValidatorUtil.formatMessages(validate)).hasSize(1);
-        assertTrue(validate.stream().anyMatch(p -> p.getMessageType().equals(DMNMessageType.MISSING_VARIABLE)));
+        assertThat(validate.stream().anyMatch(p -> p.getMessageType().equals(DMNMessageType.MISSING_VARIABLE))).isTrue();
     }
 
     @Test
@@ -101,7 +100,7 @@ public class ValidatorDecisionTest extends AbstractValidatorTest {
         try (final Reader reader = getReader("decision/DECISION_MISSING_VARbis.dmn")) {
             final List<DMNMessage> validate = validator.validate(reader, VALIDATE_SCHEMA, VALIDATE_MODEL, VALIDATE_COMPILATION);
             assertThat(validate).as(ValidatorUtil.formatMessages(validate)).hasSize(1);
-            assertTrue(validate.stream().anyMatch(p -> p.getMessageType().equals(DMNMessageType.MISSING_VARIABLE)));
+            assertThat(validate.stream().anyMatch(p -> p.getMessageType().equals(DMNMessageType.MISSING_VARIABLE))).isTrue();
         }
     }
 
@@ -110,7 +109,7 @@ public class ValidatorDecisionTest extends AbstractValidatorTest {
         final List<DMNMessage> validate = validator.validate(
                 getFile("decision/DECISION_MISSING_VARbis.dmn"), VALIDATE_SCHEMA, VALIDATE_MODEL, VALIDATE_COMPILATION);
         assertThat(validate).as(ValidatorUtil.formatMessages(validate)).hasSize(1);
-        assertTrue(validate.stream().anyMatch(p -> p.getMessageType().equals(DMNMessageType.MISSING_VARIABLE)));
+        assertThat(validate.stream().anyMatch(p -> p.getMessageType().equals(DMNMessageType.MISSING_VARIABLE))).isTrue();
     }
 
     @Test
@@ -121,7 +120,7 @@ public class ValidatorDecisionTest extends AbstractValidatorTest {
                                "DECISION_MISSING_VARbis"),
                 VALIDATE_MODEL, VALIDATE_COMPILATION);
         assertThat(validate).as(ValidatorUtil.formatMessages(validate)).hasSize(1);
-        assertTrue(validate.stream().anyMatch(p -> p.getMessageType().equals(DMNMessageType.MISSING_VARIABLE)));
+        assertThat(validate.stream().anyMatch(p -> p.getMessageType().equals(DMNMessageType.MISSING_VARIABLE))).isTrue();
     }
 
     @Test
@@ -129,7 +128,7 @@ public class ValidatorDecisionTest extends AbstractValidatorTest {
         try (final Reader reader = getReader("decision/DECISION_MISMATCH_VAR.dmn")) {
             final List<DMNMessage> validate = validator.validate(reader, VALIDATE_SCHEMA, VALIDATE_MODEL, VALIDATE_COMPILATION);
             assertThat(validate).as(ValidatorUtil.formatMessages(validate)).hasSize(1);
-            assertTrue(validate.stream().anyMatch(p -> p.getMessageType().equals(DMNMessageType.VARIABLE_NAME_MISMATCH)));
+            assertThat(validate.stream().anyMatch(p -> p.getMessageType().equals(DMNMessageType.VARIABLE_NAME_MISMATCH))).isTrue();
         }
     }
 
@@ -138,7 +137,7 @@ public class ValidatorDecisionTest extends AbstractValidatorTest {
         final List<DMNMessage> validate = validator.validate(
                 getFile("decision/DECISION_MISMATCH_VAR.dmn"), VALIDATE_SCHEMA, VALIDATE_MODEL, VALIDATE_COMPILATION);
         assertThat(validate).as(ValidatorUtil.formatMessages(validate)).hasSize(1);
-        assertTrue(validate.stream().anyMatch(p -> p.getMessageType().equals(DMNMessageType.VARIABLE_NAME_MISMATCH)));
+        assertThat(validate.stream().anyMatch(p -> p.getMessageType().equals(DMNMessageType.VARIABLE_NAME_MISMATCH))).isTrue();
     }
 
     @Test
@@ -149,7 +148,7 @@ public class ValidatorDecisionTest extends AbstractValidatorTest {
                                "DECISION_MISSING_VAR"),
                 VALIDATE_MODEL, VALIDATE_COMPILATION);
         assertThat(validate).as(ValidatorUtil.formatMessages(validate)).hasSize(1);
-        assertTrue(validate.stream().anyMatch(p -> p.getMessageType().equals(DMNMessageType.VARIABLE_NAME_MISMATCH)));
+        assertThat(validate.stream().anyMatch(p -> p.getMessageType().equals(DMNMessageType.VARIABLE_NAME_MISMATCH))).isTrue();
     }
 
     @Test
@@ -157,7 +156,7 @@ public class ValidatorDecisionTest extends AbstractValidatorTest {
         try (final Reader reader = getReader("decision/DECISION_MULTIPLE_EXPRESSIONS.dmn")) {
             final List<DMNMessage> validate = validator.validate(reader, VALIDATE_SCHEMA, VALIDATE_MODEL, VALIDATE_COMPILATION);
             assertThat(validate).as(ValidatorUtil.formatMessages(validate)).hasSize(1);
-            assertTrue(validate.stream().anyMatch(p -> p.getMessageType().equals(DMNMessageType.FAILED_XML_VALIDATION)));
+            assertThat(validate.stream().anyMatch(p -> p.getMessageType().equals(DMNMessageType.FAILED_XML_VALIDATION))).isTrue();
         }
     }
 
@@ -166,7 +165,7 @@ public class ValidatorDecisionTest extends AbstractValidatorTest {
         final List<DMNMessage> validate = validator.validate(
                 getFile("decision/DECISION_MULTIPLE_EXPRESSIONS.dmn"), VALIDATE_SCHEMA, VALIDATE_MODEL, VALIDATE_COMPILATION);
         assertThat(validate).as(ValidatorUtil.formatMessages(validate)).hasSize(1);
-        assertTrue(validate.stream().anyMatch(p -> p.getMessageType().equals(DMNMessageType.FAILED_XML_VALIDATION)));
+        assertThat(validate.stream().anyMatch(p -> p.getMessageType().equals(DMNMessageType.FAILED_XML_VALIDATION))).isTrue();
     }
 
     @Test
@@ -184,7 +183,7 @@ public class ValidatorDecisionTest extends AbstractValidatorTest {
         try (final Reader reader = getReader("decision/DECISION_PERF_INDICATOR_WRONG_TYPE.dmn")) {
             final List<DMNMessage> validate = validator.validate(reader, VALIDATE_SCHEMA, VALIDATE_MODEL, VALIDATE_COMPILATION);
             assertThat(validate).as(ValidatorUtil.formatMessages(validate)).hasSize(2);
-            assertTrue(validate.stream().anyMatch(p -> p.getMessageType().equals(DMNMessageType.REQ_NOT_FOUND)));
+            assertThat(validate.stream().anyMatch(p -> p.getMessageType().equals(DMNMessageType.REQ_NOT_FOUND))).isTrue();
         }
     }
 
@@ -193,7 +192,7 @@ public class ValidatorDecisionTest extends AbstractValidatorTest {
         final List<DMNMessage> validate = validator.validate(
                 getFile("decision/DECISION_PERF_INDICATOR_WRONG_TYPE.dmn"), VALIDATE_SCHEMA, VALIDATE_MODEL, VALIDATE_COMPILATION);
         assertThat(validate).as(ValidatorUtil.formatMessages(validate)).hasSize(2);
-        assertTrue(validate.stream().anyMatch(p -> p.getMessageType().equals(DMNMessageType.REQ_NOT_FOUND)));
+        assertThat(validate.stream().anyMatch(p -> p.getMessageType().equals(DMNMessageType.REQ_NOT_FOUND))).isTrue();
     }
 
     @Test
@@ -204,7 +203,7 @@ public class ValidatorDecisionTest extends AbstractValidatorTest {
                                "DECISION_PERF_INDICATOR_WRONG_TYPE"),
                 VALIDATE_MODEL, VALIDATE_COMPILATION);
         assertThat(validate).as(ValidatorUtil.formatMessages(validate)).hasSize(2);
-        assertTrue(validate.stream().anyMatch(p -> p.getMessageType().equals(DMNMessageType.REQ_NOT_FOUND)));
+        assertThat(validate.stream().anyMatch(p -> p.getMessageType().equals(DMNMessageType.REQ_NOT_FOUND))).isTrue();
     }
 
     @Test
@@ -212,7 +211,7 @@ public class ValidatorDecisionTest extends AbstractValidatorTest {
         try (final Reader reader = getReader("decision/DECISION_DECISION_MAKER_WRONG_TYPE.dmn")) {
             final List<DMNMessage> validate = validator.validate(reader, VALIDATE_SCHEMA, VALIDATE_MODEL, VALIDATE_COMPILATION);
             assertThat(validate).as(ValidatorUtil.formatMessages(validate)).hasSize(2);
-            assertTrue(validate.stream().anyMatch(p -> p.getMessageType().equals(DMNMessageType.REQ_NOT_FOUND)));
+            assertThat(validate.stream().anyMatch(p -> p.getMessageType().equals(DMNMessageType.REQ_NOT_FOUND))).isTrue();
         }
     }
 
@@ -221,7 +220,7 @@ public class ValidatorDecisionTest extends AbstractValidatorTest {
         final List<DMNMessage> validate = validator.validate(
                 getFile("decision/DECISION_DECISION_MAKER_WRONG_TYPE.dmn"), VALIDATE_SCHEMA, VALIDATE_MODEL, VALIDATE_COMPILATION);
         assertThat(validate).as(ValidatorUtil.formatMessages(validate)).hasSize(2);
-        assertTrue(validate.stream().anyMatch(p -> p.getMessageType().equals(DMNMessageType.REQ_NOT_FOUND)));
+        assertThat(validate.stream().anyMatch(p -> p.getMessageType().equals(DMNMessageType.REQ_NOT_FOUND))).isTrue();
     }
 
     @Test
@@ -232,7 +231,7 @@ public class ValidatorDecisionTest extends AbstractValidatorTest {
                                "DECISION_DECISION_MAKER_WRONG_TYPE"),
                 VALIDATE_MODEL, VALIDATE_COMPILATION);
         assertThat(validate).as(ValidatorUtil.formatMessages(validate)).hasSize(2);
-        assertTrue(validate.stream().anyMatch(p -> p.getMessageType().equals(DMNMessageType.REQ_NOT_FOUND)));
+        assertThat(validate.stream().anyMatch(p -> p.getMessageType().equals(DMNMessageType.REQ_NOT_FOUND))).isTrue();
     }
 
     @Test
@@ -240,7 +239,7 @@ public class ValidatorDecisionTest extends AbstractValidatorTest {
         try (final Reader reader = getReader("decision/DECISION_DECISION_OWNER_WRONG_TYPE.dmn")) {
             final List<DMNMessage> validate = validator.validate(reader, VALIDATE_SCHEMA, VALIDATE_MODEL, VALIDATE_COMPILATION);
             assertThat(validate).as(ValidatorUtil.formatMessages(validate)).hasSize(2);
-            assertTrue(validate.stream().anyMatch(p -> p.getMessageType().equals(DMNMessageType.REQ_NOT_FOUND)));
+            assertThat(validate.stream().anyMatch(p -> p.getMessageType().equals(DMNMessageType.REQ_NOT_FOUND))).isTrue();
         }
     }
 
@@ -249,7 +248,7 @@ public class ValidatorDecisionTest extends AbstractValidatorTest {
         final List<DMNMessage> validate = validator.validate(
                 getFile("decision/DECISION_DECISION_OWNER_WRONG_TYPE.dmn"), VALIDATE_SCHEMA, VALIDATE_MODEL, VALIDATE_COMPILATION);
         assertThat(validate).as(ValidatorUtil.formatMessages(validate)).hasSize(2);
-        assertTrue(validate.stream().anyMatch(p -> p.getMessageType().equals(DMNMessageType.REQ_NOT_FOUND)));
+        assertThat(validate.stream().anyMatch(p -> p.getMessageType().equals(DMNMessageType.REQ_NOT_FOUND))).isTrue();
     }
 
     @Test
@@ -260,7 +259,7 @@ public class ValidatorDecisionTest extends AbstractValidatorTest {
                                "DECISION_DECISION_MAKER_WRONG_TYPE"),
                 VALIDATE_MODEL, VALIDATE_COMPILATION);
         assertThat(validate).as(ValidatorUtil.formatMessages(validate)).hasSize(2);
-        assertTrue(validate.stream().anyMatch(p -> p.getMessageType().equals(DMNMessageType.REQ_NOT_FOUND)));
+        assertThat(validate.stream().anyMatch(p -> p.getMessageType().equals(DMNMessageType.REQ_NOT_FOUND))).isTrue();
     }
 
     @Test
@@ -268,7 +267,7 @@ public class ValidatorDecisionTest extends AbstractValidatorTest {
         try (final Reader reader = getReader("decision/DECISION_CYCLIC_DEPENDENCY.dmn")) {
             final List<DMNMessage> validate = validator.validate( reader, VALIDATE_SCHEMA, VALIDATE_MODEL, VALIDATE_COMPILATION );
             assertThat(validate).as(ValidatorUtil.formatMessages(validate)).hasSize(2);
-            assertTrue(validate.stream().anyMatch(p -> p.getMessageType().equals(DMNMessageType.REQ_NOT_FOUND)));
+            assertThat(validate.stream().anyMatch(p -> p.getMessageType().equals(DMNMessageType.REQ_NOT_FOUND))).isTrue();
         }
     }
 
@@ -276,7 +275,7 @@ public class ValidatorDecisionTest extends AbstractValidatorTest {
     public void testDECISION_CYCLIC_DEPENDENCY_FileInput() {
         final List<DMNMessage> validate = validator.validate( getFile("decision/DECISION_CYCLIC_DEPENDENCY.dmn"), VALIDATE_SCHEMA, VALIDATE_MODEL, VALIDATE_COMPILATION );
         assertThat(validate).as(ValidatorUtil.formatMessages(validate)).hasSize(2);
-        assertTrue(validate.stream().anyMatch(p -> p.getMessageType().equals(DMNMessageType.REQ_NOT_FOUND)));
+        assertThat(validate.stream().anyMatch(p -> p.getMessageType().equals(DMNMessageType.REQ_NOT_FOUND))).isTrue();
     }
 
     @Test
@@ -287,7 +286,7 @@ public class ValidatorDecisionTest extends AbstractValidatorTest {
                                "DECISION_CYCLIC_DEPENDENCY"),
                 VALIDATE_MODEL, VALIDATE_COMPILATION );
         assertThat(validate).as(ValidatorUtil.formatMessages(validate)).hasSize(2);
-        assertTrue(validate.stream().anyMatch(p -> p.getMessageType().equals(DMNMessageType.REQ_NOT_FOUND)));
+        assertThat(validate.stream().anyMatch(p -> p.getMessageType().equals(DMNMessageType.REQ_NOT_FOUND))).isTrue();
     }
 
     @Test
@@ -295,7 +294,7 @@ public class ValidatorDecisionTest extends AbstractValidatorTest {
         try (final Reader reader = getReader("decision/DECISION_CYCLIC_DEPENDENCY_SELF_REFERENCE.dmn")) {
             final List<DMNMessage> validate = validator.validate( reader, VALIDATE_SCHEMA, VALIDATE_MODEL, VALIDATE_COMPILATION );
             assertThat(validate).as(ValidatorUtil.formatMessages(validate)).hasSize(1);
-            assertTrue(validate.stream().anyMatch(p -> p.getMessageType().equals(DMNMessageType.REQ_NOT_FOUND)));
+            assertThat(validate.stream().anyMatch(p -> p.getMessageType().equals(DMNMessageType.REQ_NOT_FOUND))).isTrue();
         }
     }
 
@@ -303,7 +302,7 @@ public class ValidatorDecisionTest extends AbstractValidatorTest {
     public void testDECISION_CYCLIC_DEPENDENCY_SELF_REFERENCE_FileInput() {
         final List<DMNMessage> validate = validator.validate( getFile("decision/DECISION_CYCLIC_DEPENDENCY_SELF_REFERENCE.dmn"), VALIDATE_SCHEMA, VALIDATE_MODEL, VALIDATE_COMPILATION );
         assertThat(validate).as(ValidatorUtil.formatMessages(validate)).hasSize(1);
-        assertTrue(validate.stream().anyMatch(p -> p.getMessageType().equals(DMNMessageType.REQ_NOT_FOUND)));
+        assertThat(validate.stream().anyMatch(p -> p.getMessageType().equals(DMNMessageType.REQ_NOT_FOUND))).isTrue();
     }
 
     @Test
@@ -314,7 +313,7 @@ public class ValidatorDecisionTest extends AbstractValidatorTest {
                                "DECISION_CYCLIC_DEPENDENCY_SELF_REFERENCE"),
                 VALIDATE_MODEL, VALIDATE_COMPILATION );
         assertThat(validate).as(ValidatorUtil.formatMessages(validate)).hasSize(1);
-        assertTrue(validate.stream().anyMatch(p -> p.getMessageType().equals(DMNMessageType.REQ_NOT_FOUND)));
+        assertThat(validate.stream().anyMatch(p -> p.getMessageType().equals(DMNMessageType.REQ_NOT_FOUND))).isTrue();
     }
 
     @Test

--- a/kie-dmn/kie-dmn-legacy-tests/src/test/java/org/kie/dmn/legacy/tests/validation/v1_1/ValidatorImportTest.java
+++ b/kie-dmn/kie-dmn-legacy-tests/src/test/java/org/kie/dmn/legacy/tests/validation/v1_1/ValidatorImportTest.java
@@ -39,7 +39,6 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.Assert.assertTrue;
 import static org.kie.dmn.core.util.DynamicTypeUtils.entry;
 import static org.kie.dmn.core.util.DynamicTypeUtils.mapOf;
 
@@ -113,10 +112,10 @@ public class ValidatorImportTest extends AbstractValidatorTest {
             final List<DMNMessage> messages = validator.validateUsing(Validation.VALIDATE_MODEL)
                                                        .theseModels(reader0, reader1);
             assertThat(messages).as(ValidatorUtil.formatMessages(messages)).hasSize(1);
-            assertTrue(messages.stream().anyMatch(p -> p.getMessageType().equals(DMNMessageType.REQ_NOT_FOUND) &&
-                                                       p.getSourceReference() instanceof DMNElementReference &&
-                                                       ((DMNElementReference) p.getSourceReference()).getHref()
-                                                                                                     .equals("http://www.trisotech.com/definitions/_70df1ad5-2a33-4ede-b8b2-869988ac1d30#_1d52934e-aa4e-47c9-a011-fc989d795664")));
+            assertThat(messages.stream().anyMatch(p -> p.getMessageType().equals(DMNMessageType.REQ_NOT_FOUND) &&
+                    p.getSourceReference() instanceof DMNElementReference &&
+                    ((DMNElementReference) p.getSourceReference()).getHref()
+                            .equals("http://www.trisotech.com/definitions/_70df1ad5-2a33-4ede-b8b2-869988ac1d30#_1d52934e-aa4e-47c9-a011-fc989d795664"))).isTrue();
         }
     }
     
@@ -126,10 +125,10 @@ public class ValidatorImportTest extends AbstractValidatorTest {
                                                    .theseModels(getFile("import/Base-model.dmn"),
                                                                 getFile("import/Wrong-Import-base-model.dmn"));
         assertThat(messages).as(ValidatorUtil.formatMessages(messages)).hasSize(1);
-        assertTrue(messages.stream().anyMatch(p -> p.getMessageType().equals(DMNMessageType.REQ_NOT_FOUND) &&
-                                                   p.getSourceReference() instanceof DMNElementReference &&
-                                                   ((DMNElementReference) p.getSourceReference()).getHref()
-                                                                                                 .equals("http://www.trisotech.com/definitions/_70df1ad5-2a33-4ede-b8b2-869988ac1d30#_1d52934e-aa4e-47c9-a011-fc989d795664")));
+        assertThat(messages.stream().anyMatch(p -> p.getMessageType().equals(DMNMessageType.REQ_NOT_FOUND) &&
+                p.getSourceReference() instanceof DMNElementReference &&
+                ((DMNElementReference) p.getSourceReference()).getHref()
+                        .equals("http://www.trisotech.com/definitions/_70df1ad5-2a33-4ede-b8b2-869988ac1d30#_1d52934e-aa4e-47c9-a011-fc989d795664"))).isTrue();
     }
 
     @Test
@@ -141,24 +140,24 @@ public class ValidatorImportTest extends AbstractValidatorTest {
                                                                 getDefinitions(Arrays.asList("import/Base-model.dmn", "import/Wrong-Import-base-model.dmn"),
                                                                                "http://www.trisotech.com/dmn/definitions/_719a2325-5cac-47ea-8a99-665c01d570a5",
                                                                                "Wrong Import base model"));
-        assertTrue(messages.stream().anyMatch(p -> p.getMessageType().equals(DMNMessageType.REQ_NOT_FOUND) &&
-                                                   p.getSourceReference() instanceof DMNElementReference &&
-                                                   ((DMNElementReference) p.getSourceReference()).getHref()
-                                                                                                 .equals("http://www.trisotech.com/definitions/_70df1ad5-2a33-4ede-b8b2-869988ac1d30#_1d52934e-aa4e-47c9-a011-fc989d795664")));
+        assertThat(messages.stream().anyMatch(p -> p.getMessageType().equals(DMNMessageType.REQ_NOT_FOUND) &&
+                p.getSourceReference() instanceof DMNElementReference &&
+                ((DMNElementReference) p.getSourceReference()).getHref()
+                        .equals("http://www.trisotech.com/definitions/_70df1ad5-2a33-4ede-b8b2-869988ac1d30#_1d52934e-aa4e-47c9-a011-fc989d795664"))).isTrue();
     }
 
     @Test
     public void testOnlyImportBaseModelFromReaderInput() throws IOException {
         try (final Reader reader1 = getReader("import/Only-Import-base-model.dmn");) {
             final List<DMNMessage> messages = validator.validate(reader1, Validation.VALIDATE_MODEL);
-            assertTrue(messages.stream().anyMatch(p -> p.getMessageType().equals(DMNMessageType.IMPORT_NOT_FOUND)));
+            assertThat(messages.stream().anyMatch(p -> p.getMessageType().equals(DMNMessageType.IMPORT_NOT_FOUND))).isTrue();
         }
     }
 
     @Test
     public void testOnlyImportBaseModelFromFileInput() throws IOException {
         final List<DMNMessage> messages = validator.validate(getFile("import/Only-Import-base-model.dmn"), Validation.VALIDATE_MODEL);
-        assertTrue(messages.stream().anyMatch(p -> p.getMessageType().equals(DMNMessageType.IMPORT_NOT_FOUND)));
+        assertThat(messages.stream().anyMatch(p -> p.getMessageType().equals(DMNMessageType.IMPORT_NOT_FOUND))).isTrue();
     }
 
     @Test
@@ -167,6 +166,6 @@ public class ValidatorImportTest extends AbstractValidatorTest {
                                                                             "http://www.trisotech.com/dmn/definitions/_a9bfa4de-cf5c-4b2f-9011-ab576e00b162",
                                                                             "Only Import base model"),
                                                              Validation.VALIDATE_MODEL);
-        assertTrue(messages.stream().anyMatch(p -> p.getMessageType().equals(DMNMessageType.IMPORT_NOT_FOUND)));
+        assertThat(messages.stream().anyMatch(p -> p.getMessageType().equals(DMNMessageType.IMPORT_NOT_FOUND))).isTrue();
     }
 }

--- a/kie-dmn/kie-dmn-legacy-tests/src/test/java/org/kie/dmn/legacy/tests/validation/v1_1/ValidatorInformationRequirementTest.java
+++ b/kie-dmn/kie-dmn-legacy-tests/src/test/java/org/kie/dmn/legacy/tests/validation/v1_1/ValidatorInformationRequirementTest.java
@@ -27,7 +27,6 @@ import org.kie.dmn.validation.AbstractValidatorTest;
 import org.kie.dmn.validation.ValidatorUtil;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.Assert.assertTrue;
 import static org.kie.dmn.validation.DMNValidator.Validation.VALIDATE_COMPILATION;
 import static org.kie.dmn.validation.DMNValidator.Validation.VALIDATE_MODEL;
 import static org.kie.dmn.validation.DMNValidator.Validation.VALIDATE_SCHEMA;
@@ -41,8 +40,8 @@ public class ValidatorInformationRequirementTest extends AbstractValidatorTest {
                     reader,
                     VALIDATE_SCHEMA, VALIDATE_MODEL, VALIDATE_COMPILATION);
             assertThat(validate).as(ValidatorUtil.formatMessages(validate)).hasSize(2);
-            assertTrue( validate.stream().anyMatch( p -> p.getMessageType().equals( DMNMessageType.MISSING_EXPRESSION ) ) );
-            assertTrue( validate.stream().anyMatch( p -> p.getMessageType().equals( DMNMessageType.REQ_NOT_FOUND ) ) );
+            assertThat(validate.stream().anyMatch(p -> p.getMessageType().equals(DMNMessageType.MISSING_EXPRESSION))).isTrue();
+            assertThat(validate.stream().anyMatch(p -> p.getMessageType().equals(DMNMessageType.REQ_NOT_FOUND))).isTrue();
         }
     }
 
@@ -52,8 +51,8 @@ public class ValidatorInformationRequirementTest extends AbstractValidatorTest {
                 getFile( "informationrequirement/INFOREQ_MISSING_INPUT.dmn" ),
                 VALIDATE_SCHEMA, VALIDATE_MODEL, VALIDATE_COMPILATION);
         assertThat(validate).as(ValidatorUtil.formatMessages(validate)).hasSize(2);
-        assertTrue( validate.stream().anyMatch( p -> p.getMessageType().equals( DMNMessageType.MISSING_EXPRESSION ) ) );
-        assertTrue( validate.stream().anyMatch( p -> p.getMessageType().equals( DMNMessageType.REQ_NOT_FOUND ) ) );
+        assertThat(validate.stream().anyMatch(p -> p.getMessageType().equals(DMNMessageType.MISSING_EXPRESSION))).isTrue();
+        assertThat(validate.stream().anyMatch(p -> p.getMessageType().equals(DMNMessageType.REQ_NOT_FOUND))).isTrue();
     }
 
     @Test
@@ -64,8 +63,8 @@ public class ValidatorInformationRequirementTest extends AbstractValidatorTest {
                                 "INFOREQ_MISSING_INPUT"),
                 VALIDATE_MODEL, VALIDATE_COMPILATION);
         assertThat(validate).as(ValidatorUtil.formatMessages(validate)).hasSize(2);
-        assertTrue( validate.stream().anyMatch( p -> p.getMessageType().equals( DMNMessageType.MISSING_EXPRESSION ) ) );
-        assertTrue( validate.stream().anyMatch( p -> p.getMessageType().equals( DMNMessageType.REQ_NOT_FOUND ) ) );
+        assertThat(validate.stream().anyMatch(p -> p.getMessageType().equals(DMNMessageType.MISSING_EXPRESSION))).isTrue();
+        assertThat(validate.stream().anyMatch(p -> p.getMessageType().equals(DMNMessageType.REQ_NOT_FOUND))).isTrue();
     }
 
     @Test
@@ -75,8 +74,8 @@ public class ValidatorInformationRequirementTest extends AbstractValidatorTest {
                     reader,
                     VALIDATE_SCHEMA, VALIDATE_MODEL, VALIDATE_COMPILATION);
             assertThat(validate).as(ValidatorUtil.formatMessages(validate)).hasSize(2);
-            assertTrue( validate.stream().anyMatch( p -> p.getMessageType().equals( DMNMessageType.MISSING_EXPRESSION ) ) );
-            assertTrue( validate.stream().anyMatch( p -> p.getMessageType().equals( DMNMessageType.REQ_NOT_FOUND ) ) );
+            assertThat(validate.stream().anyMatch(p -> p.getMessageType().equals(DMNMessageType.MISSING_EXPRESSION))).isTrue();
+            assertThat(validate.stream().anyMatch(p -> p.getMessageType().equals(DMNMessageType.REQ_NOT_FOUND))).isTrue();
         }
     }
 
@@ -86,8 +85,8 @@ public class ValidatorInformationRequirementTest extends AbstractValidatorTest {
                 getFile( "informationrequirement/INFOREQ_INPUT_NOT_INPUTDATA.dmn" ),
                 VALIDATE_SCHEMA, VALIDATE_MODEL, VALIDATE_COMPILATION);
         assertThat(validate).as(ValidatorUtil.formatMessages(validate)).hasSize(2);
-        assertTrue( validate.stream().anyMatch( p -> p.getMessageType().equals( DMNMessageType.MISSING_EXPRESSION ) ) );
-        assertTrue( validate.stream().anyMatch( p -> p.getMessageType().equals( DMNMessageType.REQ_NOT_FOUND ) ) );
+        assertThat(validate.stream().anyMatch(p -> p.getMessageType().equals(DMNMessageType.MISSING_EXPRESSION))).isTrue();
+        assertThat(validate.stream().anyMatch(p -> p.getMessageType().equals(DMNMessageType.REQ_NOT_FOUND))).isTrue();
     }
 
     @Test
@@ -98,8 +97,8 @@ public class ValidatorInformationRequirementTest extends AbstractValidatorTest {
                                 "INFOREQ_INPUT_NOT_INPUTDATA"),
                 VALIDATE_MODEL, VALIDATE_COMPILATION);
         assertThat(validate).as(ValidatorUtil.formatMessages(validate)).hasSize(2);
-        assertTrue( validate.stream().anyMatch( p -> p.getMessageType().equals( DMNMessageType.MISSING_EXPRESSION ) ) );
-        assertTrue( validate.stream().anyMatch( p -> p.getMessageType().equals( DMNMessageType.REQ_NOT_FOUND ) ) );
+        assertThat(validate.stream().anyMatch(p -> p.getMessageType().equals(DMNMessageType.MISSING_EXPRESSION))).isTrue();
+        assertThat(validate.stream().anyMatch(p -> p.getMessageType().equals(DMNMessageType.REQ_NOT_FOUND))).isTrue();
     }
 
     @Test
@@ -109,8 +108,8 @@ public class ValidatorInformationRequirementTest extends AbstractValidatorTest {
                     reader,
                     VALIDATE_SCHEMA, VALIDATE_MODEL, VALIDATE_COMPILATION);
             assertThat(validate).as(ValidatorUtil.formatMessages(validate)).hasSize(2);
-            assertTrue( validate.stream().anyMatch( p -> p.getMessageType().equals( DMNMessageType.MISSING_EXPRESSION ) ) );
-            assertTrue( validate.stream().anyMatch( p -> p.getMessageType().equals( DMNMessageType.REQ_NOT_FOUND ) ) );
+            assertThat(validate.stream().anyMatch(p -> p.getMessageType().equals(DMNMessageType.MISSING_EXPRESSION))).isTrue();
+            assertThat(validate.stream().anyMatch(p -> p.getMessageType().equals(DMNMessageType.REQ_NOT_FOUND))).isTrue();
         }
     }
 
@@ -120,8 +119,8 @@ public class ValidatorInformationRequirementTest extends AbstractValidatorTest {
                 getFile( "informationrequirement/INFOREQ_MISSING_DECISION.dmn" ),
                 VALIDATE_SCHEMA, VALIDATE_MODEL, VALIDATE_COMPILATION);
         assertThat(validate).as(ValidatorUtil.formatMessages(validate)).hasSize(2);
-        assertTrue( validate.stream().anyMatch( p -> p.getMessageType().equals( DMNMessageType.MISSING_EXPRESSION ) ) );
-        assertTrue( validate.stream().anyMatch( p -> p.getMessageType().equals( DMNMessageType.REQ_NOT_FOUND ) ) );
+        assertThat(validate.stream().anyMatch(p -> p.getMessageType().equals(DMNMessageType.MISSING_EXPRESSION))).isTrue();
+        assertThat(validate.stream().anyMatch(p -> p.getMessageType().equals(DMNMessageType.REQ_NOT_FOUND))).isTrue();
     }
 
     @Test
@@ -132,8 +131,8 @@ public class ValidatorInformationRequirementTest extends AbstractValidatorTest {
                                 "INFOREQ_MISSING_DECISION"),
                 VALIDATE_MODEL, VALIDATE_COMPILATION);
         assertThat(validate).as(ValidatorUtil.formatMessages(validate)).hasSize(2);
-        assertTrue( validate.stream().anyMatch( p -> p.getMessageType().equals( DMNMessageType.MISSING_EXPRESSION ) ) );
-        assertTrue( validate.stream().anyMatch( p -> p.getMessageType().equals( DMNMessageType.REQ_NOT_FOUND ) ) );
+        assertThat(validate.stream().anyMatch(p -> p.getMessageType().equals(DMNMessageType.MISSING_EXPRESSION))).isTrue();
+        assertThat(validate.stream().anyMatch(p -> p.getMessageType().equals(DMNMessageType.REQ_NOT_FOUND))).isTrue();
     }
 
     @Test
@@ -143,8 +142,8 @@ public class ValidatorInformationRequirementTest extends AbstractValidatorTest {
                     reader,
                     VALIDATE_SCHEMA, VALIDATE_MODEL, VALIDATE_COMPILATION);
             assertThat(validate).as(ValidatorUtil.formatMessages(validate)).hasSize(2);
-            assertTrue( validate.stream().anyMatch( p -> p.getMessageType().equals( DMNMessageType.MISSING_EXPRESSION ) ) );
-            assertTrue( validate.stream().anyMatch( p -> p.getMessageType().equals( DMNMessageType.REQ_NOT_FOUND ) ) );
+            assertThat(validate.stream().anyMatch(p -> p.getMessageType().equals(DMNMessageType.MISSING_EXPRESSION))).isTrue();
+            assertThat(validate.stream().anyMatch(p -> p.getMessageType().equals(DMNMessageType.REQ_NOT_FOUND))).isTrue();
         }
     }
 
@@ -154,8 +153,8 @@ public class ValidatorInformationRequirementTest extends AbstractValidatorTest {
                 getFile( "informationrequirement/INFOREQ_DECISION_NOT_DECISION.dmn" ),
                 VALIDATE_SCHEMA, VALIDATE_MODEL, VALIDATE_COMPILATION);
         assertThat(validate).as(ValidatorUtil.formatMessages(validate)).hasSize(2);
-        assertTrue( validate.stream().anyMatch( p -> p.getMessageType().equals( DMNMessageType.MISSING_EXPRESSION ) ) );
-        assertTrue( validate.stream().anyMatch( p -> p.getMessageType().equals( DMNMessageType.REQ_NOT_FOUND ) ) );
+        assertThat(validate.stream().anyMatch(p -> p.getMessageType().equals(DMNMessageType.MISSING_EXPRESSION))).isTrue();
+        assertThat(validate.stream().anyMatch(p -> p.getMessageType().equals(DMNMessageType.REQ_NOT_FOUND))).isTrue();
     }
 
     @Test
@@ -166,7 +165,7 @@ public class ValidatorInformationRequirementTest extends AbstractValidatorTest {
                                 "INFOREQ_DECISION_NOT_DECISION"),
                 VALIDATE_MODEL, VALIDATE_COMPILATION);
         assertThat(validate).as(ValidatorUtil.formatMessages(validate)).hasSize(2);
-        assertTrue( validate.stream().anyMatch( p -> p.getMessageType().equals( DMNMessageType.MISSING_EXPRESSION ) ) );
-        assertTrue( validate.stream().anyMatch( p -> p.getMessageType().equals( DMNMessageType.REQ_NOT_FOUND ) ) );
+        assertThat(validate.stream().anyMatch(p -> p.getMessageType().equals(DMNMessageType.MISSING_EXPRESSION))).isTrue();
+        assertThat(validate.stream().anyMatch(p -> p.getMessageType().equals(DMNMessageType.REQ_NOT_FOUND))).isTrue();
     }
 }

--- a/kie-dmn/kie-dmn-legacy-tests/src/test/java/org/kie/dmn/legacy/tests/validation/v1_1/ValidatorInputDataTest.java
+++ b/kie-dmn/kie-dmn-legacy-tests/src/test/java/org/kie/dmn/legacy/tests/validation/v1_1/ValidatorInputDataTest.java
@@ -27,7 +27,6 @@ import org.kie.dmn.validation.AbstractValidatorTest;
 import org.kie.dmn.validation.ValidatorUtil;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.Assert.assertTrue;
 import static org.kie.dmn.validation.DMNValidator.Validation.VALIDATE_COMPILATION;
 import static org.kie.dmn.validation.DMNValidator.Validation.VALIDATE_MODEL;
 import static org.kie.dmn.validation.DMNValidator.Validation.VALIDATE_SCHEMA;
@@ -41,7 +40,7 @@ public class ValidatorInputDataTest extends AbstractValidatorTest {
                     reader,
                     VALIDATE_SCHEMA, VALIDATE_MODEL, VALIDATE_COMPILATION);
             assertThat(validate).as(ValidatorUtil.formatMessages(validate)).hasSize(1);
-            assertTrue(validate.stream().anyMatch(p -> p.getMessageType().equals(DMNMessageType.MISSING_VARIABLE)));
+            assertThat(validate.stream().anyMatch(p -> p.getMessageType().equals(DMNMessageType.MISSING_VARIABLE))).isTrue();
         }
     }
 
@@ -51,7 +50,7 @@ public class ValidatorInputDataTest extends AbstractValidatorTest {
                 getFile("inputdata/INPUTDATA_MISSING_VAR.dmn"),
                 VALIDATE_SCHEMA, VALIDATE_MODEL, VALIDATE_COMPILATION);
         assertThat(validate).as(ValidatorUtil.formatMessages(validate)).hasSize(1);
-        assertTrue(validate.stream().anyMatch(p -> p.getMessageType().equals(DMNMessageType.MISSING_VARIABLE)));
+        assertThat(validate.stream().anyMatch(p -> p.getMessageType().equals(DMNMessageType.MISSING_VARIABLE))).isTrue();
     }
 
     @Test
@@ -62,7 +61,7 @@ public class ValidatorInputDataTest extends AbstractValidatorTest {
                                "INPUTDATA_MISSING_VAR"),
                 VALIDATE_MODEL, VALIDATE_COMPILATION);
         assertThat(validate).as(ValidatorUtil.formatMessages(validate)).hasSize(1);
-        assertTrue(validate.stream().anyMatch(p -> p.getMessageType().equals(DMNMessageType.MISSING_VARIABLE)));
+        assertThat(validate.stream().anyMatch(p -> p.getMessageType().equals(DMNMessageType.MISSING_VARIABLE))).isTrue();
     }
 
     @Test
@@ -72,7 +71,7 @@ public class ValidatorInputDataTest extends AbstractValidatorTest {
                     reader,
                     VALIDATE_SCHEMA, VALIDATE_MODEL, VALIDATE_COMPILATION);
             assertThat(validate).as(ValidatorUtil.formatMessages(validate)).hasSize(1);
-            assertTrue(validate.stream().anyMatch(p -> p.getMessageType().equals(DMNMessageType.VARIABLE_NAME_MISMATCH)));
+            assertThat(validate.stream().anyMatch(p -> p.getMessageType().equals(DMNMessageType.VARIABLE_NAME_MISMATCH))).isTrue();
         }
     }
 
@@ -82,7 +81,7 @@ public class ValidatorInputDataTest extends AbstractValidatorTest {
                 getFile("inputdata/INPUTDATA_MISMATCH_VAR.dmn"),
                 VALIDATE_SCHEMA, VALIDATE_MODEL, VALIDATE_COMPILATION);
         assertThat(validate).as(ValidatorUtil.formatMessages(validate)).hasSize(1);
-        assertTrue(validate.stream().anyMatch(p -> p.getMessageType().equals(DMNMessageType.VARIABLE_NAME_MISMATCH)));
+        assertThat(validate.stream().anyMatch(p -> p.getMessageType().equals(DMNMessageType.VARIABLE_NAME_MISMATCH))).isTrue();
     }
 
     @Test
@@ -93,6 +92,6 @@ public class ValidatorInputDataTest extends AbstractValidatorTest {
                                "INPUTDATA_MISSING_VAR"),
                 VALIDATE_MODEL, VALIDATE_COMPILATION);
         assertThat(validate).as(ValidatorUtil.formatMessages(validate)).hasSize(1);
-        assertTrue(validate.stream().anyMatch(p -> p.getMessageType().equals(DMNMessageType.VARIABLE_NAME_MISMATCH)));
+        assertThat(validate.stream().anyMatch(p -> p.getMessageType().equals(DMNMessageType.VARIABLE_NAME_MISMATCH))).isTrue();
     }
 }

--- a/kie-dmn/kie-dmn-legacy-tests/src/test/java/org/kie/dmn/legacy/tests/validation/v1_1/ValidatorKnowledgeRequirementTest.java
+++ b/kie-dmn/kie-dmn-legacy-tests/src/test/java/org/kie/dmn/legacy/tests/validation/v1_1/ValidatorKnowledgeRequirementTest.java
@@ -27,7 +27,6 @@ import org.kie.dmn.validation.AbstractValidatorTest;
 import org.kie.dmn.validation.ValidatorUtil;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.Assert.assertTrue;
 import static org.kie.dmn.validation.DMNValidator.Validation.VALIDATE_COMPILATION;
 import static org.kie.dmn.validation.DMNValidator.Validation.VALIDATE_MODEL;
 import static org.kie.dmn.validation.DMNValidator.Validation.VALIDATE_SCHEMA;
@@ -41,8 +40,8 @@ public class ValidatorKnowledgeRequirementTest extends AbstractValidatorTest {
                     reader,
                     VALIDATE_SCHEMA, VALIDATE_MODEL, VALIDATE_COMPILATION);
             assertThat(validate).as(ValidatorUtil.formatMessages(validate)).hasSize(2);
-            assertTrue( validate.stream().anyMatch( p -> p.getMessageType().equals( DMNMessageType.MISSING_EXPRESSION ) ) );
-            assertTrue( validate.stream().anyMatch( p -> p.getMessageType().equals( DMNMessageType.REQ_NOT_FOUND ) ) );
+            assertThat(validate.stream().anyMatch(p -> p.getMessageType().equals(DMNMessageType.MISSING_EXPRESSION))).isTrue();
+            assertThat(validate.stream().anyMatch(p -> p.getMessageType().equals(DMNMessageType.REQ_NOT_FOUND))).isTrue();
         }
     }
 
@@ -52,8 +51,8 @@ public class ValidatorKnowledgeRequirementTest extends AbstractValidatorTest {
                 getFile( "knowledgerequirement/KNOWREQ_MISSING_BKM.dmn" ),
                 VALIDATE_SCHEMA, VALIDATE_MODEL, VALIDATE_COMPILATION);
         assertThat(validate).as(ValidatorUtil.formatMessages(validate)).hasSize(2);
-        assertTrue( validate.stream().anyMatch( p -> p.getMessageType().equals( DMNMessageType.MISSING_EXPRESSION ) ) );
-        assertTrue( validate.stream().anyMatch( p -> p.getMessageType().equals( DMNMessageType.REQ_NOT_FOUND ) ) );
+        assertThat(validate.stream().anyMatch(p -> p.getMessageType().equals(DMNMessageType.MISSING_EXPRESSION))).isTrue();
+        assertThat(validate.stream().anyMatch(p -> p.getMessageType().equals(DMNMessageType.REQ_NOT_FOUND))).isTrue();
     }
 
     @Test
@@ -64,8 +63,8 @@ public class ValidatorKnowledgeRequirementTest extends AbstractValidatorTest {
                                 "KNOWREQ_MISSING_BKM"),
                 VALIDATE_MODEL, VALIDATE_COMPILATION);
         assertThat(validate).as(ValidatorUtil.formatMessages(validate)).hasSize(2);
-        assertTrue( validate.stream().anyMatch( p -> p.getMessageType().equals( DMNMessageType.MISSING_EXPRESSION ) ) );
-        assertTrue( validate.stream().anyMatch( p -> p.getMessageType().equals( DMNMessageType.REQ_NOT_FOUND ) ) );
+        assertThat(validate.stream().anyMatch(p -> p.getMessageType().equals(DMNMessageType.MISSING_EXPRESSION))).isTrue();
+        assertThat(validate.stream().anyMatch(p -> p.getMessageType().equals(DMNMessageType.REQ_NOT_FOUND))).isTrue();
     }
 
     @Test
@@ -75,8 +74,8 @@ public class ValidatorKnowledgeRequirementTest extends AbstractValidatorTest {
                     reader,
                     VALIDATE_SCHEMA, VALIDATE_MODEL, VALIDATE_COMPILATION);
             assertThat(validate).as(ValidatorUtil.formatMessages(validate)).hasSize(2);
-            assertTrue( validate.stream().anyMatch( p -> p.getMessageType().equals( DMNMessageType.MISSING_EXPRESSION ) ) );
-            assertTrue( validate.stream().anyMatch( p -> p.getMessageType().equals( DMNMessageType.REQ_NOT_FOUND ) ) );
+            assertThat(validate.stream().anyMatch(p -> p.getMessageType().equals(DMNMessageType.MISSING_EXPRESSION))).isTrue();
+            assertThat(validate.stream().anyMatch(p -> p.getMessageType().equals(DMNMessageType.REQ_NOT_FOUND))).isTrue();
         }
     }
 
@@ -86,8 +85,8 @@ public class ValidatorKnowledgeRequirementTest extends AbstractValidatorTest {
                 getFile( "knowledgerequirement/KNOWREQ_REQ_DECISION_NOT_BKM.dmn" ),
                 VALIDATE_SCHEMA, VALIDATE_MODEL, VALIDATE_COMPILATION);
         assertThat(validate).as(ValidatorUtil.formatMessages(validate)).hasSize(2);
-        assertTrue( validate.stream().anyMatch( p -> p.getMessageType().equals( DMNMessageType.MISSING_EXPRESSION ) ) );
-        assertTrue( validate.stream().anyMatch( p -> p.getMessageType().equals( DMNMessageType.REQ_NOT_FOUND ) ) );
+        assertThat(validate.stream().anyMatch(p -> p.getMessageType().equals(DMNMessageType.MISSING_EXPRESSION))).isTrue();
+        assertThat(validate.stream().anyMatch(p -> p.getMessageType().equals(DMNMessageType.REQ_NOT_FOUND))).isTrue();
     }
 
     @Test
@@ -98,7 +97,7 @@ public class ValidatorKnowledgeRequirementTest extends AbstractValidatorTest {
                                 "KNOWREQ_REQ_DECISION_NOT_BKM"),
                 VALIDATE_MODEL, VALIDATE_COMPILATION);
         assertThat(validate).as(ValidatorUtil.formatMessages(validate)).hasSize(2);
-        assertTrue( validate.stream().anyMatch( p -> p.getMessageType().equals( DMNMessageType.MISSING_EXPRESSION ) ) );
-        assertTrue( validate.stream().anyMatch( p -> p.getMessageType().equals( DMNMessageType.REQ_NOT_FOUND ) ) );
+        assertThat(validate.stream().anyMatch(p -> p.getMessageType().equals(DMNMessageType.MISSING_EXPRESSION))).isTrue();
+        assertThat(validate.stream().anyMatch(p -> p.getMessageType().equals(DMNMessageType.REQ_NOT_FOUND))).isTrue();
     }
 }

--- a/kie-dmn/kie-dmn-legacy-tests/src/test/java/org/kie/dmn/legacy/tests/validation/v1_1/ValidatorKnowledgeSourceTest.java
+++ b/kie-dmn/kie-dmn-legacy-tests/src/test/java/org/kie/dmn/legacy/tests/validation/v1_1/ValidatorKnowledgeSourceTest.java
@@ -27,7 +27,6 @@ import org.kie.dmn.validation.AbstractValidatorTest;
 import org.kie.dmn.validation.ValidatorUtil;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.Assert.assertTrue;
 import static org.kie.dmn.validation.DMNValidator.Validation.VALIDATE_COMPILATION;
 import static org.kie.dmn.validation.DMNValidator.Validation.VALIDATE_MODEL;
 import static org.kie.dmn.validation.DMNValidator.Validation.VALIDATE_SCHEMA;
@@ -41,7 +40,7 @@ public class ValidatorKnowledgeSourceTest extends AbstractValidatorTest {
                     reader,
                     VALIDATE_SCHEMA, VALIDATE_MODEL, VALIDATE_COMPILATION);
             assertThat(validate).as(ValidatorUtil.formatMessages(validate)).hasSize(1);
-            assertTrue( validate.stream().anyMatch( p -> p.getMessageType().equals( DMNMessageType.REQ_NOT_FOUND ) ) );
+            assertThat(validate.stream().anyMatch(p -> p.getMessageType().equals(DMNMessageType.REQ_NOT_FOUND))).isTrue();
         }
     }
 
@@ -51,7 +50,7 @@ public class ValidatorKnowledgeSourceTest extends AbstractValidatorTest {
                 getFile( "knowledgesource/KNOW_SOURCE_MISSING_OWNER.dmn" ),
                 VALIDATE_SCHEMA, VALIDATE_MODEL, VALIDATE_COMPILATION);
         assertThat(validate).as(ValidatorUtil.formatMessages(validate)).hasSize(1);
-        assertTrue( validate.stream().anyMatch( p -> p.getMessageType().equals( DMNMessageType.REQ_NOT_FOUND ) ) );
+        assertThat(validate.stream().anyMatch(p -> p.getMessageType().equals(DMNMessageType.REQ_NOT_FOUND))).isTrue();
     }
 
     @Test
@@ -62,7 +61,7 @@ public class ValidatorKnowledgeSourceTest extends AbstractValidatorTest {
                                 "KNOW_SOURCE_MISSING_OWNER"),
                 VALIDATE_MODEL, VALIDATE_COMPILATION);
         assertThat(validate).as(ValidatorUtil.formatMessages(validate)).hasSize(1);
-        assertTrue( validate.stream().anyMatch( p -> p.getMessageType().equals( DMNMessageType.REQ_NOT_FOUND ) ) );
+        assertThat(validate.stream().anyMatch(p -> p.getMessageType().equals(DMNMessageType.REQ_NOT_FOUND))).isTrue();
     }
 
     @Test
@@ -72,7 +71,7 @@ public class ValidatorKnowledgeSourceTest extends AbstractValidatorTest {
                     reader,
                     VALIDATE_SCHEMA, VALIDATE_MODEL, VALIDATE_COMPILATION);
             assertThat(validate).as(ValidatorUtil.formatMessages(validate)).hasSize(3);
-            assertTrue( validate.stream().anyMatch( p -> p.getMessageType().equals( DMNMessageType.REQ_NOT_FOUND ) ) );
+            assertThat(validate.stream().anyMatch(p -> p.getMessageType().equals(DMNMessageType.REQ_NOT_FOUND))).isTrue();
         }
     }
 
@@ -82,7 +81,7 @@ public class ValidatorKnowledgeSourceTest extends AbstractValidatorTest {
                 getFile( "knowledgesource/KNOW_SOURCE_OWNER_NOT_ORG_UNIT.dmn" ),
                 VALIDATE_SCHEMA, VALIDATE_MODEL, VALIDATE_COMPILATION);
         assertThat(validate).as(ValidatorUtil.formatMessages(validate)).hasSize(3);
-        assertTrue( validate.stream().anyMatch( p -> p.getMessageType().equals( DMNMessageType.REQ_NOT_FOUND ) ) );
+        assertThat(validate.stream().anyMatch(p -> p.getMessageType().equals(DMNMessageType.REQ_NOT_FOUND))).isTrue();
     }
 
     @Test
@@ -93,6 +92,6 @@ public class ValidatorKnowledgeSourceTest extends AbstractValidatorTest {
                                 "KNOW_SOURCE_OWNER_NOT_ORG_UNIT"),
                 VALIDATE_MODEL, VALIDATE_COMPILATION);
         assertThat(validate).as(ValidatorUtil.formatMessages(validate)).hasSize(3);
-        assertTrue( validate.stream().anyMatch( p -> p.getMessageType().equals( DMNMessageType.REQ_NOT_FOUND ) ) );
+        assertThat(validate.stream().anyMatch(p -> p.getMessageType().equals(DMNMessageType.REQ_NOT_FOUND))).isTrue();
     }
 }

--- a/kie-dmn/kie-dmn-legacy-tests/src/test/java/org/kie/dmn/legacy/tests/validation/v1_1/ValidatorTest.java
+++ b/kie-dmn/kie-dmn-legacy-tests/src/test/java/org/kie/dmn/legacy/tests/validation/v1_1/ValidatorTest.java
@@ -40,8 +40,7 @@ import org.kie.dmn.validation.DMNValidatorFactory;
 import org.kie.dmn.validation.ValidatorUtil;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
+import static org.assertj.core.api.Assertions.fail;
 import static org.kie.dmn.validation.DMNValidator.Validation.VALIDATE_COMPILATION;
 import static org.kie.dmn.validation.DMNValidator.Validation.VALIDATE_MODEL;
 import static org.kie.dmn.validation.DMNValidator.Validation.VALIDATE_SCHEMA;
@@ -129,31 +128,31 @@ public class ValidatorTest extends AbstractValidatorTest {
     public void testNAME_INVALID_empty_name() {
         List<DMNMessage> validate = validator.validate( getReader( "DROOLS-1447.dmn" ), VALIDATE_SCHEMA, VALIDATE_MODEL, VALIDATE_COMPILATION);
         assertThat(validate).as(ValidatorUtil.formatMessages(validate)).hasSize(4);
-        assertTrue( validate.stream().anyMatch( p -> p.getMessageType().equals( DMNMessageType.FAILED_XML_VALIDATION ) ) );
-        assertTrue( validate.stream().anyMatch( p -> p.getMessageType().equals( DMNMessageType.VARIABLE_NAME_MISMATCH ) ) );
-        assertTrue( validate.stream().anyMatch( p -> p.getMessageType().equals( DMNMessageType.INVALID_NAME ) && p.getSourceId().equals( "_5e43b55c-888e-443c-b1b9-80e4aa6746bd" ) ) );
-        assertTrue( validate.stream().anyMatch( p -> p.getMessageType().equals( DMNMessageType.INVALID_NAME ) && p.getSourceId().equals( "_b1e4588e-9ce1-4474-8e4e-48dbcdb7524b" ) ) );
+        assertThat(validate.stream().anyMatch(p -> p.getMessageType().equals(DMNMessageType.FAILED_XML_VALIDATION))).isTrue();
+        assertThat(validate.stream().anyMatch(p -> p.getMessageType().equals(DMNMessageType.VARIABLE_NAME_MISMATCH))).isTrue();
+        assertThat(validate.stream().anyMatch(p -> p.getMessageType().equals(DMNMessageType.INVALID_NAME) && p.getSourceId().equals("_5e43b55c-888e-443c-b1b9-80e4aa6746bd"))).isTrue();
+        assertThat(validate.stream().anyMatch(p -> p.getMessageType().equals(DMNMessageType.INVALID_NAME) && p.getSourceId().equals("_b1e4588e-9ce1-4474-8e4e-48dbcdb7524b"))).isTrue();
     }
     
     @Test
     public void testDRGELEM_NOT_UNIQUE() {
         List<DMNMessage> validate = validator.validate( getReader( "DRGELEM_NOT_UNIQUE.dmn" ), VALIDATE_SCHEMA, VALIDATE_MODEL, VALIDATE_COMPILATION);
         assertThat(validate).as(ValidatorUtil.formatMessages(validate)).hasSize(2);
-        assertTrue( validate.stream().anyMatch( p -> p.getMessageType().equals( DMNMessageType.DUPLICATE_NAME ) ) );
+        assertThat(validate.stream().anyMatch(p -> p.getMessageType().equals(DMNMessageType.DUPLICATE_NAME))).isTrue();
     }
     
     @Test
     public void testFORMAL_PARAM_DUPLICATED() {
         List<DMNMessage> validate = validator.validate( getReader( "FORMAL_PARAM_DUPLICATED.dmn" ), VALIDATE_SCHEMA, VALIDATE_MODEL, VALIDATE_COMPILATION);
         assertThat(validate).as(ValidatorUtil.formatMessages(validate)).hasSize(3);
-        assertTrue( validate.stream().anyMatch( p -> p.getMessageType().equals( DMNMessageType.DUPLICATED_PARAM ) ) );
+        assertThat(validate.stream().anyMatch(p -> p.getMessageType().equals(DMNMessageType.DUPLICATED_PARAM))).isTrue();
     }
     
     @Test
     public void testINVOCATION_INCONSISTENT_PARAM_NAMES() {
         List<DMNMessage> validate = validator.validate( getReader( "INVOCATION_INCONSISTENT_PARAM_NAMES.dmn" ), VALIDATE_SCHEMA, VALIDATE_MODEL, VALIDATE_COMPILATION);
         assertThat(validate).as(ValidatorUtil.formatMessages(validate)).hasSizeGreaterThan(0);
-        assertTrue( validate.stream().anyMatch( p -> p.getMessageType().equals( DMNMessageType.PARAMETER_MISMATCH ) ) );
+        assertThat(validate.stream().anyMatch(p -> p.getMessageType().equals(DMNMessageType.PARAMETER_MISMATCH))).isTrue();
     }
     
     @Test @Ignore( "Needs to be improved as invocations can be used to invoke functions node defined in BKMs. E.g., FEEL built in functions, etc.")
@@ -177,21 +176,21 @@ public class ValidatorTest extends AbstractValidatorTest {
     public void testINVOCATION_WRONG_PARAM_COUNT() {
         List<DMNMessage> validate = validator.validate( getReader( "INVOCATION_WRONG_PARAM_COUNT.dmn" ), VALIDATE_SCHEMA, VALIDATE_MODEL, VALIDATE_COMPILATION);
         assertThat(validate).as(ValidatorUtil.formatMessages(validate)).hasSizeGreaterThan(0);
-        assertTrue( validate.stream().anyMatch( p -> p.getMessageType().equals( DMNMessageType.PARAMETER_MISMATCH ) ) );
+        assertThat(validate.stream().anyMatch(p -> p.getMessageType().equals(DMNMessageType.PARAMETER_MISMATCH))).isTrue();
     }
     
     @Test
     public void testITEMCOMP_DUPLICATED() {
         List<DMNMessage> validate = validator.validate( getReader( "ITEMCOMP_DUPLICATED.dmn" ), VALIDATE_SCHEMA, VALIDATE_MODEL, VALIDATE_COMPILATION);
         assertThat(validate).as(ValidatorUtil.formatMessages(validate)).hasSize(2);
-        assertTrue( validate.stream().anyMatch( p -> p.getMessageType().equals( DMNMessageType.DUPLICATED_ITEM_DEF ) ) );
+        assertThat(validate.stream().anyMatch(p -> p.getMessageType().equals(DMNMessageType.DUPLICATED_ITEM_DEF))).isTrue();
     }
     
     @Test
     public void testITEMDEF_NOT_UNIQUE() {
         List<DMNMessage> validate = validator.validate( getReader( "ITEMDEF_NOT_UNIQUE.dmn" ), VALIDATE_SCHEMA, VALIDATE_MODEL, VALIDATE_COMPILATION);
         assertThat(validate).as(ValidatorUtil.formatMessages(validate)).hasSize(2);
-        assertTrue( validate.stream().anyMatch( p -> p.getMessageType().equals( DMNMessageType.DUPLICATED_ITEM_DEF ) ) );
+        assertThat(validate.stream().anyMatch(p -> p.getMessageType().equals(DMNMessageType.DUPLICATED_ITEM_DEF))).isTrue();
     }
     
     @Test
@@ -205,22 +204,22 @@ public class ValidatorTest extends AbstractValidatorTest {
     public void testRELATION_DUP_COLUMN() {
         List<DMNMessage> validate = validator.validate( getReader( "RELATION_DUP_COLUMN.dmn" ), VALIDATE_SCHEMA, VALIDATE_MODEL, VALIDATE_COMPILATION);
         assertThat(validate).as(ValidatorUtil.formatMessages(validate)).hasSize(2);
-        assertTrue( validate.stream().anyMatch( p -> p.getMessageType().equals( DMNMessageType.DUPLICATED_RELATION_COLUMN ) ) );
+        assertThat(validate.stream().anyMatch(p -> p.getMessageType().equals(DMNMessageType.DUPLICATED_RELATION_COLUMN))).isTrue();
     }
     
     @Test
     public void testRELATION_ROW_CELL_NOTLITERAL() {
         List<DMNMessage> validate = validator.validate( getReader( "RELATION_ROW_CELL_NOTLITERAL.dmn" ), VALIDATE_SCHEMA, VALIDATE_MODEL, VALIDATE_COMPILATION);
         assertThat(validate).as(ValidatorUtil.formatMessages(validate)).hasSize(2);
-        assertTrue( validate.stream().anyMatch( p -> p.getMessageType().equals( DMNMessageType.RELATION_CELL_NOT_LITERAL ) ) );
-        assertTrue( validate.stream().anyMatch( p -> p.getMessageType().equals( DMNMessageType.MISSING_EXPRESSION ) ) );
+        assertThat(validate.stream().anyMatch(p -> p.getMessageType().equals(DMNMessageType.RELATION_CELL_NOT_LITERAL))).isTrue();
+        assertThat(validate.stream().anyMatch(p -> p.getMessageType().equals(DMNMessageType.MISSING_EXPRESSION))).isTrue();
     }
     
     @Test
     public void testRELATION_ROW_CELLCOUNTMISMATCH() {
         List<DMNMessage> validate = validator.validate( getReader( "RELATION_ROW_CELLCOUNTMISMATCH.dmn" ), VALIDATE_SCHEMA, VALIDATE_MODEL, VALIDATE_COMPILATION);
         assertThat(validate).as(ValidatorUtil.formatMessages(validate)).hasSize(1);
-        assertTrue( validate.stream().anyMatch( p -> p.getMessageType().equals( DMNMessageType.RELATION_CELL_COUNT_MISMATCH ) ) );
+        assertThat(validate.stream().anyMatch(p -> p.getMessageType().equals(DMNMessageType.RELATION_CELL_COUNT_MISMATCH))).isTrue();
     }
 
     @Test
@@ -228,7 +227,7 @@ public class ValidatorTest extends AbstractValidatorTest {
         // This file has a gazillion errors. The goal of this test is simply check that the validator itself is not blowing up
         // and raising an exception. The errors in the file itself are irrelevant.
         List<DMNMessage> validate = validator.validate( getReader( "MortgageRecommender.dmn" ), VALIDATE_SCHEMA, VALIDATE_MODEL, VALIDATE_COMPILATION);
-        assertThat(validate.isEmpty()).as(ValidatorUtil.formatMessages(validate)).isFalse();
+        assertThat(validate).as(ValidatorUtil.formatMessages(validate)).isNotEmpty();
     }
 
     @Test
@@ -242,7 +241,7 @@ public class ValidatorTest extends AbstractValidatorTest {
     public void testVARIABLE_LEADING_TRAILING_SPACES() {
         List<DMNMessage> validate = validator.validate( getReader( "VARIABLE_LEADING_TRAILING_SPACES.dmn" ), VALIDATE_SCHEMA, VALIDATE_MODEL, VALIDATE_COMPILATION);
         assertThat(validate).as(ValidatorUtil.formatMessages(validate)).hasSize(1);
-        assertTrue( validate.stream().anyMatch( p -> p.getMessageType().equals( DMNMessageType.INVALID_NAME ) ) );
+        assertThat(validate.stream().anyMatch(p -> p.getMessageType().equals(DMNMessageType.INVALID_NAME))).isTrue();
         assertThat( validate.get(0).getSourceId()).isEqualTo("_dd662d27-7896-42cb-9d14-bd74203bdbec");
     }
 
@@ -250,19 +249,19 @@ public class ValidatorTest extends AbstractValidatorTest {
     public void testUNKNOWN_VARIABLE() {
         List<DMNMessage> validate = validator.validate( getReader( "UNKNOWN_VARIABLE.dmn" ), VALIDATE_SCHEMA, VALIDATE_MODEL, VALIDATE_COMPILATION);
         assertThat(validate).as(ValidatorUtil.formatMessages(validate)).hasSize(1);
-        assertTrue( validate.stream().anyMatch( p -> p.getMessageType().equals( DMNMessageType.ERR_COMPILING_FEEL ) ) );
+        assertThat(validate.stream().anyMatch(p -> p.getMessageType().equals(DMNMessageType.ERR_COMPILING_FEEL))).isTrue();
     }
 
     @Test
     public void testVALIDATION() {
         List<DMNMessage> validate = validator.validate( getReader( "validation.dmn" ), VALIDATE_MODEL, VALIDATE_COMPILATION);
         assertThat(validate).as(ValidatorUtil.formatMessages(validate)).hasSize(5);
-        assertTrue( validate.stream().anyMatch( p -> p.getMessageType().equals( DMNMessageType.INVALID_NAME ) ) );
-        assertTrue( validate.stream().anyMatch( p -> p.getMessageType().equals( DMNMessageType.MISSING_TYPE_REF ) ) );
-        assertTrue( validate.stream().anyMatch( p -> p.getMessageType().equals( DMNMessageType.MISSING_EXPRESSION ) ) );
-        assertTrue( validate.stream().anyMatch( p -> p.getMessageType().equals( DMNMessageType.ERR_COMPILING_FEEL ) ) );
+        assertThat(validate.stream().anyMatch(p -> p.getMessageType().equals(DMNMessageType.INVALID_NAME))).isTrue();
+        assertThat(validate.stream().anyMatch(p -> p.getMessageType().equals(DMNMessageType.MISSING_TYPE_REF))).isTrue();
+        assertThat(validate.stream().anyMatch(p -> p.getMessageType().equals(DMNMessageType.MISSING_EXPRESSION))).isTrue();
+        assertThat(validate.stream().anyMatch(p -> p.getMessageType().equals(DMNMessageType.ERR_COMPILING_FEEL))).isTrue();
         // on node DTI the `Loan Payment` is of type `tLoanPayment` hence the property is `monthlyAmount`, NOT `amount` as reported in the model FEEL expression: (Loan Payment.amount+...
-        assertTrue( validate.stream().anyMatch( p -> p.getMessageType().equals( DMNMessageType.ERR_COMPILING_FEEL ) ) );
+        assertThat(validate.stream().anyMatch(p -> p.getMessageType().equals(DMNMessageType.ERR_COMPILING_FEEL))).isTrue();
     }
 
     @Test

--- a/kie-dmn/kie-dmn-legacy-tests/src/test/java/org/kie/dmn/legacy/tests/validation/v1_1/ValidatorTypeRefTest.java
+++ b/kie-dmn/kie-dmn-legacy-tests/src/test/java/org/kie/dmn/legacy/tests/validation/v1_1/ValidatorTypeRefTest.java
@@ -27,7 +27,6 @@ import org.kie.dmn.validation.AbstractValidatorTest;
 import org.kie.dmn.validation.ValidatorUtil;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.Assert.assertTrue;
 import static org.kie.dmn.validation.DMNValidator.Validation.VALIDATE_COMPILATION;
 import static org.kie.dmn.validation.DMNValidator.Validation.VALIDATE_MODEL;
 import static org.kie.dmn.validation.DMNValidator.Validation.VALIDATE_SCHEMA;
@@ -41,7 +40,7 @@ public class ValidatorTypeRefTest extends AbstractValidatorTest {
                     reader,
                     VALIDATE_SCHEMA, VALIDATE_MODEL, VALIDATE_COMPILATION);
      assertThat(validate).as(ValidatorUtil.formatMessages(validate)).hasSize(1);
-            assertTrue(validate.stream().anyMatch(p -> p.getMessageType().equals(DMNMessageType.TYPE_REF_NOT_FOUND)));
+            assertThat(validate.stream().anyMatch(p -> p.getMessageType().equals(DMNMessageType.TYPE_REF_NOT_FOUND))).isTrue();
         }
     }
 
@@ -51,7 +50,7 @@ public class ValidatorTypeRefTest extends AbstractValidatorTest {
                 getFile("typeref/TYPEREF_NO_FEEL_TYPE.dmn"),
                 VALIDATE_SCHEMA, VALIDATE_MODEL, VALIDATE_COMPILATION);
         assertThat(validate).as(ValidatorUtil.formatMessages(validate)).hasSize(1);
-        assertTrue(validate.stream().anyMatch(p -> p.getMessageType().equals(DMNMessageType.TYPE_REF_NOT_FOUND)));
+        assertThat(validate.stream().anyMatch(p -> p.getMessageType().equals(DMNMessageType.TYPE_REF_NOT_FOUND))).isTrue();
     }
 
     @Test
@@ -60,7 +59,7 @@ public class ValidatorTypeRefTest extends AbstractValidatorTest {
                 getDefinitions("typeref/TYPEREF_NO_FEEL_TYPE.dmn", "https://github.com/kiegroup/kie-dmn", "TYPEREF_NO_FEEL_TYPE"),
                 VALIDATE_MODEL, VALIDATE_COMPILATION);
  assertThat(validate).as(ValidatorUtil.formatMessages(validate)).hasSize(1);
-        assertTrue(validate.stream().anyMatch(p -> p.getMessageType().equals(DMNMessageType.TYPE_REF_NOT_FOUND)));
+        assertThat(validate.stream().anyMatch(p -> p.getMessageType().equals(DMNMessageType.TYPE_REF_NOT_FOUND))).isTrue();
     }
 
     @Test
@@ -70,8 +69,8 @@ public class ValidatorTypeRefTest extends AbstractValidatorTest {
                     reader,
                     VALIDATE_SCHEMA, VALIDATE_MODEL, VALIDATE_COMPILATION);
              assertThat(validate).as(ValidatorUtil.formatMessages(validate)).hasSize(2);
-            assertTrue(validate.stream().anyMatch(p -> p.getMessageType().equals(DMNMessageType.FAILED_XML_VALIDATION)));
-            assertTrue(validate.stream().anyMatch(p -> p.getMessageType().equals(DMNMessageType.TYPE_DEF_NOT_FOUND)));
+            assertThat(validate.stream().anyMatch(p -> p.getMessageType().equals(DMNMessageType.FAILED_XML_VALIDATION))).isTrue();
+            assertThat(validate.stream().anyMatch(p -> p.getMessageType().equals(DMNMessageType.TYPE_DEF_NOT_FOUND))).isTrue();
         }
     }
 
@@ -81,8 +80,8 @@ public class ValidatorTypeRefTest extends AbstractValidatorTest {
                 getFile("typeref/TYPEREF_NO_NS.dmn"),
                 VALIDATE_SCHEMA, VALIDATE_MODEL, VALIDATE_COMPILATION);
          assertThat(validate).as(ValidatorUtil.formatMessages(validate)).hasSize(2);
-        assertTrue(validate.stream().anyMatch(p -> p.getMessageType().equals(DMNMessageType.FAILED_XML_VALIDATION)));
-        assertTrue(validate.stream().anyMatch(p -> p.getMessageType().equals(DMNMessageType.TYPE_DEF_NOT_FOUND)));
+        assertThat(validate.stream().anyMatch(p -> p.getMessageType().equals(DMNMessageType.FAILED_XML_VALIDATION))).isTrue();
+        assertThat(validate.stream().anyMatch(p -> p.getMessageType().equals(DMNMessageType.TYPE_DEF_NOT_FOUND))).isTrue();
     }
 
     @Test
@@ -91,7 +90,7 @@ public class ValidatorTypeRefTest extends AbstractValidatorTest {
                 getDefinitions("typeref/TYPEREF_NO_NS.dmn", "https://github.com/kiegroup/kie-dmn", "TYPEREF_NO_NS"),
                 VALIDATE_MODEL, VALIDATE_COMPILATION);
  assertThat(validate).as(ValidatorUtil.formatMessages(validate)).hasSize(1);
-        assertTrue(validate.stream().anyMatch(p -> p.getMessageType().equals(DMNMessageType.TYPE_DEF_NOT_FOUND)));
+        assertThat(validate.stream().anyMatch(p -> p.getMessageType().equals(DMNMessageType.TYPE_DEF_NOT_FOUND))).isTrue();
     }
 
     @Test
@@ -101,8 +100,8 @@ public class ValidatorTypeRefTest extends AbstractValidatorTest {
                     reader,
                     VALIDATE_SCHEMA, VALIDATE_MODEL, VALIDATE_COMPILATION);
              assertThat(validate).as(ValidatorUtil.formatMessages(validate)).hasSize(2);
-            assertTrue(validate.stream().anyMatch(p -> p.getMessageType().equals(DMNMessageType.INVALID_NAME)));
-            assertTrue(validate.stream().anyMatch(p -> p.getMessageType().equals(DMNMessageType.TYPE_DEF_NOT_FOUND)));
+            assertThat(validate.stream().anyMatch(p -> p.getMessageType().equals(DMNMessageType.INVALID_NAME))).isTrue();
+            assertThat(validate.stream().anyMatch(p -> p.getMessageType().equals(DMNMessageType.TYPE_DEF_NOT_FOUND))).isTrue();
         }
     }
 
@@ -112,8 +111,8 @@ public class ValidatorTypeRefTest extends AbstractValidatorTest {
                 getFile("typeref/TYPEREF_NOT_FEEL_NOT_DEF.dmn"),
                 VALIDATE_SCHEMA, VALIDATE_MODEL, VALIDATE_COMPILATION);
          assertThat(validate).as(ValidatorUtil.formatMessages(validate)).hasSize(2);
-        assertTrue(validate.stream().anyMatch(p -> p.getMessageType().equals(DMNMessageType.INVALID_NAME)));
-        assertTrue(validate.stream().anyMatch(p -> p.getMessageType().equals(DMNMessageType.TYPE_DEF_NOT_FOUND)));
+        assertThat(validate.stream().anyMatch(p -> p.getMessageType().equals(DMNMessageType.INVALID_NAME))).isTrue();
+        assertThat(validate.stream().anyMatch(p -> p.getMessageType().equals(DMNMessageType.TYPE_DEF_NOT_FOUND))).isTrue();
     }
 
     @Test
@@ -122,8 +121,8 @@ public class ValidatorTypeRefTest extends AbstractValidatorTest {
                 getDefinitions("typeref/TYPEREF_NOT_FEEL_NOT_DEF.dmn", "https://github.com/kiegroup/kie-dmn", "TYPEREF_NOT_FEEL_NOT_DEF"),
                 VALIDATE_MODEL, VALIDATE_COMPILATION);
          assertThat(validate).as(ValidatorUtil.formatMessages(validate)).hasSize(2);
-        assertTrue(validate.stream().anyMatch(p -> p.getMessageType().equals(DMNMessageType.INVALID_NAME)));
-        assertTrue(validate.stream().anyMatch(p -> p.getMessageType().equals(DMNMessageType.TYPE_DEF_NOT_FOUND)));
+        assertThat(validate.stream().anyMatch(p -> p.getMessageType().equals(DMNMessageType.INVALID_NAME))).isTrue();
+        assertThat(validate.stream().anyMatch(p -> p.getMessageType().equals(DMNMessageType.TYPE_DEF_NOT_FOUND))).isTrue();
     }
 
     @Test

--- a/kie-dmn/kie-dmn-pmml-tests-parent/kie-dmn-pmml-tests/src/test/java/org/kie/dmn/pmml/DMNRuntimePMMLTest.java
+++ b/kie-dmn/kie-dmn-pmml-tests-parent/kie-dmn-pmml-tests/src/test/java/org/kie/dmn/pmml/DMNRuntimePMMLTest.java
@@ -54,7 +54,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.Assert.assertEquals;
+import static org.assertj.core.api.Assertions.within;
 
 public abstract class DMNRuntimePMMLTest {
 
@@ -138,12 +138,12 @@ public abstract class DMNRuntimePMMLTest {
 
         kfs.write("src/main/resources/org/acme/test_scorecard.pmml", ks.getResources().newClassPathResource("test_scorecard.pmml", DMNRuntimePMMLTest.class));
         KieBuilder kieBuilder = ks.newKieBuilder(kfs).buildAll(DrlProject.class);
-        assertEquals(0, kieBuilder.getResults().getMessages(org.kie.api.builder.Message.Level.ERROR).size());
+        assertThat(kieBuilder.getResults().getMessages(org.kie.api.builder.Message.Level.ERROR)).hasSize(0);
 
         kfs.write("src/main/resources/org/acme/KiePMMLScoreCard.dmn", ks.getResources().newClassPathResource("KiePMMLScoreCard.dmn", DMNRuntimePMMLTest.class));
         IncrementalResults addResults = ((InternalKieBuilder) kieBuilder).createFileSet("src/main/resources/org/acme/KiePMMLScoreCard.dmn").build();
-        assertEquals(0, addResults.getAddedMessages().size());
-        assertEquals(0, addResults.getRemovedMessages().size());
+        assertThat(addResults.getAddedMessages()).hasSize(0);
+        assertThat(addResults.getRemovedMessages()).hasSize(0);
 
         KieRepository kr = ks.getRepository();
         KieContainer kieContainer = ks.newKieContainer(kr.getDefaultReleaseId());
@@ -173,9 +173,9 @@ public abstract class DMNRuntimePMMLTest {
 
         final DMNContext resultContext = dmnResult.getContext();
         final Map<String, Object> result = (Map<String, Object>) resultContext.get("my decision");
-        assertEquals("catD", (String)result.get("RegOut"));
-        assertEquals(0.8279559384018024, ((BigDecimal)result.get("RegProb")).doubleValue(), COMPARISON_DELTA);
-        assertEquals(0.0022681396056233208, ((BigDecimal)result.get("RegProbA")).doubleValue(), COMPARISON_DELTA);
+        assertThat((String) result.get("RegOut")).isEqualTo("catD");
+        assertThat(((BigDecimal) result.get("RegProb")).doubleValue()).isCloseTo(0.8279559384018024, within(COMPARISON_DELTA));
+        assertThat(((BigDecimal) result.get("RegProbA")).doubleValue()).isCloseTo(0.0022681396056233208, within(COMPARISON_DELTA));
 
         DMNType dmnFEELNumber = ((DMNModelImpl) dmnModel).getTypeRegistry().resolveType(dmnModel.getDefinitions().getURIFEEL(), BuiltInType.NUMBER.getName());
         DMNType dmnFEELString = ((DMNModelImpl) dmnModel).getTypeRegistry().resolveType(dmnModel.getDefinitions().getURIFEEL(), BuiltInType.STRING.getName());
@@ -191,39 +191,39 @@ public abstract class DMNRuntimePMMLTest {
 
         Map<String, DMNType> inputFields = m0.getInputFields();
         SimpleTypeImpl fld1 = (SimpleTypeImpl)inputFields.get("fld1");
-        assertEquals("test_regression_clax", fld1.getNamespace());
-        assertEquals(BuiltInType.NUMBER, fld1.getFeelType());
-        assertEquals(dmnFEELNumber, fld1.getBaseType());
+        assertThat(fld1.getNamespace()).isEqualTo("test_regression_clax");
+        assertThat(fld1.getFeelType()).isEqualTo(BuiltInType.NUMBER);
+        assertThat(fld1.getBaseType()).isEqualTo(dmnFEELNumber);
 
         SimpleTypeImpl fld2 = (SimpleTypeImpl)inputFields.get("fld2");
-        assertEquals("test_regression_clax", fld2.getNamespace());
-        assertEquals(BuiltInType.NUMBER, fld2.getFeelType());
-        assertEquals(dmnFEELNumber, fld2.getBaseType());
+        assertThat(fld2.getNamespace()).isEqualTo("test_regression_clax");
+        assertThat(fld2.getFeelType()).isEqualTo(BuiltInType.NUMBER);
+        assertThat(fld2.getBaseType()).isEqualTo(dmnFEELNumber);
 
         SimpleTypeImpl fld3 = (SimpleTypeImpl)inputFields.get("fld3");
-        assertEquals("test_regression_clax", fld3.getNamespace());
-        assertEquals(BuiltInType.STRING, fld3.getFeelType());
-        assertEquals(dmnFEELString, fld3.getBaseType());
+        assertThat(fld3.getNamespace()).isEqualTo("test_regression_clax");
+        assertThat(fld3.getFeelType()).isEqualTo(BuiltInType.STRING);
+        assertThat(fld3.getBaseType()).isEqualTo(dmnFEELString);
 
         Map<String, DMNType> outputFields = m0.getOutputFields();
         CompositeTypeImpl output = (CompositeTypeImpl)outputFields.get("LinReg");
-        assertEquals("test_regression_clax", output.getNamespace());
+        assertThat(output.getNamespace()).isEqualTo("test_regression_clax");
 
         Map<String, DMNType> fields = output.getFields();
         SimpleTypeImpl regOut = (SimpleTypeImpl)fields.get("RegOut");
 
-        assertEquals("test_regression_clax", regOut.getNamespace());
-        assertEquals(BuiltInType.STRING, regOut.getFeelType());
-        assertEquals(dmnFEELString, regOut.getBaseType());
+        assertThat(regOut.getNamespace()).isEqualTo("test_regression_clax");
+        assertThat(regOut.getFeelType()).isEqualTo(BuiltInType.STRING);
+        assertThat(regOut.getBaseType()).isEqualTo(dmnFEELString);
 
         SimpleTypeImpl regProb = (SimpleTypeImpl)fields.get("RegProb");
-        assertEquals("test_regression_clax", regProb.getNamespace());
-        assertEquals(BuiltInType.NUMBER, regProb.getFeelType());
-        assertEquals(dmnFEELNumber, regProb.getBaseType());
+        assertThat(regProb.getNamespace()).isEqualTo("test_regression_clax");
+        assertThat(regProb.getFeelType()).isEqualTo(BuiltInType.NUMBER);
+        assertThat(regProb.getBaseType()).isEqualTo(dmnFEELNumber);
 
         SimpleTypeImpl regProbA = (SimpleTypeImpl)fields.get("RegProbA");
-        assertEquals("test_regression_clax", regProbA.getNamespace());
-        assertEquals(BuiltInType.NUMBER, regProbA.getFeelType());
-        assertEquals(dmnFEELNumber, regProbA.getBaseType());
+        assertThat(regProbA.getNamespace()).isEqualTo("test_regression_clax");
+        assertThat(regProbA.getFeelType()).isEqualTo(BuiltInType.NUMBER);
+        assertThat(regProbA.getBaseType()).isEqualTo(dmnFEELNumber);
     }
 }

--- a/kie-dmn/kie-dmn-signavio/src/test/java/org/kie/dmn/signavio/SignavioTest.java
+++ b/kie-dmn/kie-dmn-signavio/src/test/java/org/kie/dmn/signavio/SignavioTest.java
@@ -41,9 +41,6 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
 
 public class SignavioTest {
     public static final Logger LOG = LoggerFactory.getLogger(SignavioTest.class);
@@ -96,7 +93,7 @@ public class SignavioTest {
         LOG.info("{}", evaluateAll.getContext());
         evaluateAll.getMessages().forEach(System.out::println);
 
-        assertEquals(true, evaluateAll.getContext().get("myContext"));
+        assertThat(evaluateAll.getContext().get("myContext")).isEqualTo(true);
     }
 
     /**
@@ -118,9 +115,9 @@ public class SignavioTest {
         DMNResult evaluateAll = runtime.evaluateAll(model0, context);
         evaluateAll.getMessages().forEach(System.out::println);
 
-        assertFalse(evaluateAll.getMessages().toString(), evaluateAll.hasErrors());
+        assertThat(evaluateAll.hasErrors()).as(evaluateAll.getMessages().toString()).isFalse();
 
-        assertEquals(startsWithAnA, evaluateAll.getContext().get("startsWithAnA"));
+        assertThat(evaluateAll.getContext().get("startsWithAnA")).isEqualTo(startsWithAnA);
     }
 
     @Test
@@ -156,7 +153,7 @@ public class SignavioTest {
         Results results = kieBuilder.getResults();
         LOG.info("buildAll() completed.");
         results.getMessages(Level.WARNING).forEach(e -> LOG.warn("{}", e));
-        assertTrue(results.getMessages(Level.WARNING).size() == 0);
+        assertThat(results.getMessages(Level.WARNING)).isEmpty();
 
         final KieContainer kieContainer = ks.newKieContainer(ks.getRepository().getDefaultReleaseId());
         DMNRuntime runtime = kieContainer.newKieSession().getKieRuntime(DMNRuntime.class);
@@ -247,8 +244,8 @@ public class SignavioTest {
         LOG.info("EVALUATE ALL:");
         DMNResult evaluateAll = runtime.evaluateAll(model0, context);
         LOG.info("{}", evaluateAll);
-    
-        assertEquals("JohnJaneDoe", evaluateAll.getDecisionResultByName("concatNames").getResult());
+
+        assertThat(evaluateAll.getDecisionResultByName("concatNames").getResult()).isEqualTo("JohnJaneDoe");
     }
     
     
@@ -285,8 +282,8 @@ public class SignavioTest {
         LOG.info("EVALUATE ALL:");
         DMNResult evaluateAll = runtime.evaluateAll(model0, context);
         LOG.info("{}", evaluateAll);
-    
-        assertEquals(Arrays.asList("John Doe", "Alice"), evaluateAll.getDecisionResultByName("extractNames").getResult());
+
+        assertThat(evaluateAll.getDecisionResultByName("extractNames").getResult()).isEqualTo(Arrays.asList("John Doe", "Alice"));
     }
     
     @Test

--- a/kie-dmn/kie-dmn-trisotech/src/test/java/org/kie/dmn/trisotech/backend/marshalling/v1_3/xstream/UnmarshalMarshalTest.java
+++ b/kie-dmn/kie-dmn-trisotech/src/test/java/org/kie/dmn/trisotech/backend/marshalling/v1_3/xstream/UnmarshalMarshalTest.java
@@ -48,8 +48,7 @@ import org.xmlunit.validation.ValidationProblem;
 import org.xmlunit.validation.ValidationResult;
 import org.xmlunit.validation.Validator;
 
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
+import static org.assertj.core.api.Assertions.assertThat;
 
 public class UnmarshalMarshalTest {
 
@@ -96,7 +95,7 @@ public class UnmarshalMarshalTest {
                 LOG.error("{}", p);
             }
         }
-        assertTrue(validateInputResult.isValid());
+        assertThat(validateInputResult.isValid()).isTrue();
 
         final File subdirFile = new File(baseOutputDir, subdir);
         if (!subdirFile.mkdirs()) {
@@ -122,7 +121,7 @@ public class UnmarshalMarshalTest {
                 LOG.error("{}", p);
             }
         }
-        assertTrue(validateOutputResult.isValid());
+        assertThat(validateOutputResult.isValid()).isTrue();
 
         LOG.debug("\n---\nDefault XMLUnit comparison:");
         Source control = Input.fromFile(inputXMLFile).build();
@@ -219,7 +218,7 @@ public class UnmarshalMarshalTest {
         if (!checkSimilar.getDifferences().iterator().hasNext()) {
             LOG.info("[ EMPTY - no diffs using customized similarity ]");
         }
-        assertFalse("XML are NOT similar: " + checkSimilar.toString(), checkSimilar.hasDifferences());
+        assertThat(checkSimilar.hasDifferences()).as("XML are NOT similar: " + checkSimilar.toString()).isFalse();
     }
 
     private String safeStripDMNPRefix(Node target) {

--- a/kie-dmn/kie-dmn-trisotech/src/test/java/org/kie/dmn/trisotech/core/DMN14ExpressionsTest.java
+++ b/kie-dmn/kie-dmn-trisotech/src/test/java/org/kie/dmn/trisotech/core/DMN14ExpressionsTest.java
@@ -42,9 +42,6 @@ import org.kie.dmn.trisotech.TrisotechDMNProfile;
 import org.kie.dmn.trisotech.core.compiler.TrisotechDMNEvaluatorCompilerFactory;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
 
 @RunWith(Parameterized.class)
 public class DMN14ExpressionsTest {
@@ -86,7 +83,7 @@ public class DMN14ExpressionsTest {
                             "</kmodule>");
         kfs.generateAndWritePomXML(releaseId);
         final KieBuilder kieBuilder = ks.newKieBuilder(kfs).buildAll();
-        assertTrue(kieBuilder.getResults().getMessages().toString(), kieBuilder.getResults().getMessages().isEmpty());
+        assertThat(kieBuilder.getResults().getMessages()).as(kieBuilder.getResults().getMessages().toString()).isEmpty();
         final KieContainer kieContainer = ks.newKieContainer(releaseId);
         final DMNRuntime runtime = DMNRuntimeUtil.typeSafeGetKieRuntime(kieContainer);
         return runtime;
@@ -116,105 +113,105 @@ public class DMN14ExpressionsTest {
     @Test
     public void testConditionalWithInput() throws Throwable {
         DMNResult results = runtime.evaluateByName(model, new DMNContextImpl(Collections.singletonMap("Boolean Input", true)), "Conditional");
-        assertEquals("Conditional evaluated to TRUE", results.getDecisionResultByName("Conditional").getResult());
+        assertThat(results.getDecisionResultByName("Conditional").getResult()).isEqualTo("Conditional evaluated to TRUE");
 
         results = runtime.evaluateByName(model, new DMNContextImpl(Collections.singletonMap("Boolean Input", false)), "Conditional");
-        assertEquals("Conditional evaluated to FALSE", results.getDecisionResultByName("Conditional").getResult());
+        assertThat(results.getDecisionResultByName("Conditional").getResult()).isEqualTo("Conditional evaluated to FALSE");
 
         results = runtime.evaluateByName(model, new DMNContextImpl(Collections.singletonMap("Boolean Input", null)), "Conditional");
-        assertEquals("Conditional evaluated to FALSE", results.getDecisionResultByName("Conditional").getResult());
+        assertThat(results.getDecisionResultByName("Conditional").getResult()).isEqualTo("Conditional evaluated to FALSE");
 
     }
 
     @Test
     public void testConditionalNonBooleanIf() throws Throwable {
         DMNResult results = runtime.evaluateByName(model, new DMNContextImpl(), "Non boolean");
-        assertEquals(1, results.getMessages().size());
-        assertEquals(DMNMessageType.ERROR_EVAL_NODE, results.getMessages().iterator().next().getMessageType());
+        assertThat(results.getMessages()).hasSize(1);
+        assertThat(results.getMessages().iterator().next().getMessageType()).isEqualTo(DMNMessageType.ERROR_EVAL_NODE);
 
     }
 
     @Test
     public void testIteratorFor() throws Throwable {
         DMNResult results = runtime.evaluateByName(model, new DMNContextImpl(Collections.singletonMap("Number Input", 1)), "Addition");
-        assertEquals(Arrays.asList(2, 3, 4, 5).toString(), results.getDecisionResultByName("Addition").getResult().toString());
+        assertThat(results.getDecisionResultByName("Addition").getResult().toString()).isEqualTo(Arrays.asList(2, 3, 4, 5).toString());
 
         results = runtime.evaluateByName(model, new DMNContextImpl(Collections.singletonMap("Number Input", 2)), "Addition");
-        assertEquals(Arrays.asList(3, 4, 5, 6).toString(), results.getDecisionResultByName("Addition").getResult().toString());
+        assertThat(results.getDecisionResultByName("Addition").getResult().toString()).isEqualTo(Arrays.asList(3, 4, 5, 6).toString());
     }
 
     @Test
     public void testIteratorForPartial() throws Throwable {
         DMNResult results = runtime.evaluateByName(model, new DMNContextImpl(Collections.singletonMap("Number Input", 0)), "Addition Partial");
-        assertEquals(Arrays.asList(1, 3, 6, 10).toString(), results.getDecisionResultByName("Addition Partial").getResult().toString());
+        assertThat(results.getDecisionResultByName("Addition Partial").getResult().toString()).isEqualTo(Arrays.asList(1, 3, 6, 10).toString());
 
         results = runtime.evaluateByName(model, new DMNContextImpl(Collections.singletonMap("Number Input", 5)), "Addition Partial");
-        assertEquals(Arrays.asList(1, 8, 16, 25).toString(), results.getDecisionResultByName("Addition Partial").getResult().toString());
+        assertThat(results.getDecisionResultByName("Addition Partial").getResult().toString()).isEqualTo(Arrays.asList(1, 8, 16, 25).toString());
     }
     
     @Test
     public void testIteratorForInRangeClose() throws Throwable {
         DMNResult results = runtime.evaluateByName(model, new DMNContextImpl(Collections.singletonMap("Number Input", 1)), "Addition Range Close");
-        assertEquals(Arrays.asList(3, 4).toString(), results.getDecisionResultByName("Addition Range Close").getResult().toString());
+        assertThat(results.getDecisionResultByName("Addition Range Close").getResult().toString()).isEqualTo(Arrays.asList(3, 4).toString());
 
         results = runtime.evaluateByName(model, new DMNContextImpl(Collections.singletonMap("Number Input", 2)), "Addition Range Close");
-        assertEquals(Arrays.asList(4, 5).toString(), results.getDecisionResultByName("Addition Range Close").getResult().toString());
+        assertThat(results.getDecisionResultByName("Addition Range Close").getResult().toString()).isEqualTo(Arrays.asList(4, 5).toString());
     } 
 
     @Test
     public void testIteratorForInRangeOpen() throws Throwable {
         DMNResult results = runtime.evaluateByName(model, new DMNContextImpl(Collections.singletonMap("Number Input", 1)), "Addition Range Open");
-        assertEquals(Arrays.asList(2, 3, 4, 5).toString(), results.getDecisionResultByName("Addition Range Open").getResult().toString());
+        assertThat(results.getDecisionResultByName("Addition Range Open").getResult().toString()).isEqualTo(Arrays.asList(2, 3, 4, 5).toString());
 
         results = runtime.evaluateByName(model, new DMNContextImpl(Collections.singletonMap("Number Input", 2)), "Addition Range Open");
-        assertEquals(Arrays.asList(3, 4, 5, 6).toString(), results.getDecisionResultByName("Addition Range Open").getResult().toString());
+        assertThat(results.getDecisionResultByName("Addition Range Open").getResult().toString()).isEqualTo(Arrays.asList(3, 4, 5, 6).toString());
     } 
 
     
     @Test
     public void testIteratorSome() throws Throwable {
         DMNResult results = runtime.evaluateByName(model, new DMNContextImpl(Collections.singletonMap("Number Input", 5)), "Number Greater Exists");
-        assertTrue(((Boolean) results.getDecisionResultByName("Number Greater Exists").getResult()).booleanValue());
+        assertThat(((Boolean) results.getDecisionResultByName("Number Greater Exists").getResult()).booleanValue()).isTrue();
 
         results = runtime.evaluateByName(model, new DMNContextImpl(Collections.singletonMap("Number Input", -1)), "Number Greater Exists");
-        assertTrue(((Boolean) results.getDecisionResultByName("Number Greater Exists").getResult()).booleanValue());
+        assertThat(((Boolean) results.getDecisionResultByName("Number Greater Exists").getResult()).booleanValue()).isTrue();
 
         results = runtime.evaluateByName(model, new DMNContextImpl(Collections.singletonMap("Number Input", 11)), "Number Greater Exists");
-        assertFalse(((Boolean) results.getDecisionResultByName("Number Greater Exists").getResult()).booleanValue());
+        assertThat(((Boolean) results.getDecisionResultByName("Number Greater Exists").getResult()).booleanValue()).isFalse();
     }
 
     @Test
     public void testIteratorEvery() throws Throwable {
         DMNResult results = runtime.evaluateByName(model, new DMNContextImpl(Collections.singletonMap("Number Input", 5)), "All Greater");
-        assertFalse(((Boolean) results.getDecisionResultByName("All Greater").getResult()).booleanValue());
+        assertThat(((Boolean) results.getDecisionResultByName("All Greater").getResult()).booleanValue()).isFalse();
 
         results = runtime.evaluateByName(model, new DMNContextImpl(Collections.singletonMap("Number Input", -1)), "All Greater");
-        assertTrue(((Boolean) results.getDecisionResultByName("All Greater").getResult()).booleanValue());
+        assertThat(((Boolean) results.getDecisionResultByName("All Greater").getResult()).booleanValue()).isTrue();
 
         results = runtime.evaluateByName(model, new DMNContextImpl(Collections.singletonMap("Number Input", 11)), "All Greater");
-        assertFalse(((Boolean) results.getDecisionResultByName("All Greater").getResult()).booleanValue());
+        assertThat(((Boolean) results.getDecisionResultByName("All Greater").getResult()).booleanValue()).isFalse();
     }
 
     @Test
     public void testFilterIndex() throws Throwable {
         DMNResult results = runtime.evaluateByName(model, new DMNContextImpl(Collections.singletonMap("Number Input", 5)), "Match by index");
-        assertEquals(new BigDecimal(5), results.getDecisionResultByName("Match by index").getResult());
+        assertThat(results.getDecisionResultByName("Match by index").getResult()).isEqualTo(new BigDecimal(5));
 
         results = runtime.evaluateByName(model, new DMNContextImpl(Collections.singletonMap("Number Input", -2)), "Match by index");
-        assertEquals(new BigDecimal(9), results.getDecisionResultByName("Match by index").getResult());
+        assertThat(results.getDecisionResultByName("Match by index").getResult()).isEqualTo(new BigDecimal(9));
 
         results = runtime.evaluateByName(model, new DMNContextImpl(Collections.singletonMap("Number Input", 0)), "Match by index");
-        assertTrue(results.getMessages().size() > 0);
+        assertThat(results.getMessages()).hasSizeGreaterThan(0);
 
     }
 
     @Test
     public void testFilterExpression() throws Throwable {
         DMNResult results = runtime.evaluateByName(model, new DMNContextImpl(Collections.singletonMap("Number Input", 5)), "Match by Fnct");
-        assertEquals(Arrays.asList(6, 7, 8, 9, 10).toString(), results.getDecisionResultByName("Match by Fnct").getResult().toString());
+        assertThat(results.getDecisionResultByName("Match by Fnct").getResult().toString()).isEqualTo(Arrays.asList(6, 7, 8, 9, 10).toString());
 
         results = runtime.evaluateByName(model, new DMNContextImpl(Collections.singletonMap("Number Input", 11)), "Match by Fnct");
-        assertEquals(Arrays.asList().toString(), results.getDecisionResultByName("Match by Fnct").getResult().toString());
+        assertThat(results.getDecisionResultByName("Match by Fnct").getResult().toString()).isEqualTo(Arrays.asList().toString());
 
     }
 }

--- a/kie-dmn/kie-dmn-trisotech/src/test/java/org/kie/dmn/trisotech/core/DMN14GenericSynthTest.java
+++ b/kie-dmn/kie-dmn-trisotech/src/test/java/org/kie/dmn/trisotech/core/DMN14GenericSynthTest.java
@@ -31,7 +31,6 @@ import org.kie.dmn.trisotech.core.compiler.TrisotechDMNEvaluatorCompilerFactory;
 import org.kie.dmn.trisotech.validation.TrisotechValidationTest;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.Assert.assertEquals;
 import static org.kie.dmn.core.util.DynamicTypeUtils.entry;
 import static org.kie.dmn.core.util.DynamicTypeUtils.prototype;
 
@@ -63,7 +62,7 @@ public class DMN14GenericSynthTest {
         DMNContext context = runtime.newContext();
         context.set("Input", Arrays.asList(tc1, tc2, tc3));
         DMNResult results = runtime.evaluateAll(model, context);
-        assertEquals(Arrays.asList(tc1, tc3), results.getDecisionResultByName("Decision").getResult());
+        assertThat(results.getDecisionResultByName("Decision").getResult()).isEqualTo(Arrays.asList(tc1, tc3));
     }
 
     @Test
@@ -93,7 +92,7 @@ public class DMN14GenericSynthTest {
         DMNContext context = runtime.newContext();
         context.set("Input", Arrays.asList(tc1, tc2, tc3));
         DMNResult results = runtime.evaluateAll(model, context);
-        assertEquals(Arrays.asList("x", "y", "z"), results.getDecisionResultByName("Decision").getResult());
+        assertThat(results.getDecisionResultByName("Decision").getResult()).isEqualTo(Arrays.asList("x", "y", "z"));
     }
 
     @Test

--- a/kie-dmn/kie-dmn-trisotech/src/test/java/org/kie/dmn/trisotech/validation/TrisotechValidationTest.java
+++ b/kie-dmn/kie-dmn-trisotech/src/test/java/org/kie/dmn/trisotech/validation/TrisotechValidationTest.java
@@ -34,7 +34,7 @@ import org.kie.dmn.trisotech.core.compiler.TrisotechDMNEvaluatorCompilerFactory;
 import org.kie.dmn.validation.DMNValidator;
 import org.kie.dmn.validation.DMNValidatorFactory;
 
-import static org.junit.Assert.assertEquals;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.kie.dmn.validation.DMNValidator.Validation.VALIDATE_COMPILATION;
 import static org.kie.dmn.validation.DMNValidator.Validation.VALIDATE_MODEL;
 import static org.kie.dmn.validation.DMNValidator.Validation.VALIDATE_SCHEMA;
@@ -70,7 +70,7 @@ public class TrisotechValidationTest {
         List<DMNMessage> validate = validator.validateUsing(VALIDATE_SCHEMA, VALIDATE_MODEL, VALIDATE_COMPILATION)
                                              .usingSchema(TrisotechSchema.INSTANCEv1_3)
                                              .theseModels(getReader("boxedcontextextension/conditional.dmn"));
-        assertEquals(0, validate.size());
+        assertThat(validate).hasSize(0);
     }
 
     @Test
@@ -78,14 +78,14 @@ public class TrisotechValidationTest {
         List<DMNMessage> validate = validator.validateUsing(VALIDATE_SCHEMA, VALIDATE_MODEL, VALIDATE_COMPILATION)
                                              .usingSchema(TrisotechSchema.INSTANCEv1_3)
                                              .theseModels(getReader("boxedcontextextension/iterator.dmn"));
-        assertEquals(0, validate.size());
+        assertThat(validate).hasSize(0);
     }
     @Test
     public void testBoxedExtension_IteratorDataType13() {
         List<DMNMessage> validate = validator.validateUsing(VALIDATE_SCHEMA, VALIDATE_MODEL, VALIDATE_COMPILATION)
                                              .usingSchema(TrisotechSchema.INSTANCEv1_3)
                                              .theseModels(getReader("boxedcontextextension/iterator-datatype.dmn"));
-        assertEquals(0, validate.size());
+        assertThat(validate).hasSize(0);
     }
 
     @Test
@@ -93,7 +93,7 @@ public class TrisotechValidationTest {
         List<DMNMessage> validate = validator.validateUsing(VALIDATE_SCHEMA, VALIDATE_MODEL, VALIDATE_COMPILATION)
                                              .usingSchema(TrisotechSchema.INSTANCEv1_3)
                                              .theseModels(getReader("boxedcontextextension/filter.dmn"));
-        assertEquals(0, validate.size());
+        assertThat(validate).hasSize(0);
     }
 
     @Test
@@ -101,6 +101,6 @@ public class TrisotechValidationTest {
         List<DMNMessage> validate = validator.validateUsing(VALIDATE_SCHEMA, VALIDATE_MODEL, VALIDATE_COMPILATION)
                                              .usingSchema(TrisotechSchema.INSTANCEv1_3)
                                              .theseModels(getReader("boxedcontextextension/filter-datatype.dmn"));
-        assertEquals(0, validate.size());
+        assertThat(validate).hasSize(0);
     }
 }

--- a/kie-dmn/kie-dmn-validation/src/test/java/org/kie/dmn/validation/AbstractValidatorTest.java
+++ b/kie-dmn/kie-dmn-validation/src/test/java/org/kie/dmn/validation/AbstractValidatorTest.java
@@ -109,7 +109,7 @@ public abstract class AbstractValidatorTest {
                                                       .map(this::getReader)
                                                       .map(marshaller::unmarshal)
                                                       .collect(Collectors.toList());
-        assertThat(definitionss.isEmpty()).isFalse();
+        assertThat(definitionss).isNotEmpty();
 
         final Optional<Definitions> definitions = definitionss.stream()
                                                               .filter(d -> {

--- a/kie-dmn/kie-dmn-validation/src/test/java/org/kie/dmn/validation/UsingResourceValidatorTest.java
+++ b/kie-dmn/kie-dmn-validation/src/test/java/org/kie/dmn/validation/UsingResourceValidatorTest.java
@@ -27,7 +27,6 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.Assert.assertTrue;
 import static org.kie.dmn.validation.DMNValidator.Validation.VALIDATE_COMPILATION;
 import static org.kie.dmn.validation.DMNValidator.Validation.VALIDATE_MODEL;
 import static org.kie.dmn.validation.DMNValidator.Validation.VALIDATE_SCHEMA;
@@ -56,7 +55,7 @@ public class UsingResourceValidatorTest extends AbstractValidatorTest {
     public void testFailingModelValidation_single() {
         final List<DMNMessage> messages = validator.validate( getResource("import/importingMyHelloDSbkmBoxedInvocation_wrongDoubleImportName.dmn"), VALIDATE_SCHEMA, VALIDATE_MODEL );
         LOG.debug("{}", messages);
-        assertTrue(messages.stream().anyMatch(p -> p.getPath().endsWith("importingMyHelloDSbkmBoxedInvocation_wrongDoubleImportName.dmn") && p.getText().contains("myHelloDS") && p.getMessageType().equals(DMNMessageType.DUPLICATE_NAME)));
+        assertThat(messages.stream().anyMatch(p -> p.getPath().endsWith("importingMyHelloDSbkmBoxedInvocation_wrongDoubleImportName.dmn") && p.getText().contains("myHelloDS") && p.getMessageType().equals(DMNMessageType.DUPLICATE_NAME))).isTrue();
     }
     
     @Test
@@ -65,14 +64,14 @@ public class UsingResourceValidatorTest extends AbstractValidatorTest {
                                                    .theseModels(getResource("myHelloDS.dmn", DMNDecisionServicesTest.class),
                                                                 getResource("import/importingMyHelloDSbkmBoxedInvocation_wrongDoubleImportName.dmn"));
         LOG.debug("{}", messages);
-        assertTrue(messages.stream().anyMatch(p -> p.getPath().endsWith("importingMyHelloDSbkmBoxedInvocation_wrongDoubleImportName.dmn") && p.getText().contains("myHelloDS") && p.getMessageType().equals(DMNMessageType.DUPLICATE_NAME)));
+        assertThat(messages.stream().anyMatch(p -> p.getPath().endsWith("importingMyHelloDSbkmBoxedInvocation_wrongDoubleImportName.dmn") && p.getText().contains("myHelloDS") && p.getMessageType().equals(DMNMessageType.DUPLICATE_NAME))).isTrue();
     }
     
     @Test
     public void testFailingCompilation_single() {
         final List<DMNMessage> messages = validator.validate( getResource("invalidFEEL.dmn"), VALIDATE_SCHEMA, VALIDATE_MODEL, VALIDATE_COMPILATION );
         LOG.debug("{}", messages);
-        assertTrue(messages.stream().anyMatch(p -> p.getPath().endsWith("invalidFEEL.dmn") && p.getText().contains("Error compiling FEEL expression") && p.getMessageType().equals(DMNMessageType.ERR_COMPILING_FEEL)));
+        assertThat(messages.stream().anyMatch(p -> p.getPath().endsWith("invalidFEEL.dmn") && p.getText().contains("Error compiling FEEL expression") && p.getMessageType().equals(DMNMessageType.ERR_COMPILING_FEEL))).isTrue();
     }
     
     @Test
@@ -80,7 +79,7 @@ public class UsingResourceValidatorTest extends AbstractValidatorTest {
         final List<DMNMessage> messages = validator.validateUsing(VALIDATE_SCHEMA, VALIDATE_MODEL, VALIDATE_COMPILATION)
                 .theseModels(getResource("invalidFEEL.dmn"));
         LOG.debug("{}", messages);
-        assertTrue(messages.stream().anyMatch(p -> p.getPath().endsWith("invalidFEEL.dmn") && p.getText().contains("Error compiling FEEL expression") && p.getMessageType().equals(DMNMessageType.ERR_COMPILING_FEEL)));
+        assertThat(messages.stream().anyMatch(p -> p.getPath().endsWith("invalidFEEL.dmn") && p.getText().contains("Error compiling FEEL expression") && p.getMessageType().equals(DMNMessageType.ERR_COMPILING_FEEL))).isTrue();
     }
 
 }

--- a/kie-dmn/kie-dmn-validation/src/test/java/org/kie/dmn/validation/ValidatorArtifactTest.java
+++ b/kie-dmn/kie-dmn-validation/src/test/java/org/kie/dmn/validation/ValidatorArtifactTest.java
@@ -25,7 +25,6 @@ import org.kie.dmn.api.core.DMNMessage;
 import org.kie.dmn.api.core.DMNMessageType;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.Assert.assertTrue;
 import static org.kie.dmn.validation.DMNValidator.Validation.VALIDATE_COMPILATION;
 import static org.kie.dmn.validation.DMNValidator.Validation.VALIDATE_MODEL;
 import static org.kie.dmn.validation.DMNValidator.Validation.VALIDATE_SCHEMA;
@@ -39,7 +38,7 @@ public class ValidatorArtifactTest extends AbstractValidatorTest {
                     reader,
                     VALIDATE_SCHEMA, VALIDATE_MODEL, VALIDATE_COMPILATION);
             assertThat(validate).as(ValidatorUtil.formatMessages(validate)).hasSize(2);
-            assertTrue( validate.stream().anyMatch( p -> p.getMessageType().equals( DMNMessageType.REQ_NOT_FOUND ) ) );
+            assertThat(validate.stream().anyMatch(p -> p.getMessageType().equals(DMNMessageType.REQ_NOT_FOUND))).isTrue();
         }
     }
 
@@ -49,7 +48,7 @@ public class ValidatorArtifactTest extends AbstractValidatorTest {
                 getFile( "artifact/ASSOC_REFERENCES_NOT_EMPTY.dmn" ),
                 VALIDATE_SCHEMA, VALIDATE_MODEL, VALIDATE_COMPILATION);
         assertThat(validate).as(ValidatorUtil.formatMessages(validate)).hasSize(2);
-        assertTrue( validate.stream().anyMatch( p -> p.getMessageType().equals( DMNMessageType.REQ_NOT_FOUND ) ) );
+        assertThat(validate.stream().anyMatch(p -> p.getMessageType().equals(DMNMessageType.REQ_NOT_FOUND))).isTrue();
     }
 
     @Test
@@ -60,6 +59,6 @@ public class ValidatorArtifactTest extends AbstractValidatorTest {
                                 "ASSOC_REFERENCES_NOT_EMPTY"),
                 VALIDATE_MODEL, VALIDATE_COMPILATION);
         assertThat(validate).as(ValidatorUtil.formatMessages(validate)).hasSize(2);
-        assertTrue( validate.stream().anyMatch( p -> p.getMessageType().equals( DMNMessageType.REQ_NOT_FOUND ) ) );
+        assertThat(validate.stream().anyMatch(p -> p.getMessageType().equals(DMNMessageType.REQ_NOT_FOUND))).isTrue();
     }
 }

--- a/kie-dmn/kie-dmn-validation/src/test/java/org/kie/dmn/validation/ValidatorAuthorityRequirementTest.java
+++ b/kie-dmn/kie-dmn-validation/src/test/java/org/kie/dmn/validation/ValidatorAuthorityRequirementTest.java
@@ -25,7 +25,6 @@ import org.kie.dmn.api.core.DMNMessage;
 import org.kie.dmn.api.core.DMNMessageType;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.Assert.assertTrue;
 import static org.kie.dmn.validation.DMNValidator.Validation.VALIDATE_COMPILATION;
 import static org.kie.dmn.validation.DMNValidator.Validation.VALIDATE_MODEL;
 import static org.kie.dmn.validation.DMNValidator.Validation.VALIDATE_SCHEMA;
@@ -39,7 +38,7 @@ public class ValidatorAuthorityRequirementTest extends AbstractValidatorTest {
                     reader,
                     VALIDATE_SCHEMA, VALIDATE_MODEL, VALIDATE_COMPILATION);
             assertThat(validate).as(ValidatorUtil.formatMessages(validate)).hasSize(3);
-            assertTrue(validate.stream().anyMatch(p -> p.getMessageType().equals(DMNMessageType.REQ_NOT_FOUND)));
+            assertThat(validate.stream().anyMatch(p -> p.getMessageType().equals(DMNMessageType.REQ_NOT_FOUND))).isTrue();
         }
     }
 
@@ -49,7 +48,7 @@ public class ValidatorAuthorityRequirementTest extends AbstractValidatorTest {
                 getFile("authorityrequirement/AUTHREQ_MISSING_DEPENDENCY_REQ_AUTH.dmn"),
                 VALIDATE_SCHEMA, VALIDATE_MODEL, VALIDATE_COMPILATION);
         assertThat(validate).as(ValidatorUtil.formatMessages(validate)).hasSize(3);
-        assertTrue(validate.stream().anyMatch(p -> p.getMessageType().equals(DMNMessageType.REQ_NOT_FOUND)));
+        assertThat(validate.stream().anyMatch(p -> p.getMessageType().equals(DMNMessageType.REQ_NOT_FOUND))).isTrue();
     }
 
     @Test
@@ -60,7 +59,7 @@ public class ValidatorAuthorityRequirementTest extends AbstractValidatorTest {
                                "AUTHREQ_MISSING_DEPENDENCY_REQ_AUTH"),
                 VALIDATE_MODEL, VALIDATE_COMPILATION);
         assertThat(validate).as(ValidatorUtil.formatMessages(validate)).hasSize(3);
-        assertTrue(validate.stream().anyMatch(p -> p.getMessageType().equals(DMNMessageType.REQ_NOT_FOUND)));
+        assertThat(validate.stream().anyMatch(p -> p.getMessageType().equals(DMNMessageType.REQ_NOT_FOUND))).isTrue();
     }
 
     @Test
@@ -70,7 +69,7 @@ public class ValidatorAuthorityRequirementTest extends AbstractValidatorTest {
                     reader,
                     VALIDATE_SCHEMA, VALIDATE_MODEL, VALIDATE_COMPILATION);
             assertThat(validate).as(ValidatorUtil.formatMessages(validate)).hasSize(3);
-            assertTrue(validate.stream().anyMatch(p -> p.getMessageType().equals(DMNMessageType.REQ_NOT_FOUND)));
+            assertThat(validate.stream().anyMatch(p -> p.getMessageType().equals(DMNMessageType.REQ_NOT_FOUND))).isTrue();
         }
     }
 
@@ -80,7 +79,7 @@ public class ValidatorAuthorityRequirementTest extends AbstractValidatorTest {
                 getFile("authorityrequirement/AUTHREQ_MISSING_DEPENDENCY_REQ_DEC.dmn"),
                 VALIDATE_SCHEMA, VALIDATE_MODEL, VALIDATE_COMPILATION);
         assertThat(validate).as(ValidatorUtil.formatMessages(validate)).hasSize(3);
-        assertTrue(validate.stream().anyMatch(p -> p.getMessageType().equals(DMNMessageType.REQ_NOT_FOUND)));
+        assertThat(validate.stream().anyMatch(p -> p.getMessageType().equals(DMNMessageType.REQ_NOT_FOUND))).isTrue();
     }
 
     @Test
@@ -91,7 +90,7 @@ public class ValidatorAuthorityRequirementTest extends AbstractValidatorTest {
                                "AUTHREQ_MISSING_DEPENDENCY_REQ_DEC"),
                 VALIDATE_MODEL, VALIDATE_COMPILATION);
         assertThat(validate).as(ValidatorUtil.formatMessages(validate)).hasSize(3);
-        assertTrue(validate.stream().anyMatch(p -> p.getMessageType().equals(DMNMessageType.REQ_NOT_FOUND)));
+        assertThat(validate.stream().anyMatch(p -> p.getMessageType().equals(DMNMessageType.REQ_NOT_FOUND))).isTrue();
     }
 
     @Test
@@ -101,7 +100,7 @@ public class ValidatorAuthorityRequirementTest extends AbstractValidatorTest {
                     reader,
                     VALIDATE_SCHEMA, VALIDATE_MODEL, VALIDATE_COMPILATION);
             assertThat(validate).as(ValidatorUtil.formatMessages(validate)).hasSize(3);
-            assertTrue(validate.stream().anyMatch(p -> p.getMessageType().equals(DMNMessageType.REQ_NOT_FOUND)));
+            assertThat(validate.stream().anyMatch(p -> p.getMessageType().equals(DMNMessageType.REQ_NOT_FOUND))).isTrue();
         }
     }
 
@@ -111,7 +110,7 @@ public class ValidatorAuthorityRequirementTest extends AbstractValidatorTest {
                 getFile("authorityrequirement/AUTHREQ_MISSING_DEPENDENCY_REQ_INPUT.dmn"),
                 VALIDATE_SCHEMA, VALIDATE_MODEL, VALIDATE_COMPILATION);
         assertThat(validate).as(ValidatorUtil.formatMessages(validate)).hasSize(3);
-        assertTrue(validate.stream().anyMatch(p -> p.getMessageType().equals(DMNMessageType.REQ_NOT_FOUND)));
+        assertThat(validate.stream().anyMatch(p -> p.getMessageType().equals(DMNMessageType.REQ_NOT_FOUND))).isTrue();
     }
 
     @Test
@@ -122,7 +121,7 @@ public class ValidatorAuthorityRequirementTest extends AbstractValidatorTest {
                                "AUTHREQ_MISSING_DEPENDENCY_REQ_INPUT"),
                 VALIDATE_MODEL, VALIDATE_COMPILATION);
         assertThat(validate).as(ValidatorUtil.formatMessages(validate)).hasSize(3);
-        assertTrue(validate.stream().anyMatch(p -> p.getMessageType().equals(DMNMessageType.REQ_NOT_FOUND)));
+        assertThat(validate.stream().anyMatch(p -> p.getMessageType().equals(DMNMessageType.REQ_NOT_FOUND))).isTrue();
     }
 
     @Test
@@ -132,7 +131,7 @@ public class ValidatorAuthorityRequirementTest extends AbstractValidatorTest {
                     reader,
                     VALIDATE_SCHEMA, VALIDATE_MODEL, VALIDATE_COMPILATION);
             assertThat(validate).as(ValidatorUtil.formatMessages(validate)).hasSize(3);
-            assertTrue(validate.stream().anyMatch(p -> p.getMessageType().equals(DMNMessageType.REQ_NOT_FOUND)));
+            assertThat(validate.stream().anyMatch(p -> p.getMessageType().equals(DMNMessageType.REQ_NOT_FOUND))).isTrue();
         }
     }
 
@@ -142,7 +141,7 @@ public class ValidatorAuthorityRequirementTest extends AbstractValidatorTest {
                 getFile("authorityrequirement/AUTHREQ_DEP_REQ_AUTH_NOT_KNOWLEDGESOURCE.dmn"),
                 VALIDATE_SCHEMA, VALIDATE_MODEL, VALIDATE_COMPILATION);
         assertThat(validate).as(ValidatorUtil.formatMessages(validate)).hasSize(3);
-        assertTrue(validate.stream().anyMatch(p -> p.getMessageType().equals(DMNMessageType.REQ_NOT_FOUND)));
+        assertThat(validate.stream().anyMatch(p -> p.getMessageType().equals(DMNMessageType.REQ_NOT_FOUND))).isTrue();
     }
 
     @Test
@@ -153,7 +152,7 @@ public class ValidatorAuthorityRequirementTest extends AbstractValidatorTest {
                                "AUTHREQ_DEP_REQ_AUTH_NOT_KNOWLEDGESOURCE"),
                 VALIDATE_MODEL, VALIDATE_COMPILATION);
         assertThat(validate).as(ValidatorUtil.formatMessages(validate)).hasSize(3);
-        assertTrue(validate.stream().anyMatch(p -> p.getMessageType().equals(DMNMessageType.REQ_NOT_FOUND)));
+        assertThat(validate.stream().anyMatch(p -> p.getMessageType().equals(DMNMessageType.REQ_NOT_FOUND))).isTrue();
     }
 
     @Test
@@ -163,7 +162,7 @@ public class ValidatorAuthorityRequirementTest extends AbstractValidatorTest {
                     reader,
                     VALIDATE_SCHEMA, VALIDATE_MODEL, VALIDATE_COMPILATION);
             assertThat(validate).as(ValidatorUtil.formatMessages(validate)).hasSize(3);
-            assertTrue(validate.stream().anyMatch(p -> p.getMessageType().equals(DMNMessageType.REQ_NOT_FOUND)));
+            assertThat(validate.stream().anyMatch(p -> p.getMessageType().equals(DMNMessageType.REQ_NOT_FOUND))).isTrue();
         }
     }
 
@@ -173,7 +172,7 @@ public class ValidatorAuthorityRequirementTest extends AbstractValidatorTest {
                 getFile("authorityrequirement/AUTHREQ_DEP_REQ_DEC_NOT_DECISION.dmn"),
                 VALIDATE_SCHEMA, VALIDATE_MODEL, VALIDATE_COMPILATION);
         assertThat(validate).as(ValidatorUtil.formatMessages(validate)).hasSize(3);
-        assertTrue(validate.stream().anyMatch(p -> p.getMessageType().equals(DMNMessageType.REQ_NOT_FOUND)));
+        assertThat(validate.stream().anyMatch(p -> p.getMessageType().equals(DMNMessageType.REQ_NOT_FOUND))).isTrue();
     }
 
     @Test
@@ -184,7 +183,7 @@ public class ValidatorAuthorityRequirementTest extends AbstractValidatorTest {
                                "AUTHREQ_DEP_REQ_DEC_NOT_DECISION"),
                 VALIDATE_MODEL, VALIDATE_COMPILATION);
         assertThat(validate).as(ValidatorUtil.formatMessages(validate)).hasSize(3);
-        assertTrue(validate.stream().anyMatch(p -> p.getMessageType().equals(DMNMessageType.REQ_NOT_FOUND)));
+        assertThat(validate.stream().anyMatch(p -> p.getMessageType().equals(DMNMessageType.REQ_NOT_FOUND))).isTrue();
     }
 
     @Test
@@ -194,7 +193,7 @@ public class ValidatorAuthorityRequirementTest extends AbstractValidatorTest {
                     reader,
                     VALIDATE_SCHEMA, VALIDATE_MODEL, VALIDATE_COMPILATION);
             assertThat(validate).as(ValidatorUtil.formatMessages(validate)).hasSize(3);
-            assertTrue(validate.stream().anyMatch(p -> p.getMessageType().equals(DMNMessageType.REQ_NOT_FOUND)));
+            assertThat(validate.stream().anyMatch(p -> p.getMessageType().equals(DMNMessageType.REQ_NOT_FOUND))).isTrue();
         }
     }
 
@@ -204,7 +203,7 @@ public class ValidatorAuthorityRequirementTest extends AbstractValidatorTest {
                 getFile("authorityrequirement/AUTHREQ_DEP_REQ_INPUT_NOT_INPUT.dmn"),
                 VALIDATE_SCHEMA, VALIDATE_MODEL, VALIDATE_COMPILATION);
         assertThat(validate).as(ValidatorUtil.formatMessages(validate)).hasSize(3);
-        assertTrue(validate.stream().anyMatch(p -> p.getMessageType().equals(DMNMessageType.REQ_NOT_FOUND)));
+        assertThat(validate.stream().anyMatch(p -> p.getMessageType().equals(DMNMessageType.REQ_NOT_FOUND))).isTrue();
     }
 
     @Test
@@ -215,6 +214,6 @@ public class ValidatorAuthorityRequirementTest extends AbstractValidatorTest {
                                "AUTHREQ_DEP_REQ_INPUT_NOT_INPUT"),
                 VALIDATE_MODEL, VALIDATE_COMPILATION);
         assertThat(validate).as(ValidatorUtil.formatMessages(validate)).hasSize(3);
-        assertTrue(validate.stream().anyMatch(p -> p.getMessageType().equals(DMNMessageType.REQ_NOT_FOUND)));
+        assertThat(validate.stream().anyMatch(p -> p.getMessageType().equals(DMNMessageType.REQ_NOT_FOUND))).isTrue();
     }
 }

--- a/kie-dmn/kie-dmn-validation/src/test/java/org/kie/dmn/validation/ValidatorBusinessContextTest.java
+++ b/kie-dmn/kie-dmn-validation/src/test/java/org/kie/dmn/validation/ValidatorBusinessContextTest.java
@@ -25,7 +25,6 @@ import org.kie.dmn.api.core.DMNMessage;
 import org.kie.dmn.api.core.DMNMessageType;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.Assert.assertTrue;
 import static org.kie.dmn.validation.DMNValidator.Validation.VALIDATE_COMPILATION;
 import static org.kie.dmn.validation.DMNValidator.Validation.VALIDATE_MODEL;
 import static org.kie.dmn.validation.DMNValidator.Validation.VALIDATE_SCHEMA;
@@ -39,7 +38,7 @@ public class ValidatorBusinessContextTest extends AbstractValidatorTest {
                     reader,
                     VALIDATE_SCHEMA, VALIDATE_MODEL, VALIDATE_COMPILATION);
             assertThat(validate).as(ValidatorUtil.formatMessages(validate)).hasSize(2);
-            assertTrue(validate.stream().anyMatch(p -> p.getMessageType().equals(DMNMessageType.REQ_NOT_FOUND)));
+            assertThat(validate.stream().anyMatch(p -> p.getMessageType().equals(DMNMessageType.REQ_NOT_FOUND))).isTrue();
         }
     }
 
@@ -49,7 +48,7 @@ public class ValidatorBusinessContextTest extends AbstractValidatorTest {
                 getFile("businesscontext/ORG_UNIT_DECISION_MADE_WRONG_TYPE.dmn"),
                 VALIDATE_SCHEMA, VALIDATE_MODEL, VALIDATE_COMPILATION);
         assertThat(validate).as(ValidatorUtil.formatMessages(validate)).hasSize(2);
-        assertTrue(validate.stream().anyMatch(p -> p.getMessageType().equals(DMNMessageType.REQ_NOT_FOUND)));
+        assertThat(validate.stream().anyMatch(p -> p.getMessageType().equals(DMNMessageType.REQ_NOT_FOUND))).isTrue();
     }
 
     @Test
@@ -60,7 +59,7 @@ public class ValidatorBusinessContextTest extends AbstractValidatorTest {
                                "ORG_UNIT_DECISION_MADE_WRONG_TYPE"),
                 VALIDATE_MODEL, VALIDATE_COMPILATION);
         assertThat(validate).as(ValidatorUtil.formatMessages(validate)).hasSize(2);
-        assertTrue(validate.stream().anyMatch(p -> p.getMessageType().equals(DMNMessageType.REQ_NOT_FOUND)));
+        assertThat(validate.stream().anyMatch(p -> p.getMessageType().equals(DMNMessageType.REQ_NOT_FOUND))).isTrue();
     }
 
     @Test
@@ -70,7 +69,7 @@ public class ValidatorBusinessContextTest extends AbstractValidatorTest {
                     reader,
                     VALIDATE_SCHEMA, VALIDATE_MODEL, VALIDATE_COMPILATION);
             assertThat(validate).as(ValidatorUtil.formatMessages(validate)).hasSize(2);
-            assertTrue(validate.stream().anyMatch(p -> p.getMessageType().equals(DMNMessageType.REQ_NOT_FOUND)));
+            assertThat(validate.stream().anyMatch(p -> p.getMessageType().equals(DMNMessageType.REQ_NOT_FOUND))).isTrue();
         }
     }
 
@@ -80,7 +79,7 @@ public class ValidatorBusinessContextTest extends AbstractValidatorTest {
                 getFile("businesscontext/ORG_UNIT_DECISION_OWNED_WRONG_TYPE.dmn"),
                 VALIDATE_SCHEMA, VALIDATE_MODEL, VALIDATE_COMPILATION);
         assertThat(validate).as(ValidatorUtil.formatMessages(validate)).hasSize(2);
-        assertTrue(validate.stream().anyMatch(p -> p.getMessageType().equals(DMNMessageType.REQ_NOT_FOUND)));
+        assertThat(validate.stream().anyMatch(p -> p.getMessageType().equals(DMNMessageType.REQ_NOT_FOUND))).isTrue();
     }
 
     @Test
@@ -91,7 +90,7 @@ public class ValidatorBusinessContextTest extends AbstractValidatorTest {
                                "ORG_UNIT_DECISION_OWNED_WRONG_TYPE"),
                 VALIDATE_MODEL, VALIDATE_COMPILATION);
         assertThat(validate).as(ValidatorUtil.formatMessages(validate)).hasSize(2);
-        assertTrue(validate.stream().anyMatch(p -> p.getMessageType().equals(DMNMessageType.REQ_NOT_FOUND)));
+        assertThat(validate.stream().anyMatch(p -> p.getMessageType().equals(DMNMessageType.REQ_NOT_FOUND))).isTrue();
     }
 
     @Test
@@ -101,7 +100,7 @@ public class ValidatorBusinessContextTest extends AbstractValidatorTest {
                     reader,
                     VALIDATE_SCHEMA, VALIDATE_MODEL, VALIDATE_COMPILATION);
             assertThat(validate).as(ValidatorUtil.formatMessages(validate)).hasSize(2);
-            assertTrue(validate.stream().anyMatch(p -> p.getMessageType().equals(DMNMessageType.REQ_NOT_FOUND)));
+            assertThat(validate.stream().anyMatch(p -> p.getMessageType().equals(DMNMessageType.REQ_NOT_FOUND))).isTrue();
         }
     }
 
@@ -111,7 +110,7 @@ public class ValidatorBusinessContextTest extends AbstractValidatorTest {
                 getFile("businesscontext/PERF_INDICATOR_IMP_DECISION_WRONG_TYPE.dmn"),
                 VALIDATE_SCHEMA, VALIDATE_MODEL, VALIDATE_COMPILATION);
         assertThat(validate).as(ValidatorUtil.formatMessages(validate)).hasSize(2);
-        assertTrue(validate.stream().anyMatch(p -> p.getMessageType().equals(DMNMessageType.REQ_NOT_FOUND)));
+        assertThat(validate.stream().anyMatch(p -> p.getMessageType().equals(DMNMessageType.REQ_NOT_FOUND))).isTrue();
     }
 
     @Test
@@ -122,6 +121,6 @@ public class ValidatorBusinessContextTest extends AbstractValidatorTest {
                                "PERF_INDICATOR_IMP_DECISION_WRONG_TYPE"),
                 VALIDATE_MODEL, VALIDATE_COMPILATION);
         assertThat(validate).as(ValidatorUtil.formatMessages(validate)).hasSize(2);
-        assertTrue(validate.stream().anyMatch(p -> p.getMessageType().equals(DMNMessageType.REQ_NOT_FOUND)));
+        assertThat(validate.stream().anyMatch(p -> p.getMessageType().equals(DMNMessageType.REQ_NOT_FOUND))).isTrue();
     }
 }

--- a/kie-dmn/kie-dmn-validation/src/test/java/org/kie/dmn/validation/ValidatorBusinessKnowledgeModelTest.java
+++ b/kie-dmn/kie-dmn-validation/src/test/java/org/kie/dmn/validation/ValidatorBusinessKnowledgeModelTest.java
@@ -28,7 +28,6 @@ import org.kie.dmn.api.core.DMNMessage;
 import org.kie.dmn.api.core.DMNMessageType;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.Assert.assertTrue;
 
 public class ValidatorBusinessKnowledgeModelTest extends AbstractValidatorTest {
 
@@ -39,7 +38,7 @@ public class ValidatorBusinessKnowledgeModelTest extends AbstractValidatorTest {
                     reader,
                     VALIDATE_SCHEMA, VALIDATE_MODEL, VALIDATE_COMPILATION);
             assertThat(validate).withFailMessage(ValidatorUtil.formatMessages(validate)).hasSize(1);
-            assertTrue(validate.stream().anyMatch(p -> p.getMessageType().equals(DMNMessageType.MISSING_VARIABLE)));
+            assertThat(validate.stream().anyMatch(p -> p.getMessageType().equals(DMNMessageType.MISSING_VARIABLE))).isTrue();
         }
     }
 
@@ -49,7 +48,7 @@ public class ValidatorBusinessKnowledgeModelTest extends AbstractValidatorTest {
                 getFile("businessknowledgemodel/BKM_MISSING_VAR.dmn"),
                 VALIDATE_SCHEMA, VALIDATE_MODEL, VALIDATE_COMPILATION);
         assertThat(validate).withFailMessage(ValidatorUtil.formatMessages(validate)).hasSize(1);
-        assertTrue(validate.stream().anyMatch(p -> p.getMessageType().equals(DMNMessageType.MISSING_VARIABLE)));
+        assertThat(validate.stream().anyMatch(p -> p.getMessageType().equals(DMNMessageType.MISSING_VARIABLE))).isTrue();
     }
 
     @Test
@@ -60,7 +59,7 @@ public class ValidatorBusinessKnowledgeModelTest extends AbstractValidatorTest {
                                "BKM_MISSING_VAR"),
                 VALIDATE_MODEL, VALIDATE_COMPILATION);
         assertThat(validate).withFailMessage(ValidatorUtil.formatMessages(validate)).hasSize(1);
-        assertTrue(validate.stream().anyMatch(p -> p.getMessageType().equals(DMNMessageType.MISSING_VARIABLE)));
+        assertThat(validate.stream().anyMatch(p -> p.getMessageType().equals(DMNMessageType.MISSING_VARIABLE))).isTrue();
     }
 
     @Test
@@ -70,7 +69,7 @@ public class ValidatorBusinessKnowledgeModelTest extends AbstractValidatorTest {
                     reader,
                     VALIDATE_SCHEMA, VALIDATE_MODEL, VALIDATE_COMPILATION);
             assertThat(validate).withFailMessage(ValidatorUtil.formatMessages(validate)).hasSize(1);
-            assertTrue(validate.stream().anyMatch(p -> p.getMessageType().equals(DMNMessageType.VARIABLE_NAME_MISMATCH)));
+            assertThat(validate.stream().anyMatch(p -> p.getMessageType().equals(DMNMessageType.VARIABLE_NAME_MISMATCH))).isTrue();
         }
     }
 
@@ -80,7 +79,7 @@ public class ValidatorBusinessKnowledgeModelTest extends AbstractValidatorTest {
                 getFile("businessknowledgemodel/BKM_MISMATCH_VAR.dmn"),
                 VALIDATE_SCHEMA, VALIDATE_MODEL, VALIDATE_COMPILATION);
         assertThat(validate).withFailMessage(ValidatorUtil.formatMessages(validate)).hasSize(1);
-        assertTrue(validate.stream().anyMatch(p -> p.getMessageType().equals(DMNMessageType.VARIABLE_NAME_MISMATCH)));
+        assertThat(validate.stream().anyMatch(p -> p.getMessageType().equals(DMNMessageType.VARIABLE_NAME_MISMATCH))).isTrue();
     }
 
     @Test
@@ -91,7 +90,7 @@ public class ValidatorBusinessKnowledgeModelTest extends AbstractValidatorTest {
                                "BKM_MISSING_VAR"),
                 VALIDATE_MODEL, VALIDATE_COMPILATION);
         assertThat(validate).withFailMessage(ValidatorUtil.formatMessages(validate)).hasSize(1);
-        assertTrue(validate.stream().anyMatch(p -> p.getMessageType().equals(DMNMessageType.VARIABLE_NAME_MISMATCH)));
+        assertThat(validate.stream().anyMatch(p -> p.getMessageType().equals(DMNMessageType.VARIABLE_NAME_MISMATCH))).isTrue();
     }
 
     @Test

--- a/kie-dmn/kie-dmn-validation/src/test/java/org/kie/dmn/validation/ValidatorContextTest.java
+++ b/kie-dmn/kie-dmn-validation/src/test/java/org/kie/dmn/validation/ValidatorContextTest.java
@@ -30,7 +30,6 @@ import org.kie.dmn.model.api.Context;
 import org.kie.dmn.model.api.ContextEntry;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.Assert.assertTrue;
 
 public class ValidatorContextTest extends AbstractValidatorTest {
 
@@ -41,8 +40,8 @@ public class ValidatorContextTest extends AbstractValidatorTest {
                     reader,
                     VALIDATE_SCHEMA, VALIDATE_MODEL, VALIDATE_COMPILATION);
             assertThat(validate).withFailMessage(ValidatorUtil.formatMessages(validate)).hasSize(2);
-            assertTrue(validate.stream().anyMatch(p -> p.getMessageType().equals(DMNMessageType.FAILED_XML_VALIDATION))); // this is schema validation
-            assertTrue(validate.stream().anyMatch(p -> p.getMessageType().equals(DMNMessageType.MISSING_EXPRESSION)));
+            assertThat(validate.stream().anyMatch(p -> p.getMessageType().equals(DMNMessageType.FAILED_XML_VALIDATION))).isTrue(); // this is schema validation
+            assertThat(validate.stream().anyMatch(p -> p.getMessageType().equals(DMNMessageType.MISSING_EXPRESSION))).isTrue();
         }
     }
 
@@ -52,8 +51,8 @@ public class ValidatorContextTest extends AbstractValidatorTest {
                 getFile("context/CONTEXT_MISSING_EXPR.dmn"),
                 VALIDATE_SCHEMA, VALIDATE_MODEL, VALIDATE_COMPILATION);
         assertThat(validate).withFailMessage(ValidatorUtil.formatMessages(validate)).hasSize(2);
-        assertTrue(validate.stream().anyMatch(p -> p.getMessageType().equals(DMNMessageType.FAILED_XML_VALIDATION))); // this is schema validation
-        assertTrue(validate.stream().anyMatch(p -> p.getMessageType().equals(DMNMessageType.MISSING_EXPRESSION)));
+        assertThat(validate.stream().anyMatch(p -> p.getMessageType().equals(DMNMessageType.FAILED_XML_VALIDATION))).isTrue(); // this is schema validation
+        assertThat(validate.stream().anyMatch(p -> p.getMessageType().equals(DMNMessageType.MISSING_EXPRESSION))).isTrue();
     }
 
     @Test
@@ -64,7 +63,7 @@ public class ValidatorContextTest extends AbstractValidatorTest {
                                "CONTEXT_MISSING_EXPR"),
                 VALIDATE_MODEL, VALIDATE_COMPILATION);
         assertThat(validate).withFailMessage(ValidatorUtil.formatMessages(validate)).hasSize(1);
-        assertTrue(validate.stream().anyMatch(p -> p.getMessageType().equals(DMNMessageType.MISSING_EXPRESSION)));
+        assertThat(validate.stream().anyMatch(p -> p.getMessageType().equals(DMNMessageType.MISSING_EXPRESSION))).isTrue();
     }
 
     @Test
@@ -74,7 +73,7 @@ public class ValidatorContextTest extends AbstractValidatorTest {
                     reader,
                     VALIDATE_SCHEMA, VALIDATE_MODEL, VALIDATE_COMPILATION);
             assertThat(validate).withFailMessage(ValidatorUtil.formatMessages(validate)).hasSize(1);
-            assertTrue(validate.stream().anyMatch(p -> p.getMessageType().equals(DMNMessageType.MISSING_EXPRESSION)));
+            assertThat(validate.stream().anyMatch(p -> p.getMessageType().equals(DMNMessageType.MISSING_EXPRESSION))).isTrue();
         }
     }
 
@@ -84,7 +83,7 @@ public class ValidatorContextTest extends AbstractValidatorTest {
                 getFile("context/CONTEXT_MISSING_ENTRIES.dmn"),
                 VALIDATE_SCHEMA, VALIDATE_MODEL, VALIDATE_COMPILATION);
         assertThat(validate).withFailMessage(ValidatorUtil.formatMessages(validate)).hasSize(1);
-        assertTrue(validate.stream().anyMatch(p -> p.getMessageType().equals(DMNMessageType.MISSING_EXPRESSION)));
+        assertThat(validate.stream().anyMatch(p -> p.getMessageType().equals(DMNMessageType.MISSING_EXPRESSION))).isTrue();
     }
 
     @Test
@@ -95,7 +94,7 @@ public class ValidatorContextTest extends AbstractValidatorTest {
                                "CONTEXT_MISSING_EXPR"),
                 VALIDATE_MODEL, VALIDATE_COMPILATION);
         assertThat(validate).withFailMessage(ValidatorUtil.formatMessages(validate)).hasSize(1);
-        assertTrue(validate.stream().anyMatch(p -> p.getMessageType().equals(DMNMessageType.MISSING_EXPRESSION)));
+        assertThat(validate.stream().anyMatch(p -> p.getMessageType().equals(DMNMessageType.MISSING_EXPRESSION))).isTrue();
     }
 
     @Test
@@ -105,7 +104,7 @@ public class ValidatorContextTest extends AbstractValidatorTest {
                     reader,
                     VALIDATE_SCHEMA, VALIDATE_MODEL, VALIDATE_COMPILATION);
             assertThat(validate).withFailMessage(ValidatorUtil.formatMessages(validate)).hasSize(1);
-            assertTrue(validate.stream().anyMatch(p -> p.getMessageType().equals(DMNMessageType.MISSING_VARIABLE)));
+            assertThat(validate.stream().anyMatch(p -> p.getMessageType().equals(DMNMessageType.MISSING_VARIABLE))).isTrue();
             // check that it reports and error for the second context entry, but not for the last one
             final ContextEntry ce = (ContextEntry) validate.get(0).getSourceReference();
             assertThat(((Context) ce.getParent()).getContextEntry().indexOf(ce)).isEqualTo(1);
@@ -118,7 +117,7 @@ public class ValidatorContextTest extends AbstractValidatorTest {
                 getFile("context/CONTEXT_ENTRY_MISSING_VARIABLE.dmn"),
                 VALIDATE_SCHEMA, VALIDATE_MODEL, VALIDATE_COMPILATION);
         assertThat(validate).withFailMessage(ValidatorUtil.formatMessages(validate)).hasSize(1);
-        assertTrue(validate.stream().anyMatch(p -> p.getMessageType().equals(DMNMessageType.MISSING_VARIABLE)));
+        assertThat(validate.stream().anyMatch(p -> p.getMessageType().equals(DMNMessageType.MISSING_VARIABLE))).isTrue();
         // check that it reports and error for the second context entry, but not for the last one
         final ContextEntry ce = (ContextEntry) validate.get(0).getSourceReference();
         assertThat(((Context) ce.getParent()).getContextEntry().indexOf(ce)).isEqualTo(1);
@@ -132,7 +131,7 @@ public class ValidatorContextTest extends AbstractValidatorTest {
                                "CONTEXT_MISSING_EXPR"),
                 VALIDATE_MODEL, VALIDATE_COMPILATION);
         assertThat(validate).withFailMessage(ValidatorUtil.formatMessages(validate)).hasSize(1);
-        assertTrue(validate.stream().anyMatch(p -> p.getMessageType().equals(DMNMessageType.MISSING_VARIABLE)));
+        assertThat(validate.stream().anyMatch(p -> p.getMessageType().equals(DMNMessageType.MISSING_VARIABLE))).isTrue();
         // check that it reports and error for the second context entry, but not for the last one
         final ContextEntry ce = (ContextEntry) validate.get(0).getSourceReference();
         assertThat(((Context) ce.getParent()).getContextEntry().indexOf(ce)).isEqualTo(1);
@@ -145,7 +144,7 @@ public class ValidatorContextTest extends AbstractValidatorTest {
                     reader,
                     VALIDATE_SCHEMA, VALIDATE_MODEL, VALIDATE_COMPILATION);
             assertThat(validate).withFailMessage(ValidatorUtil.formatMessages(validate)).hasSize(2);
-            assertTrue(validate.stream().anyMatch(p -> p.getMessageType().equals(DMNMessageType.DUPLICATE_NAME)));
+            assertThat(validate.stream().anyMatch(p -> p.getMessageType().equals(DMNMessageType.DUPLICATE_NAME))).isTrue();
         }
     }
 
@@ -155,7 +154,7 @@ public class ValidatorContextTest extends AbstractValidatorTest {
                 getFile("context/CONTEXT_DUP_ENTRY.dmn"),
                 VALIDATE_SCHEMA, VALIDATE_MODEL, VALIDATE_COMPILATION);
         assertThat(validate).withFailMessage(ValidatorUtil.formatMessages(validate)).hasSize(2);
-        assertTrue(validate.stream().anyMatch(p -> p.getMessageType().equals(DMNMessageType.DUPLICATE_NAME)));
+        assertThat(validate.stream().anyMatch(p -> p.getMessageType().equals(DMNMessageType.DUPLICATE_NAME))).isTrue();
     }
 
     @Test
@@ -166,7 +165,7 @@ public class ValidatorContextTest extends AbstractValidatorTest {
                                "CONTEXT_DUP_ENTRY"),
                 VALIDATE_MODEL, VALIDATE_COMPILATION);
         assertThat(validate).withFailMessage(ValidatorUtil.formatMessages(validate)).hasSize(2);
-        assertTrue(validate.stream().anyMatch(p -> p.getMessageType().equals(DMNMessageType.DUPLICATE_NAME)));
+        assertThat(validate.stream().anyMatch(p -> p.getMessageType().equals(DMNMessageType.DUPLICATE_NAME))).isTrue();
     }
 
     @Test
@@ -176,7 +175,7 @@ public class ValidatorContextTest extends AbstractValidatorTest {
                     reader,
                     VALIDATE_SCHEMA, VALIDATE_MODEL, VALIDATE_COMPILATION);
             assertThat(validate).withFailMessage(ValidatorUtil.formatMessages(validate)).hasSize(2);
-            assertTrue(validate.stream().anyMatch(p -> p.getMessageType().equals(DMNMessageType.MISSING_TYPE_REF)));
+            assertThat(validate.stream().anyMatch(p -> p.getMessageType().equals(DMNMessageType.MISSING_TYPE_REF))).isTrue();
         }
     }
 
@@ -186,7 +185,7 @@ public class ValidatorContextTest extends AbstractValidatorTest {
                 getFile("context/CONTEXT_ENTRY_NOTYPEREF.dmn"),
                 VALIDATE_SCHEMA, VALIDATE_MODEL, VALIDATE_COMPILATION);
         assertThat(validate).withFailMessage(ValidatorUtil.formatMessages(validate)).hasSize(2);
-        assertTrue(validate.stream().anyMatch(p -> p.getMessageType().equals(DMNMessageType.MISSING_TYPE_REF)));
+        assertThat(validate.stream().anyMatch(p -> p.getMessageType().equals(DMNMessageType.MISSING_TYPE_REF))).isTrue();
     }
 
     @Test
@@ -197,6 +196,6 @@ public class ValidatorContextTest extends AbstractValidatorTest {
                                "CONTEXT_ENTRY_NOTYPEREF"),
                 VALIDATE_MODEL, VALIDATE_COMPILATION);
         assertThat(validate).withFailMessage(ValidatorUtil.formatMessages(validate)).hasSize(2);
-        assertTrue(validate.stream().anyMatch(p -> p.getMessageType().equals(DMNMessageType.MISSING_TYPE_REF)));
+        assertThat(validate.stream().anyMatch(p -> p.getMessageType().equals(DMNMessageType.MISSING_TYPE_REF))).isTrue();
     }
 }

--- a/kie-dmn/kie-dmn-validation/src/test/java/org/kie/dmn/validation/ValidatorDMN14Test.java
+++ b/kie-dmn/kie-dmn-validation/src/test/java/org/kie/dmn/validation/ValidatorDMN14Test.java
@@ -16,11 +16,6 @@
 
 package org.kie.dmn.validation;
 
-import static org.junit.Assert.assertEquals;
-import static org.kie.dmn.validation.DMNValidator.Validation.VALIDATE_COMPILATION;
-import static org.kie.dmn.validation.DMNValidator.Validation.VALIDATE_MODEL;
-import static org.kie.dmn.validation.DMNValidator.Validation.VALIDATE_SCHEMA;
-
 import java.io.IOException;
 import java.io.Reader;
 import java.util.List;
@@ -29,6 +24,12 @@ import org.junit.Test;
 import org.kie.dmn.api.core.DMNMessage;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.kie.dmn.validation.DMNValidator.Validation.VALIDATE_COMPILATION;
+import static org.kie.dmn.validation.DMNValidator.Validation.VALIDATE_MODEL;
+import static org.kie.dmn.validation.DMNValidator.Validation.VALIDATE_SCHEMA;
+
 
 public class ValidatorDMN14Test extends AbstractValidatorTest {
 	
@@ -40,7 +41,7 @@ public class ValidatorDMN14Test extends AbstractValidatorTest {
             final List<DMNMessage> validate = validator.validate(
                     reader,
                     VALIDATE_SCHEMA, VALIDATE_MODEL, VALIDATE_COMPILATION);
-            assertEquals(0, validate.size());
+            assertThat(validate).hasSize(0);
         }
     }
 
@@ -49,7 +50,7 @@ public class ValidatorDMN14Test extends AbstractValidatorTest {
         final List<DMNMessage> validate = validator.validate(
                 getFile("dmn14simple.dmn"),
                 VALIDATE_SCHEMA, VALIDATE_MODEL, VALIDATE_COMPILATION);
-        assertEquals(0, validate.size());
+        assertThat(validate).hasSize(0);
     }
 
     @Test
@@ -59,7 +60,7 @@ public class ValidatorDMN14Test extends AbstractValidatorTest {
                                "http://www.trisotech.com/definitions/_d9232146-7aaa-49a9-8668-261a01844ace",
                                "Drawing 1"),
                 VALIDATE_MODEL, VALIDATE_COMPILATION);
-        assertEquals(0, validate.size());
+        assertThat(validate).hasSize(0);
     }
 
     @Test
@@ -67,7 +68,7 @@ public class ValidatorDMN14Test extends AbstractValidatorTest {
         List<DMNMessage> validate = validator.validateUsing(VALIDATE_SCHEMA, VALIDATE_MODEL, VALIDATE_COMPILATION)
                                              .theseModels(getReader("dmn14boxed/conditional.dmn"));
         LOG.debug("{}", validate);
-        assertEquals(0, validate.size());
+        assertThat(validate).hasSize(0);
     }
 
     @Test
@@ -75,26 +76,26 @@ public class ValidatorDMN14Test extends AbstractValidatorTest {
         List<DMNMessage> validate = validator.validateUsing(VALIDATE_SCHEMA, VALIDATE_MODEL, VALIDATE_COMPILATION)
                                              .theseModels(getReader("dmn14boxed/iterator.dmn"));
         LOG.debug("{}", validate);
-        assertEquals(0, validate.size());
+        assertThat(validate).hasSize(0);
     }
     @Test
     public void testBoxedExtension_IteratorDataType14() {
         List<DMNMessage> validate = validator.validateUsing(VALIDATE_SCHEMA, VALIDATE_MODEL, VALIDATE_COMPILATION)
                                              .theseModels(getReader("dmn14boxed/iterator-datatype.dmn"));
-        assertEquals(0, validate.size());
+        assertThat(validate).hasSize(0);
     }
 
     @Test
     public void testBoxedExtension_Filter14() {
         List<DMNMessage> validate = validator.validateUsing(VALIDATE_SCHEMA, VALIDATE_MODEL, VALIDATE_COMPILATION)
                                              .theseModels(getReader("dmn14boxed/filter.dmn"));
-        assertEquals(0, validate.size());
+        assertThat(validate).hasSize(0);
     }
 
     @Test
     public void testBoxedExtension_FilterDataType14() {
         List<DMNMessage> validate = validator.validateUsing(VALIDATE_SCHEMA, VALIDATE_MODEL, VALIDATE_COMPILATION)
                                              .theseModels(getReader("dmn14boxed/filter-datatype.dmn"));
-        assertEquals(0, validate.size());
+        assertThat(validate).hasSize(0);
     }
 }

--- a/kie-dmn/kie-dmn-validation/src/test/java/org/kie/dmn/validation/ValidatorDMNElementReferenceTest.java
+++ b/kie-dmn/kie-dmn-validation/src/test/java/org/kie/dmn/validation/ValidatorDMNElementReferenceTest.java
@@ -25,7 +25,6 @@ import org.kie.dmn.api.core.DMNMessage;
 import org.kie.dmn.api.core.DMNMessageType;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.Assert.assertTrue;
 import static org.kie.dmn.validation.DMNValidator.Validation.VALIDATE_COMPILATION;
 import static org.kie.dmn.validation.DMNValidator.Validation.VALIDATE_MODEL;
 import static org.kie.dmn.validation.DMNValidator.Validation.VALIDATE_SCHEMA;
@@ -62,9 +61,9 @@ public class ValidatorDMNElementReferenceTest extends AbstractValidatorTest {
 
     private void assertValiadationResult(List<DMNMessage> validationMessages) {
     	assertThat(validationMessages).as(ValidatorUtil.formatMessages(validationMessages)).hasSize(3);
-        assertTrue(validationMessages.stream().anyMatch(p -> p.getMessageType().equals(DMNMessageType.MISSING_EXPRESSION)));
-        assertTrue(validationMessages.stream().anyMatch(p -> p.getMessageType().equals(DMNMessageType.INVALID_HREF_SYNTAX)));
-        assertTrue(validationMessages.stream().anyMatch(p -> p.getMessageType().equals(DMNMessageType.REQ_NOT_FOUND)));
+        assertThat(validationMessages.stream().anyMatch(p -> p.getMessageType().equals(DMNMessageType.MISSING_EXPRESSION))).isTrue();
+        assertThat(validationMessages.stream().anyMatch(p -> p.getMessageType().equals(DMNMessageType.INVALID_HREF_SYNTAX))).isTrue();
+        assertThat(validationMessages.stream().anyMatch(p -> p.getMessageType().equals(DMNMessageType.REQ_NOT_FOUND))).isTrue();
     }
 
 }

--- a/kie-dmn/kie-dmn-validation/src/test/java/org/kie/dmn/validation/ValidatorDecisionTableTest.java
+++ b/kie-dmn/kie-dmn-validation/src/test/java/org/kie/dmn/validation/ValidatorDecisionTableTest.java
@@ -25,7 +25,6 @@ import org.kie.dmn.api.core.DMNMessage;
 import org.kie.dmn.api.core.DMNMessageType;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.Assert.assertTrue;
 import static org.kie.dmn.validation.DMNValidator.Validation.VALIDATE_COMPILATION;
 import static org.kie.dmn.validation.DMNValidator.Validation.VALIDATE_MODEL;
 import static org.kie.dmn.validation.DMNValidator.Validation.VALIDATE_SCHEMA;
@@ -40,7 +39,7 @@ public class ValidatorDecisionTableTest
                     reader,
                     VALIDATE_MODEL, VALIDATE_COMPILATION);
             assertThat(validate).as(ValidatorUtil.formatMessages(validate)).hasSize(2);
-            assertTrue(validate.stream().anyMatch(p -> p.getMessageType().equals(DMNMessageType.MISSING_EXPRESSION)));
+            assertThat(validate.stream().anyMatch(p -> p.getMessageType().equals(DMNMessageType.MISSING_EXPRESSION))).isTrue();
         }
     }
 
@@ -50,7 +49,7 @@ public class ValidatorDecisionTableTest
                 getFile("DTABLE_EMPTY_ENTRY.dmn"),
                 VALIDATE_MODEL, VALIDATE_COMPILATION);
         assertThat(validate).as(ValidatorUtil.formatMessages(validate)).hasSize(2);
-        assertTrue(validate.stream().anyMatch(p -> p.getMessageType().equals(DMNMessageType.MISSING_EXPRESSION)));
+        assertThat(validate.stream().anyMatch(p -> p.getMessageType().equals(DMNMessageType.MISSING_EXPRESSION))).isTrue();
     }
 
     @Test
@@ -61,7 +60,7 @@ public class ValidatorDecisionTableTest
                                "DTABLE_PRIORITY_MISSING_OUTVALS"),
                 VALIDATE_MODEL, VALIDATE_COMPILATION);
         assertThat(validate).as(ValidatorUtil.formatMessages(validate)).hasSize(2);
-        assertTrue(validate.stream().anyMatch(p -> p.getMessageType().equals(DMNMessageType.MISSING_EXPRESSION)));
+        assertThat(validate.stream().anyMatch(p -> p.getMessageType().equals(DMNMessageType.MISSING_EXPRESSION))).isTrue();
     }
 
     @Test
@@ -69,9 +68,9 @@ public class ValidatorDecisionTableTest
         try (final Reader reader = getReader( "DTABLE_MULTIPLEOUTPUT_WRONG_OUTPUT.dmn" )) {
             List<DMNMessage> validate = validator.validate( reader, VALIDATE_SCHEMA, VALIDATE_MODEL, VALIDATE_COMPILATION);
             assertThat(validate).as(ValidatorUtil.formatMessages(validate)).hasSize(5);
-            assertTrue( validate.stream().anyMatch( p -> p.getMessageType().equals( DMNMessageType.MISSING_NAME ) ) );
-            assertTrue( validate.stream().anyMatch( p -> p.getMessageType().equals( DMNMessageType.MISSING_TYPE_REF ) ) );
-            assertTrue( validate.stream().anyMatch( p -> p.getMessageType().equals( DMNMessageType.INVALID_NAME ) ) );
+            assertThat(validate.stream().anyMatch(p -> p.getMessageType().equals(DMNMessageType.MISSING_NAME))).isTrue();
+            assertThat(validate.stream().anyMatch(p -> p.getMessageType().equals(DMNMessageType.MISSING_TYPE_REF))).isTrue();
+            assertThat(validate.stream().anyMatch(p -> p.getMessageType().equals(DMNMessageType.INVALID_NAME))).isTrue();
         }
     }
 
@@ -79,9 +78,9 @@ public class ValidatorDecisionTableTest
     public void testDTABLE_MULTIPLEOUT_NAME_FileInput() {
         List<DMNMessage> validate = validator.validate( getFile( "DTABLE_MULTIPLEOUTPUT_WRONG_OUTPUT.dmn" ), VALIDATE_SCHEMA, VALIDATE_MODEL, VALIDATE_COMPILATION);
         assertThat(validate).as(ValidatorUtil.formatMessages(validate)).hasSize(5);
-        assertTrue( validate.stream().anyMatch( p -> p.getMessageType().equals( DMNMessageType.MISSING_NAME ) ) );
-        assertTrue( validate.stream().anyMatch( p -> p.getMessageType().equals( DMNMessageType.MISSING_TYPE_REF ) ) );
-        assertTrue( validate.stream().anyMatch( p -> p.getMessageType().equals( DMNMessageType.INVALID_NAME ) ) );
+        assertThat(validate.stream().anyMatch(p -> p.getMessageType().equals(DMNMessageType.MISSING_NAME))).isTrue();
+        assertThat(validate.stream().anyMatch(p -> p.getMessageType().equals(DMNMessageType.MISSING_TYPE_REF))).isTrue();
+        assertThat(validate.stream().anyMatch(p -> p.getMessageType().equals(DMNMessageType.INVALID_NAME))).isTrue();
     }
 
     @Test
@@ -92,25 +91,25 @@ public class ValidatorDecisionTableTest
                                 "DTABLE_MULTIPLEOUTPUT_WRONG_OUTPUT"),
                 VALIDATE_MODEL, VALIDATE_COMPILATION);
         assertThat(validate).as(ValidatorUtil.formatMessages(validate)).hasSize(5);
-        assertTrue( validate.stream().anyMatch( p -> p.getMessageType().equals( DMNMessageType.MISSING_NAME ) ) );
-        assertTrue( validate.stream().anyMatch( p -> p.getMessageType().equals( DMNMessageType.MISSING_TYPE_REF ) ) );
-        assertTrue( validate.stream().anyMatch( p -> p.getMessageType().equals( DMNMessageType.INVALID_NAME ) ) );
+        assertThat(validate.stream().anyMatch(p -> p.getMessageType().equals(DMNMessageType.MISSING_NAME))).isTrue();
+        assertThat(validate.stream().anyMatch(p -> p.getMessageType().equals(DMNMessageType.MISSING_TYPE_REF))).isTrue();
+        assertThat(validate.stream().anyMatch(p -> p.getMessageType().equals(DMNMessageType.INVALID_NAME))).isTrue();
     }
 
     @Test
     public void testDTABLE_PRIORITY_MISSING_OUTVALS_ReaderInput() throws IOException {
         try (final Reader reader = getReader( "DTABLE_PRIORITY_MISSING_OUTVALS.dmn" )) {
             List<DMNMessage> validate = validator.validate( reader, VALIDATE_SCHEMA, VALIDATE_MODEL, VALIDATE_COMPILATION);
-            assertThat(validate.isEmpty()).as(ValidatorUtil.formatMessages(validate)).isFalse();
-            assertTrue( validate.stream().anyMatch( p -> p.getMessageType().equals( DMNMessageType.MISSING_OUTPUT_VALUES ) ) );
+            assertThat(validate).as(ValidatorUtil.formatMessages(validate)).isNotEmpty();
+            assertThat(validate.stream().anyMatch(p -> p.getMessageType().equals(DMNMessageType.MISSING_OUTPUT_VALUES))).isTrue();
         }
     }
 
     @Test
     public void testDTABLE_PRIORITY_MISSING_OUTVALS_FileInput() {
         List<DMNMessage> validate = validator.validate( getFile( "DTABLE_PRIORITY_MISSING_OUTVALS.dmn" ), VALIDATE_SCHEMA, VALIDATE_MODEL, VALIDATE_COMPILATION);
-        assertThat(validate.isEmpty()).as(ValidatorUtil.formatMessages(validate)).isFalse();
-        assertTrue( validate.stream().anyMatch( p -> p.getMessageType().equals( DMNMessageType.MISSING_OUTPUT_VALUES ) ) );
+        assertThat(validate).as(ValidatorUtil.formatMessages(validate)).isNotEmpty();
+        assertThat(validate.stream().anyMatch(p -> p.getMessageType().equals(DMNMessageType.MISSING_OUTPUT_VALUES))).isTrue();
     }
 
     @Test
@@ -120,8 +119,8 @@ public class ValidatorDecisionTableTest
                                 "https://github.com/kiegroup/kie-dmn",
                                 "DTABLE_PRIORITY_MISSING_OUTVALS"),
                 VALIDATE_MODEL, VALIDATE_COMPILATION);
-        assertThat(validate.isEmpty()).as(ValidatorUtil.formatMessages(validate)).isFalse();
-        assertTrue( validate.stream().anyMatch( p -> p.getMessageType().equals( DMNMessageType.MISSING_OUTPUT_VALUES ) ) );
+        assertThat(validate).as(ValidatorUtil.formatMessages(validate)).isNotEmpty();
+        assertThat(validate.stream().anyMatch(p -> p.getMessageType().equals(DMNMessageType.MISSING_OUTPUT_VALUES))).isTrue();
     }
 
     @Test
@@ -129,8 +128,8 @@ public class ValidatorDecisionTableTest
         try (final Reader reader = getReader( "DTABLE_SINGLEOUTPUT_WRONG_OUTPUT.dmn" )) {
             List<DMNMessage> validate = validator.validate( reader, VALIDATE_SCHEMA, VALIDATE_MODEL, VALIDATE_COMPILATION);
             assertThat(validate).as(ValidatorUtil.formatMessages(validate)).hasSize(2);
-            assertTrue( validate.stream().anyMatch( p -> p.getMessageType().equals( DMNMessageType.ILLEGAL_USE_OF_NAME ) ) );
-            assertTrue( validate.stream().anyMatch( p -> p.getMessageType().equals( DMNMessageType.ILLEGAL_USE_OF_TYPEREF ) ) );
+            assertThat(validate.stream().anyMatch(p -> p.getMessageType().equals(DMNMessageType.ILLEGAL_USE_OF_NAME))).isTrue();
+            assertThat(validate.stream().anyMatch(p -> p.getMessageType().equals(DMNMessageType.ILLEGAL_USE_OF_TYPEREF))).isTrue();
         }
     }
 
@@ -138,8 +137,8 @@ public class ValidatorDecisionTableTest
     public void testDTABLE_SINGLEOUT_NONAME_FileInput() {
         List<DMNMessage> validate = validator.validate( getFile( "DTABLE_SINGLEOUTPUT_WRONG_OUTPUT.dmn" ), VALIDATE_SCHEMA, VALIDATE_MODEL, VALIDATE_COMPILATION);
         assertThat(validate).as(ValidatorUtil.formatMessages(validate)).hasSize(2);
-        assertTrue( validate.stream().anyMatch( p -> p.getMessageType().equals( DMNMessageType.ILLEGAL_USE_OF_NAME ) ) );
-        assertTrue( validate.stream().anyMatch( p -> p.getMessageType().equals( DMNMessageType.ILLEGAL_USE_OF_TYPEREF ) ) );
+        assertThat(validate.stream().anyMatch(p -> p.getMessageType().equals(DMNMessageType.ILLEGAL_USE_OF_NAME))).isTrue();
+        assertThat(validate.stream().anyMatch(p -> p.getMessageType().equals(DMNMessageType.ILLEGAL_USE_OF_TYPEREF))).isTrue();
     }
 
     @Test
@@ -150,7 +149,7 @@ public class ValidatorDecisionTableTest
                                "DTABLE_SINGLEOUTPUT_WRONG_OUTPUT"),
                 VALIDATE_MODEL, VALIDATE_COMPILATION);
         assertThat(validate).as(ValidatorUtil.formatMessages(validate)).hasSize(2);
-        assertTrue( validate.stream().anyMatch( p -> p.getMessageType().equals( DMNMessageType.ILLEGAL_USE_OF_NAME ) ) );
-        assertTrue( validate.stream().anyMatch( p -> p.getMessageType().equals( DMNMessageType.ILLEGAL_USE_OF_TYPEREF ) ) );
+        assertThat(validate.stream().anyMatch(p -> p.getMessageType().equals(DMNMessageType.ILLEGAL_USE_OF_NAME))).isTrue();
+        assertThat(validate.stream().anyMatch(p -> p.getMessageType().equals(DMNMessageType.ILLEGAL_USE_OF_TYPEREF))).isTrue();
     }
 }

--- a/kie-dmn/kie-dmn-validation/src/test/java/org/kie/dmn/validation/ValidatorDecisionTest.java
+++ b/kie-dmn/kie-dmn-validation/src/test/java/org/kie/dmn/validation/ValidatorDecisionTest.java
@@ -31,7 +31,6 @@ import org.kie.dmn.core.util.DMNRuntimeUtil;
 import org.kie.dmn.model.api.Definitions;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.Assert.assertTrue;
 import static org.kie.dmn.validation.DMNValidator.Validation.VALIDATE_COMPILATION;
 import static org.kie.dmn.validation.DMNValidator.Validation.VALIDATE_MODEL;
 import static org.kie.dmn.validation.DMNValidator.Validation.VALIDATE_SCHEMA;
@@ -76,7 +75,7 @@ public class ValidatorDecisionTest extends AbstractValidatorTest {
                     reader,
                     VALIDATE_SCHEMA, VALIDATE_MODEL, VALIDATE_COMPILATION);
             assertThat(validate).as(ValidatorUtil.formatMessages(validate)).hasSize(1);
-            assertTrue(validate.stream().anyMatch(p -> p.getMessageType().equals(DMNMessageType.MISSING_VARIABLE)));
+            assertThat(validate.stream().anyMatch(p -> p.getMessageType().equals(DMNMessageType.MISSING_VARIABLE))).isTrue();
         }
     }
 
@@ -86,7 +85,7 @@ public class ValidatorDecisionTest extends AbstractValidatorTest {
                 getFile("decision/DECISION_MISSING_VAR.dmn"),
                 VALIDATE_SCHEMA, VALIDATE_MODEL, VALIDATE_COMPILATION);
         assertThat(validate).as(ValidatorUtil.formatMessages(validate)).hasSize(1);
-        assertTrue(validate.stream().anyMatch(p -> p.getMessageType().equals(DMNMessageType.MISSING_VARIABLE)));
+        assertThat(validate.stream().anyMatch(p -> p.getMessageType().equals(DMNMessageType.MISSING_VARIABLE))).isTrue();
     }
 
     @Test
@@ -97,7 +96,7 @@ public class ValidatorDecisionTest extends AbstractValidatorTest {
                                "DECISION_MISSING_VAR"),
                 VALIDATE_MODEL, VALIDATE_COMPILATION);
         assertThat(validate).as(ValidatorUtil.formatMessages(validate)).hasSize(1);
-        assertTrue(validate.stream().anyMatch(p -> p.getMessageType().equals(DMNMessageType.MISSING_VARIABLE)));
+        assertThat(validate.stream().anyMatch(p -> p.getMessageType().equals(DMNMessageType.MISSING_VARIABLE))).isTrue();
     }
 
     @Test
@@ -105,7 +104,7 @@ public class ValidatorDecisionTest extends AbstractValidatorTest {
         try (final Reader reader = getReader("decision/DECISION_MISSING_VARbis.dmn")) {
             final List<DMNMessage> validate = validator.validate(reader, VALIDATE_SCHEMA, VALIDATE_MODEL, VALIDATE_COMPILATION);
             assertThat(validate).as(ValidatorUtil.formatMessages(validate)).hasSize(1);
-            assertTrue(validate.stream().anyMatch(p -> p.getMessageType().equals(DMNMessageType.MISSING_VARIABLE)));
+            assertThat(validate.stream().anyMatch(p -> p.getMessageType().equals(DMNMessageType.MISSING_VARIABLE))).isTrue();
         }
     }
 
@@ -114,7 +113,7 @@ public class ValidatorDecisionTest extends AbstractValidatorTest {
         final List<DMNMessage> validate = validator.validate(
                 getFile("decision/DECISION_MISSING_VARbis.dmn"), VALIDATE_SCHEMA, VALIDATE_MODEL, VALIDATE_COMPILATION);
         assertThat(validate).as(ValidatorUtil.formatMessages(validate)).hasSize(1);
-        assertTrue(validate.stream().anyMatch(p -> p.getMessageType().equals(DMNMessageType.MISSING_VARIABLE)));
+        assertThat(validate.stream().anyMatch(p -> p.getMessageType().equals(DMNMessageType.MISSING_VARIABLE))).isTrue();
     }
 
     @Test
@@ -125,7 +124,7 @@ public class ValidatorDecisionTest extends AbstractValidatorTest {
                                "DECISION_MISSING_VARbis"),
                 VALIDATE_MODEL, VALIDATE_COMPILATION);
         assertThat(validate).as(ValidatorUtil.formatMessages(validate)).hasSize(1);
-        assertTrue(validate.stream().anyMatch(p -> p.getMessageType().equals(DMNMessageType.MISSING_VARIABLE)));
+        assertThat(validate.stream().anyMatch(p -> p.getMessageType().equals(DMNMessageType.MISSING_VARIABLE))).isTrue();
     }
 
     @Test
@@ -133,7 +132,7 @@ public class ValidatorDecisionTest extends AbstractValidatorTest {
         try (final Reader reader = getReader("decision/DECISION_MISMATCH_VAR.dmn")) {
             final List<DMNMessage> validate = validator.validate(reader, VALIDATE_SCHEMA, VALIDATE_MODEL, VALIDATE_COMPILATION);
             assertThat(validate).as(ValidatorUtil.formatMessages(validate)).hasSize(1);
-            assertTrue(validate.stream().anyMatch(p -> p.getMessageType().equals(DMNMessageType.VARIABLE_NAME_MISMATCH)));
+            assertThat(validate.stream().anyMatch(p -> p.getMessageType().equals(DMNMessageType.VARIABLE_NAME_MISMATCH))).isTrue();
         }
     }
 
@@ -142,7 +141,7 @@ public class ValidatorDecisionTest extends AbstractValidatorTest {
         final List<DMNMessage> validate = validator.validate(
                 getFile("decision/DECISION_MISMATCH_VAR.dmn"), VALIDATE_SCHEMA, VALIDATE_MODEL, VALIDATE_COMPILATION);
         assertThat(validate).as(ValidatorUtil.formatMessages(validate)).hasSize(1);
-        assertTrue(validate.stream().anyMatch(p -> p.getMessageType().equals(DMNMessageType.VARIABLE_NAME_MISMATCH)));
+        assertThat(validate.stream().anyMatch(p -> p.getMessageType().equals(DMNMessageType.VARIABLE_NAME_MISMATCH))).isTrue();
     }
 
     @Test
@@ -153,7 +152,7 @@ public class ValidatorDecisionTest extends AbstractValidatorTest {
                                "DECISION_MISSING_VAR"),
                 VALIDATE_MODEL, VALIDATE_COMPILATION);
         assertThat(validate).as(ValidatorUtil.formatMessages(validate)).hasSize(1);
-        assertTrue(validate.stream().anyMatch(p -> p.getMessageType().equals(DMNMessageType.VARIABLE_NAME_MISMATCH)));
+        assertThat(validate.stream().anyMatch(p -> p.getMessageType().equals(DMNMessageType.VARIABLE_NAME_MISMATCH))).isTrue();
     }
 
     @Test
@@ -161,7 +160,7 @@ public class ValidatorDecisionTest extends AbstractValidatorTest {
         try (final Reader reader = getReader("decision/DECISION_MULTIPLE_EXPRESSIONS.dmn")) {
             final List<DMNMessage> validate = validator.validate(reader, VALIDATE_SCHEMA, VALIDATE_MODEL, VALIDATE_COMPILATION);
             assertThat(validate).as(ValidatorUtil.formatMessages(validate)).hasSize(1);
-            assertTrue(validate.stream().anyMatch(p -> p.getMessageType().equals(DMNMessageType.FAILED_XML_VALIDATION)));
+            assertThat(validate.stream().anyMatch(p -> p.getMessageType().equals(DMNMessageType.FAILED_XML_VALIDATION))).isTrue();
         }
     }
 
@@ -170,7 +169,7 @@ public class ValidatorDecisionTest extends AbstractValidatorTest {
         final List<DMNMessage> validate = validator.validate(
                 getFile("decision/DECISION_MULTIPLE_EXPRESSIONS.dmn"), VALIDATE_SCHEMA, VALIDATE_MODEL, VALIDATE_COMPILATION);
         assertThat(validate).as(ValidatorUtil.formatMessages(validate)).hasSize(1);
-        assertTrue(validate.stream().anyMatch(p -> p.getMessageType().equals(DMNMessageType.FAILED_XML_VALIDATION)));
+        assertThat(validate.stream().anyMatch(p -> p.getMessageType().equals(DMNMessageType.FAILED_XML_VALIDATION))).isTrue();
     }
 
     @Test
@@ -188,7 +187,7 @@ public class ValidatorDecisionTest extends AbstractValidatorTest {
         try (final Reader reader = getReader("decision/DECISION_PERF_INDICATOR_WRONG_TYPE.dmn")) {
             final List<DMNMessage> validate = validator.validate(reader, VALIDATE_SCHEMA, VALIDATE_MODEL, VALIDATE_COMPILATION);
             assertThat(validate).as(ValidatorUtil.formatMessages(validate)).hasSize(2);
-            assertTrue(validate.stream().anyMatch(p -> p.getMessageType().equals(DMNMessageType.REQ_NOT_FOUND)));
+            assertThat(validate.stream().anyMatch(p -> p.getMessageType().equals(DMNMessageType.REQ_NOT_FOUND))).isTrue();
         }
     }
 
@@ -197,7 +196,7 @@ public class ValidatorDecisionTest extends AbstractValidatorTest {
         final List<DMNMessage> validate = validator.validate(
                 getFile("decision/DECISION_PERF_INDICATOR_WRONG_TYPE.dmn"), VALIDATE_SCHEMA, VALIDATE_MODEL, VALIDATE_COMPILATION);
         assertThat(validate).as(ValidatorUtil.formatMessages(validate)).hasSize(2);
-        assertTrue(validate.stream().anyMatch(p -> p.getMessageType().equals(DMNMessageType.REQ_NOT_FOUND)));
+        assertThat(validate.stream().anyMatch(p -> p.getMessageType().equals(DMNMessageType.REQ_NOT_FOUND))).isTrue();
     }
 
     @Test
@@ -208,7 +207,7 @@ public class ValidatorDecisionTest extends AbstractValidatorTest {
                                "DECISION_PERF_INDICATOR_WRONG_TYPE"),
                 VALIDATE_MODEL, VALIDATE_COMPILATION);
         assertThat(validate).as(ValidatorUtil.formatMessages(validate)).hasSize(2);
-        assertTrue(validate.stream().anyMatch(p -> p.getMessageType().equals(DMNMessageType.REQ_NOT_FOUND)));
+        assertThat(validate.stream().anyMatch(p -> p.getMessageType().equals(DMNMessageType.REQ_NOT_FOUND))).isTrue();
     }
 
     @Test
@@ -216,7 +215,7 @@ public class ValidatorDecisionTest extends AbstractValidatorTest {
         try (final Reader reader = getReader("decision/DECISION_DECISION_MAKER_WRONG_TYPE.dmn")) {
             final List<DMNMessage> validate = validator.validate(reader, VALIDATE_SCHEMA, VALIDATE_MODEL, VALIDATE_COMPILATION);
             assertThat(validate).as(ValidatorUtil.formatMessages(validate)).hasSize(2);
-            assertTrue(validate.stream().anyMatch(p -> p.getMessageType().equals(DMNMessageType.REQ_NOT_FOUND)));
+            assertThat(validate.stream().anyMatch(p -> p.getMessageType().equals(DMNMessageType.REQ_NOT_FOUND))).isTrue();
         }
     }
 
@@ -225,7 +224,7 @@ public class ValidatorDecisionTest extends AbstractValidatorTest {
         final List<DMNMessage> validate = validator.validate(
                 getFile("decision/DECISION_DECISION_MAKER_WRONG_TYPE.dmn"), VALIDATE_SCHEMA, VALIDATE_MODEL, VALIDATE_COMPILATION);
         assertThat(validate).as(ValidatorUtil.formatMessages(validate)).hasSize(2);
-        assertTrue(validate.stream().anyMatch(p -> p.getMessageType().equals(DMNMessageType.REQ_NOT_FOUND)));
+        assertThat(validate.stream().anyMatch(p -> p.getMessageType().equals(DMNMessageType.REQ_NOT_FOUND))).isTrue();
     }
 
     @Test
@@ -236,7 +235,7 @@ public class ValidatorDecisionTest extends AbstractValidatorTest {
                                "DECISION_DECISION_MAKER_WRONG_TYPE"),
                 VALIDATE_MODEL, VALIDATE_COMPILATION);
         assertThat(validate).as(ValidatorUtil.formatMessages(validate)).hasSize(2);
-        assertTrue(validate.stream().anyMatch(p -> p.getMessageType().equals(DMNMessageType.REQ_NOT_FOUND)));
+        assertThat(validate.stream().anyMatch(p -> p.getMessageType().equals(DMNMessageType.REQ_NOT_FOUND))).isTrue();
     }
 
     @Test
@@ -244,7 +243,7 @@ public class ValidatorDecisionTest extends AbstractValidatorTest {
         try (final Reader reader = getReader("decision/DECISION_DECISION_OWNER_WRONG_TYPE.dmn")) {
             final List<DMNMessage> validate = validator.validate(reader, VALIDATE_SCHEMA, VALIDATE_MODEL, VALIDATE_COMPILATION);
             assertThat(validate).as(ValidatorUtil.formatMessages(validate)).hasSize(2);
-            assertTrue(validate.stream().anyMatch(p -> p.getMessageType().equals(DMNMessageType.REQ_NOT_FOUND)));
+            assertThat(validate.stream().anyMatch(p -> p.getMessageType().equals(DMNMessageType.REQ_NOT_FOUND))).isTrue();
         }
     }
 
@@ -253,7 +252,7 @@ public class ValidatorDecisionTest extends AbstractValidatorTest {
         final List<DMNMessage> validate = validator.validate(
                 getFile("decision/DECISION_DECISION_OWNER_WRONG_TYPE.dmn"), VALIDATE_SCHEMA, VALIDATE_MODEL, VALIDATE_COMPILATION);
         assertThat(validate).as(ValidatorUtil.formatMessages(validate)).hasSize(2);
-        assertTrue(validate.stream().anyMatch(p -> p.getMessageType().equals(DMNMessageType.REQ_NOT_FOUND)));
+        assertThat(validate.stream().anyMatch(p -> p.getMessageType().equals(DMNMessageType.REQ_NOT_FOUND))).isTrue();
     }
 
     @Test
@@ -264,7 +263,7 @@ public class ValidatorDecisionTest extends AbstractValidatorTest {
                                "DECISION_DECISION_MAKER_WRONG_TYPE"),
                 VALIDATE_MODEL, VALIDATE_COMPILATION);
         assertThat(validate).as(ValidatorUtil.formatMessages(validate)).hasSize(2);
-        assertTrue(validate.stream().anyMatch(p -> p.getMessageType().equals(DMNMessageType.REQ_NOT_FOUND)));
+        assertThat(validate.stream().anyMatch(p -> p.getMessageType().equals(DMNMessageType.REQ_NOT_FOUND))).isTrue();
     }
 
     @Test
@@ -272,7 +271,7 @@ public class ValidatorDecisionTest extends AbstractValidatorTest {
         try (final Reader reader = getReader("decision/DECISION_CYCLIC_DEPENDENCY.dmn")) {
             final List<DMNMessage> validate = validator.validate( reader, VALIDATE_SCHEMA, VALIDATE_MODEL, VALIDATE_COMPILATION );
             assertThat(validate).as(ValidatorUtil.formatMessages(validate)).hasSize(2);
-            assertTrue(validate.stream().anyMatch(p -> p.getMessageType().equals(DMNMessageType.REQ_NOT_FOUND)));
+            assertThat(validate.stream().anyMatch(p -> p.getMessageType().equals(DMNMessageType.REQ_NOT_FOUND))).isTrue();
         }
     }
 
@@ -280,7 +279,7 @@ public class ValidatorDecisionTest extends AbstractValidatorTest {
     public void testDECISION_CYCLIC_DEPENDENCY_FileInput() {
         final List<DMNMessage> validate = validator.validate( getFile("decision/DECISION_CYCLIC_DEPENDENCY.dmn"), VALIDATE_SCHEMA, VALIDATE_MODEL, VALIDATE_COMPILATION );
         assertThat(validate).as(ValidatorUtil.formatMessages(validate)).hasSize(2);
-        assertTrue(validate.stream().anyMatch(p -> p.getMessageType().equals(DMNMessageType.REQ_NOT_FOUND)));
+        assertThat(validate.stream().anyMatch(p -> p.getMessageType().equals(DMNMessageType.REQ_NOT_FOUND))).isTrue();
     }
 
     @Test
@@ -291,7 +290,7 @@ public class ValidatorDecisionTest extends AbstractValidatorTest {
                                "DECISION_CYCLIC_DEPENDENCY"),
                 VALIDATE_MODEL, VALIDATE_COMPILATION );
         assertThat(validate).as(ValidatorUtil.formatMessages(validate)).hasSize(2);
-        assertTrue(validate.stream().anyMatch(p -> p.getMessageType().equals(DMNMessageType.REQ_NOT_FOUND)));
+        assertThat(validate.stream().anyMatch(p -> p.getMessageType().equals(DMNMessageType.REQ_NOT_FOUND))).isTrue();
     }
 
     @Test
@@ -299,7 +298,7 @@ public class ValidatorDecisionTest extends AbstractValidatorTest {
         try (final Reader reader = getReader("decision/DECISION_CYCLIC_DEPENDENCY_SELF_REFERENCE.dmn")) {
             final List<DMNMessage> validate = validator.validate( reader, VALIDATE_SCHEMA, VALIDATE_MODEL, VALIDATE_COMPILATION );
             assertThat(validate).as(ValidatorUtil.formatMessages(validate)).hasSize(1);
-            assertTrue(validate.stream().anyMatch(p -> p.getMessageType().equals(DMNMessageType.REQ_NOT_FOUND)));
+            assertThat(validate.stream().anyMatch(p -> p.getMessageType().equals(DMNMessageType.REQ_NOT_FOUND))).isTrue();
         }
     }
 
@@ -307,7 +306,7 @@ public class ValidatorDecisionTest extends AbstractValidatorTest {
     public void testDECISION_CYCLIC_DEPENDENCY_SELF_REFERENCE_FileInput() {
         final List<DMNMessage> validate = validator.validate( getFile("decision/DECISION_CYCLIC_DEPENDENCY_SELF_REFERENCE.dmn"), VALIDATE_SCHEMA, VALIDATE_MODEL, VALIDATE_COMPILATION );
         assertThat(validate).as(ValidatorUtil.formatMessages(validate)).hasSize(1);
-        assertTrue(validate.stream().anyMatch(p -> p.getMessageType().equals(DMNMessageType.REQ_NOT_FOUND)));
+        assertThat(validate.stream().anyMatch(p -> p.getMessageType().equals(DMNMessageType.REQ_NOT_FOUND))).isTrue();
     }
 
     @Test
@@ -318,7 +317,7 @@ public class ValidatorDecisionTest extends AbstractValidatorTest {
                                "DECISION_CYCLIC_DEPENDENCY_SELF_REFERENCE"),
                 VALIDATE_MODEL, VALIDATE_COMPILATION );
         assertThat(validate).as(ValidatorUtil.formatMessages(validate)).hasSize(1);
-        assertTrue(validate.stream().anyMatch(p -> p.getMessageType().equals(DMNMessageType.REQ_NOT_FOUND)));
+        assertThat(validate.stream().anyMatch(p -> p.getMessageType().equals(DMNMessageType.REQ_NOT_FOUND))).isTrue();
     }
 
     @Test
@@ -374,7 +373,7 @@ public class ValidatorDecisionTest extends AbstractValidatorTest {
         try (final Reader reader = getReader("decision/DECISION_MISSING_REQ.dmn")) {
             final List<DMNMessage> validate = validator.validate(reader, VALIDATE_SCHEMA, VALIDATE_MODEL);
             assertThat(validate).as(ValidatorUtil.formatMessages(validate)).hasSize(1);
-            assertTrue(validate.stream().anyMatch(p -> p.getMessageType().equals(DMNMessageType.REQ_NOT_FOUND)));
+            assertThat(validate.stream().anyMatch(p -> p.getMessageType().equals(DMNMessageType.REQ_NOT_FOUND))).isTrue();
         }
     }
     
@@ -382,7 +381,7 @@ public class ValidatorDecisionTest extends AbstractValidatorTest {
     public void testDECISION_MISSING_REQ_FileInput() {
         final List<DMNMessage> validate = validator.validate( getFile("decision/DECISION_MISSING_REQ.dmn"), VALIDATE_SCHEMA, VALIDATE_MODEL );
         assertThat(validate).as(ValidatorUtil.formatMessages(validate)).hasSize(1);
-        assertTrue(validate.stream().anyMatch(p -> p.getMessageType().equals(DMNMessageType.REQ_NOT_FOUND)));
+        assertThat(validate.stream().anyMatch(p -> p.getMessageType().equals(DMNMessageType.REQ_NOT_FOUND))).isTrue();
     }
 
     @Test
@@ -393,7 +392,7 @@ public class ValidatorDecisionTest extends AbstractValidatorTest {
                                "DECISION_MISSING_REQ"),
                 VALIDATE_MODEL );
         assertThat(validate).as(ValidatorUtil.formatMessages(validate)).hasSize(1);
-        assertTrue(validate.stream().anyMatch(p -> p.getMessageType().equals(DMNMessageType.REQ_NOT_FOUND)));
+        assertThat(validate.stream().anyMatch(p -> p.getMessageType().equals(DMNMessageType.REQ_NOT_FOUND))).isTrue();
     }
     
     @Test
@@ -408,8 +407,8 @@ public class ValidatorDecisionTest extends AbstractValidatorTest {
 
         List<DMNMessage> validate = DMNValidatorFactory.newValidator().validate(definitions, VALIDATE_MODEL, VALIDATE_COMPILATION);
         assertThat(validate).as(ValidatorUtil.formatMessages(validate)).hasSize(1);
-        assertTrue(ValidatorUtil.formatMessages(validate), validate.stream()
-                   .allMatch(p -> p.getLevel() == Level.WARNING && 
-                       p.getText().contains("Collect with Operator for compound outputs")));
+        assertThat(validate.stream()
+                .allMatch(p -> p.getLevel() == Level.WARNING &&
+                        p.getText().contains("Collect with Operator for compound outputs"))).as(ValidatorUtil.formatMessages(validate)).isTrue();
     }
 }

--- a/kie-dmn/kie-dmn-validation/src/test/java/org/kie/dmn/validation/ValidatorImportTest.java
+++ b/kie-dmn/kie-dmn-validation/src/test/java/org/kie/dmn/validation/ValidatorImportTest.java
@@ -39,7 +39,6 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.Assert.assertTrue;
 import static org.kie.dmn.core.util.DynamicTypeUtils.entry;
 import static org.kie.dmn.core.util.DynamicTypeUtils.mapOf;
 
@@ -113,10 +112,10 @@ public class ValidatorImportTest extends AbstractValidatorTest {
             final List<DMNMessage> messages = validator.validateUsing(Validation.VALIDATE_MODEL)
                                                        .theseModels(reader0, reader1);
             assertThat(messages).as(ValidatorUtil.formatMessages(messages)).hasSize(1);
-            assertTrue(messages.stream().anyMatch(p -> p.getMessageType().equals(DMNMessageType.REQ_NOT_FOUND) &&
-                                                       p.getSourceReference() instanceof DMNElementReference &&
-                                                       ((DMNElementReference) p.getSourceReference()).getHref()
-                                                                                                     .equals("http://www.trisotech.com/definitions/_70df1ad5-2a33-4ede-b8b2-869988ac1d30#_1d52934e-aa4e-47c9-a011-fc989d795664")));
+            assertThat(messages.stream().anyMatch(p -> p.getMessageType().equals(DMNMessageType.REQ_NOT_FOUND) &&
+                    p.getSourceReference() instanceof DMNElementReference &&
+                    ((DMNElementReference) p.getSourceReference()).getHref()
+                            .equals("http://www.trisotech.com/definitions/_70df1ad5-2a33-4ede-b8b2-869988ac1d30#_1d52934e-aa4e-47c9-a011-fc989d795664"))).isTrue();
         }
     }
     
@@ -126,10 +125,10 @@ public class ValidatorImportTest extends AbstractValidatorTest {
                                                    .theseModels(getFile("import/Base-model.dmn"),
                                                                 getFile("import/Wrong-Import-base-model.dmn"));
         assertThat(messages).as(ValidatorUtil.formatMessages(messages)).hasSize(1);
-        assertTrue(messages.stream().anyMatch(p -> p.getMessageType().equals(DMNMessageType.REQ_NOT_FOUND) &&
-                                                   p.getSourceReference() instanceof DMNElementReference &&
-                                                   ((DMNElementReference) p.getSourceReference()).getHref()
-                                                                                                 .equals("http://www.trisotech.com/definitions/_70df1ad5-2a33-4ede-b8b2-869988ac1d30#_1d52934e-aa4e-47c9-a011-fc989d795664")));
+        assertThat(messages.stream().anyMatch(p -> p.getMessageType().equals(DMNMessageType.REQ_NOT_FOUND) &&
+                p.getSourceReference() instanceof DMNElementReference &&
+                ((DMNElementReference) p.getSourceReference()).getHref()
+                        .equals("http://www.trisotech.com/definitions/_70df1ad5-2a33-4ede-b8b2-869988ac1d30#_1d52934e-aa4e-47c9-a011-fc989d795664"))).isTrue();
     }
 
     @Test
@@ -141,24 +140,24 @@ public class ValidatorImportTest extends AbstractValidatorTest {
                                                                 getDefinitions(Arrays.asList("import/Base-model.dmn", "import/Wrong-Import-base-model.dmn"),
                                                                                "http://www.trisotech.com/dmn/definitions/_719a2325-5cac-47ea-8a99-665c01d570a5",
                                                                                "Wrong Import base model"));
-        assertTrue(messages.stream().anyMatch(p -> p.getMessageType().equals(DMNMessageType.REQ_NOT_FOUND) &&
-                                                   p.getSourceReference() instanceof DMNElementReference &&
-                                                   ((DMNElementReference) p.getSourceReference()).getHref()
-                                                                                                 .equals("http://www.trisotech.com/definitions/_70df1ad5-2a33-4ede-b8b2-869988ac1d30#_1d52934e-aa4e-47c9-a011-fc989d795664")));
+        assertThat(messages.stream().anyMatch(p -> p.getMessageType().equals(DMNMessageType.REQ_NOT_FOUND) &&
+                p.getSourceReference() instanceof DMNElementReference &&
+                ((DMNElementReference) p.getSourceReference()).getHref()
+                        .equals("http://www.trisotech.com/definitions/_70df1ad5-2a33-4ede-b8b2-869988ac1d30#_1d52934e-aa4e-47c9-a011-fc989d795664"))).isTrue();
     }
 
     @Test
     public void testOnlyImportBaseModelFromReaderInput() throws IOException {
         try (final Reader reader1 = getReader("import/Only-Import-base-model.dmn");) {
             final List<DMNMessage> messages = validator.validate(reader1, Validation.VALIDATE_MODEL);
-            assertTrue(messages.stream().anyMatch(p -> p.getMessageType().equals(DMNMessageType.IMPORT_NOT_FOUND)));
+            assertThat(messages.stream().anyMatch(p -> p.getMessageType().equals(DMNMessageType.IMPORT_NOT_FOUND))).isTrue();
         }
     }
 
     @Test
     public void testOnlyImportBaseModelFromFileInput() throws IOException {
         final List<DMNMessage> messages = validator.validate(getFile("import/Only-Import-base-model.dmn"), Validation.VALIDATE_MODEL);
-        assertTrue(messages.stream().anyMatch(p -> p.getMessageType().equals(DMNMessageType.IMPORT_NOT_FOUND)));
+        assertThat(messages.stream().anyMatch(p -> p.getMessageType().equals(DMNMessageType.IMPORT_NOT_FOUND))).isTrue();
     }
 
     @Test
@@ -167,7 +166,7 @@ public class ValidatorImportTest extends AbstractValidatorTest {
                                                                             "http://www.trisotech.com/dmn/definitions/_a9bfa4de-cf5c-4b2f-9011-ab576e00b162",
                                                                             "Only Import base model"),
                                                              Validation.VALIDATE_MODEL);
-        assertTrue(messages.stream().anyMatch(p -> p.getMessageType().equals(DMNMessageType.IMPORT_NOT_FOUND)));
+        assertThat(messages.stream().anyMatch(p -> p.getMessageType().equals(DMNMessageType.IMPORT_NOT_FOUND))).isTrue();
     }
 
     @Test
@@ -204,7 +203,7 @@ public class ValidatorImportTest extends AbstractValidatorTest {
         final List<DMNMessage> messages = validator.validateUsing(Validation.VALIDATE_MODEL, Validation.VALIDATE_COMPILATION)
                                                    .theseModels(getReader("myHelloDS.dmn", DMNDecisionServicesTest.class),
                                                                 getReader("import/importingMyHelloDSbkmBoxedInvocation_wrongBKMname.dmn"));
-        assertTrue(messages.stream().anyMatch(p -> p.getText().contains("myHelloDS") && p.getMessageType().equals(DMNMessageType.DUPLICATE_NAME)));
+        assertThat(messages.stream().anyMatch(p -> p.getText().contains("myHelloDS") && p.getMessageType().equals(DMNMessageType.DUPLICATE_NAME))).isTrue();
     }
     
     @Test
@@ -212,7 +211,7 @@ public class ValidatorImportTest extends AbstractValidatorTest {
         final List<DMNMessage> messages = validator.validateUsing(Validation.VALIDATE_MODEL, Validation.VALIDATE_COMPILATION)
                                                    .theseModels(getReader("myHelloDS.dmn", DMNDecisionServicesTest.class),
                                                                 getReader("import/importingMyHelloDSbkmBoxedInvocation_wrongItemDefName.dmn"));
-        assertTrue(messages.stream().anyMatch(p -> p.getText().contains("myHelloDS") && p.getMessageType().equals(DMNMessageType.DUPLICATE_NAME)));
+        assertThat(messages.stream().anyMatch(p -> p.getText().contains("myHelloDS") && p.getMessageType().equals(DMNMessageType.DUPLICATE_NAME))).isTrue();
     }
     
     @Test
@@ -228,6 +227,6 @@ public class ValidatorImportTest extends AbstractValidatorTest {
         final List<DMNMessage> messages = validator.validateUsing(Validation.VALIDATE_MODEL, Validation.VALIDATE_COMPILATION)
                                                    .theseModels(getReader("myHelloDS.dmn", DMNDecisionServicesTest.class),
                                                                 getReader("import/importingMyHelloDSbkmBoxedInvocation_wrongDoubleImportName.dmn"));
-        assertTrue(messages.stream().anyMatch(p -> p.getText().contains("myHelloDS") && p.getMessageType().equals(DMNMessageType.DUPLICATE_NAME)));
+        assertThat(messages.stream().anyMatch(p -> p.getText().contains("myHelloDS") && p.getMessageType().equals(DMNMessageType.DUPLICATE_NAME))).isTrue();
     }
 }

--- a/kie-dmn/kie-dmn-validation/src/test/java/org/kie/dmn/validation/ValidatorInformationRequirementTest.java
+++ b/kie-dmn/kie-dmn-validation/src/test/java/org/kie/dmn/validation/ValidatorInformationRequirementTest.java
@@ -25,7 +25,6 @@ import org.kie.dmn.api.core.DMNMessage;
 import org.kie.dmn.api.core.DMNMessageType;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.Assert.assertTrue;
 import static org.kie.dmn.validation.DMNValidator.Validation.VALIDATE_COMPILATION;
 import static org.kie.dmn.validation.DMNValidator.Validation.VALIDATE_MODEL;
 import static org.kie.dmn.validation.DMNValidator.Validation.VALIDATE_SCHEMA;
@@ -39,8 +38,8 @@ public class ValidatorInformationRequirementTest extends AbstractValidatorTest {
                     reader,
                     VALIDATE_SCHEMA, VALIDATE_MODEL, VALIDATE_COMPILATION);
             assertThat(validate).as(ValidatorUtil.formatMessages(validate)).hasSize(2);
-            assertTrue( validate.stream().anyMatch( p -> p.getMessageType().equals( DMNMessageType.MISSING_EXPRESSION ) ) );
-            assertTrue( validate.stream().anyMatch( p -> p.getMessageType().equals( DMNMessageType.REQ_NOT_FOUND ) ) );
+            assertThat(validate.stream().anyMatch(p -> p.getMessageType().equals(DMNMessageType.MISSING_EXPRESSION))).isTrue();
+            assertThat(validate.stream().anyMatch(p -> p.getMessageType().equals(DMNMessageType.REQ_NOT_FOUND))).isTrue();
         }
     }
 
@@ -50,8 +49,8 @@ public class ValidatorInformationRequirementTest extends AbstractValidatorTest {
                 getFile( "informationrequirement/INFOREQ_MISSING_INPUT.dmn" ),
                 VALIDATE_SCHEMA, VALIDATE_MODEL, VALIDATE_COMPILATION);
         assertThat(validate).as(ValidatorUtil.formatMessages(validate)).hasSize(2);
-        assertTrue( validate.stream().anyMatch( p -> p.getMessageType().equals( DMNMessageType.MISSING_EXPRESSION ) ) );
-        assertTrue( validate.stream().anyMatch( p -> p.getMessageType().equals( DMNMessageType.REQ_NOT_FOUND ) ) );
+        assertThat(validate.stream().anyMatch(p -> p.getMessageType().equals(DMNMessageType.MISSING_EXPRESSION))).isTrue();
+        assertThat(validate.stream().anyMatch(p -> p.getMessageType().equals(DMNMessageType.REQ_NOT_FOUND))).isTrue();
     }
 
     @Test
@@ -62,8 +61,8 @@ public class ValidatorInformationRequirementTest extends AbstractValidatorTest {
                                 "INFOREQ_MISSING_INPUT"),
                 VALIDATE_MODEL, VALIDATE_COMPILATION);
         assertThat(validate).as(ValidatorUtil.formatMessages(validate)).hasSize(2);
-        assertTrue( validate.stream().anyMatch( p -> p.getMessageType().equals( DMNMessageType.MISSING_EXPRESSION ) ) );
-        assertTrue( validate.stream().anyMatch( p -> p.getMessageType().equals( DMNMessageType.REQ_NOT_FOUND ) ) );
+        assertThat(validate.stream().anyMatch(p -> p.getMessageType().equals(DMNMessageType.MISSING_EXPRESSION))).isTrue();
+        assertThat(validate.stream().anyMatch(p -> p.getMessageType().equals(DMNMessageType.REQ_NOT_FOUND))).isTrue();
     }
 
     @Test
@@ -73,8 +72,8 @@ public class ValidatorInformationRequirementTest extends AbstractValidatorTest {
                     reader,
                     VALIDATE_SCHEMA, VALIDATE_MODEL, VALIDATE_COMPILATION);
             assertThat(validate).as(ValidatorUtil.formatMessages(validate)).hasSize(2);
-            assertTrue( validate.stream().anyMatch( p -> p.getMessageType().equals( DMNMessageType.MISSING_EXPRESSION ) ) );
-            assertTrue( validate.stream().anyMatch( p -> p.getMessageType().equals( DMNMessageType.REQ_NOT_FOUND ) ) );
+            assertThat(validate.stream().anyMatch(p -> p.getMessageType().equals(DMNMessageType.MISSING_EXPRESSION))).isTrue();
+            assertThat(validate.stream().anyMatch(p -> p.getMessageType().equals(DMNMessageType.REQ_NOT_FOUND))).isTrue();
         }
     }
 
@@ -84,8 +83,8 @@ public class ValidatorInformationRequirementTest extends AbstractValidatorTest {
                 getFile( "informationrequirement/INFOREQ_INPUT_NOT_INPUTDATA.dmn" ),
                 VALIDATE_SCHEMA, VALIDATE_MODEL, VALIDATE_COMPILATION);
         assertThat(validate).as(ValidatorUtil.formatMessages(validate)).hasSize(2);
-        assertTrue( validate.stream().anyMatch( p -> p.getMessageType().equals( DMNMessageType.MISSING_EXPRESSION ) ) );
-        assertTrue( validate.stream().anyMatch( p -> p.getMessageType().equals( DMNMessageType.REQ_NOT_FOUND ) ) );
+        assertThat(validate.stream().anyMatch(p -> p.getMessageType().equals(DMNMessageType.MISSING_EXPRESSION))).isTrue();
+        assertThat(validate.stream().anyMatch(p -> p.getMessageType().equals(DMNMessageType.REQ_NOT_FOUND))).isTrue();
     }
 
     @Test
@@ -96,8 +95,8 @@ public class ValidatorInformationRequirementTest extends AbstractValidatorTest {
                                 "INFOREQ_INPUT_NOT_INPUTDATA"),
                 VALIDATE_MODEL, VALIDATE_COMPILATION);
         assertThat(validate).as(ValidatorUtil.formatMessages(validate)).hasSize(2);
-        assertTrue( validate.stream().anyMatch( p -> p.getMessageType().equals( DMNMessageType.MISSING_EXPRESSION ) ) );
-        assertTrue( validate.stream().anyMatch( p -> p.getMessageType().equals( DMNMessageType.REQ_NOT_FOUND ) ) );
+        assertThat(validate.stream().anyMatch(p -> p.getMessageType().equals(DMNMessageType.MISSING_EXPRESSION))).isTrue();
+        assertThat(validate.stream().anyMatch(p -> p.getMessageType().equals(DMNMessageType.REQ_NOT_FOUND))).isTrue();
     }
 
     @Test
@@ -107,8 +106,8 @@ public class ValidatorInformationRequirementTest extends AbstractValidatorTest {
                     reader,
                     VALIDATE_SCHEMA, VALIDATE_MODEL, VALIDATE_COMPILATION);
             assertThat(validate).as(ValidatorUtil.formatMessages(validate)).hasSize(2);
-            assertTrue( validate.stream().anyMatch( p -> p.getMessageType().equals( DMNMessageType.MISSING_EXPRESSION ) ) );
-            assertTrue( validate.stream().anyMatch( p -> p.getMessageType().equals( DMNMessageType.REQ_NOT_FOUND ) ) );
+            assertThat(validate.stream().anyMatch(p -> p.getMessageType().equals(DMNMessageType.MISSING_EXPRESSION))).isTrue();
+            assertThat(validate.stream().anyMatch(p -> p.getMessageType().equals(DMNMessageType.REQ_NOT_FOUND))).isTrue();
         }
     }
 
@@ -118,8 +117,8 @@ public class ValidatorInformationRequirementTest extends AbstractValidatorTest {
                 getFile( "informationrequirement/INFOREQ_MISSING_DECISION.dmn" ),
                 VALIDATE_SCHEMA, VALIDATE_MODEL, VALIDATE_COMPILATION);
         assertThat(validate).as(ValidatorUtil.formatMessages(validate)).hasSize(2);
-        assertTrue( validate.stream().anyMatch( p -> p.getMessageType().equals( DMNMessageType.MISSING_EXPRESSION ) ) );
-        assertTrue( validate.stream().anyMatch( p -> p.getMessageType().equals( DMNMessageType.REQ_NOT_FOUND ) ) );
+        assertThat(validate.stream().anyMatch(p -> p.getMessageType().equals(DMNMessageType.MISSING_EXPRESSION))).isTrue();
+        assertThat(validate.stream().anyMatch(p -> p.getMessageType().equals(DMNMessageType.REQ_NOT_FOUND))).isTrue();
     }
 
     @Test
@@ -130,8 +129,8 @@ public class ValidatorInformationRequirementTest extends AbstractValidatorTest {
                                 "INFOREQ_MISSING_DECISION"),
                 VALIDATE_MODEL, VALIDATE_COMPILATION);
         assertThat(validate).as(ValidatorUtil.formatMessages(validate)).hasSize(2);
-        assertTrue( validate.stream().anyMatch( p -> p.getMessageType().equals( DMNMessageType.MISSING_EXPRESSION ) ) );
-        assertTrue( validate.stream().anyMatch( p -> p.getMessageType().equals( DMNMessageType.REQ_NOT_FOUND ) ) );
+        assertThat(validate.stream().anyMatch(p -> p.getMessageType().equals(DMNMessageType.MISSING_EXPRESSION))).isTrue();
+        assertThat(validate.stream().anyMatch(p -> p.getMessageType().equals(DMNMessageType.REQ_NOT_FOUND))).isTrue();
     }
 
     @Test
@@ -141,8 +140,8 @@ public class ValidatorInformationRequirementTest extends AbstractValidatorTest {
                     reader,
                     VALIDATE_SCHEMA, VALIDATE_MODEL, VALIDATE_COMPILATION);
             assertThat(validate).as(ValidatorUtil.formatMessages(validate)).hasSize(2);
-            assertTrue( validate.stream().anyMatch( p -> p.getMessageType().equals( DMNMessageType.MISSING_EXPRESSION ) ) );
-            assertTrue( validate.stream().anyMatch( p -> p.getMessageType().equals( DMNMessageType.REQ_NOT_FOUND ) ) );
+            assertThat(validate.stream().anyMatch(p -> p.getMessageType().equals(DMNMessageType.MISSING_EXPRESSION))).isTrue();
+            assertThat(validate.stream().anyMatch(p -> p.getMessageType().equals(DMNMessageType.REQ_NOT_FOUND))).isTrue();
         }
     }
 
@@ -152,8 +151,8 @@ public class ValidatorInformationRequirementTest extends AbstractValidatorTest {
                 getFile( "informationrequirement/INFOREQ_DECISION_NOT_DECISION.dmn" ),
                 VALIDATE_SCHEMA, VALIDATE_MODEL, VALIDATE_COMPILATION);
         assertThat(validate).as(ValidatorUtil.formatMessages(validate)).hasSize(2);
-        assertTrue( validate.stream().anyMatch( p -> p.getMessageType().equals( DMNMessageType.MISSING_EXPRESSION ) ) );
-        assertTrue( validate.stream().anyMatch( p -> p.getMessageType().equals( DMNMessageType.REQ_NOT_FOUND ) ) );
+        assertThat(validate.stream().anyMatch(p -> p.getMessageType().equals(DMNMessageType.MISSING_EXPRESSION))).isTrue();
+        assertThat(validate.stream().anyMatch(p -> p.getMessageType().equals(DMNMessageType.REQ_NOT_FOUND))).isTrue();
     }
 
     @Test
@@ -164,7 +163,7 @@ public class ValidatorInformationRequirementTest extends AbstractValidatorTest {
                                 "INFOREQ_DECISION_NOT_DECISION"),
                 VALIDATE_MODEL, VALIDATE_COMPILATION);
         assertThat(validate).as(ValidatorUtil.formatMessages(validate)).hasSize(2);
-        assertTrue( validate.stream().anyMatch( p -> p.getMessageType().equals( DMNMessageType.MISSING_EXPRESSION ) ) );
-        assertTrue( validate.stream().anyMatch( p -> p.getMessageType().equals( DMNMessageType.REQ_NOT_FOUND ) ) );
+        assertThat(validate.stream().anyMatch(p -> p.getMessageType().equals(DMNMessageType.MISSING_EXPRESSION))).isTrue();
+        assertThat(validate.stream().anyMatch(p -> p.getMessageType().equals(DMNMessageType.REQ_NOT_FOUND))).isTrue();
     }
 }

--- a/kie-dmn/kie-dmn-validation/src/test/java/org/kie/dmn/validation/ValidatorInputDataTest.java
+++ b/kie-dmn/kie-dmn-validation/src/test/java/org/kie/dmn/validation/ValidatorInputDataTest.java
@@ -17,7 +17,6 @@
 package org.kie.dmn.validation;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.Assert.assertTrue;
 import static org.kie.dmn.validation.DMNValidator.Validation.VALIDATE_COMPILATION;
 import static org.kie.dmn.validation.DMNValidator.Validation.VALIDATE_MODEL;
 import static org.kie.dmn.validation.DMNValidator.Validation.VALIDATE_SCHEMA;
@@ -38,7 +37,7 @@ public class ValidatorInputDataTest extends AbstractValidatorTest {
                     reader,
                     VALIDATE_SCHEMA, VALIDATE_MODEL, VALIDATE_COMPILATION);
             assertThat(validate).withFailMessage(ValidatorUtil.formatMessages(validate)).hasSize(1);
-            assertTrue(validate.stream().anyMatch(p -> p.getMessageType().equals(DMNMessageType.MISSING_VARIABLE)));
+            assertThat(validate.stream().anyMatch(p -> p.getMessageType().equals(DMNMessageType.MISSING_VARIABLE))).isTrue();
         }
     }
 
@@ -48,7 +47,7 @@ public class ValidatorInputDataTest extends AbstractValidatorTest {
                 getFile("inputdata/INPUTDATA_MISSING_VAR.dmn"),
                 VALIDATE_SCHEMA, VALIDATE_MODEL, VALIDATE_COMPILATION);
         assertThat(validate).withFailMessage(ValidatorUtil.formatMessages(validate)).hasSize(1);
-        assertTrue(validate.stream().anyMatch(p -> p.getMessageType().equals(DMNMessageType.MISSING_VARIABLE)));
+        assertThat(validate.stream().anyMatch(p -> p.getMessageType().equals(DMNMessageType.MISSING_VARIABLE))).isTrue();
     }
 
     @Test
@@ -59,7 +58,7 @@ public class ValidatorInputDataTest extends AbstractValidatorTest {
                                "INPUTDATA_MISSING_VAR"),
                 VALIDATE_MODEL, VALIDATE_COMPILATION);
         assertThat(validate).withFailMessage(ValidatorUtil.formatMessages(validate)).hasSize(1);
-        assertTrue(validate.stream().anyMatch(p -> p.getMessageType().equals(DMNMessageType.MISSING_VARIABLE)));
+        assertThat(validate.stream().anyMatch(p -> p.getMessageType().equals(DMNMessageType.MISSING_VARIABLE))).isTrue();
     }
 
     @Test
@@ -69,7 +68,7 @@ public class ValidatorInputDataTest extends AbstractValidatorTest {
                     reader,
                     VALIDATE_SCHEMA, VALIDATE_MODEL, VALIDATE_COMPILATION);
             assertThat(validate).withFailMessage(ValidatorUtil.formatMessages(validate)).hasSize(1);
-            assertTrue(validate.stream().anyMatch(p -> p.getMessageType().equals(DMNMessageType.VARIABLE_NAME_MISMATCH)));
+            assertThat(validate.stream().anyMatch(p -> p.getMessageType().equals(DMNMessageType.VARIABLE_NAME_MISMATCH))).isTrue();
         }
     }
 
@@ -79,7 +78,7 @@ public class ValidatorInputDataTest extends AbstractValidatorTest {
                 getFile("inputdata/INPUTDATA_MISMATCH_VAR.dmn"),
                 VALIDATE_SCHEMA, VALIDATE_MODEL, VALIDATE_COMPILATION);
         assertThat(validate).withFailMessage(ValidatorUtil.formatMessages(validate)).hasSize(1);
-        assertTrue(validate.stream().anyMatch(p -> p.getMessageType().equals(DMNMessageType.VARIABLE_NAME_MISMATCH)));
+        assertThat(validate.stream().anyMatch(p -> p.getMessageType().equals(DMNMessageType.VARIABLE_NAME_MISMATCH))).isTrue();
     }
 
     @Test
@@ -90,6 +89,6 @@ public class ValidatorInputDataTest extends AbstractValidatorTest {
                                "INPUTDATA_MISSING_VAR"),
                 VALIDATE_MODEL, VALIDATE_COMPILATION);
         assertThat(validate).withFailMessage(ValidatorUtil.formatMessages(validate)).hasSize(1);
-        assertTrue(validate.stream().anyMatch(p -> p.getMessageType().equals(DMNMessageType.VARIABLE_NAME_MISMATCH)));
+        assertThat(validate.stream().anyMatch(p -> p.getMessageType().equals(DMNMessageType.VARIABLE_NAME_MISMATCH))).isTrue();
     }
 }

--- a/kie-dmn/kie-dmn-validation/src/test/java/org/kie/dmn/validation/ValidatorKnowledgeRequirementTest.java
+++ b/kie-dmn/kie-dmn-validation/src/test/java/org/kie/dmn/validation/ValidatorKnowledgeRequirementTest.java
@@ -28,7 +28,6 @@ import org.kie.dmn.api.core.DMNMessage;
 import org.kie.dmn.api.core.DMNMessageType;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.Assert.assertTrue;
 
 public class ValidatorKnowledgeRequirementTest extends AbstractValidatorTest {
 
@@ -39,8 +38,8 @@ public class ValidatorKnowledgeRequirementTest extends AbstractValidatorTest {
                     reader,
                     VALIDATE_SCHEMA, VALIDATE_MODEL, VALIDATE_COMPILATION);
             assertThat(validate).withFailMessage(ValidatorUtil.formatMessages(validate)).hasSize(2);
-            assertTrue( validate.stream().anyMatch( p -> p.getMessageType().equals( DMNMessageType.MISSING_EXPRESSION ) ) );
-            assertTrue( validate.stream().anyMatch( p -> p.getMessageType().equals( DMNMessageType.REQ_NOT_FOUND ) ) );
+            assertThat(validate.stream().anyMatch(p -> p.getMessageType().equals(DMNMessageType.MISSING_EXPRESSION))).isTrue();
+            assertThat(validate.stream().anyMatch(p -> p.getMessageType().equals(DMNMessageType.REQ_NOT_FOUND))).isTrue();
         }
     }
 
@@ -50,8 +49,8 @@ public class ValidatorKnowledgeRequirementTest extends AbstractValidatorTest {
                 getFile( "knowledgerequirement/KNOWREQ_MISSING_BKM.dmn" ),
                 VALIDATE_SCHEMA, VALIDATE_MODEL, VALIDATE_COMPILATION);
         assertThat(validate).withFailMessage(ValidatorUtil.formatMessages(validate)).hasSize(2);
-        assertTrue( validate.stream().anyMatch( p -> p.getMessageType().equals( DMNMessageType.MISSING_EXPRESSION ) ) );
-        assertTrue( validate.stream().anyMatch( p -> p.getMessageType().equals( DMNMessageType.REQ_NOT_FOUND ) ) );
+        assertThat(validate.stream().anyMatch(p -> p.getMessageType().equals(DMNMessageType.MISSING_EXPRESSION))).isTrue();
+        assertThat(validate.stream().anyMatch(p -> p.getMessageType().equals(DMNMessageType.REQ_NOT_FOUND))).isTrue();
     }
 
     @Test
@@ -62,8 +61,8 @@ public class ValidatorKnowledgeRequirementTest extends AbstractValidatorTest {
                                 "KNOWREQ_MISSING_BKM"),
                 VALIDATE_MODEL, VALIDATE_COMPILATION);
         assertThat(validate).withFailMessage(ValidatorUtil.formatMessages(validate)).hasSize(2);
-        assertTrue( validate.stream().anyMatch( p -> p.getMessageType().equals( DMNMessageType.MISSING_EXPRESSION ) ) );
-        assertTrue( validate.stream().anyMatch( p -> p.getMessageType().equals( DMNMessageType.REQ_NOT_FOUND ) ) );
+        assertThat(validate.stream().anyMatch(p -> p.getMessageType().equals(DMNMessageType.MISSING_EXPRESSION))).isTrue();
+        assertThat(validate.stream().anyMatch(p -> p.getMessageType().equals(DMNMessageType.REQ_NOT_FOUND))).isTrue();
     }
 
     @Test
@@ -73,8 +72,8 @@ public class ValidatorKnowledgeRequirementTest extends AbstractValidatorTest {
                     reader,
                     VALIDATE_SCHEMA, VALIDATE_MODEL, VALIDATE_COMPILATION);
             assertThat(validate).withFailMessage(ValidatorUtil.formatMessages(validate)).hasSize(2);
-            assertTrue( validate.stream().anyMatch( p -> p.getMessageType().equals( DMNMessageType.MISSING_EXPRESSION ) ) );
-            assertTrue( validate.stream().anyMatch( p -> p.getMessageType().equals( DMNMessageType.REQ_NOT_FOUND ) ) );
+            assertThat(validate.stream().anyMatch(p -> p.getMessageType().equals(DMNMessageType.MISSING_EXPRESSION))).isTrue();
+            assertThat(validate.stream().anyMatch(p -> p.getMessageType().equals(DMNMessageType.REQ_NOT_FOUND))).isTrue();
         }
     }
 
@@ -84,8 +83,8 @@ public class ValidatorKnowledgeRequirementTest extends AbstractValidatorTest {
                 getFile( "knowledgerequirement/KNOWREQ_REQ_DECISION_NOT_BKM.dmn" ),
                 VALIDATE_SCHEMA, VALIDATE_MODEL, VALIDATE_COMPILATION);
         assertThat(validate).withFailMessage(ValidatorUtil.formatMessages(validate)).hasSize(2);
-        assertTrue( validate.stream().anyMatch( p -> p.getMessageType().equals( DMNMessageType.MISSING_EXPRESSION ) ) );
-        assertTrue( validate.stream().anyMatch( p -> p.getMessageType().equals( DMNMessageType.REQ_NOT_FOUND ) ) );
+        assertThat(validate.stream().anyMatch(p -> p.getMessageType().equals(DMNMessageType.MISSING_EXPRESSION))).isTrue();
+        assertThat(validate.stream().anyMatch(p -> p.getMessageType().equals(DMNMessageType.REQ_NOT_FOUND))).isTrue();
     }
 
     @Test
@@ -96,7 +95,7 @@ public class ValidatorKnowledgeRequirementTest extends AbstractValidatorTest {
                                 "KNOWREQ_REQ_DECISION_NOT_BKM"),
                 VALIDATE_MODEL, VALIDATE_COMPILATION);
         assertThat(validate).withFailMessage(ValidatorUtil.formatMessages(validate)).hasSize(2);
-        assertTrue( validate.stream().anyMatch( p -> p.getMessageType().equals( DMNMessageType.MISSING_EXPRESSION ) ) );
-        assertTrue( validate.stream().anyMatch( p -> p.getMessageType().equals( DMNMessageType.REQ_NOT_FOUND ) ) );
+        assertThat(validate.stream().anyMatch(p -> p.getMessageType().equals(DMNMessageType.MISSING_EXPRESSION))).isTrue();
+        assertThat(validate.stream().anyMatch(p -> p.getMessageType().equals(DMNMessageType.REQ_NOT_FOUND))).isTrue();
     }
 }

--- a/kie-dmn/kie-dmn-validation/src/test/java/org/kie/dmn/validation/ValidatorKnowledgeSourceTest.java
+++ b/kie-dmn/kie-dmn-validation/src/test/java/org/kie/dmn/validation/ValidatorKnowledgeSourceTest.java
@@ -25,7 +25,6 @@ import org.kie.dmn.api.core.DMNMessage;
 import org.kie.dmn.api.core.DMNMessageType;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.Assert.assertTrue;
 import static org.kie.dmn.validation.DMNValidator.Validation.VALIDATE_COMPILATION;
 import static org.kie.dmn.validation.DMNValidator.Validation.VALIDATE_MODEL;
 import static org.kie.dmn.validation.DMNValidator.Validation.VALIDATE_SCHEMA;
@@ -39,7 +38,7 @@ public class ValidatorKnowledgeSourceTest extends AbstractValidatorTest {
                     reader,
                     VALIDATE_SCHEMA, VALIDATE_MODEL, VALIDATE_COMPILATION);
             assertThat(validate).as(ValidatorUtil.formatMessages(validate)).hasSize(1);
-            assertTrue( validate.stream().anyMatch( p -> p.getMessageType().equals( DMNMessageType.REQ_NOT_FOUND ) ) );
+            assertThat(validate.stream().anyMatch(p -> p.getMessageType().equals(DMNMessageType.REQ_NOT_FOUND))).isTrue();
         }
     }
 
@@ -49,7 +48,7 @@ public class ValidatorKnowledgeSourceTest extends AbstractValidatorTest {
                 getFile( "knowledgesource/KNOW_SOURCE_MISSING_OWNER.dmn" ),
                 VALIDATE_SCHEMA, VALIDATE_MODEL, VALIDATE_COMPILATION);
         assertThat(validate).as(ValidatorUtil.formatMessages(validate)).hasSize(1);
-        assertTrue( validate.stream().anyMatch( p -> p.getMessageType().equals( DMNMessageType.REQ_NOT_FOUND ) ) );
+        assertThat(validate.stream().anyMatch(p -> p.getMessageType().equals(DMNMessageType.REQ_NOT_FOUND))).isTrue();
     }
 
     @Test
@@ -60,7 +59,7 @@ public class ValidatorKnowledgeSourceTest extends AbstractValidatorTest {
                                 "KNOW_SOURCE_MISSING_OWNER"),
                 VALIDATE_MODEL, VALIDATE_COMPILATION);
         assertThat(validate).as(ValidatorUtil.formatMessages(validate)).hasSize(1);
-        assertTrue( validate.stream().anyMatch( p -> p.getMessageType().equals( DMNMessageType.REQ_NOT_FOUND ) ) );
+        assertThat(validate.stream().anyMatch(p -> p.getMessageType().equals(DMNMessageType.REQ_NOT_FOUND))).isTrue();
     }
 
     @Test
@@ -70,7 +69,7 @@ public class ValidatorKnowledgeSourceTest extends AbstractValidatorTest {
                     reader,
                     VALIDATE_SCHEMA, VALIDATE_MODEL, VALIDATE_COMPILATION);
             assertThat(validate).as(ValidatorUtil.formatMessages(validate)).hasSize(3);
-            assertTrue( validate.stream().anyMatch( p -> p.getMessageType().equals( DMNMessageType.REQ_NOT_FOUND ) ) );
+            assertThat(validate.stream().anyMatch(p -> p.getMessageType().equals(DMNMessageType.REQ_NOT_FOUND))).isTrue();
         }
     }
 
@@ -80,7 +79,7 @@ public class ValidatorKnowledgeSourceTest extends AbstractValidatorTest {
                 getFile( "knowledgesource/KNOW_SOURCE_OWNER_NOT_ORG_UNIT.dmn" ),
                 VALIDATE_SCHEMA, VALIDATE_MODEL, VALIDATE_COMPILATION);
         assertThat(validate).as(ValidatorUtil.formatMessages(validate)).hasSize(3);
-        assertTrue( validate.stream().anyMatch( p -> p.getMessageType().equals( DMNMessageType.REQ_NOT_FOUND ) ) );
+        assertThat(validate.stream().anyMatch(p -> p.getMessageType().equals(DMNMessageType.REQ_NOT_FOUND))).isTrue();
     }
 
     @Test
@@ -91,6 +90,6 @@ public class ValidatorKnowledgeSourceTest extends AbstractValidatorTest {
                                 "KNOW_SOURCE_OWNER_NOT_ORG_UNIT"),
                 VALIDATE_MODEL, VALIDATE_COMPILATION);
         assertThat(validate).as(ValidatorUtil.formatMessages(validate)).hasSize(3);
-        assertTrue( validate.stream().anyMatch( p -> p.getMessageType().equals( DMNMessageType.REQ_NOT_FOUND ) ) );
+        assertThat(validate.stream().anyMatch(p -> p.getMessageType().equals(DMNMessageType.REQ_NOT_FOUND))).isTrue();
     }
 }

--- a/kie-dmn/kie-dmn-validation/src/test/java/org/kie/dmn/validation/ValidatorTest.java
+++ b/kie-dmn/kie-dmn-validation/src/test/java/org/kie/dmn/validation/ValidatorTest.java
@@ -43,8 +43,7 @@ import org.kie.dmn.model.api.DMNModelInstrumentedBase;
 import org.kie.dmn.model.api.Definitions;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
+import static org.assertj.core.api.Assertions.fail;
 import static org.kie.dmn.validation.DMNValidator.Validation.VALIDATE_COMPILATION;
 import static org.kie.dmn.validation.DMNValidator.Validation.VALIDATE_MODEL;
 import static org.kie.dmn.validation.DMNValidator.Validation.VALIDATE_SCHEMA;
@@ -132,31 +131,31 @@ public class ValidatorTest extends AbstractValidatorTest {
     public void testNAME_INVALID_empty_name() {
         List<DMNMessage> validate = validator.validate( getReader( "DROOLS-1447.dmn" ), VALIDATE_SCHEMA, VALIDATE_MODEL, VALIDATE_COMPILATION);
         assertThat(validate).withFailMessage(ValidatorUtil.formatMessages(validate)).hasSize(4);
-        assertTrue( validate.stream().anyMatch( p -> p.getMessageType().equals( DMNMessageType.FAILED_XML_VALIDATION ) ) );
-        assertTrue( validate.stream().anyMatch( p -> p.getMessageType().equals( DMNMessageType.VARIABLE_NAME_MISMATCH ) ) );
-        assertTrue( validate.stream().anyMatch( p -> p.getMessageType().equals( DMNMessageType.INVALID_NAME ) && p.getSourceId().equals( "_5e43b55c-888e-443c-b1b9-80e4aa6746bd" ) ) );
-        assertTrue( validate.stream().anyMatch( p -> p.getMessageType().equals( DMNMessageType.INVALID_NAME ) && p.getSourceId().equals( "_b1e4588e-9ce1-4474-8e4e-48dbcdb7524b" ) ) );
+        assertThat(validate.stream().anyMatch(p -> p.getMessageType().equals(DMNMessageType.FAILED_XML_VALIDATION))).isTrue();
+        assertThat(validate.stream().anyMatch(p -> p.getMessageType().equals(DMNMessageType.VARIABLE_NAME_MISMATCH))).isTrue();
+        assertThat(validate.stream().anyMatch(p -> p.getMessageType().equals(DMNMessageType.INVALID_NAME) && p.getSourceId().equals("_5e43b55c-888e-443c-b1b9-80e4aa6746bd"))).isTrue();
+        assertThat(validate.stream().anyMatch(p -> p.getMessageType().equals(DMNMessageType.INVALID_NAME) && p.getSourceId().equals("_b1e4588e-9ce1-4474-8e4e-48dbcdb7524b"))).isTrue();
     }
     
     @Test
     public void testDRGELEM_NOT_UNIQUE() {
         List<DMNMessage> validate = validator.validate( getReader( "DRGELEM_NOT_UNIQUE.dmn" ), VALIDATE_SCHEMA, VALIDATE_MODEL, VALIDATE_COMPILATION);
         assertThat(validate).withFailMessage(ValidatorUtil.formatMessages(validate)).hasSize(2);
-        assertTrue( validate.stream().anyMatch( p -> p.getMessageType().equals( DMNMessageType.DUPLICATE_NAME ) ) );
+        assertThat(validate.stream().anyMatch(p -> p.getMessageType().equals(DMNMessageType.DUPLICATE_NAME))).isTrue();
     }
     
     @Test
     public void testFORMAL_PARAM_DUPLICATED() {
         List<DMNMessage> validate = validator.validate( getReader( "FORMAL_PARAM_DUPLICATED.dmn" ), VALIDATE_SCHEMA, VALIDATE_MODEL, VALIDATE_COMPILATION);
         assertThat(validate).withFailMessage(ValidatorUtil.formatMessages(validate)).hasSize(3);
-        assertTrue( validate.stream().anyMatch( p -> p.getMessageType().equals( DMNMessageType.DUPLICATED_PARAM ) ) );
+        assertThat(validate.stream().anyMatch(p -> p.getMessageType().equals(DMNMessageType.DUPLICATED_PARAM))).isTrue();
     }
     
     @Test
     public void testINVOCATION_INCONSISTENT_PARAM_NAMES() {
         List<DMNMessage> validate = validator.validate( getReader( "INVOCATION_INCONSISTENT_PARAM_NAMES.dmn" ), VALIDATE_SCHEMA, VALIDATE_MODEL, VALIDATE_COMPILATION);
         assertThat(validate).withFailMessage(ValidatorUtil.formatMessages(validate)).hasSizeGreaterThan(0);
-        assertTrue( validate.stream().anyMatch( p -> p.getMessageType().equals( DMNMessageType.PARAMETER_MISMATCH ) ) );
+        assertThat(validate.stream().anyMatch(p -> p.getMessageType().equals(DMNMessageType.PARAMETER_MISMATCH))).isTrue();
     }
     
     @Test @Ignore( "Needs to be improved as invocations can be used to invoke functions node defined in BKMs. E.g., FEEL built in functions, etc.")
@@ -180,21 +179,21 @@ public class ValidatorTest extends AbstractValidatorTest {
     public void testINVOCATION_WRONG_PARAM_COUNT() {
         List<DMNMessage> validate = validator.validate( getReader( "INVOCATION_WRONG_PARAM_COUNT.dmn" ), VALIDATE_SCHEMA, VALIDATE_MODEL, VALIDATE_COMPILATION);
         assertThat(validate).withFailMessage(ValidatorUtil.formatMessages(validate)).hasSizeGreaterThan(0);
-        assertTrue( validate.stream().anyMatch( p -> p.getMessageType().equals( DMNMessageType.PARAMETER_MISMATCH ) ) );
+        assertThat(validate.stream().anyMatch(p -> p.getMessageType().equals(DMNMessageType.PARAMETER_MISMATCH))).isTrue();
     }
     
     @Test
     public void testITEMCOMP_DUPLICATED() {
         List<DMNMessage> validate = validator.validate( getReader( "ITEMCOMP_DUPLICATED.dmn" ), VALIDATE_SCHEMA, VALIDATE_MODEL, VALIDATE_COMPILATION);
         assertThat(validate).withFailMessage(ValidatorUtil.formatMessages(validate)).hasSize(2);
-        assertTrue( validate.stream().anyMatch( p -> p.getMessageType().equals( DMNMessageType.DUPLICATED_ITEM_DEF ) ) );
+        assertThat(validate.stream().anyMatch(p -> p.getMessageType().equals(DMNMessageType.DUPLICATED_ITEM_DEF))).isTrue();
     }
     
     @Test
     public void testITEMDEF_NOT_UNIQUE() {
         List<DMNMessage> validate = validator.validate( getReader( "ITEMDEF_NOT_UNIQUE.dmn" ), VALIDATE_SCHEMA, VALIDATE_MODEL, VALIDATE_COMPILATION);
         assertThat(validate).withFailMessage(ValidatorUtil.formatMessages(validate)).hasSize(2);
-        assertTrue( validate.stream().anyMatch( p -> p.getMessageType().equals( DMNMessageType.DUPLICATED_ITEM_DEF ) ) );
+        assertThat(validate.stream().anyMatch(p -> p.getMessageType().equals(DMNMessageType.DUPLICATED_ITEM_DEF))).isTrue();
     }
     
     @Test
@@ -208,22 +207,22 @@ public class ValidatorTest extends AbstractValidatorTest {
     public void testRELATION_DUP_COLUMN() {
         List<DMNMessage> validate = validator.validate( getReader( "RELATION_DUP_COLUMN.dmn" ), VALIDATE_SCHEMA, VALIDATE_MODEL, VALIDATE_COMPILATION);
         assertThat(validate).withFailMessage(ValidatorUtil.formatMessages(validate)).hasSize(2);
-        assertTrue( validate.stream().anyMatch( p -> p.getMessageType().equals( DMNMessageType.DUPLICATED_RELATION_COLUMN ) ) );
+        assertThat(validate.stream().anyMatch(p -> p.getMessageType().equals(DMNMessageType.DUPLICATED_RELATION_COLUMN))).isTrue();
     }
     
     @Test
     public void testRELATION_ROW_CELL_NOTLITERAL() {
         List<DMNMessage> validate = validator.validate( getReader( "RELATION_ROW_CELL_NOTLITERAL.dmn" ), VALIDATE_SCHEMA, VALIDATE_MODEL, VALIDATE_COMPILATION);
         assertThat(validate).withFailMessage(ValidatorUtil.formatMessages(validate)).hasSize(2);
-        assertTrue( validate.stream().anyMatch( p -> p.getMessageType().equals( DMNMessageType.RELATION_CELL_NOT_LITERAL ) ) );
-        assertTrue( validate.stream().anyMatch( p -> p.getMessageType().equals( DMNMessageType.MISSING_EXPRESSION ) ) );
+        assertThat(validate.stream().anyMatch(p -> p.getMessageType().equals(DMNMessageType.RELATION_CELL_NOT_LITERAL))).isTrue();
+        assertThat(validate.stream().anyMatch(p -> p.getMessageType().equals(DMNMessageType.MISSING_EXPRESSION))).isTrue();
     }
     
     @Test
     public void testRELATION_ROW_CELLCOUNTMISMATCH() {
         List<DMNMessage> validate = validator.validate( getReader( "RELATION_ROW_CELLCOUNTMISMATCH.dmn" ), VALIDATE_SCHEMA, VALIDATE_MODEL, VALIDATE_COMPILATION);
         assertThat(validate).withFailMessage(ValidatorUtil.formatMessages(validate)).hasSize(1);
-        assertTrue( validate.stream().anyMatch( p -> p.getMessageType().equals( DMNMessageType.RELATION_CELL_COUNT_MISMATCH ) ) );
+        assertThat(validate.stream().anyMatch(p -> p.getMessageType().equals(DMNMessageType.RELATION_CELL_COUNT_MISMATCH))).isTrue();
     }
 
     @Test
@@ -231,7 +230,7 @@ public class ValidatorTest extends AbstractValidatorTest {
         // This file has a gazillion errors. The goal of this test is simply check that the validator itself is not blowing up
         // and raising an exception. The errors in the file itself are irrelevant.
         List<DMNMessage> validate = validator.validate( getReader( "MortgageRecommender.dmn" ), VALIDATE_SCHEMA, VALIDATE_MODEL, VALIDATE_COMPILATION);
-        assertThat(validate.isEmpty()).withFailMessage(ValidatorUtil.formatMessages(validate)).isFalse();
+        assertThat(validate).withFailMessage(ValidatorUtil.formatMessages(validate)).isNotEmpty();
     }
 
     @Test
@@ -245,7 +244,7 @@ public class ValidatorTest extends AbstractValidatorTest {
     public void testVARIABLE_LEADING_TRAILING_SPACES() {
         List<DMNMessage> validate = validator.validate( getReader( "VARIABLE_LEADING_TRAILING_SPACES.dmn" ), VALIDATE_SCHEMA, VALIDATE_MODEL, VALIDATE_COMPILATION);
         assertThat(validate).withFailMessage(ValidatorUtil.formatMessages(validate)).hasSize(1);
-        assertTrue(validate.stream().anyMatch(p -> p.getMessageType().equals( DMNMessageType.INVALID_NAME)));
+        assertThat(validate.stream().anyMatch(p -> p.getMessageType().equals(DMNMessageType.INVALID_NAME))).isTrue();
         assertThat(validate.get(0).getSourceId()).isEqualTo("_dd662d27-7896-42cb-9d14-bd74203bdbec");
     }
 
@@ -253,7 +252,7 @@ public class ValidatorTest extends AbstractValidatorTest {
     public void testUNKNOWN_VARIABLE() {
         List<DMNMessage> validate = validator.validate( getReader( "UNKNOWN_VARIABLE.dmn" ), VALIDATE_SCHEMA, VALIDATE_MODEL, VALIDATE_COMPILATION);
         assertThat(validate).withFailMessage(ValidatorUtil.formatMessages(validate)).hasSize(1);
-        assertTrue( validate.stream().anyMatch( p -> p.getMessageType().equals( DMNMessageType.ERR_COMPILING_FEEL ) ) );
+        assertThat(validate.stream().anyMatch(p -> p.getMessageType().equals(DMNMessageType.ERR_COMPILING_FEEL))).isTrue();
     }
 
     @Test
@@ -269,12 +268,12 @@ public class ValidatorTest extends AbstractValidatorTest {
     public void testVALIDATION() {
         List<DMNMessage> validate = validator.validate( getReader( "validation.dmn" ), VALIDATE_MODEL, VALIDATE_COMPILATION);
         assertThat(validate).withFailMessage(ValidatorUtil.formatMessages(validate)).hasSize(5);
-        assertTrue( validate.stream().anyMatch( p -> p.getMessageType().equals( DMNMessageType.INVALID_NAME ) ) );
-        assertTrue( validate.stream().anyMatch( p -> p.getMessageType().equals( DMNMessageType.MISSING_TYPE_REF ) ) );
-        assertTrue( validate.stream().anyMatch( p -> p.getMessageType().equals( DMNMessageType.MISSING_EXPRESSION ) ) );
-        assertTrue( validate.stream().anyMatch( p -> p.getMessageType().equals( DMNMessageType.ERR_COMPILING_FEEL ) ) );
+        assertThat(validate.stream().anyMatch(p -> p.getMessageType().equals(DMNMessageType.INVALID_NAME))).isTrue();
+        assertThat(validate.stream().anyMatch(p -> p.getMessageType().equals(DMNMessageType.MISSING_TYPE_REF))).isTrue();
+        assertThat(validate.stream().anyMatch(p -> p.getMessageType().equals(DMNMessageType.MISSING_EXPRESSION))).isTrue();
+        assertThat(validate.stream().anyMatch(p -> p.getMessageType().equals(DMNMessageType.ERR_COMPILING_FEEL))).isTrue();
         // on node DTI the `Loan Payment` is of type `tLoanPayment` hence the property is `monthlyAmount`, NOT `amount` as reported in the model FEEL expression: (Loan Payment.amount+...
-        assertTrue( validate.stream().anyMatch( p -> p.getMessageType().equals( DMNMessageType.ERR_COMPILING_FEEL ) ) );
+        assertThat(validate.stream().anyMatch(p -> p.getMessageType().equals(DMNMessageType.ERR_COMPILING_FEEL))).isTrue();
     }
 
     @Test
@@ -323,7 +322,7 @@ public class ValidatorTest extends AbstractValidatorTest {
     public void testBoxedInvocationMissingExpression() {
         // DROOLS-2813 DMN boxed invocation missing expression NPE and Validator issue
         List<DMNMessage> validate = validator.validate(getReader("DROOLS-2813-NPE-BoxedInvocationMissingExpression.dmn", DMNRuntimeTest.class), VALIDATE_MODEL);
-        assertTrue(validate.stream().anyMatch(p -> p.getMessageType().equals(DMNMessageType.MISSING_EXPRESSION) && p.getSourceId().equals("_a111c4df-c5b5-4d84-81e7-3ec735b50d06")));
+        assertThat(validate.stream().anyMatch(p -> p.getMessageType().equals(DMNMessageType.MISSING_EXPRESSION) && p.getSourceId().equals("_a111c4df-c5b5-4d84-81e7-3ec735b50d06"))).isTrue();
     }
 
     @Test
@@ -343,10 +342,10 @@ public class ValidatorTest extends AbstractValidatorTest {
 
         // DMN v1.2 CH11 example for Adjudication does not define decision logic nor typeRef:
         assertThat(validate).withFailMessage(ValidatorUtil.formatMessages(validate)).hasSize(2);
-        assertTrue(validate.stream().anyMatch(p -> p.getMessageType().equals(DMNMessageType.MISSING_TYPE_REF)));
-        assertTrue(validate.stream().anyMatch(p -> p.getLevel() == Level.WARNING &&
-                                                   p.getMessageType().equals(DMNMessageType.MISSING_EXPRESSION) &&
-                                                   p.getSourceId().equals("d_Adjudication")));
+        assertThat(validate.stream().anyMatch(p -> p.getMessageType().equals(DMNMessageType.MISSING_TYPE_REF))).isTrue();
+        assertThat(validate.stream().anyMatch(p -> p.getLevel() == Level.WARNING &&
+                p.getMessageType().equals(DMNMessageType.MISSING_EXPRESSION) &&
+                p.getSourceId().equals("d_Adjudication"))).isTrue();
     }
 
     @Test
@@ -367,7 +366,7 @@ public class ValidatorTest extends AbstractValidatorTest {
 
         // DMNMessage{ severity=WARN, type=MISSING_TYPE_REF, message='Variable named 'Decision Service ABC' is missing its type reference on node 'Decision Service ABC'', sourceId='_63d05cff-8e3b-4dad-a355-fd88f8bcd613', exception='', feelEvent=''}
         assertThat(validate).withFailMessage(ValidatorUtil.formatMessages(validate)).hasSize(1);
-        assertTrue(validate.stream().anyMatch(p -> p.getMessageType().equals(DMNMessageType.MISSING_TYPE_REF) && p.getSourceId().equals("_63d05cff-8e3b-4dad-a355-fd88f8bcd613")));
+        assertThat(validate.stream().anyMatch(p -> p.getMessageType().equals(DMNMessageType.MISSING_TYPE_REF) && p.getSourceId().equals("_63d05cff-8e3b-4dad-a355-fd88f8bcd613"))).isTrue();
     }
 
     @Test
@@ -430,14 +429,12 @@ public class ValidatorTest extends AbstractValidatorTest {
                                              .theseModels(getReader("Financial.dmn", DMN13specificTest.class),
                                                           getReader("Chapter 11 Example.dmn", DMN13specificTest.class));
         assertThat(validate).withFailMessage(ValidatorUtil.formatMessages(validate)).hasSize(2);
-        assertTrue(ValidatorUtil.formatMessages(validate),
-                   validate.stream().anyMatch(p -> p.getLevel() == Level.WARNING &&
-                                                   p.getMessageType().equals(DMNMessageType.MISSING_EXPRESSION) &&
-                                                   p.getSourceId().equals("_4bd33d4a-741b-444a-968b-64e1841211e7")));
-        assertTrue(ValidatorUtil.formatMessages(validate),
-                   validate.stream().anyMatch(p -> p.getLevel() == Level.ERROR &&
-                                                   p.getMessageType().equals(DMNMessageType.INVALID_NAME) &&
-                                                   p.getSourceId().equals("_96b30012-a6e7-4545-89d3-068ec722469c")));
+        assertThat(validate.stream().anyMatch(p -> p.getLevel() == Level.WARNING &&
+                p.getMessageType().equals(DMNMessageType.MISSING_EXPRESSION) &&
+                p.getSourceId().equals("_4bd33d4a-741b-444a-968b-64e1841211e7"))).as(ValidatorUtil.formatMessages(validate)).isTrue();
+        assertThat(validate.stream().anyMatch(p -> p.getLevel() == Level.ERROR &&
+                p.getMessageType().equals(DMNMessageType.INVALID_NAME) &&
+                p.getSourceId().equals("_96b30012-a6e7-4545-89d3-068ec722469c"))).as(ValidatorUtil.formatMessages(validate)).isTrue();
     }
 
     @Test
@@ -447,10 +444,9 @@ public class ValidatorTest extends AbstractValidatorTest {
                                                             VALIDATE_COMPILATION)
                                              .theseModels(getReader("somethingInBetween.dmn"));
         assertThat(validate).withFailMessage(ValidatorUtil.formatMessages(validate)).hasSize(1);
-        assertTrue(ValidatorUtil.formatMessages(validate),
-                   validate.stream().anyMatch(p -> p.getLevel() == Level.ERROR &&
-                                                   p.getMessageType().equals(DMNMessageType.ERR_COMPILING_FEEL) &&
-                                                   p.getSourceId().equals("_841ed91c-db69-401e-890b-08a5bf44222d")));
+        assertThat(validate.stream().anyMatch(p -> p.getLevel() == Level.ERROR &&
+                p.getMessageType().equals(DMNMessageType.ERR_COMPILING_FEEL) &&
+                p.getSourceId().equals("_841ed91c-db69-401e-890b-08a5bf44222d"))).as(ValidatorUtil.formatMessages(validate)).isTrue();
     }
 
     @Test
@@ -480,16 +476,13 @@ public class ValidatorTest extends AbstractValidatorTest {
                                                        VALIDATE_SCHEMA,
                                                        VALIDATE_MODEL,
                                                        VALIDATE_COMPILATION);
-        assertTrue(ValidatorUtil.formatMessages(validate),
-                   validate.stream().allMatch(p -> p.getLevel() == Level.WARNING));
+        assertThat(validate.stream().allMatch(p -> p.getLevel() == Level.WARNING)).as(ValidatorUtil.formatMessages(validate)).isTrue();
         assertThat(validate).withFailMessage(ValidatorUtil.formatMessages(validate)).hasSize(2);
-        assertTrue(ValidatorUtil.formatMessages(validate),
-                   validate.stream().anyMatch(p -> p.getLevel() == Level.WARNING &&
-                                                   p.getSourceId() != null &&
-                                                   p.getSourceId().equals("_3ce3c41a-450a-40d1-9e9c-09180cd29879")));
-        assertTrue(ValidatorUtil.formatMessages(validate),
-                   validate.stream().anyMatch(p -> p.getLevel() == Level.WARNING &&
-                                                   ((DMNElement) ((DMNModelInstrumentedBase) p.getSourceReference()).getParent()).getId().equals("_d8b0c243-3fb6-40ec-a29c-28f8bdb92e13")));
+        assertThat(validate.stream().anyMatch(p -> p.getLevel() == Level.WARNING &&
+                p.getSourceId() != null &&
+                p.getSourceId().equals("_3ce3c41a-450a-40d1-9e9c-09180cd29879"))).as(ValidatorUtil.formatMessages(validate)).isTrue();
+        assertThat(validate.stream().anyMatch(p -> p.getLevel() == Level.WARNING &&
+                ((DMNElement) ((DMNModelInstrumentedBase) p.getSourceReference()).getParent()).getId().equals("_d8b0c243-3fb6-40ec-a29c-28f8bdb92e13"))).as(ValidatorUtil.formatMessages(validate)).isTrue();
     }
 
     @Test
@@ -513,9 +506,8 @@ public class ValidatorTest extends AbstractValidatorTest {
     private void checkInformationItemMissingTypeRef(DMNValidator.Validation... options) {
         List<DMNMessage> validate = validator.validate(getReader("variableMissingTypeRef.dmn"),
                                                        options);
-        assertTrue(ValidatorUtil.formatMessages(validate),
-                   validate.stream().allMatch(p -> p.getLevel() == Level.WARNING &&
-                                                   p.getSourceId().equals("_FE47213A-2042-49DE-9A44-65831DA6AD11")));
+        assertThat(validate.stream().allMatch(p -> p.getLevel() == Level.WARNING &&
+                p.getSourceId().equals("_FE47213A-2042-49DE-9A44-65831DA6AD11"))).as(ValidatorUtil.formatMessages(validate)).isTrue();
     }
 
 }

--- a/kie-dmn/kie-dmn-validation/src/test/java/org/kie/dmn/validation/ValidatorTypeRefTest.java
+++ b/kie-dmn/kie-dmn-validation/src/test/java/org/kie/dmn/validation/ValidatorTypeRefTest.java
@@ -25,7 +25,6 @@ import org.kie.dmn.api.core.DMNMessage;
 import org.kie.dmn.api.core.DMNMessageType;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.Assert.assertTrue;
 import static org.kie.dmn.validation.DMNValidator.Validation.VALIDATE_COMPILATION;
 import static org.kie.dmn.validation.DMNValidator.Validation.VALIDATE_MODEL;
 import static org.kie.dmn.validation.DMNValidator.Validation.VALIDATE_SCHEMA;
@@ -39,7 +38,7 @@ public class ValidatorTypeRefTest extends AbstractValidatorTest {
                     reader,
                     VALIDATE_SCHEMA, VALIDATE_MODEL, VALIDATE_COMPILATION);
             assertThat(validate).as(ValidatorUtil.formatMessages(validate)).hasSize(1);
-            assertTrue(validate.stream().anyMatch(p -> p.getMessageType().equals(DMNMessageType.TYPE_DEF_NOT_FOUND)));
+            assertThat(validate.stream().anyMatch(p -> p.getMessageType().equals(DMNMessageType.TYPE_DEF_NOT_FOUND))).isTrue();
         }
     }
 
@@ -49,7 +48,7 @@ public class ValidatorTypeRefTest extends AbstractValidatorTest {
                 getFile("typeref/TYPEREF_NO_FEEL_TYPE.dmn"),
                 VALIDATE_SCHEMA, VALIDATE_MODEL, VALIDATE_COMPILATION);
         assertThat(validate).as(ValidatorUtil.formatMessages(validate)).hasSize(1);
-        assertTrue(validate.stream().anyMatch(p -> p.getMessageType().equals(DMNMessageType.TYPE_DEF_NOT_FOUND)));
+        assertThat(validate.stream().anyMatch(p -> p.getMessageType().equals(DMNMessageType.TYPE_DEF_NOT_FOUND))).isTrue();
     }
 
     @Test
@@ -58,7 +57,7 @@ public class ValidatorTypeRefTest extends AbstractValidatorTest {
                 getDefinitions("typeref/TYPEREF_NO_FEEL_TYPE.dmn", "https://github.com/kiegroup/kie-dmn", "TYPEREF_NO_FEEL_TYPE"),
                 VALIDATE_MODEL, VALIDATE_COMPILATION);
         assertThat(validate).as(ValidatorUtil.formatMessages(validate)).hasSize(1);
-        assertTrue(validate.stream().anyMatch(p -> p.getMessageType().equals(DMNMessageType.TYPE_DEF_NOT_FOUND)));
+        assertThat(validate.stream().anyMatch(p -> p.getMessageType().equals(DMNMessageType.TYPE_DEF_NOT_FOUND))).isTrue();
     }
 
     @Test
@@ -68,7 +67,7 @@ public class ValidatorTypeRefTest extends AbstractValidatorTest {
                     reader,
                     VALIDATE_SCHEMA, VALIDATE_MODEL, VALIDATE_COMPILATION);
             assertThat(validate).as(ValidatorUtil.formatMessages(validate)).hasSize(1);
-            assertTrue(validate.stream().anyMatch(p -> p.getMessageType().equals(DMNMessageType.TYPE_DEF_NOT_FOUND)));
+            assertThat(validate.stream().anyMatch(p -> p.getMessageType().equals(DMNMessageType.TYPE_DEF_NOT_FOUND))).isTrue();
         }
     }
 
@@ -78,7 +77,7 @@ public class ValidatorTypeRefTest extends AbstractValidatorTest {
                 getFile("typeref/TYPEREF_NO_NS.dmn"),
                 VALIDATE_SCHEMA, VALIDATE_MODEL, VALIDATE_COMPILATION);
         assertThat(validate).as(ValidatorUtil.formatMessages(validate)).hasSize(1);
-        assertTrue(validate.stream().anyMatch(p -> p.getMessageType().equals(DMNMessageType.TYPE_DEF_NOT_FOUND)));
+        assertThat(validate.stream().anyMatch(p -> p.getMessageType().equals(DMNMessageType.TYPE_DEF_NOT_FOUND))).isTrue();
     }
 
     @Test
@@ -87,7 +86,7 @@ public class ValidatorTypeRefTest extends AbstractValidatorTest {
                 getDefinitions("typeref/TYPEREF_NO_NS.dmn", "https://github.com/kiegroup/kie-dmn", "TYPEREF_NO_NS"),
                 VALIDATE_MODEL, VALIDATE_COMPILATION);
         assertThat(validate).as(ValidatorUtil.formatMessages(validate)).hasSize(1);
-        assertTrue(validate.stream().anyMatch(p -> p.getMessageType().equals(DMNMessageType.TYPE_DEF_NOT_FOUND)));
+        assertThat(validate.stream().anyMatch(p -> p.getMessageType().equals(DMNMessageType.TYPE_DEF_NOT_FOUND))).isTrue();
     }
 
     @Test
@@ -97,8 +96,8 @@ public class ValidatorTypeRefTest extends AbstractValidatorTest {
                     reader,
                     VALIDATE_SCHEMA, VALIDATE_MODEL, VALIDATE_COMPILATION);
             assertThat(validate).as(ValidatorUtil.formatMessages(validate)).hasSize(2);
-            assertTrue(validate.stream().anyMatch(p -> p.getMessageType().equals(DMNMessageType.INVALID_NAME)));
-            assertTrue(validate.stream().anyMatch(p -> p.getMessageType().equals(DMNMessageType.TYPE_DEF_NOT_FOUND)));
+            assertThat(validate.stream().anyMatch(p -> p.getMessageType().equals(DMNMessageType.INVALID_NAME))).isTrue();
+            assertThat(validate.stream().anyMatch(p -> p.getMessageType().equals(DMNMessageType.TYPE_DEF_NOT_FOUND))).isTrue();
         }
     }
 
@@ -108,8 +107,8 @@ public class ValidatorTypeRefTest extends AbstractValidatorTest {
                 getFile("typeref/TYPEREF_NOT_FEEL_NOT_DEF.dmn"),
                 VALIDATE_SCHEMA, VALIDATE_MODEL, VALIDATE_COMPILATION);
         assertThat(validate).as(ValidatorUtil.formatMessages(validate)).hasSize(2);
-        assertTrue(validate.stream().anyMatch(p -> p.getMessageType().equals(DMNMessageType.INVALID_NAME)));
-        assertTrue(validate.stream().anyMatch(p -> p.getMessageType().equals(DMNMessageType.TYPE_DEF_NOT_FOUND)));
+        assertThat(validate.stream().anyMatch(p -> p.getMessageType().equals(DMNMessageType.INVALID_NAME))).isTrue();
+        assertThat(validate.stream().anyMatch(p -> p.getMessageType().equals(DMNMessageType.TYPE_DEF_NOT_FOUND))).isTrue();
     }
 
     @Test
@@ -118,8 +117,8 @@ public class ValidatorTypeRefTest extends AbstractValidatorTest {
                 getDefinitions("typeref/TYPEREF_NOT_FEEL_NOT_DEF.dmn", "https://github.com/kiegroup/kie-dmn", "TYPEREF_NOT_FEEL_NOT_DEF"),
                 VALIDATE_MODEL, VALIDATE_COMPILATION);
         assertThat(validate).as(ValidatorUtil.formatMessages(validate)).hasSize(2);
-        assertTrue(validate.stream().anyMatch(p -> p.getMessageType().equals(DMNMessageType.INVALID_NAME)));
-        assertTrue(validate.stream().anyMatch(p -> p.getMessageType().equals(DMNMessageType.TYPE_DEF_NOT_FOUND)));
+        assertThat(validate.stream().anyMatch(p -> p.getMessageType().equals(DMNMessageType.INVALID_NAME))).isTrue();
+        assertThat(validate.stream().anyMatch(p -> p.getMessageType().equals(DMNMessageType.TYPE_DEF_NOT_FOUND))).isTrue();
     }
 
     @Test

--- a/kie-dmn/kie-dmn-validation/src/test/java/org/kie/dmn/validation/classloader/ValidatorClassloaderTest.java
+++ b/kie-dmn/kie-dmn-validation/src/test/java/org/kie/dmn/validation/classloader/ValidatorClassloaderTest.java
@@ -41,7 +41,6 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.Assert.assertTrue;
 import static org.kie.dmn.validation.DMNValidator.Validation.VALIDATE_COMPILATION;
 import static org.kie.dmn.validation.DMNValidator.Validation.VALIDATE_MODEL;
 import static org.kie.dmn.validation.DMNValidator.Validation.VALIDATE_SCHEMA;
@@ -66,7 +65,7 @@ public class ValidatorClassloaderTest extends AbstractValidatorTest {
         kfs.generateAndWritePomXML(kjarReleaseId);
 
         final KieBuilder kieBuilder = ks.newKieBuilder(kfs).buildAll();
-        assertTrue(kieBuilder.getResults().getMessages().toString(), kieBuilder.getResults().getMessages().isEmpty());
+        assertThat(kieBuilder.getResults().getMessages()).as(kieBuilder.getResults().getMessages().toString()).isEmpty();
 
         final KieContainer container = ks.newKieContainer(kjarReleaseId);
         final DMNRuntime runtime = KieRuntimeFactory.of(container.getKieBase()).get(DMNRuntime.class);

--- a/kie-dmn/kie-dmn-validation/src/test/java/org/kie/dmn/validation/dtanalysis/Check1stNFViolationTest.java
+++ b/kie-dmn/kie-dmn-validation/src/test/java/org/kie/dmn/validation/dtanalysis/Check1stNFViolationTest.java
@@ -27,7 +27,6 @@ import org.kie.dmn.api.core.DMNMessageType;
 import org.kie.dmn.validation.dtanalysis.model.DTAnalysis;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.Assert.assertTrue;
 import static org.kie.dmn.validation.DMNValidator.Validation.ANALYZE_DECISION_TABLE;
 
 public class Check1stNFViolationTest extends AbstractDTAnalysisTest {
@@ -40,18 +39,15 @@ public class Check1stNFViolationTest extends AbstractDTAnalysisTest {
         assertThat(analysisDuplicate.is1stNFViolation()).isTrue();
         assertThat(analysisDuplicate.getDuplicateRulesTuples()).hasSize(1);
         assertThat(analysisDuplicate.getDuplicateRulesTuples()).containsAll(Collections.singletonList(Arrays.asList(1, 2)));
-        assertTrue("It should contain at DMNMessage for the 1st NF Violation",
-                   validate.stream().anyMatch(p -> p.getSourceId().equals("_053034d5-0e1f-4c4a-8513-ab3c6ba538db") && p.getMessageType().equals(DMNMessageType.DECISION_TABLE_1STNFVIOLATION)));
+        assertThat(validate.stream().anyMatch(p -> p.getSourceId().equals("_053034d5-0e1f-4c4a-8513-ab3c6ba538db") && p.getMessageType().equals(DMNMessageType.DECISION_TABLE_1STNFVIOLATION))).as("It should contain at DMNMessage for the 1st NF Violation").isTrue();
 
         DTAnalysis analysisFIRST = getAnalysis(validate, "_1ca6acde-c1d4-4c50-8e21-f3b11e106f3d");
         assertThat(analysisFIRST.is1stNFViolation()).isTrue();
-        assertTrue("It should contain at DMNMessage for the 1st NF Violation",
-                   validate.stream().anyMatch(p -> p.getSourceId().equals("_1ca6acde-c1d4-4c50-8e21-f3b11e106f3d") && p.getMessageType().equals(DMNMessageType.DECISION_TABLE_1STNFVIOLATION)));
+        assertThat(validate.stream().anyMatch(p -> p.getSourceId().equals("_1ca6acde-c1d4-4c50-8e21-f3b11e106f3d") && p.getMessageType().equals(DMNMessageType.DECISION_TABLE_1STNFVIOLATION))).as("It should contain at DMNMessage for the 1st NF Violation").isTrue();
 
         DTAnalysis analysisRULE_ORDER = getAnalysis(validate, "_03522945-b520-4b45-ac5e-ef3cbd7f1eaf");
         assertThat(analysisRULE_ORDER.is1stNFViolation()).isTrue();
-        assertTrue("It should contain at DMNMessage for the 1st NF Violation",
-                   validate.stream().anyMatch(p -> p.getSourceId().equals("_03522945-b520-4b45-ac5e-ef3cbd7f1eaf") && p.getMessageType().equals(DMNMessageType.DECISION_TABLE_1STNFVIOLATION)));
+        assertThat(validate.stream().anyMatch(p -> p.getSourceId().equals("_03522945-b520-4b45-ac5e-ef3cbd7f1eaf") && p.getMessageType().equals(DMNMessageType.DECISION_TABLE_1STNFVIOLATION))).as("It should contain at DMNMessage for the 1st NF Violation").isTrue();
     }
 
     @Test
@@ -62,8 +58,7 @@ public class Check1stNFViolationTest extends AbstractDTAnalysisTest {
         assertThat(analysisDuplicate.is1stNFViolation()).isTrue();
         assertThat(analysisDuplicate.getDuplicateRulesTuples()).hasSize(1);
         assertThat(analysisDuplicate.getDuplicateRulesTuples()).containsAll(Collections.singletonList(Arrays.asList(1, 2)));
-        assertTrue("It should contain at DMNMessage for the 1st NF Violation",
-                   validate.stream().anyMatch(p -> p.getSourceId().equals("_053034d5-0e1f-4c4a-8513-ab3c6ba538db") && p.getMessageType().equals(DMNMessageType.DECISION_TABLE_1STNFVIOLATION)));
+        assertThat(validate.stream().anyMatch(p -> p.getSourceId().equals("_053034d5-0e1f-4c4a-8513-ab3c6ba538db") && p.getMessageType().equals(DMNMessageType.DECISION_TABLE_1STNFVIOLATION))).as("It should contain at DMNMessage for the 1st NF Violation").isTrue();
     }
 
     @Test
@@ -74,11 +69,9 @@ public class Check1stNFViolationTest extends AbstractDTAnalysisTest {
         assertThat(analysis.is1stNFViolation()).isTrue();
         assertThat(analysis.getDuplicateRulesTuples()).hasSize(1);
         assertThat(analysis.getDuplicateRulesTuples()).containsAll(Collections.singletonList(Arrays.asList(1, 2)));
-        assertTrue("It should contain at DMNMessage for the 1st NF Violation",
-                   validate.stream().anyMatch(p -> p.getMessageType().equals(DMNMessageType.DECISION_TABLE_1STNFVIOLATION)));
-        assertThat(analysis.getSubsumptions().isEmpty()).isFalse();
-        assertTrue("No message about subsumption",
-                   validate.stream().noneMatch(p -> p.getMessageType().equals(DMNMessageType.DECISION_TABLE_SUBSUMPTION_RULE)));
+        assertThat(validate.stream().anyMatch(p -> p.getMessageType().equals(DMNMessageType.DECISION_TABLE_1STNFVIOLATION))).as("It should contain at DMNMessage for the 1st NF Violation").isTrue();
+        assertThat(analysis.getSubsumptions()).isNotEmpty();
+        assertThat(validate.stream().noneMatch(p -> p.getMessageType().equals(DMNMessageType.DECISION_TABLE_SUBSUMPTION_RULE))).as("No message about subsumption").isTrue();
     }
 
     @Test
@@ -88,11 +81,9 @@ public class Check1stNFViolationTest extends AbstractDTAnalysisTest {
         DTAnalysis analysisDuplicate = getAnalysis(validate, "_4237d55b-2589-48a5-8183-f9f4e0e00c07");
         assertThat(analysisDuplicate.is1stNFViolation()).isTrue();
         assertThat(analysisDuplicate.getDuplicateRulesTuples()).hasSize(2);
-        assertTrue("It should contain DMNMessage(s) for the 1st NF Violation",
-                   validate.stream().anyMatch(p -> p.getSourceId().equals("_4237d55b-2589-48a5-8183-f9f4e0e00c07") && p.getMessageType().equals(DMNMessageType.DECISION_TABLE_1STNFVIOLATION)));
-        assertTrue("Being a C table, DMNMessage(s) for the 1st NF Violation are of type Warning",
-                   validate.stream()
-                           .filter(p -> p.getSourceId().equals("_4237d55b-2589-48a5-8183-f9f4e0e00c07") && p.getMessageType().equals(DMNMessageType.DECISION_TABLE_1STNFVIOLATION))
-                           .allMatch(p -> p.getLevel() == Level.WARNING));
+        assertThat(validate.stream().anyMatch(p -> p.getSourceId().equals("_4237d55b-2589-48a5-8183-f9f4e0e00c07") && p.getMessageType().equals(DMNMessageType.DECISION_TABLE_1STNFVIOLATION))).as("It should contain DMNMessage(s) for the 1st NF Violation").isTrue();
+        assertThat(validate.stream()
+                .filter(p -> p.getSourceId().equals("_4237d55b-2589-48a5-8183-f9f4e0e00c07") && p.getMessageType().equals(DMNMessageType.DECISION_TABLE_1STNFVIOLATION))
+                .allMatch(p -> p.getLevel() == Level.WARNING)).as("Being a C table, DMNMessage(s) for the 1st NF Violation are of type Warning").isTrue();
     }
 }

--- a/kie-dmn/kie-dmn-validation/src/test/java/org/kie/dmn/validation/dtanalysis/Check2ndNFViolationTest.java
+++ b/kie-dmn/kie-dmn-validation/src/test/java/org/kie/dmn/validation/dtanalysis/Check2ndNFViolationTest.java
@@ -25,7 +25,6 @@ import org.kie.dmn.validation.dtanalysis.model.Contraction;
 import org.kie.dmn.validation.dtanalysis.model.DTAnalysis;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.Assert.assertTrue;
 import static org.kie.dmn.validation.DMNValidator.Validation.ANALYZE_DECISION_TABLE;
 
 public class Check2ndNFViolationTest extends AbstractDTAnalysisTest {
@@ -41,8 +40,7 @@ public class Check2ndNFViolationTest extends AbstractDTAnalysisTest {
         assertThat(c2NFViolation.rule).isEqualTo(1);
         assertThat(c2NFViolation.pairedRules).contains(2);
         assertThat(c2NFViolation.adjacentDimension).isEqualTo(3);
-        assertTrue("It should contain at DMNMessage for the 2nd NF Violation",
-                   validate.stream().anyMatch(p -> p.getSourceId().equals("_4e358bae-7012-42dd-acea-e88b3aa3c8b2") && p.getMessageType().equals(DMNMessageType.DECISION_TABLE_2NDNFVIOLATION)));
+        assertThat(validate.stream().anyMatch(p -> p.getSourceId().equals("_4e358bae-7012-42dd-acea-e88b3aa3c8b2") && p.getMessageType().equals(DMNMessageType.DECISION_TABLE_2NDNFVIOLATION))).as("It should contain at DMNMessage for the 2nd NF Violation").isTrue();
 
     }
 

--- a/kie-dmn/kie-dmn-validation/src/test/java/org/kie/dmn/validation/dtanalysis/FailingOutputConstraintsTest.java
+++ b/kie-dmn/kie-dmn-validation/src/test/java/org/kie/dmn/validation/dtanalysis/FailingOutputConstraintsTest.java
@@ -24,7 +24,6 @@ import org.kie.dmn.api.core.DMNMessageType;
 import org.kie.dmn.validation.dtanalysis.model.DTAnalysis;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.Assert.assertTrue;
 import static org.kie.dmn.validation.DMNValidator.Validation.ANALYZE_DECISION_TABLE;
 
 public class FailingOutputConstraintsTest extends AbstractDTAnalysisTest {
@@ -32,8 +31,7 @@ public class FailingOutputConstraintsTest extends AbstractDTAnalysisTest {
     @Test
     public void testFailingOutputConstraints() {
         List<DMNMessage> validate = validator.validate(getReader("FailingOutputConstraints.dmn"), ANALYZE_DECISION_TABLE);
-        assertTrue("It should contain DMNMessage for output outside of LoV",
-                   validate.stream().anyMatch(p -> p.getMessageType().equals(DMNMessageType.DECISION_TABLE_ANALYSIS_ERROR)));
+        assertThat(validate.stream().anyMatch(p -> p.getMessageType().equals(DMNMessageType.DECISION_TABLE_ANALYSIS_ERROR))).as("It should contain DMNMessage for output outside of LoV").isTrue();
         debugValidatorMsg(validate);
 
         DTAnalysis analysis = getAnalysis(validate, "_E72BD036-C550-4992-AA6D-A8AD4666C63A");
@@ -46,8 +44,7 @@ public class FailingOutputConstraintsTest extends AbstractDTAnalysisTest {
     public void testFailingOutputConstraintsWhenOutputIsSymbol() {
         List<DMNMessage> validate = validator.validate(getReader("FailingOutputConstraints2.dmn"), ANALYZE_DECISION_TABLE);
         debugValidatorMsg(validate);
-        assertTrue("It should NOT contain DMNMessage for output outside of LoV (using a symbol in output)",
-                   validate.stream().noneMatch(p -> p.getMessageType().equals(DMNMessageType.DECISION_TABLE_ANALYSIS_ERROR)));
+        assertThat(validate.stream().noneMatch(p -> p.getMessageType().equals(DMNMessageType.DECISION_TABLE_ANALYSIS_ERROR))).as("It should NOT contain DMNMessage for output outside of LoV (using a symbol in output)").isTrue();
 
         DTAnalysis analysis = getAnalysis(validate, "_E72BD036-C550-4992-AA6D-A8AD4666C63A");
         assertThat(analysis.isError()).isFalse();

--- a/kie-dmn/kie-dmn-validation/src/test/java/org/kie/dmn/validation/dtanalysis/HitPolicyFirstTest.java
+++ b/kie-dmn/kie-dmn-validation/src/test/java/org/kie/dmn/validation/dtanalysis/HitPolicyFirstTest.java
@@ -24,7 +24,6 @@ import org.kie.dmn.api.core.DMNMessageType;
 import org.kie.dmn.validation.dtanalysis.model.DTAnalysis;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.Assert.assertTrue;
 import static org.kie.dmn.validation.DMNValidator.Validation.ANALYZE_DECISION_TABLE;
 
 public class HitPolicyFirstTest extends AbstractDTAnalysisTest {
@@ -36,7 +35,6 @@ public class HitPolicyFirstTest extends AbstractDTAnalysisTest {
 
         assertThat(analysis.getGaps()).hasSize(0);
         assertThat(analysis.getOverlaps()).hasSize(0);
-        assertTrue("It should contain at least 1 DMNMessage for the type " + DMNMessageType.DECISION_TABLE_1STNFVIOLATION,
-                   validate.stream().anyMatch(p -> p.getMessageType().equals(DMNMessageType.DECISION_TABLE_1STNFVIOLATION)));
+        assertThat(validate.stream().anyMatch(p -> p.getMessageType().equals(DMNMessageType.DECISION_TABLE_1STNFVIOLATION))).as("It should contain at least 1 DMNMessage for the type " + DMNMessageType.DECISION_TABLE_1STNFVIOLATION).isTrue();
     }
 }

--- a/kie-dmn/kie-dmn-validation/src/test/java/org/kie/dmn/validation/dtanalysis/MaskTest.java
+++ b/kie-dmn/kie-dmn-validation/src/test/java/org/kie/dmn/validation/dtanalysis/MaskTest.java
@@ -32,7 +32,6 @@ import org.kie.dmn.validation.dtanalysis.model.MaskedRule;
 import org.kie.dmn.validation.dtanalysis.model.Overlap;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.Assert.assertTrue;
 import static org.kie.dmn.validation.DMNValidator.Validation.ANALYZE_DECISION_TABLE;
 import static org.kie.dmn.validation.DMNValidator.Validation.VALIDATE_COMPILATION;
 
@@ -64,10 +63,8 @@ public class MaskTest extends AbstractDTAnalysisTest {
         List<MaskedRule> maskedRules = Arrays.asList(new MaskedRule(1, 2));
         assertThat(maskedRules).hasSize(1);
         assertThat(analysis.getMaskedRules()).containsAll(maskedRules);
-        assertTrue("It should contain at least 1 DMNMessage for the MaskedRule",
-                   validate.stream().anyMatch(p -> p.getMessageType().equals(DMNMessageType.DECISION_TABLE_MASKED_RULE)));
-        assertTrue("It should not contain DMNMessage for the MisleadingRule",
-                   validate.stream().noneMatch(p -> p.getMessageType().equals(DMNMessageType.DECISION_TABLE_MISLEADING_RULE)));
+        assertThat(validate.stream().anyMatch(p -> p.getMessageType().equals(DMNMessageType.DECISION_TABLE_MASKED_RULE))).as("It should contain at least 1 DMNMessage for the MaskedRule").isTrue();
+        assertThat(validate.stream().noneMatch(p -> p.getMessageType().equals(DMNMessageType.DECISION_TABLE_MISLEADING_RULE))).as("It should not contain DMNMessage for the MisleadingRule").isTrue();
     }
 
     @Test
@@ -108,10 +105,8 @@ public class MaskTest extends AbstractDTAnalysisTest {
         List<MaskedRule> maskedRules = Arrays.asList(new MaskedRule(1, 2));
         assertThat(maskedRules).hasSize(1);
         assertThat(analysis.getMaskedRules()).containsAll(maskedRules);
-        assertTrue("It should contain at least 1 DMNMessage for the MaskedRule",
-                   validate.stream().anyMatch(p -> p.getMessageType().equals(DMNMessageType.DECISION_TABLE_MASKED_RULE)));
-        assertTrue("It should not contain DMNMessage for the MisleadingRule",
-                   validate.stream().noneMatch(p -> p.getMessageType().equals(DMNMessageType.DECISION_TABLE_MISLEADING_RULE)));
+        assertThat(validate.stream().anyMatch(p -> p.getMessageType().equals(DMNMessageType.DECISION_TABLE_MASKED_RULE))).as("It should contain at least 1 DMNMessage for the MaskedRule").isTrue();
+        assertThat(validate.stream().noneMatch(p -> p.getMessageType().equals(DMNMessageType.DECISION_TABLE_MISLEADING_RULE))).as("It should not contain DMNMessage for the MisleadingRule").isTrue();
     }
 
 }

--- a/kie-dmn/kie-dmn-validation/src/test/java/org/kie/dmn/validation/dtanalysis/MisleadingRulesTest.java
+++ b/kie-dmn/kie-dmn-validation/src/test/java/org/kie/dmn/validation/dtanalysis/MisleadingRulesTest.java
@@ -31,7 +31,6 @@ import org.kie.dmn.validation.dtanalysis.model.MisleadingRule;
 import org.kie.dmn.validation.dtanalysis.model.Overlap;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.Assert.assertTrue;
 import static org.kie.dmn.validation.DMNValidator.Validation.ANALYZE_DECISION_TABLE;
 import static org.kie.dmn.validation.DMNValidator.Validation.VALIDATE_COMPILATION;
 
@@ -69,10 +68,8 @@ public class MisleadingRulesTest extends AbstractDTAnalysisTest {
         List<MisleadingRule> misleadingRules = Arrays.asList(new MisleadingRule(4, 2));
         assertThat(misleadingRules).hasSize(1);
         assertThat(analysis.getMisleadingRules()).containsAll(misleadingRules);
-        assertTrue("It should contain at least 1 DMNMessage for the MisleadingRule",
-                   validate.stream().anyMatch(p -> p.getMessageType().equals(DMNMessageType.DECISION_TABLE_MISLEADING_RULE)));
-        assertTrue("This test case is not a Masked rule example",
-                   validate.stream().noneMatch(p -> p.getMessageType().equals(DMNMessageType.DECISION_TABLE_MASKED_RULE)));
+        assertThat(validate.stream().anyMatch(p -> p.getMessageType().equals(DMNMessageType.DECISION_TABLE_MISLEADING_RULE))).as("It should contain at least 1 DMNMessage for the MisleadingRule").isTrue();
+        assertThat(validate.stream().noneMatch(p -> p.getMessageType().equals(DMNMessageType.DECISION_TABLE_MASKED_RULE))).as("This test case is not a Masked rule example").isTrue();
     }
 
     @Test

--- a/kie-dmn/kie-dmn-validation/src/test/java/org/kie/dmn/validation/dtanalysis/OverlapHitPolicyTest.java
+++ b/kie-dmn/kie-dmn-validation/src/test/java/org/kie/dmn/validation/dtanalysis/OverlapHitPolicyTest.java
@@ -39,7 +39,6 @@ import org.kie.dmn.validation.dtanalysis.model.Interval;
 import org.kie.dmn.validation.dtanalysis.model.Overlap;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.Assert.assertTrue;
 import static org.kie.dmn.validation.DMNValidator.Validation.ANALYZE_DECISION_TABLE;
 import static org.kie.dmn.validation.DMNValidator.Validation.VALIDATE_COMPILATION;
 
@@ -66,16 +65,14 @@ public class OverlapHitPolicyTest extends AbstractDTAnalysisTest {
         checkAnalysis(validate);
 
         if (hp == HitPolicy.UNIQUE) {
-            assertTrue("It should contain at least 1 DMNMessage for the type",
-                       validate.stream().anyMatch(p -> p.getMessageType().equals(DMNMessageType.DECISION_TABLE_OVERLAP_HITPOLICY_UNIQUE)));
+            assertThat(validate.stream().anyMatch(p -> p.getMessageType().equals(DMNMessageType.DECISION_TABLE_OVERLAP_HITPOLICY_UNIQUE))).as("It should contain at least 1 DMNMessage for the type").isTrue();
         } else if (hp == HitPolicy.ANY) {
-            assertTrue("It should contain at least 1 DMNMessage for the type",
-                       validate.stream().anyMatch(p -> p.getMessageType().equals(DMNMessageType.DECISION_TABLE_OVERLAP_HITPOLICY_ANY)));
+            assertThat(validate.stream().anyMatch(p -> p.getMessageType().equals(DMNMessageType.DECISION_TABLE_OVERLAP_HITPOLICY_ANY))).as("It should contain at least 1 DMNMessage for the type").isTrue();
         } else {
             LOG.debug("Testing for {} I am expecting there is NOT DMNMessage pertaining to Overlaps", hp);
-            assertTrue(validate.stream().noneMatch(p -> p.getMessageType().equals(DMNMessageType.DECISION_TABLE_OVERLAP_HITPOLICY_UNIQUE)) &&
-                       validate.stream().noneMatch(p -> p.getMessageType().equals(DMNMessageType.DECISION_TABLE_OVERLAP_HITPOLICY_ANY)) &&
-                       validate.stream().noneMatch(p -> p.getMessageType().equals(DMNMessageType.DECISION_TABLE_OVERLAP)));
+            assertThat(validate.stream().noneMatch(p -> p.getMessageType().equals(DMNMessageType.DECISION_TABLE_OVERLAP_HITPOLICY_UNIQUE)) &&
+                    validate.stream().noneMatch(p -> p.getMessageType().equals(DMNMessageType.DECISION_TABLE_OVERLAP_HITPOLICY_ANY)) &&
+                    validate.stream().noneMatch(p -> p.getMessageType().equals(DMNMessageType.DECISION_TABLE_OVERLAP))).isTrue();
         }
     }
 

--- a/kie-dmn/kie-dmn-validation/src/test/java/org/kie/dmn/validation/dtanalysis/RecommenderHitPolicyTest.java
+++ b/kie-dmn/kie-dmn-validation/src/test/java/org/kie/dmn/validation/dtanalysis/RecommenderHitPolicyTest.java
@@ -29,7 +29,6 @@ import org.kie.dmn.model.api.HitPolicy;
 import org.kie.dmn.validation.dtanalysis.model.DTAnalysis;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.Assert.assertTrue;
 import static org.kie.dmn.validation.DMNValidator.Validation.ANALYZE_DECISION_TABLE;
 import static org.kie.dmn.validation.DMNValidator.Validation.VALIDATE_COMPILATION;
 
@@ -43,7 +42,7 @@ public class RecommenderHitPolicyTest extends AbstractDTAnalysisTest {
 
         debugValidatorMsg(validate);
         assertThat(analysis.getGaps()).hasSize(1);
-        assertTrue(validate.stream().noneMatch(m -> m.getMessageType() == DMNMessageType.DECISION_TABLE_HITPOLICY_RECOMMENDER));
+        assertThat(validate.stream().noneMatch(m -> m.getMessageType() == DMNMessageType.DECISION_TABLE_HITPOLICY_RECOMMENDER)).isTrue();
     }
 
     @Test
@@ -51,11 +50,11 @@ public class RecommenderHitPolicyTest extends AbstractDTAnalysisTest {
         List<HitPolicy> wrongHPs = Arrays.asList(HitPolicy.ANY, HitPolicy.PRIORITY, HitPolicy.FIRST);
         for (HitPolicy hp : wrongHPs) {
             List<DMNMessage> validate = getRecommenderHitPolicy2(hp);
-            assertTrue(validate.stream().anyMatch(m -> m.getMessageType() == DMNMessageType.DECISION_TABLE_HITPOLICY_RECOMMENDER));
+            assertThat(validate.stream().anyMatch(m -> m.getMessageType() == DMNMessageType.DECISION_TABLE_HITPOLICY_RECOMMENDER)).isTrue();
         }
 
         List<DMNMessage> validate = getRecommenderHitPolicy2(HitPolicy.UNIQUE);
-        assertTrue(validate.stream().noneMatch(m -> m.getMessageType() == DMNMessageType.DECISION_TABLE_HITPOLICY_RECOMMENDER));
+        assertThat(validate.stream().noneMatch(m -> m.getMessageType() == DMNMessageType.DECISION_TABLE_HITPOLICY_RECOMMENDER)).isTrue();
     }
 
     private List<DMNMessage> getRecommenderHitPolicy2(HitPolicy hp) {
@@ -76,11 +75,11 @@ public class RecommenderHitPolicyTest extends AbstractDTAnalysisTest {
         List<HitPolicy> wrongHPs = Arrays.asList(HitPolicy.UNIQUE, HitPolicy.PRIORITY, HitPolicy.FIRST);
         for (HitPolicy hp : wrongHPs) {
             List<DMNMessage> validate = getRecommenderHitPolicy3(hp);
-            assertTrue(validate.stream().anyMatch(m -> m.getMessageType() == DMNMessageType.DECISION_TABLE_HITPOLICY_RECOMMENDER));
+            assertThat(validate.stream().anyMatch(m -> m.getMessageType() == DMNMessageType.DECISION_TABLE_HITPOLICY_RECOMMENDER)).isTrue();
         }
 
         List<DMNMessage> validate = getRecommenderHitPolicy3(HitPolicy.ANY);
-        assertTrue(validate.stream().noneMatch(m -> m.getMessageType() == DMNMessageType.DECISION_TABLE_HITPOLICY_RECOMMENDER));
+        assertThat(validate.stream().noneMatch(m -> m.getMessageType() == DMNMessageType.DECISION_TABLE_HITPOLICY_RECOMMENDER)).isTrue();
     }
 
     private List<DMNMessage> getRecommenderHitPolicy3(HitPolicy hp) {
@@ -101,11 +100,11 @@ public class RecommenderHitPolicyTest extends AbstractDTAnalysisTest {
         List<HitPolicy> wrongHPs = Arrays.asList(HitPolicy.UNIQUE, HitPolicy.ANY, HitPolicy.FIRST);
         for (HitPolicy hp : wrongHPs) {
             List<DMNMessage> validate = getRecommenderHitPolicy4(hp);
-            assertTrue(validate.stream().anyMatch(m -> m.getMessageType() == DMNMessageType.DECISION_TABLE_HITPOLICY_RECOMMENDER));
+            assertThat(validate.stream().anyMatch(m -> m.getMessageType() == DMNMessageType.DECISION_TABLE_HITPOLICY_RECOMMENDER)).isTrue();
         }
 
         List<DMNMessage> validate = getRecommenderHitPolicy4(HitPolicy.PRIORITY);
-        assertTrue(validate.stream().noneMatch(m -> m.getMessageType() == DMNMessageType.DECISION_TABLE_HITPOLICY_RECOMMENDER));
+        assertThat(validate.stream().noneMatch(m -> m.getMessageType() == DMNMessageType.DECISION_TABLE_HITPOLICY_RECOMMENDER)).isTrue();
     }
 
     private List<DMNMessage> getRecommenderHitPolicy4(HitPolicy hp) {

--- a/kie-dmn/kie-dmn-validation/src/test/java/org/kie/dmn/validation/dtanalysis/SameMsgInAllAPITest.java
+++ b/kie-dmn/kie-dmn-validation/src/test/java/org/kie/dmn/validation/dtanalysis/SameMsgInAllAPITest.java
@@ -32,7 +32,6 @@ import org.kie.dmn.validation.dtanalysis.model.MaskedRule;
 import org.kie.dmn.validation.dtanalysis.model.Overlap;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.Assert.assertTrue;
 import static org.kie.dmn.validation.DMNValidator.Validation.ANALYZE_DECISION_TABLE;
 import static org.kie.dmn.validation.DMNValidator.Validation.VALIDATE_COMPILATION;
 import static org.kie.dmn.validation.DMNValidator.Validation.VALIDATE_MODEL;
@@ -117,7 +116,6 @@ public class SameMsgInAllAPITest extends AbstractDTAnalysisTest {
                                                      new MaskedRule(4, 3));
         assertThat(maskedRules).hasSize(2);
         assertThat(analysis.getMaskedRules()).containsAll(maskedRules);
-        assertTrue("It should contain DMNMessage for the MaskedRule",
-                   validate.stream().anyMatch(p -> p.getMessageType().equals(DMNMessageType.DECISION_TABLE_MASKED_RULE)));
+        assertThat(validate.stream().anyMatch(p -> p.getMessageType().equals(DMNMessageType.DECISION_TABLE_MASKED_RULE))).as("It should contain DMNMessage for the MaskedRule").isTrue();
     }
 }

--- a/kie-dmn/kie-dmn-validation/src/test/java/org/kie/dmn/validation/dtanalysis/SimpleStringNoGapTest.java
+++ b/kie-dmn/kie-dmn-validation/src/test/java/org/kie/dmn/validation/dtanalysis/SimpleStringNoGapTest.java
@@ -24,7 +24,6 @@ import org.kie.dmn.api.core.DMNMessageType;
 import org.kie.dmn.validation.dtanalysis.model.DTAnalysis;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.Assert.assertTrue;
 import static org.kie.dmn.validation.DMNValidator.Validation.ANALYZE_DECISION_TABLE;
 import static org.kie.dmn.validation.DMNValidator.Validation.VALIDATE_COMPILATION;
 import static org.kie.dmn.validation.DMNValidator.Validation.VALIDATE_MODEL;
@@ -35,8 +34,7 @@ public class SimpleStringNoGapTest extends AbstractDTAnalysisTest {
     public void test() {
         List<DMNMessage> validate = validator.validate(getReader("simpleStringNoGap.dmn"), VALIDATE_COMPILATION, VALIDATE_MODEL, ANALYZE_DECISION_TABLE);
         assertThat(validate).hasSize(1); // Gap Analysis skipped because of free string.
-        assertTrue("It should contain DMNMessage for the skipped gap analysis",
-                   validate.stream().anyMatch(p -> p.getMessageType().equals(DMNMessageType.DECISION_TABLE_GAP)));
+        assertThat(validate.stream().anyMatch(p -> p.getMessageType().equals(DMNMessageType.DECISION_TABLE_GAP))).as("It should contain DMNMessage for the skipped gap analysis").isTrue();
         debugValidatorMsg(validate);
 
         DTAnalysis analysis = getAnalysis(validate, "_3D5BDDEF-8B71-4797-8662-5026A9C2A112");

--- a/kie-dmn/kie-dmn-validation/src/test/java/org/kie/dmn/validation/dtanalysis/StringWithoutEnumNoGapTest.java
+++ b/kie-dmn/kie-dmn-validation/src/test/java/org/kie/dmn/validation/dtanalysis/StringWithoutEnumNoGapTest.java
@@ -33,7 +33,6 @@ import org.kie.dmn.validation.dtanalysis.model.MisleadingRule;
 import org.kie.dmn.validation.dtanalysis.model.Overlap;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.Assert.assertTrue;
 import static org.kie.dmn.validation.DMNValidator.Validation.ANALYZE_DECISION_TABLE;
 import static org.kie.dmn.validation.DMNValidator.Validation.VALIDATE_COMPILATION;
 import static org.kie.dmn.validation.DMNValidator.Validation.VALIDATE_MODEL;
@@ -96,8 +95,7 @@ public class StringWithoutEnumNoGapTest extends AbstractDTAnalysisTest {
                                                      new MaskedRule(2, 3));
         assertThat(maskedRules).hasSize(2);
         assertThat(analysis.getMaskedRules()).containsAll(maskedRules);
-        assertTrue("It should contain DMNMessage for the MaskedRule",
-                   validate.stream().anyMatch(p -> p.getMessageType().equals(DMNMessageType.DECISION_TABLE_MASKED_RULE)));
+        assertThat(validate.stream().anyMatch(p -> p.getMessageType().equals(DMNMessageType.DECISION_TABLE_MASKED_RULE))).as("It should contain DMNMessage for the MaskedRule").isTrue();
 
         // MisleadingRules are duplicate of Masked, so are no longer displayed.
         assertThat(analysis.getMisleadingRules()).hasSize(2);
@@ -105,7 +103,6 @@ public class StringWithoutEnumNoGapTest extends AbstractDTAnalysisTest {
                                                              new MisleadingRule(3, 2));
         assertThat(misleadingRules).hasSize(2);
         assertThat(analysis.getMisleadingRules()).containsAll(misleadingRules);
-        assertTrue("It should NOT contain DMNMessage for the MisleadingRule",
-                   validate.stream().noneMatch(p -> p.getMessageType().equals(DMNMessageType.DECISION_TABLE_MISLEADING_RULE)));
+        assertThat(validate.stream().noneMatch(p -> p.getMessageType().equals(DMNMessageType.DECISION_TABLE_MISLEADING_RULE))).as("It should NOT contain DMNMessage for the MisleadingRule").isTrue();
     }
 }

--- a/kie-dmn/kie-dmn-validation/src/test/java/org/kie/dmn/validation/dtanalysis/SubsumptionRulesTest.java
+++ b/kie-dmn/kie-dmn-validation/src/test/java/org/kie/dmn/validation/dtanalysis/SubsumptionRulesTest.java
@@ -32,7 +32,6 @@ import org.kie.dmn.validation.dtanalysis.model.Overlap;
 import org.kie.dmn.validation.dtanalysis.model.Subsumption;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.Assert.assertTrue;
 import static org.kie.dmn.validation.DMNValidator.Validation.ANALYZE_DECISION_TABLE;
 
 public class SubsumptionRulesTest extends AbstractDTAnalysisTest {
@@ -84,7 +83,6 @@ public class SubsumptionRulesTest extends AbstractDTAnalysisTest {
         List<Subsumption> results = Arrays.asList(new Subsumption(2, 4));
         assertThat(results).hasSize(1);
         assertThat(analysis.getSubsumptions()).containsAll(results);
-        assertTrue("It should contain at least 1 DMNMessage for the Subsumtption",
-                   validate.stream().anyMatch(p -> p.getMessageType().equals(DMNMessageType.DECISION_TABLE_SUBSUMPTION_RULE)));
+        assertThat(validate.stream().anyMatch(p -> p.getMessageType().equals(DMNMessageType.DECISION_TABLE_SUBSUMPTION_RULE))).as("It should contain at least 1 DMNMessage for the Subsumtption").isTrue();
     }
 }


### PR DESCRIPTION
This is backport to 7.x of [#4413](https://github.com/kiegroup/drools/pull/4413)

**JIRA**:  [DROOLS-6932](https://issues.redhat.com/browse/DROOLS-6932)

<details>
<summary>
How to replicate CI configuration locally?
</summary>

Build Chain tool does "simple" maven build(s), the builds are just Maven commands, but because the repositories relates and depends on each other and any change in API or class method could affect several of those repositories there is a need to use [build-chain tool](https://github.com/kiegroup/github-action-build-chain) to handle cross repository builds and be sure that we always use latest version of the code for each repository.
 
[build-chain tool](https://github.com/kiegroup/github-action-build-chain) is a build tool which can be used on command line locally or in Github Actions workflow(s), in case you need to change multiple repositories and send multiple dependent pull requests related with a change you can easily reproduce the same build by executing it on Github hosted environment or locally in your development environment. See [local execution](https://github.com/kiegroup/github-action-build-chain#local-execution) details to get more information about it.
</details>

<details>
<summary>
How to retest this PR or trigger a specific build:
</summary>

- for <b>pull request checks</b>  
  Please add comment: <b>Jenkins retest this</b>

- for a <b>specific pull request check</b>  
  Please add comment: <b>Jenkins (re)run [drools|kogito-runtimes|optaplanner|kogito-apps|kogito-examples|optaplanner-quickstarts|optaweb-employee-rostering|optaweb-vehicle-routing] tests</b>

- for a <b>full downstream build</b> 
  - for <b>jenkins</b> job: please add comment: <b>Jenkins run fdb</b>
  - for <b>github actions</b> job: add the label `run_fdb`

- <b>a compile downstream build</b> please  add comment: <b>Jenkins run cdb</b>

- <b>a full production downstream build</b> please add comment: <b>Jenkins execute product fdb</b>

- <b>an upstream build</b> please add comment: <b>Jenkins run upstream</b>

- for <b>quarkus branch checks</b>  
  Run checks against Quarkus current used branch  
  Please add comment: <b>Jenkins run quarkus-branch</b>

- for a <b>quarkus branch specific check</b>  
  Run checks against Quarkus current used branch  
  Please add comment: <b>Jenkins (re)run [drools|kogito-runtimes|optaplanner|kogito-apps|kogito-examples|optaplanner-quickstarts|optaweb-employee-rostering|optaweb-vehicle-routing] quarkus-branch</b>

- for <b>quarkus main checks</b>  
  Run checks against Quarkus main branch  
  Please add comment: <b>Jenkins run quarkus-main</b>

- for a <b>specific quarkus main check</b>  
  Run checks against Quarkus main branch  
  Please add comment: <b>Jenkins (re)run [drools|kogito-runtimes|optaplanner|kogito-apps|kogito-examples|optaplanner-quickstarts|optaweb-employee-rostering|optaweb-vehicle-routing] quarkus-branch</b>

- for <b>native checks</b>  
  Run native checks  
  Please add comment: <b>Jenkins run native</b>

- for a <b>specific native check</b>  
  Run native checks 
  Please add comment: <b>Jenkins (re)run [drools|kogito-runtimes|optaplanner|kogito-apps|kogito-examples|optaplanner-quickstarts|optaweb-employee-rostering|optaweb-vehicle-routing] native</b>

- for <b>mandrel checks</b>  
  Run native checks against Mandrel image
  Please add comment: <b>Jenkins run mandrel</b>

- for a <b>specific mandrel check</b>  
  Run native checks against Mandrel image  
  Please add comment: <b>Jenkins (re)run [drools|kogito-runtimes|optaplanner|kogito-apps|kogito-examples|optaplanner-quickstarts|optaweb-employee-rostering|optaweb-vehicle-routing] mandrel</b>
</details>
