### PR TITLE
DROOLS-6972 Refactor immutable compilation phases

### DIFF
--- a/drools-compiler/src/main/java/org/drools/compiler/builder/impl/KnowledgeBuilderImpl.java
+++ b/drools-compiler/src/main/java/org/drools/compiler/builder/impl/KnowledgeBuilderImpl.java
@@ -25,7 +25,7 @@ import org.drools.compiler.builder.impl.processors.ConsequenceCompilationPhase;
 import org.drools.compiler.builder.impl.processors.FunctionCompiler;
 import org.drools.compiler.builder.impl.processors.PackageCompilationPhase;
 import org.drools.compiler.builder.impl.processors.ReteCompiler;
-import org.drools.compiler.builder.impl.processors.RuleCompiler;
+import org.drools.compiler.builder.impl.processors.RuleCompilationPhase;
 import org.drools.compiler.builder.impl.processors.RuleValidator;
 import org.drools.compiler.builder.impl.resources.DrlResourceHandler;
 import org.drools.compiler.compiler.DroolsWarning;
@@ -619,8 +619,8 @@ public class KnowledgeBuilderImpl implements InternalKnowledgeBuilder, TypeDecla
 
         List<CompilationPhase> phases = asList(
                 new RuleValidator(packageRegistry, packageDescr, configuration), // validateUniqueRuleNames
-                new FunctionCompiler(packageDescr, pkgRegistry, assetFilter, rootClassLoader),
-                new RuleCompiler(pkgRegistry, packageDescr, kBase, parallelRulesBuildThreshold,
+                new FunctionCompiler(pkgRegistry, packageDescr, assetFilter, rootClassLoader),
+                new RuleCompilationPhase(pkgRegistry, packageDescr, kBase, parallelRulesBuildThreshold,
                         assetFilter, packageAttributes, resource, this));
         phases.forEach(CompilationPhase::process);
         phases.forEach(p -> this.results.addAll(p.getResults()));

--- a/drools-compiler/src/main/java/org/drools/compiler/builder/impl/processors/FunctionCompilationPhase.java
+++ b/drools-compiler/src/main/java/org/drools/compiler/builder/impl/processors/FunctionCompilationPhase.java
@@ -1,3 +1,20 @@
+/*
+ * Copyright 2022 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ *
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.drools.compiler.builder.impl.processors;
 
 import org.drools.compiler.compiler.DuplicateFunction;

--- a/drools-compiler/src/main/java/org/drools/compiler/builder/impl/processors/FunctionCompiler.java
+++ b/drools-compiler/src/main/java/org/drools/compiler/builder/impl/processors/FunctionCompiler.java
@@ -23,7 +23,7 @@ import org.drools.drl.ast.descr.FunctionDescr;
 import org.drools.drl.ast.descr.PackageDescr;
 import org.kie.internal.builder.ResourceChange;
 
-public class FunctionCompiler extends SimpleFunctionCompiler {
+public class FunctionCompiler extends ImmutableFunctionCompiler {
 
     private final AssetFilter assetFilter;
 

--- a/drools-compiler/src/main/java/org/drools/compiler/builder/impl/processors/FunctionCompiler.java
+++ b/drools-compiler/src/main/java/org/drools/compiler/builder/impl/processors/FunctionCompiler.java
@@ -1,3 +1,20 @@
+/*
+ * Copyright 2022 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ *
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.drools.compiler.builder.impl.processors;
 
 import org.drools.compiler.builder.impl.AssetFilter;

--- a/drools-compiler/src/main/java/org/drools/compiler/builder/impl/processors/FunctionCompiler.java
+++ b/drools-compiler/src/main/java/org/drools/compiler/builder/impl/processors/FunctionCompiler.java
@@ -1,63 +1,32 @@
 package org.drools.compiler.builder.impl.processors;
 
 import org.drools.compiler.builder.impl.AssetFilter;
-import org.drools.compiler.compiler.Dialect;
 import org.drools.compiler.compiler.PackageRegistry;
-import org.drools.core.rule.JavaDialectRuntimeData;
 import org.drools.drl.ast.descr.FunctionDescr;
 import org.drools.drl.ast.descr.PackageDescr;
-import org.drools.wiring.api.classloader.ProjectClassLoader;
 import org.kie.internal.builder.ResourceChange;
 
-import java.util.List;
-
-import static org.drools.core.impl.KnowledgeBaseImpl.registerFunctionClassAndInnerClasses;
-import static org.drools.util.StringUtils.isEmpty;
-
-public class FunctionCompiler extends AbstractPackageCompilationPhase {
+public class FunctionCompiler extends SimpleFunctionCompiler {
 
     private final AssetFilter assetFilter;
-    private ClassLoader rootClassLoader;
 
-    public FunctionCompiler(PackageDescr packageDescr, PackageRegistry pkgRegistry, AssetFilter assetFilter, ClassLoader rootClassLoader) {
-        super(pkgRegistry, packageDescr);
+    public FunctionCompiler(PackageRegistry pkgRegistry, PackageDescr packageDescr, AssetFilter assetFilter, ClassLoader rootClassLoader) {
+        super(pkgRegistry, packageDescr, rootClassLoader);
         this.assetFilter = assetFilter;
-        this.rootClassLoader = rootClassLoader;
     }
 
-    public void process() {
-        List<FunctionDescr> functions = packageDescr.getFunctions();
-        if (!functions.isEmpty()) {
 
-            for (FunctionDescr functionDescr : functions) {
-                if (isEmpty(functionDescr.getNamespace())) {
-                    // make sure namespace is set on components
-                    functionDescr.setNamespace(packageDescr.getNamespace());
-                }
+    @Override
+    protected void postCompileAddFunction(FunctionDescr functionDescr) {
+        if (filterAccepts(functionDescr)) {
+            super.postCompileAddFunction(functionDescr);
+        }
+    }
 
-                // make sure functions are compiled using java dialect
-                functionDescr.setDialect("java");
-
-                preCompileAddFunction(functionDescr, pkgRegistry);
-            }
-
-            // iterate and compile
-            for (FunctionDescr functionDescr : functions) {
-                if (filterAccepts(functionDescr)) {
-
-                    // inherit the dialect from the package
-                    addFunction(functionDescr, pkgRegistry);
-                }
-            }
-
-            // compile functions in this pkgRegistry
-            pkgRegistry.compileAll();
-
-            for (FunctionDescr functionDescr : functions) {
-                if (filterAccepts(functionDescr)) {
-                    postCompileAddFunction(functionDescr, pkgRegistry);
-                }
-            }
+    @Override
+    protected void addFunction(FunctionDescr functionDescr) {
+        if (filterAccepts(functionDescr)) {
+            super.addFunction(functionDescr);
         }
     }
 
@@ -68,38 +37,6 @@ public class FunctionCompiler extends AbstractPackageCompilationPhase {
                                 ResourceChange.Type.FUNCTION,
                                 functionDescr.getNamespace(),
                                 functionDescr.getName()));
-    }
-
-
-    private void preCompileAddFunction(final FunctionDescr functionDescr, PackageRegistry pkgRegistry) {
-        Dialect dialect = pkgRegistry.getDialectCompiletimeRegistry().getDialect(functionDescr.getDialect());
-        dialect.preCompileAddFunction(functionDescr,
-                pkgRegistry.getTypeResolver());
-    }
-
-
-    private void addFunction(final FunctionDescr functionDescr, PackageRegistry pkgRegistry) {
-        Dialect dialect = pkgRegistry.getDialectCompiletimeRegistry().getDialect(functionDescr.getDialect());
-        dialect.addFunction(functionDescr,
-                pkgRegistry.getTypeResolver(),
-                null/*this.resource*/);
-    }
-
-
-
-    private void postCompileAddFunction(final FunctionDescr functionDescr, PackageRegistry pkgRegistry) {
-        Dialect dialect = pkgRegistry.getDialectCompiletimeRegistry().getDialect(functionDescr.getDialect());
-        dialect.postCompileAddFunction(functionDescr, pkgRegistry.getTypeResolver());
-
-        if (rootClassLoader instanceof ProjectClassLoader) {
-            String functionClassName = functionDescr.getClassName();
-            JavaDialectRuntimeData runtime = ((JavaDialectRuntimeData) pkgRegistry.getDialectRuntimeRegistry().getDialectData("java"));
-            try {
-                registerFunctionClassAndInnerClasses(functionClassName, runtime, ((ProjectClassLoader) rootClassLoader)::storeClass);
-            } catch (ClassNotFoundException e) {
-                throw new RuntimeException(e);
-            }
-        }
     }
 
 }

--- a/drools-compiler/src/main/java/org/drools/compiler/builder/impl/processors/GlobalCompilationPhase.java
+++ b/drools-compiler/src/main/java/org/drools/compiler/builder/impl/processors/GlobalCompilationPhase.java
@@ -1,3 +1,20 @@
+/*
+ * Copyright 2022 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ *
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.drools.compiler.builder.impl.processors;
 
 import org.drools.compiler.builder.impl.AssetFilter;

--- a/drools-compiler/src/main/java/org/drools/compiler/builder/impl/processors/GlobalCompilationPhase.java
+++ b/drools-compiler/src/main/java/org/drools/compiler/builder/impl/processors/GlobalCompilationPhase.java
@@ -2,71 +2,36 @@ package org.drools.compiler.builder.impl.processors;
 
 import org.drools.compiler.builder.impl.AssetFilter;
 import org.drools.compiler.builder.impl.GlobalVariableContext;
-import org.drools.compiler.compiler.GlobalError;
 import org.drools.compiler.compiler.PackageRegistry;
 import org.drools.core.definitions.InternalKnowledgePackage;
-import org.drools.drl.ast.descr.GlobalDescr;
 import org.drools.drl.ast.descr.PackageDescr;
 import org.drools.kiesession.rulebase.InternalKnowledgeBase;
 import org.kie.internal.builder.ResourceChange;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
-import java.util.HashSet;
-import java.util.Set;
-
-public class GlobalCompilationPhase extends AbstractPackageCompilationPhase {
-    protected static final transient Logger logger = LoggerFactory.getLogger(GlobalCompilationPhase.class);
+public class GlobalCompilationPhase extends ImmutableGlobalCompilationPhase {
 
     private final InternalKnowledgeBase kBase;
-    private final GlobalVariableContext globalVariableContext;
     private final AssetFilter assetFilter;
 
     public GlobalCompilationPhase(PackageRegistry pkgRegistry, PackageDescr packageDescr, InternalKnowledgeBase kBase, GlobalVariableContext globalVariableContext, AssetFilter filterAcceptsRemoval) {
-        super(pkgRegistry, packageDescr);
+        super(pkgRegistry, packageDescr, globalVariableContext);
         this.kBase = kBase;
-        this.globalVariableContext = globalVariableContext;
         this.assetFilter = filterAcceptsRemoval;
     }
 
-    public void process() {
-        InternalKnowledgePackage pkg = pkgRegistry.getPackage();
-        Set<String> existingGlobals = new HashSet<>(pkg.getGlobals().keySet());
-
-        for (final GlobalDescr global : packageDescr.getGlobals()) {
-            final String identifier = global.getIdentifier();
-            existingGlobals.remove(identifier);
-            String className = global.getType();
-
-            // JBRULES-3039: can't handle type name with generic params
-            while (className.indexOf('<') >= 0) {
-                className = className.replaceAll("<[^<>]+?>", "");
-            }
-
-            try {
-                Class<?> clazz = pkgRegistry.getTypeResolver().resolveType(className);
-                if (clazz.isPrimitive()) {
-                    this.results.add(new GlobalError(global, " Primitive types are not allowed in globals : " + className));
-                    return;
-                }
-                pkg.addGlobal(identifier, clazz);
-                globalVariableContext.addGlobal(identifier, clazz);
-
-                if (kBase != null) {
-                    kBase.addGlobal(identifier, clazz);
-                }
-            } catch (final ClassNotFoundException e) {
-                this.results.add(new GlobalError(global, e.getMessage()));
-                logger.warn("ClassNotFoundException occured!", e);
-            }
+    @Override
+    protected void addGlobal(InternalKnowledgePackage pkg, String identifier, Class<?> clazz) {
+        super.addGlobal(pkg, identifier, clazz);
+        if (kBase != null) {
+            kBase.addGlobal(identifier, clazz);
         }
+    }
 
-        for (String toBeRemoved : existingGlobals) {
-            if (assetFilter != null && AssetFilter.Action.REMOVE.equals(assetFilter.accept(ResourceChange.Type.GLOBAL, pkg.getName(), toBeRemoved))) {
-                pkg.removeGlobal(toBeRemoved);
-                if (kBase != null) {
-                    kBase.removeGlobal(toBeRemoved);
-                }
+    protected void removeGlobal(InternalKnowledgePackage pkg, String toBeRemoved) {
+        if (assetFilter != null && AssetFilter.Action.REMOVE.equals(assetFilter.accept(ResourceChange.Type.GLOBAL, pkg.getName(), toBeRemoved))) {
+            pkg.removeGlobal(toBeRemoved);
+            if (kBase != null) {
+                kBase.removeGlobal(toBeRemoved);
             }
         }
     }

--- a/drools-compiler/src/main/java/org/drools/compiler/builder/impl/processors/ImmutableFunctionCompiler.java
+++ b/drools-compiler/src/main/java/org/drools/compiler/builder/impl/processors/ImmutableFunctionCompiler.java
@@ -29,11 +29,11 @@ import java.util.List;
 import static org.drools.core.impl.KnowledgeBaseImpl.registerFunctionClassAndInnerClasses;
 import static org.drools.util.StringUtils.isEmpty;
 
-public class SimpleFunctionCompiler extends AbstractPackageCompilationPhase {
+public class ImmutableFunctionCompiler extends AbstractPackageCompilationPhase {
 
     private ClassLoader rootClassLoader;
 
-    public SimpleFunctionCompiler(PackageRegistry pkgRegistry, PackageDescr packageDescr, ClassLoader rootClassLoader) {
+    public ImmutableFunctionCompiler(PackageRegistry pkgRegistry, PackageDescr packageDescr, ClassLoader rootClassLoader) {
         super(pkgRegistry, packageDescr);
         this.rootClassLoader = rootClassLoader;
     }

--- a/drools-compiler/src/main/java/org/drools/compiler/builder/impl/processors/ImmutableGlobalCompilationPhase.java
+++ b/drools-compiler/src/main/java/org/drools/compiler/builder/impl/processors/ImmutableGlobalCompilationPhase.java
@@ -1,0 +1,67 @@
+package org.drools.compiler.builder.impl.processors;
+
+import org.drools.compiler.builder.impl.GlobalVariableContext;
+import org.drools.compiler.builder.impl.KnowledgeBuilderImpl;
+import org.drools.compiler.compiler.GlobalError;
+import org.drools.compiler.compiler.PackageRegistry;
+import org.drools.core.definitions.InternalKnowledgePackage;
+import org.drools.drl.ast.descr.GlobalDescr;
+import org.drools.drl.ast.descr.PackageDescr;
+import org.kie.internal.builder.ResourceChange;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.HashSet;
+import java.util.Set;
+
+public class ImmutableGlobalCompilationPhase extends AbstractPackageCompilationPhase {
+    protected static final transient Logger logger = LoggerFactory.getLogger(ImmutableGlobalCompilationPhase.class);
+
+    private final GlobalVariableContext globalVariableContext;
+
+    public ImmutableGlobalCompilationPhase(PackageRegistry pkgRegistry, PackageDescr packageDescr, GlobalVariableContext globalVariableContext) {
+        super(pkgRegistry, packageDescr);
+        this.globalVariableContext = globalVariableContext;
+    }
+
+    public final void process() {
+        InternalKnowledgePackage pkg = pkgRegistry.getPackage();
+        Set<String> existingGlobals = new HashSet<>(pkg.getGlobals().keySet());
+
+        for (final GlobalDescr global : packageDescr.getGlobals()) {
+            final String identifier = global.getIdentifier();
+            existingGlobals.remove(identifier);
+            String className = global.getType();
+
+            // JBRULES-3039: can't handle type name with generic params
+            while (className.indexOf('<') >= 0) {
+                className = className.replaceAll("<[^<>]+?>", "");
+            }
+
+            try {
+                Class<?> clazz = pkgRegistry.getTypeResolver().resolveType(className);
+                if (clazz.isPrimitive()) {
+                    this.results.add(new GlobalError(global, " Primitive types are not allowed in globals : " + className));
+                    return;
+                }
+                addGlobal(pkg, identifier, clazz);
+            } catch (final ClassNotFoundException e) {
+                this.results.add(new GlobalError(global, e.getMessage()));
+                logger.warn("ClassNotFoundException occured!", e);
+            }
+        }
+
+        for (String toBeRemoved : existingGlobals) {
+            removeGlobal(pkg, toBeRemoved);
+        }
+    }
+
+    protected void addGlobal(InternalKnowledgePackage pkg, String identifier, Class<?> clazz) {
+        pkg.addGlobal(identifier, clazz);
+        globalVariableContext.addGlobal(identifier, clazz);
+    }
+
+    protected void removeGlobal(InternalKnowledgePackage pkg, String toBeRemoved) {
+        pkg.removeGlobal(toBeRemoved);
+    }
+}

--- a/drools-compiler/src/main/java/org/drools/compiler/builder/impl/processors/ImmutableGlobalCompilationPhase.java
+++ b/drools-compiler/src/main/java/org/drools/compiler/builder/impl/processors/ImmutableGlobalCompilationPhase.java
@@ -1,3 +1,20 @@
+/*
+ * Copyright 2022 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ *
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.drools.compiler.builder.impl.processors;
 
 import org.drools.compiler.builder.impl.GlobalVariableContext;

--- a/drools-compiler/src/main/java/org/drools/compiler/builder/impl/processors/ImmutableRuleCompilationPhase.java
+++ b/drools-compiler/src/main/java/org/drools/compiler/builder/impl/processors/ImmutableRuleCompilationPhase.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2021 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.drools.compiler.builder.impl.processors;
 
 import org.drools.compiler.builder.impl.KnowledgeBuilderImpl;

--- a/drools-compiler/src/main/java/org/drools/compiler/builder/impl/processors/ImmutableRuleCompilationPhase.java
+++ b/drools-compiler/src/main/java/org/drools/compiler/builder/impl/processors/ImmutableRuleCompilationPhase.java
@@ -1,21 +1,17 @@
 package org.drools.compiler.builder.impl.processors;
 
-import org.drools.compiler.builder.impl.AssetFilter;
 import org.drools.compiler.builder.impl.KnowledgeBuilderImpl;
 import org.drools.compiler.builder.impl.TypeDeclarationContext;
 import org.drools.compiler.compiler.DialectCompiletimeRegistry;
 import org.drools.compiler.compiler.PackageRegistry;
 import org.drools.compiler.compiler.RuleBuildError;
-import org.drools.compiler.lang.descr.CompositePackageDescr;
 import org.drools.compiler.rule.builder.RuleBuildContext;
 import org.drools.compiler.rule.builder.RuleBuilder;
 import org.drools.core.definitions.InternalKnowledgePackage;
-import org.drools.core.definitions.rule.impl.RuleImpl;
-import org.drools.util.StringUtils;
 import org.drools.drl.ast.descr.AttributeDescr;
 import org.drools.drl.ast.descr.PackageDescr;
 import org.drools.drl.ast.descr.RuleDescr;
-import org.drools.kiesession.rulebase.InternalKnowledgeBase;
+import org.drools.util.StringUtils;
 import org.kie.api.io.Resource;
 import org.kie.internal.builder.KnowledgeBuilderResult;
 import org.kie.internal.builder.ResourceChange;
@@ -36,41 +32,33 @@ import java.util.concurrent.ExecutionException;
 import static org.drools.compiler.rule.builder.RuleBuildContext.descrToRule;
 import static org.drools.util.StringUtils.isEmpty;
 
-public class RuleCompiler extends AbstractPackageCompilationPhase {
+public class ImmutableRuleCompilationPhase extends AbstractPackageCompilationPhase {
 
-    private InternalKnowledgeBase kBase;
     private int parallelRulesBuildThreshold;
-    private final AssetFilter assetFilter;
 
     //This list of package level attributes is initialised with the PackageDescr's attributes added to the assembler.
     //The package level attributes are inherited by individual rules not containing explicit overriding parameters.
     //The map contains a map of AttributeDescr's keyed on the AttributeDescr's name.
     private final Map<String, AttributeDescr> packageAttributes;
     private final Resource resource;
-    private final TypeDeclarationContext kBuilder;
+    private final TypeDeclarationContext typeDeclarationContext;
 
 
-    public RuleCompiler(
+    public ImmutableRuleCompilationPhase(
             PackageRegistry pkgRegistry,
             PackageDescr packageDescr,
-            InternalKnowledgeBase kBase,
             int parallelRulesBuildThreshold,
-            AssetFilter assetFilter,
             Map<String, AttributeDescr> packageAttributes,
             Resource resource,
-            TypeDeclarationContext kBuilder) {
+            TypeDeclarationContext typeDeclarationContext) {
         super(pkgRegistry, packageDescr);
-        this.kBase = kBase;
         this.parallelRulesBuildThreshold = parallelRulesBuildThreshold;
-        this.assetFilter = assetFilter;
         this.packageAttributes = packageAttributes;
         this.resource = resource;
-        this.kBuilder = kBuilder;
+        this.typeDeclarationContext = typeDeclarationContext;
     }
 
     public void process() {
-        preProcessRules(packageDescr, pkgRegistry);
-
         // ensure that rules are ordered by dependency, so that dependent rules are built later
         SortedRules sortedRules = sortRulesByDependency(packageDescr, pkgRegistry);
 
@@ -82,71 +70,9 @@ public class RuleCompiler extends AbstractPackageCompilationPhase {
         }
     }
 
-
-    private void preProcessRules(PackageDescr packageDescr, PackageRegistry pkgRegistry) {
-        if (this.kBase == null) {
-            return;
-        }
-
-        InternalKnowledgePackage pkg = pkgRegistry.getPackage();
-        boolean needsRemoval = false;
-
-        // first, check if any rules no longer exist
-        for (org.kie.api.definition.rule.Rule rule : pkg.getRules()) {
-            if (filterAcceptsRemoval(ResourceChange.Type.RULE, rule.getPackageName(), rule.getName())) {
-                needsRemoval = true;
-                break;
-            }
-        }
-
-        if (!needsRemoval) {
-            for (RuleDescr ruleDescr : packageDescr.getRules()) {
-                if (filterAccepts(ResourceChange.Type.RULE, ruleDescr.getNamespace(), ruleDescr.getName())) {
-                    if (pkg.getRule(ruleDescr.getName()) != null) {
-                        needsRemoval = true;
-                        break;
-                    }
-                }
-            }
-        }
-
-        if (needsRemoval) {
-            kBase.enqueueModification(() -> {
-                Collection<RuleImpl> rulesToBeRemoved = new HashSet<>();
-
-                for (org.kie.api.definition.rule.Rule rule : pkg.getRules()) {
-                    if (filterAcceptsRemoval(ResourceChange.Type.RULE, rule.getPackageName(), rule.getName())) {
-                        rulesToBeRemoved.add(((RuleImpl) rule));
-                    }
-                }
-
-                rulesToBeRemoved.forEach(pkg::removeRule);
-
-                for (RuleDescr ruleDescr : packageDescr.getRules()) {
-                    if (filterAccepts(ResourceChange.Type.RULE, ruleDescr.getNamespace(), ruleDescr.getName())) {
-                        RuleImpl rule = pkg.getRule(ruleDescr.getName());
-                        if (rule != null) {
-                            rulesToBeRemoved.add(rule);
-                        }
-                    }
-                }
-
-                if (!rulesToBeRemoved.isEmpty()) {
-                    rulesToBeRemoved.addAll(findChildrenRulesToBeRemoved(packageDescr, rulesToBeRemoved));
-                    kBase.removeRules(rulesToBeRemoved);
-                }
-            });
-        }
+    protected boolean filterAccepts(ResourceChange.Type type, String namespace, String name) {
+        return true;
     }
-
-    private boolean filterAccepts(ResourceChange.Type type, String namespace, String name) {
-        return assetFilter == null || !AssetFilter.Action.DO_NOTHING.equals(assetFilter.accept(type, namespace, name));
-    }
-
-    private boolean filterAcceptsRemoval(ResourceChange.Type type, String namespace, String name) {
-        return assetFilter != null && AssetFilter.Action.REMOVE.equals(assetFilter.accept(type, namespace, name));
-    }
-
 
     private SortedRules sortRulesByDependency(PackageDescr packageDescr, PackageRegistry pkgRegistry) {
         // Using a topological sorting algorithm
@@ -313,7 +239,7 @@ public class RuleCompiler extends AbstractPackageCompilationPhase {
         }
 
         DialectCompiletimeRegistry ctr = pkgRegistry.getDialectCompiletimeRegistry();
-        RuleBuildContext context = new RuleBuildContext(kBuilder,
+        RuleBuildContext context = new RuleBuildContext(typeDeclarationContext,
                 ruleDescr,
                 ctr,
                 pkgRegistry.getPackage(),
@@ -323,7 +249,7 @@ public class RuleCompiler extends AbstractPackageCompilationPhase {
     }
 
     private void compileRulesLevel(PackageDescr packageDescr, PackageRegistry pkgRegistry, List<RuleDescr> rules) {
-        boolean parallelRulesBuild = this.kBase == null && parallelRulesBuildThreshold != -1 && rules.size() > parallelRulesBuildThreshold;
+        boolean parallelRulesBuild = parallelRulesBuild(rules);
         if (parallelRulesBuild) {
             Map<String, RuleBuildContext> ruleCxts = new ConcurrentHashMap<>();
             try {
@@ -363,32 +289,9 @@ public class RuleCompiler extends AbstractPackageCompilationPhase {
         }
     }
 
-
-    private Collection<RuleImpl> findChildrenRulesToBeRemoved(PackageDescr packageDescr, Collection<RuleImpl> rulesToBeRemoved) {
-        Collection<String> childrenRuleNamesToBeRemoved = new HashSet<>();
-        Collection<RuleImpl> childrenRulesToBeRemoved = new HashSet<>();
-        for (RuleImpl rule : rulesToBeRemoved) {
-            if (rule.hasChildren()) {
-                for (RuleImpl child : rule.getChildren()) {
-                    if (!rulesToBeRemoved.contains(child)) {
-                        // if a rule has a child rule not marked to be removed ...
-                        childrenRulesToBeRemoved.add(child);
-                        childrenRuleNamesToBeRemoved.add(child.getName());
-                        // ... remove the child rule but also add it back to the PackageDescr in order to readd it when also the parent rule will be readded ...
-                        RuleDescr toBeReadded = new RuleDescr(child.getName());
-                        toBeReadded.setNamespace(packageDescr.getNamespace());
-                        packageDescr.addRule(toBeReadded);
-                    }
-                }
-            }
-        }
-        // ... add a filter to the PackageDescr to also consider the readded children rules as updated together with the parent one
-        if (!childrenRuleNamesToBeRemoved.isEmpty()) {
-            ((CompositePackageDescr) packageDescr).addFilter((type, pkgName, assetName) -> childrenRuleNamesToBeRemoved.contains(assetName) ? AssetFilter.Action.UPDATE : AssetFilter.Action.DO_NOTHING);
-        }
-        return childrenRulesToBeRemoved;
+    protected boolean parallelRulesBuild(List<RuleDescr> rules) {
+        return parallelRulesBuildThreshold != -1 && rules.size() > parallelRulesBuildThreshold;
     }
-
 
     private void initRuleDescr(PackageDescr packageDescr, PackageRegistry pkgRegistry, RuleDescr ruleDescr) {
         if (isEmpty(ruleDescr.getNamespace())) {

--- a/drools-compiler/src/main/java/org/drools/compiler/builder/impl/processors/RuleCompilationPhase.java
+++ b/drools-compiler/src/main/java/org/drools/compiler/builder/impl/processors/RuleCompilationPhase.java
@@ -1,0 +1,140 @@
+package org.drools.compiler.builder.impl.processors;
+
+import org.drools.compiler.builder.impl.AssetFilter;
+import org.drools.compiler.builder.impl.TypeDeclarationContext;
+import org.drools.compiler.compiler.PackageRegistry;
+import org.drools.compiler.lang.descr.CompositePackageDescr;
+import org.drools.core.definitions.InternalKnowledgePackage;
+import org.drools.core.definitions.rule.impl.RuleImpl;
+import org.drools.drl.ast.descr.AttributeDescr;
+import org.drools.drl.ast.descr.PackageDescr;
+import org.drools.drl.ast.descr.RuleDescr;
+import org.drools.kiesession.rulebase.InternalKnowledgeBase;
+import org.kie.api.io.Resource;
+import org.kie.internal.builder.ResourceChange;
+
+import java.util.Collection;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+
+public class RuleCompilationPhase extends ImmutableRuleCompilationPhase {
+
+    private InternalKnowledgeBase kBase;
+    private final AssetFilter assetFilter;
+
+    public RuleCompilationPhase(
+            PackageRegistry pkgRegistry,
+            PackageDescr packageDescr,
+            InternalKnowledgeBase kBase,
+            int parallelRulesBuildThreshold,
+            AssetFilter assetFilter,
+            Map<String, AttributeDescr> packageAttributes,
+            Resource resource,
+            TypeDeclarationContext typeDeclarationContext) {
+        super(pkgRegistry, packageDescr, parallelRulesBuildThreshold, packageAttributes, resource, typeDeclarationContext);
+        this.kBase = kBase;
+        this.assetFilter = assetFilter;
+    }
+
+    @Override
+    public void process() {
+        preProcessRules(packageDescr, pkgRegistry);
+        super.process();
+    }
+
+    protected boolean parallelRulesBuild(List<RuleDescr> rules) {
+        return this.kBase == null && super.parallelRulesBuild(rules);
+    }
+
+    private void preProcessRules(PackageDescr packageDescr, PackageRegistry pkgRegistry) {
+        if (this.kBase == null) {
+            return;
+        }
+
+        InternalKnowledgePackage pkg = pkgRegistry.getPackage();
+        boolean needsRemoval = false;
+
+        // first, check if any rules no longer exist
+        for (org.kie.api.definition.rule.Rule rule : pkg.getRules()) {
+            if (filterAcceptsRemoval(ResourceChange.Type.RULE, rule.getPackageName(), rule.getName())) {
+                needsRemoval = true;
+                break;
+            }
+        }
+
+        if (!needsRemoval) {
+            for (RuleDescr ruleDescr : packageDescr.getRules()) {
+                if (filterAccepts(ResourceChange.Type.RULE, ruleDescr.getNamespace(), ruleDescr.getName())) {
+                    if (pkg.getRule(ruleDescr.getName()) != null) {
+                        needsRemoval = true;
+                        break;
+                    }
+                }
+            }
+        }
+
+        if (needsRemoval) {
+            kBase.enqueueModification(() -> {
+                Collection<RuleImpl> rulesToBeRemoved = new HashSet<>();
+
+                for (org.kie.api.definition.rule.Rule rule : pkg.getRules()) {
+                    if (filterAcceptsRemoval(ResourceChange.Type.RULE, rule.getPackageName(), rule.getName())) {
+                        rulesToBeRemoved.add(((RuleImpl) rule));
+                    }
+                }
+
+                rulesToBeRemoved.forEach(pkg::removeRule);
+
+                for (RuleDescr ruleDescr : packageDescr.getRules()) {
+                    if (filterAccepts(ResourceChange.Type.RULE, ruleDescr.getNamespace(), ruleDescr.getName())) {
+                        RuleImpl rule = pkg.getRule(ruleDescr.getName());
+                        if (rule != null) {
+                            rulesToBeRemoved.add(rule);
+                        }
+                    }
+                }
+
+                if (!rulesToBeRemoved.isEmpty()) {
+                    rulesToBeRemoved.addAll(findChildrenRulesToBeRemoved(packageDescr, rulesToBeRemoved));
+                    kBase.removeRules(rulesToBeRemoved);
+                }
+            });
+        }
+    }
+
+    @Override
+    protected boolean filterAccepts(ResourceChange.Type type, String namespace, String name) {
+        return assetFilter == null || !AssetFilter.Action.DO_NOTHING.equals(assetFilter.accept(type, namespace, name));
+    }
+
+    private boolean filterAcceptsRemoval(ResourceChange.Type type, String namespace, String name) {
+        return assetFilter != null && AssetFilter.Action.REMOVE.equals(assetFilter.accept(type, namespace, name));
+    }
+
+    private Collection<RuleImpl> findChildrenRulesToBeRemoved(PackageDescr packageDescr, Collection<RuleImpl> rulesToBeRemoved) {
+        Collection<String> childrenRuleNamesToBeRemoved = new HashSet<>();
+        Collection<RuleImpl> childrenRulesToBeRemoved = new HashSet<>();
+        for (RuleImpl rule : rulesToBeRemoved) {
+            if (rule.hasChildren()) {
+                for (RuleImpl child : rule.getChildren()) {
+                    if (!rulesToBeRemoved.contains(child)) {
+                        // if a rule has a child rule not marked to be removed ...
+                        childrenRulesToBeRemoved.add(child);
+                        childrenRuleNamesToBeRemoved.add(child.getName());
+                        // ... remove the child rule but also add it back to the PackageDescr in order to readd it when also the parent rule will be readded ...
+                        RuleDescr toBeReadded = new RuleDescr(child.getName());
+                        toBeReadded.setNamespace(packageDescr.getNamespace());
+                        packageDescr.addRule(toBeReadded);
+                    }
+                }
+            }
+        }
+        // ... add a filter to the PackageDescr to also consider the readded children rules as updated together with the parent one
+        if (!childrenRuleNamesToBeRemoved.isEmpty()) {
+            ((CompositePackageDescr) packageDescr).addFilter((type, pkgName, assetName) -> childrenRuleNamesToBeRemoved.contains(assetName) ? AssetFilter.Action.UPDATE : AssetFilter.Action.DO_NOTHING);
+        }
+        return childrenRulesToBeRemoved;
+    }
+
+}

--- a/drools-compiler/src/main/java/org/drools/compiler/builder/impl/processors/RuleCompilationPhase.java
+++ b/drools-compiler/src/main/java/org/drools/compiler/builder/impl/processors/RuleCompilationPhase.java
@@ -1,3 +1,20 @@
+/*
+ * Copyright 2022 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ *
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.drools.compiler.builder.impl.processors;
 
 import org.drools.compiler.builder.impl.AssetFilter;

--- a/drools-compiler/src/main/java/org/drools/compiler/builder/impl/processors/SimpleFunctionCompiler.java
+++ b/drools-compiler/src/main/java/org/drools/compiler/builder/impl/processors/SimpleFunctionCompiler.java
@@ -1,3 +1,20 @@
+/*
+ * Copyright 2022 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ *
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.drools.compiler.builder.impl.processors;
 
 import org.drools.compiler.compiler.Dialect;

--- a/drools-compiler/src/main/java/org/drools/compiler/builder/impl/processors/SimpleFunctionCompiler.java
+++ b/drools-compiler/src/main/java/org/drools/compiler/builder/impl/processors/SimpleFunctionCompiler.java
@@ -1,0 +1,94 @@
+package org.drools.compiler.builder.impl.processors;
+
+import org.drools.compiler.compiler.Dialect;
+import org.drools.compiler.compiler.PackageRegistry;
+import org.drools.core.rule.JavaDialectRuntimeData;
+import org.drools.drl.ast.descr.FunctionDescr;
+import org.drools.drl.ast.descr.PackageDescr;
+import org.drools.wiring.api.classloader.ProjectClassLoader;
+
+import java.util.List;
+
+import static org.drools.core.impl.KnowledgeBaseImpl.registerFunctionClassAndInnerClasses;
+import static org.drools.util.StringUtils.isEmpty;
+
+public class SimpleFunctionCompiler extends AbstractPackageCompilationPhase {
+
+    private ClassLoader rootClassLoader;
+
+    public SimpleFunctionCompiler(PackageRegistry pkgRegistry, PackageDescr packageDescr, ClassLoader rootClassLoader) {
+        super(pkgRegistry, packageDescr);
+        this.rootClassLoader = rootClassLoader;
+    }
+
+    public final void process() {
+        List<FunctionDescr> functions = packageDescr.getFunctions();
+        if (!functions.isEmpty()) {
+
+            for (FunctionDescr functionDescr : functions) {
+                if (isEmpty(functionDescr.getNamespace())) {
+                    // make sure namespace is set on components
+                    functionDescr.setNamespace(packageDescr.getNamespace());
+                }
+
+                // make sure functions are compiled using java dialect
+                functionDescr.setDialect("java");
+
+                preCompileAddFunction(functionDescr, pkgRegistry);
+            }
+
+            // iterate and compile
+            for (FunctionDescr functionDescr : functions) {
+                addFunction(functionDescr);
+            }
+
+            // compile functions in this pkgRegistry
+            pkgRegistry.compileAll();
+
+            for (FunctionDescr functionDescr : functions) {
+                postCompileAddFunction(functionDescr);
+            }
+        }
+    }
+
+    protected void postCompileAddFunction(FunctionDescr functionDescr) {
+        postCompileAddFunction(functionDescr, pkgRegistry);
+    }
+
+    protected void addFunction(FunctionDescr functionDescr) {
+        // inherit the dialect from the package
+        addFunction(functionDescr, pkgRegistry);
+    }
+
+    private void preCompileAddFunction(final FunctionDescr functionDescr, PackageRegistry pkgRegistry) {
+        Dialect dialect = pkgRegistry.getDialectCompiletimeRegistry().getDialect(functionDescr.getDialect());
+        dialect.preCompileAddFunction(functionDescr,
+                pkgRegistry.getTypeResolver());
+    }
+
+
+    private void addFunction(final FunctionDescr functionDescr, PackageRegistry pkgRegistry) {
+        Dialect dialect = pkgRegistry.getDialectCompiletimeRegistry().getDialect(functionDescr.getDialect());
+        dialect.addFunction(functionDescr,
+                pkgRegistry.getTypeResolver(),
+                null/*this.resource*/);
+    }
+
+
+
+    private void postCompileAddFunction(final FunctionDescr functionDescr, PackageRegistry pkgRegistry) {
+        Dialect dialect = pkgRegistry.getDialectCompiletimeRegistry().getDialect(functionDescr.getDialect());
+        dialect.postCompileAddFunction(functionDescr, pkgRegistry.getTypeResolver());
+
+        if (rootClassLoader instanceof ProjectClassLoader) {
+            String functionClassName = functionDescr.getClassName();
+            JavaDialectRuntimeData runtime = ((JavaDialectRuntimeData) pkgRegistry.getDialectRuntimeRegistry().getDialectData("java"));
+            try {
+                registerFunctionClassAndInnerClasses(functionClassName, runtime, ((ProjectClassLoader) rootClassLoader)::storeClass);
+            } catch (ClassNotFoundException e) {
+                throw new RuntimeException(e);
+            }
+        }
+    }
+
+}

--- a/drools-model/drools-model-codegen/src/main/java/org/drools/model/codegen/tool/ExplicitCanonicalModelCompiler.java
+++ b/drools-model/drools-model-codegen/src/main/java/org/drools/model/codegen/tool/ExplicitCanonicalModelCompiler.java
@@ -18,6 +18,7 @@ import org.drools.compiler.builder.impl.processors.AccumulateFunctionCompilation
 import org.drools.compiler.builder.impl.processors.CompilationPhase;
 import org.drools.compiler.builder.impl.processors.FunctionCompilationPhase;
 import org.drools.compiler.builder.impl.processors.GlobalCompilationPhase;
+import org.drools.compiler.builder.impl.processors.ImmutableGlobalCompilationPhase;
 import org.drools.compiler.builder.impl.processors.IteratingPhase;
 import org.drools.compiler.builder.impl.processors.RuleValidator;
 import org.drools.compiler.builder.impl.processors.SinglePackagePhaseFactory;
@@ -58,7 +59,6 @@ public class ExplicitCanonicalModelCompiler<T extends PackageSources> {
     private final KnowledgeBuilderConfigurationImpl configuration;
     private final BuildResultCollector results;
     private final TypeDeclarationContext typeDeclarationContext;
-    private final InternalKnowledgeBase kBase = null;
     private final GlobalVariableContext globalVariableContext;
     private final PackageSourceManager<T> packageSourceManager;
     private final Function<PackageModel, T> sourceDumpFunction;
@@ -121,7 +121,7 @@ public class ExplicitCanonicalModelCompiler<T extends PackageSources> {
             phases.add(iteratingPhase((reg, acc) -> new WindowDeclarationCompilationPhase(reg, acc, typeDeclarationContext)));
         }
         phases.add(iteratingPhase((reg, acc) -> new FunctionCompilationPhase(reg, acc, configuration)));
-        phases.add(iteratingPhase((reg, acc) -> new GlobalCompilationPhase(reg, acc, kBase, globalVariableContext, acc.getFilter())));
+        phases.add(iteratingPhase((reg, acc) -> new ImmutableGlobalCompilationPhase(reg, acc, globalVariableContext)));
         phases.add(new DeclaredTypeDeregistrationPhase(packages, pkgRegistryManager));
 
         // ---

--- a/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/compiler/integrationtests/phases/ExplicitCompilerTest.java
+++ b/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/compiler/integrationtests/phases/ExplicitCompilerTest.java
@@ -36,7 +36,7 @@ import org.drools.compiler.builder.impl.processors.ImmutableRuleCompilationPhase
 import org.drools.compiler.builder.impl.processors.ImportCompilationPhase;
 import org.drools.compiler.builder.impl.processors.RuleAnnotationNormalizer;
 import org.drools.compiler.builder.impl.processors.RuleValidator;
-import org.drools.compiler.builder.impl.processors.SimpleFunctionCompiler;
+import org.drools.compiler.builder.impl.processors.ImmutableFunctionCompiler;
 import org.drools.compiler.builder.impl.processors.TypeDeclarationAnnotationNormalizer;
 import org.drools.compiler.builder.impl.processors.TypeDeclarationCompilationPhase;
 import org.drools.compiler.builder.impl.processors.WindowDeclarationCompilationPhase;
@@ -122,7 +122,7 @@ public class ExplicitCompilerTest {
                 new RuleAnnotationNormalizer(annotationNormalizer, packageDescr),
                 /*         packageRegistry.setDialect(getPackageDialect(packageDescr)) */
                 new RuleValidator(packageRegistry, packageDescr, configuration),
-                new SimpleFunctionCompiler(packageRegistry, packageDescr, rootClassLoader),
+                new ImmutableFunctionCompiler(packageRegistry, packageDescr, rootClassLoader),
                 new ImmutableRuleCompilationPhase(packageRegistry, packageDescr, parallelRulesBuildThreshold,
                         attributesForPackage, resource, typeDeclarationContext),
 //                new ReteCompiler(packageRegistry, packageDescr, kBase, null), // no-op when kbase==null

--- a/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/compiler/integrationtests/phases/ExplicitCompilerTest.java
+++ b/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/compiler/integrationtests/phases/ExplicitCompilerTest.java
@@ -31,13 +31,12 @@ import org.drools.compiler.builder.impl.processors.CompilationPhase;
 import org.drools.compiler.builder.impl.processors.ConsequenceCompilationPhase;
 import org.drools.compiler.builder.impl.processors.EntryPointDeclarationCompilationPhase;
 import org.drools.compiler.builder.impl.processors.FunctionCompilationPhase;
-import org.drools.compiler.builder.impl.processors.FunctionCompiler;
-import org.drools.compiler.builder.impl.processors.GlobalCompilationPhase;
+import org.drools.compiler.builder.impl.processors.ImmutableGlobalCompilationPhase;
+import org.drools.compiler.builder.impl.processors.ImmutableRuleCompilationPhase;
 import org.drools.compiler.builder.impl.processors.ImportCompilationPhase;
-import org.drools.compiler.builder.impl.processors.ReteCompiler;
 import org.drools.compiler.builder.impl.processors.RuleAnnotationNormalizer;
-import org.drools.compiler.builder.impl.processors.RuleCompiler;
 import org.drools.compiler.builder.impl.processors.RuleValidator;
+import org.drools.compiler.builder.impl.processors.SimpleFunctionCompiler;
 import org.drools.compiler.builder.impl.processors.TypeDeclarationAnnotationNormalizer;
 import org.drools.compiler.builder.impl.processors.TypeDeclarationCompilationPhase;
 import org.drools.compiler.builder.impl.processors.WindowDeclarationCompilationPhase;
@@ -119,14 +118,14 @@ public class ExplicitCompilerTest {
                 new TypeDeclarationCompilationPhase(packageDescr, typeBuilder, packageRegistry, null),
                 new WindowDeclarationCompilationPhase(packageRegistry, packageDescr, typeDeclarationContext),
                 new FunctionCompilationPhase(packageRegistry, packageDescr, configuration),
-                new GlobalCompilationPhase(packageRegistry, packageDescr, kBase, globalVariableContext, null),
+                new ImmutableGlobalCompilationPhase(packageRegistry, packageDescr, globalVariableContext),
                 new RuleAnnotationNormalizer(annotationNormalizer, packageDescr),
                 /*         packageRegistry.setDialect(getPackageDialect(packageDescr)) */
                 new RuleValidator(packageRegistry, packageDescr, configuration),
-                new FunctionCompiler(packageDescr, packageRegistry, null, rootClassLoader),
-                new RuleCompiler(packageRegistry, packageDescr, kBase, parallelRulesBuildThreshold,
-                        null, attributesForPackage, resource, typeDeclarationContext),
-                new ReteCompiler(packageRegistry, packageDescr, kBase, null),
+                new SimpleFunctionCompiler(packageRegistry, packageDescr, rootClassLoader),
+                new ImmutableRuleCompilationPhase(packageRegistry, packageDescr, parallelRulesBuildThreshold,
+                        attributesForPackage, resource, typeDeclarationContext),
+//                new ReteCompiler(packageRegistry, packageDescr, kBase, null), // no-op when kbase==null
                 new ConsequenceCompilationPhase(packageRegistryManager)
         );
 


### PR DESCRIPTION
Compilation Phases that have been refactored from the KnowledgeBuilder and ModelBuilder are still in some cases referring to a kBase and assetFilters that in immutable use cases are always null.

We refactor these phases into "simple" or "immutable" phases, that do no take any filter or kbase as a parameter. The original phases will extend such "basic" phases.

The new basic phases can be instantiated directly in all those case when a kbase and/or an asset filter is irrelevant