### PR TITLE
DROOLS-7027 Move AssetFilter out of KnowledgeBuilderImpl

### DIFF
--- a/drools-compiler/src/main/java/org/drools/compiler/builder/impl/AssetFilter.java
+++ b/drools-compiler/src/main/java/org/drools/compiler/builder/impl/AssetFilter.java
@@ -1,0 +1,30 @@
+/*
+ * Copyright 2022 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.drools.compiler.builder.impl;
+
+import org.kie.internal.builder.ResourceChange;
+
+public interface AssetFilter {
+
+    enum Action {
+        DO_NOTHING,
+        ADD,
+        REMOVE,
+        UPDATE
+    }
+
+    Action accept(ResourceChange.Type type, String pkgName, String assetName);
+}

--- a/drools-compiler/src/main/java/org/drools/compiler/builder/impl/CompositeKnowledgeBuilderImpl.java
+++ b/drools-compiler/src/main/java/org/drools/compiler/builder/impl/CompositeKnowledgeBuilderImpl.java
@@ -234,11 +234,11 @@ public class CompositeKnowledgeBuilderImpl implements CompositeKnowledgeBuilder 
             }
         }
 
-        public KnowledgeBuilderImpl.AssetFilter getFilter() {
+        public AssetFilter getFilter() {
             return changeMap == null ? null : this.new ChangeSetAssetFilter();
         }
 
-        private class ChangeSetAssetFilter implements KnowledgeBuilderImpl.AssetFilter {
+        private class ChangeSetAssetFilter implements AssetFilter {
             @Override
             public Action accept(ResourceChange.Type type, String pkgName, String assetName) {
                 if (globalChangeType != null) {

--- a/drools-compiler/src/main/java/org/drools/compiler/builder/impl/KnowledgeBuilderImpl.java
+++ b/drools-compiler/src/main/java/org/drools/compiler/builder/impl/KnowledgeBuilderImpl.java
@@ -1057,18 +1057,6 @@ public class KnowledgeBuilderImpl implements InternalKnowledgeBuilder, TypeDecla
         }
     }
 
-    public interface AssetFilter {
-
-        enum Action {
-            DO_NOTHING,
-            ADD,
-            REMOVE,
-            UPDATE
-        }
-
-        Action accept(ResourceChange.Type type, String pkgName, String assetName);
-    }
-
     public void setAssetFilter(AssetFilter assetFilter) {
         this.assetFilter = assetFilter;
     }

--- a/drools-compiler/src/main/java/org/drools/compiler/builder/impl/processors/FunctionCompiler.java
+++ b/drools-compiler/src/main/java/org/drools/compiler/builder/impl/processors/FunctionCompiler.java
@@ -1,6 +1,6 @@
 package org.drools.compiler.builder.impl.processors;
 
-import org.drools.compiler.builder.impl.KnowledgeBuilderImpl;
+import org.drools.compiler.builder.impl.AssetFilter;
 import org.drools.compiler.compiler.Dialect;
 import org.drools.compiler.compiler.PackageRegistry;
 import org.drools.core.rule.JavaDialectRuntimeData;
@@ -16,10 +16,10 @@ import static org.drools.util.StringUtils.isEmpty;
 
 public class FunctionCompiler extends AbstractPackageCompilationPhase {
 
-    private final KnowledgeBuilderImpl.AssetFilter assetFilter;
+    private final AssetFilter assetFilter;
     private ClassLoader rootClassLoader;
 
-    public FunctionCompiler(PackageDescr packageDescr, PackageRegistry pkgRegistry, KnowledgeBuilderImpl.AssetFilter assetFilter, ClassLoader rootClassLoader) {
+    public FunctionCompiler(PackageDescr packageDescr, PackageRegistry pkgRegistry, AssetFilter assetFilter, ClassLoader rootClassLoader) {
         super(pkgRegistry, packageDescr);
         this.assetFilter = assetFilter;
         this.rootClassLoader = rootClassLoader;
@@ -63,7 +63,7 @@ public class FunctionCompiler extends AbstractPackageCompilationPhase {
 
     private boolean filterAccepts(FunctionDescr functionDescr) {
         return assetFilter == null ||
-                !KnowledgeBuilderImpl.AssetFilter.Action.DO_NOTHING.equals(
+                !AssetFilter.Action.DO_NOTHING.equals(
                         assetFilter.accept(
                                 ResourceChange.Type.FUNCTION,
                                 functionDescr.getNamespace(),

--- a/drools-compiler/src/main/java/org/drools/compiler/builder/impl/processors/GlobalCompilationPhase.java
+++ b/drools-compiler/src/main/java/org/drools/compiler/builder/impl/processors/GlobalCompilationPhase.java
@@ -1,7 +1,7 @@
 package org.drools.compiler.builder.impl.processors;
 
+import org.drools.compiler.builder.impl.AssetFilter;
 import org.drools.compiler.builder.impl.GlobalVariableContext;
-import org.drools.compiler.builder.impl.KnowledgeBuilderImpl;
 import org.drools.compiler.compiler.GlobalError;
 import org.drools.compiler.compiler.PackageRegistry;
 import org.drools.core.definitions.InternalKnowledgePackage;
@@ -20,9 +20,9 @@ public class GlobalCompilationPhase extends AbstractPackageCompilationPhase {
 
     private final InternalKnowledgeBase kBase;
     private final GlobalVariableContext globalVariableContext;
-    private final KnowledgeBuilderImpl.AssetFilter assetFilter;
+    private final AssetFilter assetFilter;
 
-    public GlobalCompilationPhase(PackageRegistry pkgRegistry, PackageDescr packageDescr, InternalKnowledgeBase kBase, GlobalVariableContext globalVariableContext, KnowledgeBuilderImpl.AssetFilter filterAcceptsRemoval) {
+    public GlobalCompilationPhase(PackageRegistry pkgRegistry, PackageDescr packageDescr, InternalKnowledgeBase kBase, GlobalVariableContext globalVariableContext, AssetFilter filterAcceptsRemoval) {
         super(pkgRegistry, packageDescr);
         this.kBase = kBase;
         this.globalVariableContext = globalVariableContext;
@@ -62,7 +62,7 @@ public class GlobalCompilationPhase extends AbstractPackageCompilationPhase {
         }
 
         for (String toBeRemoved : existingGlobals) {
-            if (assetFilter != null && KnowledgeBuilderImpl.AssetFilter.Action.REMOVE.equals(assetFilter.accept(ResourceChange.Type.GLOBAL, pkg.getName(), toBeRemoved))) {
+            if (assetFilter != null && AssetFilter.Action.REMOVE.equals(assetFilter.accept(ResourceChange.Type.GLOBAL, pkg.getName(), toBeRemoved))) {
                 pkg.removeGlobal(toBeRemoved);
                 if (kBase != null) {
                     kBase.removeGlobal(toBeRemoved);

--- a/drools-compiler/src/main/java/org/drools/compiler/builder/impl/processors/OtherDeclarationCompilationPhase.java
+++ b/drools-compiler/src/main/java/org/drools/compiler/builder/impl/processors/OtherDeclarationCompilationPhase.java
@@ -1,7 +1,7 @@
 package org.drools.compiler.builder.impl.processors;
 
+import org.drools.compiler.builder.impl.AssetFilter;
 import org.drools.compiler.builder.impl.GlobalVariableContext;
-import org.drools.compiler.builder.impl.KnowledgeBuilderImpl;
 import org.drools.compiler.builder.impl.TypeDeclarationContext;
 import org.drools.compiler.compiler.PackageRegistry;
 import org.drools.drl.ast.descr.PackageDescr;
@@ -18,7 +18,7 @@ public class OtherDeclarationCompilationPhase extends AbstractPackageCompilation
     private final TypeDeclarationContext typeDeclarationContext;
     private final InternalKnowledgeBase kBase;
     private final KnowledgeBuilderConfiguration configuration;
-    private final KnowledgeBuilderImpl.AssetFilter assetFilter;
+    private final AssetFilter assetFilter;
 
     public OtherDeclarationCompilationPhase(
             PackageRegistry pkgRegistry,
@@ -27,7 +27,7 @@ public class OtherDeclarationCompilationPhase extends AbstractPackageCompilation
             TypeDeclarationContext typeDeclarationContext,
             InternalKnowledgeBase kBase,
             KnowledgeBuilderConfiguration configuration,
-            KnowledgeBuilderImpl.AssetFilter assetFilter) {
+            AssetFilter assetFilter) {
         super(pkgRegistry, packageDescr);
         this.globalVariableContext = globalVariableContext;
         this.typeDeclarationContext = typeDeclarationContext;

--- a/drools-compiler/src/main/java/org/drools/compiler/builder/impl/processors/PackageCompilationPhase.java
+++ b/drools-compiler/src/main/java/org/drools/compiler/builder/impl/processors/PackageCompilationPhase.java
@@ -1,5 +1,6 @@
 package org.drools.compiler.builder.impl.processors;
 
+import org.drools.compiler.builder.impl.AssetFilter;
 import org.drools.compiler.builder.impl.KnowledgeBuilderConfigurationImpl;
 import org.drools.compiler.builder.impl.KnowledgeBuilderImpl;
 import org.drools.compiler.builder.impl.TypeDeclarationBuilder;
@@ -17,7 +18,7 @@ public final class PackageCompilationPhase extends AbstractPackageCompilationPha
     private final InternalKnowledgeBase kBase;
     private final KnowledgeBuilderConfigurationImpl configuration;
     private final TypeDeclarationBuilder typeBuilder;
-    private final KnowledgeBuilderImpl.AssetFilter filterCondition;
+    private final AssetFilter filterCondition;
     private final Resource currentResource;
 
     public PackageCompilationPhase(
@@ -25,7 +26,7 @@ public final class PackageCompilationPhase extends AbstractPackageCompilationPha
             InternalKnowledgeBase kBase,
             KnowledgeBuilderConfigurationImpl configuration,
             TypeDeclarationBuilder typeBuilder,
-            KnowledgeBuilderImpl.AssetFilter filterCondition,
+            AssetFilter filterCondition,
             PackageRegistry pkgRegistry,
             PackageDescr packageDescr,
             Resource currentResource) {

--- a/drools-compiler/src/main/java/org/drools/compiler/builder/impl/processors/ReteCompiler.java
+++ b/drools-compiler/src/main/java/org/drools/compiler/builder/impl/processors/ReteCompiler.java
@@ -1,6 +1,6 @@
 package org.drools.compiler.builder.impl.processors;
 
-import org.drools.compiler.builder.impl.KnowledgeBuilderImpl;
+import org.drools.compiler.builder.impl.AssetFilter;
 import org.drools.compiler.compiler.PackageRegistry;
 import org.drools.core.definitions.InternalKnowledgePackage;
 import org.drools.core.definitions.rule.impl.RuleImpl;
@@ -13,10 +13,10 @@ import java.util.ArrayList;
 import java.util.Collection;
 
 public class ReteCompiler extends AbstractPackageCompilationPhase {
-    private final KnowledgeBuilderImpl.AssetFilter assetFilter;
+    private final AssetFilter assetFilter;
     private RuleBase kBase;
 
-    public ReteCompiler(PackageRegistry pkgRegistry, PackageDescr packageDescr, RuleBase kBase, KnowledgeBuilderImpl.AssetFilter assetFilter) {
+    public ReteCompiler(PackageRegistry pkgRegistry, PackageDescr packageDescr, RuleBase kBase, AssetFilter assetFilter) {
         super(pkgRegistry, packageDescr);
         this.kBase = kBase;
         this.assetFilter = assetFilter;
@@ -39,7 +39,7 @@ public class ReteCompiler extends AbstractPackageCompilationPhase {
     }
 
     private boolean filterAccepts(ResourceChange.Type type, String namespace, String name) {
-        return assetFilter == null || !KnowledgeBuilderImpl.AssetFilter.Action.DO_NOTHING.equals(assetFilter.accept(type, namespace, name));
+        return assetFilter == null || !AssetFilter.Action.DO_NOTHING.equals(assetFilter.accept(type, namespace, name));
     }
 
 }

--- a/drools-compiler/src/main/java/org/drools/compiler/builder/impl/processors/RuleCompiler.java
+++ b/drools-compiler/src/main/java/org/drools/compiler/builder/impl/processors/RuleCompiler.java
@@ -1,6 +1,6 @@
 package org.drools.compiler.builder.impl.processors;
 
-import org.drools.compiler.builder.DroolsAssemblerContext;
+import org.drools.compiler.builder.impl.AssetFilter;
 import org.drools.compiler.builder.impl.KnowledgeBuilderImpl;
 import org.drools.compiler.builder.impl.TypeDeclarationContext;
 import org.drools.compiler.compiler.DialectCompiletimeRegistry;
@@ -40,7 +40,7 @@ public class RuleCompiler extends AbstractPackageCompilationPhase {
 
     private InternalKnowledgeBase kBase;
     private int parallelRulesBuildThreshold;
-    private final KnowledgeBuilderImpl.AssetFilter assetFilter;
+    private final AssetFilter assetFilter;
 
     //This list of package level attributes is initialised with the PackageDescr's attributes added to the assembler.
     //The package level attributes are inherited by individual rules not containing explicit overriding parameters.
@@ -55,7 +55,7 @@ public class RuleCompiler extends AbstractPackageCompilationPhase {
             PackageDescr packageDescr,
             InternalKnowledgeBase kBase,
             int parallelRulesBuildThreshold,
-            KnowledgeBuilderImpl.AssetFilter assetFilter,
+            AssetFilter assetFilter,
             Map<String, AttributeDescr> packageAttributes,
             Resource resource,
             TypeDeclarationContext kBuilder) {
@@ -140,11 +140,11 @@ public class RuleCompiler extends AbstractPackageCompilationPhase {
     }
 
     private boolean filterAccepts(ResourceChange.Type type, String namespace, String name) {
-        return assetFilter == null || !KnowledgeBuilderImpl.AssetFilter.Action.DO_NOTHING.equals(assetFilter.accept(type, namespace, name));
+        return assetFilter == null || !AssetFilter.Action.DO_NOTHING.equals(assetFilter.accept(type, namespace, name));
     }
 
     private boolean filterAcceptsRemoval(ResourceChange.Type type, String namespace, String name) {
-        return assetFilter != null && KnowledgeBuilderImpl.AssetFilter.Action.REMOVE.equals(assetFilter.accept(type, namespace, name));
+        return assetFilter != null && AssetFilter.Action.REMOVE.equals(assetFilter.accept(type, namespace, name));
     }
 
 
@@ -384,7 +384,7 @@ public class RuleCompiler extends AbstractPackageCompilationPhase {
         }
         // ... add a filter to the PackageDescr to also consider the readded children rules as updated together with the parent one
         if (!childrenRuleNamesToBeRemoved.isEmpty()) {
-            ((CompositePackageDescr) packageDescr).addFilter((type, pkgName, assetName) -> childrenRuleNamesToBeRemoved.contains(assetName) ? KnowledgeBuilderImpl.AssetFilter.Action.UPDATE : KnowledgeBuilderImpl.AssetFilter.Action.DO_NOTHING);
+            ((CompositePackageDescr) packageDescr).addFilter((type, pkgName, assetName) -> childrenRuleNamesToBeRemoved.contains(assetName) ? AssetFilter.Action.UPDATE : AssetFilter.Action.DO_NOTHING);
         }
         return childrenRulesToBeRemoved;
     }

--- a/drools-compiler/src/main/java/org/drools/compiler/lang/descr/CompositePackageDescr.java
+++ b/drools-compiler/src/main/java/org/drools/compiler/lang/descr/CompositePackageDescr.java
@@ -20,7 +20,7 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
 
-import org.drools.compiler.builder.impl.KnowledgeBuilderImpl;
+import org.drools.compiler.builder.impl.AssetFilter;
 import org.drools.drl.ast.descr.AccumulateImportDescr;
 import org.drools.drl.ast.descr.AttributeDescr;
 import org.drools.drl.ast.descr.EntryPointDeclarationDescr;
@@ -134,7 +134,7 @@ public class CompositePackageDescr extends PackageDescr {
         return filter;
     }
     
-    public void addFilter( KnowledgeBuilderImpl.AssetFilter f ) {
+    public void addFilter( AssetFilter f ) {
         if( f != null ) {
             if( filter == null ) {
                 this.filter = new CompositeAssetFilter();
@@ -143,12 +143,12 @@ public class CompositePackageDescr extends PackageDescr {
         }
     }
     
-    public static class CompositeAssetFilter implements KnowledgeBuilderImpl.AssetFilter {
-        public List<KnowledgeBuilderImpl.AssetFilter> filters = new ArrayList<KnowledgeBuilderImpl.AssetFilter>();
+    public static class CompositeAssetFilter implements AssetFilter {
+        public List<AssetFilter> filters = new ArrayList<AssetFilter>();
 
         @Override
         public Action accept(ResourceChange.Type type, String pkgName, String assetName) {
-            for( KnowledgeBuilderImpl.AssetFilter filter : filters ) {
+            for( AssetFilter filter : filters ) {
                 Action result = filter.accept(type, pkgName, assetName);
                 if( !Action.DO_NOTHING.equals( result ) ) {
                     return result;


### PR DESCRIPTION
`AssetFilter` is now being used in multiple places and it should no longer be an inner class of KnowledgeBuilderImpl