### PR TITLE
[DROOLS-7092] Fixing IndexFileTest - Enable default windows build

### DIFF
--- a/.github/workflows/drools-pr.yml
+++ b/.github/workflows/drools-pr.yml
@@ -20,7 +20,7 @@ jobs:
     timeout-minutes: 120
     strategy:
       matrix:
-        os: [ubuntu-latest]
+        os: [ubuntu-latest, windows-latest]
         java-version: [11]
         maven-version: ['3.8.6']
       fail-fast: false

--- a/efesto/efesto-core/efesto-common-api/src/test/java/org/kie/efesto/common/api/io/IndexFileTest.java
+++ b/efesto/efesto-core/efesto-common-api/src/test/java/org/kie/efesto/common/api/io/IndexFileTest.java
@@ -29,15 +29,17 @@ class IndexFileTest {
 
     @Test
     void validatePathName() {
-        String toValidate = "/this/is/valid/file.model_json";
+        String toValidate = String.format("%1$sthis%1$sis%1$svalid%1$sfile.model_json", File.separator);
         assertThat(IndexFile.validatePathName(toValidate)).isEqualTo(toValidate);
     }
 
     @Test
     void validateWrongPathName() {
-        final List<String> toValidate = Arrays.asList("/this/is/invalid/file._json", "/this/is/invalid/file.model");
+        String toValidate1 = String.format("%1$sthis%1$sis%1$sinvalid%1$sfile._json", File.separator);
+        String toValidate2 = String.format("%1$sthis%1$sis%1$sinvalid%1$sfile.model", File.separator);
+        final List<String> toValidate = Arrays.asList(toValidate1, toValidate2);
         toValidate.forEach(toVal -> {
-            String fileName = toVal.substring(toVal.lastIndexOf('/') + 1);
+            String fileName = toVal.substring(toVal.lastIndexOf(File.separator) + 1);
             String expectedMessage = String.format("Wrong file name %s", fileName);
             assertThatThrownBy(() -> IndexFile.validatePathName(toVal))
                     .isInstanceOf(KieEfestoCommonException.class)
@@ -57,7 +59,7 @@ class IndexFileTest {
 
     @Test
     void testGetModel() {
-        String fileName = "/this/is/valid/file.model_json";
+        String fileName = String.format("%1$sthis%1$sis%1$svalid%1$sfile.model_json", File.separator);
         String expected = "model";
         IndexFile indexFile = new IndexFile(fileName);
         assertThat(indexFile.getModel()).isEqualTo(expected);


### PR DESCRIPTION
@danielezonca 
This is a quick fix for windows build.

[This](https://issues.redhat.com/browse/DROOLS-7091) will fully address the issue.


**JIRA**: 

[link](https://issues.redhat.com/browse/DROOLS-7092)

<details>
<summary>
How to replicate CI configuration locally?
</summary>

Build Chain tool does "simple" maven build(s), the builds are just Maven commands, but because the repositories relates and depends on each other and any change in API or class method could affect several of those repositories there is a need to use [build-chain tool](https://github.com/kiegroup/github-action-build-chain) to handle cross repository builds and be sure that we always use latest version of the code for each repository.
 
[build-chain tool](https://github.com/kiegroup/github-action-build-chain) is a build tool which can be used on command line locally or in Github Actions workflow(s), in case you need to change multiple repositories and send multiple dependent pull requests related with a change you can easily reproduce the same build by executing it on Github hosted environment or locally in your development environment. See [local execution](https://github.com/kiegroup/github-action-build-chain#local-execution) details to get more information about it.
</details>

<details>
<summary>
How to retest this PR or trigger a specific build:
</summary>

- for <b>pull request checks</b>  
  Please add comment: <b>Jenkins retest this</b>

- for a <b>specific pull request check</b>  
  Please add comment: <b>Jenkins (re)run [drools|kogito-runtimes|kogito-apps|kogito-examples] tests</b>

- for a <b>full downstream build</b> 
  - for <b>jenkins</b> job: please add comment: <b>Jenkins run fdb</b>
  - for <b>github actions</b> job: add the label `run_fdb`

- <b>a compile downstream build</b> please  add comment: <b>Jenkins run cdb</b>

- <b>a full production downstream build</b> please add comment: <b>Jenkins execute product fdb</b>

- <b>an upstream build</b> please add comment: <b>Jenkins run upstream</b>

- for <b>quarkus branch checks</b>  
  Run checks against Quarkus current used branch  
  Please add comment: <b>Jenkins run quarkus-branch</b>

- for a <b>quarkus branch specific check</b>  
  Run checks against Quarkus current used branch  
  Please add comment: <b>Jenkins (re)run [drools|kogito-runtimes|kogito-apps|kogito-examples] quarkus-branch</b>

- for <b>quarkus main checks</b>  
  Run checks against Quarkus main branch  
  Please add comment: <b>Jenkins run quarkus-main</b>

- for a <b>specific quarkus main check</b>  
  Run checks against Quarkus main branch  
  Please add comment: <b>Jenkins (re)run [drools|kogito-runtimes|kogito-apps|kogito-examples] quarkus-branch</b>

- for <b>native checks</b>  
  Run native checks  
  Please add comment: <b>Jenkins run native</b>

- for a <b>specific native check</b>  
  Run native checks 
  Please add comment: <b>Jenkins (re)run [drools|kogito-runtimes|kogito-apps|kogito-examples] native</b>

- for <b>mandrel checks</b>  
  Run native checks against Mandrel image
  Please add comment: <b>Jenkins run mandrel</b>

- for a <b>specific mandrel check</b>  
  Run native checks against Mandrel image  
  Please add comment: <b>Jenkins (re)run [drools|kogito-runtimes|kogito-apps|kogito-examples] mandrel</b>
</details>
