### PR TITLE
DROOLS-7140 Drools 8 enforce JDK and Maven versions as a rule

### DIFF
--- a/build-parent/pom.xml
+++ b/build-parent/pom.xml
@@ -226,6 +226,11 @@
 
     <version.org.awaitility>4.2.0</version.org.awaitility>
     <version.io.github.bonigarcia>5.1.1</version.io.github.bonigarcia>
+
+    <!-- DROOLS-7140 Drools 8 enforce JDK and Maven versions as a rule --> 
+    <version.jdk>${maven.compiler.release}</version.jdk>
+    <version.maven>${version.org.apache.maven}</version.maven>
+    
   </properties>
 
   <dependencyManagement>
@@ -1624,6 +1629,22 @@
                     <checkProfiles>true</checkProfiles>
                     <failOnViolation>true</failOnViolation>
                   </requireManagedDeps>
+                </rules>
+              </configuration>
+            </execution>
+            <execution>
+              <id>enforce-versions</id>
+              <goals>
+                <goal>enforce</goal>
+              </goals>
+              <configuration>
+                <rules>
+                  <requireMavenVersion>
+                    <version>${version.maven}</version>
+                  </requireMavenVersion>
+                  <requireJavaVersion>
+                    <version>${version.jdk}</version>
+                  </requireJavaVersion>
                 </rules>
               </configuration>
             </execution>


### PR DESCRIPTION
Enforce min JDK and min Maven
following Kogito-like style

Followup of https://github.com/kiegroup/drools/pull/4656#pullrequestreview-1094393730

Reference: https://github.com/kiegroup/kogito-runtimes/blob/main/kogito-build/kogito-build-no-bom-parent/pom.xml#L205-L223

Reference:

<img width="850" alt="image" src="https://user-images.githubusercontent.com/1699252/188798346-746ce9f3-fdc4-4cb4-b827-164fb8bcd94e.png">

Demonstration local testing using an environment not matching minimum requirements:

![Screenshot 2022-09-07 at 07 42 18](https://user-images.githubusercontent.com/1699252/188798439-2f217d6f-676b-4c97-8fd7-710145164d1b.png)

The log is presented as a Warning, but any Enforcer rule failure would cause Maven build to Fail, as expected.

**JIRA**:  https://issues.redhat.com/browse/DROOLS-7140

**referenced Pull Requests**:

- followup of https://github.com/kiegroup/drools/pull/4656#pullrequestreview-1094393730

<details>
<summary>
How to replicate CI configuration locally?
</summary>

Build Chain tool does "simple" maven build(s), the builds are just Maven commands, but because the repositories relates and depends on each other and any change in API or class method could affect several of those repositories there is a need to use [build-chain tool](https://github.com/kiegroup/github-action-build-chain) to handle cross repository builds and be sure that we always use latest version of the code for each repository.
 
[build-chain tool](https://github.com/kiegroup/github-action-build-chain) is a build tool which can be used on command line locally or in Github Actions workflow(s), in case you need to change multiple repositories and send multiple dependent pull requests related with a change you can easily reproduce the same build by executing it on Github hosted environment or locally in your development environment. See [local execution](https://github.com/kiegroup/github-action-build-chain#local-execution) details to get more information about it.
</details>

<details>
<summary>
How to retest this PR or trigger a specific build:
</summary>

- for <b>pull request checks</b>  
  Please add comment: <b>Jenkins retest this</b>

- for a <b>specific pull request check</b>  
  Please add comment: <b>Jenkins (re)run [drools|kogito-runtimes|kogito-apps|kogito-examples] tests</b>

- for a <b>full downstream build</b> 
  - for <b>jenkins</b> job: please add comment: <b>Jenkins run fdb</b>
  - for <b>github actions</b> job: add the label `run_fdb`

- <b>a compile downstream build</b> please  add comment: <b>Jenkins run cdb</b>

- <b>a full production downstream build</b> please add comment: <b>Jenkins execute product fdb</b>

- <b>an upstream build</b> please add comment: <b>Jenkins run upstream</b>

- for <b>quarkus branch checks</b>  
  Run checks against Quarkus current used branch  
  Please add comment: <b>Jenkins run quarkus-branch</b>

- for a <b>quarkus branch specific check</b>  
  Run checks against Quarkus current used branch  
  Please add comment: <b>Jenkins (re)run [drools|kogito-runtimes|kogito-apps|kogito-examples] quarkus-branch</b>

- for <b>quarkus main checks</b>  
  Run checks against Quarkus main branch  
  Please add comment: <b>Jenkins run quarkus-main</b>

- for a <b>specific quarkus main check</b>  
  Run checks against Quarkus main branch  
  Please add comment: <b>Jenkins (re)run [drools|kogito-runtimes|kogito-apps|kogito-examples] quarkus-branch</b>

- for <b>native checks</b>  
  Run native checks  
  Please add comment: <b>Jenkins run native</b>

- for a <b>specific native check</b>  
  Run native checks 
  Please add comment: <b>Jenkins (re)run [drools|kogito-runtimes|kogito-apps|kogito-examples] native</b>

- for <b>mandrel checks</b>  
  Run native checks against Mandrel image
  Please add comment: <b>Jenkins run mandrel</b>

- for a <b>specific mandrel check</b>  
  Run native checks against Mandrel image  
  Please add comment: <b>Jenkins (re)run [drools|kogito-runtimes|kogito-apps|kogito-examples] mandrel</b>
</details>
