### PR TITLE
DROOLS-6993 DMN DT Analysis report when symbol in DT (#4423)

### DIFF
--- a/kie-dmn/kie-dmn-feel/src/main/java/org/kie/dmn/feel/lang/impl/UnaryTestInterpretedExecutableExpression.java
+++ b/kie-dmn/kie-dmn-feel/src/main/java/org/kie/dmn/feel/lang/impl/UnaryTestInterpretedExecutableExpression.java
@@ -33,6 +33,11 @@ public class UnaryTestInterpretedExecutableExpression implements CompiledFEELExp
         public List<UnaryTest> apply(EvaluationContext evaluationContext) {
             return Collections.emptyList();
         }
+
+        @Override
+        public ASTNode getASTNode() {
+            throw new UnsupportedOperationException("Unsupported for EMPTY");
+        }
     };
     private final CompiledExpressionImpl expr;
 

--- a/kie-dmn/kie-dmn-validation/src/main/java/org/kie/dmn/validation/dtanalysis/DMNDTAnalyserValueFromNodeVisitor.java
+++ b/kie-dmn/kie-dmn-validation/src/main/java/org/kie/dmn/validation/dtanalysis/DMNDTAnalyserValueFromNodeVisitor.java
@@ -27,6 +27,7 @@ import org.kie.dmn.feel.lang.ast.BooleanNode;
 import org.kie.dmn.feel.lang.ast.FunctionInvocationNode;
 import org.kie.dmn.feel.lang.ast.NameRefNode;
 import org.kie.dmn.feel.lang.ast.NumberNode;
+import org.kie.dmn.feel.lang.ast.QualifiedNameNode;
 import org.kie.dmn.feel.lang.ast.SignedUnaryNode;
 import org.kie.dmn.feel.lang.ast.SignedUnaryNode.Sign;
 import org.kie.dmn.feel.lang.ast.StringNode;
@@ -53,7 +54,17 @@ public class DMNDTAnalyserValueFromNodeVisitor extends DefaultedVisitor<Comparab
 
     @Override
     public Comparable<?> defaultVisit(ASTNode n) {
-        throw new UnsupportedOperationException("Gaps/Overlaps analysis cannot be performed for InputEntry with unary test: {}" + n.getText());
+        throw new UnsupportedOperationException("Gaps/Overlaps analysis cannot be performed for InputEntry with unary test containing: " + n.getText());
+    }
+    
+    @Override
+    public Comparable<?> visit(NameRefNode n) {
+        throw new UnsupportedOperationException("Gaps/Overlaps analysis cannot be performed for InputEntry with unary test containing symbol reference: '" + n.getText() + "'."); // ref DROOLS-4607
+    }
+
+    @Override
+    public Comparable<?> visit(QualifiedNameNode n) {
+        throw new UnsupportedOperationException("Gaps/Overlaps analysis cannot be performed for InputEntry with unary test containing symbol reference: '" + n.getText() + "'."); // ref DROOLS-4607
     }
 
     @Override
@@ -104,6 +115,16 @@ public class DMNDTAnalyserValueFromNodeVisitor extends DefaultedVisitor<Comparab
         @Override
         public Comparable<?> defaultVisit(ASTNode n) {
             return new DDTAOutputEntryExpression(n);
+        }
+        
+        @Override
+        public Comparable<?> visit(NameRefNode n) {
+            return defaultVisit(n); // symbols allowed in output clause
+        }
+
+        @Override
+        public Comparable<?> visit(QualifiedNameNode n) {
+            return defaultVisit(n); // symbols allowed in output clause
         }
 
     }

--- a/kie-dmn/kie-dmn-validation/src/test/java/org/kie/dmn/validation/dtanalysis/SymbolInDTTest.java
+++ b/kie-dmn/kie-dmn-validation/src/test/java/org/kie/dmn/validation/dtanalysis/SymbolInDTTest.java
@@ -1,0 +1,53 @@
+/*
+ * Copyright 2021 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.kie.dmn.validation.dtanalysis;
+
+import java.util.List;
+import java.util.function.Predicate;
+
+import org.junit.Test;
+import org.kie.dmn.api.core.DMNMessage;
+import org.kie.dmn.api.core.DMNMessageType;
+import org.kie.dmn.validation.dtanalysis.model.DTAnalysis;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.kie.dmn.validation.DMNValidator.Validation.ANALYZE_DECISION_TABLE;
+
+public class SymbolInDTTest extends AbstractDTAnalysisTest {
+
+    @Test
+    public void testSymbolMyThreshold() {
+        List<DMNMessage> validate = validator.validate(getReader("SymbolInDT.dmn"), ANALYZE_DECISION_TABLE);
+        assertThat(validate.stream().anyMatch(messageForSymbol("my threshold"))).as("It should contain DMNMessage for symbol not supported in input").isTrue();
+
+        DTAnalysis analysis1 = getAnalysis(validate, "_50D70081-079A-40DA-BA9C-B1173F0D2831");
+        assertThat(analysis1.isError()).isTrue();
+    }
+
+    private Predicate<? super DMNMessage> messageForSymbol(String symbolName) {
+        return p -> p.getMessageType().equals(DMNMessageType.DECISION_TABLE_ANALYSIS_ERROR) && p.getText().contains("symbol reference: '"+symbolName+"'.");
+    }
+    
+    @Test
+    public void testSymbolLastDateOfWork() {
+        List<DMNMessage> validate = validator.validate(getReader("SymbolInDT2.dmn"), ANALYZE_DECISION_TABLE);
+        assertThat(validate.stream().anyMatch(messageForSymbol("Last Date of Work"))).as("It should contain DMNMessage for symbol not supported in input").isTrue();
+
+        DTAnalysis analysis1 = getAnalysis(validate, "_50D70081-079A-40DA-BA9C-B1173F0D2831");
+        assertThat(analysis1.isError()).isTrue();
+    }
+}

--- a/kie-dmn/kie-dmn-validation/src/test/resources/org/kie/dmn/validation/dtanalysis/SymbolInDT.dmn
+++ b/kie-dmn/kie-dmn-validation/src/test/resources/org/kie/dmn/validation/dtanalysis/SymbolInDT.dmn
@@ -1,0 +1,102 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<dmn:definitions xmlns:dmn="http://www.omg.org/spec/DMN/20180521/MODEL/" xmlns="https://kiegroup.org/dmn/_CE9D7B8B-1200-425E-85F7-06E8E5818A83" xmlns:feel="http://www.omg.org/spec/DMN/20180521/FEEL/" xmlns:kie="http://www.drools.org/kie/dmn/1.2" xmlns:dmndi="http://www.omg.org/spec/DMN/20180521/DMNDI/" xmlns:di="http://www.omg.org/spec/DMN/20180521/DI/" xmlns:dc="http://www.omg.org/spec/DMN/20180521/DC/" id="_62FC5EC7-5DAB-45B7-8427-C7815387639C" name="SymbolInDT" typeLanguage="http://www.omg.org/spec/DMN/20180521/FEEL/" namespace="https://kiegroup.org/dmn/_CE9D7B8B-1200-425E-85F7-06E8E5818A83">
+  <dmn:extensionElements/>
+  <dmn:inputData id="_BEAE48CE-26F0-4F0A-8D2A-E8F6DC9C2D48" name="x">
+    <dmn:extensionElements/>
+    <dmn:variable id="_27D5FD69-EEC4-4804-814B-FEC84B501204" name="x" typeRef="number"/>
+  </dmn:inputData>
+  <dmn:decision id="_4A657DA8-ABD0-4265-9D7B-D1F138BFD7EC" name="Decision-1">
+    <dmn:extensionElements/>
+    <dmn:variable id="_ACFA1185-6BF6-487B-834B-9C5A9D783987" name="Decision-1" typeRef="Any"/>
+    <dmn:informationRequirement id="_A61DEFC3-2DCA-42C9-9487-88A316824977">
+      <dmn:requiredInput href="#_BEAE48CE-26F0-4F0A-8D2A-E8F6DC9C2D48"/>
+    </dmn:informationRequirement>
+    <dmn:informationRequirement id="_54C00058-5EA4-4FB9-872A-7744FC015936">
+      <dmn:requiredDecision href="#_015EBA8C-56D8-4DDB-B5AE-0B3A4D6BD1E2"/>
+    </dmn:informationRequirement>
+    <dmn:decisionTable id="_50D70081-079A-40DA-BA9C-B1173F0D2831" hitPolicy="FIRST" preferredOrientation="Rule-as-Row">
+      <dmn:input id="_CD313E17-B55D-4025-9B01-51D8D8A60012">
+        <dmn:inputExpression id="_E98DB4B3-43A2-4CA3-AAD8-5DE3B28C2914" typeRef="number">
+          <dmn:text>x</dmn:text>
+        </dmn:inputExpression>
+      </dmn:input>
+      <dmn:output id="_760182FA-AC33-48D3-9F61-7873EBEE164C"/>
+      <dmn:annotation name="annotation-1"/>
+      <dmn:rule id="_B0708183-4C57-46DF-AF93-9EA56627EECA">
+        <dmn:inputEntry id="_10BA37CE-222A-4FAB-B48C-C32D91327511">
+          <dmn:text>&gt;=my threshold</dmn:text>
+        </dmn:inputEntry>
+        <dmn:outputEntry id="_56AF319C-AEF3-4010-91A0-EAC793B8A53F">
+          <dmn:text>"over"</dmn:text>
+        </dmn:outputEntry>
+        <dmn:annotationEntry>
+          <dmn:text/>
+        </dmn:annotationEntry>
+      </dmn:rule>
+      <dmn:rule id="_504080BF-4767-4B55-A59C-4B1892BB44AD">
+        <dmn:inputEntry id="_D49F3A9B-AD4F-4DEB-B491-0B524101786E">
+          <dmn:text>-</dmn:text>
+        </dmn:inputEntry>
+        <dmn:outputEntry id="_ECE64FB3-CFB0-432D-8C45-3C4AC5B52C3B">
+          <dmn:text>"not over"</dmn:text>
+        </dmn:outputEntry>
+        <dmn:annotationEntry>
+          <dmn:text/>
+        </dmn:annotationEntry>
+      </dmn:rule>
+    </dmn:decisionTable>
+  </dmn:decision>
+  <dmn:decision id="_015EBA8C-56D8-4DDB-B5AE-0B3A4D6BD1E2" name="my threshold">
+    <dmn:extensionElements/>
+    <dmn:variable id="_4396C816-5377-4F72-BCCD-2E6EFA84DB3E" name="my threshold" typeRef="number"/>
+  </dmn:decision>
+  <dmndi:DMNDI>
+    <dmndi:DMNDiagram id="_62AC3140-D0DA-4E12-931B-AE0C23A8220A" name="DRG">
+      <di:extension>
+        <kie:ComponentsWidthsExtension>
+          <kie:ComponentWidths dmnElementRef="_50D70081-079A-40DA-BA9C-B1173F0D2831">
+            <kie:width>50</kie:width>
+            <kie:width>127</kie:width>
+            <kie:width>100</kie:width>
+            <kie:width>100</kie:width>
+          </kie:ComponentWidths>
+        </kie:ComponentsWidthsExtension>
+      </di:extension>
+      <dmndi:DMNShape id="dmnshape-drg-_BEAE48CE-26F0-4F0A-8D2A-E8F6DC9C2D48" dmnElementRef="_BEAE48CE-26F0-4F0A-8D2A-E8F6DC9C2D48" isCollapsed="false">
+        <dmndi:DMNStyle>
+          <dmndi:FillColor red="255" green="255" blue="255"/>
+          <dmndi:StrokeColor red="0" green="0" blue="0"/>
+          <dmndi:FontColor red="0" green="0" blue="0"/>
+        </dmndi:DMNStyle>
+        <dc:Bounds x="450" y="233" width="100" height="50"/>
+        <dmndi:DMNLabel/>
+      </dmndi:DMNShape>
+      <dmndi:DMNShape id="dmnshape-drg-_4A657DA8-ABD0-4265-9D7B-D1F138BFD7EC" dmnElementRef="_4A657DA8-ABD0-4265-9D7B-D1F138BFD7EC" isCollapsed="false">
+        <dmndi:DMNStyle>
+          <dmndi:FillColor red="255" green="255" blue="255"/>
+          <dmndi:StrokeColor red="0" green="0" blue="0"/>
+          <dmndi:FontColor red="0" green="0" blue="0"/>
+        </dmndi:DMNStyle>
+        <dc:Bounds x="668" y="233" width="100" height="50"/>
+        <dmndi:DMNLabel/>
+      </dmndi:DMNShape>
+      <dmndi:DMNShape id="dmnshape-drg-_015EBA8C-56D8-4DDB-B5AE-0B3A4D6BD1E2" dmnElementRef="_015EBA8C-56D8-4DDB-B5AE-0B3A4D6BD1E2" isCollapsed="false">
+        <dmndi:DMNStyle>
+          <dmndi:FillColor red="255" green="255" blue="255"/>
+          <dmndi:StrokeColor red="0" green="0" blue="0"/>
+          <dmndi:FontColor red="0" green="0" blue="0"/>
+        </dmndi:DMNStyle>
+        <dc:Bounds x="520" y="346" width="100" height="50"/>
+        <dmndi:DMNLabel/>
+      </dmndi:DMNShape>
+      <dmndi:DMNEdge id="dmnedge-drg-_A61DEFC3-2DCA-42C9-9487-88A316824977-AUTO-SOURCE-AUTO-TARGET" dmnElementRef="_A61DEFC3-2DCA-42C9-9487-88A316824977">
+        <di:waypoint x="500" y="233"/>
+        <di:waypoint x="718" y="283"/>
+      </dmndi:DMNEdge>
+      <dmndi:DMNEdge id="dmnedge-drg-_54C00058-5EA4-4FB9-872A-7744FC015936" dmnElementRef="_54C00058-5EA4-4FB9-872A-7744FC015936">
+        <di:waypoint x="570" y="371"/>
+        <di:waypoint x="718" y="258"/>
+      </dmndi:DMNEdge>
+    </dmndi:DMNDiagram>
+  </dmndi:DMNDI>
+</dmn:definitions>

--- a/kie-dmn/kie-dmn-validation/src/test/resources/org/kie/dmn/validation/dtanalysis/SymbolInDT2.dmn
+++ b/kie-dmn/kie-dmn-validation/src/test/resources/org/kie/dmn/validation/dtanalysis/SymbolInDT2.dmn
@@ -1,0 +1,102 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<dmn:definitions xmlns:dmn="http://www.omg.org/spec/DMN/20180521/MODEL/" xmlns="https://kiegroup.org/dmn/_CE9D7B8B-1200-425E-85F7-06E8E5818A83" xmlns:feel="http://www.omg.org/spec/DMN/20180521/FEEL/" xmlns:kie="http://www.drools.org/kie/dmn/1.2" xmlns:dmndi="http://www.omg.org/spec/DMN/20180521/DMNDI/" xmlns:di="http://www.omg.org/spec/DMN/20180521/DI/" xmlns:dc="http://www.omg.org/spec/DMN/20180521/DC/" id="_62FC5EC7-5DAB-45B7-8427-C7815387639C" name="SymbolInDT" typeLanguage="http://www.omg.org/spec/DMN/20180521/FEEL/" namespace="https://kiegroup.org/dmn/_CE9D7B8B-1200-425E-85F7-06E8E5818A83">
+  <dmn:extensionElements/>
+  <dmn:inputData id="_BEAE48CE-26F0-4F0A-8D2A-E8F6DC9C2D48" name="x">
+    <dmn:extensionElements/>
+    <dmn:variable id="_27D5FD69-EEC4-4804-814B-FEC84B501204" name="x" typeRef="number"/>
+  </dmn:inputData>
+  <dmn:decision id="_4A657DA8-ABD0-4265-9D7B-D1F138BFD7EC" name="Decision-1">
+    <dmn:extensionElements/>
+    <dmn:variable id="_ACFA1185-6BF6-487B-834B-9C5A9D783987" name="Decision-1" typeRef="Any"/>
+    <dmn:informationRequirement id="_A61DEFC3-2DCA-42C9-9487-88A316824977">
+      <dmn:requiredInput href="#_BEAE48CE-26F0-4F0A-8D2A-E8F6DC9C2D48"/>
+    </dmn:informationRequirement>
+    <dmn:informationRequirement id="_54C00058-5EA4-4FB9-872A-7744FC015936">
+      <dmn:requiredDecision href="#_015EBA8C-56D8-4DDB-B5AE-0B3A4D6BD1E2"/>
+    </dmn:informationRequirement>
+    <dmn:decisionTable id="_50D70081-079A-40DA-BA9C-B1173F0D2831" hitPolicy="FIRST" preferredOrientation="Rule-as-Row">
+      <dmn:input id="_CD313E17-B55D-4025-9B01-51D8D8A60012">
+        <dmn:inputExpression id="_E98DB4B3-43A2-4CA3-AAD8-5DE3B28C2914" typeRef="number">
+          <dmn:text>x</dmn:text>
+        </dmn:inputExpression>
+      </dmn:input>
+      <dmn:output id="_760182FA-AC33-48D3-9F61-7873EBEE164C"/>
+      <dmn:annotation name="annotation-1"/>
+      <dmn:rule id="_B0708183-4C57-46DF-AF93-9EA56627EECA">
+        <dmn:inputEntry id="_10BA37CE-222A-4FAB-B48C-C32D91327511">
+          <dmn:text>&gt;=Last Date of Work</dmn:text>
+        </dmn:inputEntry>
+        <dmn:outputEntry id="_56AF319C-AEF3-4010-91A0-EAC793B8A53F">
+          <dmn:text>"over"</dmn:text>
+        </dmn:outputEntry>
+        <dmn:annotationEntry>
+          <dmn:text/>
+        </dmn:annotationEntry>
+      </dmn:rule>
+      <dmn:rule id="_504080BF-4767-4B55-A59C-4B1892BB44AD">
+        <dmn:inputEntry id="_D49F3A9B-AD4F-4DEB-B491-0B524101786E">
+          <dmn:text>-</dmn:text>
+        </dmn:inputEntry>
+        <dmn:outputEntry id="_ECE64FB3-CFB0-432D-8C45-3C4AC5B52C3B">
+          <dmn:text>"not over"</dmn:text>
+        </dmn:outputEntry>
+        <dmn:annotationEntry>
+          <dmn:text/>
+        </dmn:annotationEntry>
+      </dmn:rule>
+    </dmn:decisionTable>
+  </dmn:decision>
+  <dmn:decision id="_015EBA8C-56D8-4DDB-B5AE-0B3A4D6BD1E2" name="Last Date of Work">
+    <dmn:extensionElements/>
+    <dmn:variable id="_4396C816-5377-4F72-BCCD-2E6EFA84DB3E" name="Last Date of Work" typeRef="number"/>
+  </dmn:decision>
+  <dmndi:DMNDI>
+    <dmndi:DMNDiagram id="_62AC3140-D0DA-4E12-931B-AE0C23A8220A" name="DRG">
+      <di:extension>
+        <kie:ComponentsWidthsExtension>
+          <kie:ComponentWidths dmnElementRef="_50D70081-079A-40DA-BA9C-B1173F0D2831">
+            <kie:width>50</kie:width>
+            <kie:width>127</kie:width>
+            <kie:width>100</kie:width>
+            <kie:width>100</kie:width>
+          </kie:ComponentWidths>
+        </kie:ComponentsWidthsExtension>
+      </di:extension>
+      <dmndi:DMNShape id="dmnshape-drg-_BEAE48CE-26F0-4F0A-8D2A-E8F6DC9C2D48" dmnElementRef="_BEAE48CE-26F0-4F0A-8D2A-E8F6DC9C2D48" isCollapsed="false">
+        <dmndi:DMNStyle>
+          <dmndi:FillColor red="255" green="255" blue="255"/>
+          <dmndi:StrokeColor red="0" green="0" blue="0"/>
+          <dmndi:FontColor red="0" green="0" blue="0"/>
+        </dmndi:DMNStyle>
+        <dc:Bounds x="450" y="233" width="100" height="50"/>
+        <dmndi:DMNLabel/>
+      </dmndi:DMNShape>
+      <dmndi:DMNShape id="dmnshape-drg-_4A657DA8-ABD0-4265-9D7B-D1F138BFD7EC" dmnElementRef="_4A657DA8-ABD0-4265-9D7B-D1F138BFD7EC" isCollapsed="false">
+        <dmndi:DMNStyle>
+          <dmndi:FillColor red="255" green="255" blue="255"/>
+          <dmndi:StrokeColor red="0" green="0" blue="0"/>
+          <dmndi:FontColor red="0" green="0" blue="0"/>
+        </dmndi:DMNStyle>
+        <dc:Bounds x="668" y="233" width="100" height="50"/>
+        <dmndi:DMNLabel/>
+      </dmndi:DMNShape>
+      <dmndi:DMNShape id="dmnshape-drg-_015EBA8C-56D8-4DDB-B5AE-0B3A4D6BD1E2" dmnElementRef="_015EBA8C-56D8-4DDB-B5AE-0B3A4D6BD1E2" isCollapsed="false">
+        <dmndi:DMNStyle>
+          <dmndi:FillColor red="255" green="255" blue="255"/>
+          <dmndi:StrokeColor red="0" green="0" blue="0"/>
+          <dmndi:FontColor red="0" green="0" blue="0"/>
+        </dmndi:DMNStyle>
+        <dc:Bounds x="520" y="346" width="100" height="50"/>
+        <dmndi:DMNLabel/>
+      </dmndi:DMNShape>
+      <dmndi:DMNEdge id="dmnedge-drg-_A61DEFC3-2DCA-42C9-9487-88A316824977-AUTO-SOURCE-AUTO-TARGET" dmnElementRef="_A61DEFC3-2DCA-42C9-9487-88A316824977">
+        <di:waypoint x="500" y="233"/>
+        <di:waypoint x="718" y="283"/>
+      </dmndi:DMNEdge>
+      <dmndi:DMNEdge id="dmnedge-drg-_54C00058-5EA4-4FB9-872A-7744FC015936" dmnElementRef="_54C00058-5EA4-4FB9-872A-7744FC015936">
+        <di:waypoint x="570" y="371"/>
+        <di:waypoint x="718" y="258"/>
+      </dmndi:DMNEdge>
+    </dmndi:DMNDiagram>
+  </dmndi:DMNDI>
+</dmn:definitions>


### PR DESCRIPTION
7.x backport of https://github.com/kiegroup/drools/pull/4423

<details>
<summary>
How to replicate CI configuration locally?
</summary>

Build Chain tool does "simple" maven build(s), the builds are just Maven commands, but because the repositories relates and depends on each other and any change in API or class method could affect several of those repositories there is a need to use [build-chain tool](https://github.com/kiegroup/github-action-build-chain) to handle cross repository builds and be sure that we always use latest version of the code for each repository.
 
[build-chain tool](https://github.com/kiegroup/github-action-build-chain) is a build tool which can be used on command line locally or in Github Actions workflow(s), in case you need to change multiple repositories and send multiple dependent pull requests related with a change you can easily reproduce the same build by executing it on Github hosted environment or locally in your development environment. See [local execution](https://github.com/kiegroup/github-action-build-chain#local-execution) details to get more information about it.
</details>

<details>
<summary>
How to retest this PR or trigger a specific build:
</summary>

- for <b>pull request checks</b>  
  Please add comment: <b>Jenkins retest this</b>

- for a <b>specific pull request check</b>  
  Please add comment: <b>Jenkins (re)run [drools|kogito-runtimes|optaplanner|kogito-apps|kogito-examples|optaplanner-quickstarts|optaweb-employee-rostering|optaweb-vehicle-routing] tests</b>

- for a <b>full downstream build</b> 
  - for <b>jenkins</b> job: please add comment: <b>Jenkins run fdb</b>
  - for <b>github actions</b> job: add the label `run_fdb`

- <b>a compile downstream build</b> please  add comment: <b>Jenkins run cdb</b>

- <b>a full production downstream build</b> please add comment: <b>Jenkins execute product fdb</b>

- <b>an upstream build</b> please add comment: <b>Jenkins run upstream</b>

- for <b>quarkus branch checks</b>  
  Run checks against Quarkus current used branch  
  Please add comment: <b>Jenkins run quarkus-branch</b>

- for a <b>quarkus branch specific check</b>  
  Run checks against Quarkus current used branch  
  Please add comment: <b>Jenkins (re)run [drools|kogito-runtimes|optaplanner|kogito-apps|kogito-examples|optaplanner-quickstarts|optaweb-employee-rostering|optaweb-vehicle-routing] quarkus-branch</b>

- for <b>quarkus main checks</b>  
  Run checks against Quarkus main branch  
  Please add comment: <b>Jenkins run quarkus-main</b>

- for a <b>specific quarkus main check</b>  
  Run checks against Quarkus main branch  
  Please add comment: <b>Jenkins (re)run [drools|kogito-runtimes|optaplanner|kogito-apps|kogito-examples|optaplanner-quickstarts|optaweb-employee-rostering|optaweb-vehicle-routing] quarkus-branch</b>

- for <b>native checks</b>  
  Run native checks  
  Please add comment: <b>Jenkins run native</b>

- for a <b>specific native check</b>  
  Run native checks 
  Please add comment: <b>Jenkins (re)run [drools|kogito-runtimes|optaplanner|kogito-apps|kogito-examples|optaplanner-quickstarts|optaweb-employee-rostering|optaweb-vehicle-routing] native</b>

- for <b>mandrel checks</b>  
  Run native checks against Mandrel image
  Please add comment: <b>Jenkins run mandrel</b>

- for a <b>specific mandrel check</b>  
  Run native checks against Mandrel image  
  Please add comment: <b>Jenkins (re)run [drools|kogito-runtimes|optaplanner|kogito-apps|kogito-examples|optaplanner-quickstarts|optaweb-employee-rostering|optaweb-vehicle-routing] mandrel</b>
</details>
