### PR TITLE
[DROOLS-6678] review dependencies to remove them or move them to local modules

### DIFF
--- a/build-parent/pom.xml
+++ b/build-parent/pom.xml
@@ -41,20 +41,12 @@
     <version.com.fasterxml.jackson>2.13.3</version.com.fasterxml.jackson>
     <version.com.fasterxml.jackson.databind>2.13.3</version.com.fasterxml.jackson.databind>
     <version.com.fasterxml.jackson.annotations>2.13.3</version.com.fasterxml.jackson.annotations>
-    <!-- DROOLS-6678: only used in one drools-examples -->
-    <version.com.google.code.gson>2.9.1</version.com.google.code.gson>
     <version.org.jresearch.gwt.time>2.0.3</version.org.jresearch.gwt.time>
     <version.domino-slf4j-logger>1.0.1</version.domino-slf4j-logger>
-    <!-- DROOLS-6678: only used by drools-verifier and drools-examples -->
-    <version.com.google.guava>30.1.1-jre</version.com.google.guava>
     <version.com.google.inject.guice>4.0</version.com.google.inject.guice>
     <version.com.google.gwt>2.9.0</version.com.google.gwt>
     <version.com.google.protobuf>3.19.3</version.com.google.protobuf>
     <version.com.h2database>2.1.214</version.com.h2database>
-    <!-- DROOLS-6678: only used by drools-verifier -->
-    <version.com.lowagie.itext>2.1.7</version.com.lowagie.itext>
-    <!-- DROOLS-6678: only used by drools-examples -->
-    <version.com.miglayout>3.7.4</version.com.miglayout>
     <version.com.networknt.json-schema-validator>1.0.43</version.com.networknt.json-schema-validator>
     <version.com.sun.xml.bind>2.3.0</version.com.sun.xml.bind>
     <version.com.thoughtworks.xstream>1.4.19</version.com.thoughtworks.xstream>
@@ -74,19 +66,12 @@
     <version.org.apache.commons.lang3>3.12.0</version.org.apache.commons.lang3>
     <version.org.apache.commons.math3>3.4.1</version.org.apache.commons.math3>
 
-    <!-- DROOLS-6678: only used by kie-util-maven-support and kie-util-maven-integration -->
-    <version.org.apache.httpcomponents.httpclient>4.5.13</version.org.apache.httpcomponents.httpclient>
-    <version.org.apache.httpcomponents.httpcore>4.4.15</version.org.apache.httpcomponents.httpcore>
     <version.org.apache.maven>3.8.6</version.org.apache.maven>
     <version.org.apache.maven.resolver>1.7.3</version.org.apache.maven.resolver>
     <version.org.apache.maven.wagon>3.5.1</version.org.apache.maven.wagon>
     <version.org.apache.poi>5.1.0</version.org.apache.poi>
-    <!-- DROOLS-6678: only used by kie-test-util -->
-    <version.org.apache.tomcat.tomcat-dbcp>9.0.21</version.org.apache.tomcat.tomcat-dbcp>
     <version.org.assertj>3.23.1</version.org.assertj>
     <version.org.eclipse.jdt>3.18.0</version.org.eclipse.jdt>
-    <!-- DROOLS-6678: only used by kie-ci, kie-util-maven-support and kie-util-maven-integration -->
-    <version.org.eclipse.sisu>0.3.5</version.org.eclipse.sisu>
     <version.org.glassfish.jaxb>2.3.6</version.org.glassfish.jaxb>
     <version.org.hibernate>5.6.0.Final</version.org.hibernate>
     <!--This needs to be in sync with JUnit-->
@@ -94,41 +79,29 @@
     <version.org.javassist>3.26.0-GA</version.org.javassist>
     <version.org.jboss.narayana.tomcat>5.13.1.Alpha1</version.org.jboss.narayana.tomcat>
     <version.org.jboss.transaction.spi>7.6.1.Final</version.org.jboss.transaction.spi>
-    <!-- DROOLS-6678: make sure weld is used only for test -->
-    <version.org.jboss.weld.weld>3.1.6.Final</version.org.jboss.weld.weld>
     <version.jakarta.enterprise.cdi-api>2.0.2</version.jakarta.enterprise.cdi-api>
     <version.jakarta.activation-api>1.2.1</version.jakarta.activation-api>
     <version.jakarta.inject-api>1.0</version.jakarta.inject-api>
     <version.jakarta.annotation-api>1.3.5</version.jakarta.annotation-api>
-    <version.jakarta.ejb-api>3.2.6</version.jakarta.ejb-api>
-    <version.jakarta.security.jacc-api>1.6.1</version.jakarta.security.jacc-api>
     <version.jakarta.servlet.jsp-api>2.3.6</version.jakarta.servlet.jsp-api>
     <version.jakarta.servlet.jsp.jstl-api>2.0.0</version.jakarta.servlet.jsp.jstl-api>
     <version.jakarta.transaction-api>1.3.3</version.jakarta.transaction-api>
     <version.jakarta.ws.rs-api>2.1.6</version.jakarta.ws.rs-api>
     <version.jakarta.xml.ws-api>2.3.3</version.jakarta.xml.ws-api>
-    <version.jakarta.xml.soap-api>1.4.2</version.jakarta.xml.soap-api>
-    <version.jakarta.websocket-api>1.1.2</version.jakarta.websocket-api>
     <version.jakarta.persistence-api>2.2.3</version.jakarta.persistence-api>
     <version.jakarta.servlet-api>4.0.3</version.jakarta.servlet-api>
     <version.jakarta.xml.bind-api>2.3.3</version.jakarta.xml.bind-api>
     <version.jakarta.json.bind-api>1.0.2</version.jakarta.json.bind-api>
-    <version.jakarta.jws-api>2.1.0</version.jakarta.jws-api>
     <version.jakarta.json-api>1.1.6</version.jakarta.json-api>
     <version.org.jpmml.model>1.5.1</version.org.jpmml.model> <!-- jpmml-model BSD 3C license - ATTENTION 1.5.1 intentional, because 1.5.1 evaluators works with 1.5.1 -->
     <version.org.junit>5.9.0</version.org.junit>
     <version.org.mvel>2.4.14.Final</version.org.mvel>
     <version.org.powermock>2.0.7</version.org.powermock>
     <version.org.slf4j>1.7.30</version.org.slf4j>
-    <version.org.subethamail>1.2</version.org.subethamail>
-    <version.org.subethamail.subethasmtp>3.1.6</version.org.subethamail.subethasmtp>
     <version.xerces>2.12.0.SP03</version.xerces>
     <version.xmlpull>1.2.0</version.xmlpull>
     <version.xmlunit>1.3</version.xmlunit>
     <version.xpp3>${version.xmlpull}</version.xpp3>
-
-    <!-- Declared here but used for dependencyManagement inside drools-templates -->
-    <version.org.hsqldb>2.3.0</version.org.hsqldb>
 
     <!-- External dependency versions bom -->
     <!-- ################################################################################ -->
@@ -147,9 +120,6 @@
     <!-- The version greater than 1.0.0.GA is not compatible with GWT 2.8.x -->
     <!-- therefore the property is rewritten in that repository parent -->
     <version.javax.validation>2.0.1.Final</version.javax.validation>
-    <!-- simple-jndi is a small library that helps us avoid JNDI error messages during testing -->
-    <!-- DROOLS-6678: only used by kie-test-util -->
-    <version.simple-jndi>0.11.4.1</version.simple-jndi>
     <version.org.asciidoctor.asciidoctorj>2.2.0</version.org.asciidoctor.asciidoctorj>
     <version.org.asciidoctor.asciidoctorj-pdf>1.5.0</version.org.asciidoctor.asciidoctorj-pdf>
     <version.org.w3c.dom>2.3.0-jaxb-1.0.6</version.org.w3c.dom>
@@ -319,18 +289,6 @@
       </dependency>
 
       <dependency>
-        <groupId>com.google.code.gson</groupId>
-        <artifactId>gson</artifactId>
-        <version>${version.com.google.code.gson}</version>
-      </dependency>
-
-      <dependency>
-        <groupId>com.google.guava</groupId>
-        <artifactId>guava</artifactId>
-        <version>${version.com.google.guava}</version>
-      </dependency>
-
-      <dependency>
         <groupId>com.google.inject</groupId>
         <artifactId>guice</artifactId>
         <version>${version.com.google.inject.guice}</version>
@@ -341,11 +299,6 @@
             <artifactId>javax.inject</artifactId>
           </exclusion>
         </exclusions>
-      </dependency>
-      <dependency>
-        <groupId>com.google.guava</groupId>
-        <artifactId>guava-gwt</artifactId>
-        <version>${version.com.google.guava}</version>
       </dependency>
 
       <dependency>
@@ -370,33 +323,6 @@
         <groupId>com.h2database</groupId>
         <artifactId>h2</artifactId>
         <version>${version.com.h2database}</version>
-      </dependency>
-
-      <dependency>
-        <groupId>com.lowagie</groupId>
-        <artifactId>itext</artifactId>
-        <version>${version.com.lowagie.itext}</version>
-        <exclusions>
-          <!-- The bouncycastle dependencies should be optional=true in itext's pom -->
-          <exclusion>
-            <groupId>bouncycastle</groupId>
-            <artifactId>bcmail-jdk14</artifactId>
-          </exclusion>
-          <exclusion>
-            <groupId>bouncycastle</groupId>
-            <artifactId>bcprov-jdk14</artifactId>
-          </exclusion>
-          <exclusion>
-            <groupId>bouncycastle</groupId>
-            <artifactId>bctsp-jdk14</artifactId>
-          </exclusion>
-        </exclusions>
-      </dependency>
-
-      <dependency>
-        <groupId>com.miglayout</groupId>
-        <artifactId>miglayout</artifactId>
-        <version>${version.com.miglayout}</version>
       </dependency>
 
       <dependency>
@@ -483,11 +409,6 @@
         <version>${version.org.glassfish.jaxb}</version>
       </dependency>
       <dependency>
-        <groupId>jakarta.jws</groupId>
-        <artifactId>jakarta.jws-api</artifactId>
-        <version>${version.jakarta.jws-api}</version>
-      </dependency>
-      <dependency>
         <groupId>jakarta.json.bind</groupId>
         <artifactId>jakarta.json.bind-api</artifactId>
         <version>${version.jakarta.json.bind-api}</version>
@@ -514,16 +435,6 @@
         <version>${version.jakarta.annotation-api}</version>
       </dependency>
       <dependency>
-        <groupId>jakarta.ejb</groupId>
-        <artifactId>jakarta.ejb-api</artifactId>
-        <version>${version.jakarta.ejb-api}</version>
-      </dependency>
-      <dependency>
-        <groupId>jakarta.security.jacc</groupId>
-        <artifactId>jakarta.security.jacc-api</artifactId>
-        <version>${version.jakarta.security.jacc-api}</version>
-      </dependency>
-      <dependency>
         <groupId>jakarta.servlet.jsp</groupId>
         <artifactId>jakarta.servlet.jsp-api</artifactId>
         <version>${version.jakarta.servlet.jsp-api}</version>
@@ -547,16 +458,6 @@
         <groupId>jakarta.xml.ws</groupId>
         <artifactId>jakarta.xml.ws-api</artifactId>
         <version>${version.jakarta.xml.ws-api}</version>
-      </dependency>
-      <dependency>
-        <groupId>jakarta.xml.soap</groupId>
-        <artifactId>jakarta.xml.soap-api</artifactId>
-        <version>${version.jakarta.xml.soap-api}</version>
-      </dependency>
-      <dependency>
-        <groupId>jakarta.websocket</groupId>
-        <artifactId>jakarta.websocket-api</artifactId>
-        <version>${version.jakarta.websocket-api}</version>
       </dependency>
       <dependency>
         <groupId>jakarta.persistence</groupId>
@@ -729,39 +630,6 @@
         <groupId>org.apache.commons</groupId>
         <artifactId>commons-math3</artifactId>
         <version>${version.org.apache.commons.math3}</version>
-      </dependency>
-
-      <dependency>
-        <groupId>org.apache.httpcomponents</groupId>
-        <artifactId>httpclient</artifactId>
-        <version>${version.org.apache.httpcomponents.httpclient}</version>
-        <exclusions>
-          <exclusion>
-            <groupId>commons-logging</groupId>
-            <artifactId>commons-logging</artifactId>
-          </exclusion>
-        </exclusions>
-      </dependency>
-      <dependency>
-        <groupId>org.apache.httpcomponents</groupId>
-        <artifactId>fluent-hc</artifactId>
-        <version>${version.org.apache.httpcomponents.httpclient}</version>
-        <exclusions>
-          <exclusion>
-            <groupId>commons-logging</groupId>
-            <artifactId>commons-logging</artifactId>
-          </exclusion>
-        </exclusions>
-      </dependency>
-      <dependency>
-        <groupId>org.apache.httpcomponents</groupId>
-        <artifactId>httpcore</artifactId>
-        <version>${version.org.apache.httpcomponents.httpcore}</version>
-      </dependency>
-      <dependency>
-        <groupId>org.apache.httpcomponents</groupId>
-        <artifactId>httpmime</artifactId>
-        <version>${version.org.apache.httpcomponents.httpclient}</version>
       </dependency>
 
       <dependency>
@@ -943,60 +811,6 @@
         <version>${version.org.javassist}</version>
       </dependency>
 
-      <dependency>
-        <groupId>org.jboss.weld</groupId>
-        <artifactId>weld-core-impl</artifactId>
-        <version>${version.org.jboss.weld.weld}</version>
-        <exclusions>
-          <exclusion>
-            <groupId>org.jboss.spec.javax.annotation</groupId>
-            <artifactId>jboss-annotations-api_1.3_spec</artifactId>
-          </exclusion>
-          <exclusion>
-            <groupId>org.jboss.spec.javax.interceptor</groupId>
-            <artifactId>jboss-interceptors-api_1.2_spec</artifactId>
-          </exclusion>
-          <exclusion>
-            <groupId>org.jboss.spec.javax.el</groupId>
-            <artifactId>jboss-el-api_3.0_spec</artifactId>
-          </exclusion>
-          <exclusion>
-            <groupId>javax.annotation</groupId>
-            <artifactId>jsr250-api</artifactId>
-          </exclusion>
-        </exclusions>
-      </dependency>
-      <dependency>
-        <groupId>org.jboss.weld.se</groupId>
-        <artifactId>weld-se-core</artifactId>
-        <version>${version.org.jboss.weld.weld}</version>
-        <exclusions>
-          <exclusion>
-            <groupId>org.jboss.spec.javax.el</groupId>
-            <artifactId>jboss-el-api_3.0_spec</artifactId>
-          </exclusion>
-          <exclusion>
-            <groupId>org.jboss.spec.javax.ws.rs</groupId>
-            <artifactId>jboss-jaxrs-api_2.1_spec</artifactId>
-          </exclusion>
-          <exclusion>
-            <groupId>org.jboss.spec.javax.el</groupId>
-            <artifactId>jboss-el-api_3.0_spec</artifactId>
-          </exclusion>
-          <exclusion>
-            <groupId>org.jboss.spec.javax.annotation</groupId>
-            <artifactId>jboss-annotations-api_1.3_spec</artifactId>
-          </exclusion>
-          <exclusion>
-            <groupId>org.jboss.spec.javax.interceptor</groupId>
-            <artifactId>jboss-interceptors-api_1.2_spec</artifactId>
-          </exclusion>
-          <exclusion>
-            <groupId>javax.annotation</groupId>
-            <artifactId>jsr250-api</artifactId>
-          </exclusion>
-        </exclusions>
-      </dependency>
 
       <!-- Do not add mockito-all as it is uberjar! -->
       <dependency>
@@ -1087,37 +901,6 @@
       </dependency>
 
       <dependency>
-        <groupId>org.subethamail</groupId>
-        <artifactId>subethasmtp-wiser</artifactId>
-        <version>${version.org.subethamail}</version>
-        <exclusions>
-          <exclusion>
-            <groupId>javax.mail</groupId>
-            <artifactId>mail</artifactId>
-          </exclusion>
-          <exclusion>
-            <groupId>commons-logging</groupId>
-            <artifactId>commons-logging</artifactId>
-          </exclusion>
-        </exclusions>
-      </dependency>
-      <dependency>
-        <groupId>org.subethamail</groupId>
-        <artifactId>subethasmtp</artifactId>
-        <version>${version.org.subethamail.subethasmtp}</version>
-        <exclusions>
-          <exclusion>
-            <groupId>javax.mail</groupId>
-            <artifactId>mail</artifactId>
-          </exclusion>
-          <exclusion>
-            <groupId>javax.activation</groupId>
-            <artifactId>activation</artifactId>
-          </exclusion>
-        </exclusions>
-      </dependency>
-
-      <dependency>
         <groupId>xerces</groupId>
         <artifactId>xercesImpl</artifactId>
         <version>${version.xerces}</version>
@@ -1161,18 +944,6 @@
         <groupId>org.antlr</groupId>
         <artifactId>antlr4-runtime</artifactId>
         <version>${version.org.antlr4}</version>
-      </dependency>
-
-      <dependency>
-        <groupId>org.eclipse.sisu</groupId>
-        <artifactId>org.eclipse.sisu.inject</artifactId>
-        <version>${version.org.eclipse.sisu}</version>
-        <exclusions>
-          <exclusion>
-            <groupId>com.google.inject</groupId>
-            <artifactId>guice</artifactId>
-          </exclusion>
-        </exclusions>
       </dependency>
 
       <dependency>
@@ -1358,11 +1129,6 @@
           </exclusion>
         </exclusions>
       </dependency>
-      <dependency>
-        <groupId>org.apache.tomcat</groupId>
-        <artifactId>tomcat-dbcp</artifactId>
-        <version>${version.org.apache.tomcat.tomcat-dbcp}</version>
-      </dependency>
 
       <dependency>
         <groupId>org.xmlunit</groupId>
@@ -1380,13 +1146,6 @@
         <groupId>org.xmlunit</groupId>
         <artifactId>xmlunit-assertj</artifactId>
         <version>${version.org.xmlunit}</version>
-        <scope>test</scope>
-      </dependency>
-
-      <dependency>
-        <groupId>simple-jndi</groupId>
-        <artifactId>simple-jndi</artifactId>
-        <version>${version.simple-jndi}</version>
         <scope>test</scope>
       </dependency>
 
@@ -1685,7 +1444,6 @@
                       <exclude>javax.enterprise:cdi-api</exclude>
                       <exclude>javax.inject:javax.inject</exclude>
                       <exclude>javax.interceptor:javax.interceptor-api</exclude>
-                      <exclude>javax.jws:javax.jws-api</exclude>
                       <exclude>javax.jws:jsr181-api</exclude>
                       <exclude>javax.persistence:javax.persistence-api</exclude>
                       <exclude>javax.servlet:javax.servlet-api</exclude>

--- a/build-parent/pom.xml
+++ b/build-parent/pom.xml
@@ -42,6 +42,8 @@
     <version.com.fasterxml.jackson.databind>2.13.3</version.com.fasterxml.jackson.databind>
     <version.com.fasterxml.jackson.annotations>2.13.3</version.com.fasterxml.jackson.annotations>
     <version.org.jresearch.gwt.time>2.0.3</version.org.jresearch.gwt.time>
+    <version.com.lowagie.itext>2.1.7</version.com.lowagie.itext>
+    <version.com.miglayout>3.7.4</version.com.miglayout>
     <version.domino-slf4j-logger>1.0.1</version.domino-slf4j-logger>
     <version.com.google.inject.guice>4.0</version.com.google.inject.guice>
     <version.com.google.gwt>2.9.0</version.com.google.gwt>
@@ -65,24 +67,28 @@
     <version.org.apache.ant>1.10.11</version.org.apache.ant>
     <version.org.apache.commons.lang3>3.12.0</version.org.apache.commons.lang3>
     <version.org.apache.commons.math3>3.4.1</version.org.apache.commons.math3>
-
+    <version.org.apache.httpcomponents.httpcore>4.4.15</version.org.apache.httpcomponents.httpcore>
     <version.org.apache.maven>3.8.6</version.org.apache.maven>
     <version.org.apache.maven.resolver>1.7.3</version.org.apache.maven.resolver>
     <version.org.apache.maven.wagon>3.5.1</version.org.apache.maven.wagon>
     <version.org.apache.poi>5.1.0</version.org.apache.poi>
+    <version.org.apache.tomcat.tomcat-dbcp>9.0.21</version.org.apache.tomcat.tomcat-dbcp>
     <version.org.assertj>3.23.1</version.org.assertj>
     <version.org.eclipse.jdt>3.18.0</version.org.eclipse.jdt>
     <version.org.glassfish.jaxb>2.3.6</version.org.glassfish.jaxb>
-    <version.org.hibernate>5.6.0.Final</version.org.hibernate>
     <!--This needs to be in sync with JUnit-->
     <version.org.hamcrest>1.3</version.org.hamcrest>
+    <version.org.hibernate>5.6.0.Final</version.org.hibernate>
+    <version.org.hsqldb>2.3.0</version.org.hsqldb>
     <version.org.javassist>3.26.0-GA</version.org.javassist>
     <version.org.jboss.narayana.tomcat>5.13.1.Alpha1</version.org.jboss.narayana.tomcat>
     <version.org.jboss.transaction.spi>7.6.1.Final</version.org.jboss.transaction.spi>
+    <version.org.jboss.weld.weld>3.1.6.Final</version.org.jboss.weld.weld>
     <version.jakarta.enterprise.cdi-api>2.0.2</version.jakarta.enterprise.cdi-api>
     <version.jakarta.activation-api>1.2.1</version.jakarta.activation-api>
     <version.jakarta.inject-api>1.0</version.jakarta.inject-api>
     <version.jakarta.annotation-api>1.3.5</version.jakarta.annotation-api>
+    <version.jakarta.ejb-api>3.2.6</version.jakarta.ejb-api>
     <version.jakarta.servlet.jsp-api>2.3.6</version.jakarta.servlet.jsp-api>
     <version.jakarta.servlet.jsp.jstl-api>2.0.0</version.jakarta.servlet.jsp.jstl-api>
     <version.jakarta.transaction-api>1.3.3</version.jakarta.transaction-api>
@@ -98,6 +104,8 @@
     <version.org.mvel>2.4.14.Final</version.org.mvel>
     <version.org.powermock>2.0.7</version.org.powermock>
     <version.org.slf4j>1.7.30</version.org.slf4j>
+    <!-- simple-jndi is a small library that helps us avoid JNDI error messages during testing -->
+    <version.simple-jndi>0.11.4.1</version.simple-jndi>
     <version.xerces>2.12.0.SP03</version.xerces>
     <version.xmlpull>1.2.0</version.xmlpull>
     <version.xmlunit>1.3</version.xmlunit>

--- a/drools-examples/pom.xml
+++ b/drools-examples/pom.xml
@@ -65,7 +65,7 @@
       <dependency>
         <groupId>com.miglayout</groupId>
         <artifactId>miglayout</artifactId>
-        <version>3.7.4</version>
+        <version>${version.com.miglayout}</version>
       </dependency>
     </dependencies>
   </dependencyManagement>

--- a/drools-examples/pom.xml
+++ b/drools-examples/pom.xml
@@ -60,6 +60,16 @@
     </plugins>
   </build>
 
+  <dependencyManagement>
+    <dependencies>
+      <dependency>
+        <groupId>com.miglayout</groupId>
+        <artifactId>miglayout</artifactId>
+        <version>3.7.4</version>
+      </dependency>
+    </dependencies>
+  </dependencyManagement>
+
   <dependencies>
     <!-- Internal dependencies -->
     <dependency>
@@ -114,9 +124,10 @@
       drools-distribution/src/main/assembly/assembly-drools.xml
     -->
     <dependency>
-       <groupId>com.miglayout</groupId>
-       <artifactId>miglayout</artifactId>
+      <groupId>com.miglayout</groupId>
+      <artifactId>miglayout</artifactId>
     </dependency>
+
     <dependency>
       <groupId>commons-io</groupId>
       <artifactId>commons-io</artifactId>
@@ -126,16 +137,12 @@
       <artifactId>logback-classic</artifactId>
     </dependency>
     <dependency>
-      <groupId>com.google.code.gson</groupId>
-      <artifactId>gson</artifactId>
-    </dependency>
-    <dependency>
-      <groupId>com.google.guava</groupId>
-      <artifactId>guava</artifactId>
-    </dependency>
-    <dependency>
       <groupId>org.drools</groupId>
       <artifactId>drools-xml-support</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>com.fasterxml.jackson.core</groupId>
+      <artifactId>jackson-databind</artifactId>
     </dependency>
   </dependencies>
 

--- a/drools-examples/src/main/java/org/drools/examples/performance/PerformanceExample.java
+++ b/drools-examples/src/main/java/org/drools/examples/performance/PerformanceExample.java
@@ -2,8 +2,8 @@ package org.drools.examples.performance;
 
 import java.util.ArrayList;
 
-import com.google.gson.Gson;
-import com.google.gson.GsonBuilder;
+import com.fasterxml.jackson.core.JsonFactory;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import org.drools.kiesession.rulebase.InternalKnowledgeBase;
 import org.drools.kiesession.rulebase.KnowledgeBaseFactory;
 import org.kie.api.KieBase;
@@ -52,14 +52,14 @@ public class PerformanceExample {
         ArrayList output = new ArrayList();
         kSession.setGlobal("mo", output);
         Object o = ft.newInstance();
-        Gson gConverter = new GsonBuilder().setDateFormat("yyyy-MM-dd'T'HH:mm:ss").create();
-        Object fo = gConverter.fromJson(getFact(), o.getClass());
+        ObjectMapper mapper = new ObjectMapper(new JsonFactory());
+        Object fo = mapper.readValue(getFact(), o.getClass());
         kSession.execute(fo); //initial execute
         startTime = System.currentTimeMillis();
         kSession.execute(fo);
         endTime = System.currentTimeMillis();
         System.out.println("Execution time: " + (endTime - startTime)  + " ms" );
-        String rulesOutput = gConverter.toJson(output);
+        String rulesOutput = mapper.writeValueAsString(output);
         System.out.println(rulesOutput);
 
     }
@@ -112,19 +112,19 @@ public class PerformanceExample {
 
     private static String getFact() {
         return "{\n" +
-                "\"TransactionNumber\": \"88882\",\n" +
-                "\"TrackingID\": \"T001\",\n" +
-                "\"CurrencyCode\": \"USD\",\n" +
-                "\"TransactionNetTotal\" : 100.0,\n" +
-                "\"StoreCode\": \"D001\",\n" +
-                "\"CardNumber\": \"3614838386\",\n" +
-                "\"TransactionDetails\": [\n" +
+                "\"transactionNumber\": \"88882\",\n" +
+                "\"trackingID\": \"T001\",\n" +
+                "\"currencyCode\": \"USD\",\n" +
+                "\"transactionNetTotal\" : 100.0,\n" +
+                "\"storeCode\": \"D001\",\n" +
+                "\"cardNumber\": \"3614838386\",\n" +
+                "\"transactionDetails\": [\n" +
                 "{\n" +
-                "\"Quantity\": 25,\n" +
-                "\"ItemNumber\": \"SKU1_0\",\n" +
-                "\"BrandID\": \"Nike\",\n" +
-                "\"SKU\": \"SKU1\",\n" +
-                "\"ProductCategoryCode\" : \"Clothing\"\n" +
+                "\"quantity\": 25,\n" +
+                "\"itemNumber\": \"SKU1_0\",\n" +
+                "\"brandID\": \"Nike\",\n" +
+                "\"sku\": \"SKU1\",\n" +
+                "\"productCategoryCode\" : \"Clothing\"\n" +
                 "}]\n" +
                 "}";
     }

--- a/drools-persistence/drools-persistence-jpa/pom.xml
+++ b/drools-persistence/drools-persistence-jpa/pom.xml
@@ -59,6 +59,16 @@
     </plugins>
   </build>
 
+  <dependencyManagement>
+    <dependencies>
+      <dependency>
+        <groupId>org.jboss.weld.se</groupId>
+        <artifactId>weld-se-core</artifactId>
+        <version>3.1.6.Final</version>
+      </dependency>
+    </dependencies>
+  </dependencyManagement>
+
   <dependencies>
     <dependency>
       <groupId>org.kie</groupId>
@@ -197,11 +207,39 @@
       <artifactId>jakarta.enterprise.cdi-api</artifactId>
       <scope>test</scope>
     </dependency>
+
     <dependency>
       <groupId>org.jboss.weld.se</groupId>
       <artifactId>weld-se-core</artifactId>
       <scope>test</scope>
+      <exclusions>
+        <exclusion>
+          <groupId>org.jboss.spec.javax.el</groupId>
+          <artifactId>jboss-el-api_3.0_spec</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>org.jboss.spec.javax.ws.rs</groupId>
+          <artifactId>jboss-jaxrs-api_2.1_spec</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>org.jboss.spec.javax.el</groupId>
+          <artifactId>jboss-el-api_3.0_spec</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>org.jboss.spec.javax.annotation</groupId>
+          <artifactId>jboss-annotations-api_1.3_spec</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>org.jboss.spec.javax.interceptor</groupId>
+          <artifactId>jboss-interceptors-api_1.2_spec</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>javax.annotation</groupId>
+          <artifactId>jsr250-api</artifactId>
+        </exclusion>
+      </exclusions>
     </dependency>
+
     <dependency>
       <groupId>org.assertj</groupId>
       <artifactId>assertj-core</artifactId>

--- a/drools-persistence/drools-persistence-jpa/pom.xml
+++ b/drools-persistence/drools-persistence-jpa/pom.xml
@@ -64,7 +64,7 @@
       <dependency>
         <groupId>org.jboss.weld.se</groupId>
         <artifactId>weld-se-core</artifactId>
-        <version>3.1.6.Final</version>
+        <version>${version.org.jboss.weld.weld}</version>
       </dependency>
     </dependencies>
   </dependencyManagement>

--- a/drools-templates/pom.xml
+++ b/drools-templates/pom.xml
@@ -24,7 +24,7 @@
       <dependency>
         <groupId>org.hsqldb</groupId>
         <artifactId>hsqldb</artifactId>
-        <version>${version.org.hsqldb}</version>
+        <version>2.3.0</version>
       </dependency>
     </dependencies>
   </dependencyManagement>

--- a/drools-templates/pom.xml
+++ b/drools-templates/pom.xml
@@ -24,7 +24,7 @@
       <dependency>
         <groupId>org.hsqldb</groupId>
         <artifactId>hsqldb</artifactId>
-        <version>2.3.0</version>
+        <version>${version.org.hsqldb}</version>
       </dependency>
     </dependencies>
   </dependencyManagement>

--- a/drools-verifier/drools-verifier-drl/pom.xml
+++ b/drools-verifier/drools-verifier-drl/pom.xml
@@ -18,6 +18,16 @@
     <java.module.name>org.drools.verifier</java.module.name>
   </properties>
 
+  <dependencyManagement>
+    <dependencies>
+      <dependency>
+        <groupId>com.lowagie</groupId>
+        <artifactId>itext</artifactId>
+        <version>2.1.7</version>
+      </dependency>
+    </dependencies>
+  </dependencyManagement>
+
   <dependencies>
     <!-- Internal dependencies -->
     <dependency>
@@ -45,20 +55,33 @@
       <artifactId>drools-mvel</artifactId>
     </dependency>
     <dependency>
-      <groupId>com.google.guava</groupId>
-      <artifactId>guava</artifactId>
-    </dependency>
-    <dependency>
       <groupId>com.thoughtworks.xstream</groupId>
       <artifactId>xstream</artifactId>
     </dependency>
     <dependency>
-      <groupId>com.lowagie</groupId>
-      <artifactId>itext</artifactId>
-    </dependency>
-    <dependency>
       <groupId>org.mvel</groupId>
       <artifactId>mvel2</artifactId>
+    </dependency>
+
+
+    <dependency>
+      <groupId>com.lowagie</groupId>
+      <artifactId>itext</artifactId>
+      <exclusions>
+        <!-- The bouncycastle dependencies should be optional=true in itext's pom -->
+        <exclusion>
+          <groupId>bouncycastle</groupId>
+          <artifactId>bcmail-jdk14</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>bouncycastle</groupId>
+          <artifactId>bcprov-jdk14</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>bouncycastle</groupId>
+          <artifactId>bctsp-jdk14</artifactId>
+        </exclusion>
+      </exclusions>
     </dependency>
 
     <dependency>

--- a/drools-verifier/drools-verifier-drl/pom.xml
+++ b/drools-verifier/drools-verifier-drl/pom.xml
@@ -23,7 +23,7 @@
       <dependency>
         <groupId>com.lowagie</groupId>
         <artifactId>itext</artifactId>
-        <version>2.1.7</version>
+        <version>${version.com.lowagie.itext}</version>
       </dependency>
     </dependencies>
   </dependencyManagement>

--- a/drools-verifier/drools-verifier-drl/src/main/java/org/drools/verifier/components/ObjectType.java
+++ b/drools-verifier/drools-verifier-drl/src/main/java/org/drools/verifier/components/ObjectType.java
@@ -20,11 +20,9 @@ import java.io.Serializable;
 import java.util.HashSet;
 import java.util.Set;
 
-import com.google.common.collect.Multimap;
-import com.google.common.collect.TreeMultimap;
-
 import org.drools.drl.ast.descr.BaseDescr;
 import org.drools.verifier.data.VerifierComponent;
+import org.drools.verifier.misc.Multimap;
 
 public class ObjectType extends VerifierComponent<BaseDescr>
     implements
@@ -40,7 +38,7 @@ public class ObjectType extends VerifierComponent<BaseDescr>
     private Set<Field>          fields           = new HashSet<>();
 
 
-    private Multimap<String, String> metadata         = TreeMultimap.create();
+    private Multimap<String, String> metadata         = new Multimap<>();
 
     
     public ObjectType(BaseDescr descr) {

--- a/drools-verifier/drools-verifier-drl/src/main/java/org/drools/verifier/data/VerifierDataMaps.java
+++ b/drools-verifier/drools-verifier-drl/src/main/java/org/drools/verifier/data/VerifierDataMaps.java
@@ -16,11 +16,27 @@
 
 package org.drools.verifier.data;
 
-import com.google.common.collect.Multimap;
-import com.google.common.collect.TreeMultimap;
-import org.drools.verifier.components.*;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.Comparator;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.TreeMap;
 
-import java.util.*;
+import org.drools.verifier.components.EntryPoint;
+import org.drools.verifier.components.Field;
+import org.drools.verifier.components.Import;
+import org.drools.verifier.components.ObjectType;
+import org.drools.verifier.components.Pattern;
+import org.drools.verifier.components.Restriction;
+import org.drools.verifier.components.RulePackage;
+import org.drools.verifier.components.Variable;
+import org.drools.verifier.components.VerifierComponentType;
+import org.drools.verifier.components.VerifierRule;
+import org.drools.verifier.misc.Multimap;
 
 class VerifierDataMaps
         implements
@@ -31,15 +47,15 @@ class VerifierDataMaps
     private Map<String, RulePackage> packagesByName = new TreeMap<>(STRING_NULL_SAFE_COMPARATOR);
     private Map<String, ObjectType> objectTypesByFullName = new TreeMap<>(STRING_NULL_SAFE_COMPARATOR);
     private Map<String, Field> fieldsByObjectTypeAndFieldName = new TreeMap<>(STRING_NULL_SAFE_COMPARATOR);
-    private Multimap<String, Field> fieldsByObjectTypeId = TreeMultimap.create();
-    private Multimap<String, Pattern> patternsByObjectTypeId = TreeMultimap.create();
-    private Multimap<String, Pattern> patternsByRuleName = TreeMultimap.create();
-    private Multimap<String, Restriction> restrictionsByFieldId = TreeMultimap.create();
+    private Multimap<String, Field> fieldsByObjectTypeId = new Multimap<>();
+    private Multimap<String, Pattern> patternsByObjectTypeId = new Multimap<>();
+    private Multimap<String, Pattern> patternsByRuleName = new Multimap<>();
+    private Multimap<String, Restriction> restrictionsByFieldId = new Multimap<>();
     private Map<String, Variable> variablesByRuleAndVariableName = new TreeMap<>(STRING_NULL_SAFE_COMPARATOR);
     private Map<String, EntryPoint> entryPointsByEntryId = new TreeMap<>(STRING_NULL_SAFE_COMPARATOR);
     private Map<String, VerifierRule> rulesByName = new TreeMap<>(STRING_NULL_SAFE_COMPARATOR);
     private Map<String, Import> importsByName = new TreeMap<>(STRING_NULL_SAFE_COMPARATOR);
-    private Multimap<String, VerifierRule> rulesByCategory = TreeMultimap.create();
+    private Multimap<String, VerifierRule> rulesByCategory = new Multimap<>();
 
     public Collection<ObjectType> getObjectTypesByRuleName(String ruleName) {
         Set<ObjectType> set = new HashSet<>();

--- a/drools-verifier/drools-verifier-drl/src/main/java/org/drools/verifier/data/VerifierReportImpl.java
+++ b/drools-verifier/drools-verifier-drl/src/main/java/org/drools/verifier/data/VerifierReportImpl.java
@@ -23,14 +23,12 @@ import java.util.List;
 import java.util.Map;
 import java.util.TreeMap;
 
+import org.drools.verifier.misc.Multimap;
 import org.drools.verifier.report.components.Gap;
 import org.drools.verifier.report.components.MissingNumberPattern;
 import org.drools.verifier.report.components.MissingRange;
 import org.drools.verifier.report.components.Severity;
 import org.drools.verifier.report.components.VerifierMessageBase;
-
-import com.google.common.collect.Multimap;
-import com.google.common.collect.TreeMultimap;
 
 public class VerifierReportImpl
     implements
@@ -38,12 +36,12 @@ public class VerifierReportImpl
     private static final long                       serialVersionUID               = 510l;
 
     private Map<String, Gap>                        gapsById                       = new TreeMap<>();
-    private Multimap<String, Gap>                   gapsByFieldId                  = TreeMultimap.create();
+    private Multimap<String, Gap>                   gapsByFieldId                  = new Multimap<>();
     private Map<String, MissingNumberPattern>       missingNumberPatternsById      = new TreeMap<>();
-    private Multimap<String, MissingNumberPattern>  missingNumberPatternsByFieldId = TreeMultimap.create();
+    private Multimap<String, MissingNumberPattern>  missingNumberPatternsByFieldId = new Multimap<>();
 
     private List<VerifierMessageBase>               messages                       = new ArrayList<>();
-    private Multimap<Severity, VerifierMessageBase> messagesBySeverity             = TreeMultimap.create();
+    private Multimap<Severity, VerifierMessageBase> messagesBySeverity             = new Multimap<>();
 
     private VerifierData                            data;
 

--- a/drools-verifier/drools-verifier-drl/src/main/java/org/drools/verifier/doc/DroolsDocsComponentFactory.java
+++ b/drools-verifier/drools-verifier-drl/src/main/java/org/drools/verifier/doc/DroolsDocsComponentFactory.java
@@ -25,7 +25,6 @@ import java.util.Map;
 import org.drools.verifier.misc.DrlPackageParser;
 import org.drools.verifier.misc.DrlRuleParser;
 
-import com.google.common.collect.Lists;
 import com.lowagie.text.BadElementException;
 import com.lowagie.text.Cell;
 import com.lowagie.text.Chunk;

--- a/drools-verifier/drools-verifier-drl/src/main/java/org/drools/verifier/jarloader/PackageHeaderLoader.java
+++ b/drools-verifier/drools-verifier-drl/src/main/java/org/drools/verifier/jarloader/PackageHeaderLoader.java
@@ -25,9 +25,9 @@ import java.util.Map;
 import java.util.Set;
 import java.util.jar.JarInputStream;
 
-import com.google.common.collect.TreeMultimap;
-import org.drools.util.ClassTypeResolver;
 import org.drools.mvel.asm.ClassFieldInspectorImpl;
+import org.drools.util.ClassTypeResolver;
+import org.drools.verifier.misc.Multimap;
 
 public class PackageHeaderLoader {
 
@@ -37,7 +37,7 @@ public class PackageHeaderLoader {
 
     private Map<String, String> fieldTypesByClassAndFieldNames = new HashMap<>();
 
-    private TreeMultimap<String, String> fieldsByClassNames = TreeMultimap.create();
+    private Multimap<String, String> fieldsByClassNames = new Multimap<>();
     private List<String> missingClasses = new ArrayList<>();
 
     public PackageHeaderLoader(Collection<String> imports, List<JarInputStream> jarInputStreams) throws IOException {

--- a/drools-verifier/drools-verifier-drl/src/main/java/org/drools/verifier/misc/Multimap.java
+++ b/drools-verifier/drools-verifier-drl/src/main/java/org/drools/verifier/misc/Multimap.java
@@ -1,0 +1,53 @@
+/*
+ * Copyright 2022 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.drools.verifier.misc;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+public class Multimap<K,V> {
+
+    private final Map<K, Collection<V>> map = new HashMap<>();
+    
+    public Collection<V> get(K key) {
+        return map.getOrDefault(key, Collections.emptyList());
+    }
+
+    public void put(K key, V value) {
+        map.computeIfAbsent(key, K -> new ArrayList<>()).add(value);
+    }
+
+    public void remove(K key, V value) {
+        Collection<V> values = map.get(key);
+        if (values != null) {
+            values.remove(value);
+        }
+    }
+
+    public Iterable<V> values() {
+        return map.values().stream().flatMap(Collection::stream).collect(Collectors.toList());
+    }
+
+    public Set<K> keySet() {
+        return map.keySet();
+    }
+}

--- a/drools-verifier/drools-verifier-drl/src/main/java/org/drools/verifier/report/html/MissingRangesReportVisitor.java
+++ b/drools-verifier/drools-verifier-drl/src/main/java/org/drools/verifier/report/html/MissingRangesReportVisitor.java
@@ -28,13 +28,12 @@ import org.drools.verifier.components.NumberRestriction;
 import org.drools.verifier.components.Restriction;
 import org.drools.verifier.components.VerifierComponentType;
 import org.drools.verifier.data.VerifierData;
+import org.drools.verifier.misc.Multimap;
 import org.drools.verifier.report.components.MissingRange;
 import org.drools.verifier.report.components.VerifierRangeCheckMessage;
 import org.mvel2.templates.TemplateRuntime;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import com.google.common.collect.Multimap;
-import com.google.common.collect.TreeMultimap;
 
 class MissingRangesReportVisitor extends ReportVisitor {
 
@@ -44,7 +43,7 @@ class MissingRangesReportVisitor extends ReportVisitor {
                                                                  Collection<Restriction> restrictions,
                                                                  Collection<MissingRange> causes) {
 
-        Multimap<String, DataRow> dt =  TreeMultimap.create();
+        Multimap<String, DataRow> dt =  new Multimap<>();
         Collection<String> stringRows = new ArrayList<>();
 
         for ( MissingRange cause : causes ) {

--- a/kie-dmn/kie-dmn-feel-gwt-showcase/pom.xml
+++ b/kie-dmn/kie-dmn-feel-gwt-showcase/pom.xml
@@ -61,7 +61,7 @@
       <dependency>
         <groupId>jakarta.ejb</groupId>
         <artifactId>jakarta.ejb-api</artifactId>
-        <version>3.2.6</version>
+        <version>${version.jakarta.ejb-api}</version>
       </dependency>
     </dependencies>
   </dependencyManagement>

--- a/kie-dmn/kie-dmn-feel-gwt-showcase/pom.xml
+++ b/kie-dmn/kie-dmn-feel-gwt-showcase/pom.xml
@@ -53,6 +53,12 @@
       </dependency>
 
       <dependency>
+        <groupId>com.google.guava</groupId>
+        <artifactId>guava-gwt</artifactId>
+        <version>30.1.1-jre</version>
+      </dependency>
+
+      <dependency>
         <groupId>jakarta.ejb</groupId>
         <artifactId>jakarta.ejb-api</artifactId>
         <version>3.2.6</version>

--- a/kie-dmn/kie-dmn-feel-gwt-showcase/pom.xml
+++ b/kie-dmn/kie-dmn-feel-gwt-showcase/pom.xml
@@ -55,7 +55,7 @@
       <dependency>
         <groupId>com.google.guava</groupId>
         <artifactId>guava-gwt</artifactId>
-        <version>30.1.1-jre</version>
+        <version>${version.com.google.guava}</version>
       </dependency>
 
       <dependency>

--- a/kie-dmn/kie-dmn-feel-gwt-showcase/pom.xml
+++ b/kie-dmn/kie-dmn-feel-gwt-showcase/pom.xml
@@ -51,6 +51,12 @@
           </exclusion>
         </exclusions>
       </dependency>
+
+      <dependency>
+        <groupId>jakarta.ejb</groupId>
+        <artifactId>jakarta.ejb-api</artifactId>
+        <version>3.2.6</version>
+      </dependency>
     </dependencies>
   </dependencyManagement>
 

--- a/kie-test-util/pom.xml
+++ b/kie-test-util/pom.xml
@@ -23,14 +23,14 @@
       <dependency>
         <groupId>org.apache.tomcat</groupId>
         <artifactId>tomcat-dbcp</artifactId>
-        <version>9.0.21</version>
+        <version>${version.org.apache.tomcat.tomcat-dbcp}</version>
       </dependency>
 
       <!-- simple-jndi is a small library that helps us avoid JNDI error messages during testing -->
       <dependency>
         <groupId>simple-jndi</groupId>
         <artifactId>simple-jndi</artifactId>
-        <version>0.11.4.1</version>
+        <version>${version.simple-jndi}</version>
       </dependency>
     </dependencies>
   </dependencyManagement>

--- a/kie-test-util/pom.xml
+++ b/kie-test-util/pom.xml
@@ -18,6 +18,23 @@
     <java.module.name>org.kie.testutil</java.module.name>
   </properties>
 
+  <dependencyManagement>
+    <dependencies>
+      <dependency>
+        <groupId>org.apache.tomcat</groupId>
+        <artifactId>tomcat-dbcp</artifactId>
+        <version>9.0.21</version>
+      </dependency>
+
+      <!-- simple-jndi is a small library that helps us avoid JNDI error messages during testing -->
+      <dependency>
+        <groupId>simple-jndi</groupId>
+        <artifactId>simple-jndi</artifactId>
+        <version>0.11.4.1</version>
+      </dependency>
+    </dependencies>
+  </dependencyManagement>
+
   <dependencies>
     <!-- IMPORTANT! Do not add any drools/jbpm/kie dependencies here. -->
     <!-- This is meant to be a lightweight test utility artifact. -->

--- a/kie-util/kie-util-maven-integration/pom.xml
+++ b/kie-util/kie-util-maven-integration/pom.xml
@@ -17,6 +17,16 @@
     <java.module.name>org.kie.util.maven.integration</java.module.name>
   </properties>
 
+  <dependencyManagement>
+    <dependencies>
+      <dependency>
+        <groupId>org.apache.httpcomponents</groupId>
+        <artifactId>httpcore</artifactId>
+        <version>4.4.15</version>
+      </dependency>
+    </dependencies>
+  </dependencyManagement>
+
   <dependencies>
     <dependency>
       <groupId>org.kie</groupId>

--- a/kie-util/kie-util-maven-integration/pom.xml
+++ b/kie-util/kie-util-maven-integration/pom.xml
@@ -22,7 +22,7 @@
       <dependency>
         <groupId>org.apache.httpcomponents</groupId>
         <artifactId>httpcore</artifactId>
-        <version>4.4.15</version>
+        <version>${version.org.apache.httpcomponents.httpcore}</version>
       </dependency>
     </dependencies>
   </dependencyManagement>


### PR DESCRIPTION
**JIRA**: https://issues.redhat.com/browse/DROOLS-6678

I removed the unnecessary dependencies, or when it was necessary but used only in one specific module for a very specific reason, I moved it away from the parent pom and declared it only in that module.

For what regards `guava` I found that it was only used by `drools-verifier` and only to have a `Multimap` implementation. I reimplemented it in the simplest possible way (that anyway seems to work in all cases) and removed the dependency.