### PR TITLE
[DO-NOT-MERGE] For Jenkins test : [DROOLS-7006] Publish Antora docs as drools job

### DIFF
--- a/.ci/jenkins/Jenkinsfile.promote
+++ b/.ci/jenkins/Jenkinsfile.promote
@@ -47,6 +47,12 @@ pipeline {
 
                     if (isRelease()) {
                         // Verify version is set and if on right release branch
+                        projectVersionValue = getProjectVersion()
+                        buildBranchValue = getBuildBranch()
+                        releaseBranchValue = util.getReleaseBranchFromVersion(getProjectVersion())
+                        echo "projectVersionValue ${projectVersionValue}"
+                        echo "buildBranchValue ${buildBranchValue}"
+                        echo "releaseBranchValue ${releaseBranchValue}"
                         assert getProjectVersion()
                         assert getBuildBranch() == util.getReleaseBranchFromVersion(getProjectVersion())
                     }

--- a/.ci/jenkins/Jenkinsfile.promote
+++ b/.ci/jenkins/Jenkinsfile.promote
@@ -67,6 +67,19 @@ pipeline {
                 }
             }
         }
+
+        stage('Upload drools binaries and documentation') {
+            when {
+                expression { return isRelease() }
+            }
+            steps {
+                script {
+                    getMavenCommand().inDirectory(getRepoName()).skipTests(true).withProperty('full').run('clean install')
+                    uploadFileMgmt(getRepoName())
+                }
+            }
+        }
+
         stage('Set next snapshot version') {
             when {
                 expression { return isRelease() }
@@ -258,4 +271,11 @@ void runMavenDeploy() {
         mvnCmd.withDeployRepository(env.MAVEN_DEPLOY_REPOSITORY)
     }
     mvnCmd.skipTests(true).run('clean deploy')
+}
+
+void uploadFileMgmt(String directory) {
+    echo "upload binaries and docs for ${directory}"
+    dir(directory) {
+        sh "script/release/upload_filemgmt.sh ${getProjectVersion()}"
+    }
 }

--- a/.ci/jenkins/Jenkinsfile.promote
+++ b/.ci/jenkins/Jenkinsfile.promote
@@ -274,8 +274,19 @@ void runMavenDeploy() {
 }
 
 void uploadFileMgmt(String directory) {
-    echo "upload binaries and docs for ${directory}"
-    dir(directory) {
-        sh "script/release/upload_filemgmt.sh ${getProjectVersion()}"
+    if (isNotTestingBuild()) {
+        echo "upload binaries and docs for ${directory}"
+        dir(directory) {
+            withCredentials(bindings: [sshUserPrivateKey(credentialsId: 'drools-filemgmt',
+                            keyFileVariable: 'SSH_KEY_JBOSS_FILEMGMT')]) {
+                sh "script/release/upload_filemgmt.sh ${getProjectVersion()} $SSH_KEY_JBOSS_FILEMGMT"
+            }
+        }
+    } else {
+        echo 'No uploadFileMgmt due to testing build'
     }
+}
+
+boolean isNotTestingBuild() {
+    return getGitAuthor() == 'kiegroup'
 }

--- a/.ci/jenkins/Jenkinsfile.promote
+++ b/.ci/jenkins/Jenkinsfile.promote
@@ -224,7 +224,7 @@ String getSnapshotBranch() {
 
 void checkoutRepo() {
     deleteDir()
-    checkout(githubscm.resolveRepository(getRepoName(), getGitAuthor(), getBuildBranch(), false))
+    checkout(githubscm.resolveRepository(getRepoName(), getGitAuthor(), getGitTag(), false))
     // need to manually checkout branch since on a detached branch after checkout command
     sh "git checkout ${getBuildBranch()}"
 }

--- a/.ci/jenkins/Jenkinsfile.promote
+++ b/.ci/jenkins/Jenkinsfile.promote
@@ -61,8 +61,8 @@ pipeline {
                 script {
                     dir(getRepoName()) {
                         checkoutRepo()
-                        mergeAndPush(getDeployPrLink())
-                        tagLatest()
+                        //mergeAndPush(getDeployPrLink())
+                        //tagLatest()
                     }
                 }
             }
@@ -80,32 +80,32 @@ pipeline {
             }
         }
 
-        stage('Set next snapshot version') {
-            when {
-                expression { return isRelease() }
-            }
-            steps {
-                script {
-                    dir('pr') {
-                        prepareForPR()
+        //stage('Set next snapshot version') {
+        //    when {
+        //        expression { return isRelease() }
+        //    }
+        //    steps {
+        //        script {
+        //            dir('pr') {
+        //                prepareForPR()
 
-                        maven.mvnVersionsSet(getMavenCommand(), getSnapshotVersion(), true)
+        //                maven.mvnVersionsSet(getMavenCommand(), getSnapshotVersion(), true)
 
-                        commitAndCreatePR()
-                    }
-                    dir(getRepoName()) {
-                        sh "git checkout ${getBuildBranch()}"
-                        mergeAndPush(getPipelinePrLink())
+        //                commitAndCreatePR()
+        //            }
+        //            dir(getRepoName()) {
+        //                sh "git checkout ${getBuildBranch()}"
+        //                mergeAndPush(getPipelinePrLink())
 
-                        if (shouldDeployToRepository()) {
-                            runMavenDeploy()
-                        } else {
-                            echo 'Testing environment and no specific deploy repository given => no deployment'
-                        }
-                    }
-                }
-            }
-        }
+        //                if (shouldDeployToRepository()) {
+        //                    runMavenDeploy()
+        //                } else {
+        //                    echo 'Testing environment and no specific deploy repository given => no deployment'
+        //                }
+        //            }
+        //        }
+        //    }
+        //}
     }
     post {
         unsuccessful {

--- a/drools-docs/README.adoc
+++ b/drools-docs/README.adoc
@@ -31,7 +31,7 @@ Finally install the Lunr extension with:
 
 == Building the website locally
 
-This folder contains an antora playbook, `antora-playbook.yml` to generate documentation from the source of your locally installed drools project. To run the latter and generate the documentation manually under the `drools-docs` folder use:
+This folder contains an antora playbook, `antora-playbook.yml` to generate documentation from the source of your locally installed drools project. You can build the website with `mvn clean install`. To generate the website manually, use:
 
 `npx antora antora-playbook.yml`
 

--- a/drools-docs/pom.xml
+++ b/drools-docs/pom.xml
@@ -115,8 +115,39 @@
           </execution>
         </executions>
       </plugin>
-
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-assembly-plugin</artifactId>
+      </plugin>
     </plugins>
+
+    <pluginManagement>
+      <plugins>
+        <plugin>
+          <groupId>org.apache.maven.plugins</groupId>
+          <artifactId>maven-assembly-plugin</artifactId>
+          <executions>
+            <execution>
+              <id>package-generated-docs</id>
+              <phase>package</phase>
+              <goals>
+                <goal>single</goal>
+              </goals>
+              <configuration>
+                <finalName>${project.artifactId}-${project.version}</finalName>
+                <appendAssemblyId>false</appendAssemblyId>
+                <descriptors>
+                  <descriptor>src/main/assembly/generated-docs-zip.xml</descriptor>
+                </descriptors>
+                <archive>
+                  <addMavenDescriptor>true</addMavenDescriptor>
+                </archive>
+              </configuration>
+            </execution>
+          </executions>
+        </plugin>
+      </plugins>
+    </pluginManagement>
   </build>
 
   <profiles>

--- a/drools-docs/src/main/assembly/generated-docs-zip.xml
+++ b/drools-docs/src/main/assembly/generated-docs-zip.xml
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<assembly xmlns="http://maven.apache.org/plugins/maven-assembly-plugin/assembly/1.1.2"
+          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+          xsi:schemaLocation="http://maven.apache.org/plugins/maven-assembly-plugin/assembly/1.1.2 http://maven.apache.org/xsd/assembly-1.1.2.xsd">
+
+  <id>prepare-generated-docs-for-upload</id>
+  <formats>
+    <format>dir</format>
+  </formats>
+
+  <includeBaseDirectory>false</includeBaseDirectory>
+  <fileSets>
+    <fileSet>
+      <directory>${project.build.directory}/website/docs/</directory>
+      <outputDirectory>docs-website/</outputDirectory>
+    </fileSet>
+  </fileSets>
+</assembly>

--- a/script/release/upload_filemgmt.sh
+++ b/script/release/upload_filemgmt.sh
@@ -54,10 +54,12 @@ cd filemgmt_links
 touch ${kieVersion}
 ln -s ${kieVersion} latest
 
-# Comment out until Drools 8 GA
-#echo "Uploading normal links..."
-#rsync -e "ssh -p 2222 -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null" --protocol=28 -a latest $rsync_filemgmt:${droolsDocs}
-#rsync -e "ssh -p 2222 -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null" --protocol=28 -a latest $rsync_filemgmt:${droolsHtdocs}
+# do not link latest to Beta
+if [[ "${kieVersion}" == *Final* ]]; then
+    echo "Uploading normal links..."
+    rsync -e "ssh -p 2222 -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null" --protocol=28 -a latest $rsync_filemgmt:${droolsDocs}
+    rsync -e "ssh -p 2222 -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null" --protocol=28 -a latest $rsync_filemgmt:${droolsHtdocs}
+fi
 
 ###############################################################################
 # latestFinal drools links

--- a/script/release/upload_filemgmt.sh
+++ b/script/release/upload_filemgmt.sh
@@ -1,0 +1,77 @@
+#!/bin/bash -e
+
+this_script_directory="${BASH_SOURCE%/*}"
+if [[ ! -d "$this_script_directory" ]]; then
+  this_script_directory="$PWD"
+fi
+
+kieVersion=$1
+drools_project_root=$this_script_directory/../..
+filemgmtServer=drools@filemgmt-prod.jboss.org
+rsync_filemgmt=drools@filemgmt-prod-sync.jboss.org
+droolsDocs=docs_htdocs/drools/release
+droolsHtdocs=downloads_htdocs/drools/release
+
+cd "${drools_project_root}"
+
+# create directory on filemgmt-prod.jboss.org for new release
+touch create_version
+echo "-mkdir ${droolsDocs}/${kieVersion}" > create_version
+echo "-mkdir ${droolsHtdocs}/${kieVersion}" >> create_version
+chmod +x create_version
+sftp -b create_version $filemgmtServer
+
+# creates directory kie-api-javadoc for drools on filemgmt-prod.jboss.org
+touch create_kie_api_javadoc_dir
+echo "-mkdir ${droolsDocs}/${kieVersion}/kie-api-javadoc" > create_kie_api_javadoc_dir
+chmod +x create_kie_api_javadoc_dir
+sftp -b create_kie_api_javadoc_dir $filemgmtServer
+
+# creates directory drools-docs on filemgmt-prod.jboss.org
+touch create_drools_docs_dir
+echo "-mkdir ${droolsDocs}/${kieVersion}/drools-docs" > create_drools_docs_dir
+chmod +x create_drools_docs_dir
+sftp -b create_drools_docs_dir $filemgmtServer
+
+# upload binaries to filemgmt-prod.jboss.org
+touch upload_binaries
+echo "put drools-distribution/target/drools-distribution-${kieVersion}.zip ${droolsHtdocs}/${kieVersion}" > upload_binaries
+chmod +x upload_binaries
+sftp -b upload_binaries $filemgmtServer
+
+# upload docs to filemgmt-prod.jboss.org
+rsync -Pavqr -e 'ssh -p 2222' --protocol=28 --delete-after drools-docs/target/drools-docs-${kieVersion}/* ${rsync_filemgmt}:${droolsDocs}/${kieVersion}/drools-docs
+rsync -Pavqr -e 'ssh -p 2222' --protocol=28 --delete-after kie-api/target/apidocs/* ${rsync_filemgmt}:${droolsDocs}/${kieVersion}/kie-api-javadoc
+
+
+# make filemgmt symbolic links for drools
+mkdir filemgmt_links
+cd filemgmt_links
+
+###############################################################################
+# latest drools links
+###############################################################################
+touch ${kieVersion}
+ln -s ${kieVersion} latest
+
+# Comment out until Drools 8 GA
+#echo "Uploading normal links..."
+#rsync -e "ssh -p 2222 -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null" --protocol=28 -a latest $rsync_filemgmt:${droolsDocs}
+#rsync -e "ssh -p 2222 -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null" --protocol=28 -a latest $rsync_filemgmt:${droolsHtdocs}
+
+###############################################################################
+# latestFinal drools links
+###############################################################################
+if [[ "${kieVersion}" == *Final* ]]; then
+    ln -s ${kieVersion} latestFinal
+    echo "Uploading Final links..."
+    rsync -e "ssh -p 2222 -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null" --protocol=28 -a latestFinal $rsync_filemgmt:${droolsDocs}
+    rsync -e "ssh -p 2222 -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null" --protocol=28 -a latestFinal $rsync_filemgmt:${droolsHtdocs}
+fi
+
+# remove files and directories for uploading drools
+cd ..
+rm -rf create_version
+rm -rf create_*_dir
+rm -rf upload_binaries
+rm -rf filemgmt_links


### PR DESCRIPTION
This PR is just to share code with @radtriste for Jenkins test. The actual PR is https://github.com/kiegroup/drools/pull/4459

<details>
<summary>
How to replicate CI configuration locally?
</summary>

Build Chain tool does "simple" maven build(s), the builds are just Maven commands, but because the repositories relates and depends on each other and any change in API or class method could affect several of those repositories there is a need to use [build-chain tool](https://github.com/kiegroup/github-action-build-chain) to handle cross repository builds and be sure that we always use latest version of the code for each repository.
 
[build-chain tool](https://github.com/kiegroup/github-action-build-chain) is a build tool which can be used on command line locally or in Github Actions workflow(s), in case you need to change multiple repositories and send multiple dependent pull requests related with a change you can easily reproduce the same build by executing it on Github hosted environment or locally in your development environment. See [local execution](https://github.com/kiegroup/github-action-build-chain#local-execution) details to get more information about it.
</details>

<details>
<summary>
How to retest this PR or trigger a specific build:
</summary>

- for <b>pull request checks</b>  
  Please add comment: <b>Jenkins retest this</b>

- for a <b>specific pull request check</b>  
  Please add comment: <b>Jenkins (re)run [drools|kogito-runtimes|kogito-apps|kogito-examples] tests</b>

- for a <b>full downstream build</b> 
  - for <b>jenkins</b> job: please add comment: <b>Jenkins run fdb</b>
  - for <b>github actions</b> job: add the label `run_fdb`

- <b>a compile downstream build</b> please  add comment: <b>Jenkins run cdb</b>

- <b>a full production downstream build</b> please add comment: <b>Jenkins execute product fdb</b>

- <b>an upstream build</b> please add comment: <b>Jenkins run upstream</b>

- for <b>quarkus branch checks</b>  
  Run checks against Quarkus current used branch  
  Please add comment: <b>Jenkins run quarkus-branch</b>

- for a <b>quarkus branch specific check</b>  
  Run checks against Quarkus current used branch  
  Please add comment: <b>Jenkins (re)run [drools|kogito-runtimes|kogito-apps|kogito-examples] quarkus-branch</b>

- for <b>quarkus main checks</b>  
  Run checks against Quarkus main branch  
  Please add comment: <b>Jenkins run quarkus-main</b>

- for a <b>specific quarkus main check</b>  
  Run checks against Quarkus main branch  
  Please add comment: <b>Jenkins (re)run [drools|kogito-runtimes|kogito-apps|kogito-examples] quarkus-branch</b>

- for <b>native checks</b>  
  Run native checks  
  Please add comment: <b>Jenkins run native</b>

- for a <b>specific native check</b>  
  Run native checks 
  Please add comment: <b>Jenkins (re)run [drools|kogito-runtimes|kogito-apps|kogito-examples] native</b>

- for <b>mandrel checks</b>  
  Run native checks against Mandrel image
  Please add comment: <b>Jenkins run mandrel</b>

- for a <b>specific mandrel check</b>  
  Run native checks against Mandrel image  
  Please add comment: <b>Jenkins (re)run [drools|kogito-runtimes|kogito-apps|kogito-examples] mandrel</b>
</details>
