### PR TITLE
[DROOLS-7056] NullPointerException when sending DeleteCommand for non…

### DIFF
--- a/drools-core/src/main/java/org/drools/core/common/NamedEntryPoint.java
+++ b/drools-core/src/main/java/org/drools/core/common/NamedEntryPoint.java
@@ -471,7 +471,7 @@ public class NamedEntryPoint
                     handle = this.objectStore.reconnect(handle);
                 }
                 if (handle == null) {
-                    // the handle doesn't exist. no op
+                    log.warn("The factHandle doesn't exist so cannot be deleted. " + factHandle.toExternalForm());
                     return;
                 }
 

--- a/drools-core/src/main/java/org/drools/core/common/NamedEntryPoint.java
+++ b/drools-core/src/main/java/org/drools/core/common/NamedEntryPoint.java
@@ -470,6 +470,10 @@ public class NamedEntryPoint
                 if (handle.isDisconnected()) {
                     handle = this.objectStore.reconnect(handle);
                 }
+                if (handle == null) {
+                    // the handle doesn't exist. no op
+                    return;
+                }
 
                 if (!handle.getEntryPointId().equals( entryPoint )) {
                     throw new IllegalArgumentException("Invalid Entry Point. You updated the FactHandle on entry point '" + handle.getEntryPointId() + "' instead of '" + getEntryPointId() + "'");

--- a/drools-core/src/test/java/org/drools/core/command/runtime/rule/DeleteCommandTest.java
+++ b/drools-core/src/test/java/org/drools/core/command/runtime/rule/DeleteCommandTest.java
@@ -1,0 +1,66 @@
+/*
+ * Copyright 2022 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+*/
+
+package org.drools.core.command.runtime.rule;
+
+import org.drools.core.impl.InternalKnowledgeBase;
+import org.drools.core.impl.KnowledgeBaseFactory;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.kie.api.runtime.Context;
+import org.kie.api.runtime.ExecutableRunner;
+import org.kie.api.runtime.KieSession;
+import org.kie.api.runtime.RequestContext;
+import org.kie.api.runtime.rule.FactHandle;
+import org.kie.internal.command.RegistryContext;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class DeleteCommandTest {
+
+    private KieSession ksession;
+    private ExecutableRunner<RequestContext> runner;
+    private Context context;
+
+    @Before
+    public void setup() {
+        InternalKnowledgeBase kbase = KnowledgeBaseFactory.newKnowledgeBase();
+        ksession = kbase.newKieSession();
+        runner = ExecutableRunner.create();
+        context = ((RegistryContext) runner.createContext()).register(KieSession.class, ksession);
+    }
+
+    @After
+    public void cleanUp() {
+        ksession.dispose();
+    }
+
+    @Test
+    public void testDeleteDisconnectedNonExistingFactHandle() {
+        // DROOLS-7056
+        String fact = "fact";
+        InsertObjectCommand insertObjectCommand = new InsertObjectCommand(fact);
+        FactHandle handle = (FactHandle) runner.execute(insertObjectCommand, context);
+
+        DeleteCommand deleteCommand1 = new DeleteCommand(handle);
+        runner.execute(deleteCommand1, context);
+
+        DeleteCommand deleteCommand2 = new DeleteCommand(handle); // delete twice
+        runner.execute(deleteCommand2, context); // No Exception
+
+        assertThat(ksession.getFactCount()).isEqualTo(0);
+    }
+}


### PR DESCRIPTION
…-existing fact

**Ports** 
This PR is for 7.x
for main -> https://github.com/kiegroup/drools/pull/4536

**JIRA**: 
https://issues.redhat.com/browse/DROOLS-7056

**referenced Pull Requests**: 
* https://github.com/kiegroup/droolsjbpm-integration/pull/2797


<details>
<summary>
How to replicate CI configuration locally?
</summary>

Build Chain tool does "simple" maven build(s), the builds are just Maven commands, but because the repositories relates and depends on each other and any change in API or class method could affect several of those repositories there is a need to use [build-chain tool](https://github.com/kiegroup/github-action-build-chain) to handle cross repository builds and be sure that we always use latest version of the code for each repository.
 
[build-chain tool](https://github.com/kiegroup/github-action-build-chain) is a build tool which can be used on command line locally or in Github Actions workflow(s), in case you need to change multiple repositories and send multiple dependent pull requests related with a change you can easily reproduce the same build by executing it on Github hosted environment or locally in your development environment. See [local execution](https://github.com/kiegroup/github-action-build-chain#local-execution) details to get more information about it.
</details>

<details>
<summary>
How to retest this PR or trigger a specific build:
</summary>

- for <b>pull request checks</b>  
  Please add comment: <b>Jenkins retest this</b>

- for a <b>specific pull request check</b>  
  Please add comment: <b>Jenkins (re)run [drools|kogito-runtimes|kogito-apps|kogito-examples] tests</b>

- for a <b>full downstream build</b> 
  - for <b>jenkins</b> job: please add comment: <b>Jenkins run fdb</b>
  - for <b>github actions</b> job: add the label `run_fdb`

- <b>a compile downstream build</b> please  add comment: <b>Jenkins run cdb</b>

- <b>a full production downstream build</b> please add comment: <b>Jenkins execute product fdb</b>

- <b>an upstream build</b> please add comment: <b>Jenkins run upstream</b>

- for <b>quarkus branch checks</b>  
  Run checks against Quarkus current used branch  
  Please add comment: <b>Jenkins run quarkus-branch</b>

- for a <b>quarkus branch specific check</b>  
  Run checks against Quarkus current used branch  
  Please add comment: <b>Jenkins (re)run [drools|kogito-runtimes|kogito-apps|kogito-examples] quarkus-branch</b>

- for <b>quarkus main checks</b>  
  Run checks against Quarkus main branch  
  Please add comment: <b>Jenkins run quarkus-main</b>

- for a <b>specific quarkus main check</b>  
  Run checks against Quarkus main branch  
  Please add comment: <b>Jenkins (re)run [drools|kogito-runtimes|kogito-apps|kogito-examples] quarkus-branch</b>

- for <b>native checks</b>  
  Run native checks  
  Please add comment: <b>Jenkins run native</b>

- for a <b>specific native check</b>  
  Run native checks 
  Please add comment: <b>Jenkins (re)run [drools|kogito-runtimes|kogito-apps|kogito-examples] native</b>

- for <b>mandrel checks</b>  
  Run native checks against Mandrel image
  Please add comment: <b>Jenkins run mandrel</b>

- for a <b>specific mandrel check</b>  
  Run native checks against Mandrel image  
  Please add comment: <b>Jenkins (re)run [drools|kogito-runtimes|kogito-apps|kogito-examples] mandrel</b>
</details>
