### PR TITLE
[DROOLS-7095] fix varargs analysis in mvel ConditionAnalyzer (#4595)

### DIFF
--- a/drools-mvel/src/main/java/org/drools/mvel/ConditionAnalyzer.java
+++ b/drools-mvel/src/main/java/org/drools/mvel/ConditionAnalyzer.java
@@ -539,7 +539,7 @@ public class ConditionAnalyzer {
         }
 
         // if it's a vararg, but the last argument is already an array there's no need for any special treatment
-        isVarArgs &= !(params.length == paramTypes.length && params[paramTypes.length-1].getKnownEgressType().isArray());
+        isVarArgs = isVarArgs && !(params.length == paramTypes.length && params[paramTypes.length-1].getKnownEgressType().isArray());
 
         for (int i = 0; i < (isVarArgs ? paramTypes.length-1 : paramTypes.length); i++) {
             invocation.addArgument(statementToExpression(params[i], paramTypes[i]));

--- a/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/integrationtests/JittingTest.java
+++ b/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/integrationtests/JittingTest.java
@@ -351,4 +351,29 @@ public class JittingTest {
         kieSession.insert("CX");
         assertThat(kieSession.fireAllRules()).isEqualTo(1);
     }
+
+     public static class Tester {
+        public String get(String x) {
+            return "test";
+        }
+    }
+
+    @Test
+    public void testInvokeVarargsConstructor() {
+        // DROOLS-7095
+        String drl =
+                "package test\n" +
+                "import " + Tester.class.getCanonicalName() + "\n" +
+                "\n" +
+                "rule R1 when \n" +
+                "    Tester( \"test\" == get( new String() ) )\n" +
+                "then \n" +
+                "end";
+
+        final KieModule kieModule = KieUtil.getKieModuleFromDrls("test", kieBaseTestConfiguration, drl);
+        final KieBase kieBase = KieBaseUtil.newKieBaseFromKieModuleWithAdditionalOptions(kieModule, kieBaseTestConfiguration, ConstraintJittingThresholdOption.get(0));
+        KieSession ksession = kieBase.newKieSession();
+        ksession.insert(new Tester());
+        assertThat(ksession.fireAllRules()).isEqualTo(1);
+    }
 }


### PR DESCRIPTION
(cherry picked from commit 6d4bab86b8b055b98f01042cce8f3af397070840)

