### PR TITLE
[DROOLS-7076] DefaultFactHandle.createFromExternalFormat() fails with…

### DIFF
--- a/drools-core/src/main/java/org/drools/core/command/runtime/rule/FromExternalFactHandleCommand.java
+++ b/drools-core/src/main/java/org/drools/core/command/runtime/rule/FromExternalFactHandleCommand.java
@@ -44,7 +44,7 @@ public class FromExternalFactHandleCommand implements ExecutableCommand<FactHand
     public FactHandle execute(Context context) {
         KieSession ksession = ((RegistryContext) context).lookup( KieSession.class );
         Collection<FactHandle> factHandles = ksession.getFactHandles();
-        int fhId = Integer.parseInt(factHandleExternalForm.split(":")[1]);
+        long fhId = Long.parseLong(factHandleExternalForm.split(":")[1]);
         for (FactHandle factHandle : factHandles) {
             if (factHandle instanceof InternalFactHandle
                     && ((InternalFactHandle) factHandle).getId() == fhId) {

--- a/drools-core/src/main/java/org/drools/core/common/DefaultFactHandle.java
+++ b/drools-core/src/main/java/org/drools/core/common/DefaultFactHandle.java
@@ -467,7 +467,7 @@ public class DefaultFactHandle extends AbstractBaseLinkedListNode<DefaultFactHan
     }
 
     private static void populateFactHandleFromExternalForm( String[] elements, DefaultFactHandle handle ) {
-        handle.id = Integer.parseInt( elements[1] );
+        handle.id = Long.parseLong( elements[1] );
         handle.identityHashCode = Integer.parseInt( elements[2] );
         handle.objectHashCode = Integer.parseInt( elements[3] );
         handle.recency = Long.parseLong( elements[4] );

--- a/drools-core/src/main/java/org/drools/core/common/DisconnectedFactHandle.java
+++ b/drools-core/src/main/java/org/drools/core/common/DisconnectedFactHandle.java
@@ -142,7 +142,7 @@ public class DisconnectedFactHandle
             throw new IllegalArgumentException( "externalFormat did not have enough elements ["+externalFormat+"]" );
         }
 
-        this.id = Integer.parseInt( elements[1] );
+        this.id = Long.parseLong( elements[1] );
         this.identityHashCode = Integer.parseInt( elements[2] );
         this.objectHashCode = Integer.parseInt(elements[3]);
         this.recency = Long.parseLong( elements[4] );

--- a/drools-core/src/test/java/org/drools/core/command/runtime/rule/FromExternalFactHandleCommandTest.java
+++ b/drools-core/src/test/java/org/drools/core/command/runtime/rule/FromExternalFactHandleCommandTest.java
@@ -1,0 +1,60 @@
+/*
+ * Copyright 2022 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+*/
+
+package org.drools.core.command.runtime.rule;
+
+import org.drools.core.impl.InternalKnowledgeBase;
+import org.drools.core.impl.KnowledgeBaseFactory;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.kie.api.runtime.Context;
+import org.kie.api.runtime.ExecutableRunner;
+import org.kie.api.runtime.KieSession;
+import org.kie.api.runtime.RequestContext;
+import org.kie.api.runtime.rule.FactHandle;
+import org.kie.internal.command.RegistryContext;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class FromExternalFactHandleCommandTest {
+
+    private KieSession ksession;
+    private ExecutableRunner<RequestContext> runner;
+    private Context context;
+
+    @Before
+    public void setup() {
+        InternalKnowledgeBase kbase = KnowledgeBaseFactory.newKnowledgeBase();
+        ksession = kbase.newKieSession();
+        runner = ExecutableRunner.create();
+        context = ((RegistryContext) runner.createContext()).register(KieSession.class, ksession);
+    }
+
+    @After
+    public void cleanUp() {
+        ksession.dispose();
+    }
+
+    @Test
+    public void testFromExternalFactHandleCommandNumberFormatException() {
+        // DROOLS-7076 : Just to test not to throw NumberFormatException 
+        String externalFormat = "0:2147483648:171497379:-1361525545:2147483648:null:NON_TRAIT:java.lang.String";
+        FromExternalFactHandleCommand fromExternalFactHandleCommand = new FromExternalFactHandleCommand(externalFormat);
+        FactHandle handle = (FactHandle) runner.execute(fromExternalFactHandleCommand, context);
+
+        assertThat(handle).isNull();
+    }
+}

--- a/drools-core/src/test/java/org/drools/core/reteoo/FactHandleTest.java
+++ b/drools-core/src/test/java/org/drools/core/reteoo/FactHandleTest.java
@@ -17,6 +17,7 @@
 package org.drools.core.reteoo;
 
 import org.drools.core.common.DefaultFactHandle;
+import org.drools.core.common.DisconnectedFactHandle;
 import org.drools.core.common.DisconnectedWorkingMemoryEntryPoint;
 import org.junit.Test;
 
@@ -84,4 +85,19 @@ public class FactHandleTest {
         assertThat(f0.getId()).isEqualTo(134);
     }
 
+    @Test
+    public void testDefaultFactHandleCreateFromExternalFormat() {
+        // DROOLS-7076
+        String externalFormat = "0:2147483648:171497379:-1361525545:2147483648:null:NON_TRAIT:java.lang.String";
+        final DefaultFactHandle f0 = DefaultFactHandle.createFromExternalFormat(externalFormat);
+        assertThat(f0.getId()).isEqualTo(2147483648L);
+    }
+
+    @Test
+    public void testDisconnectedFactHandleCreateFromExternalFormat() {
+        // DROOLS-7076
+        String externalFormat = "0:2147483648:171497379:-1361525545:2147483648:null:NON_TRAIT:java.lang.String";
+        final DisconnectedFactHandle f0 = new DisconnectedFactHandle(externalFormat);
+        assertThat(f0.getId()).isEqualTo(2147483648L);
+    }
 }


### PR DESCRIPTION
… NumberFormatException when ID is larger than 2147483647

**Ports** 
This PR is for 7.x
for main -> https://github.com/kiegroup/drools/pull/4568

**JIRA**: 
https://issues.redhat.com/browse/DROOLS-7076

<details>
<summary>
How to replicate CI configuration locally?
</summary>

Build Chain tool does "simple" maven build(s), the builds are just Maven commands, but because the repositories relates and depends on each other and any change in API or class method could affect several of those repositories there is a need to use [build-chain tool](https://github.com/kiegroup/github-action-build-chain) to handle cross repository builds and be sure that we always use latest version of the code for each repository.
 
[build-chain tool](https://github.com/kiegroup/github-action-build-chain) is a build tool which can be used on command line locally or in Github Actions workflow(s), in case you need to change multiple repositories and send multiple dependent pull requests related with a change you can easily reproduce the same build by executing it on Github hosted environment or locally in your development environment. See [local execution](https://github.com/kiegroup/github-action-build-chain#local-execution) details to get more information about it.
</details>

<details>
<summary>
How to retest this PR or trigger a specific build:
</summary>

- for <b>pull request checks</b>  
  Please add comment: <b>Jenkins retest this</b>

- for a <b>specific pull request check</b>  
  Please add comment: <b>Jenkins (re)run [drools|kogito-runtimes|kogito-apps|kogito-examples] tests</b>

- for a <b>full downstream build</b> 
  - for <b>jenkins</b> job: please add comment: <b>Jenkins run fdb</b>
  - for <b>github actions</b> job: add the label `run_fdb`

- <b>a compile downstream build</b> please  add comment: <b>Jenkins run cdb</b>

- <b>a full production downstream build</b> please add comment: <b>Jenkins execute product fdb</b>

- <b>an upstream build</b> please add comment: <b>Jenkins run upstream</b>

- for <b>quarkus branch checks</b>  
  Run checks against Quarkus current used branch  
  Please add comment: <b>Jenkins run quarkus-branch</b>

- for a <b>quarkus branch specific check</b>  
  Run checks against Quarkus current used branch  
  Please add comment: <b>Jenkins (re)run [drools|kogito-runtimes|kogito-apps|kogito-examples] quarkus-branch</b>

- for <b>quarkus main checks</b>  
  Run checks against Quarkus main branch  
  Please add comment: <b>Jenkins run quarkus-main</b>

- for a <b>specific quarkus main check</b>  
  Run checks against Quarkus main branch  
  Please add comment: <b>Jenkins (re)run [drools|kogito-runtimes|kogito-apps|kogito-examples] quarkus-branch</b>

- for <b>native checks</b>  
  Run native checks  
  Please add comment: <b>Jenkins run native</b>

- for a <b>specific native check</b>  
  Run native checks 
  Please add comment: <b>Jenkins (re)run [drools|kogito-runtimes|kogito-apps|kogito-examples] native</b>

- for <b>mandrel checks</b>  
  Run native checks against Mandrel image
  Please add comment: <b>Jenkins run mandrel</b>

- for a <b>specific mandrel check</b>  
  Run native checks against Mandrel image  
  Please add comment: <b>Jenkins (re)run [drools|kogito-runtimes|kogito-apps|kogito-examples] mandrel</b>
</details>
