### PR TITLE
[7.x] [RHPAM-4504] Update KeyStoreHelper signature fails on ibm1.8 jdk cert…

### DIFF
--- a/drools-core/src/main/java/org/drools/core/util/KeyStoreHelper.java
+++ b/drools-core/src/main/java/org/drools/core/util/KeyStoreHelper.java
@@ -237,12 +237,11 @@ public class KeyStoreHelper {
         Signature sig = Signature.getInstance( SHA512WITH_RSA );
         sig.initVerify( cert.getPublicKey() );
         sig.update( data );
-        boolean result;
+        boolean result = false;
         try {
             result = sig.verify(signature); // IBM JDK 1.8 returns false without SignatureException
         } catch (SignatureException e) {
             logger.warn("Exception while verifying signature", e);
-            return verifyWithFallbackAlgorithmIfAllowed(cert, data, signature);
         }
         return result || verifyWithFallbackAlgorithmIfAllowed(cert, data, signature);
     }

--- a/drools-core/src/main/java/org/drools/core/util/KeyStoreHelper.java
+++ b/drools-core/src/main/java/org/drools/core/util/KeyStoreHelper.java
@@ -32,6 +32,8 @@ import java.security.cert.CertificateException;
 import javax.crypto.SecretKey;
 
 import org.drools.core.RuleBaseConfiguration;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import static org.drools.core.util.KeyStoreConstants.KEY_CERTIFICATE_TYPE;
 import static org.drools.core.util.KeyStoreConstants.KEY_PASSWORD_TYPE;
@@ -59,6 +61,8 @@ import static org.drools.core.util.KeyStoreConstants.PROP_PWD_KS_URL;
  * drools.serialization.public.keyStorePwd = <password>
  */
 public class KeyStoreHelper {
+
+    private final Logger logger = LoggerFactory.getLogger(KeyStoreHelper.class);
 
     private static final String SHA512WITH_RSA = "SHA512withRSA";
     private static final String MD5WITH_RSA = "MD5withRSA";
@@ -233,19 +237,27 @@ public class KeyStoreHelper {
         Signature sig = Signature.getInstance( SHA512WITH_RSA );
         sig.initVerify( cert.getPublicKey() );
         sig.update( data );
+        boolean result;
         try {
-            return sig.verify( signature );
+            result = sig.verify(signature); // IBM JDK 1.8 returns false without SignatureException
         } catch (SignatureException e) {
-            if (allowVerifyOldSignAlgo) {
-                // Fallback for old sign algorithm
-                sig = Signature.getInstance(MD5WITH_RSA);
-                sig.initVerify(cert.getPublicKey());
-                sig.update(data);
-                return sig.verify(signature);
-            } else {
-                throw new RuntimeException("Failed to verify signature. If you call this method for data signed by old Drools version," +
-                                                   " set system property \"" + KeyStoreConstants.PROP_VERIFY_OLD_SIGN + "\" to true" , e);
-            }
+            logger.warn("Exception while verifying signature", e);
+            return verifyWithFallbackAlgorithmIfAllowed(cert, data, signature);
+        }
+        return result || verifyWithFallbackAlgorithmIfAllowed(cert, data, signature);
+    }
+
+    private boolean verifyWithFallbackAlgorithmIfAllowed(Certificate cert, byte[] data, byte[] signature) throws NoSuchAlgorithmException, InvalidKeyException, SignatureException {
+        if (allowVerifyOldSignAlgo) {
+            // Fallback for old sign algorithm
+            Signature sig = Signature.getInstance(MD5WITH_RSA);
+            sig.initVerify(cert.getPublicKey());
+            sig.update(data);
+            return sig.verify(signature);
+        } else {
+            logger.warn("Failed to verify signature. If you call this method for data signed by old Drools version," +
+                                " set system property \"" + KeyStoreConstants.PROP_VERIFY_OLD_SIGN + "\" to true");
+            return false;
         }
     }
 


### PR DESCRIPTION
…ification test

**Ports** 
This PR is for 7.x.
Will do for 7.67.x
Will do for 7.67.x-blue
for main -> https://github.com/kiegroup/drools/pull/4678

**JIRA**: 
https://issues.redhat.com/browse/RHPAM-4504


<details>
<summary>
How to replicate CI configuration locally?
</summary>

Build Chain tool does "simple" maven build(s), the builds are just Maven commands, but because the repositories relates and depends on each other and any change in API or class method could affect several of those repositories there is a need to use [build-chain tool](https://github.com/kiegroup/github-action-build-chain) to handle cross repository builds and be sure that we always use latest version of the code for each repository.
 
[build-chain tool](https://github.com/kiegroup/github-action-build-chain) is a build tool which can be used on command line locally or in Github Actions workflow(s), in case you need to change multiple repositories and send multiple dependent pull requests related with a change you can easily reproduce the same build by executing it on Github hosted environment or locally in your development environment. See [local execution](https://github.com/kiegroup/github-action-build-chain#local-execution) details to get more information about it.
</details>

<details>
<summary>
How to retest this PR or trigger a specific build:
</summary>

- for <b>pull request checks</b>  
  Please add comment: <b>Jenkins retest this</b>

- for a <b>specific pull request check</b>  
  Please add comment: <b>Jenkins (re)run [drools|kogito-runtimes|kogito-apps|kogito-examples] tests</b>

- for a <b>full downstream build</b> 
  - for <b>jenkins</b> job: please add comment: <b>Jenkins run fdb</b>
  - for <b>github actions</b> job: add the label `run_fdb`

- <b>a compile downstream build</b> please  add comment: <b>Jenkins run cdb</b>

- <b>a full production downstream build</b> please add comment: <b>Jenkins execute product fdb</b>

- <b>an upstream build</b> please add comment: <b>Jenkins run upstream</b>

- for <b>quarkus branch checks</b>  
  Run checks against Quarkus current used branch  
  Please add comment: <b>Jenkins run quarkus-branch</b>

- for a <b>quarkus branch specific check</b>  
  Run checks against Quarkus current used branch  
  Please add comment: <b>Jenkins (re)run [drools|kogito-runtimes|kogito-apps|kogito-examples] quarkus-branch</b>

- for <b>quarkus main checks</b>  
  Run checks against Quarkus main branch  
  Please add comment: <b>Jenkins run quarkus-main</b>

- for a <b>specific quarkus main check</b>  
  Run checks against Quarkus main branch  
  Please add comment: <b>Jenkins (re)run [drools|kogito-runtimes|kogito-apps|kogito-examples] quarkus-branch</b>

- for <b>native checks</b>  
  Run native checks  
  Please add comment: <b>Jenkins run native</b>

- for a <b>specific native check</b>  
  Run native checks 
  Please add comment: <b>Jenkins (re)run [drools|kogito-runtimes|kogito-apps|kogito-examples] native</b>

- for <b>mandrel checks</b>  
  Run native checks against Mandrel image
  Please add comment: <b>Jenkins run mandrel</b>

- for a <b>specific mandrel check</b>  
  Run native checks against Mandrel image  
  Please add comment: <b>Jenkins (re)run [drools|kogito-runtimes|kogito-apps|kogito-examples] mandrel</b>
</details>
