### PR TITLE
[DROOLS-7171] add javadocs for RuleUnit API

### DIFF
--- a/drools-ruleunits/drools-ruleunits-api/src/main/java/org/drools/ruleunits/api/DataHandle.java
+++ b/drools-ruleunits/drools-ruleunits-api/src/main/java/org/drools/ruleunits/api/DataHandle.java
@@ -15,6 +15,13 @@
  */
 package org.drools.ruleunits.api;
 
+/**
+ * An handle to an object inserted into a {@link DataStore}.
+ */
 public interface DataHandle {
+
+    /**
+     * The object referred by this handle.
+     */
     Object getObject();
 }

--- a/drools-ruleunits/drools-ruleunits-api/src/main/java/org/drools/ruleunits/api/DataObserver.java
+++ b/drools-ruleunits/drools-ruleunits-api/src/main/java/org/drools/ruleunits/api/DataObserver.java
@@ -19,6 +19,7 @@ import java.util.function.Consumer;
 
 import org.kie.api.runtime.rule.FactHandle;
 
+// TODO to be removed (or moved to test code base)
 public interface DataObserver {
 
     static <T> DataProcessor<T> of(Consumer<T> consumer) {

--- a/drools-ruleunits/drools-ruleunits-api/src/main/java/org/drools/ruleunits/api/DataProcessor.java
+++ b/drools-ruleunits/drools-ruleunits-api/src/main/java/org/drools/ruleunits/api/DataProcessor.java
@@ -17,15 +17,31 @@ package org.drools.ruleunits.api;
 
 import org.kie.api.runtime.rule.FactHandle;
 
+/**
+ * The interface to implement in order to be notified of all the changes occurred to the facts managed by a {@link DataSource}
+ * @param <T> The type of objects observed by this DataProcessor.
+ */
 public interface DataProcessor<T> {
 
+    /**
+     * Notifies this DataProcessor that an object has been inserted in the observed {@link DataSource}.
+     */
     default void insert(T object) {
         insert(null, object);
     }
 
+    /**
+     * Notifies this DataProcessor that an object with the given {@link DataHandle} has been inserted in the observed {@link DataSource}.
+     */
     FactHandle insert(DataHandle handle, T object);
 
+    /**
+     * Notifies this DataProcessor that an object with the given {@link DataHandle} has been updated in the observed {@link DataSource}.
+     */
     void update(DataHandle handle, T object);
 
+    /**
+     * Notifies this DataProcessor that an object with the given {@link DataHandle} has been deleted from the observed {@link DataSource}.
+     */
     void delete(DataHandle handle);
 }

--- a/drools-ruleunits/drools-ruleunits-api/src/main/java/org/drools/ruleunits/api/DataSource.java
+++ b/drools-ruleunits/drools-ruleunits-api/src/main/java/org/drools/ruleunits/api/DataSource.java
@@ -17,8 +17,16 @@ package org.drools.ruleunits.api;
 
 import org.kie.api.internal.utils.KieService;
 
+/**
+ * A strongly typed source of data for a {@link RuleUnit}.
+ * @param <T> The type of objects managed by this DataSource.
+ */
 public interface DataSource<T> {
 
+    /**
+     * Subscribes this DataSource to a {@link DataProcessor} that will be notified of all the changes occurred
+     * to the facts going through the DataSource.
+     */
     void subscribe(DataProcessor<T> subscriber);
 
     interface Factory extends KieService {
@@ -31,18 +39,30 @@ public interface DataSource<T> {
         <T> SingletonStore<T> createSingleton();
     }
 
+    /**
+     * Creates a {@link DataStream}, a DataSource of immutable facts, without any buffer.
+     */
     static <T> DataStream<T> createStream() {
         return FactoryHolder.get().createStream();
     }
 
+    /**
+     * Creates a {@link DataStream}, a DataSource of immutable facts, without a buffer retaining at most the number of facts defined in bufferSize.
+     */
     static <T> DataStream<T> createBufferedStream(int bufferSize) {
         return FactoryHolder.get().createBufferedStream(bufferSize);
     }
 
+    /**
+     * Creates a {@link DataStore}, a DataSource of mutable facts.
+     */
     static <T> DataStore<T> createStore() {
         return FactoryHolder.get().createStore();
     }
 
+    /**
+     * Creates a {@link SingletonStore}, a data store that contains at most one value.
+     */
     static <T> SingletonStore<T> createSingleton() {
         return FactoryHolder.get().createSingleton();
     }

--- a/drools-ruleunits/drools-ruleunits-api/src/main/java/org/drools/ruleunits/api/DataStore.java
+++ b/drools-ruleunits/drools-ruleunits-api/src/main/java/org/drools/ruleunits/api/DataStore.java
@@ -15,12 +15,20 @@
  */
 package org.drools.ruleunits.api;
 
+/**
+ * A {@link DataSource} of mutable data.
+ * @param <T> The type of objects managed by this DataSource.
+ */
 public interface DataStore<T> extends DataSource<T> {
 
+    /**
+     * Add an object to this DataStore.
+     * @return The {@link DataHandle} to further modified
+     */
     DataHandle add(T object);
 
     /**
-     * Updates the fact for which the given DataHandle was assigned with the new
+     * Updates the fact for which the given {@link DataHandle} was assigned with the new
      * fact set as the second parameter in this method.
      * It is also possible to optionally specify the set of properties that have been modified.
      *
@@ -30,11 +38,14 @@ public interface DataStore<T> extends DataSource<T> {
     void update(DataHandle handle, T object);
 
     /**
-     * Deletes the fact for which the given DataHandle was assigned
+     * Deletes the fact for which the given {@link DataHandle} was assigned.
      *
      * @param handle the handle whose fact is to be retracted.
      */
     void remove(DataHandle handle);
 
+    /**
+     * Deletes a fact from this DataStore.
+     */
     void remove(T object);
 }

--- a/drools-ruleunits/drools-ruleunits-api/src/main/java/org/drools/ruleunits/api/DataStore.java
+++ b/drools-ruleunits/drools-ruleunits-api/src/main/java/org/drools/ruleunits/api/DataStore.java
@@ -23,7 +23,7 @@ public interface DataStore<T> extends DataSource<T> {
 
     /**
      * Add an object to this DataStore.
-     * @return The {@link DataHandle} to further modified
+     * @return The {@link DataHandle} to be further modified
      */
     DataHandle add(T object);
 

--- a/drools-ruleunits/drools-ruleunits-api/src/main/java/org/drools/ruleunits/api/DataStream.java
+++ b/drools-ruleunits/drools-ruleunits-api/src/main/java/org/drools/ruleunits/api/DataStream.java
@@ -15,6 +15,18 @@
  */
 package org.drools.ruleunits.api;
 
+/**
+ * A {@link DataSource} of immutable data.
+ * By default, this Stream doesn't retain any data and just forwards the facts appended to it to the {@link DataProcessor}s
+ * that are registered at the time of insertion. In particular this means that if a fact is inserted into the DataStream declared in a
+ * {@link RuleUnitData} before any {@link RuleUnitInstance} has been created from it, this fact's insertion will be simply get lost.
+ * It can be optionally buffered and retain a fixed amount of the latest appended facts.
+ * @param <T> The type of objects managed by this DataSource.
+ */
 public interface DataStream<T> extends DataSource<T> {
+
+    /**
+     * Append an object to this stream of data.
+     */
     void append(T value);
 }

--- a/drools-ruleunits/drools-ruleunits-api/src/main/java/org/drools/ruleunits/api/RuleUnit.java
+++ b/drools-ruleunits/drools-ruleunits-api/src/main/java/org/drools/ruleunits/api/RuleUnit.java
@@ -15,8 +15,18 @@
  */
 package org.drools.ruleunits.api;
 
+/**
+ * A rule unit is an atomic module defining a set of rules and a set of strongly typed {@link DataSource}s through which
+ * the facts processed by the rule engine are inserted. Users never need to implement this interface since the concrete
+ * implementation, reflecting what has been defined in the corresponding {@link RuleUnitData} is automatically generated
+ * by the engine. It is possible to obtain an instance of the generated rule unit programmatically via the {@link RuleUnitProvider}
+ * or declaratively via dependency injection.
+ *
+ * @param <T> The {@link RuleUnitData} for which this rule unit is generated.
+ */
 public interface RuleUnit<T extends RuleUnitData> {
 
+    // TODO this method is a leaky abstraction and should be removed from the public API
     String id();
 
     default RuleUnitInstance<T> createInstance(T data) {

--- a/drools-ruleunits/drools-ruleunits-api/src/main/java/org/drools/ruleunits/api/RuleUnitData.java
+++ b/drools-ruleunits/drools-ruleunits-api/src/main/java/org/drools/ruleunits/api/RuleUnitData.java
@@ -15,6 +15,12 @@
  */
 package org.drools.ruleunits.api;
 
+/**
+ * A marker interface that has to be implemented by a POJO defining the set of data belonging to and used by a {@link RuleUnit}.
+ * All fields of the implementing POJO that are instance of {@link DataSource} are equivalent to typed {@link org.kie.api.runtime.rule.EntryPoint}s
+ * through which inserting (and update and remove when allowed) the facts on which the rule engine will attempt a pattern matching.
+ * All other fields are equivalent to {@link org.kie.api.definition.rule.Global} for this rule unit.
+ */
 public interface RuleUnitData {
 
 }

--- a/drools-ruleunits/drools-ruleunits-api/src/main/java/org/drools/ruleunits/api/RuleUnitInstance.java
+++ b/drools-ruleunits/drools-ruleunits-api/src/main/java/org/drools/ruleunits/api/RuleUnitInstance.java
@@ -20,19 +20,50 @@ import java.util.Map;
 
 import org.kie.api.time.SessionClock;
 
+/**
+ * An instance of a {@link RuleUnit} working on the data contained in a specific {@link RuleUnitData}.
+ *
+ * @param <T> The {@link RuleUnitData} for which this rule unit is generated.
+ */
 public interface RuleUnitInstance<T extends RuleUnitData> {
 
+    /**
+     * The {@link RuleUnit} from which this RuleUnitInstance has been created.
+     */
     RuleUnit<T> unit();
 
+    /**
+     * The instance of {@link RuleUnitData} containing the data used by this RuleUnitInstance.
+     */
     T ruleUnitData();
 
+    /**
+     * Trigger the pattern matching algorithm on all the facts contained in the @{@link DataSource}s of the {@link RuleUnitData}
+     * used by this RuleUnitInstance and fires all the rules activated by them.
+     * @return The number of fired rules.
+     */
     int fire();
 
+    /**
+     * Executes the query with the given name on this instance, using the given set of arguments
+     * @param query The name of the query to be executed
+     * @param arguments The arguments to be passed to the query
+     * @return TODO this should return a {@link org.kie.api.runtime.rule.QueryResults}
+     */
     List<Map<String, Object>> executeQuery(String query, Object... arguments);
 
+    // TODO check if we want to keep this method (and also the RuleUnitQuery in the public API)
     <Q> Q executeQuery(Class<? extends RuleUnitQuery<Q>> query);
 
+    /**
+     * @return the session clock instance used by this RuleUnitInstance
+     */
     <T extends SessionClock> T getClock();
 
+    /**
+     * Releases all resources used by this RuleUnitInstance, setting it up for garbage collection.
+     * This method <b>must</b> always be called after finishing using the RuleUnitInstance, or the engine
+     * will not free the memory it uses.
+     */
     void dispose();
 }

--- a/drools-ruleunits/drools-ruleunits-api/src/main/java/org/drools/ruleunits/api/RuleUnitInstance.java
+++ b/drools-ruleunits/drools-ruleunits-api/src/main/java/org/drools/ruleunits/api/RuleUnitInstance.java
@@ -38,7 +38,7 @@ public interface RuleUnitInstance<T extends RuleUnitData> {
     T ruleUnitData();
 
     /**
-     * Trigger the pattern matching algorithm on all the facts contained in the @{@link DataSource}s of the {@link RuleUnitData}
+     * Trigger the pattern matching algorithm on all the facts contained in the {@link DataSource}s of the {@link RuleUnitData}
      * used by this RuleUnitInstance and fires all the rules activated by them.
      * @return The number of fired rules.
      */

--- a/drools-ruleunits/drools-ruleunits-api/src/main/java/org/drools/ruleunits/api/RuleUnitProvider.java
+++ b/drools-ruleunits/drools-ruleunits-api/src/main/java/org/drools/ruleunits/api/RuleUnitProvider.java
@@ -17,10 +17,25 @@ package org.drools.ruleunits.api;
 
 import org.kie.api.internal.utils.KieService;
 
+/**
+ * A provider of {@link RuleUnit} and {@link RuleUnitInstance} from a given {@link RuleUnitData}.
+ */
 public interface RuleUnitProvider extends KieService {
 
+    /**
+     * Provides the {@link RuleUnit} generated for the given {@link RuleUnitData}.
+     * @return The generated {@link RuleUnit} or null if there's no {@link RuleUnit} generated for the given {@link RuleUnitData}.
+     */
     <T extends RuleUnitData> RuleUnit<T> getRuleUnit(T ruleUnitData);
 
+    /**
+     * Creates a new {@link RuleUnitInstance} from the {@link RuleUnit} generated for the given {@link RuleUnitData}.
+     * This is equivalent to
+     * <pre>
+     * RuleUnitProvider.get().getRuleUnit(ruleUnitData).createInstance(ruleUnitData);
+     * </pre>
+     * throwing a runtime exception if there isn't any {@link RuleUnit} generated for the given {@link RuleUnitData}.
+     */
     default <T extends RuleUnitData> RuleUnitInstance<T> createRuleUnitInstance(T ruleUnitData) {
         RuleUnit<T> ruleUnit = getRuleUnit(ruleUnitData);
         if (ruleUnit == null) {
@@ -29,6 +44,9 @@ public interface RuleUnitProvider extends KieService {
         return ruleUnit.createInstance(ruleUnitData);
     }
 
+    /**
+     * Returns an instance of the RuleUnitProvider.
+     */
     static RuleUnitProvider get() {
         return RuleUnitProvider.Factory.get();
     }

--- a/drools-ruleunits/drools-ruleunits-dsl/src/main/java/org/drools/ruleunits/dsl/Accumulators.java
+++ b/drools-ruleunits/drools-ruleunits-dsl/src/main/java/org/drools/ruleunits/dsl/Accumulators.java
@@ -33,6 +33,9 @@ import org.drools.ruleunits.dsl.accumulate.Accumulator1;
 
 import static org.drools.model.functions.Function1.identity;
 
+/**
+ * A set of convenient factory methods to create the accumulators used in the rule unit Java DSL.
+ */
 public class Accumulators {
 
     public static <A, B> Accumulator1<A, Long> count() {

--- a/drools-ruleunits/drools-ruleunits-dsl/src/main/java/org/drools/ruleunits/dsl/RuleFactory.java
+++ b/drools-ruleunits/drools-ruleunits-dsl/src/main/java/org/drools/ruleunits/dsl/RuleFactory.java
@@ -25,6 +25,9 @@ import org.drools.ruleunits.dsl.patterns.Pattern2Def;
 import org.drools.ruleunits.dsl.patterns.PatternDef;
 import org.drools.ruleunits.impl.datasources.ConsequenceDataStore;
 
+/**
+ * The root of the fluent Java DSL to define a rule.
+ */
 public interface RuleFactory {
 
     <A> Pattern1Def<A> on(DataSource<A> dataSource);

--- a/drools-ruleunits/drools-ruleunits-dsl/src/main/java/org/drools/ruleunits/dsl/RuleUnitDefinition.java
+++ b/drools-ruleunits/drools-ruleunits-dsl/src/main/java/org/drools/ruleunits/dsl/RuleUnitDefinition.java
@@ -15,8 +15,17 @@
  */
 package org.drools.ruleunits.dsl;
 
+import org.drools.ruleunits.api.RuleUnit;
 import org.drools.ruleunits.api.RuleUnitData;
 
+/**
+ * A {@link RuleUnitData} allowing to define not only the set of data used by a {@link RuleUnit}, but also,
+ * through a convenient fluent Java DSL, the set of rules belonging to it.
+ */
 public interface RuleUnitDefinition extends RuleUnitData {
+
+    /**
+     * The method to be implemented to define the set of rules for this {@link RuleUnit}.
+     */
     void defineRules(RulesFactory rulesFactory);
 }

--- a/drools-ruleunits/drools-ruleunits-dsl/src/main/java/org/drools/ruleunits/dsl/RulesFactory.java
+++ b/drools-ruleunits/drools-ruleunits-dsl/src/main/java/org/drools/ruleunits/dsl/RulesFactory.java
@@ -28,6 +28,9 @@ import org.drools.ruleunits.dsl.util.RuleDefinition;
 
 import static org.drools.model.DSL.globalOf;
 
+/**
+ * The starting point to create and define rules through the rule unit Java DSL.
+ */
 public class RulesFactory {
 
     private final RuleUnitDefinition unit;
@@ -40,10 +43,16 @@ public class RulesFactory {
         this.globals = new UnitGlobals(unit);
     }
 
+    /**
+     * Creates a new rule and automatically adds it to the ones belonging to the {@link RuleUnitDefinition}.
+     */
     public RuleFactory rule() {
         return rule(UUID.randomUUID().toString());
     }
 
+    /**
+     * Creates a new rule with the given name and automatically adds it to the ones belonging to the {@link RuleUnitDefinition}.
+     */
     public RuleFactory rule(String name) {
         RuleDefinition rule = new RuleDefinition(name, unit, globals);
         rules.add(rule);
@@ -66,11 +75,11 @@ public class RulesFactory {
 
         private final RuleUnitDefinition unit;
 
-        public UnitGlobals(RuleUnitDefinition unit) {
+        private UnitGlobals(RuleUnitDefinition unit) {
             this.unit = unit;
         }
 
-        Map<Object, Global> getGlobals() {
+        private Map<Object, Global> getGlobals() {
             return globals;
         }
 


### PR DESCRIPTION
**JIRA**: https://issues.redhat.com/browse/DROOLS-7171

@tkobayas I added the javadocs for the RuleUnit API but, as anticipated during today's call, doing so I found a few methods that I consider leaky abstractions and I would like to remove, change or at least hide into a more internal API. To this purpose I left a few TODOs. Before doing so I was waiting for a pull request of @evacchi to be finalized to avoid conflicts. I just merged that PR so tomorrow I will work on that. For now please concentrate on the remaining parts of this PR and let me know if there is anything to change in the wording. 

I also added very minimal javadocs in the DSL part. I'm in doubt if it makes sense to also document all other methods there because I believe (or at least hope) that the DSL should be self-documenting or anyway clearer referring to examples in tests instead of javadocs. Even there any feedback is welcome.