### PR TITLE
[BXMSPROD-1766] efesto module added to productized profile

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -282,6 +282,7 @@
         <module>drools-alphanetwork-compiler</module>
         <module>kie-internal</module>
         <module>kie-test-util</module>
+        <module>efesto</module>
         <module>kie-dmn</module>
         <module>kie-pmml-trusty</module>
         <module>drools-drl-quarkus-extension</module>


### PR DESCRIPTION
efesto-common-api required by kie-dm-api. See https://github.com/kiegroup/drools/blob/3949acb7214e2f232454d30fdf7db87f3ed1bf2c/kie-dmn/kie-dmn-api/pom.xml#L26

Otherwise
```
[INFO] 
[INFO] ------------------------< org.kie:kie-dmn-api >-------------------------
[INFO] Building KIE :: Decision Model Notation :: API 8.26.0.redhat-2022080206 [52/111]
[INFO] --------------------------------[ jar ]---------------------------------
[INFO] Downloading from qe-repository: https://REPO_URL/org/kie/efesto-common-api/8.26.0.redhat-2022080206/efesto-common-api-8.26.0.redhat-2022080206.pom

[WARNING] The POM for org.kie:efesto-common-api:jar:8.26.0.redhat-2022080206 is missing, no dependency information available
[INFO] Downloading from qe-repository: https://REPO_URL/org/kie/efesto-common-api/8.26.0.redhat-2022080206/efesto-common-api-8.26.0.redhat-2022080206.jar

[INFO] 
```

Related Ticket:

* https://issues.redhat.com/browse/BXMSPROD-1766

<details>
<summary>
How to replicate CI configuration locally?
</summary>

Build Chain tool does "simple" maven build(s), the builds are just Maven commands, but because the repositories relates and depends on each other and any change in API or class method could affect several of those repositories there is a need to use [build-chain tool](https://github.com/kiegroup/github-action-build-chain) to handle cross repository builds and be sure that we always use latest version of the code for each repository.
 
[build-chain tool](https://github.com/kiegroup/github-action-build-chain) is a build tool which can be used on command line locally or in Github Actions workflow(s), in case you need to change multiple repositories and send multiple dependent pull requests related with a change you can easily reproduce the same build by executing it on Github hosted environment or locally in your development environment. See [local execution](https://github.com/kiegroup/github-action-build-chain#local-execution) details to get more information about it.
</details>

<details>
<summary>
How to retest this PR or trigger a specific build:
</summary>

- for <b>pull request checks</b>  
  Please add comment: <b>Jenkins retest this</b>

- for a <b>specific pull request check</b>  
  Please add comment: <b>Jenkins (re)run [drools|kogito-runtimes|kogito-apps|kogito-examples] tests</b>

- for a <b>full downstream build</b> 
  - for <b>jenkins</b> job: please add comment: <b>Jenkins run fdb</b>
  - for <b>github actions</b> job: add the label `run_fdb`

- <b>a compile downstream build</b> please  add comment: <b>Jenkins run cdb</b>

- <b>a full production downstream build</b> please add comment: <b>Jenkins execute product fdb</b>

- <b>an upstream build</b> please add comment: <b>Jenkins run upstream</b>

- for <b>quarkus branch checks</b>  
  Run checks against Quarkus current used branch  
  Please add comment: <b>Jenkins run quarkus-branch</b>

- for a <b>quarkus branch specific check</b>  
  Run checks against Quarkus current used branch  
  Please add comment: <b>Jenkins (re)run [drools|kogito-runtimes|kogito-apps|kogito-examples] quarkus-branch</b>

- for <b>quarkus main checks</b>  
  Run checks against Quarkus main branch  
  Please add comment: <b>Jenkins run quarkus-main</b>

- for a <b>specific quarkus main check</b>  
  Run checks against Quarkus main branch  
  Please add comment: <b>Jenkins (re)run [drools|kogito-runtimes|kogito-apps|kogito-examples] quarkus-branch</b>

- for <b>native checks</b>  
  Run native checks  
  Please add comment: <b>Jenkins run native</b>

- for a <b>specific native check</b>  
  Run native checks 
  Please add comment: <b>Jenkins (re)run [drools|kogito-runtimes|kogito-apps|kogito-examples] native</b>

- for <b>mandrel checks</b>  
  Run native checks against Mandrel image
  Please add comment: <b>Jenkins run mandrel</b>

- for a <b>specific mandrel check</b>  
  Run native checks against Mandrel image  
  Please add comment: <b>Jenkins (re)run [drools|kogito-runtimes|kogito-apps|kogito-examples] mandrel</b>
</details>
