### PR TITLE
[DROOLS-7009] Create Drools 8 archetype for exec-model and RuleUnit

### DIFF
--- a/kie-archetypes/kie-drools-exec-model-ruleunit-archetype/.gitignore
+++ b/kie-archetypes/kie-drools-exec-model-ruleunit-archetype/.gitignore
@@ -1,0 +1,14 @@
+/target
+/local
+
+# Eclipse, Netbeans and IntelliJ files
+/.*
+!.gitignore
+/nbproject
+/*.ipr
+/*.iws
+/*.iml
+*.xpr
+
+# Repository wide ignore mac DS_Store files
+.DS_Store

--- a/kie-archetypes/kie-drools-exec-model-ruleunit-archetype/pom.xml
+++ b/kie-archetypes/kie-drools-exec-model-ruleunit-archetype/pom.xml
@@ -1,0 +1,52 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+  <parent>
+    <groupId>org.kie</groupId>
+    <artifactId>kie-archetypes</artifactId>
+    <version>8.23.0-SNAPSHOT</version>
+  </parent>
+
+  <artifactId>kie-drools-exec-model-ruleunit-archetype</artifactId>
+  <packaging>maven-archetype</packaging>
+
+  <name>KIE :: Drools Maven Archetype with Executable Model and RuleUnit</name>
+  <description>
+      Drools rule example with executable model and RuleUnit.
+      Use property droolsVersion to specify which version of Drools to use in generated project.
+  </description>
+  <url>http://drools.org</url>
+
+  <properties>
+    <dollar>$</dollar>
+  </properties>
+
+  <build>
+    <resources>
+      <resource>
+        <directory>src/main/resources</directory>
+        <filtering>true</filtering>
+      </resource>
+    </resources>
+
+    <extensions>
+      <extension>
+        <groupId>org.apache.maven.archetype</groupId>
+        <artifactId>archetype-packaging</artifactId>
+        <version>3.2.1</version>
+      </extension>
+    </extensions>
+
+    <pluginManagement>
+      <plugins>
+        <plugin>
+          <artifactId>maven-archetype-plugin</artifactId>
+          <version>3.2.1</version>
+          <configuration>
+            <ignoreEOLStyle>true</ignoreEOLStyle>
+          </configuration>
+        </plugin>
+      </plugins>
+    </pluginManagement>
+  </build>
+</project>

--- a/kie-archetypes/kie-drools-exec-model-ruleunit-archetype/src/main/resources/META-INF/maven/archetype-metadata.xml
+++ b/kie-archetypes/kie-drools-exec-model-ruleunit-archetype/src/main/resources/META-INF/maven/archetype-metadata.xml
@@ -1,0 +1,51 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<archetype-descriptor xsi:schemaLocation="http://maven.apache.org/plugins/maven-archetype-plugin/archetype-descriptor/1.0.0 http://maven.apache.org/xsd/archetype-descriptor-1.0.0.xsd" name="drools6test.asd"
+    xmlns="http://maven.apache.org/plugins/maven-archetype-plugin/archetype-descriptor/1.0.0"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+  <requiredProperties>
+    <requiredProperty key="droolsVersion">
+      <defaultValue>${project.version}</defaultValue>
+    </requiredProperty>
+    <requiredProperty key="slf4jVersion">
+      <defaultValue>${version.org.slf4j}</defaultValue>
+    </requiredProperty>
+    <requiredProperty key="junitVersion">
+      <defaultValue>${version.junit}</defaultValue>
+    </requiredProperty>
+    <requiredProperty key="logbackVersion">
+      <defaultValue>${version.ch.qos.logback}</defaultValue>
+    </requiredProperty>
+  </requiredProperties>
+  <fileSets>
+    <fileSet filtered="true" packaged="true" encoding="UTF-8">
+      <directory>src/main/java</directory>
+      <includes>
+        <include>**/*.java</include>
+      </includes>
+    </fileSet>
+    <fileSet filtered="true" encoding="UTF-8">
+      <directory>src/main/resources</directory>
+      <includes>
+        <include>**/*.xml</include>
+      </includes>
+    </fileSet>
+    <fileSet filtered="true" packaged="false" encoding="UTF-8"> <!-- to have .drl file processed with mvn ${} macros but to avoid it being sub-directory java packaged. -->
+      <directory>src/main/resources</directory>
+      <includes>
+        <include>**/*.drl</include>
+      </includes>
+    </fileSet>
+    <fileSet filtered="true" packaged="true" encoding="UTF-8">
+      <directory>src/test/java</directory>
+      <includes>
+        <include>**/*.java</include>
+      </includes>
+    </fileSet>
+    <fileSet filtered="true" encoding="UTF-8">
+      <directory>src/test/resources</directory>
+      <includes>
+        <include>**/*.xml</include>
+      </includes>
+    </fileSet>
+  </fileSets>
+</archetype-descriptor>

--- a/kie-archetypes/kie-drools-exec-model-ruleunit-archetype/src/main/resources/archetype-resources/pom.xml
+++ b/kie-archetypes/kie-drools-exec-model-ruleunit-archetype/src/main/resources/archetype-resources/pom.xml
@@ -1,0 +1,83 @@
+#set( $symbol_pound = '#' )
+#set( $symbol_dollar = '$' )
+#set( $symbol_escape = '\' )
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <groupId>${dollar}{groupId}</groupId>
+  <artifactId>${dollar}{artifactId}</artifactId>
+  <version>${dollar}{version}</version>
+  <packaging>kjar</packaging>
+
+  <name>${dollar}{artifactId}</name>
+
+  <properties>
+    <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+    <drools-version>${droolsVersion}</drools-version>
+    <slf4j-version>${slf4jVersion}</slf4j-version>
+    <junit-version>${junitVersion}</junit-version>
+    <logback-version>${logbackVersion}</logback-version>
+  </properties>
+
+  <dependencyManagement>
+    <dependencies>
+      <dependency>
+        <groupId>org.drools</groupId>
+        <artifactId>drools-bom</artifactId>
+        <type>pom</type>
+        <version>${drools-version}</version>
+        <scope>import</scope>
+      </dependency>
+    </dependencies>
+  </dependencyManagement>
+
+  <dependencies>
+
+    <dependency>
+      <groupId>org.drools</groupId>
+      <artifactId>drools-engine</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.drools</groupId>
+      <artifactId>drools-ruleunits-impl</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.drools</groupId>
+      <artifactId>drools-model-compiler</artifactId>
+    </dependency>
+
+    <dependency>
+      <groupId>junit</groupId>
+      <artifactId>junit</artifactId>
+      <version>${junit-version}</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>ch.qos.logback</groupId>
+      <artifactId>logback-classic</artifactId>
+      <version>${logback-version}</version>
+      <scope>test</scope>
+    </dependency>
+  </dependencies>
+
+  <build>
+    <plugins>
+      <plugin>
+        <artifactId>maven-compiler-plugin</artifactId>
+        <version>3.1</version>
+        <configuration>
+          <source>${maven.compiler.source}</source>
+          <target>${maven.compiler.target}</target>
+        </configuration>
+      </plugin>
+      <plugin>
+        <groupId>org.kie</groupId>
+        <artifactId>kie-maven-plugin</artifactId>
+        <version>${drools-version}</version>
+        <extensions>true</extensions>
+      </plugin>
+    </plugins>
+
+  </build>
+</project>

--- a/kie-archetypes/kie-drools-exec-model-ruleunit-archetype/src/main/resources/archetype-resources/src/main/java/Measurement.java
+++ b/kie-archetypes/kie-drools-exec-model-ruleunit-archetype/src/main/resources/archetype-resources/src/main/java/Measurement.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright 2022 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+*/
+
+#set( $symbol_pound = '#' )
+#set( $symbol_dollar = '$' )
+#set( $symbol_escape = '\' )
+package ${package};
+
+public class Measurement {
+    private String id;
+    private String val;
+
+    public Measurement(String id, String val) {
+        super();
+        this.id = id;
+        this.val = val;
+    }
+
+    public String getId() {
+        return id;
+    }
+
+    public String getVal() {
+        return val;
+    }
+
+    @Override
+    public String toString() {
+        StringBuilder builder = new StringBuilder();
+        builder.append("Measurement [");
+        if (id != null)
+            builder.append("id=").append(id).append(", ");
+        if (val != null)
+            builder.append("val=").append(val);
+        builder.append("]");
+        return builder.toString();
+    }
+}

--- a/kie-archetypes/kie-drools-exec-model-ruleunit-archetype/src/main/resources/archetype-resources/src/main/java/MeasurementUnit.java
+++ b/kie-archetypes/kie-drools-exec-model-ruleunit-archetype/src/main/resources/archetype-resources/src/main/java/MeasurementUnit.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright 2022 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#set( $symbol_pound = '#' )
+#set( $symbol_dollar = '$' )
+#set( $symbol_escape = '\' )
+package ${package};
+
+import java.util.HashSet;
+import java.util.Set;
+
+import org.drools.ruleunits.api.DataSource;
+import org.drools.ruleunits.api.DataStore;
+import org.drools.ruleunits.api.RuleUnitData;
+
+public class MeasurementUnit implements RuleUnitData {
+
+    private final DataStore<Measurement> measurements;
+    private final Set<String> controlSet = new HashSet<>();
+
+    public MeasurementUnit() {
+        this(DataSource.createStore());
+    }
+
+    public MeasurementUnit(DataStore<Measurement> measurements) {
+        this.measurements = measurements;
+    }
+
+    public DataStore<Measurement> getMeasurements() {
+        return measurements;
+    }
+
+    public Set<String> getControlSet() {
+        return controlSet;
+    }
+}

--- a/kie-archetypes/kie-drools-exec-model-ruleunit-archetype/src/main/resources/archetype-resources/src/main/resources/org/example/rules.drl
+++ b/kie-archetypes/kie-drools-exec-model-ruleunit-archetype/src/main/resources/archetype-resources/src/main/resources/org/example/rules.drl
@@ -1,0 +1,32 @@
+/*
+ * Copyright 2022 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+*/
+
+#set( $symbol_pound = '#' )
+#set( $symbol_dollar = '$' )
+#set( $symbol_escape = '\' )
+package ${package};
+
+unit MeasurementUnit;
+
+rule "will execute per each Measurement having ID color"
+when
+	/measurements[ id == "color", $colorVal : val ]
+then
+	controlSet.add($colorVal);
+end
+
+query FindColor
+    $m: /measurements[ id == "color" ]
+end

--- a/kie-archetypes/kie-drools-exec-model-ruleunit-archetype/src/main/resources/archetype-resources/src/test/java/RuleTest.java
+++ b/kie-archetypes/kie-drools-exec-model-ruleunit-archetype/src/main/resources/archetype-resources/src/test/java/RuleTest.java
@@ -1,0 +1,57 @@
+/*
+ * Copyright 2022 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+*/
+
+#set( $symbol_pound = '#' )
+#set( $symbol_dollar = '$' )
+#set( $symbol_escape = '\' )
+package ${package};
+
+import java.util.List;
+
+import org.drools.ruleunits.api.RuleUnitInstance;
+import org.drools.ruleunits.api.RuleUnitInstanceFactory;
+import org.junit.Test;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import static java.util.stream.Collectors.toList;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+public class RuleTest {
+
+    static final Logger LOG = LoggerFactory.getLogger(RuleTest.class);
+
+    @Test
+    public void test() {
+        LOG.info("Creating RuleUnit");
+        MeasurementUnit measurementUnit = new MeasurementUnit();
+
+        RuleUnitInstance<MeasurementUnit> instance = RuleUnitInstanceFactory.instance(measurementUnit);
+
+        LOG.info("Insert data");
+        measurementUnit.getMeasurements().add(new Measurement("color", "red"));
+        measurementUnit.getMeasurements().add(new Measurement("color", "green"));
+        measurementUnit.getMeasurements().add(new Measurement("color", "blue"));
+
+        LOG.info("Run query. Rules are also fired");
+        List<Measurement> queryResult = instance.executeQuery("FindColor").stream().map(tuple -> (Measurement) tuple.get("$m")).collect(toList());
+
+        assertEquals(3, queryResult.size());
+        assertTrue("contains red", measurementUnit.getControlSet().contains("red"));
+        assertTrue("contains green", measurementUnit.getControlSet().contains("green"));
+        assertTrue("contains blue", measurementUnit.getControlSet().contains("blue"));
+    }
+}

--- a/kie-archetypes/kie-drools-exec-model-ruleunit-archetype/src/main/resources/archetype-resources/src/test/resources/logback-test.xml
+++ b/kie-archetypes/kie-drools-exec-model-ruleunit-archetype/src/main/resources/archetype-resources/src/test/resources/logback-test.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<configuration>
+  <appender name="consoleAppender" class="ch.qos.logback.core.ConsoleAppender">
+    <encoder>
+      <pattern>%d [%t] %-5p %m%n</pattern>
+    </encoder>
+  </appender>
+
+  <root level="info">
+    <appender-ref ref="consoleAppender" />
+  </root>
+</configuration>

--- a/kie-archetypes/kie-drools-exec-model-ruleunit-archetype/src/test/resources/projects/integrationtestDefaults/archetype.properties
+++ b/kie-archetypes/kie-drools-exec-model-ruleunit-archetype/src/test/resources/projects/integrationtestDefaults/archetype.properties
@@ -1,0 +1,10 @@
+#Sun Sep 07 11:34:37 CEST 2014
+package=it.pkg
+version=0.1-SNAPSHOT
+groupId=archetype.it
+artifactId=basic
+droolsVersion=9.9.9-DUMMY
+slf4jVersion=1.7.2
+junitVersion=4.11
+logbackVersion=1.2.9
+

--- a/kie-archetypes/kie-drools-exec-model-ruleunit-archetype/src/test/resources/projects/integrationtestDefaults/reference/pom.xml
+++ b/kie-archetypes/kie-drools-exec-model-ruleunit-archetype/src/test/resources/projects/integrationtestDefaults/reference/pom.xml
@@ -1,0 +1,80 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <groupId>archetype.it</groupId>
+  <artifactId>basic</artifactId>
+  <version>0.1-SNAPSHOT</version>
+  <packaging>kjar</packaging>
+
+  <name>basic</name>
+
+  <properties>
+    <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+    <drools-version>9.9.9-DUMMY</drools-version>
+    <slf4j-version>1.7.2</slf4j-version>
+    <junit-version>4.11</junit-version>
+    <logback-version>1.2.9</logback-version>
+  </properties>
+
+  <dependencyManagement>
+    <dependencies>
+      <dependency>
+        <groupId>org.drools</groupId>
+        <artifactId>drools-bom</artifactId>
+        <type>pom</type>
+        <version>${drools-version}</version>
+        <scope>import</scope>
+      </dependency>
+    </dependencies>
+  </dependencyManagement>
+
+  <dependencies>
+
+    <dependency>
+      <groupId>org.drools</groupId>
+      <artifactId>drools-engine</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.drools</groupId>
+      <artifactId>drools-ruleunits-impl</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.drools</groupId>
+      <artifactId>drools-model-compiler</artifactId>
+    </dependency>
+
+    <dependency>
+      <groupId>junit</groupId>
+      <artifactId>junit</artifactId>
+      <version>${junit-version}</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>ch.qos.logback</groupId>
+      <artifactId>logback-classic</artifactId>
+      <version>${logback-version}</version>
+      <scope>test</scope>
+    </dependency>
+  </dependencies>
+
+  <build>
+    <plugins>
+      <plugin>
+        <artifactId>maven-compiler-plugin</artifactId>
+        <version>3.1</version>
+        <configuration>
+          <source>1.8</source>
+          <target>1.8</target>
+        </configuration>
+      </plugin>
+      <plugin>
+        <groupId>org.kie</groupId>
+        <artifactId>kie-maven-plugin</artifactId>
+        <version>${drools-version}</version>
+        <extensions>true</extensions>
+      </plugin>
+    </plugins>
+
+  </build>
+</project>

--- a/kie-archetypes/kie-drools-exec-model-ruleunit-archetype/src/test/resources/projects/integrationtestDefaults/reference/src/main/java/it/pkg/Measurement.java
+++ b/kie-archetypes/kie-drools-exec-model-ruleunit-archetype/src/test/resources/projects/integrationtestDefaults/reference/src/main/java/it/pkg/Measurement.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright 2022 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+*/
+
+package it.pkg;
+
+public class Measurement {
+    private String id;
+    private String val;
+
+    public Measurement(String id, String val) {
+        super();
+        this.id = id;
+        this.val = val;
+    }
+
+    public String getId() {
+        return id;
+    }
+
+    public String getVal() {
+        return val;
+    }
+
+    @Override
+    public String toString() {
+        StringBuilder builder = new StringBuilder();
+        builder.append("Measurement [");
+        if (id != null)
+            builder.append("id=").append(id).append(", ");
+        if (val != null)
+            builder.append("val=").append(val);
+        builder.append("]");
+        return builder.toString();
+    }
+}

--- a/kie-archetypes/kie-drools-exec-model-ruleunit-archetype/src/test/resources/projects/integrationtestDefaults/reference/src/main/java/it/pkg/MeasurementUnit.java
+++ b/kie-archetypes/kie-drools-exec-model-ruleunit-archetype/src/test/resources/projects/integrationtestDefaults/reference/src/main/java/it/pkg/MeasurementUnit.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright 2022 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package it.pkg;
+
+import java.util.HashSet;
+import java.util.Set;
+
+import org.drools.ruleunits.api.DataSource;
+import org.drools.ruleunits.api.DataStore;
+import org.drools.ruleunits.api.RuleUnitData;
+
+public class MeasurementUnit implements RuleUnitData {
+
+    private final DataStore<Measurement> measurements;
+    private final Set<String> controlSet = new HashSet<>();
+
+    public MeasurementUnit() {
+        this(DataSource.createStore());
+    }
+
+    public MeasurementUnit(DataStore<Measurement> measurements) {
+        this.measurements = measurements;
+    }
+
+    public DataStore<Measurement> getMeasurements() {
+        return measurements;
+    }
+
+    public Set<String> getControlSet() {
+        return controlSet;
+    }
+}

--- a/kie-archetypes/kie-drools-exec-model-ruleunit-archetype/src/test/resources/projects/integrationtestDefaults/reference/src/main/resources/org/example/rules.drl
+++ b/kie-archetypes/kie-drools-exec-model-ruleunit-archetype/src/test/resources/projects/integrationtestDefaults/reference/src/main/resources/org/example/rules.drl
@@ -1,0 +1,29 @@
+/*
+ * Copyright 2022 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+*/
+
+package it.pkg;
+
+unit MeasurementUnit;
+
+rule "will execute per each Measurement having ID color"
+when
+	/measurements[ id == "color", $colorVal : val ]
+then
+	controlSet.add($colorVal);
+end
+
+query FindColor
+    $m: /measurements[ id == "color" ]
+end

--- a/kie-archetypes/kie-drools-exec-model-ruleunit-archetype/src/test/resources/projects/integrationtestDefaults/reference/src/test/java/it/pkg/RuleTest.java
+++ b/kie-archetypes/kie-drools-exec-model-ruleunit-archetype/src/test/resources/projects/integrationtestDefaults/reference/src/test/java/it/pkg/RuleTest.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright 2022 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+*/
+
+package it.pkg;
+
+import java.util.List;
+
+import org.drools.ruleunits.api.RuleUnitInstance;
+import org.drools.ruleunits.api.RuleUnitInstanceFactory;
+import org.junit.Test;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import static java.util.stream.Collectors.toList;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+public class RuleTest {
+
+    static final Logger LOG = LoggerFactory.getLogger(RuleTest.class);
+
+    @Test
+    public void test() {
+        LOG.info("Creating RuleUnit");
+        MeasurementUnit measurementUnit = new MeasurementUnit();
+
+        RuleUnitInstance<MeasurementUnit> instance = RuleUnitInstanceFactory.instance(measurementUnit);
+
+        LOG.info("Insert data");
+        measurementUnit.getMeasurements().add(new Measurement("color", "red"));
+        measurementUnit.getMeasurements().add(new Measurement("color", "green"));
+        measurementUnit.getMeasurements().add(new Measurement("color", "blue"));
+
+        LOG.info("Run query. Rules are also fired");
+        List<Measurement> queryResult = instance.executeQuery("FindColor").stream().map(tuple -> (Measurement) tuple.get("$m")).collect(toList());
+
+        assertEquals(3, queryResult.size());
+        assertTrue("contains red", measurementUnit.getControlSet().contains("red"));
+        assertTrue("contains green", measurementUnit.getControlSet().contains("green"));
+        assertTrue("contains blue", measurementUnit.getControlSet().contains("blue"));
+    }
+}

--- a/kie-archetypes/kie-drools-exec-model-ruleunit-archetype/src/test/resources/projects/integrationtestDefaults/reference/src/test/resources/logback-test.xml
+++ b/kie-archetypes/kie-drools-exec-model-ruleunit-archetype/src/test/resources/projects/integrationtestDefaults/reference/src/test/resources/logback-test.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<configuration>
+  <appender name="consoleAppender" class="ch.qos.logback.core.ConsoleAppender">
+    <encoder>
+      <pattern>%d [%t] %-5p %m%n</pattern>
+    </encoder>
+  </appender>
+
+  <root level="info">
+    <appender-ref ref="consoleAppender" />
+  </root>
+</configuration>

--- a/kie-archetypes/pom.xml
+++ b/kie-archetypes/pom.xml
@@ -18,6 +18,7 @@
 
   <modules>
     <module>kie-drools-archetype</module>
+    <module>kie-drools-exec-model-ruleunit-archetype</module>
     <module>kie-model-archetype</module>
     <module>kie-kjar-archetype</module>
     <module>kie-service-spring-boot-archetype</module>


### PR DESCRIPTION
**JIRA**: 
https://issues.redhat.com/browse/DROOLS-7009

<details>
<summary>
How to replicate CI configuration locally?
</summary>

Build Chain tool does "simple" maven build(s), the builds are just Maven commands, but because the repositories relates and depends on each other and any change in API or class method could affect several of those repositories there is a need to use [build-chain tool](https://github.com/kiegroup/github-action-build-chain) to handle cross repository builds and be sure that we always use latest version of the code for each repository.
 
[build-chain tool](https://github.com/kiegroup/github-action-build-chain) is a build tool which can be used on command line locally or in Github Actions workflow(s), in case you need to change multiple repositories and send multiple dependent pull requests related with a change you can easily reproduce the same build by executing it on Github hosted environment or locally in your development environment. See [local execution](https://github.com/kiegroup/github-action-build-chain#local-execution) details to get more information about it.
</details>

<details>
<summary>
How to retest this PR or trigger a specific build:
</summary>

- for <b>pull request checks</b>  
  Please add comment: <b>Jenkins retest this</b>

- for a <b>specific pull request check</b>  
  Please add comment: <b>Jenkins (re)run [drools|kogito-runtimes|optaplanner|kogito-apps|kogito-examples|optaplanner-quickstarts|optaweb-employee-rostering|optaweb-vehicle-routing] tests</b>

- for a <b>full downstream build</b> 
  - for <b>jenkins</b> job: please add comment: <b>Jenkins run fdb</b>
  - for <b>github actions</b> job: add the label `run_fdb`

- <b>a compile downstream build</b> please  add comment: <b>Jenkins run cdb</b>

- <b>a full production downstream build</b> please add comment: <b>Jenkins execute product fdb</b>

- <b>an upstream build</b> please add comment: <b>Jenkins run upstream</b>

- for <b>quarkus branch checks</b>  
  Run checks against Quarkus current used branch  
  Please add comment: <b>Jenkins run quarkus-branch</b>

- for a <b>quarkus branch specific check</b>  
  Run checks against Quarkus current used branch  
  Please add comment: <b>Jenkins (re)run [drools|kogito-runtimes|optaplanner|kogito-apps|kogito-examples|optaplanner-quickstarts|optaweb-employee-rostering|optaweb-vehicle-routing] quarkus-branch</b>

- for <b>quarkus main checks</b>  
  Run checks against Quarkus main branch  
  Please add comment: <b>Jenkins run quarkus-main</b>

- for a <b>specific quarkus main check</b>  
  Run checks against Quarkus main branch  
  Please add comment: <b>Jenkins (re)run [drools|kogito-runtimes|optaplanner|kogito-apps|kogito-examples|optaplanner-quickstarts|optaweb-employee-rostering|optaweb-vehicle-routing] quarkus-branch</b>

- for <b>native checks</b>  
  Run native checks  
  Please add comment: <b>Jenkins run native</b>

- for a <b>specific native check</b>  
  Run native checks 
  Please add comment: <b>Jenkins (re)run [drools|kogito-runtimes|optaplanner|kogito-apps|kogito-examples|optaplanner-quickstarts|optaweb-employee-rostering|optaweb-vehicle-routing] native</b>

- for <b>mandrel checks</b>  
  Run native checks against Mandrel image
  Please add comment: <b>Jenkins run mandrel</b>

- for a <b>specific mandrel check</b>  
  Run native checks against Mandrel image  
  Please add comment: <b>Jenkins (re)run [drools|kogito-runtimes|optaplanner|kogito-apps|kogito-examples|optaplanner-quickstarts|optaweb-employee-rostering|optaweb-vehicle-routing] mandrel</b>
</details>
