### PR TITLE
efesto-common-utils added to default list of modules

### DIFF
--- a/efesto/efesto-core/pom.xml
+++ b/efesto/efesto-core/pom.xml
@@ -16,21 +16,8 @@
 
   <modules>
     <module>efesto-common-api</module>
+    <module>efesto-compilation-manager</module>
+    <module>efesto-runtime-manager</module>
   </modules>
-
-  <profiles>
-    <profile>
-      <id>default</id>
-      <activation>
-        <property>
-          <name>!productized</name>
-        </property>
-      </activation>
-      <modules>
-        <module>efesto-compilation-manager</module>
-        <module>efesto-runtime-manager</module>
-      </modules>
-    </profile>
-  </profiles>
 
 </project>

--- a/efesto/pom.xml
+++ b/efesto/pom.xml
@@ -27,6 +27,7 @@
   <modules>
     <module>efesto-core</module>
     <module>efesto-dependencies</module>
+    <module>efesto-common-utils</module>
   </modules>
 
   <!-- Dependencies core to all modules. Keep that as limited as possible. Please avoid indirect or looped dependencies-->
@@ -159,19 +160,5 @@
       </plugin>
     </plugins>
   </build>
-
-  <profiles>
-    <profile>
-      <id>default</id>
-      <activation>
-        <property>
-          <name>!productized</name>
-        </property>
-      </activation>
-      <modules>
-        <module>efesto-common-utils</module>
-      </modules>
-    </profile>
-  </profiles>
 
 </project>


### PR DESCRIPTION
Since `efesto-common-utils` is needed by `efesto-dependencies` module (see [1]) I would take it out from `!productized` profile

[1] https://github.com/kiegroup/drools/blob/ebc6f17f341c280442057be2c7f676349b08f35b/efesto/efesto-dependencies/pom.xml#L27

The same for `efesto-compilation-manager-api` and `efesto-compilation-manager-core`
https://github.com/kiegroup/drools/blob/ebc6f17f341c280442057be2c7f676349b08f35b/efesto/efesto-dependencies/pom.xml#L35
https://github.com/kiegroup/drools/blob/ebc6f17f341c280442057be2c7f676349b08f35b/efesto/efesto-dependencies/pom.xml#L39

<details>
<summary>
How to replicate CI configuration locally?
</summary>

Build Chain tool does "simple" maven build(s), the builds are just Maven commands, but because the repositories relates and depends on each other and any change in API or class method could affect several of those repositories there is a need to use [build-chain tool](https://github.com/kiegroup/github-action-build-chain) to handle cross repository builds and be sure that we always use latest version of the code for each repository.
 
[build-chain tool](https://github.com/kiegroup/github-action-build-chain) is a build tool which can be used on command line locally or in Github Actions workflow(s), in case you need to change multiple repositories and send multiple dependent pull requests related with a change you can easily reproduce the same build by executing it on Github hosted environment or locally in your development environment. See [local execution](https://github.com/kiegroup/github-action-build-chain#local-execution) details to get more information about it.
</details>

<details>
<summary>
How to retest this PR or trigger a specific build:
</summary>

- for <b>pull request checks</b>  
  Please add comment: <b>Jenkins retest this</b>

- for a <b>specific pull request check</b>  
  Please add comment: <b>Jenkins (re)run [drools|kogito-runtimes|kogito-apps|kogito-examples] tests</b>

- for a <b>full downstream build</b> 
  - for <b>jenkins</b> job: please add comment: <b>Jenkins run fdb</b>
  - for <b>github actions</b> job: add the label `run_fdb`

- <b>a compile downstream build</b> please  add comment: <b>Jenkins run cdb</b>

- <b>a full production downstream build</b> please add comment: <b>Jenkins execute product fdb</b>

- <b>an upstream build</b> please add comment: <b>Jenkins run upstream</b>

- for <b>quarkus branch checks</b>  
  Run checks against Quarkus current used branch  
  Please add comment: <b>Jenkins run quarkus-branch</b>

- for a <b>quarkus branch specific check</b>  
  Run checks against Quarkus current used branch  
  Please add comment: <b>Jenkins (re)run [drools|kogito-runtimes|kogito-apps|kogito-examples] quarkus-branch</b>

- for <b>quarkus main checks</b>  
  Run checks against Quarkus main branch  
  Please add comment: <b>Jenkins run quarkus-main</b>

- for a <b>specific quarkus main check</b>  
  Run checks against Quarkus main branch  
  Please add comment: <b>Jenkins (re)run [drools|kogito-runtimes|kogito-apps|kogito-examples] quarkus-branch</b>

- for <b>native checks</b>  
  Run native checks  
  Please add comment: <b>Jenkins run native</b>

- for a <b>specific native check</b>  
  Run native checks 
  Please add comment: <b>Jenkins (re)run [drools|kogito-runtimes|kogito-apps|kogito-examples] native</b>

- for <b>mandrel checks</b>  
  Run native checks against Mandrel image
  Please add comment: <b>Jenkins run mandrel</b>

- for a <b>specific mandrel check</b>  
  Run native checks against Mandrel image  
  Please add comment: <b>Jenkins (re)run [drools|kogito-runtimes|kogito-apps|kogito-examples] mandrel</b>
</details>
