### PR TITLE
[DROOLS-7158] enforce that ProjectClassLoader.CACHE_NON_EXISTING_CLAS…

### DIFF
--- a/drools-wiring/drools-wiring-api/pom.xml
+++ b/drools-wiring/drools-wiring-api/pom.xml
@@ -35,6 +35,17 @@
           <groupId>org.kie</groupId>
           <artifactId>kie-memory-compiler</artifactId>
       </dependency>
+
+      <dependency>
+        <groupId>org.assertj</groupId>
+        <artifactId>assertj-core</artifactId>
+        <scope>test</scope>
+      </dependency>
+      <dependency>
+        <groupId>junit</groupId>
+        <artifactId>junit</artifactId>
+        <scope>test</scope>
+      </dependency>
     </dependencies>
 
 </project>

--- a/drools-wiring/drools-wiring-api/src/main/java/org/drools/wiring/api/classloader/ProjectClassLoader.java
+++ b/drools-wiring/drools-wiring-api/src/main/java/org/drools/wiring/api/classloader/ProjectClassLoader.java
@@ -43,7 +43,7 @@ import static org.drools.util.ClassUtils.findParentClassLoader;
 
 public abstract class ProjectClassLoader extends ClassLoader implements KieTypeResolver, StoreClassLoader, WritableClassLoader {
 
-    private static final boolean CACHE_NON_EXISTING_CLASSES = true;
+    static final boolean CACHE_NON_EXISTING_CLASSES = true;
 
     private static boolean enableStoreFirst = Boolean.valueOf(System.getProperty("drools.projectClassLoader.enableStoreFirst", "true"));
 

--- a/drools-wiring/drools-wiring-api/src/test/java/org/drools/wiring/api/classloader/ProjectClassLoaderTest.java
+++ b/drools-wiring/drools-wiring-api/src/test/java/org/drools/wiring/api/classloader/ProjectClassLoaderTest.java
@@ -1,0 +1,28 @@
+/*
+ * Copyright 2022 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.drools.wiring.api.classloader;
+
+import org.junit.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class ProjectClassLoaderTest {
+
+    @Test
+    public void testNonExistingClassCacheIsEnabled() {
+        assertThat(ProjectClassLoader.CACHE_NON_EXISTING_CLASSES).isTrue();
+    }
+}


### PR DESCRIPTION
…SES is always set to true with a proper test case

**JIRA**: https://issues.redhat.com/browse/DROOLS-7158