### PR TITLE
[KOGITO-6466] implement addLogical on DataStores in exec model generation

### DIFF
--- a/drools-core/src/main/java/org/drools/core/reteoo/PropertySpecificUtil.java
+++ b/drools-core/src/main/java/org/drools/core/reteoo/PropertySpecificUtil.java
@@ -46,7 +46,7 @@ public class PropertySpecificUtil {
     }
 
     public static BitMask getEmptyPropertyReactiveMask(int settablePropertiesSize) {
-        return BitMask.Factory.getEmpty(settablePropertiesSize + CUSTOM_BITS_OFFSET);
+        return BitMask.getEmpty(settablePropertiesSize + CUSTOM_BITS_OFFSET);
     }
 
     public static BitMask onlyTraitBitSetMask() {

--- a/drools-core/src/main/java/org/drools/core/util/bitmask/AllSetBitMask.java
+++ b/drools-core/src/main/java/org/drools/core/util/bitmask/AllSetBitMask.java
@@ -37,7 +37,7 @@ public class AllSetBitMask extends SingleLongBitMask implements BitMask, AllSetM
 
     @Override
     public BitMask reset(int index) {
-        return BitMask.Factory.getFull(index+1).reset(index);
+        return BitMask.getFull(index+1).reset(index);
     }
 
     @Override
@@ -51,7 +51,7 @@ public class AllSetBitMask extends SingleLongBitMask implements BitMask, AllSetM
         } else if (mask instanceof AllSetButLastBitMask) {
             return EmptyButLastBitMask.get();
         }
-        return BitMask.Factory.getFull(mask instanceof LongBitMask ? 1 : 65).resetAll(mask);
+        return BitMask.getFull(mask instanceof LongBitMask ? 1 : 65).resetAll(mask);
     }
 
     @Override

--- a/drools-core/src/main/java/org/drools/core/util/bitmask/AllSetButLastBitMask.java
+++ b/drools-core/src/main/java/org/drools/core/util/bitmask/AllSetButLastBitMask.java
@@ -40,7 +40,7 @@ public class AllSetButLastBitMask extends SingleLongBitMask implements BitMask, 
         if (index == 0) {
             return this;
         }
-        return BitMask.Factory.getFull(index+1).reset(0).reset(index);
+        return BitMask.getFull(index+1).reset(0).reset(index);
     }
 
     @Override
@@ -51,7 +51,7 @@ public class AllSetButLastBitMask extends SingleLongBitMask implements BitMask, 
         if (mask instanceof AllSetMask) {
             return EmptyBitMask.get();
         }
-        return BitMask.Factory.getFull(mask instanceof LongBitMask ? 1 : 65).reset(0).resetAll(mask);
+        return BitMask.getFull(mask instanceof LongBitMask ? 1 : 65).reset(0).resetAll(mask);
     }
 
     @Override

--- a/drools-core/src/main/java/org/drools/core/util/bitmask/BitMask.java
+++ b/drools-core/src/main/java/org/drools/core/util/bitmask/BitMask.java
@@ -36,22 +36,20 @@ public interface BitMask extends Serializable, Cloneable {
 
     String getInstancingStatement();
 
-    public class Factory {
-        public static BitMask getEmpty(int numBits) {
-            return numBits <= 64 ? new LongBitMask() : new OpenBitSet(numBits);
-        }
+    static BitMask getEmpty(int numBits) {
+        return numBits <= 64 ? new LongBitMask() : new OpenBitSet(numBits);
+    }
 
-        public static BitMask getFull(int numBits) {
-            if (numBits <= 64) {
-                return new LongBitMask(-1L);
-            }
-            int nWords = (numBits / 64) + 1;
-            long[] bits = new long[nWords];
-            for (int i = 0; i < bits.length; i++) {
-                bits[i] = -1L;
-            }
-            return new OpenBitSet(bits, nWords);
+    static BitMask getFull(int numBits) {
+        if (numBits <= 64) {
+            return new LongBitMask(-1L);
         }
+        int nWords = (numBits / 64) + 1;
+        long[] bits = new long[nWords];
+        for (int i = 0; i < bits.length; i++) {
+            bits[i] = -1L;
+        }
+        return new OpenBitSet(bits, nWords);
     }
 
 }

--- a/drools-core/src/main/java/org/drools/core/util/bitmask/EmptyBitMask.java
+++ b/drools-core/src/main/java/org/drools/core/util/bitmask/EmptyBitMask.java
@@ -27,7 +27,7 @@ public class EmptyBitMask extends SingleLongBitMask implements BitMask, EmptyMas
 
     @Override
     public BitMask set(int index) {
-        return BitMask.Factory.getEmpty(index+1).set(index);
+        return BitMask.getEmpty(index+1).set(index);
     }
 
     @Override

--- a/drools-core/src/main/java/org/drools/core/util/bitmask/EmptyButLastBitMask.java
+++ b/drools-core/src/main/java/org/drools/core/util/bitmask/EmptyButLastBitMask.java
@@ -27,7 +27,7 @@ public class EmptyButLastBitMask extends SingleLongBitMask implements BitMask, E
 
     @Override
     public BitMask set(int index) {
-        return BitMask.Factory.getEmpty(index+1).set(index).set(0);
+        return BitMask.getEmpty(index+1).set(index).set(0);
     }
 
     @Override

--- a/drools-core/src/main/java/org/drools/core/util/bitmask/LongBitMask.java
+++ b/drools-core/src/main/java/org/drools/core/util/bitmask/LongBitMask.java
@@ -28,7 +28,7 @@ public class LongBitMask extends SingleLongBitMask implements BitMask {
     @Override
     public BitMask set(int index) {
         if (index >= 64) {
-            return BitMask.Factory.getEmpty(index+1).setAll(this).set(index);
+            return BitMask.getEmpty(index+1).setAll(this).set(index);
         }
         this.mask = this.mask | (1L << index);
         return this;

--- a/drools-model/drools-model-codegen/src/main/java/org/drools/model/codegen/execmodel/generator/Consequence.java
+++ b/drools-model/drools-model-codegen/src/main/java/org/drools/model/codegen/execmodel/generator/Consequence.java
@@ -412,7 +412,11 @@ public class Consequence {
                         }
                     }
 
-                    updateExpr.addArgument( "mask_" + updatedVar );
+                    Expression bitMaskArgExpr = new NameExpr("mask_" + updatedVar);
+                    if (hasRuleUnit() && updateExpr.toString().contains("ConsequenceDataStoreImpl")) {
+                        bitMaskArgExpr = new MethodCallExpr("org.drools.modelcompiler.util.EvaluationUtil.adaptBitMask", bitMaskArgExpr);
+                    }
+                    updateExpr.addArgument(bitMaskArgExpr);
                     initializedBitmaskFields.add( updatedVar );
                 }
             }
@@ -537,5 +541,9 @@ public class Consequence {
         return scope.isNameExpr() && context.getDeclarationById(scope.asNameExpr().getNameAsString())
                 .map(DeclarationSpec::getDeclarationClass)
                 .map(dataStoreClass::isAssignableFrom).orElse(false);
+    }
+
+    private static boolean hasRuleUnit() {
+        return dataStoreClass != null;
     }
 }

--- a/drools-model/drools-model-codegen/src/main/java/org/drools/model/codegen/execmodel/generator/Consequence.java
+++ b/drools-model/drools-model-codegen/src/main/java/org/drools/model/codegen/execmodel/generator/Consequence.java
@@ -26,7 +26,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
-import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
@@ -44,16 +43,16 @@ import com.github.javaparser.ast.expr.FieldAccessExpr;
 import com.github.javaparser.ast.expr.LambdaExpr;
 import com.github.javaparser.ast.expr.MethodCallExpr;
 import com.github.javaparser.ast.expr.NameExpr;
+import com.github.javaparser.ast.expr.ObjectCreationExpr;
 import com.github.javaparser.ast.expr.SimpleName;
 import com.github.javaparser.ast.expr.VariableDeclarationExpr;
 import com.github.javaparser.ast.stmt.BlockStmt;
 import com.github.javaparser.ast.stmt.ExpressionStmt;
 import com.github.javaparser.ast.type.Type;
 import org.drools.compiler.compiler.MissingDependencyError;
-import org.drools.drl.ast.descr.RuleDescr;
 import org.drools.core.common.TruthMaintenanceSystemFactory;
 import org.drools.core.factmodel.ClassDefinition;
-import org.drools.util.StringUtils;
+import org.drools.drl.ast.descr.RuleDescr;
 import org.drools.model.BitMask;
 import org.drools.model.bitmask.AllSetButLastBitMask;
 import org.drools.model.codegen.execmodel.PackageModel;
@@ -65,15 +64,11 @@ import org.drools.modelcompiler.consequence.DroolsImpl;
 import org.drools.mvelcompiler.CompiledBlockResult;
 import org.drools.mvelcompiler.ModifyCompiler;
 import org.drools.mvelcompiler.MvelCompilerException;
+import org.drools.util.StringUtils;
 
 import static com.github.javaparser.StaticJavaParser.parseExpression;
 import static com.github.javaparser.ast.NodeList.nodeList;
 import static java.util.stream.Collectors.toSet;
-import static org.drools.util.ClassUtils.getter2property;
-import static org.drools.util.ClassUtils.isGetter;
-import static org.drools.util.ClassUtils.isReadableProperty;
-import static org.drools.util.ClassUtils.isSetter;
-import static org.drools.util.ClassUtils.setter2property;
 import static org.drools.model.codegen.execmodel.PackageModel.DOMAIN_CLASSESS_METADATA_FILE_NAME;
 import static org.drools.model.codegen.execmodel.PackageModel.DOMAIN_CLASS_METADATA_INSTANCE;
 import static org.drools.model.codegen.execmodel.generator.DrlxParseUtil.addCurlyBracesToBlock;
@@ -89,11 +84,20 @@ import static org.drools.model.codegen.execmodel.generator.DslMethodNames.ON_CAL
 import static org.drools.model.codegen.execmodel.generator.DslMethodNames.createDslTopLevelMethod;
 import static org.drools.modelcompiler.util.ClassUtil.asJavaSourceName;
 import static org.drools.mvel.parser.printer.PrintUtil.printNode;
+import static org.drools.util.ClassUtils.getter2property;
+import static org.drools.util.ClassUtils.isGetter;
+import static org.drools.util.ClassUtils.isReadableProperty;
+import static org.drools.util.ClassUtils.isSetter;
+import static org.drools.util.ClassUtils.setter2property;
 
 public class Consequence {
 
     public static final Set<String> knowledgeHelperMethods = new HashSet<>();
     public static final Set<String> implicitDroolsMethods = new HashSet<>();
+
+    public static final Set<String> dataStoreMethods = new HashSet<>();
+
+    public static Class<?> dataStoreClass;
 
     private Expression createAsKnowledgeHelperExpression() {
         return parseExpression(String.format("((%s) drools).asKnowledgeHelper()", DroolsImpl.class.getCanonicalName()));
@@ -116,6 +120,14 @@ public class Consequence {
         knowledgeHelperMethods.add("insertLogical");
         knowledgeHelperMethods.add("run");
         knowledgeHelperMethods.add("guard");
+
+        try {
+            dataStoreClass = Class.forName("org.drools.ruleunits.api.DataStore");
+            dataStoreMethods.add("addLogical");
+            dataStoreMethods.add("update");
+        } catch (ClassNotFoundException e) {
+            // not using rule units, ignore
+        }
     }
 
     private final RuleContext context;
@@ -319,7 +331,6 @@ public class Consequence {
     }
 
     private boolean rewriteRHS(BlockStmt ruleBlock, BlockStmt rhs) {
-        AtomicBoolean requireDrools = new AtomicBoolean(false);
         List<MethodCallExpr> methodCallExprs = rhs.findAll(MethodCallExpr.class);
         List<AssignExpr> assignExprs = rhs.findAll(AssignExpr.class);
         List<MethodCallExpr> updateExprs = new ArrayList<>();
@@ -329,28 +340,54 @@ public class Consequence {
             rhsBodyDeclarations.put(variableDeclarator.getNameAsString(), variableDeclarator.getType());
         }
 
+        boolean requireDrools = false;
         for (MethodCallExpr methodCallExpr : methodCallExprs) {
-            if (!methodCallExpr.getScope().isPresent() && isImplicitDroolsMethod( methodCallExpr )) {
-                if ( methodCallExpr.getNameAsString().equals("insertLogical") && !TruthMaintenanceSystemFactory.present() ) {
-                    context.addCompilationError(new MissingDependencyError(TruthMaintenanceSystemFactory.NO_TMS));
-                }
-                methodCallExpr.setScope(new NameExpr("drools"));
-            }
-            if (hasDroolsScope( methodCallExpr ) || hasDroolsAsParameter( methodCallExpr )) {
-                if (knowledgeHelperMethods.contains(methodCallExpr.getNameAsString())) {
-                    methodCallExpr.setScope(createAsKnowledgeHelperExpression());
-                } else if (methodCallExpr.getNameAsString().equals("update")) {
-                    if (methodCallExpr.toString().contains( "FactHandle" )) {
-                        methodCallExpr.setScope( new NameExpr( "((org.drools.modelcompiler.consequence.DroolsImpl) drools)" ) );
-                    }
-                    updateExprs.add(methodCallExpr);
-                } else if (methodCallExpr.getNameAsString().equals("retract")) {
-                    methodCallExpr.setName(new SimpleName("delete"));
-                }
-                requireDrools.set(true);
-            }
+            requireDrools |= rewriteMethodCall(updateExprs, methodCallExpr);
         }
 
+        addUpdateBitMask(ruleBlock, methodCallExprs, assignExprs, updateExprs, rhsBodyDeclarations);
+
+        return requireDrools;
+    }
+
+    private boolean rewriteMethodCall(List<MethodCallExpr> updateExprs, MethodCallExpr methodCallExpr) {
+        if ( methodCallExpr.getScope().isPresent() ) {
+            if ( dataStoreMethods.contains(methodCallExpr.getNameAsString()) ) {
+                Expression scope = methodCallExpr.getScope().get();
+                if (isDataStoreScope(scope)) {
+                    if ( methodCallExpr.getNameAsString().equals("addLogical") && !TruthMaintenanceSystemFactory.present() ) {
+                        context.addCompilationError(new MissingDependencyError(TruthMaintenanceSystemFactory.NO_TMS));
+                    }
+                    NodeList<Expression> args = NodeList.nodeList(
+                            new CastExpr(toClassOrInterfaceType( org.kie.api.runtime.rule.RuleContext.class ), new NameExpr( "drools" ) ),
+                            methodCallExpr.getScope().get());
+                    methodCallExpr.setScope( new ObjectCreationExpr(null, toClassOrInterfaceType("org.drools.ruleunits.impl.ConsequenceDataStoreImpl"), args) );
+                }
+            }
+        } else if ( implicitDroolsMethods.contains(methodCallExpr.getNameAsString()) ) {
+            if ( methodCallExpr.getNameAsString().equals("insertLogical") && !TruthMaintenanceSystemFactory.present() ) {
+                context.addCompilationError(new MissingDependencyError(TruthMaintenanceSystemFactory.NO_TMS));
+            }
+            methodCallExpr.setScope(new NameExpr("drools"));
+        }
+
+        if (hasDroolsScope(methodCallExpr) || hasDroolsAsParameter(methodCallExpr)) {
+            if (knowledgeHelperMethods.contains(methodCallExpr.getNameAsString())) {
+                methodCallExpr.setScope(createAsKnowledgeHelperExpression());
+            } else if (methodCallExpr.getNameAsString().equals("update")) {
+                if (methodCallExpr.toString().contains( "FactHandle" )) {
+                    methodCallExpr.setScope( new EnclosedExpr( new CastExpr(toClassOrInterfaceType( DroolsImpl.class ), new NameExpr( "drools" ) ) ) );
+                }
+                updateExprs.add(methodCallExpr);
+            } else if (methodCallExpr.getNameAsString().equals("retract")) {
+                methodCallExpr.setName(new SimpleName("delete"));
+            }
+            return true;
+        }
+        return false;
+    }
+
+    private void addUpdateBitMask(BlockStmt ruleBlock, List<MethodCallExpr> methodCallExprs, List<AssignExpr> assignExprs, List<MethodCallExpr> updateExprs, Map<String, Type> rhsBodyDeclarations) {
         Set<String> initializedBitmaskFields = new HashSet<>();
         for (MethodCallExpr updateExpr : updateExprs) {
             Expression argExpr = updateExpr.getArgument( 0 );
@@ -366,8 +403,8 @@ public class Consequence {
                 if (context.isPropertyReactive(updatedClass)) {
 
                     if ( !initializedBitmaskFields.contains( updatedVar ) ) {
-                        Set<String> modifiedProps = findModifiedProperties( methodCallExprs, updateExpr, updatedVar, updatedClass );
-                        modifiedProps.addAll(findModifiedPropertiesFromAssignment( assignExprs, updateExpr, updatedVar, updatedClass ));
+                        Set<String> modifiedProps = findModifiedProperties(methodCallExprs, updateExpr, updatedVar, updatedClass );
+                        modifiedProps.addAll(findModifiedPropertiesFromAssignment(assignExprs, updateExpr, updatedVar, updatedClass ));
                         MethodCallExpr bitMaskCreation = createBitMaskInitialization( updatedClass, modifiedProps );
                         AssignExpr bitMaskAssign = createBitMaskField(updatedVar, bitMaskCreation);
                         if (!DrlxParseUtil.hasDuplicateExpr(ruleBlock, bitMaskAssign)) {
@@ -380,8 +417,6 @@ public class Consequence {
                 }
             }
         }
-
-        return requireDrools.get();
     }
 
     private Class<?> classFromRHSDeclarations(Map<String, Type> rhsDeclarations, String updatedVar) {
@@ -498,7 +533,9 @@ public class Consequence {
                 .isPresent();
     }
 
-    private static boolean isImplicitDroolsMethod( MethodCallExpr mce ) {
-        return !mce.getScope().isPresent() && implicitDroolsMethods.contains(mce.getNameAsString());
+    private boolean isDataStoreScope(Expression scope) {
+        return scope.isNameExpr() && context.getDeclarationById(scope.asNameExpr().getNameAsString())
+                .map(DeclarationSpec::getDeclarationClass)
+                .map(dataStoreClass::isAssignableFrom).orElse(false);
     }
 }

--- a/drools-model/drools-model-compiler/src/main/java/org/drools/modelcompiler/consequence/DroolsImpl.java
+++ b/drools-model/drools-model-compiler/src/main/java/org/drools/modelcompiler/consequence/DroolsImpl.java
@@ -27,6 +27,7 @@ import org.drools.model.BitMask;
 import org.drools.model.Channel;
 import org.drools.model.Drools;
 import org.drools.model.DroolsEntryPoint;
+import org.kie.api.KieBase;
 import org.kie.api.runtime.KieRuntime;
 import org.kie.api.runtime.rule.EntryPoint;
 import org.kie.api.runtime.rule.FactHandle;
@@ -156,6 +157,11 @@ public class DroolsImpl implements Drools, org.kie.api.runtime.rule.RuleContext 
     @Override
     public void setFocus( String focus ) {
         knowledgeHelper.setFocus( focus );
+    }
+
+    @Override
+    public KieBase getKieBase() {
+        return (KieBase) reteEvaluator.getKnowledgeBase();
     }
 
     @Override

--- a/drools-ruleunits/drools-ruleunits-dsl/src/test/java/org/drools/ruleunits/dsl/InferenceUnit.java
+++ b/drools-ruleunits/drools-ruleunits-dsl/src/test/java/org/drools/ruleunits/dsl/InferenceUnit.java
@@ -22,7 +22,6 @@ import org.drools.ruleunits.dsl.domain.Person;
 import static org.drools.model.Index.ConstraintType.EQUAL;
 import static org.drools.model.Index.ConstraintType.GREATER_OR_EQUAL;
 import static org.drools.model.Index.ConstraintType.GREATER_THAN;
-import static org.drools.model.Index.ConstraintType.LESS_THAN;
 
 public class InferenceUnit implements RuleUnitDefinition {
 
@@ -56,11 +55,10 @@ public class InferenceUnit implements RuleUnitDefinition {
         rulesFactory.rule()
                 .on(persons)
                 .filter("name", p -> p.getName() , EQUAL, "Mario")
-                .filter("age", p -> p.getAge() , LESS_THAN, 18)
                 // executeOnDataStore is required when using methods specific of a DataStore like update or addLogical
                 .executeOnDataStore(persons, (ps, p) -> {
                     p.setAge(p.getAge()+1);
-                    ps.update(p);
+                    ps.update(p, "age"); // property reactivity update
                 });
 
         rulesFactory.rule()

--- a/drools-ruleunits/drools-ruleunits-impl/pom.xml
+++ b/drools-ruleunits/drools-ruleunits-impl/pom.xml
@@ -65,6 +65,11 @@
       </dependency>
       <dependency>
         <groupId>org.drools</groupId>
+        <artifactId>drools-tms</artifactId>
+        <scope>test</scope>
+      </dependency>
+      <dependency>
+        <groupId>org.drools</groupId>
         <artifactId>drools-wiring-dynamic</artifactId>
         <scope>test</scope>
       </dependency>

--- a/drools-ruleunits/drools-ruleunits-impl/src/main/java/org/drools/ruleunits/impl/ConsequenceDataStore.java
+++ b/drools-ruleunits/drools-ruleunits-impl/src/main/java/org/drools/ruleunits/impl/ConsequenceDataStore.java
@@ -16,11 +16,11 @@
 package org.drools.ruleunits.impl;
 
 public interface ConsequenceDataStore<T> {
-    void add(T t);
+    void add(T object);
 
-    void addLogical(T t);
+    void addLogical(T object);
 
-    void update(T t);
+    void update(T object, String... modifiedProperties);
 
-    void remove(T t);
+    void remove(T object);
 }

--- a/drools-ruleunits/drools-ruleunits-impl/src/main/java/org/drools/ruleunits/impl/ConsequenceDataStoreImpl.java
+++ b/drools-ruleunits/drools-ruleunits-impl/src/main/java/org/drools/ruleunits/impl/ConsequenceDataStoreImpl.java
@@ -15,10 +15,14 @@
  */
 package org.drools.ruleunits.impl;
 
+import org.drools.core.impl.RuleBase;
 import org.drools.core.rule.consequence.Activation;
+import org.drools.core.util.bitmask.AllSetBitMask;
 import org.drools.core.util.bitmask.BitMask;
 import org.drools.ruleunits.api.DataStore;
 import org.kie.api.runtime.rule.RuleContext;
+
+import static org.drools.kiesession.entrypoints.NamedEntryPoint.calculateUpdateBitMask;
 
 public class ConsequenceDataStoreImpl<T> implements ConsequenceDataStore<T> {
 
@@ -32,26 +36,27 @@ public class ConsequenceDataStoreImpl<T> implements ConsequenceDataStore<T> {
     }
 
     @Override
-    public void add(T t) {
-        dataStore.add(t);
+    public void add(T object) {
+        dataStore.add(object);
     }
 
     @Override
-    public void addLogical(T t) {
-        ((InternalStoreCallback)dataStore).addLogical(ruleContext, t);
+    public void addLogical(T object) {
+        ((InternalStoreCallback)dataStore).addLogical(ruleContext, object);
     }
 
     @Override
-    public void update(T t) {
-        dataStore.update(((InternalStoreCallback)dataStore).lookup(t), t);
+    public void update(T object, String... modifiedProperties) {
+        BitMask bitMask = modifiedProperties.length == 0 ? AllSetBitMask.get() : calculateUpdateBitMask((RuleBase) ruleContext.getKieBase(), object, modifiedProperties);
+        update(object, bitMask);
     }
 
-    public void update(T t, BitMask bitMask) {
-        ((InternalStoreCallback)dataStore).update(((InternalStoreCallback)dataStore).lookup(t), t, bitMask, t.getClass(), (Activation) ruleContext.getMatch());
+    public void update(T object, BitMask bitMask) {
+        ((InternalStoreCallback)dataStore).update(((InternalStoreCallback)dataStore).lookup(object), object, bitMask, object.getClass(), (Activation) ruleContext.getMatch());
     }
 
     @Override
-    public void remove(T t) {
-        dataStore.remove(t);
+    public void remove(T object) {
+        dataStore.remove(object);
     }
 }

--- a/drools-ruleunits/drools-ruleunits-impl/src/main/java/org/drools/ruleunits/impl/ConsequenceDataStoreImpl.java
+++ b/drools-ruleunits/drools-ruleunits-impl/src/main/java/org/drools/ruleunits/impl/ConsequenceDataStoreImpl.java
@@ -15,6 +15,8 @@
  */
 package org.drools.ruleunits.impl;
 
+import org.drools.core.rule.consequence.Activation;
+import org.drools.core.util.bitmask.BitMask;
 import org.drools.ruleunits.api.DataStore;
 import org.kie.api.runtime.rule.RuleContext;
 
@@ -42,6 +44,10 @@ public class ConsequenceDataStoreImpl<T> implements ConsequenceDataStore<T> {
     @Override
     public void update(T t) {
         dataStore.update(((InternalStoreCallback)dataStore).lookup(t), t);
+    }
+
+    public void update(T t, BitMask bitMask) {
+        ((InternalStoreCallback)dataStore).update(((InternalStoreCallback)dataStore).lookup(t), t, bitMask, t.getClass(), (Activation) ruleContext.getMatch());
     }
 
     @Override

--- a/drools-ruleunits/drools-ruleunits-impl/src/main/java/org/drools/ruleunits/impl/FieldDataStore.java
+++ b/drools-ruleunits/drools-ruleunits-impl/src/main/java/org/drools/ruleunits/impl/FieldDataStore.java
@@ -105,7 +105,11 @@ public class FieldDataStore<T> implements SingletonStore<T>, InternalStoreCallba
 
     @Override
     public void update(RuleUnitInternalFactHandle fh, Object obj, BitMask mask, Class<?> modifiedClass, Activation activation) {
-        DataHandle dh = fh.getDataHandle();
+        update(fh.getDataHandle(), obj, mask, modifiedClass, activation);
+    }
+
+    @Override
+    public void update(DataHandle dh, Object obj, BitMask mask, Class<?> modifiedClass, Activation activation) {
         entryPointSubscribers.forEach(s -> s.update(dh, obj, mask, modifiedClass, activation));
         subscribers.forEach(s -> s.update(dh, (T) obj));
     }

--- a/drools-ruleunits/drools-ruleunits-impl/src/main/java/org/drools/ruleunits/impl/InternalStoreCallback.java
+++ b/drools-ruleunits/drools-ruleunits-impl/src/main/java/org/drools/ruleunits/impl/InternalStoreCallback.java
@@ -28,6 +28,7 @@ public interface InternalStoreCallback {
     DataHandle lookup(Object object);
 
     void update(RuleUnitInternalFactHandle fh, Object obj, BitMask mask, Class<?> modifiedClass, Activation activation);
+    void update(DataHandle dh, Object obj, BitMask mask, Class<?> modifiedClass, Activation activation);
 
     void delete(RuleUnitInternalFactHandle fh, RuleImpl rule, TerminalNode terminalNode, FactHandle.State fhState);
 

--- a/drools-ruleunits/drools-ruleunits-impl/src/main/java/org/drools/ruleunits/impl/ListDataStore.java
+++ b/drools-ruleunits/drools-ruleunits-impl/src/main/java/org/drools/ruleunits/impl/ListDataStore.java
@@ -102,7 +102,11 @@ public class ListDataStore<T> implements DataStore<T>, InternalStoreCallback {
 
     @Override
     public void update(RuleUnitInternalFactHandle fh, Object obj, BitMask mask, Class<?> modifiedClass, Activation activation) {
-        DataHandle dh = fh.getDataHandle();
+        update(fh.getDataHandle(), obj, mask, modifiedClass, activation);
+    }
+
+    @Override
+    public void update(DataHandle dh, Object obj, BitMask mask, Class<?> modifiedClass, Activation activation) {
         entryPointSubscribers.forEach(s -> s.update(dh, obj, mask, modifiedClass, activation));
         subscribers.forEach(s -> s.update(dh, (T) obj));
     }

--- a/drools-ruleunits/drools-ruleunits-impl/src/test/java/org/drools/ruleunits/impl/InterpretedRuleUnitTest.java
+++ b/drools-ruleunits/drools-ruleunits-impl/src/test/java/org/drools/ruleunits/impl/InterpretedRuleUnitTest.java
@@ -65,6 +65,7 @@ public class InterpretedRuleUnitTest {
 
     @Test
     public void testLogicalAdd() {
+        // KOGITO-6466
         LogicalAddTestUnit unit = new LogicalAddTestUnit();
 
         RuleUnitInstance<LogicalAddTestUnit> unitInstance = InMemoryRuleUnitInstanceFactory.generateAndInstance(unit);
@@ -79,5 +80,17 @@ public class InterpretedRuleUnitTest {
         unit.getStrings().remove(dh);
         assertThat(unitInstance.fire()).isEqualTo(1);
         assertThat(unit.getResults()).containsExactly("not exists");
+    }
+
+    @Test
+    public void testUpdate() {
+        UpdateTestUnit unit = new UpdateTestUnit();
+
+        RuleUnitInstance<UpdateTestUnit> unitInstance = InMemoryRuleUnitInstanceFactory.generateAndInstance(unit);
+
+        unit.getPersons().add(new Person("Mario", 17));
+
+        assertThat(unitInstance.fire()).isEqualTo(2);
+        assertThat(unit.getResults()).containsExactly("ok");
     }
 }

--- a/drools-ruleunits/drools-ruleunits-impl/src/test/java/org/drools/ruleunits/impl/InterpretedRuleUnitTest.java
+++ b/drools-ruleunits/drools-ruleunits-impl/src/test/java/org/drools/ruleunits/impl/InterpretedRuleUnitTest.java
@@ -15,9 +15,11 @@
  */
 package org.drools.ruleunits.impl;
 
+import org.drools.ruleunits.api.DataHandle;
 import org.drools.ruleunits.api.RuleUnitInstance;
 import org.junit.jupiter.api.Test;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
@@ -59,5 +61,23 @@ public class InterpretedRuleUnitTest {
 
         RuleUnitInstance<NotTestUnit> unitInstance = InMemoryRuleUnitInstanceFactory.generateAndInstance(unit);
         assertEquals(2, unitInstance.fire());
+    }
+
+    @Test
+    public void testLogicalAdd() {
+        LogicalAddTestUnit unit = new LogicalAddTestUnit();
+
+        RuleUnitInstance<LogicalAddTestUnit> unitInstance = InMemoryRuleUnitInstanceFactory.generateAndInstance(unit);
+
+        DataHandle dh = unit.getStrings().add("abc");
+
+        assertThat(unitInstance.fire()).isEqualTo(2);
+        assertThat(unit.getResults()).containsExactly("exists");
+
+        unit.getResults().clear();
+
+        unit.getStrings().remove(dh);
+        assertThat(unitInstance.fire()).isEqualTo(1);
+        assertThat(unit.getResults()).containsExactly("not exists");
     }
 }

--- a/drools-ruleunits/drools-ruleunits-impl/src/test/java/org/drools/ruleunits/impl/LogicalAddTestUnit.java
+++ b/drools-ruleunits/drools-ruleunits-impl/src/test/java/org/drools/ruleunits/impl/LogicalAddTestUnit.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright 2022 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.drools.ruleunits.impl;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.drools.ruleunits.api.DataSource;
+import org.drools.ruleunits.api.DataStore;
+import org.drools.ruleunits.api.RuleUnitData;
+
+public class LogicalAddTestUnit implements RuleUnitData {
+    private final DataStore<String> strings;
+    private final DataStore<Integer> ints;
+    private final List<String> results = new ArrayList<>();
+
+    public LogicalAddTestUnit() {
+        this(DataSource.createStore(), DataSource.createStore());
+    }
+
+    public LogicalAddTestUnit(DataStore<String> strings, DataStore<Integer> ints) {
+        this.strings = strings;
+        this.ints = ints;
+    }
+
+    public DataStore<String> getStrings() {
+        return strings;
+    }
+
+    public DataStore<Integer> getInts() {
+        return ints;
+    }
+
+    public List<String> getResults() {
+        return results;
+    }
+}

--- a/drools-ruleunits/drools-ruleunits-impl/src/test/java/org/drools/ruleunits/impl/Person.java
+++ b/drools-ruleunits/drools-ruleunits-impl/src/test/java/org/drools/ruleunits/impl/Person.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright 2022 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.drools.ruleunits.impl;
+
+public class Person {
+
+    private String name;
+
+    private int age;
+
+    public Person(String name, int age) {
+        this.name = name;
+        this.age = age;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    public int getAge() {
+        return age;
+    }
+
+    public void setAge(int age) {
+        this.age = age;
+    }
+}

--- a/drools-ruleunits/drools-ruleunits-impl/src/test/java/org/drools/ruleunits/impl/UpdateTestUnit.java
+++ b/drools-ruleunits/drools-ruleunits-impl/src/test/java/org/drools/ruleunits/impl/UpdateTestUnit.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright 2022 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.drools.ruleunits.impl;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.drools.ruleunits.api.DataSource;
+import org.drools.ruleunits.api.DataStore;
+import org.drools.ruleunits.api.RuleUnitData;
+
+public class UpdateTestUnit implements RuleUnitData {
+    private final List<String> results = new ArrayList<>();
+    private final DataStore<Person> persons;
+
+    public UpdateTestUnit() {
+        this(DataSource.createStore());
+    }
+
+    public UpdateTestUnit(DataStore<Person> persons) {
+        this.persons = persons;
+    }
+
+    public DataStore<Person> getPersons() {
+        return persons;
+    }
+
+    public List<String> getResults() {
+        return results;
+    }
+}

--- a/drools-ruleunits/drools-ruleunits-impl/src/test/resources/org/drools/ruleunits/impl/LogicalAddTestUnit.drl
+++ b/drools-ruleunits/drools-ruleunits-impl/src/test/resources/org/drools/ruleunits/impl/LogicalAddTestUnit.drl
@@ -1,0 +1,35 @@
+/**
+ * Copyright 2022 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.drools.ruleunits.impl;
+unit LogicalAddTestUnit;
+
+rule R1 when
+    $s: /strings
+then
+    ints.addLogical($s.length());
+end
+
+rule R2 when
+    exists ( /ints )
+then
+    results.add("exists");
+end
+
+rule R3 when
+    not ( /ints )
+then
+    results.add("not exists");
+end

--- a/drools-ruleunits/drools-ruleunits-impl/src/test/resources/org/drools/ruleunits/impl/UpdateTestUnit.drl
+++ b/drools-ruleunits/drools-ruleunits-impl/src/test/resources/org/drools/ruleunits/impl/UpdateTestUnit.drl
@@ -1,0 +1,30 @@
+/**
+ * Copyright 2022 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.drools.ruleunits.impl;
+unit UpdateTestUnit;
+
+rule R1 when
+    $p: /persons[ name == "Mario" ]
+then
+    $p.setAge( $p.getAge() + 1);
+    persons.update($p);
+end
+
+rule R2 when
+    $p: /persons[ age >= 18 ]
+then
+    results.add("ok");
+end

--- a/kie-api/src/main/java/org/kie/api/runtime/KieContext.java
+++ b/kie-api/src/main/java/org/kie/api/runtime/KieContext.java
@@ -16,8 +16,14 @@
 
 package org.kie.api.runtime;
 
+import org.kie.api.KieBase;
+
 public interface KieContext {
     KieRuntime getKieRuntime();
+
+    default KieBase getKieBase() {
+        return getKieRuntime().getKieBase();
+    }
 
     /**
      * Added for backwards compatibility.


### PR DESCRIPTION
**JIRA**: https://issues.redhat.com/browse/KOGITO-6466

Second part of the implementation of `addLogical` on `DataStore`s, this time addressing the exec model generation. While working on it I also found and fixed a problem in propagating the property reactivity mask when performing an update through a `DataStore`. Consistently I also implemented updates with property reactivity on the rule unit Java DSL.