### PR TITLE
DROOLS-7128 cleanup header in _generated_ Archetypes

### DIFF
--- a/kie-archetypes/kie-drools-exec-model-archetype/src/main/resources/archetype-resources/src/main/java/Measurement.java
+++ b/kie-archetypes/kie-drools-exec-model-archetype/src/main/resources/archetype-resources/src/main/java/Measurement.java
@@ -1,4 +1,4 @@
-/*
+#*
  * Copyright 2022 Red Hat, Inc. and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -11,8 +11,7 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
-*/
-
+*#
 #set( $symbol_pound = '#' )
 #set( $symbol_dollar = '$' )
 #set( $symbol_escape = '\' )

--- a/kie-archetypes/kie-drools-exec-model-archetype/src/main/resources/archetype-resources/src/main/resources/org/example/rules.drl
+++ b/kie-archetypes/kie-drools-exec-model-archetype/src/main/resources/archetype-resources/src/main/resources/org/example/rules.drl
@@ -1,4 +1,4 @@
-/*
+#*
  * Copyright 2022 Red Hat, Inc. and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -11,8 +11,7 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
-*/
-
+*#
 #set( $symbol_pound = '#' )
 #set( $symbol_dollar = '$' )
 #set( $symbol_escape = '\' )

--- a/kie-archetypes/kie-drools-exec-model-archetype/src/main/resources/archetype-resources/src/test/java/RuleTest.java
+++ b/kie-archetypes/kie-drools-exec-model-archetype/src/main/resources/archetype-resources/src/test/java/RuleTest.java
@@ -1,4 +1,4 @@
-/*
+#*
  * Copyright 2022 Red Hat, Inc. and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -11,8 +11,7 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
-*/
-
+*#
 #set( $symbol_pound = '#' )
 #set( $symbol_dollar = '$' )
 #set( $symbol_escape = '\' )

--- a/kie-archetypes/kie-drools-exec-model-archetype/src/test/resources/projects/integrationtestDefaults/reference/src/main/java/it/pkg/Measurement.java
+++ b/kie-archetypes/kie-drools-exec-model-archetype/src/test/resources/projects/integrationtestDefaults/reference/src/main/java/it/pkg/Measurement.java
@@ -1,17 +1,3 @@
-/*
- * Copyright 2022 Red Hat, Inc. and/or its affiliates.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- *
- *      http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
-*/
 
 package it.pkg;
 

--- a/kie-archetypes/kie-drools-exec-model-archetype/src/test/resources/projects/integrationtestDefaults/reference/src/main/resources/org/example/rules.drl
+++ b/kie-archetypes/kie-drools-exec-model-archetype/src/test/resources/projects/integrationtestDefaults/reference/src/main/resources/org/example/rules.drl
@@ -1,17 +1,3 @@
-/*
- * Copyright 2022 Red Hat, Inc. and/or its affiliates.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- *
- *      http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
-*/
 
 package it.pkg;
 

--- a/kie-archetypes/kie-drools-exec-model-archetype/src/test/resources/projects/integrationtestDefaults/reference/src/test/java/it/pkg/RuleTest.java
+++ b/kie-archetypes/kie-drools-exec-model-archetype/src/test/resources/projects/integrationtestDefaults/reference/src/test/java/it/pkg/RuleTest.java
@@ -1,17 +1,3 @@
-/*
- * Copyright 2022 Red Hat, Inc. and/or its affiliates.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- *
- *      http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
-*/
 
 package it.pkg;
 

--- a/kie-archetypes/kie-drools-exec-model-ruleunit-archetype/src/main/resources/archetype-resources/src/main/java/Measurement.java
+++ b/kie-archetypes/kie-drools-exec-model-ruleunit-archetype/src/main/resources/archetype-resources/src/main/java/Measurement.java
@@ -1,4 +1,4 @@
-/*
+#*
  * Copyright 2022 Red Hat, Inc. and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -11,8 +11,7 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
-*/
-
+*#
 #set( $symbol_pound = '#' )
 #set( $symbol_dollar = '$' )
 #set( $symbol_escape = '\' )

--- a/kie-archetypes/kie-drools-exec-model-ruleunit-archetype/src/main/resources/archetype-resources/src/main/java/MeasurementUnit.java
+++ b/kie-archetypes/kie-drools-exec-model-ruleunit-archetype/src/main/resources/archetype-resources/src/main/java/MeasurementUnit.java
@@ -1,4 +1,4 @@
-/*
+#*
  * Copyright 2022 Red Hat, Inc. and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -11,8 +11,7 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- */
-
+ *#
 #set( $symbol_pound = '#' )
 #set( $symbol_dollar = '$' )
 #set( $symbol_escape = '\' )

--- a/kie-archetypes/kie-drools-exec-model-ruleunit-archetype/src/main/resources/archetype-resources/src/main/resources/org/example/rules.drl
+++ b/kie-archetypes/kie-drools-exec-model-ruleunit-archetype/src/main/resources/archetype-resources/src/main/resources/org/example/rules.drl
@@ -1,4 +1,4 @@
-/*
+#*
  * Copyright 2022 Red Hat, Inc. and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -11,8 +11,7 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
-*/
-
+*#
 #set( $symbol_pound = '#' )
 #set( $symbol_dollar = '$' )
 #set( $symbol_escape = '\' )

--- a/kie-archetypes/kie-drools-exec-model-ruleunit-archetype/src/main/resources/archetype-resources/src/test/java/RuleTest.java
+++ b/kie-archetypes/kie-drools-exec-model-ruleunit-archetype/src/main/resources/archetype-resources/src/test/java/RuleTest.java
@@ -1,4 +1,4 @@
-/*
+#*
  * Copyright 2022 Red Hat, Inc. and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -11,8 +11,7 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
-*/
-
+*#
 #set( $symbol_pound = '#' )
 #set( $symbol_dollar = '$' )
 #set( $symbol_escape = '\' )

--- a/kie-archetypes/kie-drools-exec-model-ruleunit-archetype/src/test/resources/projects/integrationtestDefaults/reference/src/main/java/it/pkg/Measurement.java
+++ b/kie-archetypes/kie-drools-exec-model-ruleunit-archetype/src/test/resources/projects/integrationtestDefaults/reference/src/main/java/it/pkg/Measurement.java
@@ -1,17 +1,3 @@
-/*
- * Copyright 2022 Red Hat, Inc. and/or its affiliates.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- *
- *      http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
-*/
 
 package it.pkg;
 

--- a/kie-archetypes/kie-drools-exec-model-ruleunit-archetype/src/test/resources/projects/integrationtestDefaults/reference/src/main/java/it/pkg/MeasurementUnit.java
+++ b/kie-archetypes/kie-drools-exec-model-ruleunit-archetype/src/test/resources/projects/integrationtestDefaults/reference/src/main/java/it/pkg/MeasurementUnit.java
@@ -1,17 +1,3 @@
-/*
- * Copyright 2022 Red Hat, Inc. and/or its affiliates.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- *
- *      http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
 
 package it.pkg;
 

--- a/kie-archetypes/kie-drools-exec-model-ruleunit-archetype/src/test/resources/projects/integrationtestDefaults/reference/src/main/resources/org/example/rules.drl
+++ b/kie-archetypes/kie-drools-exec-model-ruleunit-archetype/src/test/resources/projects/integrationtestDefaults/reference/src/main/resources/org/example/rules.drl
@@ -1,17 +1,3 @@
-/*
- * Copyright 2022 Red Hat, Inc. and/or its affiliates.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- *
- *      http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
-*/
 
 package it.pkg;
 

--- a/kie-archetypes/kie-drools-exec-model-ruleunit-archetype/src/test/resources/projects/integrationtestDefaults/reference/src/test/java/it/pkg/RuleTest.java
+++ b/kie-archetypes/kie-drools-exec-model-ruleunit-archetype/src/test/resources/projects/integrationtestDefaults/reference/src/test/java/it/pkg/RuleTest.java
@@ -1,17 +1,3 @@
-/*
- * Copyright 2022 Red Hat, Inc. and/or its affiliates.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- *
- *      http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
-*/
 
 package it.pkg;
 


### PR DESCRIPTION
ref 👉 https://github.com/kiegroup/drools/pull/4582#pullrequestreview-1057556192

PLEASE NOTICE in the "source" the header is kept, as a Apache Velocity header comment. In the resulting file this header is therefore no longer present: these are the files the end-user obtain when Maven archetype generating, so they won't contain copyrights headers in the resulting kjar project files.

e.g.: I use a archetype with Maven archetype generate, the resulting maven project is the project I will start to modify source code etc... there is no reason the resulting project code is already copyrighted.

**JIRA**: https://issues.redhat.com/browse/DROOLS-7128

**referenced Pull Requests**: none

<details>
<summary>
How to replicate CI configuration locally?
</summary>

Build Chain tool does "simple" maven build(s), the builds are just Maven commands, but because the repositories relates and depends on each other and any change in API or class method could affect several of those repositories there is a need to use [build-chain tool](https://github.com/kiegroup/github-action-build-chain) to handle cross repository builds and be sure that we always use latest version of the code for each repository.
 
[build-chain tool](https://github.com/kiegroup/github-action-build-chain) is a build tool which can be used on command line locally or in Github Actions workflow(s), in case you need to change multiple repositories and send multiple dependent pull requests related with a change you can easily reproduce the same build by executing it on Github hosted environment or locally in your development environment. See [local execution](https://github.com/kiegroup/github-action-build-chain#local-execution) details to get more information about it.
</details>

<details>
<summary>
How to retest this PR or trigger a specific build:
</summary>

- for <b>pull request checks</b>  
  Please add comment: <b>Jenkins retest this</b>

- for a <b>specific pull request check</b>  
  Please add comment: <b>Jenkins (re)run [drools|kogito-runtimes|kogito-apps|kogito-examples] tests</b>

- for a <b>full downstream build</b> 
  - for <b>jenkins</b> job: please add comment: <b>Jenkins run fdb</b>
  - for <b>github actions</b> job: add the label `run_fdb`

- <b>a compile downstream build</b> please  add comment: <b>Jenkins run cdb</b>

- <b>a full production downstream build</b> please add comment: <b>Jenkins execute product fdb</b>

- <b>an upstream build</b> please add comment: <b>Jenkins run upstream</b>

- for <b>quarkus branch checks</b>  
  Run checks against Quarkus current used branch  
  Please add comment: <b>Jenkins run quarkus-branch</b>

- for a <b>quarkus branch specific check</b>  
  Run checks against Quarkus current used branch  
  Please add comment: <b>Jenkins (re)run [drools|kogito-runtimes|kogito-apps|kogito-examples] quarkus-branch</b>

- for <b>quarkus main checks</b>  
  Run checks against Quarkus main branch  
  Please add comment: <b>Jenkins run quarkus-main</b>

- for a <b>specific quarkus main check</b>  
  Run checks against Quarkus main branch  
  Please add comment: <b>Jenkins (re)run [drools|kogito-runtimes|kogito-apps|kogito-examples] quarkus-branch</b>

- for <b>native checks</b>  
  Run native checks  
  Please add comment: <b>Jenkins run native</b>

- for a <b>specific native check</b>  
  Run native checks 
  Please add comment: <b>Jenkins (re)run [drools|kogito-runtimes|kogito-apps|kogito-examples] native</b>

- for <b>mandrel checks</b>  
  Run native checks against Mandrel image
  Please add comment: <b>Jenkins run mandrel</b>

- for a <b>specific mandrel check</b>  
  Run native checks against Mandrel image  
  Please add comment: <b>Jenkins (re)run [drools|kogito-runtimes|kogito-apps|kogito-examples] mandrel</b>
</details>
