### PR TITLE
[7.x] DROOLS-7033: Potential Regex injection in DMNScenarioRunnerHelper

### DIFF
--- a/drools-scenario-simulation/drools-scenario-simulation-backend/src/main/java/org/drools/scenariosimulation/backend/runner/DMNScenarioRunnerHelper.java
+++ b/drools-scenario-simulation/drools-scenario-simulation-backend/src/main/java/org/drools/scenariosimulation/backend/runner/DMNScenarioRunnerHelper.java
@@ -105,7 +105,10 @@ public class DMNScenarioRunnerHelper extends AbstractRunnerHelper {
             String factName = input.getFactIdentifier().getName();
             String importPrefix = input.getFactIdentifier().getImportPrefix();
             if (importPrefix != null && !importPrefix.isEmpty()) {
-                String importedFactName = factName.replaceFirst(importPrefix + ".", "");
+                if (!factName.startsWith(importPrefix)) {
+                    throw new IllegalArgumentException("Fact name: " + factName + " has defined an invalid import prefix: " + importPrefix);
+                }
+                String importedFactName = factName.replaceFirst("^" + importPrefix + "\\.", "");
                 Map<String, Object> groupedFacts = importedInputValues.computeIfAbsent(importPrefix, k -> new HashMap<>());
                 Object value = groupedFacts.containsKey(importedFactName) ?
                         mergeValues(groupedFacts.get(importedFactName), input.getValue()) :

--- a/drools-scenario-simulation/drools-scenario-simulation-backend/src/main/java/org/drools/scenariosimulation/backend/runner/DMNScenarioRunnerHelper.java
+++ b/drools-scenario-simulation/drools-scenario-simulation-backend/src/main/java/org/drools/scenariosimulation/backend/runner/DMNScenarioRunnerHelper.java
@@ -21,6 +21,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.atomic.AtomicInteger;
+import java.util.regex.Pattern;
 
 import org.drools.scenariosimulation.api.model.ExpressionElement;
 import org.drools.scenariosimulation.api.model.ExpressionIdentifier;
@@ -108,7 +109,7 @@ public class DMNScenarioRunnerHelper extends AbstractRunnerHelper {
                 if (!factName.startsWith(importPrefix)) {
                     throw new IllegalArgumentException("Fact name: " + factName + " has defined an invalid import prefix: " + importPrefix);
                 }
-                String importedFactName = factName.replaceFirst("^" + importPrefix + "\\.", "");
+                String importedFactName = factName.replaceFirst(Pattern.quote(importPrefix + "."), "");
                 Map<String, Object> groupedFacts = importedInputValues.computeIfAbsent(importPrefix, k -> new HashMap<>());
                 Object value = groupedFacts.containsKey(importedFactName) ?
                         mergeValues(groupedFacts.get(importedFactName), input.getValue()) :

--- a/drools-scenario-simulation/drools-scenario-simulation-backend/src/test/java/org/drools/scenariosimulation/backend/runner/DMNScenarioRunnerHelperTest.java
+++ b/drools-scenario-simulation/drools-scenario-simulation-backend/src/test/java/org/drools/scenariosimulation/backend/runner/DMNScenarioRunnerHelperTest.java
@@ -63,6 +63,7 @@ import org.kie.dmn.api.core.DMNResult;
 import org.kie.dmn.api.core.ast.DecisionNode;
 import org.kie.dmn.core.impl.DMNMessageImpl;
 import org.mockito.ArgumentCaptor;
+import org.mockito.Captor;
 import org.mockito.Mock;
 import org.mockito.junit.MockitoJUnitRunner;
 
@@ -118,6 +119,11 @@ public class DMNScenarioRunnerHelperTest {
     protected DMNScenarioExecutableBuilder dmnScenarioExecutableBuilderMock;
     @Mock
     protected KieContainer kieContainerMock;
+    @Captor
+    private ArgumentCaptor<Object> valueCaptor;
+    @Captor
+    private ArgumentCaptor<String> keyCaptor;
+
     private Simulation simulation;
     private Settings settings;
     private FactIdentifier personFactIdentifier;
@@ -370,9 +376,6 @@ public class DMNScenarioRunnerHelperTest {
 
     @Test
     public void executeScenario() {
-        ArgumentCaptor<Object> setValueCaptor = ArgumentCaptor.forClass(Object.class);
-        ArgumentCaptor<String> setKeyCaptor = ArgumentCaptor.forClass(String.class);
-
         FactIdentifier bookFactIdentifier = FactIdentifier.create("Book", "Book");
         FactIdentifier importedPersonFactIdentifier = FactIdentifier.create(IMPORTED_PREFIX + ".Person", IMPORTED_PREFIX + ".Person", IMPORTED_PREFIX);
         FactIdentifier importedDisputeFactIdentifier = FactIdentifier.create(IMPORTED_PREFIX + ".Dispute", IMPORTED_PREFIX + ".Dispute", IMPORTED_PREFIX);
@@ -418,11 +421,11 @@ public class DMNScenarioRunnerHelperTest {
         runnerHelper.executeScenario(kieContainerMock, scenarioRunnerData, expressionEvaluatorFactory, simulation.getScesimModelDescriptor(), settings);
 
         verify(dmnScenarioExecutableBuilderMock, times(1)).setActiveModel(DMN_FILE_PATH);
-        verify(dmnScenarioExecutableBuilderMock, times(inputObjects)).setValue(setKeyCaptor.capture(), setValueCaptor.capture());
-        assertTrue(setKeyCaptor.getAllValues().containsAll(expectedInputDataToLoad));
+        verify(dmnScenarioExecutableBuilderMock, times(inputObjects)).setValue(keyCaptor.capture(), valueCaptor.capture());
+        assertTrue(keyCaptor.getAllValues().containsAll(expectedInputDataToLoad));
         for (int i = 0; i < inputObjects; i++) {
-            String key = setKeyCaptor.getAllValues().get(i);
-            Map<String, Object> value = (Map<String, Object>) setValueCaptor.getAllValues().get(i);
+            String key = keyCaptor.getAllValues().get(i);
+            Map<String, Object> value = (Map<String, Object>) valueCaptor.getAllValues().get(i);
             if (personFactIdentifier.getName().equals(key)) {
                 assertEquals(backgroundPersonFactData.getValue(), value.get(backgroundPersonFactData.getKey()));
                 assertNotEquals(backgroundPersonFactData2.getValue(), value.get(backgroundPersonFactData2.getKey()));
@@ -466,6 +469,57 @@ public class DMNScenarioRunnerHelperTest {
         assertThatThrownBy(() -> runnerHelper.executeScenario(kieContainerMock, scenarioRunnerData, expressionEvaluatorFactory, simulation.getScesimModelDescriptor(), settings))
                 .isInstanceOf(ScenarioException.class)
                 .hasMessageStartingWith("Impossible to run");
+    }
+
+    @Test
+    public void validateWrongImportPrefix() {
+        String wrongPrefix = "WrongPrefix";
+        FactIdentifier importedPersonFactIdentifier = FactIdentifier.create(IMPORTED_PREFIX + ".Person", IMPORTED_PREFIX + ".Person", wrongPrefix);
+
+        ScenarioRunnerData scenarioRunnerData = new ScenarioRunnerData();
+        AbstractMap.SimpleEntry<String, Object> givenImportedPersonFactData = new AbstractMap.SimpleEntry<>("surname", "White");
+        AbstractMap.SimpleEntry<String, Object> givenImportedPersonFactData2 = new AbstractMap.SimpleEntry<>("age", 67);
+        scenarioRunnerData.addGiven(new InstanceGiven(importedPersonFactIdentifier, instantiateMap(givenImportedPersonFactData, givenImportedPersonFactData2)));
+
+        assertThatThrownBy(() -> runnerHelper.executeScenario(kieContainerMock,
+                                                              scenarioRunnerData,
+                                                              expressionEvaluatorFactory,
+                                                              simulation.getScesimModelDescriptor(),
+                                                              settings))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("Fact name: " + IMPORTED_PREFIX + ".Person has defined an invalid import prefix: " + wrongPrefix);
+    }
+
+    /* If a malicious user injects a regex as a prefix in both importPrefix and as a part of fact name, the injected
+       regex shouldn't be applied, but it should be used as a plain string */
+    @Test
+    public void validateUnSecureImportPrefix() {
+        String injectedPrefix = "/.(a+)+$/";
+        FactIdentifier importedPersonFactIdentifier = FactIdentifier.create(injectedPrefix + ".Person", injectedPrefix + ".Person", injectedPrefix);
+
+        ScenarioRunnerData scenarioRunnerData = new ScenarioRunnerData();
+        AbstractMap.SimpleEntry<String, Object> givenImportedPersonFactData = new AbstractMap.SimpleEntry<>("surname", "White");
+        AbstractMap.SimpleEntry<String, Object> givenImportedPersonFactData2 = new AbstractMap.SimpleEntry<>("age", 67);
+        scenarioRunnerData.addGiven(new InstanceGiven(importedPersonFactIdentifier, instantiateMap(givenImportedPersonFactData, givenImportedPersonFactData2)));
+
+        List<String> expectedInputDataToLoad = asList(injectedPrefix);
+        int inputObjects = expectedInputDataToLoad.size();
+
+        runnerHelper.executeScenario(kieContainerMock,
+                                     scenarioRunnerData,
+                                     expressionEvaluatorFactory,
+                                     simulation.getScesimModelDescriptor(),
+                                     settings);
+
+        verify(dmnScenarioExecutableBuilderMock, times(inputObjects)).setValue(keyCaptor.capture(), valueCaptor.capture());
+        assertTrue(keyCaptor.getAllValues().containsAll(expectedInputDataToLoad));
+        String key = keyCaptor.getAllValues().get(0);
+        Map<String, Object> value = (Map<String, Object>) valueCaptor.getAllValues().get(0);
+        assertEquals(injectedPrefix, key);
+        Map<String, Object> subValuePerson = (Map<String, Object>) value.get("Person");
+        assertEquals(givenImportedPersonFactData.getValue(), subValuePerson.get(givenImportedPersonFactData.getKey()));
+        assertEquals(givenImportedPersonFactData2.getValue(), subValuePerson.get(givenImportedPersonFactData2.getKey()));
+        assertEquals(2, subValuePerson.size());
     }
 
     private Map<String, Object> instantiateMap(AbstractMap.SimpleEntry<String, Object> ... entries) {


### PR DESCRIPTION
**JIRA**: https://issues.redhat.com/browse/DROOLS-7033

`factName.replaceFirst(importPrefix + ".", "")` is potentially exposed to [ReDoS](https://en.wikipedia.org/wiki/ReDoS) attacks. 
Both `factName` and `importPrefix` variables are retrieved from `.scesim` XML file, thus a malicious user could manually modify the file introducing conditions to crash the server, in 7.x branch (Business Central). 
However, the probability this can happens is near to zero, mostly because `replaceFirst()` should already be safe, matching only the first occurrence of the pattern and avoiding backtracking.
However, I decided to introduce a validation of the above variables, in order to completely remove any potential risk.
The validation checks:
- If an import prefix is defined, the related fact must have that prefix in his name. Eg. if we are referring to an imported DMN with `imp` as prefix, the related factName must begin with that prefix, `imp.Person`
- The used regex, which depends on the `importPrefix` variable, is passed using `Pattern.quote()` that returns a literal pattern String for the specified String. This means any potential character usable for search patterns (`*` or `+`) are quoted and considered as normal characters.

**Ports**: https://github.com/kiegroup/drools/pull/4484

<details>
<summary>
How to replicate CI configuration locally?
</summary>

Build Chain tool does "simple" maven build(s), the builds are just Maven commands, but because the repositories relates and depends on each other and any change in API or class method could affect several of those repositories there is a need to use [build-chain tool](https://github.com/kiegroup/github-action-build-chain) to handle cross repository builds and be sure that we always use latest version of the code for each repository.
 
[build-chain tool](https://github.com/kiegroup/github-action-build-chain) is a build tool which can be used on command line locally or in Github Actions workflow(s), in case you need to change multiple repositories and send multiple dependent pull requests related with a change you can easily reproduce the same build by executing it on Github hosted environment or locally in your development environment. See [local execution](https://github.com/kiegroup/github-action-build-chain#local-execution) details to get more information about it.
</details>

<details>
<summary>
How to retest this PR or trigger a specific build:
</summary>

- for <b>pull request checks</b>  
  Please add comment: <b>Jenkins retest this</b>

- for a <b>specific pull request check</b>  
  Please add comment: <b>Jenkins (re)run [drools|kogito-runtimes|kogito-apps|kogito-examples] tests</b>

- for a <b>full downstream build</b> 
  - for <b>jenkins</b> job: please add comment: <b>Jenkins run fdb</b>
  - for <b>github actions</b> job: add the label `run_fdb`

- <b>a compile downstream build</b> please  add comment: <b>Jenkins run cdb</b>

- <b>a full production downstream build</b> please add comment: <b>Jenkins execute product fdb</b>

- <b>an upstream build</b> please add comment: <b>Jenkins run upstream</b>

- for <b>quarkus branch checks</b>  
  Run checks against Quarkus current used branch  
  Please add comment: <b>Jenkins run quarkus-branch</b>

- for a <b>quarkus branch specific check</b>  
  Run checks against Quarkus current used branch  
  Please add comment: <b>Jenkins (re)run [drools|kogito-runtimes|kogito-apps|kogito-examples] quarkus-branch</b>

- for <b>quarkus main checks</b>  
  Run checks against Quarkus main branch  
  Please add comment: <b>Jenkins run quarkus-main</b>

- for a <b>specific quarkus main check</b>  
  Run checks against Quarkus main branch  
  Please add comment: <b>Jenkins (re)run [drools|kogito-runtimes|kogito-apps|kogito-examples] quarkus-branch</b>

- for <b>native checks</b>  
  Run native checks  
  Please add comment: <b>Jenkins run native</b>

- for a <b>specific native check</b>  
  Run native checks 
  Please add comment: <b>Jenkins (re)run [drools|kogito-runtimes|kogito-apps|kogito-examples] native</b>

- for <b>mandrel checks</b>  
  Run native checks against Mandrel image
  Please add comment: <b>Jenkins run mandrel</b>

- for a <b>specific mandrel check</b>  
  Run native checks against Mandrel image  
  Please add comment: <b>Jenkins (re)run [drools|kogito-runtimes|kogito-apps|kogito-examples] mandrel</b>
</details>
