### PR TITLE
[7.67.x][DROOLS-6912] prop with method invocation is not recognized in modify…

### DIFF
--- a/drools-model/drools-model-compiler/src/test/java/org/drools/modelcompiler/MvelDialectTest.java
+++ b/drools-model/drools-model-compiler/src/test/java/org/drools/modelcompiler/MvelDialectTest.java
@@ -1512,4 +1512,33 @@ public class MvelDialectTest extends BaseModelTest {
 
         assertEquals(1, fired);
     }
+
+    @Test
+    public void testMVELModifyPropMethodCall() {
+        String str = "package com.example.reproducer\n" +
+                "import " + Person.class.getCanonicalName() + ";\n" +
+                "rule R\n" +
+                "dialect \"mvel\"\n" +
+                "when\n" +
+                "  $p : Person()\n" +
+                "then\n" +
+                "  modify($p) {\n" +
+                "    age = 20,\n" +
+                "    addresses.clear();\n" +
+                "  }\n" +
+                "end";
+
+        KieSession ksession = getKieSession(str);
+
+        Person p = new Person("John");
+        List<Address> addresses = new ArrayList<>();
+        addresses.add(new Address("London"));
+        p.setAddresses(addresses);
+        ksession.insert(p);
+        int fired = ksession.fireAllRules();
+
+        assertEquals(20, p.getAge());
+        assertEquals(0, p.getAddresses().size());
+        assertEquals(1, fired);
+    }
 }

--- a/drools-model/drools-mvel-compiler/src/test/java/org/drools/mvelcompiler/MvelCompilerTest.java
+++ b/drools-model/drools-mvel-compiler/src/test/java/org/drools/mvelcompiler/MvelCompilerTest.java
@@ -761,6 +761,14 @@ public class MvelCompilerTest implements CompilerTest {
     }
 
     @Test
+    public void testModifyWithMethodCall() {
+        test(ctx -> ctx.addDeclaration("$p", Person.class),
+             "{ modify($p) { addresses.clear() }; }",
+             "{ { $p.getAddresses().clear(); } }",
+             result -> assertThat(allUsedBindings(result), containsInAnyOrder("$p")));
+    }
+
+    @Test
     public void testWithSemiColon() {
         test("{ with( $l = new ArrayList()) { $l.add(2); }; }",
              "{ java.util.ArrayList $l = new ArrayList(); $l.add(2); }",


### PR DESCRIPTION
…… (#4324)

* [DROOLS-6912] prop with method invocation is not recognized in modify block with executable model

* - better coding

**Ports** 
This is a backport PR of https://github.com/kiegroup/drools/pull/4324 for 7.67.x

**JIRA**: 
https://issues.redhat.com/browse/RHDM-1907

<details>
<summary>
How to replicate CI configuration locally?
</summary>

Build Chain tool does "simple" maven build(s), the builds are just Maven commands, but because the repositories relates and depends on each other and any change in API or class method could affect several of those repositories there is a need to use [build-chain tool](https://github.com/kiegroup/github-action-build-chain) to handle cross repository builds and be sure that we always use latest version of the code for each repository.
 
[build-chain tool](https://github.com/kiegroup/github-action-build-chain) is a build tool which can be used on command line locally or in Github Actions workflow(s), in case you need to change multiple repositories and send multiple dependent pull requests related with a change you can easily reproduce the same build by executing it on Github hosted environment or locally in your development environment. See [local execution](https://github.com/kiegroup/github-action-build-chain#local-execution) details to get more information about it.
</details>

<details>
<summary>
How to retest this PR or trigger a specific build:
</summary>

- for <b>pull request checks</b>  
  Please add comment: <b>Jenkins retest this</b>

- for a <b>specific pull request check</b>  
  Please add comment: <b>Jenkins (re)run [drools|kogito-runtimes|kogito-apps|kogito-examples] tests</b>

- for a <b>full downstream build</b> 
  - for <b>jenkins</b> job: please add comment: <b>Jenkins run fdb</b>
  - for <b>github actions</b> job: add the label `run_fdb`

- <b>a compile downstream build</b> please  add comment: <b>Jenkins run cdb</b>

- <b>a full production downstream build</b> please add comment: <b>Jenkins execute product fdb</b>

- <b>an upstream build</b> please add comment: <b>Jenkins run upstream</b>

- for <b>quarkus branch checks</b>  
  Run checks against Quarkus current used branch  
  Please add comment: <b>Jenkins run quarkus-branch</b>

- for a <b>quarkus branch specific check</b>  
  Run checks against Quarkus current used branch  
  Please add comment: <b>Jenkins (re)run [drools|kogito-runtimes|kogito-apps|kogito-examples] quarkus-branch</b>

- for <b>quarkus main checks</b>  
  Run checks against Quarkus main branch  
  Please add comment: <b>Jenkins run quarkus-main</b>

- for a <b>specific quarkus main check</b>  
  Run checks against Quarkus main branch  
  Please add comment: <b>Jenkins (re)run [drools|kogito-runtimes|kogito-apps|kogito-examples] quarkus-branch</b>

- for <b>native checks</b>  
  Run native checks  
  Please add comment: <b>Jenkins run native</b>

- for a <b>specific native check</b>  
  Run native checks 
  Please add comment: <b>Jenkins (re)run [drools|kogito-runtimes|kogito-apps|kogito-examples] native</b>

- for <b>mandrel checks</b>  
  Run native checks against Mandrel image
  Please add comment: <b>Jenkins run mandrel</b>

- for a <b>specific mandrel check</b>  
  Run native checks against Mandrel image  
  Please add comment: <b>Jenkins (re)run [drools|kogito-runtimes|kogito-apps|kogito-examples] mandrel</b>
</details>
