### PR TITLE
DROOLS-7045 Use 'Mutable' compilation phases when kBase != null

### DIFF
--- a/drools-compiler/src/main/java/org/drools/compiler/builder/impl/KnowledgeBuilderImpl.java
+++ b/drools-compiler/src/main/java/org/drools/compiler/builder/impl/KnowledgeBuilderImpl.java
@@ -450,8 +450,8 @@ public class KnowledgeBuilderImpl implements InternalKnowledgeBuilder, TypeDecla
 
         List<CompilationPhase> phases = asList(
                 new RuleValidator(packageRegistry, packageDescr, configuration), // validateUniqueRuleNames
-                new FunctionCompiler(pkgRegistry, packageDescr, assetFilter, rootClassLoader),
-                new RuleCompilationPhase(pkgRegistry, packageDescr, kBase, parallelRulesBuildThreshold,
+                FunctionCompiler.of(pkgRegistry, packageDescr, assetFilter, rootClassLoader),
+                RuleCompilationPhase.of(pkgRegistry, packageDescr, kBase, parallelRulesBuildThreshold,
                         assetFilter, packageAttributes, resource, this));
         phases.forEach(CompilationPhase::process);
         phases.forEach(p -> this.results.addAll(p.getResults()));

--- a/drools-compiler/src/main/java/org/drools/compiler/builder/impl/processors/CompositePackageCompilationPhase.java
+++ b/drools-compiler/src/main/java/org/drools/compiler/builder/impl/processors/CompositePackageCompilationPhase.java
@@ -87,7 +87,7 @@ public class CompositePackageCompilationPhase implements CompilationPhase {
                 iteratingPhase(AccumulateFunctionCompilationPhase::new),
                 iteratingPhase((reg, desc) -> new WindowDeclarationCompilationPhase(reg, desc, typeDeclarationContext)),
                 iteratingPhase((reg, desc) -> new FunctionCompilationPhase(reg, desc, configuration)),
-                iteratingPhase((reg, desc) -> new GlobalCompilationPhase(reg, desc, kBase, globalVariableContext, desc.getFilter())),
+                iteratingPhase((reg, desc) -> GlobalCompilationPhase.of(reg, desc, kBase, globalVariableContext, desc.getFilter())),
                 // end OtherDeclarationCompilationPhase
 
                 iteratingPhase((pkgRegistry, packageDescr) ->

--- a/drools-compiler/src/main/java/org/drools/compiler/builder/impl/processors/FunctionCompiler.java
+++ b/drools-compiler/src/main/java/org/drools/compiler/builder/impl/processors/FunctionCompiler.java
@@ -25,9 +25,17 @@ import org.kie.internal.builder.ResourceChange;
 
 public class FunctionCompiler extends ImmutableFunctionCompiler {
 
+    public static CompilationPhase of(PackageRegistry pkgRegistry, PackageDescr packageDescr, AssetFilter assetFilter, ClassLoader rootClassLoader) {
+        if (assetFilter == null) {
+            return new ImmutableFunctionCompiler(pkgRegistry, packageDescr, rootClassLoader);
+        } else {
+            return new FunctionCompiler(pkgRegistry, packageDescr, assetFilter, rootClassLoader);
+        }
+    }
+
     private final AssetFilter assetFilter;
 
-    public FunctionCompiler(PackageRegistry pkgRegistry, PackageDescr packageDescr, AssetFilter assetFilter, ClassLoader rootClassLoader) {
+    private FunctionCompiler(PackageRegistry pkgRegistry, PackageDescr packageDescr, AssetFilter assetFilter, ClassLoader rootClassLoader) {
         super(pkgRegistry, packageDescr, rootClassLoader);
         this.assetFilter = assetFilter;
     }

--- a/drools-compiler/src/main/java/org/drools/compiler/builder/impl/processors/GlobalCompilationPhase.java
+++ b/drools-compiler/src/main/java/org/drools/compiler/builder/impl/processors/GlobalCompilationPhase.java
@@ -22,6 +22,7 @@ import java.lang.reflect.Type;
 import org.drools.compiler.builder.impl.AssetFilter;
 import org.drools.compiler.builder.impl.GlobalVariableContext;
 import org.drools.compiler.compiler.PackageRegistry;
+import org.drools.compiler.lang.descr.CompositePackageDescr;
 import org.drools.core.definitions.InternalKnowledgePackage;
 import org.drools.drl.ast.descr.PackageDescr;
 import org.drools.kiesession.rulebase.InternalKnowledgeBase;
@@ -29,10 +30,18 @@ import org.kie.internal.builder.ResourceChange;
 
 public class GlobalCompilationPhase extends ImmutableGlobalCompilationPhase {
 
+    public static CompilationPhase of(PackageRegistry pkgRegistry, PackageDescr packageDescr, InternalKnowledgeBase kBase, GlobalVariableContext globalVariableContext, AssetFilter filterAcceptsRemoval) {
+        if (kBase == null) {
+            return new ImmutableGlobalCompilationPhase(pkgRegistry, packageDescr, globalVariableContext);
+        } else {
+            return new GlobalCompilationPhase(pkgRegistry, packageDescr, kBase, globalVariableContext, filterAcceptsRemoval);
+        }
+    }
+
     private final InternalKnowledgeBase kBase;
     private final AssetFilter assetFilter;
 
-    public GlobalCompilationPhase(PackageRegistry pkgRegistry, PackageDescr packageDescr, InternalKnowledgeBase kBase, GlobalVariableContext globalVariableContext, AssetFilter filterAcceptsRemoval) {
+    private GlobalCompilationPhase(PackageRegistry pkgRegistry, PackageDescr packageDescr, InternalKnowledgeBase kBase, GlobalVariableContext globalVariableContext, AssetFilter filterAcceptsRemoval) {
         super(pkgRegistry, packageDescr, globalVariableContext);
         this.kBase = kBase;
         this.assetFilter = filterAcceptsRemoval;
@@ -41,17 +50,13 @@ public class GlobalCompilationPhase extends ImmutableGlobalCompilationPhase {
     @Override
     protected void addGlobal(InternalKnowledgePackage pkg, String identifier, Type type) {
         super.addGlobal(pkg, identifier, type);
-        if (kBase != null) {
-            kBase.addGlobal(identifier, type);
-        }
+        kBase.addGlobal(identifier, type);
     }
 
     protected void removeGlobal(InternalKnowledgePackage pkg, String toBeRemoved) {
         if (assetFilter != null && AssetFilter.Action.REMOVE.equals(assetFilter.accept(ResourceChange.Type.GLOBAL, pkg.getName(), toBeRemoved))) {
             pkg.removeGlobal(toBeRemoved);
-            if (kBase != null) {
-                kBase.removeGlobal(toBeRemoved);
-            }
+            kBase.removeGlobal(toBeRemoved);
         }
     }
 

--- a/drools-compiler/src/main/java/org/drools/compiler/builder/impl/processors/ImmutableGlobalCompilationPhase.java
+++ b/drools-compiler/src/main/java/org/drools/compiler/builder/impl/processors/ImmutableGlobalCompilationPhase.java
@@ -73,6 +73,6 @@ public class ImmutableGlobalCompilationPhase extends AbstractPackageCompilationP
     }
 
     protected void removeGlobal(InternalKnowledgePackage pkg, String toBeRemoved) {
-        pkg.removeGlobal(toBeRemoved);
+        // default to no-op. This has only effect with asset filters.
     }
 }

--- a/drools-compiler/src/main/java/org/drools/compiler/builder/impl/processors/OtherDeclarationCompilationPhase.java
+++ b/drools-compiler/src/main/java/org/drools/compiler/builder/impl/processors/OtherDeclarationCompilationPhase.java
@@ -42,7 +42,7 @@ public class OtherDeclarationCompilationPhase extends AbstractPackageCompilation
                 new AccumulateFunctionCompilationPhase(pkgRegistry, packageDescr),
                 new WindowDeclarationCompilationPhase(pkgRegistry, packageDescr, typeDeclarationContext),
                 new FunctionCompilationPhase(pkgRegistry, packageDescr, configuration),
-                new GlobalCompilationPhase(pkgRegistry, packageDescr, kBase, globalVariableContext, assetFilter));
+                GlobalCompilationPhase.of(pkgRegistry, packageDescr, kBase, globalVariableContext, assetFilter));
 
         phases.forEach(CompilationPhase::process);
         phases.forEach(p -> results.addAll(p.getResults()));

--- a/drools-compiler/src/main/java/org/drools/compiler/builder/impl/processors/PackageCompilationPhase.java
+++ b/drools-compiler/src/main/java/org/drools/compiler/builder/impl/processors/PackageCompilationPhase.java
@@ -53,7 +53,7 @@ public final class PackageCompilationPhase extends AbstractPackageCompilationPha
                 new TypeDeclarationCompilationPhase(packageDescr, typeBuilder, pkgRegistry, currentResource),
                 new WindowDeclarationCompilationPhase(pkgRegistry, packageDescr, knowledgeBuilder),
                 new FunctionCompilationPhase(pkgRegistry, packageDescr, configuration),
-                new GlobalCompilationPhase(pkgRegistry, packageDescr, kBase, knowledgeBuilder, filterCondition),
+                GlobalCompilationPhase.of(pkgRegistry, packageDescr, kBase, knowledgeBuilder, filterCondition),
                 new RuleAnnotationNormalizer(annotationNormalizer, packageDescr));
 
         phases.forEach(CompilationPhase::process);

--- a/drools-compiler/src/main/java/org/drools/compiler/builder/impl/processors/RuleCompilationPhase.java
+++ b/drools-compiler/src/main/java/org/drools/compiler/builder/impl/processors/RuleCompilationPhase.java
@@ -37,10 +37,41 @@ import java.util.Map;
 
 public class RuleCompilationPhase extends ImmutableRuleCompilationPhase {
 
+    public static CompilationPhase of(
+            PackageRegistry pkgRegistry,
+                                 PackageDescr packageDescr,
+                                 InternalKnowledgeBase kBase,
+                                 int parallelRulesBuildThreshold,
+                                 AssetFilter assetFilter,
+                                 Map<String, AttributeDescr> packageAttributes,
+                                 Resource resource,
+                                 TypeDeclarationContext typeDeclarationContext) {
+
+        if (kBase == null) {
+            return new ImmutableRuleCompilationPhase(
+                    pkgRegistry,
+                    packageDescr,
+                    parallelRulesBuildThreshold,
+                    packageAttributes,
+                    resource,
+                    typeDeclarationContext);
+        } else {
+            return new RuleCompilationPhase(
+                    pkgRegistry,
+                    packageDescr,
+                    kBase,
+                    parallelRulesBuildThreshold,
+                    assetFilter,
+                    packageAttributes,
+                    resource,
+                    typeDeclarationContext);
+        }
+    }
+
     private InternalKnowledgeBase kBase;
     private final AssetFilter assetFilter;
 
-    public RuleCompilationPhase(
+    private RuleCompilationPhase(
             PackageRegistry pkgRegistry,
             PackageDescr packageDescr,
             InternalKnowledgeBase kBase,
@@ -61,14 +92,10 @@ public class RuleCompilationPhase extends ImmutableRuleCompilationPhase {
     }
 
     protected boolean parallelRulesBuild(List<RuleDescr> rules) {
-        return this.kBase == null && super.parallelRulesBuild(rules);
+        return false;
     }
 
     private void preProcessRules(PackageDescr packageDescr, PackageRegistry pkgRegistry) {
-        if (this.kBase == null) {
-            return;
-        }
-
         InternalKnowledgePackage pkg = pkgRegistry.getPackage();
         boolean needsRemoval = false;
 

--- a/drools-model/drools-model-codegen/src/main/java/org/drools/model/codegen/execmodel/processors/ModelMainCompilationPhase.java
+++ b/drools-model/drools-model-codegen/src/main/java/org/drools/model/codegen/execmodel/processors/ModelMainCompilationPhase.java
@@ -90,7 +90,7 @@ public class ModelMainCompilationPhase<T> implements CompilationPhase {
             phases.add(iteratingPhase((reg, acc) -> new WindowDeclarationCompilationPhase(reg, acc, typeDeclarationContext)));
         }
         phases.add(iteratingPhase((reg, acc) -> new FunctionCompilationPhase(reg, acc, configuration)));
-        phases.add(iteratingPhase((reg, acc) -> new GlobalCompilationPhase(reg, acc, kBase, globalVariableContext, acc.getFilter())));
+        phases.add(iteratingPhase((reg, acc) -> GlobalCompilationPhase.of(reg, acc, kBase, globalVariableContext, acc.getFilter())));
         phases.add(new DeclaredTypeDeregistrationPhase(packages, pkgRegistryManager));
 
         phases.add(iteratingPhase((reg, acc) -> new RuleValidator(reg, acc, configuration))); // validateUniqueRuleNames


### PR DESCRIPTION
Make a distinction between "mutable" and "immutable" phases, and use the right phase depending whether a `kbase` is present or not.