### PR TITLE
[8.24.x] Update GHA DSL check to use composite action

### DIFF
--- a/.ci/jenkins/dsl/test.sh
+++ b/.ci/jenkins/dsl/test.sh
@@ -1,5 +1,9 @@
 #!/bin/bash -e
 
+export DSL_DEFAULT_MAIN_CONFIG_FILE_REPO=kiegroup/kogito-pipelines
+export DSL_DEFAULT_MAIN_CONFIG_FILE_REF=main
+export DSL_DEFAULT_MAIN_CONFIG_FILE_PATH=dsl/config/main.yaml
+
 file=$(mktemp)
 # For more usage of the script, use ./test.sh -h
 curl -o ${file} https://raw.githubusercontent.com/kiegroup/kogito-pipelines/main/dsl/seed/scripts/seed_test.sh

--- a/.github/workflows/jenkins-tests-PR.yml
+++ b/.github/workflows/jenkins-tests-PR.yml
@@ -5,18 +5,28 @@ on:
   pull_request:
     paths: 
     - '.ci/jenkins/**'
+    - '.github/workflows/jenkins-tests-PR.yml'
 
 jobs:
   dsl-tests:
     runs-on: ubuntu-latest
     steps:
-    - name: Checkout 
-      uses: actions/checkout@v2
+    - name: Setup correct base branch
+      run: |
+        base_branch="${{ github.base_ref }}"
+        if [[ ${base_branch} =~ ^[0-9]+\.[0-9]+\.x$ ]]; then 
+          IFS='.' read -ra ver <<< "${base_branch}"
+          release=${ver[2]}
+          minor=${ver[1]}
+          major=${ver[0]}
+          base_branch="$((major+7)).$minor.$release"
+        fi
+        echo "BRANCH_CONFIG_NAME=${base_branch}" >> $GITHUB_ENV
 
-    - name: Set up JDK 1.11
-      uses: actions/setup-java@v1
+    - name: DSL tests
+      uses: kiegroup/kogito-pipelines/.ci/actions/dsl-tests@main
       with:
-        java-version: 11
-
-    - name: Test DSL
-      run: .ci/jenkins/dsl/test.sh -h ${{ github.head_ref }} -r ${{ github.event.pull_request.head.repo.full_name }} -b ${{ github.base_ref }} -t ${{ github.event.pull_request.base.repo.full_name }} .ci/jenkins/dsl
+        main-config-file-repo: kiegroup/kogito-pipelines
+        main-config-file-ref: main
+        main-config-file-path: dsl/config/main.yaml
+        branch-config-name: ${{ env.BRANCH_CONFIG_NAME }}

--- a/.github/workflows/jenkins-tests-PR.yml
+++ b/.github/workflows/jenkins-tests-PR.yml
@@ -19,7 +19,7 @@ jobs:
           release=${ver[2]}
           minor=${ver[1]}
           major=${ver[0]}
-          base_branch="$((major+7)).$minor.$release"
+          base_branch="$((major-7)).$minor.$release"
         fi
         echo "BRANCH_CONFIG_NAME=${base_branch}" >> $GITHUB_ENV
 


### PR DESCRIPTION
**Thank you for submitting this pull request**

**NOTE!:** Double check the target branch for this PR.
The default is `main` so it will target Drools 8 / Kogito.
If this PR is not strictly related to drools and kogito project in `drools.git`, it should probably target `7.x`as a branch

**Ports** If a forward-port or a backport is needed, paste the forward port PR here

[link](https://www.example.com)

**JIRA**: _(please edit the JIRA link if it exists)_

[link](https://www.example.com)

**referenced Pull Requests**: _(please edit the URLs of referenced pullrequests if they exist)_

* paste the link(s) from GitHub here
* link 2
* link 3 etc.

<details>
<summary>
How to replicate CI configuration locally?
</summary>

Build Chain tool does "simple" maven build(s), the builds are just Maven commands, but because the repositories relates and depends on each other and any change in API or class method could affect several of those repositories there is a need to use [build-chain tool](https://github.com/kiegroup/github-action-build-chain) to handle cross repository builds and be sure that we always use latest version of the code for each repository.
 
[build-chain tool](https://github.com/kiegroup/github-action-build-chain) is a build tool which can be used on command line locally or in Github Actions workflow(s), in case you need to change multiple repositories and send multiple dependent pull requests related with a change you can easily reproduce the same build by executing it on Github hosted environment or locally in your development environment. See [local execution](https://github.com/kiegroup/github-action-build-chain#local-execution) details to get more information about it.
</details>

<details>
<summary>
How to retest this PR or trigger a specific build:
</summary>

- for <b>pull request checks</b>  
  Please add comment: <b>Jenkins retest this</b>

- for a <b>specific pull request check</b>  
  Please add comment: <b>Jenkins (re)run [drools|kogito-runtimes|kogito-apps|kogito-examples] tests</b>

- for a <b>full downstream build</b> 
  - for <b>jenkins</b> job: please add comment: <b>Jenkins run fdb</b>
  - for <b>github actions</b> job: add the label `run_fdb`

- <b>a compile downstream build</b> please  add comment: <b>Jenkins run cdb</b>

- <b>a full production downstream build</b> please add comment: <b>Jenkins execute product fdb</b>

- <b>an upstream build</b> please add comment: <b>Jenkins run upstream</b>

- for <b>quarkus branch checks</b>  
  Run checks against Quarkus current used branch  
  Please add comment: <b>Jenkins run quarkus-branch</b>

- for a <b>quarkus branch specific check</b>  
  Run checks against Quarkus current used branch  
  Please add comment: <b>Jenkins (re)run [drools|kogito-runtimes|kogito-apps|kogito-examples] quarkus-branch</b>

- for <b>quarkus main checks</b>  
  Run checks against Quarkus main branch  
  Please add comment: <b>Jenkins run quarkus-main</b>

- for a <b>specific quarkus main check</b>  
  Run checks against Quarkus main branch  
  Please add comment: <b>Jenkins (re)run [drools|kogito-runtimes|kogito-apps|kogito-examples] quarkus-branch</b>

- for <b>native checks</b>  
  Run native checks  
  Please add comment: <b>Jenkins run native</b>

- for a <b>specific native check</b>  
  Run native checks 
  Please add comment: <b>Jenkins (re)run [drools|kogito-runtimes|kogito-apps|kogito-examples] native</b>

- for <b>mandrel checks</b>  
  Run native checks against Mandrel image
  Please add comment: <b>Jenkins run mandrel</b>

- for a <b>specific mandrel check</b>  
  Run native checks against Mandrel image  
  Please add comment: <b>Jenkins (re)run [drools|kogito-runtimes|kogito-apps|kogito-examples] mandrel</b>
</details>
