### PR TITLE
[DROOLS-7201] Migration guide : non executable model to executable model

### DIFF
--- a/drools-docs/src/modules/ROOT/pages/migration-guide/_nonexec-model-to-exec-model.adoc
+++ b/drools-docs/src/modules/ROOT/pages/migration-guide/_nonexec-model-to-exec-model.adoc
@@ -1,5 +1,5 @@
 [id='nonexec-model-to-exec-model_{context}']
-== Migration from non executable model to executable model
+== Migration from non-executable model to executable model
 The `drools-engine-classic` and `drools-mvel` execute rules with `non executable model`. `drools-engine` executes rules with `executable model`. Refer to xref:KIE/index.adoc#executable-model-con_packaging-deploying[Executable rule models] for executable model details.
 
 As we mentioned, `drools-engine-classic` and `drools-mvel` are deprecated, so we recommend you to migrate from `non executable model` to `executable model` by changing dependencies.

--- a/drools-docs/src/modules/ROOT/pages/migration-guide/_nonexec-model-to-exec-model.adoc
+++ b/drools-docs/src/modules/ROOT/pages/migration-guide/_nonexec-model-to-exec-model.adoc
@@ -7,7 +7,7 @@ As we mentioned, `drools-engine-classic` and `drools-mvel` are deprecated, so we
 In general, from an external perspective, rule evaluation and rule consequence executions results can be expected to be the same using either `non executable model` and `executable model`. You may however encounter a few edge cases during compile time or runtime; if you find any issues, please do report it to {PRODUCT} community. We have already identified some small known differences, reported below.
 
 === Invalid cast
-When you specify `dialect "mvel"` in a rule, `non executable model` is tolerant of invalid type cast. For example,
+When you specify `dialect "mvel"` in a rule, `non executable model` is tolerant of invalid type cast, because of type coercion behaviour in MVEL. For example,
 [source]
 ----
 global MyUtils myUtils;

--- a/drools-docs/src/modules/ROOT/pages/migration-guide/_nonexec-model-to-exec-model.adoc
+++ b/drools-docs/src/modules/ROOT/pages/migration-guide/_nonexec-model-to-exec-model.adoc
@@ -4,7 +4,7 @@ The `drools-engine-classic` and `drools-mvel` execute rules with `non executable
 
 As mentioned, `drools-engine-classic` and `drools-mvel` are deprecated, it is recommended to migrate from a `non-executable model` to an `executable model` by changing dependencies.
 
-In general, from an external perspective, rule evaluation and rule consequence executions results can be expected to be the same using either `non executable model` and `executable model`. You may however encounter a few edge cases during compile time or runtime; if you find any issues, please do report it to {PRODUCT} community. We have already identified some small known differences, reported below.
+In general, from an external perspective, rule evaluation and rule consequence execution results can be expected to be the same using either the `non-executable` model or the `executable model`. You may however encounter a few edge cases during compile time or runtime. If you find any issues, please report them to the {PRODUCT} community. We have already identified some small known differences, reported below.
 
 === Invalid cast
 When you specify `dialect "mvel"` in a rule, `non executable model` is tolerant of invalid type cast, because of type coercion behaviour in MVEL. For example,

--- a/drools-docs/src/modules/ROOT/pages/migration-guide/_nonexec-model-to-exec-model.adoc
+++ b/drools-docs/src/modules/ROOT/pages/migration-guide/_nonexec-model-to-exec-model.adoc
@@ -1,6 +1,6 @@
 [id='nonexec-model-to-exec-model_{context}']
 == Migration from non executable model to executable model
-`drools-engine-classic` and `drools-mvel` execute rules with `non executable model`. `drools-engine` executes rules with `executable model`. Refer to xref:KIE/index.adoc#executable-model-con_packaging-deploying[Executable rule models] for executable model details.
+The `drools-engine-classic` and `drools-mvel` execute rules with `non executable model`. `drools-engine` executes rules with `executable model`. Refer to xref:KIE/index.adoc#executable-model-con_packaging-deploying[Executable rule models] for executable model details.
 
 As we mentioned, `drools-engine-classic` and `drools-mvel` are deprecated, so we recommend you to migrate from `non executable model` to `executable model` by changing dependencies.
 

--- a/drools-docs/src/modules/ROOT/pages/migration-guide/_nonexec-model-to-exec-model.adoc
+++ b/drools-docs/src/modules/ROOT/pages/migration-guide/_nonexec-model-to-exec-model.adoc
@@ -20,7 +20,7 @@ then
   myUtils.doWork((String) $p.age )));
 end
 ----
-This rule can be built with  `non executable model` even if `$p.age` is `int` that is not acceptable in Java syntax.
+This rule can be built with  `non-executable model` even if `$p.age` is `int` which is not acceptable in Java syntax.
 
 With `executable model`, the rule fails with a build error.
 ----

--- a/drools-docs/src/modules/ROOT/pages/migration-guide/_nonexec-model-to-exec-model.adoc
+++ b/drools-docs/src/modules/ROOT/pages/migration-guide/_nonexec-model-to-exec-model.adoc
@@ -1,6 +1,6 @@
 [id='nonexec-model-to-exec-model_{context}']
 == Migration from non-executable model to executable model
-The `drools-engine-classic` and `drools-mvel` execute rules with `non executable model`. `drools-engine` executes rules with `executable model`. Refer to xref:KIE/index.adoc#executable-model-con_packaging-deploying[Executable rule models] for executable model details.
+The `drools-engine-classic` and `drools-mvel` execute rules with `non executable model`. `drools-engine` executes rules with `executable model`. For more details about the executable model, see xref:KIE/index.adoc#executable-model-con_packaging-deploying[Executable rule models].
 
 As we mentioned, `drools-engine-classic` and `drools-mvel` are deprecated, so we recommend you to migrate from `non executable model` to `executable model` by changing dependencies.
 

--- a/drools-docs/src/modules/ROOT/pages/migration-guide/_nonexec-model-to-exec-model.adoc
+++ b/drools-docs/src/modules/ROOT/pages/migration-guide/_nonexec-model-to-exec-model.adoc
@@ -4,7 +4,7 @@ The `drools-engine-classic` and `drools-mvel` execute rules with `non executable
 
 As we mentioned, `drools-engine-classic` and `drools-mvel` are deprecated, so we recommend you to migrate from `non executable model` to `executable model` by changing dependencies.
 
-Basically, rule executions results are the same with both `non executable model` and `executable model`. If you find any issues, please report it to {PRODUCT} community. However, there are a few known differences.
+In general, from an external perspective, rule evaluation and rule consequence executions results can be expected to be the same using either `non executable model` and `executable model`. You may however encounter a few edge cases during compile time or runtime; if you find any issues, please do report it to {PRODUCT} community. We have already identified some small known differences, reported below.
 
 === Invalid cast
 When you specify `dialect "mvel"` in a rule, `non executable model` is tolerant of invalid type cast. For example,

--- a/drools-docs/src/modules/ROOT/pages/migration-guide/_nonexec-model-to-exec-model.adoc
+++ b/drools-docs/src/modules/ROOT/pages/migration-guide/_nonexec-model-to-exec-model.adoc
@@ -7,7 +7,7 @@ As mentioned, `drools-engine-classic` and `drools-mvel` are deprecated, it is re
 In general, from an external perspective, rule evaluation and rule consequence execution results can be expected to be the same using either the `non-executable` model or the `executable model`. You may however encounter a few edge cases during compile time or runtime. If you find any issues, please report them to the {PRODUCT} community. We have already identified some small known differences, reported below.
 
 === Invalid cast
-When you specify `dialect "mvel"` in a rule, `non executable model` is tolerant of invalid type cast, because of type coercion behaviour in MVEL. For example,
+When you specify `dialect "mvel"` in a rule, the `non-executable model` is tolerant of invalid type cast, because of type coercion behavior in MVEL. For example,
 [source]
 ----
 global MyUtils myUtils;

--- a/drools-docs/src/modules/ROOT/pages/migration-guide/_nonexec-model-to-exec-model.adoc
+++ b/drools-docs/src/modules/ROOT/pages/migration-guide/_nonexec-model-to-exec-model.adoc
@@ -2,7 +2,7 @@
 == Migration from non-executable model to executable model
 The `drools-engine-classic` and `drools-mvel` execute rules with `non executable model`. `drools-engine` executes rules with `executable model`. For more details about the executable model, see xref:KIE/index.adoc#executable-model-con_packaging-deploying[Executable rule models].
 
-As we mentioned, `drools-engine-classic` and `drools-mvel` are deprecated, so we recommend you to migrate from `non executable model` to `executable model` by changing dependencies.
+As mentioned, `drools-engine-classic` and `drools-mvel` are deprecated, it is recommended to migrate from a `non-executable model` to an `executable model` by changing dependencies.
 
 In general, from an external perspective, rule evaluation and rule consequence executions results can be expected to be the same using either `non executable model` and `executable model`. You may however encounter a few edge cases during compile time or runtime; if you find any issues, please do report it to {PRODUCT} community. We have already identified some small known differences, reported below.
 

--- a/drools-docs/src/modules/ROOT/pages/migration-guide/_nonexec-model-to-exec-model.adoc
+++ b/drools-docs/src/modules/ROOT/pages/migration-guide/_nonexec-model-to-exec-model.adoc
@@ -27,7 +27,7 @@ With `executable model`, the rule fails with a build error.
 Cannot cast from int to String
 ----
 
-In this case, the rule needs to be fixed. For example,
+In this case, the rule can be easily fixed by using valid Java syntax. For example,
 ----
  ...
 then

--- a/drools-docs/src/modules/ROOT/pages/migration-guide/_nonexec-model-to-exec-model.adoc
+++ b/drools-docs/src/modules/ROOT/pages/migration-guide/_nonexec-model-to-exec-model.adoc
@@ -1,0 +1,36 @@
+[id='nonexec-model-to-exec-model_{context}']
+== Migration from non executable model to executable model
+`drools-engine-classic` and `drools-mvel` execute rules with `non executable model`. `drools-engine` executes rules with `executable model`. Refer to xref:KIE/index.adoc#executable-model-con_packaging-deploying[Executable rule models] for executable model details.
+
+As we mentioned, `drools-engine-classic` and `drools-mvel` are deprecated, so we recommend you to migrate from `non executable model` to `executable model` by changing dependencies.
+
+Basically, rule executions results are the same with both `non executable model` and `executable model`. If you find any issues, please report it to {PRODUCT} community. However, there are a few known differences.
+
+=== Invalid cast
+When you specify `dialect "mvel"` in a rule, `non executable model` is tolerant of invalid type cast. For example,
+[source]
+----
+global MyUtils myUtils;
+
+rule Rule1
+dialect "mvel"
+when
+  $p : Person()
+then
+  myUtils.doWork((String) $p.age )));
+end
+----
+This rule can be built with  `non executable model` even if `$p.age` is `int` that is not acceptable in Java syntax.
+
+With `executable model`, the rule fails with a build error.
+----
+Cannot cast from int to String
+----
+
+In this case, the rule needs to be fixed. For example,
+----
+ ...
+then
+  myUtils.doWork(java.util.Objects.toString( $p.age ));
+end
+----

--- a/drools-docs/src/modules/ROOT/pages/migration-guide/index.adoc
+++ b/drools-docs/src/modules/ROOT/pages/migration-guide/index.adoc
@@ -6,6 +6,7 @@ include::../_artifacts/document-attributes.adoc[]
 :context: migration-guide
 
 include::_traditional-to-ruleunit.adoc[leveloffset=+1]
+include::_nonexec-model-to-exec-model.adoc[leveloffset=+1]
 include::_missing_features_components.adoc[leveloffset=+1]
 
 // migrated to Antora:


### PR DESCRIPTION
**JIRA**: 
https://issues.redhat.com/browse/DROOLS-7201

<details>
<summary>
How to replicate CI configuration locally?
</summary>

Build Chain tool does "simple" maven build(s), the builds are just Maven commands, but because the repositories relates and depends on each other and any change in API or class method could affect several of those repositories there is a need to use [build-chain tool](https://github.com/kiegroup/github-action-build-chain) to handle cross repository builds and be sure that we always use latest version of the code for each repository.
 
[build-chain tool](https://github.com/kiegroup/github-action-build-chain) is a build tool which can be used on command line locally or in Github Actions workflow(s), in case you need to change multiple repositories and send multiple dependent pull requests related with a change you can easily reproduce the same build by executing it on Github hosted environment or locally in your development environment. See [local execution](https://github.com/kiegroup/github-action-build-chain#local-execution) details to get more information about it.
</details>

<details>
<summary>
How to retest this PR or trigger a specific build:
</summary>

- for <b>pull request checks</b>  
  Please add comment: <b>Jenkins retest this</b>

- for a <b>specific pull request check</b>  
  Please add comment: <b>Jenkins (re)run [drools|kogito-runtimes|kogito-apps|kogito-examples] tests</b>

- for a <b>full downstream build</b> 
  - for <b>jenkins</b> job: please add comment: <b>Jenkins run fdb</b>
  - for <b>github actions</b> job: add the label `run_fdb`

- <b>a compile downstream build</b> please  add comment: <b>Jenkins run cdb</b>

- <b>a full production downstream build</b> please add comment: <b>Jenkins execute product fdb</b>

- <b>an upstream build</b> please add comment: <b>Jenkins run upstream</b>

- for <b>quarkus branch checks</b>  
  Run checks against Quarkus current used branch  
  Please add comment: <b>Jenkins run quarkus-branch</b>

- for a <b>quarkus branch specific check</b>  
  Run checks against Quarkus current used branch  
  Please add comment: <b>Jenkins (re)run [drools|kogito-runtimes|kogito-apps|kogito-examples] quarkus-branch</b>

- for <b>quarkus main checks</b>  
  Run checks against Quarkus main branch  
  Please add comment: <b>Jenkins run quarkus-main</b>

- for a <b>specific quarkus main check</b>  
  Run checks against Quarkus main branch  
  Please add comment: <b>Jenkins (re)run [drools|kogito-runtimes|kogito-apps|kogito-examples] quarkus-main</b>

- for <b>quarkus lts checks</b>  
  Run checks against Quarkus lts branch  
  Please add comment: <b>Jenkins run quarkus-lts</b>

- for a <b>specific quarkus lts check</b>  
  Run checks against Quarkus lts branch  
  Please add comment: <b>Jenkins (re)run [drools|kogito-runtimes|kogito-apps|kogito-examples] quarkus-lts</b>

- for <b>native checks</b>  
  Run native checks  
  Please add comment: <b>Jenkins run native</b>

- for a <b>specific native check</b>  
  Run native checks 
  Please add comment: <b>Jenkins (re)run [drools|kogito-runtimes|kogito-apps|kogito-examples] native</b>

- for <b>mandrel checks</b>  
  Run native checks against Mandrel image
  Please add comment: <b>Jenkins run mandrel</b>

- for a <b>specific mandrel check</b>  
  Run native checks against Mandrel image  
  Please add comment: <b>Jenkins (re)run [drools|kogito-runtimes|kogito-apps|kogito-examples] mandrel</b>

 - for <b>mandrel lts checks</b>  
  Run native checks against Mandrel image and quarkus lts branch
  Please add comment: <b>Jenkins run mandrel-lts</b>

- for a <b>specific mandrel lts check</b>  
  Run native checks against Mandrel image and quarkus lts branch
  Please add comment: <b>Jenkins (re)run [drools|kogito-runtimes|kogito-apps|kogito-examples] mandrel-lts</b>
</details>
