### PR TITLE
[DROOLS-6991] Drools 8 docs : drools-engine is missing drools-xml-sup…

### DIFF
--- a/drools-docs/src/modules/ROOT/pages/KIE/BuildDeployUtilizeAndRun/_KIEBuilding-section.adoc
+++ b/drools-docs/src/modules/ROOT/pages/KIE/BuildDeployUtilizeAndRun/_KIEBuilding-section.adoc
@@ -308,7 +308,29 @@ Building a KIE module without the Maven plugin will copy all the resources, as i
 When that JAR is loaded by the runtime, it will attempt to build all the resources then.
 If there are compilation issues it will return a null KieContainer.
 It also pushes the compilation overhead to the runtime.
-In general this is not recommended, and the Maven plugin should always be used. 
+In general this is not recommended, and the Maven plugin should always be used.
+
+[[_enginedependency]]
+== Engine dependency
+
+{PRODUCT} has 2 types of engine dependency that aggregates a required collection of dependencies.
+
+*`drools-engine`* is the standard engine that enables executable model.
+
+*`drools-engine-classic`* is the old engine that utilizes MVEL interpreter. This engine and `drools-mvel` are now *deprecated*, so use `drools-engine` as possible.
+
+[source,xml]
+----
+    <dependency>
+      <groupId>org.drools</groupId>
+      <artifactId>drools-engine</artifactId>
+    </dependency>
+----
+
+[NOTE]
+====
+`drools-engine` doesn't contain `drools-xml-support`, because a Rule Unit use case doesn't require `kmodule.xml`, so no need to process xml. In other words, you have to explicitly add `drools-xml-support` dependency when you use `kmodule.xml` in your project with `drools-engine`.
+====
 
 [[_definingakiemoduleprogrammatically]]
 == Defining a KieModule programmatically

--- a/drools-docs/src/modules/ROOT/pages/KIE/BuildDeployUtilizeAndRun/_KIEBuilding-section.adoc
+++ b/drools-docs/src/modules/ROOT/pages/KIE/BuildDeployUtilizeAndRun/_KIEBuilding-section.adoc
@@ -317,7 +317,7 @@ In general this is not recommended, and the Maven plugin should always be used.
 
 *`drools-engine`* is the standard engine that enables executable model.
 
-*`drools-engine-classic`* is the old engine that utilizes MVEL interpreter. This engine and `drools-mvel` are now *deprecated*, so use `drools-engine` as possible.
+*`drools-engine-classic`* is the old engine that utilizes an MVEL interpreter.  The `drools-engine-classic` and `drools-mvel` are now *deprecated*, so use `drools-engine` as possible.
 
 [source,xml]
 ----

--- a/drools-docs/src/modules/ROOT/pages/KIE/BuildDeployUtilizeAndRun/_KIEBuilding-section.adoc
+++ b/drools-docs/src/modules/ROOT/pages/KIE/BuildDeployUtilizeAndRun/_KIEBuilding-section.adoc
@@ -330,6 +330,19 @@ In general this is not recommended, and the Maven plugin should always be used.
 [NOTE]
 ====
 `drools-engine` doesn't contain `drools-xml-support`, because a Rule Unit use case doesn't require `kmodule.xml`, so no need to process xml. In other words, you have to explicitly add `drools-xml-support` dependency when you use `kmodule.xml` in your project with `drools-engine`.
+
+For example:
+[source,xml]
+----
+    <dependency>
+      <groupId>org.drools</groupId>
+      <artifactId>drools-engine</artifactId>
+    </dependency>
+    <dependency> <!-- when not using Rule Unit and using `kmodule.xml` for defining a rule base -->
+      <groupId>org.drools</groupId>
+      <artifactId>drools-xml-support</artifactId>
+    </dependency>
+----
 ====
 
 [[_definingakiemoduleprogrammatically]]

--- a/drools-docs/src/modules/ROOT/pages/KIE/BuildDeployUtilizeAndRun/_KIEBuilding-section.adoc
+++ b/drools-docs/src/modules/ROOT/pages/KIE/BuildDeployUtilizeAndRun/_KIEBuilding-section.adoc
@@ -329,7 +329,7 @@ In general this is not recommended, and the Maven plugin should always be used.
 
 [NOTE]
 ====
-`drools-engine` doesn't contain `drools-xml-support`, because a Rule Unit use case doesn't require `kmodule.xml`, so no need to process xml. In other words, you have to explicitly add `drools-xml-support` dependency when you use `kmodule.xml` in your project with `drools-engine`.
+`drools-engine` doesn't contain `drools-xml-support`, because a Rule Unit use case doesn't require `kmodule.xml`, so no need to process XML. In other words, you have to explicitly add the `drools-xml-support` dependency when you use `kmodule.xml` in your project with `drools-engine`.
 
 For example:
 [source,xml]


### PR DESCRIPTION
…port

Adding "Engine dependency" section while mentioning `drools-mvel` and `drools-engine-classic` are deprecated.

**JIRA**: 
https://issues.redhat.com/browse/DROOLS-6991

<details>
<summary>
How to replicate CI configuration locally?
</summary>

Build Chain tool does "simple" maven build(s), the builds are just Maven commands, but because the repositories relates and depends on each other and any change in API or class method could affect several of those repositories there is a need to use [build-chain tool](https://github.com/kiegroup/github-action-build-chain) to handle cross repository builds and be sure that we always use latest version of the code for each repository.
 
[build-chain tool](https://github.com/kiegroup/github-action-build-chain) is a build tool which can be used on command line locally or in Github Actions workflow(s), in case you need to change multiple repositories and send multiple dependent pull requests related with a change you can easily reproduce the same build by executing it on Github hosted environment or locally in your development environment. See [local execution](https://github.com/kiegroup/github-action-build-chain#local-execution) details to get more information about it.
</details>

<details>
<summary>
How to retest this PR or trigger a specific build:
</summary>

- for <b>pull request checks</b>  
  Please add comment: <b>Jenkins retest this</b>

- for a <b>specific pull request check</b>  
  Please add comment: <b>Jenkins (re)run [drools|kogito-runtimes|kogito-apps|kogito-examples] tests</b>

- for a <b>full downstream build</b> 
  - for <b>jenkins</b> job: please add comment: <b>Jenkins run fdb</b>
  - for <b>github actions</b> job: add the label `run_fdb`

- <b>a compile downstream build</b> please  add comment: <b>Jenkins run cdb</b>

- <b>a full production downstream build</b> please add comment: <b>Jenkins execute product fdb</b>

- <b>an upstream build</b> please add comment: <b>Jenkins run upstream</b>

- for <b>quarkus branch checks</b>  
  Run checks against Quarkus current used branch  
  Please add comment: <b>Jenkins run quarkus-branch</b>

- for a <b>quarkus branch specific check</b>  
  Run checks against Quarkus current used branch  
  Please add comment: <b>Jenkins (re)run [drools|kogito-runtimes|kogito-apps|kogito-examples] quarkus-branch</b>

- for <b>quarkus main checks</b>  
  Run checks against Quarkus main branch  
  Please add comment: <b>Jenkins run quarkus-main</b>

- for a <b>specific quarkus main check</b>  
  Run checks against Quarkus main branch  
  Please add comment: <b>Jenkins (re)run [drools|kogito-runtimes|kogito-apps|kogito-examples] quarkus-branch</b>

- for <b>native checks</b>  
  Run native checks  
  Please add comment: <b>Jenkins run native</b>

- for a <b>specific native check</b>  
  Run native checks 
  Please add comment: <b>Jenkins (re)run [drools|kogito-runtimes|kogito-apps|kogito-examples] native</b>

- for <b>mandrel checks</b>  
  Run native checks against Mandrel image
  Please add comment: <b>Jenkins run mandrel</b>

- for a <b>specific mandrel check</b>  
  Run native checks against Mandrel image  
  Please add comment: <b>Jenkins (re)run [drools|kogito-runtimes|kogito-apps|kogito-examples] mandrel</b>
</details>
