### PR TITLE
[BXMSPROD-1770] Added OS Preparation

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -34,4 +34,6 @@ How to retest this PR or trigger a specific build:
 * <b>a full production downstream build</b> please add comment: <b>Jenkins execute product fdb</b>
 
 * <b>an upstream build</b> please add comment: <b>Jenkins run upstream</b>
+
+* <b>for windows os job</b> add the label `windows_check`
 </details>

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -2,20 +2,29 @@ name: Build Chain
 
 on:
   pull_request:
-    types: [opened, synchronize, reopened, ready_for_review]
+    types: [opened, synchronize, reopened, ready_for_review, labeled]
     paths-ignore:
       - 'LICENSE*'
       - '.gitignore'
       - '*.md'
       - '*.txt'
 jobs:
+  os-prep:
+    runs-on: ubuntu-latest
+    outputs:
+      os: ${{ steps.set-os.outputs.operating-systems }}
+    steps:
+      - name: OS Preparation
+        id: set-os
+        uses: kiegroup/droolsjbpm-build-bootstrap/.ci/actions/os-preparation@main
   build-chain:
+    needs: os-prep
     concurrency:
       group: pull_request-${{ github.head_ref }}
       cancel-in-progress: true
     strategy:
       matrix:
-        os: [ubuntu-latest, windows-latest]
+        os: ${{ fromJSON(needs.os-prep.outputs.os) }}
         java-version: [8, 11]
         maven-version: ['3.8.1']
       fail-fast: false

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -16,7 +16,7 @@ jobs:
     steps:
       - name: OS Preparation
         id: set-os
-        uses: kiegroup/droolsjbpm-build-bootstrap/.ci/actions/os-preparation@main
+        uses: lampajr/droolsjbpm-build-bootstrap/.ci/actions/os-preparation@BXMSPROD-1770_os_preparation
   build-chain:
     needs: os-prep
     concurrency:

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -16,7 +16,7 @@ jobs:
     steps:
       - name: OS Preparation
         id: set-os
-        uses: lampajr/droolsjbpm-build-bootstrap/.ci/actions/os-preparation@BXMSPROD-1770_os_preparation
+        uses: kiegroup/droolsjbpm-build-bootstrap/.ci/actions/os-preparation@main
   build-chain:
     needs: os-prep
     concurrency:


### PR DESCRIPTION

**JIRA**: 
- https://issues.redhat.com/browse/BXMSPROD-1770 

**referenced Pull Requests**: 
- https://github.com/kiegroup/droolsjbpm-build-bootstrap/pull/2040

This will work once https://github.com/kiegroup/droolsjbpm-build-bootstrap/pull/2040 will be merged in main.

<details>
<summary>
How to replicate CI configuration locally?
</summary>

Build Chain tool does "simple" maven build(s), the builds are just Maven commands, but because the repositories relates and depends on each other and any change in API or class method could affect several of those repositories there is a need to use [build-chain tool](https://github.com/kiegroup/github-action-build-chain) to handle cross repository builds and be sure that we always use latest version of the code for each repository.
 
[build-chain tool](https://github.com/kiegroup/github-action-build-chain) is a build tool which can be used on command line locally or in Github Actions workflow(s), in case you need to change multiple repositories and send multiple dependent pull requests related with a change you can easily reproduce the same build by executing it on Github hosted environment or locally in your development environment. See [local execution](https://github.com/kiegroup/github-action-build-chain#local-execution) details to get more information about it.
</details>

<details>
<summary>
How to retest this PR or trigger a specific build:
</summary>

- for <b>pull request checks</b>  
  Please add comment: <b>Jenkins retest this</b>

- for a <b>specific pull request check</b>  
  Please add comment: <b>Jenkins (re)run [drools|kogito-runtimes|kogito-apps|kogito-examples] tests</b>

- for a <b>full downstream build</b> 
  - for <b>jenkins</b> job: please add comment: <b>Jenkins run fdb</b>
  - for <b>github actions</b> job: add the label `run_fdb`

- <b>a compile downstream build</b> please  add comment: <b>Jenkins run cdb</b>

- <b>a full production downstream build</b> please add comment: <b>Jenkins execute product fdb</b>

- <b>an upstream build</b> please add comment: <b>Jenkins run upstream</b>

- for <b>quarkus branch checks</b>  
  Run checks against Quarkus current used branch  
  Please add comment: <b>Jenkins run quarkus-branch</b>

- for a <b>quarkus branch specific check</b>  
  Run checks against Quarkus current used branch  
  Please add comment: <b>Jenkins (re)run [drools|kogito-runtimes|kogito-apps|kogito-examples] quarkus-branch</b>

- for <b>quarkus main checks</b>  
  Run checks against Quarkus main branch  
  Please add comment: <b>Jenkins run quarkus-main</b>

- for a <b>specific quarkus main check</b>  
  Run checks against Quarkus main branch  
  Please add comment: <b>Jenkins (re)run [drools|kogito-runtimes|kogito-apps|kogito-examples] quarkus-branch</b>

- for <b>native checks</b>  
  Run native checks  
  Please add comment: <b>Jenkins run native</b>

- for a <b>specific native check</b>  
  Run native checks 
  Please add comment: <b>Jenkins (re)run [drools|kogito-runtimes|kogito-apps|kogito-examples] native</b>

- for <b>mandrel checks</b>  
  Run native checks against Mandrel image
  Please add comment: <b>Jenkins run mandrel</b>

- for a <b>specific mandrel check</b>  
  Run native checks against Mandrel image  
  Please add comment: <b>Jenkins (re)run [drools|kogito-runtimes|kogito-apps|kogito-examples] mandrel</b>
</details>
