### PR TITLE
DROOLS-6948 BuildResultCollectorImpl#results should be a list

### DIFF
--- a/drools-compiler/src/main/java/org/drools/compiler/builder/impl/BuildResultCollectorImpl.java
+++ b/drools-compiler/src/main/java/org/drools/compiler/builder/impl/BuildResultCollectorImpl.java
@@ -30,13 +30,13 @@ import org.kie.internal.builder.ResultSeverity;
 
 import java.util.ArrayList;
 import java.util.Collection;
-import java.util.LinkedHashSet;
+import java.util.Collections;
 import java.util.List;
 
 import static java.util.Arrays.asList;
 
 public class BuildResultCollectorImpl implements BuildResultCollector {
-    private Collection<KnowledgeBuilderResult> results = new LinkedHashSet<>(); // avoid duplicate errors
+    private Collection<KnowledgeBuilderResult> results = new ArrayList<>(); // avoid duplicate errors
 
     public BuildResultCollectorImpl() {
     }
@@ -56,7 +56,7 @@ public class BuildResultCollectorImpl implements BuildResultCollector {
     }
 
     public Collection<KnowledgeBuilderResult> getAllResults() {
-        return results;
+        return Collections.unmodifiableCollection(results);
     }
 
     public KnowledgeBuilderResults getResults(ResultSeverity... problemTypes) {

--- a/drools-compiler/src/main/java/org/drools/compiler/builder/impl/BuildResultCollectorImpl.java
+++ b/drools-compiler/src/main/java/org/drools/compiler/builder/impl/BuildResultCollectorImpl.java
@@ -36,7 +36,7 @@ import java.util.List;
 import static java.util.Arrays.asList;
 
 public class BuildResultCollectorImpl implements BuildResultCollector {
-    private Collection<KnowledgeBuilderResult> results = new ArrayList<>(); // avoid duplicate errors
+    private final Collection<KnowledgeBuilderResult> results = new ArrayList<>();
 
     public BuildResultCollectorImpl() {
     }
@@ -56,7 +56,7 @@ public class BuildResultCollectorImpl implements BuildResultCollector {
     }
 
     public Collection<KnowledgeBuilderResult> getAllResults() {
-        return Collections.unmodifiableCollection(results);
+        return results;
     }
 
     public KnowledgeBuilderResults getResults(ResultSeverity... problemTypes) {

--- a/drools-compiler/src/main/java/org/drools/compiler/builder/impl/KnowledgeBuilderImpl.java
+++ b/drools-compiler/src/main/java/org/drools/compiler/builder/impl/KnowledgeBuilderImpl.java
@@ -1002,10 +1002,10 @@ public class KnowledgeBuilderImpl implements InternalKnowledgeBuilder, TypeDecla
                         typeDeclarationManager.getTypeDeclarationBuilder(),
                         globals,
                         this, // as DroolsAssemblerContext
-                        results,
                         kBase,
                         configuration);
         compositePackageCompilationPhase.process();
+        results.addAll(compositePackageCompilationPhase.getResults());
     }
 
     private void buildRules(Collection<CompositePackageDescr> packages) {

--- a/drools-compiler/src/main/java/org/drools/compiler/builder/impl/processors/CompositePackageCompilationPhase.java
+++ b/drools-compiler/src/main/java/org/drools/compiler/builder/impl/processors/CompositePackageCompilationPhase.java
@@ -96,12 +96,7 @@ public class CompositePackageCompilationPhase implements CompilationPhase {
 
         for (CompilationPhase phase : phases) {
             phase.process();
-            Collection<? extends KnowledgeBuilderResult> results = phase.getResults();
-            results.forEach(this.buildResultCollector::addBuilderResult);
-            if (!results.isEmpty()) {
-                // early exit on error
-                break;
-            }
+            phase.getResults().forEach(this.buildResultCollector::addBuilderResult);
         }
 
     }

--- a/drools-compiler/src/main/java/org/drools/compiler/builder/impl/processors/CompositePackageCompilationPhase.java
+++ b/drools-compiler/src/main/java/org/drools/compiler/builder/impl/processors/CompositePackageCompilationPhase.java
@@ -95,7 +95,12 @@ public class CompositePackageCompilationPhase implements CompilationPhase {
 
         for (CompilationPhase phase : phases) {
             phase.process();
-            phase.getResults().forEach(this.buildResultCollector::addBuilderResult);
+            Collection<? extends KnowledgeBuilderResult> results = phase.getResults();
+            results.forEach(this.buildResultCollector::addBuilderResult);
+            if (!results.isEmpty()) {
+                // early exit on error
+                break;
+            }
         }
 
     }

--- a/drools-compiler/src/main/java/org/drools/compiler/builder/impl/processors/CompositePackageCompilationPhase.java
+++ b/drools-compiler/src/main/java/org/drools/compiler/builder/impl/processors/CompositePackageCompilationPhase.java
@@ -19,6 +19,7 @@ package org.drools.compiler.builder.impl.processors;
 
 import org.drools.compiler.builder.PackageRegistryManager;
 import org.drools.compiler.builder.impl.BuildResultCollector;
+import org.drools.compiler.builder.impl.BuildResultCollectorImpl;
 import org.drools.compiler.builder.impl.GlobalVariableContext;
 import org.drools.compiler.builder.impl.KnowledgeBuilderConfigurationImpl;
 import org.drools.compiler.builder.impl.TypeDeclarationBuilder;
@@ -47,7 +48,7 @@ public class CompositePackageCompilationPhase implements CompilationPhase {
     private final InternalKnowledgeBase kBase;
     private final KnowledgeBuilderConfigurationImpl configuration;
 
-    private final BuildResultCollector buildResultCollector;
+    private final BuildResultCollector buildResultCollector = new BuildResultCollectorImpl();
 
     public CompositePackageCompilationPhase(
             Collection<CompositePackageDescr> packages,
@@ -55,7 +56,6 @@ public class CompositePackageCompilationPhase implements CompilationPhase {
             TypeDeclarationBuilder typeBuilder,
             GlobalVariableContext globalVariableContext,
             TypeDeclarationContext typeDeclarationContext,
-            BuildResultCollector buildResultCollector,
             InternalKnowledgeBase kBase,
             KnowledgeBuilderConfigurationImpl configuration) {
         this.packages = packages;
@@ -63,7 +63,6 @@ public class CompositePackageCompilationPhase implements CompilationPhase {
         this.typeBuilder = typeBuilder;
         this.globalVariableContext = globalVariableContext;
         this.typeDeclarationContext = typeDeclarationContext;
-        this.buildResultCollector = buildResultCollector;
         this.kBase = kBase;
         this.configuration = configuration;
     }

--- a/drools-compiler/src/main/java/org/drools/compiler/builder/impl/processors/CompositePackageCompilationPhase.java
+++ b/drools-compiler/src/main/java/org/drools/compiler/builder/impl/processors/CompositePackageCompilationPhase.java
@@ -34,6 +34,7 @@ import org.kie.internal.builder.ResultSeverity;
 
 import java.util.Collection;
 import java.util.HashMap;
+import java.util.Iterator;
 import java.util.Map;
 import java.util.function.Supplier;
 
@@ -76,20 +77,20 @@ public class CompositePackageCompilationPhase implements CompilationPhase {
                 initAnnotationNormalizers();
 
         Collection<CompilationPhase> phases = asList(
-                iteratingPhase((pkgRegistry, packageDescr) ->
+                iteratingPhase("TypeDeclarationAnnotationNormalizer", (pkgRegistry, packageDescr) ->
                         new TypeDeclarationAnnotationNormalizer(annotationNormalizers.get(packageDescr.getNamespace()).get(), packageDescr)),
                 new TypeDeclarationCompositeCompilationPhase(packages, typeBuilder),
-                iteratingPhase(ImportCompilationPhase::new),
-                iteratingPhase(EntryPointDeclarationCompilationPhase::new),
+                iteratingPhase("ImportCompilationPhase", ImportCompilationPhase::new),
+                iteratingPhase("EntryPointDeclarationCompilationPhase", EntryPointDeclarationCompilationPhase::new),
 
                 // begin OtherDeclarationCompilationPhase
-                iteratingPhase(AccumulateFunctionCompilationPhase::new),
-                iteratingPhase((reg, desc) -> new WindowDeclarationCompilationPhase(reg, desc, typeDeclarationContext)),
-                iteratingPhase((reg, desc) -> new FunctionCompilationPhase(reg, desc, configuration)),
-                iteratingPhase((reg, desc) -> GlobalCompilationPhase.of(reg, desc, kBase, globalVariableContext, desc.getFilter())),
+                iteratingPhase("AccumulateFunctionCompilationPhase", AccumulateFunctionCompilationPhase::new),
+                iteratingPhase("WindowDeclarationCompilationPhase", (reg, desc) -> new WindowDeclarationCompilationPhase(reg, desc, typeDeclarationContext)),
+                iteratingPhase("FunctionCompilationPhase", (reg, desc) -> new FunctionCompilationPhase(reg, desc, configuration)),
+                iteratingPhase("GlobalCompilationPhase", (reg, desc) -> GlobalCompilationPhase.of(reg, desc, kBase, globalVariableContext, desc.getFilter())),
                 // end OtherDeclarationCompilationPhase
 
-                iteratingPhase((pkgRegistry, packageDescr) ->
+                iteratingPhase("RuleAnnotationNormalizer", (pkgRegistry, packageDescr) ->
                         new RuleAnnotationNormalizer(annotationNormalizers.get(packageDescr.getNamespace()).get(), packageDescr))
         );
 
@@ -123,8 +124,8 @@ public class CompositePackageCompilationPhase implements CompilationPhase {
         return annotationNormalizers;
     }
 
-    private IteratingPhase iteratingPhase(SinglePackagePhaseFactory phaseFactory) {
-        return new IteratingPhase(packages, pkgRegistryManager, phaseFactory);
+    private IteratingPhase iteratingPhase(String name, SinglePackagePhaseFactory phaseFactory) {
+        return new IteratingPhase(name, packages, pkgRegistryManager, phaseFactory);
     }
 
     @Override

--- a/drools-compiler/src/main/java/org/drools/compiler/builder/impl/processors/IteratingPhase.java
+++ b/drools-compiler/src/main/java/org/drools/compiler/builder/impl/processors/IteratingPhase.java
@@ -32,13 +32,18 @@ import java.util.Collection;
  *
  */
 public class IteratingPhase implements CompilationPhase {
+    private final String name;
     private final Collection<CompositePackageDescr> packages;
     private final PackageRegistryManager pkgRegistryManager;
     private final SinglePackagePhaseFactory phaseFactory;
-
     private final BuildResultCollectorImpl results = new BuildResultCollectorImpl();
 
-    public IteratingPhase(Collection<CompositePackageDescr> packages, PackageRegistryManager pkgRegistryManager, SinglePackagePhaseFactory phaseFactory) {
+    public IteratingPhase(
+            String name,
+            Collection<CompositePackageDescr> packages,
+            PackageRegistryManager pkgRegistryManager,
+            SinglePackagePhaseFactory phaseFactory) {
+        this.name = name;
         this.packages = packages;
         this.pkgRegistryManager = pkgRegistryManager;
         this.phaseFactory = phaseFactory;
@@ -62,5 +67,10 @@ public class IteratingPhase implements CompilationPhase {
     @Override
     public Collection<? extends KnowledgeBuilderResult> getResults() {
         return results.getAllResults();
+    }
+
+    @Override
+    public String toString() {
+        return "IteratingPhase(" + name + ')';
     }
 }

--- a/drools-compiler/src/main/java/org/drools/compiler/builder/impl/resources/DrlResourceHandler.java
+++ b/drools-compiler/src/main/java/org/drools/compiler/builder/impl/resources/DrlResourceHandler.java
@@ -43,6 +43,7 @@ public class DrlResourceHandler extends ResourceHandler {
 
     public PackageDescr process(Resource resource, ResourceConfiguration resourceConfig) throws DroolsParserException, IOException {
         PackageDescr pkg;
+        this.results.clear();
         boolean hasErrors = false;
         if (resource instanceof DescrResource) {
             pkg = (PackageDescr) ((DescrResource) resource).getDescr();

--- a/drools-compiler/src/main/java/org/drools/compiler/builder/impl/resources/ResourceHandler.java
+++ b/drools-compiler/src/main/java/org/drools/compiler/builder/impl/resources/ResourceHandler.java
@@ -108,7 +108,7 @@ public abstract class ResourceHandler {
     protected PackageDescr dslrReaderToPackageDescr(Resource resource, Reader dslrReader, DefaultExpander expander) throws DroolsParserException {
         boolean hasErrors;
         PackageDescr pkg;
-
+        this.results.clear();
         DrlParser parser = new DrlParser(configuration.getLanguageLevel());
 
         try {

--- a/drools-compiler/src/main/java/org/drools/compiler/builder/impl/resources/TemplateResourceHandler.java
+++ b/drools-compiler/src/main/java/org/drools/compiler/builder/impl/resources/TemplateResourceHandler.java
@@ -48,6 +48,7 @@ public class TemplateResourceHandler extends ResourceHandler {
 
     @Override
     public PackageDescr process(Resource resource, ResourceConfiguration configuration) throws DroolsParserException, IOException {
+        this.results.clear();
         GuidedRuleTemplateProvider guidedRuleTemplateProvider = GuidedRuleTemplateFactory.getGuidedRuleTemplateProvider();
         if (guidedRuleTemplateProvider == null) {
             throw new MissingImplementationException(resource, "drools-workbench-models-guided-template");

--- a/drools-model/drools-model-codegen/src/main/java/org/drools/model/codegen/execmodel/processors/DeclaredTypeCompilationPhase.java
+++ b/drools-model/drools-model-codegen/src/main/java/org/drools/model/codegen/execmodel/processors/DeclaredTypeCompilationPhase.java
@@ -61,8 +61,8 @@ public class DeclaredTypeCompilationPhase implements CompilationPhase {
     @Override
     public void process() {
         List<CompilationPhase> phases = asList(
-                iteratingPhase((reg, acc) -> new DeclaredTypeRegistrationPhase(reg, acc, pkgRegistryManager)),
-                iteratingPhase((reg, acc) ->
+                iteratingPhase("DeclaredTypeRegistrationPhase", (reg, acc) -> new DeclaredTypeRegistrationPhase(reg, acc, pkgRegistryManager)),
+                iteratingPhase("POJOGenerator", (reg, acc) ->
                         new POJOGenerator(reg.getPackage(), acc, packageModelManager.getPackageModel(acc, reg, reg.getPackage().getName()))),
                 new GeneratedPojoCompilationPhase(
                         packageModelManager, buildContext, buildConfiguration.getClassLoader()),
@@ -77,8 +77,8 @@ public class DeclaredTypeCompilationPhase implements CompilationPhase {
 
     }
 
-    private IteratingPhase iteratingPhase(SinglePackagePhaseFactory phaseFactory) {
-        return new IteratingPhase(packages, pkgRegistryManager, phaseFactory);
+    private IteratingPhase iteratingPhase(String name, SinglePackagePhaseFactory phaseFactory) {
+        return new IteratingPhase(name, packages, pkgRegistryManager, phaseFactory);
     }
 
     @Override

--- a/drools-model/drools-model-codegen/src/main/java/org/drools/model/codegen/execmodel/processors/ModelMainCompilationPhase.java
+++ b/drools-model/drools-model-codegen/src/main/java/org/drools/model/codegen/execmodel/processors/ModelMainCompilationPhase.java
@@ -85,17 +85,17 @@ public class ModelMainCompilationPhase<T> implements CompilationPhase {
     @Override
     public void process() {
         List<CompilationPhase> phases = new ArrayList<>();
-        phases.add(iteratingPhase(AccumulateFunctionCompilationPhase::new));
+        phases.add(iteratingPhase("AccumulateFunctionCompilationPhase", AccumulateFunctionCompilationPhase::new));
         if (hasMvel) {
-            phases.add(iteratingPhase((reg, acc) -> new WindowDeclarationCompilationPhase(reg, acc, typeDeclarationContext)));
+            phases.add(iteratingPhase("WindowDeclarationCompilationPhase", (reg, acc) -> new WindowDeclarationCompilationPhase(reg, acc, typeDeclarationContext)));
         }
-        phases.add(iteratingPhase((reg, acc) -> new FunctionCompilationPhase(reg, acc, configuration)));
-        phases.add(iteratingPhase((reg, acc) -> GlobalCompilationPhase.of(reg, acc, kBase, globalVariableContext, acc.getFilter())));
+        phases.add(iteratingPhase("FunctionCompilationPhase", (reg, acc) -> new FunctionCompilationPhase(reg, acc, configuration)));
+        phases.add(iteratingPhase("GlobalCompilationPhase", (reg, acc) -> GlobalCompilationPhase.of(reg, acc, kBase, globalVariableContext, acc.getFilter())));
         phases.add(new DeclaredTypeDeregistrationPhase(packages, pkgRegistryManager));
 
-        phases.add(iteratingPhase((reg, acc) -> new RuleValidator(reg, acc, configuration))); // validateUniqueRuleNames
-        phases.add(iteratingPhase((reg, acc) -> new ModelGeneratorPhase(reg, acc, packageModels.getPackageModel(acc, reg, acc.getName()), typeDeclarationContext))); // validateUniqueRuleNames
-        phases.add(iteratingPhase((reg, acc) -> new SourceCodeGenerationPhase<>(
+        phases.add(iteratingPhase("RuleValidator", (reg, acc) -> new RuleValidator(reg, acc, configuration))); // validateUniqueRuleNames
+        phases.add(iteratingPhase("ModelGeneratorPhase", (reg, acc) -> new ModelGeneratorPhase(reg, acc, packageModels.getPackageModel(acc, reg, acc.getName()), typeDeclarationContext))); // validateUniqueRuleNames
+        phases.add(iteratingPhase("SourceCodeGenerationPhase", (reg, acc) -> new SourceCodeGenerationPhase<>(
                 packageModels.getPackageModel(acc, reg, acc.getName()), packageSourceManager, sourceGenerator, oneClassPerRule))); // validateUniqueRuleNames
 
 
@@ -115,7 +115,7 @@ public class ModelMainCompilationPhase<T> implements CompilationPhase {
         return this.results.getAllResults();
     }
 
-    private IteratingPhase iteratingPhase(SinglePackagePhaseFactory phaseFactory) {
-        return new IteratingPhase(packages, pkgRegistryManager, phaseFactory);
+    private IteratingPhase iteratingPhase(String name, SinglePackagePhaseFactory phaseFactory) {
+        return new IteratingPhase(name, packages, pkgRegistryManager, phaseFactory);
     }
 }

--- a/drools-model/drools-model-codegen/src/main/java/org/drools/model/codegen/tool/ExplicitCanonicalModelCompiler.java
+++ b/drools-model/drools-model-codegen/src/main/java/org/drools/model/codegen/tool/ExplicitCanonicalModelCompiler.java
@@ -111,25 +111,26 @@ public class ExplicitCanonicalModelCompiler<T extends PackageSources> {
     public void process() {
         List<CompilationPhase> phases = new ArrayList<>();
 
-        phases.add(iteratingPhase((reg, acc) -> new DeclaredTypeRegistrationPhase(reg, acc, pkgRegistryManager)));
-        phases.add(iteratingPhase((reg, acc) ->
+        phases.add(iteratingPhase("DeclaredTypeRegistrationPhase", (reg, acc) -> new DeclaredTypeRegistrationPhase(reg, acc, pkgRegistryManager)));
+        phases.add(iteratingPhase("POJOGenerator", (reg, acc) ->
                 new POJOGenerator(reg.getPackage(), acc, packageModelManager.getPackageModel(acc, reg, reg.getPackage().getName()))));
         phases.add(new GeneratedPojoCompilationPhase(
                 packageModelManager, buildContext, configuration.getClassLoader()));
         phases.add(new PojoStoragePhase(buildContext, pkgRegistryManager, packages));
-        phases.add(iteratingPhase(AccumulateFunctionCompilationPhase::new));
+        phases.add(iteratingPhase("AccumulateFunctionCompilationPhase", AccumulateFunctionCompilationPhase::new));
         if (hasMvel) {
-            phases.add(iteratingPhase((reg, acc) -> new WindowDeclarationCompilationPhase(reg, acc, typeDeclarationContext)));
+            phases.add(iteratingPhase("WindowDeclarationCompilationPhase", (reg, acc) -> new WindowDeclarationCompilationPhase(reg, acc, typeDeclarationContext)));
         }
-        phases.add(iteratingPhase((reg, acc) -> new FunctionCompilationPhase(reg, acc, configuration)));
-        phases.add(iteratingPhase((reg, acc) -> new ImmutableGlobalCompilationPhase(reg, acc, globalVariableContext)));
+        phases.add(iteratingPhase("FunctionCompilationPhase", (reg, acc) -> new FunctionCompilationPhase(reg, acc, configuration)));
+        phases.add(iteratingPhase("ImmutableGlobalCompilationPhase", (reg, acc) -> new ImmutableGlobalCompilationPhase(reg, acc, globalVariableContext)));
         phases.add(new DeclaredTypeDeregistrationPhase(packages, pkgRegistryManager));
 
         // ---
 
-        phases.add(iteratingPhase((reg, acc) -> new RuleValidator(reg, acc, configuration))); // validateUniqueRuleNames
-        phases.add(iteratingPhase((reg, acc) -> new ModelGeneratorPhase(reg, acc, packageModelManager.getPackageModel(acc, reg, acc.getName()), typeDeclarationContext))); // validateUniqueRuleNames
-        phases.add(iteratingPhase((reg, acc) -> new SourceCodeGenerationPhase<>(
+        phases.add(iteratingPhase("RuleValidator", (reg, acc) -> new RuleValidator(reg, acc, configuration))); // validateUniqueRuleNames
+        phases.add(iteratingPhase("ModelGeneratorPhase",
+                (reg, acc) -> new ModelGeneratorPhase(reg, acc, packageModelManager.getPackageModel(acc, reg, acc.getName()), typeDeclarationContext))); // validateUniqueRuleNames
+        phases.add(iteratingPhase("SourceCodeGenerationPhase", (reg, acc) -> new SourceCodeGenerationPhase<>(
                 packageModelManager.getPackageModel(acc, reg, acc.getName()).setContext(context), packageSourceManager, sourceDumpFunction, oneClassPerRule))); // validateUniqueRuleNames
 
 
@@ -143,8 +144,8 @@ public class ExplicitCanonicalModelCompiler<T extends PackageSources> {
 
     }
 
-    private IteratingPhase iteratingPhase(SinglePackagePhaseFactory phaseFactory) {
-        return new IteratingPhase(packages, pkgRegistryManager, phaseFactory);
+    private IteratingPhase iteratingPhase(String name, SinglePackagePhaseFactory phaseFactory) {
+        return new IteratingPhase(name, packages, pkgRegistryManager, phaseFactory);
     }
 
     public BuildResultCollector getBuildResults() {

--- a/drools-model/drools-model-codegen/src/test/java/org/drools/model/codegen/execmodel/IncrementalCompilationTest.java
+++ b/drools-model/drools-model-codegen/src/test/java/org/drools/model/codegen/execmodel/IncrementalCompilationTest.java
@@ -25,6 +25,7 @@ import org.drools.model.codegen.execmodel.domain.Person;
 import org.junit.Test;
 import org.kie.api.KieServices;
 import org.kie.api.builder.ReleaseId;
+import org.kie.api.builder.Results;
 import org.kie.api.builder.model.KieModuleModel;
 import org.kie.api.runtime.KieContainer;
 import org.kie.api.runtime.KieSession;
@@ -363,7 +364,9 @@ public class IncrementalCompilationTest extends BaseModelTest {
         createAndDeployJar(ks, model2, releaseId2, drl1b);
 
         // try to update the container to version 1.1.0
-        kc.updateToVersion(releaseId2);
+        Results results = kc.updateToVersion(releaseId2);
+
+
 
         ksession.insert(new Person("Paul"));
 


### PR DESCRIPTION
https://github.com/kiegroup/drools/pull/4761 fixes the root cause for duplicated entries. This PR only substitutes the LinkedHashSet for an ArrayList and uses a BuildResultCollectorImpl when appropriate
