### PR TITLE
[DROOLS-7038] Fix invoker properties

### DIFF
--- a/kie-maven-plugin/src/it/kie-maven-plugin-test-kjar-10-default/invoker.properties
+++ b/kie-maven-plugin/src/it/kie-maven-plugin-test-kjar-10-default/invoker.properties
@@ -1,6 +1,7 @@
 # A comma or space separated list of goals/phases to execute, may
 # specify an empty list to execute the default goal of the IT project.
 # Environment variables used by maven plugins can be added here
-invoker.goals = clean verify
+invoker.goals = clean install
+
 # Uncomment the following to debug invoker. Do note that you have to connect the remote debugger after "maven-invoker-plugin:3.2.0:run" has been print on console
 #invoker.mavenOpts=-Xdebug -Xnoagent -Xrunjdwp:transport=dt_socket,server=y,suspend=y,address=8000

--- a/kie-maven-plugin/src/it/kie-maven-plugin-test-kjar-10-default/invoker.properties
+++ b/kie-maven-plugin/src/it/kie-maven-plugin-test-kjar-10-default/invoker.properties
@@ -1,6 +1,6 @@
 # A comma or space separated list of goals/phases to execute, may
 # specify an empty list to execute the default goal of the IT project.
 # Environment variables used by maven plugins can be added here
-invoker.goals = clean install
+invoker.goals = clean verify
 # Uncomment the following to debug invoker. Do note that you have to connect the remote debugger after "maven-invoker-plugin:3.2.0:run" has been print on console
 #invoker.mavenOpts=-Xdebug -Xnoagent -Xrunjdwp:transport=dt_socket,server=y,suspend=y,address=8000

--- a/kie-maven-plugin/src/it/kie-maven-plugin-test-kjar-10-default/invoker.properties
+++ b/kie-maven-plugin/src/it/kie-maven-plugin-test-kjar-10-default/invoker.properties
@@ -1,6 +1,6 @@
 # A comma or space separated list of goals/phases to execute, may
 # specify an empty list to execute the default goal of the IT project.
 # Environment variables used by maven plugins can be added here
-invoker.goals = clean package verify
+invoker.goals = clean install
 # Uncomment the following to debug invoker. Do note that you have to connect the remote debugger after "maven-invoker-plugin:3.2.0:run" has been print on console
 #invoker.mavenOpts=-Xdebug -Xnoagent -Xrunjdwp:transport=dt_socket,server=y,suspend=y,address=8000

--- a/kie-maven-plugin/src/it/kie-maven-plugin-test-kjar-10-yes-generate/invoker.properties
+++ b/kie-maven-plugin/src/it/kie-maven-plugin-test-kjar-10-yes-generate/invoker.properties
@@ -1,6 +1,7 @@
 # A comma or space separated list of goals/phases to execute, may
 # specify an empty list to execute the default goal of the IT project.
 # Environment variables used by maven plugins can be added here
-invoker.goals = clean verify
+invoker.goals = clean install
+
 # Uncomment the following to debug invoker. Do note that you have to connect the remote debugger after "maven-invoker-plugin:3.2.0:run" has been print on console
 #invoker.mavenOpts=-Xdebug -Xnoagent -Xrunjdwp:transport=dt_socket,server=y,suspend=y,address=8000

--- a/kie-maven-plugin/src/it/kie-maven-plugin-test-kjar-10-yes-generate/invoker.properties
+++ b/kie-maven-plugin/src/it/kie-maven-plugin-test-kjar-10-yes-generate/invoker.properties
@@ -1,6 +1,6 @@
 # A comma or space separated list of goals/phases to execute, may
 # specify an empty list to execute the default goal of the IT project.
 # Environment variables used by maven plugins can be added here
-invoker.goals = clean install
+invoker.goals = clean verify
 # Uncomment the following to debug invoker. Do note that you have to connect the remote debugger after "maven-invoker-plugin:3.2.0:run" has been print on console
 #invoker.mavenOpts=-Xdebug -Xnoagent -Xrunjdwp:transport=dt_socket,server=y,suspend=y,address=8000

--- a/kie-maven-plugin/src/it/kie-maven-plugin-test-kjar-10-yes-generate/invoker.properties
+++ b/kie-maven-plugin/src/it/kie-maven-plugin-test-kjar-10-yes-generate/invoker.properties
@@ -1,6 +1,6 @@
 # A comma or space separated list of goals/phases to execute, may
 # specify an empty list to execute the default goal of the IT project.
 # Environment variables used by maven plugins can be added here
-invoker.goals = clean package verify
+invoker.goals = clean install
 # Uncomment the following to debug invoker. Do note that you have to connect the remote debugger after "maven-invoker-plugin:3.2.0:run" has been print on console
 #invoker.mavenOpts=-Xdebug -Xnoagent -Xrunjdwp:transport=dt_socket,server=y,suspend=y,address=8000

--- a/kie-maven-plugin/src/it/kie-maven-plugin-test-kjar-11-default/invoker.properties
+++ b/kie-maven-plugin/src/it/kie-maven-plugin-test-kjar-11-default/invoker.properties
@@ -1,6 +1,7 @@
 # A comma or space separated list of goals/phases to execute, may
 # specify an empty list to execute the default goal of the IT project.
 # Environment variables used by maven plugins can be added here
-invoker.goals = clean verify
+invoker.goals = clean install
+
 # Uncomment the following to debug invoker. Do note that you have to connect the remote debugger after "maven-invoker-plugin:3.2.0:run" has been print on console
 #invoker.mavenOpts=-Xdebug -Xnoagent -Xrunjdwp:transport=dt_socket,server=y,suspend=y,address=8000

--- a/kie-maven-plugin/src/it/kie-maven-plugin-test-kjar-11-default/invoker.properties
+++ b/kie-maven-plugin/src/it/kie-maven-plugin-test-kjar-11-default/invoker.properties
@@ -1,6 +1,6 @@
 # A comma or space separated list of goals/phases to execute, may
 # specify an empty list to execute the default goal of the IT project.
 # Environment variables used by maven plugins can be added here
-invoker.goals = clean install
+invoker.goals = clean verify
 # Uncomment the following to debug invoker. Do note that you have to connect the remote debugger after "maven-invoker-plugin:3.2.0:run" has been print on console
 #invoker.mavenOpts=-Xdebug -Xnoagent -Xrunjdwp:transport=dt_socket,server=y,suspend=y,address=8000

--- a/kie-maven-plugin/src/it/kie-maven-plugin-test-kjar-11-default/invoker.properties
+++ b/kie-maven-plugin/src/it/kie-maven-plugin-test-kjar-11-default/invoker.properties
@@ -1,6 +1,6 @@
 # A comma or space separated list of goals/phases to execute, may
 # specify an empty list to execute the default goal of the IT project.
 # Environment variables used by maven plugins can be added here
-invoker.goals = clean package verify
+invoker.goals = clean install
 # Uncomment the following to debug invoker. Do note that you have to connect the remote debugger after "maven-invoker-plugin:3.2.0:run" has been print on console
 #invoker.mavenOpts=-Xdebug -Xnoagent -Xrunjdwp:transport=dt_socket,server=y,suspend=y,address=8000

--- a/kie-maven-plugin/src/it/kie-maven-plugin-test-kjar-11-yes-generate/invoker.properties
+++ b/kie-maven-plugin/src/it/kie-maven-plugin-test-kjar-11-yes-generate/invoker.properties
@@ -1,6 +1,7 @@
 # A comma or space separated list of goals/phases to execute, may
 # specify an empty list to execute the default goal of the IT project.
 # Environment variables used by maven plugins can be added here
-invoker.goals = clean verify
+invoker.goals = clean install
+
 # Uncomment the following to debug invoker. Do note that you have to connect the remote debugger after "maven-invoker-plugin:3.2.0:run" has been print on console
 #invoker.mavenOpts=-Xdebug -Xnoagent -Xrunjdwp:transport=dt_socket,server=y,suspend=y,address=8000

--- a/kie-maven-plugin/src/it/kie-maven-plugin-test-kjar-11-yes-generate/invoker.properties
+++ b/kie-maven-plugin/src/it/kie-maven-plugin-test-kjar-11-yes-generate/invoker.properties
@@ -1,6 +1,6 @@
 # A comma or space separated list of goals/phases to execute, may
 # specify an empty list to execute the default goal of the IT project.
 # Environment variables used by maven plugins can be added here
-invoker.goals = clean install
+invoker.goals = clean verify
 # Uncomment the following to debug invoker. Do note that you have to connect the remote debugger after "maven-invoker-plugin:3.2.0:run" has been print on console
 #invoker.mavenOpts=-Xdebug -Xnoagent -Xrunjdwp:transport=dt_socket,server=y,suspend=y,address=8000

--- a/kie-maven-plugin/src/it/kie-maven-plugin-test-kjar-11-yes-generate/invoker.properties
+++ b/kie-maven-plugin/src/it/kie-maven-plugin-test-kjar-11-yes-generate/invoker.properties
@@ -1,6 +1,6 @@
 # A comma or space separated list of goals/phases to execute, may
 # specify an empty list to execute the default goal of the IT project.
 # Environment variables used by maven plugins can be added here
-invoker.goals = clean package verify
+invoker.goals = clean install
 # Uncomment the following to debug invoker. Do note that you have to connect the remote debugger after "maven-invoker-plugin:3.2.0:run" has been print on console
 #invoker.mavenOpts=-Xdebug -Xnoagent -Xrunjdwp:transport=dt_socket,server=y,suspend=y,address=8000

--- a/kie-maven-plugin/src/it/kie-maven-plugin-test-kjar-12/invoker.properties
+++ b/kie-maven-plugin/src/it/kie-maven-plugin-test-kjar-12/invoker.properties
@@ -1,6 +1,7 @@
 # A comma or space separated list of goals/phases to execute, may
 # specify an empty list to execute the default goal of the IT project.
 # Environment variables used by maven plugins can be added here
-invoker.goals = clean verify
+invoker.goals = clean install
+
 # Uncomment the following to debug invoker. Do note that you have to connect the remote debugger after "maven-invoker-plugin:3.2.0:run" has been print on console
 #invoker.mavenOpts=-Xdebug -Xnoagent -Xrunjdwp:transport=dt_socket,server=y,suspend=y,address=8000

--- a/kie-maven-plugin/src/it/kie-maven-plugin-test-kjar-12/invoker.properties
+++ b/kie-maven-plugin/src/it/kie-maven-plugin-test-kjar-12/invoker.properties
@@ -1,6 +1,6 @@
 # A comma or space separated list of goals/phases to execute, may
 # specify an empty list to execute the default goal of the IT project.
 # Environment variables used by maven plugins can be added here
-invoker.goals = clean install
+invoker.goals = clean verify
 # Uncomment the following to debug invoker. Do note that you have to connect the remote debugger after "maven-invoker-plugin:3.2.0:run" has been print on console
 #invoker.mavenOpts=-Xdebug -Xnoagent -Xrunjdwp:transport=dt_socket,server=y,suspend=y,address=8000

--- a/kie-maven-plugin/src/it/kie-maven-plugin-test-kjar-12/invoker.properties
+++ b/kie-maven-plugin/src/it/kie-maven-plugin-test-kjar-12/invoker.properties
@@ -1,6 +1,6 @@
 # A comma or space separated list of goals/phases to execute, may
 # specify an empty list to execute the default goal of the IT project.
 # Environment variables used by maven plugins can be added here
-invoker.goals = clean package verify
+invoker.goals = clean install
 # Uncomment the following to debug invoker. Do note that you have to connect the remote debugger after "maven-invoker-plugin:3.2.0:run" has been print on console
 #invoker.mavenOpts=-Xdebug -Xnoagent -Xrunjdwp:transport=dt_socket,server=y,suspend=y,address=8000

--- a/kie-maven-plugin/src/it/kie-maven-plugin-test-kjar-13/invoker.properties
+++ b/kie-maven-plugin/src/it/kie-maven-plugin-test-kjar-13/invoker.properties
@@ -1,6 +1,7 @@
 # A comma or space separated list of goals/phases to execute, may
 # specify an empty list to execute the default goal of the IT project.
 # Environment variables used by maven plugins can be added here
-invoker.goals = clean verify
+invoker.goals = clean install
+
 # Uncomment the following to debug invoker. Do note that you have to connect the remote debugger after "maven-invoker-plugin:3.2.0:run" has been print on console
 #invoker.mavenOpts=-Xdebug -Xnoagent -Xrunjdwp:transport=dt_socket,server=y,suspend=y,address=8000

--- a/kie-maven-plugin/src/it/kie-maven-plugin-test-kjar-13/invoker.properties
+++ b/kie-maven-plugin/src/it/kie-maven-plugin-test-kjar-13/invoker.properties
@@ -1,6 +1,6 @@
 # A comma or space separated list of goals/phases to execute, may
 # specify an empty list to execute the default goal of the IT project.
 # Environment variables used by maven plugins can be added here
-invoker.goals = clean install
+invoker.goals = clean verify
 # Uncomment the following to debug invoker. Do note that you have to connect the remote debugger after "maven-invoker-plugin:3.2.0:run" has been print on console
 #invoker.mavenOpts=-Xdebug -Xnoagent -Xrunjdwp:transport=dt_socket,server=y,suspend=y,address=8000

--- a/kie-maven-plugin/src/it/kie-maven-plugin-test-kjar-13/invoker.properties
+++ b/kie-maven-plugin/src/it/kie-maven-plugin-test-kjar-13/invoker.properties
@@ -1,6 +1,6 @@
 # A comma or space separated list of goals/phases to execute, may
 # specify an empty list to execute the default goal of the IT project.
 # Environment variables used by maven plugins can be added here
-invoker.goals = clean package verify
+invoker.goals = clean install
 # Uncomment the following to debug invoker. Do note that you have to connect the remote debugger after "maven-invoker-plugin:3.2.0:run" has been print on console
 #invoker.mavenOpts=-Xdebug -Xnoagent -Xrunjdwp:transport=dt_socket,server=y,suspend=y,address=8000

--- a/kie-maven-plugin/src/it/kie-maven-plugin-test-kjar-14-ruleunits/invoker.properties
+++ b/kie-maven-plugin/src/it/kie-maven-plugin-test-kjar-14-ruleunits/invoker.properties
@@ -1,6 +1,7 @@
 # A comma or space separated list of goals/phases to execute, may
 # specify an empty list to execute the default goal of the IT project.
 # Environment variables used by maven plugins can be added here
-invoker.goals = clean verify
+invoker.goals = clean install
+
 # Uncomment the following to debug invoker. Do note that you have to connect the remote debugger after "maven-invoker-plugin:3.2.0:run" has been print on console
 #invoker.mavenOpts=-Xdebug -Xnoagent -Xrunjdwp:transport=dt_socket,server=y,suspend=y,address=8000

--- a/kie-maven-plugin/src/it/kie-maven-plugin-test-kjar-14-ruleunits/invoker.properties
+++ b/kie-maven-plugin/src/it/kie-maven-plugin-test-kjar-14-ruleunits/invoker.properties
@@ -1,6 +1,6 @@
 # A comma or space separated list of goals/phases to execute, may
 # specify an empty list to execute the default goal of the IT project.
 # Environment variables used by maven plugins can be added here
-invoker.goals = clean install
+invoker.goals = clean verify
 # Uncomment the following to debug invoker. Do note that you have to connect the remote debugger after "maven-invoker-plugin:3.2.0:run" has been print on console
 #invoker.mavenOpts=-Xdebug -Xnoagent -Xrunjdwp:transport=dt_socket,server=y,suspend=y,address=8000

--- a/kie-maven-plugin/src/it/kie-maven-plugin-test-kjar-14-ruleunits/invoker.properties
+++ b/kie-maven-plugin/src/it/kie-maven-plugin-test-kjar-14-ruleunits/invoker.properties
@@ -1,6 +1,6 @@
 # A comma or space separated list of goals/phases to execute, may
 # specify an empty list to execute the default goal of the IT project.
 # Environment variables used by maven plugins can be added here
-invoker.goals = clean package verify
+invoker.goals = clean install
 # Uncomment the following to debug invoker. Do note that you have to connect the remote debugger after "maven-invoker-plugin:3.2.0:run" has been print on console
 #invoker.mavenOpts=-Xdebug -Xnoagent -Xrunjdwp:transport=dt_socket,server=y,suspend=y,address=8000

--- a/kie-maven-plugin/src/it/kie-maven-plugin-test-kjar-2/invoker.properties
+++ b/kie-maven-plugin/src/it/kie-maven-plugin-test-kjar-2/invoker.properties
@@ -1,6 +1,7 @@
 # A comma or space separated list of goals/phases to execute, may
 # specify an empty list to execute the default goal of the IT project.
 # Environment variables used by maven plugins can be added here
-invoker.goals = clean verify
+invoker.goals = clean install
+
 # Uncomment the following to debug invoker. Do note that you have to connect the remote debugger after "maven-invoker-plugin:3.2.0:run" has been print on console
 #invoker.mavenOpts=-Xdebug -Xnoagent -Xrunjdwp:transport=dt_socket,server=y,suspend=y,address=8000

--- a/kie-maven-plugin/src/it/kie-maven-plugin-test-kjar-2/invoker.properties
+++ b/kie-maven-plugin/src/it/kie-maven-plugin-test-kjar-2/invoker.properties
@@ -1,6 +1,6 @@
 # A comma or space separated list of goals/phases to execute, may
 # specify an empty list to execute the default goal of the IT project.
 # Environment variables used by maven plugins can be added here
-invoker.goals = clean install
+invoker.goals = clean verify
 # Uncomment the following to debug invoker. Do note that you have to connect the remote debugger after "maven-invoker-plugin:3.2.0:run" has been print on console
 #invoker.mavenOpts=-Xdebug -Xnoagent -Xrunjdwp:transport=dt_socket,server=y,suspend=y,address=8000

--- a/kie-maven-plugin/src/it/kie-maven-plugin-test-kjar-2/invoker.properties
+++ b/kie-maven-plugin/src/it/kie-maven-plugin-test-kjar-2/invoker.properties
@@ -1,6 +1,6 @@
 # A comma or space separated list of goals/phases to execute, may
 # specify an empty list to execute the default goal of the IT project.
 # Environment variables used by maven plugins can be added here
-invoker.goals = clean package verify
+invoker.goals = clean install
 # Uncomment the following to debug invoker. Do note that you have to connect the remote debugger after "maven-invoker-plugin:3.2.0:run" has been print on console
 #invoker.mavenOpts=-Xdebug -Xnoagent -Xrunjdwp:transport=dt_socket,server=y,suspend=y,address=8000

--- a/kie-maven-plugin/src/it/kie-maven-plugin-test-kjar-3/invoker.properties
+++ b/kie-maven-plugin/src/it/kie-maven-plugin-test-kjar-3/invoker.properties
@@ -1,6 +1,7 @@
 # A comma or space separated list of goals/phases to execute, may
 # specify an empty list to execute the default goal of the IT project.
 # Environment variables used by maven plugins can be added here
-invoker.goals = clean verify
+invoker.goals = clean install
+
 # Uncomment the following to debug invoker. Do note that you have to connect the remote debugger after "maven-invoker-plugin:3.2.0:run" has been print on console
 #invoker.mavenOpts=-Xdebug -Xnoagent -Xrunjdwp:transport=dt_socket,server=y,suspend=y,address=8000

--- a/kie-maven-plugin/src/it/kie-maven-plugin-test-kjar-3/invoker.properties
+++ b/kie-maven-plugin/src/it/kie-maven-plugin-test-kjar-3/invoker.properties
@@ -1,6 +1,6 @@
 # A comma or space separated list of goals/phases to execute, may
 # specify an empty list to execute the default goal of the IT project.
 # Environment variables used by maven plugins can be added here
-invoker.goals = clean install
+invoker.goals = clean verify
 # Uncomment the following to debug invoker. Do note that you have to connect the remote debugger after "maven-invoker-plugin:3.2.0:run" has been print on console
 #invoker.mavenOpts=-Xdebug -Xnoagent -Xrunjdwp:transport=dt_socket,server=y,suspend=y,address=8000

--- a/kie-maven-plugin/src/it/kie-maven-plugin-test-kjar-3/invoker.properties
+++ b/kie-maven-plugin/src/it/kie-maven-plugin-test-kjar-3/invoker.properties
@@ -1,6 +1,6 @@
 # A comma or space separated list of goals/phases to execute, may
 # specify an empty list to execute the default goal of the IT project.
 # Environment variables used by maven plugins can be added here
-invoker.goals = clean package verify
+invoker.goals = clean install
 # Uncomment the following to debug invoker. Do note that you have to connect the remote debugger after "maven-invoker-plugin:3.2.0:run" has been print on console
 #invoker.mavenOpts=-Xdebug -Xnoagent -Xrunjdwp:transport=dt_socket,server=y,suspend=y,address=8000

--- a/kie-maven-plugin/src/it/kie-maven-plugin-test-kjar-7-exec-model/invoker.properties
+++ b/kie-maven-plugin/src/it/kie-maven-plugin-test-kjar-7-exec-model/invoker.properties
@@ -1,6 +1,7 @@
 # A comma or space separated list of goals/phases to execute, may
 # specify an empty list to execute the default goal of the IT project.
 # Environment variables used by maven plugins can be added here
-invoker.goals = clean verify
+invoker.goals = clean install
+
 # Uncomment the following to debug invoker. Do note that you have to connect the remote debugger after "maven-invoker-plugin:3.2.0:run" has been print on console
 #invoker.mavenOpts=-Xdebug -Xnoagent -Xrunjdwp:transport=dt_socket,server=y,suspend=y,address=8000

--- a/kie-maven-plugin/src/it/kie-maven-plugin-test-kjar-7-exec-model/invoker.properties
+++ b/kie-maven-plugin/src/it/kie-maven-plugin-test-kjar-7-exec-model/invoker.properties
@@ -1,6 +1,6 @@
 # A comma or space separated list of goals/phases to execute, may
 # specify an empty list to execute the default goal of the IT project.
 # Environment variables used by maven plugins can be added here
-invoker.goals = clean install
+invoker.goals = clean verify
 # Uncomment the following to debug invoker. Do note that you have to connect the remote debugger after "maven-invoker-plugin:3.2.0:run" has been print on console
 #invoker.mavenOpts=-Xdebug -Xnoagent -Xrunjdwp:transport=dt_socket,server=y,suspend=y,address=8000

--- a/kie-maven-plugin/src/it/kie-maven-plugin-test-kjar-7-exec-model/invoker.properties
+++ b/kie-maven-plugin/src/it/kie-maven-plugin-test-kjar-7-exec-model/invoker.properties
@@ -1,6 +1,6 @@
 # A comma or space separated list of goals/phases to execute, may
 # specify an empty list to execute the default goal of the IT project.
 # Environment variables used by maven plugins can be added here
-invoker.goals = clean package verify
+invoker.goals = clean install
 # Uncomment the following to debug invoker. Do note that you have to connect the remote debugger after "maven-invoker-plugin:3.2.0:run" has been print on console
 #invoker.mavenOpts=-Xdebug -Xnoagent -Xrunjdwp:transport=dt_socket,server=y,suspend=y,address=8000

--- a/kie-maven-plugin/src/it/kie-maven-plugin-test-kjar-7-no-exec-model/invoker.properties
+++ b/kie-maven-plugin/src/it/kie-maven-plugin-test-kjar-7-no-exec-model/invoker.properties
@@ -1,6 +1,7 @@
 # A comma or space separated list of goals/phases to execute, may
 # specify an empty list to execute the default goal of the IT project.
 # Environment variables used by maven plugins can be added here
-invoker.goals = clean verify
+invoker.goals = clean install
+
 # Uncomment the following to debug invoker. Do note that you have to connect the remote debugger after "maven-invoker-plugin:3.2.0:run" has been print on console
 #invoker.mavenOpts=-Xdebug -Xnoagent -Xrunjdwp:transport=dt_socket,server=y,suspend=y,address=8000

--- a/kie-maven-plugin/src/it/kie-maven-plugin-test-kjar-7-no-exec-model/invoker.properties
+++ b/kie-maven-plugin/src/it/kie-maven-plugin-test-kjar-7-no-exec-model/invoker.properties
@@ -1,6 +1,6 @@
 # A comma or space separated list of goals/phases to execute, may
 # specify an empty list to execute the default goal of the IT project.
 # Environment variables used by maven plugins can be added here
-invoker.goals = clean install
+invoker.goals = clean verify
 # Uncomment the following to debug invoker. Do note that you have to connect the remote debugger after "maven-invoker-plugin:3.2.0:run" has been print on console
 #invoker.mavenOpts=-Xdebug -Xnoagent -Xrunjdwp:transport=dt_socket,server=y,suspend=y,address=8000

--- a/kie-maven-plugin/src/it/kie-maven-plugin-test-kjar-7-no-exec-model/invoker.properties
+++ b/kie-maven-plugin/src/it/kie-maven-plugin-test-kjar-7-no-exec-model/invoker.properties
@@ -1,6 +1,6 @@
 # A comma or space separated list of goals/phases to execute, may
 # specify an empty list to execute the default goal of the IT project.
 # Environment variables used by maven plugins can be added here
-invoker.goals = clean package verify
+invoker.goals = clean install
 # Uncomment the following to debug invoker. Do note that you have to connect the remote debugger after "maven-invoker-plugin:3.2.0:run" has been print on console
 #invoker.mavenOpts=-Xdebug -Xnoagent -Xrunjdwp:transport=dt_socket,server=y,suspend=y,address=8000

--- a/kie-maven-plugin/src/it/kie-maven-plugin-test-kjar-8-exec-model/invoker.properties
+++ b/kie-maven-plugin/src/it/kie-maven-plugin-test-kjar-8-exec-model/invoker.properties
@@ -1,6 +1,7 @@
 # A comma or space separated list of goals/phases to execute, may
 # specify an empty list to execute the default goal of the IT project.
 # Environment variables used by maven plugins can be added here
-invoker.goals = clean verify
+invoker.goals = clean install
+
 # Uncomment the following to debug invoker. Do note that you have to connect the remote debugger after "maven-invoker-plugin:3.2.0:run" has been print on console
 #invoker.mavenOpts=-Xdebug -Xnoagent -Xrunjdwp:transport=dt_socket,server=y,suspend=y,address=8000

--- a/kie-maven-plugin/src/it/kie-maven-plugin-test-kjar-8-exec-model/invoker.properties
+++ b/kie-maven-plugin/src/it/kie-maven-plugin-test-kjar-8-exec-model/invoker.properties
@@ -1,6 +1,6 @@
 # A comma or space separated list of goals/phases to execute, may
 # specify an empty list to execute the default goal of the IT project.
 # Environment variables used by maven plugins can be added here
-invoker.goals = clean install
+invoker.goals = clean verify
 # Uncomment the following to debug invoker. Do note that you have to connect the remote debugger after "maven-invoker-plugin:3.2.0:run" has been print on console
 #invoker.mavenOpts=-Xdebug -Xnoagent -Xrunjdwp:transport=dt_socket,server=y,suspend=y,address=8000

--- a/kie-maven-plugin/src/it/kie-maven-plugin-test-kjar-8-exec-model/invoker.properties
+++ b/kie-maven-plugin/src/it/kie-maven-plugin-test-kjar-8-exec-model/invoker.properties
@@ -1,6 +1,6 @@
 # A comma or space separated list of goals/phases to execute, may
 # specify an empty list to execute the default goal of the IT project.
 # Environment variables used by maven plugins can be added here
-invoker.goals = clean package verify
+invoker.goals = clean install
 # Uncomment the following to debug invoker. Do note that you have to connect the remote debugger after "maven-invoker-plugin:3.2.0:run" has been print on console
 #invoker.mavenOpts=-Xdebug -Xnoagent -Xrunjdwp:transport=dt_socket,server=y,suspend=y,address=8000

--- a/kie-maven-plugin/src/it/kie-maven-plugin-test-kjar-8-no-exec-model/invoker.properties
+++ b/kie-maven-plugin/src/it/kie-maven-plugin-test-kjar-8-no-exec-model/invoker.properties
@@ -1,6 +1,7 @@
 # A comma or space separated list of goals/phases to execute, may
 # specify an empty list to execute the default goal of the IT project.
 # Environment variables used by maven plugins can be added here
-invoker.goals = clean verify
+invoker.goals = clean install
+
 # Uncomment the following to debug invoker. Do note that you have to connect the remote debugger after "maven-invoker-plugin:3.2.0:run" has been print on console
 #invoker.mavenOpts=-Xdebug -Xnoagent -Xrunjdwp:transport=dt_socket,server=y,suspend=y,address=8000

--- a/kie-maven-plugin/src/it/kie-maven-plugin-test-kjar-8-no-exec-model/invoker.properties
+++ b/kie-maven-plugin/src/it/kie-maven-plugin-test-kjar-8-no-exec-model/invoker.properties
@@ -1,6 +1,6 @@
 # A comma or space separated list of goals/phases to execute, may
 # specify an empty list to execute the default goal of the IT project.
 # Environment variables used by maven plugins can be added here
-invoker.goals = clean install
+invoker.goals = clean verify
 # Uncomment the following to debug invoker. Do note that you have to connect the remote debugger after "maven-invoker-plugin:3.2.0:run" has been print on console
 #invoker.mavenOpts=-Xdebug -Xnoagent -Xrunjdwp:transport=dt_socket,server=y,suspend=y,address=8000

--- a/kie-maven-plugin/src/it/kie-maven-plugin-test-kjar-8-no-exec-model/invoker.properties
+++ b/kie-maven-plugin/src/it/kie-maven-plugin-test-kjar-8-no-exec-model/invoker.properties
@@ -1,6 +1,6 @@
 # A comma or space separated list of goals/phases to execute, may
 # specify an empty list to execute the default goal of the IT project.
 # Environment variables used by maven plugins can be added here
-invoker.goals = clean package verify
+invoker.goals = clean install
 # Uncomment the following to debug invoker. Do note that you have to connect the remote debugger after "maven-invoker-plugin:3.2.0:run" has been print on console
 #invoker.mavenOpts=-Xdebug -Xnoagent -Xrunjdwp:transport=dt_socket,server=y,suspend=y,address=8000

--- a/kie-maven-plugin/src/it/kie-maven-plugin-test-kjar-9-exec-model/invoker.properties
+++ b/kie-maven-plugin/src/it/kie-maven-plugin-test-kjar-9-exec-model/invoker.properties
@@ -1,6 +1,7 @@
 # A comma or space separated list of goals/phases to execute, may
 # specify an empty list to execute the default goal of the IT project.
 # Environment variables used by maven plugins can be added here
-invoker.goals = clean verify
+invoker.goals = clean install
+
 # Uncomment the following to debug invoker. Do note that you have to connect the remote debugger after "maven-invoker-plugin:3.2.0:run" has been print on console
 #invoker.mavenOpts=-Xdebug -Xnoagent -Xrunjdwp:transport=dt_socket,server=y,suspend=y,address=8000

--- a/kie-maven-plugin/src/it/kie-maven-plugin-test-kjar-9-exec-model/invoker.properties
+++ b/kie-maven-plugin/src/it/kie-maven-plugin-test-kjar-9-exec-model/invoker.properties
@@ -1,6 +1,6 @@
 # A comma or space separated list of goals/phases to execute, may
 # specify an empty list to execute the default goal of the IT project.
 # Environment variables used by maven plugins can be added here
-invoker.goals = clean install
+invoker.goals = clean verify
 # Uncomment the following to debug invoker. Do note that you have to connect the remote debugger after "maven-invoker-plugin:3.2.0:run" has been print on console
 #invoker.mavenOpts=-Xdebug -Xnoagent -Xrunjdwp:transport=dt_socket,server=y,suspend=y,address=8000

--- a/kie-maven-plugin/src/it/kie-maven-plugin-test-kjar-9-exec-model/invoker.properties
+++ b/kie-maven-plugin/src/it/kie-maven-plugin-test-kjar-9-exec-model/invoker.properties
@@ -1,6 +1,6 @@
 # A comma or space separated list of goals/phases to execute, may
 # specify an empty list to execute the default goal of the IT project.
 # Environment variables used by maven plugins can be added here
-invoker.goals = clean package verify
+invoker.goals = clean install
 # Uncomment the following to debug invoker. Do note that you have to connect the remote debugger after "maven-invoker-plugin:3.2.0:run" has been print on console
 #invoker.mavenOpts=-Xdebug -Xnoagent -Xrunjdwp:transport=dt_socket,server=y,suspend=y,address=8000

--- a/kie-maven-plugin/src/it/kie-maven-plugin-test-kjar-9-no-exec-model/invoker.properties
+++ b/kie-maven-plugin/src/it/kie-maven-plugin-test-kjar-9-no-exec-model/invoker.properties
@@ -1,6 +1,7 @@
 # A comma or space separated list of goals/phases to execute, may
 # specify an empty list to execute the default goal of the IT project.
 # Environment variables used by maven plugins can be added here
-invoker.goals = clean verify
+invoker.goals = clean install
+
 # Uncomment the following to debug invoker. Do note that you have to connect the remote debugger after "maven-invoker-plugin:3.2.0:run" has been print on console
 #invoker.mavenOpts=-Xdebug -Xnoagent -Xrunjdwp:transport=dt_socket,server=y,suspend=y,address=8000

--- a/kie-maven-plugin/src/it/kie-maven-plugin-test-kjar-9-no-exec-model/invoker.properties
+++ b/kie-maven-plugin/src/it/kie-maven-plugin-test-kjar-9-no-exec-model/invoker.properties
@@ -1,6 +1,6 @@
 # A comma or space separated list of goals/phases to execute, may
 # specify an empty list to execute the default goal of the IT project.
 # Environment variables used by maven plugins can be added here
-invoker.goals = clean install
+invoker.goals = clean verify
 # Uncomment the following to debug invoker. Do note that you have to connect the remote debugger after "maven-invoker-plugin:3.2.0:run" has been print on console
 #invoker.mavenOpts=-Xdebug -Xnoagent -Xrunjdwp:transport=dt_socket,server=y,suspend=y,address=8000

--- a/kie-maven-plugin/src/it/kie-maven-plugin-test-kjar-9-no-exec-model/invoker.properties
+++ b/kie-maven-plugin/src/it/kie-maven-plugin-test-kjar-9-no-exec-model/invoker.properties
@@ -1,6 +1,6 @@
 # A comma or space separated list of goals/phases to execute, may
 # specify an empty list to execute the default goal of the IT project.
 # Environment variables used by maven plugins can be added here
-invoker.goals = clean package verify
+invoker.goals = clean install
 # Uncomment the following to debug invoker. Do note that you have to connect the remote debugger after "maven-invoker-plugin:3.2.0:run" has been print on console
 #invoker.mavenOpts=-Xdebug -Xnoagent -Xrunjdwp:transport=dt_socket,server=y,suspend=y,address=8000

--- a/kie-maven-plugin/src/it/kie-maven-plugin-test-kjar-setup/invoker.properties
+++ b/kie-maven-plugin/src/it/kie-maven-plugin-test-kjar-setup/invoker.properties
@@ -1,6 +1,7 @@
 # A comma or space separated list of goals/phases to execute, may
 # specify an empty list to execute the default goal of the IT project.
 # Environment variables used by maven plugins can be added here
-invoker.goals = clean verify
+invoker.goals = clean install
+
 # Uncomment the following to debug invoker. Do note that you have to connect the remote debugger after "maven-invoker-plugin:3.2.0:run" has been print on console
 #invoker.mavenOpts=-Xdebug -Xnoagent -Xrunjdwp:transport=dt_socket,server=y,suspend=y,address=8000

--- a/kie-maven-plugin/src/it/kie-maven-plugin-test-kjar-setup/invoker.properties
+++ b/kie-maven-plugin/src/it/kie-maven-plugin-test-kjar-setup/invoker.properties
@@ -1,6 +1,6 @@
 # A comma or space separated list of goals/phases to execute, may
 # specify an empty list to execute the default goal of the IT project.
 # Environment variables used by maven plugins can be added here
-invoker.goals = clean install
+invoker.goals = clean verify
 # Uncomment the following to debug invoker. Do note that you have to connect the remote debugger after "maven-invoker-plugin:3.2.0:run" has been print on console
 #invoker.mavenOpts=-Xdebug -Xnoagent -Xrunjdwp:transport=dt_socket,server=y,suspend=y,address=8000

--- a/kie-maven-plugin/src/it/kie-maven-plugin-test-kjar-setup/kie-maven-plugin-test-kjar-common/invoker.properties
+++ b/kie-maven-plugin/src/it/kie-maven-plugin-test-kjar-setup/kie-maven-plugin-test-kjar-common/invoker.properties
@@ -1,6 +1,7 @@
 # A comma or space separated list of goals/phases to execute, may
 # specify an empty list to execute the default goal of the IT project.
 # Environment variables used by maven plugins can be added here
-invoker.goals = clean verify
+invoker.goals = clean install
+
 # Uncomment the following to debug invoker. Do note that you have to connect the remote debugger after "maven-invoker-plugin:3.2.0:run" has been print on console
 #invoker.mavenOpts=-Xdebug -Xnoagent -Xrunjdwp:transport=dt_socket,server=y,suspend=y,address=8000

--- a/kie-maven-plugin/src/it/kie-maven-plugin-test-kjar-setup/kie-maven-plugin-test-kjar-common/invoker.properties
+++ b/kie-maven-plugin/src/it/kie-maven-plugin-test-kjar-setup/kie-maven-plugin-test-kjar-common/invoker.properties
@@ -1,6 +1,6 @@
 # A comma or space separated list of goals/phases to execute, may
 # specify an empty list to execute the default goal of the IT project.
 # Environment variables used by maven plugins can be added here
-invoker.goals = clean install
+invoker.goals = clean verify
 # Uncomment the following to debug invoker. Do note that you have to connect the remote debugger after "maven-invoker-plugin:3.2.0:run" has been print on console
 #invoker.mavenOpts=-Xdebug -Xnoagent -Xrunjdwp:transport=dt_socket,server=y,suspend=y,address=8000

--- a/kie-maven-plugin/src/it/kie-maven-plugin-test-kjar-setup/kie-maven-plugin-test-kjar-parent/invoker.properties
+++ b/kie-maven-plugin/src/it/kie-maven-plugin-test-kjar-setup/kie-maven-plugin-test-kjar-parent/invoker.properties
@@ -1,6 +1,7 @@
 # A comma or space separated list of goals/phases to execute, may
 # specify an empty list to execute the default goal of the IT project.
 # Environment variables used by maven plugins can be added here
-invoker.goals = clean verify
+invoker.goals = clean install
+
 # Uncomment the following to debug invoker. Do note that you have to connect the remote debugger after "maven-invoker-plugin:3.2.0:run" has been print on console
 #invoker.mavenOpts=-Xdebug -Xnoagent -Xrunjdwp:transport=dt_socket,server=y,suspend=y,address=8000

--- a/kie-maven-plugin/src/it/kie-maven-plugin-test-kjar-setup/kie-maven-plugin-test-kjar-parent/invoker.properties
+++ b/kie-maven-plugin/src/it/kie-maven-plugin-test-kjar-setup/kie-maven-plugin-test-kjar-parent/invoker.properties
@@ -1,6 +1,6 @@
 # A comma or space separated list of goals/phases to execute, may
 # specify an empty list to execute the default goal of the IT project.
 # Environment variables used by maven plugins can be added here
-invoker.goals = clean install
+invoker.goals = clean verify
 # Uncomment the following to debug invoker. Do note that you have to connect the remote debugger after "maven-invoker-plugin:3.2.0:run" has been print on console
 #invoker.mavenOpts=-Xdebug -Xnoagent -Xrunjdwp:transport=dt_socket,server=y,suspend=y,address=8000


### PR DESCRIPTION
@danielezonca @pibizza 

**JIRA**: _(please edit the JIRA link if it exists)_

[link](https://issues.redhat.com/browse/DROOLS-7038)

<details>
<summary>
How to replicate CI configuration locally?
</summary>

Build Chain tool does "simple" maven build(s), the builds are just Maven commands, but because the repositories relates and depends on each other and any change in API or class method could affect several of those repositories there is a need to use [build-chain tool](https://github.com/kiegroup/github-action-build-chain) to handle cross repository builds and be sure that we always use latest version of the code for each repository.
 
[build-chain tool](https://github.com/kiegroup/github-action-build-chain) is a build tool which can be used on command line locally or in Github Actions workflow(s), in case you need to change multiple repositories and send multiple dependent pull requests related with a change you can easily reproduce the same build by executing it on Github hosted environment or locally in your development environment. See [local execution](https://github.com/kiegroup/github-action-build-chain#local-execution) details to get more information about it.
</details>

<details>
<summary>
How to retest this PR or trigger a specific build:
</summary>

- for <b>pull request checks</b>  
  Please add comment: <b>Jenkins retest this</b>

- for a <b>specific pull request check</b>  
  Please add comment: <b>Jenkins (re)run [drools|kogito-runtimes|kogito-apps|kogito-examples] tests</b>

- for a <b>full downstream build</b> 
  - for <b>jenkins</b> job: please add comment: <b>Jenkins run fdb</b>
  - for <b>github actions</b> job: add the label `run_fdb`

- <b>a compile downstream build</b> please  add comment: <b>Jenkins run cdb</b>

- <b>a full production downstream build</b> please add comment: <b>Jenkins execute product fdb</b>

- <b>an upstream build</b> please add comment: <b>Jenkins run upstream</b>

- for <b>quarkus branch checks</b>  
  Run checks against Quarkus current used branch  
  Please add comment: <b>Jenkins run quarkus-branch</b>

- for a <b>quarkus branch specific check</b>  
  Run checks against Quarkus current used branch  
  Please add comment: <b>Jenkins (re)run [drools|kogito-runtimes|kogito-apps|kogito-examples] quarkus-branch</b>

- for <b>quarkus main checks</b>  
  Run checks against Quarkus main branch  
  Please add comment: <b>Jenkins run quarkus-main</b>

- for a <b>specific quarkus main check</b>  
  Run checks against Quarkus main branch  
  Please add comment: <b>Jenkins (re)run [drools|kogito-runtimes|kogito-apps|kogito-examples] quarkus-branch</b>

- for <b>native checks</b>  
  Run native checks  
  Please add comment: <b>Jenkins run native</b>

- for a <b>specific native check</b>  
  Run native checks 
  Please add comment: <b>Jenkins (re)run [drools|kogito-runtimes|kogito-apps|kogito-examples] native</b>

- for <b>mandrel checks</b>  
  Run native checks against Mandrel image
  Please add comment: <b>Jenkins run mandrel</b>

- for a <b>specific mandrel check</b>  
  Run native checks against Mandrel image  
  Please add comment: <b>Jenkins (re)run [drools|kogito-runtimes|kogito-apps|kogito-examples] mandrel</b>
</details>
