### PR TITLE
[DROOLS-7007] avoid memory leak in groupby

### DIFF
--- a/drools-core/src/main/java/org/drools/core/reteoo/AccumulateNode.java
+++ b/drools-core/src/main/java/org/drools/core/reteoo/AccumulateNode.java
@@ -402,11 +402,7 @@ public class AccumulateNode extends BetaNode {
             }
 
             // add list to head
-            if (toPropagateList != null) {
-                toPropagateList.setPrevious(list);
-            }
             list.setNext(toPropagateList);
-            list.setPrevious(null);
             toPropagateList = list;
 
             list.getContext().setToPropagate(true);
@@ -416,10 +412,6 @@ public class AccumulateNode extends BetaNode {
             TupleList<AccumulateContextEntry> list = toPropagateList;
             toPropagateList = null;
             return list;
-        }
-
-        public TupleList<AccumulateContextEntry> getLastTupleList() {
-            return lastTupleList;
         }
 
         public void addMatchOnLastTupleList(LeftTuple match) {

--- a/drools-core/src/main/java/org/drools/core/reteoo/FromNodeLeftTuple.java
+++ b/drools-core/src/main/java/org/drools/core/reteoo/FromNodeLeftTuple.java
@@ -60,18 +60,6 @@ public class FromNodeLeftTuple extends BaseLeftTuple {
 
     public FromNodeLeftTuple(final LeftTuple leftTuple,
                              final RightTuple rightTuple,
-                             final Sink sink,
-                             final boolean leftTupleMemoryEnabled) {
-        this( leftTuple,
-              rightTuple,
-              null,
-              null,
-              sink,
-              leftTupleMemoryEnabled );
-    }
-    
-    public FromNodeLeftTuple(final LeftTuple leftTuple,
-                             final RightTuple rightTuple,
                              final LeftTuple currentLeftChild,
                              final LeftTuple currentRightChild,
                              final Sink sink,

--- a/drools-core/src/main/java/org/drools/core/util/index/TupleList.java
+++ b/drools-core/src/main/java/org/drools/core/util/index/TupleList.java
@@ -30,7 +30,6 @@ public class TupleList<C> implements TupleMemory, Entry<TupleList<C>>, Serializa
 
     public static final long       serialVersionUID = 510l;
 
-    private TupleList<C>           previous;
     private TupleList<C>           next;
 
     private Tuple                  first;
@@ -253,14 +252,6 @@ public class TupleList<C> implements TupleMemory, Entry<TupleList<C>>, Serializa
         return false;
     }
 
-    public TupleList getPrevious() {
-        return this.previous;
-    }
-
-    public void setPrevious(final TupleList previous) {
-        this.previous = previous;
-    }
-
     public TupleList getNext() {
         return this.next;
     }
@@ -280,7 +271,6 @@ public class TupleList<C> implements TupleMemory, Entry<TupleList<C>>, Serializa
     }
 
     protected void copyStateInto(TupleList other) {
-        other.previous = previous;
         other.next = next;
         other.first = first;
         other.context = context;

--- a/drools-model/drools-model-compiler/src/test/java/org/drools/modelcompiler/GroupByTest.java
+++ b/drools-model/drools-model-compiler/src/test/java/org/drools/modelcompiler/GroupByTest.java
@@ -1752,8 +1752,7 @@ public class GroupByTest {
     }
 
     @Test
-    @Ignore // <- FIXME, see comment inside (@mario)
-    public void testNestedGroupBy3() throws Exception {
+    public void testNestedGroupBy3() {
         // DROOLS-6045
         final Global<List> var_results = D.globalOf(List.class, "defaultpkg", "results");
 
@@ -1773,7 +1772,7 @@ public class GroupByTest {
                                         D.accFunction(CountAccumulateFunction::new).as(var_$accresult)),
                                 // Bindings
                                 D.pattern(var_$accresult)
-                                        .expr(c -> ((Integer)c) > 0) // FIXME var_$accresult is collection of Long, how did this pass before(mdp) ?
+                                        .expr(c -> ((Long)c) > 0)
                         ),
                         var_$key, var_$accresult, var_$keyOuter, Pair::create
                 ),
@@ -1968,6 +1967,5 @@ public class GroupByTest {
         ksession.fireAllRules();
         assertTrue(results.contains(84));
     }
-
 }
 


### PR DESCRIPTION
**JIRA**: https://issues.redhat.com/browse/DROOLS-7007

@triceo please give a try to this fix. I reproduced the problem on my side also with a pure Drools test, but the fix is simply removing the useless data structure that was causing the leak, so now that test is meaningless simply because I cannot make any assertion against a no longer existing thing :)