### PR TITLE
[DROOLS-7042] Configure invoker to output in junit format

### DIFF
--- a/.ci/jenkins/Jenkinsfile.deploy
+++ b/.ci/jenkins/Jenkinsfile.deploy
@@ -190,7 +190,7 @@ pipeline {
 }
 
 void saveReports() {
-    junit testResults: '**/target/surefire-reports/**/*.xml, **/target/failsafe-reports/**/*.xml', allowEmptyResults: true
+    junit testResults: '**/target/surefire-reports/**/*.xml, **/target/failsafe-reports/**/*.xml, **/target/invoker-reports/**/TEST-*.xml', allowEmptyResults: true
 }
 
 void checkoutRepo() {

--- a/.ci/jenkins/Jenkinsfile.native
+++ b/.ci/jenkins/Jenkinsfile.native
@@ -52,7 +52,7 @@ pipeline {
         }
         always {
             script {
-                junit testResults: '**/target/surefire-reports/**/*.xml, **/target/failsafe-reports/**/*.xml', allowEmptyResults: true
+                junit testResults: '**/target/surefire-reports/**/*.xml, **/target/failsafe-reports/**/*.xml, **/target/invoker-reports/**/TEST-*.xml', allowEmptyResults: true
                 util.archiveConsoleLog()
             }
         }

--- a/build-parent/pom.xml
+++ b/build-parent/pom.xml
@@ -2241,7 +2241,7 @@
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-invoker-plugin</artifactId>
-          <version>2.0.0</version>
+          <version>3.2.1</version>
         </plugin>
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>

--- a/kie-maven-plugin/pom.xml
+++ b/kie-maven-plugin/pom.xml
@@ -17,15 +17,6 @@
   <name>KIE :: Maven Plugin</name>
 
   <build>
-    <pluginManagement>
-      <plugins>
-        <plugin>
-          <groupId>org.apache.maven.plugins</groupId>
-          <artifactId>maven-invoker-plugin</artifactId>
-          <version>3.2.1</version>
-        </plugin>
-      </plugins>
-    </pluginManagement>
     <plugins>
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>

--- a/kie-maven-plugin/pom.xml
+++ b/kie-maven-plugin/pom.xml
@@ -17,6 +17,15 @@
   <name>KIE :: Maven Plugin</name>
 
   <build>
+    <pluginManagement>
+      <plugins>
+        <plugin>
+          <groupId>org.apache.maven.plugins</groupId>
+          <artifactId>maven-invoker-plugin</artifactId>
+          <version>3.2.1</version>
+        </plugin>
+      </plugins>
+    </pluginManagement>
     <plugins>
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
@@ -25,12 +34,14 @@
           <goalPrefix>kie</goalPrefix>
         </configuration>
       </plugin>
-       <plugin>
+      <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-invoker-plugin</artifactId>
         <configuration>
           <skipInstallation>${skipITs}</skipInstallation>
           <skipInvocation>${skipITs}</skipInvocation>
+          <writeJunitReport>false</writeJunitReport>
+          <junitPackageName></junitPackageName>
           <setupIncludes>
             <setupInclude>kie-maven-plugin-test-kjar-setup/pom.xml</setupInclude>
           </setupIncludes>

--- a/kie-maven-plugin/pom.xml
+++ b/kie-maven-plugin/pom.xml
@@ -40,8 +40,8 @@
         <configuration>
           <skipInstallation>${skipITs}</skipInstallation>
           <skipInvocation>${skipITs}</skipInvocation>
-          <writeJunitReport>false</writeJunitReport>
-          <junitPackageName></junitPackageName>
+          <writeJunitReport>true</writeJunitReport>
+          <junitPackageName>org.kie.maven.plugin.it</junitPackageName>
           <setupIncludes>
             <setupInclude>kie-maven-plugin-test-kjar-setup/pom.xml</setupInclude>
           </setupIncludes>


### PR DESCRIPTION
@radtriste @winklerm 

**JIRA**: 

[link](https://issues.redhat.com/browse/DROOLS-7042)


With this configuration, the invoker plugin write ALSO `TEST-...` files in junit format, inside `invoker-reports`

See https://github.com/jenkinsci/maven-invoker-plugin/blob/master/README.md for jenkins junit configuration

This is the beginning of the generated `TEST-...` file

`<testsuite tests="1" failures="0" name="org.kie.maven.plugin.it.kie-maven-plugin-test-kjar-setup" time="6.103" errors="0" skipped="0">
  <testcase classname="org.kie.maven.plugin.it.kie-maven-plugin-test-kjar-setup" name="kie-maven-plugin-test-kjar-setup" time="6.103">
    <system-out>Apache Maven 3.8.1 (05c21c65bdfed0f71a2f2ada8b84da59348c4c5d)`

<details>
<summary>
How to replicate CI configuration locally?
</summary>

Build Chain tool does "simple" maven build(s), the builds are just Maven commands, but because the repositories relates and depends on each other and any change in API or class method could affect several of those repositories there is a need to use [build-chain tool](https://github.com/kiegroup/github-action-build-chain) to handle cross repository builds and be sure that we always use latest version of the code for each repository.
 
[build-chain tool](https://github.com/kiegroup/github-action-build-chain) is a build tool which can be used on command line locally or in Github Actions workflow(s), in case you need to change multiple repositories and send multiple dependent pull requests related with a change you can easily reproduce the same build by executing it on Github hosted environment or locally in your development environment. See [local execution](https://github.com/kiegroup/github-action-build-chain#local-execution) details to get more information about it.
</details>

<details>
<summary>
How to retest this PR or trigger a specific build:
</summary>

- for <b>pull request checks</b>  
  Please add comment: <b>Jenkins retest this</b>

- for a <b>specific pull request check</b>  
  Please add comment: <b>Jenkins (re)run [drools|kogito-runtimes|kogito-apps|kogito-examples] tests</b>

- for a <b>full downstream build</b> 
  - for <b>jenkins</b> job: please add comment: <b>Jenkins run fdb</b>
  - for <b>github actions</b> job: add the label `run_fdb`

- <b>a compile downstream build</b> please  add comment: <b>Jenkins run cdb</b>

- <b>a full production downstream build</b> please add comment: <b>Jenkins execute product fdb</b>

- <b>an upstream build</b> please add comment: <b>Jenkins run upstream</b>

- for <b>quarkus branch checks</b>  
  Run checks against Quarkus current used branch  
  Please add comment: <b>Jenkins run quarkus-branch</b>

- for a <b>quarkus branch specific check</b>  
  Run checks against Quarkus current used branch  
  Please add comment: <b>Jenkins (re)run [drools|kogito-runtimes|kogito-apps|kogito-examples] quarkus-branch</b>

- for <b>quarkus main checks</b>  
  Run checks against Quarkus main branch  
  Please add comment: <b>Jenkins run quarkus-main</b>

- for a <b>specific quarkus main check</b>  
  Run checks against Quarkus main branch  
  Please add comment: <b>Jenkins (re)run [drools|kogito-runtimes|kogito-apps|kogito-examples] quarkus-branch</b>

- for <b>native checks</b>  
  Run native checks  
  Please add comment: <b>Jenkins run native</b>

- for a <b>specific native check</b>  
  Run native checks 
  Please add comment: <b>Jenkins (re)run [drools|kogito-runtimes|kogito-apps|kogito-examples] native</b>

- for <b>mandrel checks</b>  
  Run native checks against Mandrel image
  Please add comment: <b>Jenkins run mandrel</b>

- for a <b>specific mandrel check</b>  
  Run native checks against Mandrel image  
  Please add comment: <b>Jenkins (re)run [drools|kogito-runtimes|kogito-apps|kogito-examples] mandrel</b>
</details>
