### PR TITLE
Memory leak at the using dynamicFacts (#3908)

### DIFF
--- a/drools-core/src/main/java/org/drools/core/common/NamedEntryPoint.java
+++ b/drools-core/src/main/java/org/drools/core/common/NamedEntryPoint.java
@@ -617,7 +617,7 @@ public class NamedEntryPoint
         Object object = ((InternalFactHandle) handle).getObject();
         try {
             if ( dynamicFacts != null && removeFromSet ) {
-                dynamicFacts.remove( object );
+                dynamicFacts.remove( handle );
             }
 
             if ( object != null ) {


### PR DESCRIPTION
You are adding handles
addPropertyChangeListener

dynamicFacts.add( handle );

but you're trying to remove objects.
This HashMap grows indefinitely until heap is exhausted.
Make it dynamicFacts.remove( handle );

(cherry picked from commit 4f9abd71f9f2388ec6a37f9c573431dd1f409b72)