### PR TITLE
[DROOLS-7107] Drop or Deprecate drools-templates

### DIFF
--- a/drools-docs/src/modules/ROOT/pages/language-reference/_XLSDecisionTable-section.adoc
+++ b/drools-docs/src/modules/ROOT/pages/language-reference/_XLSDecisionTable-section.adoc
@@ -228,3 +228,8 @@ image::language-reference/lists.png[align="center"]
 
 Some applications provide a limited ability to keep a history of changes, but it is recommended to use an alternative means of revision control.
 When changes are being made to rules over time, older versions are archived (many open source solutions exist for this, such as Subversion or Git).
+
+[WARNING]
+====
+DRT (Drools Rule Template) is deprecated. Please consider this decision table capability or third party templating features if needed.
+====

--- a/kie-api/src/main/java/org/kie/api/io/ResourceType.java
+++ b/kie-api/src/main/java/org/kie/api/io/ResourceType.java
@@ -24,7 +24,12 @@ import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 public class ResourceType implements Serializable {
+
+    private static final Logger LOG = LoggerFactory.getLogger(ResourceType.class);
 
     private static final long serialVersionUID = 1613735834228581906L;
 
@@ -206,7 +211,10 @@ public class ResourceType implements Serializable {
                                                                           "Drools Rule Template",
                                                                           "src/main/resources",
                                                                           "drl.template");
-
+    /**
+     * @deprecated Since 8. Consider <code>drools-decisiontables</code> or third party templating features
+     */
+    @Deprecated
     public static final ResourceType DRT = addResourceTypeToRegistry("DRT",
                                                                      "Drools Rule Template",
                                                                      "src/main/resources",
@@ -251,6 +259,9 @@ public class ResourceType implements Serializable {
     public static ResourceType determineResourceType(final String resourceName) {
         for ( Map.Entry<String, ResourceType> entry : CACHE.entrySet() ) {
             if (resourceName.endsWith(entry.getKey())) {
+                if (entry.getValue().equals(ResourceType.DRT)) {
+                    LOG.warn("DRT (Drools Rule Template) is deprecated. Please consider drools-decisiontables or third party templating features.");
+                }
                 return entry.getValue();
             }
         }


### PR DESCRIPTION
**JIRA**: 

https://issues.redhat.com/browse/DROOLS-7107

https://github.com/kiegroup/drools/pull/4611#discussion_r949208103
@mariofusco mentioned
> I agree that our custom made rule templates implementation is brittle and not well maintained and that we could rewrite it using a more standard and battle tested templating engine. My suggestion is taking advantage of the new major release removing not only this paragraph but also the implementation code (or at least declaring it deprecated).

Actually `drools-decisiontables` depends on `drools-templates` so we cannot remove `drools-templates`. So now I raise a warning when a user uses `DRT` file. Also added a warning in the document. Is it good enough?


<details>
<summary>
How to replicate CI configuration locally?
</summary>

Build Chain tool does "simple" maven build(s), the builds are just Maven commands, but because the repositories relates and depends on each other and any change in API or class method could affect several of those repositories there is a need to use [build-chain tool](https://github.com/kiegroup/github-action-build-chain) to handle cross repository builds and be sure that we always use latest version of the code for each repository.
 
[build-chain tool](https://github.com/kiegroup/github-action-build-chain) is a build tool which can be used on command line locally or in Github Actions workflow(s), in case you need to change multiple repositories and send multiple dependent pull requests related with a change you can easily reproduce the same build by executing it on Github hosted environment or locally in your development environment. See [local execution](https://github.com/kiegroup/github-action-build-chain#local-execution) details to get more information about it.
</details>

<details>
<summary>
How to retest this PR or trigger a specific build:
</summary>

- for <b>pull request checks</b>  
  Please add comment: <b>Jenkins retest this</b>

- for a <b>specific pull request check</b>  
  Please add comment: <b>Jenkins (re)run [drools|kogito-runtimes|kogito-apps|kogito-examples] tests</b>

- for a <b>full downstream build</b> 
  - for <b>jenkins</b> job: please add comment: <b>Jenkins run fdb</b>
  - for <b>github actions</b> job: add the label `run_fdb`

- <b>a compile downstream build</b> please  add comment: <b>Jenkins run cdb</b>

- <b>a full production downstream build</b> please add comment: <b>Jenkins execute product fdb</b>

- <b>an upstream build</b> please add comment: <b>Jenkins run upstream</b>

- for <b>quarkus branch checks</b>  
  Run checks against Quarkus current used branch  
  Please add comment: <b>Jenkins run quarkus-branch</b>

- for a <b>quarkus branch specific check</b>  
  Run checks against Quarkus current used branch  
  Please add comment: <b>Jenkins (re)run [drools|kogito-runtimes|kogito-apps|kogito-examples] quarkus-branch</b>

- for <b>quarkus main checks</b>  
  Run checks against Quarkus main branch  
  Please add comment: <b>Jenkins run quarkus-main</b>

- for a <b>specific quarkus main check</b>  
  Run checks against Quarkus main branch  
  Please add comment: <b>Jenkins (re)run [drools|kogito-runtimes|kogito-apps|kogito-examples] quarkus-branch</b>

- for <b>native checks</b>  
  Run native checks  
  Please add comment: <b>Jenkins run native</b>

- for a <b>specific native check</b>  
  Run native checks 
  Please add comment: <b>Jenkins (re)run [drools|kogito-runtimes|kogito-apps|kogito-examples] native</b>

- for <b>mandrel checks</b>  
  Run native checks against Mandrel image
  Please add comment: <b>Jenkins run mandrel</b>

- for a <b>specific mandrel check</b>  
  Run native checks against Mandrel image  
  Please add comment: <b>Jenkins (re)run [drools|kogito-runtimes|kogito-apps|kogito-examples] mandrel</b>
</details>
