### PR TITLE
[DROOLS-7145] Drools 8 docs : Review drools-mvel and drools-engine-cl…

### DIFF
--- a/drools-docs/src/modules/ROOT/pages/migration-guide/_traditional-to-ruleunit.adoc
+++ b/drools-docs/src/modules/ROOT/pages/migration-guide/_traditional-to-ruleunit.adoc
@@ -25,7 +25,7 @@ Typical {PRODUCT} 6 or early 7 projects have pom dependencies like this.
   </dependencied>
 ----
 
-But since {PRODUCT} 7.45.0, `drools-engine` and `drools-engine-classic` have been introduced as aggregator dependencies. `drools-engine-classic` is deprecated with `drools-mvel` since {PRODUCT} 8. Hence, use `drools-engine`.
+But since {PRODUCT} 7.45.0, `drools-engine` and `drools-engine-classic` have been introduced as aggregator dependencies. The dependencies `drools-engine-classic`, `drools-mvel` are deprecated starting with {PRODUCT} 8. Hence, use `drools-engine`.
 
 [xml]
 ----

--- a/drools-docs/src/modules/ROOT/pages/migration-guide/_traditional-to-ruleunit.adoc
+++ b/drools-docs/src/modules/ROOT/pages/migration-guide/_traditional-to-ruleunit.adoc
@@ -25,7 +25,7 @@ Typical {PRODUCT} 6 or early 7 projects have pom dependencies like this.
   </dependencied>
 ----
 
-But since {PRODUCT} 7.45.0, `drools-engine` and `drools-engine-classic` have been introduced as aggregator dependencies. If there is no specific reason, use `drools-engine`.
+But since {PRODUCT} 7.45.0, `drools-engine` and `drools-engine-classic` have been introduced as aggregator dependencies. `drools-engine-classic` is deprecated with `drools-mvel` since {PRODUCT} 8. Hence, use `drools-engine`.
 
 [xml]
 ----


### PR DESCRIPTION
…assic deprecation

**JIRA**: 
https://issues.redhat.com/browse/DROOLS-7145


<details>
<summary>
How to replicate CI configuration locally?
</summary>

Build Chain tool does "simple" maven build(s), the builds are just Maven commands, but because the repositories relates and depends on each other and any change in API or class method could affect several of those repositories there is a need to use [build-chain tool](https://github.com/kiegroup/github-action-build-chain) to handle cross repository builds and be sure that we always use latest version of the code for each repository.
 
[build-chain tool](https://github.com/kiegroup/github-action-build-chain) is a build tool which can be used on command line locally or in Github Actions workflow(s), in case you need to change multiple repositories and send multiple dependent pull requests related with a change you can easily reproduce the same build by executing it on Github hosted environment or locally in your development environment. See [local execution](https://github.com/kiegroup/github-action-build-chain#local-execution) details to get more information about it.
</details>

<details>
<summary>
How to retest this PR or trigger a specific build:
</summary>

- for <b>pull request checks</b>  
  Please add comment: <b>Jenkins retest this</b>

- for a <b>specific pull request check</b>  
  Please add comment: <b>Jenkins (re)run [drools|kogito-runtimes|kogito-apps|kogito-examples] tests</b>

- for a <b>full downstream build</b> 
  - for <b>jenkins</b> job: please add comment: <b>Jenkins run fdb</b>
  - for <b>github actions</b> job: add the label `run_fdb`

- <b>a compile downstream build</b> please  add comment: <b>Jenkins run cdb</b>

- <b>a full production downstream build</b> please add comment: <b>Jenkins execute product fdb</b>

- <b>an upstream build</b> please add comment: <b>Jenkins run upstream</b>

- for <b>quarkus branch checks</b>  
  Run checks against Quarkus current used branch  
  Please add comment: <b>Jenkins run quarkus-branch</b>

- for a <b>quarkus branch specific check</b>  
  Run checks against Quarkus current used branch  
  Please add comment: <b>Jenkins (re)run [drools|kogito-runtimes|kogito-apps|kogito-examples] quarkus-branch</b>

- for <b>quarkus main checks</b>  
  Run checks against Quarkus main branch  
  Please add comment: <b>Jenkins run quarkus-main</b>

- for a <b>specific quarkus main check</b>  
  Run checks against Quarkus main branch  
  Please add comment: <b>Jenkins (re)run [drools|kogito-runtimes|kogito-apps|kogito-examples] quarkus-branch</b>

- for <b>native checks</b>  
  Run native checks  
  Please add comment: <b>Jenkins run native</b>

- for a <b>specific native check</b>  
  Run native checks 
  Please add comment: <b>Jenkins (re)run [drools|kogito-runtimes|kogito-apps|kogito-examples] native</b>

- for <b>mandrel checks</b>  
  Run native checks against Mandrel image
  Please add comment: <b>Jenkins run mandrel</b>

- for a <b>specific mandrel check</b>  
  Run native checks against Mandrel image  
  Please add comment: <b>Jenkins (re)run [drools|kogito-runtimes|kogito-apps|kogito-examples] mandrel</b>
</details>
