### PR TITLE
[DROOLS-7062] ClassNotFoundException when using generics in accumulat…

### DIFF
--- a/drools-model/drools-model-codegen/src/main/java/org/drools/model/codegen/execmodel/generator/DrlxParseUtil.java
+++ b/drools-model/drools-model-codegen/src/main/java/org/drools/model/codegen/execmodel/generator/DrlxParseUtil.java
@@ -851,13 +851,11 @@ public class DrlxParseUtil {
     }
 
     public static <T extends Node> T transformDrlNameExprToNameExpr(T e) {
-        e.findAll(DrlNameExpr.class)
-                .forEach(n -> n.replace(new NameExpr(n.getName())));
-        if(e instanceof DrlNameExpr) {
+        if (e instanceof DrlNameExpr) {
             return (T) new NameExpr(((DrlNameExpr) e).getName());
-        } else {
-            return e;
         }
+        e.findAll(DrlNameExpr.class).forEach(n -> n.replace(new NameExpr(n.getName())));
+        return e;
     }
 
     public static String addCurlyBracesToBlock(String blockString) {

--- a/drools-model/drools-model-codegen/src/main/java/org/drools/model/codegen/execmodel/generator/visitor/pattern/PatternVisitor.java
+++ b/drools-model/drools-model-codegen/src/main/java/org/drools/model/codegen/execmodel/generator/visitor/pattern/PatternVisitor.java
@@ -21,7 +21,6 @@ import java.util.List;
 
 import org.drools.drl.ast.descr.AccumulateDescr;
 import org.drools.drl.ast.descr.BaseDescr;
-import org.drools.drl.ast.descr.ExprConstraintDescr;
 import org.drools.drl.ast.descr.PatternDescr;
 import org.drools.model.codegen.execmodel.PackageModel;
 import org.drools.model.codegen.execmodel.errors.InvalidExpressionErrorResult;
@@ -65,7 +64,6 @@ public class PatternVisitor {
             return () -> { };
         }
 
-        final boolean allConstraintsPositional = areAllConstraintsPositional(constraintDescrs);
         return new PatternDSLPattern(context, packageModel, pattern, constraintDescrs, patternType);
     }
 
@@ -88,11 +86,5 @@ public class PatternVisitor {
             return new PatternAccumulateConstraint(context, packageModel, pattern, (( AccumulateDescr ) pattern.getSource()), constraintDescrs );
         }
         return null;
-    }
-
-    private boolean areAllConstraintsPositional(List<? extends BaseDescr> constraintDescrs) {
-        return !constraintDescrs.isEmpty() && constraintDescrs.stream()
-                .allMatch(c -> c instanceof ExprConstraintDescr
-                        && ((ExprConstraintDescr) c).getType().equals(ExprConstraintDescr.Type.POSITIONAL));
     }
 }

--- a/drools-model/drools-model-codegen/src/test/java/org/drools/model/codegen/execmodel/GenericsTest.java
+++ b/drools-model/drools-model-codegen/src/test/java/org/drools/model/codegen/execmodel/GenericsTest.java
@@ -1,0 +1,77 @@
+/*
+ * Copyright 2022 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.drools.model.codegen.execmodel;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.drools.model.codegen.execmodel.domain.Address;
+import org.drools.model.codegen.execmodel.domain.Person;
+
+import org.junit.Test;
+import org.kie.api.runtime.KieSession;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class GenericsTest extends BaseModelTest {
+
+    public GenericsTest(RUN_TYPE testRunType) {
+        super(testRunType);
+    }
+
+    @Test
+    public void testGenericsAccumulateInlineCode() {
+        // accumulate inline code supports generics
+        String str =
+                "import " + Person.class.getCanonicalName() + ";\n" +
+                "import " + Address.class.getCanonicalName() + ";\n" +
+                "import " + List.class.getCanonicalName() + ";\n" +
+                "import " + ArrayList.class.getCanonicalName() + ";\n" +
+                "global List results;\n" +
+                "dialect \"mvel\"\n" +
+                "rule R when\n" +
+                "  $l : List() from accumulate (Person($addrList : addresses),\n" +
+                "         init( List<String> cityList = new ArrayList(); ),\n" +
+                "         action( for(Address addr: $addrList){String city = addr.getCity(); cityList.add(city);} ),\n" +
+                "         result( cityList )\n" +
+                "       )\n" +
+                "then\n" +
+                "  results.add($l);\n" +
+                "end";
+
+        KieSession ksession = getKieSession(str);
+        List<List<String>> results = new ArrayList<>();
+        ksession.setGlobal("results", results);
+
+        Person john = new Person("John");
+        Address addr1 = new Address("1");
+        Address addr2 = new Address("2");
+        john.getAddresses().add(addr1);
+        john.getAddresses().add(addr2);
+
+        Person paul = new Person("Paul");
+        Address addr3 = new Address("3");
+        Address addr4 = new Address("4");
+        john.getAddresses().add(addr3);
+        john.getAddresses().add(addr4);
+
+        ksession.insert(john);
+        ksession.insert(paul);
+        ksession.fireAllRules();
+        assertThat(results.get(0).size()).isEqualTo(4);
+    }
+}

--- a/drools-model/drools-mvel-compiler/src/main/java/org/drools/mvelcompiler/LHSPhase.java
+++ b/drools-model/drools-mvel-compiler/src/main/java/org/drools/mvelcompiler/LHSPhase.java
@@ -35,6 +35,7 @@ import com.github.javaparser.ast.expr.FieldAccessExpr;
 import com.github.javaparser.ast.expr.MethodCallExpr;
 import com.github.javaparser.ast.expr.VariableDeclarationExpr;
 import com.github.javaparser.ast.stmt.ExpressionStmt;
+import com.github.javaparser.ast.type.ClassOrInterfaceType;
 import org.drools.mvel.parser.ast.expr.DrlNameExpr;
 import org.drools.mvel.parser.ast.visitor.DrlGenericVisitor;
 import org.drools.mvelcompiler.ast.AssignExprT;
@@ -58,9 +59,9 @@ import org.slf4j.LoggerFactory;
 import static java.util.Collections.emptyList;
 import static java.util.Collections.singletonList;
 import static java.util.Optional.ofNullable;
+import static org.drools.mvel.parser.printer.PrintUtil.printNode;
 import static org.drools.util.ClassUtils.getAccessor;
 import static org.drools.util.ClassUtils.getSetter;
-import static org.drools.mvel.parser.printer.PrintUtil.printNode;
 
 /**
  * This phase processes the left hand side of a MVEL target expression, if present, such as
@@ -369,7 +370,9 @@ public class LHSPhase implements DrlGenericVisitor<TypedExpression, Void> {
     }
 
     private Class<?> getRHSorLHSType(VariableDeclarator n) {
-        return mvelCompilerContext.resolveType(n.getType().asString());
+        return mvelCompilerContext.resolveType(n.getType() instanceof ClassOrInterfaceType ?
+                n.getType().asClassOrInterfaceType().getNameAsString() :
+                n.getType().asString());
     }
 
     private void logPhase(String phase, Node statement) {


### PR DESCRIPTION
…e inline code

**JIRA**: https://issues.redhat.com/browse/DROOLS-7062

@tkobayas I reviewed your original PR ( https://github.com/kiegroup/drools/pull/4542 ) and discussed this with @lucamolteni. As he suggested the actual fix is getting rid of all the `DrlNameExpr` nodes before the printer tries to convert them in strings. Please give a look and let me know if this is ok for you. I sent this PR against main, if ok I'll close yours and then we will need to also backport this fix to 7.x