### PR TITLE
missing kie-drl modules for prod profiles

### DIFF
--- a/kie-drl/kie-drl-implementations/pom.xml
+++ b/kie-drl/kie-drl-implementations/pom.xml
@@ -17,9 +17,22 @@
     <packaging>pom</packaging>
 
     <modules>
-        <module>kie-drl-kiesession-local</module>
         <module>kie-drl-map-input</module>
     </modules>
+
+    <profiles>
+        <profile>
+        <id>default</id>
+        <activation>
+            <property>
+            <name>!productized</name>
+            </property>
+        </activation>
+        <modules>
+            <module>kie-drl-kiesession-local</module>
+        </modules>
+        </profile>
+    </profiles>
 
     
 </project>

--- a/kie-drl/pom.xml
+++ b/kie-drl/pom.xml
@@ -18,11 +18,8 @@
   <description>Support for Rules</description>
 
   <modules>
-    <module>kie-drl-api</module>
     <module>kie-drl-compilation-common</module>
-    <module>kie-drl-runtime-common</module>
     <module>kie-drl-implementations</module>
-    <module>kie-drl-tests</module>
   </modules>
 
   <dependencyManagement>
@@ -103,5 +100,21 @@
       <scope>test</scope>
     </dependency>
   </dependencies>
+
+  <profiles>
+    <profile>
+      <id>default</id>
+      <activation>
+        <property>
+          <name>!productized</name>
+        </property>
+      </activation>
+      <modules>
+        <module>kie-drl-api</module>
+        <module>kie-drl-runtime-common</module>
+        <module>kie-drl-tests</module>
+      </modules>
+    </profile>
+  </profiles>
 
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -282,10 +282,11 @@
         <module>drools-templates</module>
         <module>drools-decisiontables</module>
         <module>drools-alphanetwork-compiler</module>
+        <module>kie-dmn</module>
+        <module>kie-drl</module>
+        <module>kie-pmml-trusty</module>
         <module>kie-internal</module>
         <module>kie-test-util</module>
-        <module>kie-dmn</module>
-        <module>kie-pmml-trusty</module>
         <module>drools-drl-quarkus-extension</module>
       </modules>
     </profile>


### PR DESCRIPTION
Solving
```
[ERROR] Failed to execute goal on project kie-pmml-models-drools-tree-tests: Could not resolve dependencies for project org.kie:kie-pmml-models-drools-tree-tests:jar:8.26.0.redhat-2022081722: The following artifacts could not be resolved: org.kie:kie-drl-compilation-common:jar:8.26.0.redhat-2022081722, org.kie:kie-drl-map-input-runtime:jar:8.26.0.redhat-2022081722: Failure to find org.kie:kie-drl-compilation-common:jar:8.26.0.redhat-2022081722 in https://bxms-qe.rhev-ci-vms.eng.rdu2.redhat.com:8443/nexus/content/groups/rhba-prod-nightly was cached in the local repository, resolution will not be reattempted until the update interval of qe-repository has elapsed or updates are forced -> [Help 1]
[ERROR] Failed to execute goal on project kie-pmml-models-drools-scorecard-tests: Could not resolve dependencies for project org.kie:kie-pmml-models-drools-scorecard-tests:jar:8.26.0.redhat-2022081722: The following artifacts could not be resolved: org.kie:kie-drl-compilation-common:jar:8.26.0.redhat-2022081722, org.kie:kie-drl-map-input-runtime:jar:8.26.0.redhat-2022081722: Failure to find org.kie:kie-drl-compilation-common:jar:8.26.0.redhat-2022081722 in https://bxms-qe.rhev-ci-vms.eng.rdu2.redhat.com:8443/nexus/content/groups/rhba-prod-nightly was cached in the local repository, resolution will not be reattempted until the update interval of qe-repository has elapsed or updates are forced -> [Help 1]
```

produced by https://eng-jenkins-csb-business-automation.apps.ocp-c1.prod.psi.redhat.com/job/PROD/job/kogito.nightly/job/main/274//consoleText

There is the chance to include the whole kie-drl set of modules, up to you guys to keep it simple or very specific 

<details>
<summary>
How to replicate CI configuration locally?
</summary>

Build Chain tool does "simple" maven build(s), the builds are just Maven commands, but because the repositories relates and depends on each other and any change in API or class method could affect several of those repositories there is a need to use [build-chain tool](https://github.com/kiegroup/github-action-build-chain) to handle cross repository builds and be sure that we always use latest version of the code for each repository.
 
[build-chain tool](https://github.com/kiegroup/github-action-build-chain) is a build tool which can be used on command line locally or in Github Actions workflow(s), in case you need to change multiple repositories and send multiple dependent pull requests related with a change you can easily reproduce the same build by executing it on Github hosted environment or locally in your development environment. See [local execution](https://github.com/kiegroup/github-action-build-chain#local-execution) details to get more information about it.
</details>

<details>
<summary>
How to retest this PR or trigger a specific build:
</summary>

- for <b>pull request checks</b>  
  Please add comment: <b>Jenkins retest this</b>

- for a <b>specific pull request check</b>  
  Please add comment: <b>Jenkins (re)run [drools|kogito-runtimes|kogito-apps|kogito-examples] tests</b>

- for a <b>full downstream build</b> 
  - for <b>jenkins</b> job: please add comment: <b>Jenkins run fdb</b>
  - for <b>github actions</b> job: add the label `run_fdb`

- <b>a compile downstream build</b> please  add comment: <b>Jenkins run cdb</b>

- <b>a full production downstream build</b> please add comment: <b>Jenkins execute product fdb</b>

- <b>an upstream build</b> please add comment: <b>Jenkins run upstream</b>

- for <b>quarkus branch checks</b>  
  Run checks against Quarkus current used branch  
  Please add comment: <b>Jenkins run quarkus-branch</b>

- for a <b>quarkus branch specific check</b>  
  Run checks against Quarkus current used branch  
  Please add comment: <b>Jenkins (re)run [drools|kogito-runtimes|kogito-apps|kogito-examples] quarkus-branch</b>

- for <b>quarkus main checks</b>  
  Run checks against Quarkus main branch  
  Please add comment: <b>Jenkins run quarkus-main</b>

- for a <b>specific quarkus main check</b>  
  Run checks against Quarkus main branch  
  Please add comment: <b>Jenkins (re)run [drools|kogito-runtimes|kogito-apps|kogito-examples] quarkus-branch</b>

- for <b>native checks</b>  
  Run native checks  
  Please add comment: <b>Jenkins run native</b>

- for a <b>specific native check</b>  
  Run native checks 
  Please add comment: <b>Jenkins (re)run [drools|kogito-runtimes|kogito-apps|kogito-examples] native</b>

- for <b>mandrel checks</b>  
  Run native checks against Mandrel image
  Please add comment: <b>Jenkins run mandrel</b>

- for a <b>specific mandrel check</b>  
  Run native checks against Mandrel image  
  Please add comment: <b>Jenkins (re)run [drools|kogito-runtimes|kogito-apps|kogito-examples] mandrel</b>
</details>
