### PR TITLE
DROOLS-7184: fix NullPointerException

### DIFF
--- a/drools-core/src/main/java/org/drools/core/common/TupleSetsImpl.java
+++ b/drools-core/src/main/java/org/drools/core/common/TupleSetsImpl.java
@@ -164,7 +164,10 @@ public class TupleSetsImpl<T extends Tuple> implements TupleSets<T> {
             if ( next != null ) {
                 setPreviousTuple( next, previous );
             }
-            setNextTuple( previous, next );
+            if (previous != null)
+            {
+                setNextTuple(previous, next);
+            }
         }
         tuple.clearStaged();
         insertSize--;
@@ -202,7 +205,10 @@ public class TupleSetsImpl<T extends Tuple> implements TupleSets<T> {
             if ( next != null ) {
                 setPreviousTuple( next, previous );
             }
-            setNextTuple( previous, next );
+            if(previous != null)
+            {
+                setNextTuple(previous, next);
+            }
         }
         tuple.clearStaged();
     }

--- a/drools-core/src/main/java/org/drools/core/phreak/PhreakAccumulateNode.java
+++ b/drools-core/src/main/java/org/drools/core/phreak/PhreakAccumulateNode.java
@@ -246,7 +246,10 @@ public class PhreakAccumulateNode {
                 for ( LeftTuple leftTuple = accNode.getFirstLeftTuple( rightTuple, ltm, leftIt ); leftTuple != null; leftTuple = (LeftTuple) leftIt.next( leftTuple ) ) {
                     if ( constraints.isAllowedCachedRight( contextEntry,
                                                            leftTuple ) ) {
-                        final BaseAccumulation accctx = (BaseAccumulation) leftTuple.getContextObject();
+                        BaseAccumulation accctx = (BaseAccumulation) leftTuple.getContextObject();
+                        if (accctx == null) {
+                            accctx = initAccumulationContext( am, reteEvaluator, accumulate, leftTuple );
+                        }
                         addMatch( accNode, accumulate, leftTuple, rightTuple,
                                   null, null, reteEvaluator, am,
                                   accctx, true, false );
@@ -280,7 +283,9 @@ public class PhreakAccumulateNode {
         for (LeftTuple leftTuple = srcLeftTuples.getUpdateFirst(); leftTuple != null; ) {
             LeftTuple next = leftTuple.getStagedNext();
             BaseAccumulation accctx = (BaseAccumulation) leftTuple.getContextObject();
-
+            if (accctx == null) {
+                accctx = initAccumulationContext( am, reteEvaluator, accumulate, leftTuple );
+            }
             if (accNode.isRightInputIsRiaNode()) {
                 // This is a subnetwork, do not process further. As all matches will processed
                 // by the right updates. This is to avoid double iteration (first right side iteration
@@ -481,7 +486,10 @@ public class PhreakAccumulateNode {
                     if (leftTuple.getStagedType() == LeftTuple.NONE) {
                         trgLeftTuples.addUpdate(leftTuple);
                     }
-                    final BaseAccumulation accctx = (BaseAccumulation) leftTuple.getContextObject();
+                    BaseAccumulation accctx = (BaseAccumulation) leftTuple.getContextObject();
+                    if (accctx == null) {
+                        accctx = initAccumulationContext( am, reteEvaluator, accumulate, leftTuple );
+                    }
                     // add a new match
                     addMatch(accNode, accumulate, leftTuple, rightTuple,
                              null, null, reteEvaluator, am,
@@ -496,7 +504,10 @@ public class PhreakAccumulateNode {
                     if (leftTuple.getStagedType() == LeftTuple.NONE) {
                         trgLeftTuples.addUpdate(leftTuple);
                     }
-                    final BaseAccumulation accctx = (BaseAccumulation) leftTuple.getContextObject();
+                    BaseAccumulation accctx = (BaseAccumulation) leftTuple.getContextObject();
+                    if (accctx == null) {
+                        accctx = initAccumulationContext( am, reteEvaluator, accumulate, leftTuple );
+                    }
                     LeftTuple temp;
                     if (childLeftTuple != null && childLeftTuple.getLeftParent() == leftTuple) {
                         temp = childLeftTuple.getRightParentNext();
@@ -522,7 +533,10 @@ public class PhreakAccumulateNode {
                     }
 
                     LeftTuple temp = childLeftTuple.getRightParentNext();
-                    final BaseAccumulation accctx = (BaseAccumulation) leftTuple.getContextObject();
+                    BaseAccumulation accctx = (BaseAccumulation) leftTuple.getContextObject();
+                    if (accctx == null) {
+                        accctx = initAccumulationContext( am, reteEvaluator, accumulate, leftTuple );
+                    }
                     // FIXME This will be really slow, if it re-accumulates on the same LeftTuple (MDP)
                     // remove the match
                     removeMatch(accNode,
@@ -559,6 +573,9 @@ public class PhreakAccumulateNode {
                 ltm.remove(leftTuple);
 
                 BaseAccumulation accctx = (BaseAccumulation) leftTuple.getContextObject();
+                if (accctx == null) {
+                    accctx = initAccumulationContext( am, reteEvaluator, accumulate, leftTuple );
+                }
                 leftTuple.setContextObject( null );
 
                 removePreviousMatchesForLeftTuple(accumulate, leftTuple, reteEvaluator, am, accctx, false);
@@ -600,7 +617,10 @@ public class PhreakAccumulateNode {
                         LeftTuple nextLeft = match.getRightParentNext();
 
                         LeftTuple leftTuple = match.getLeftParent();
-                        final BaseAccumulation accctx = (BaseAccumulation) leftTuple.getContextObject();
+                        BaseAccumulation accctx = (BaseAccumulation) leftTuple.getContextObject();
+                        if (accctx == null) {
+                            accctx = initAccumulationContext( am, reteEvaluator, accumulate, leftTuple );
+                        }
                         // FIXME This will be really slow, if it re-accumulates on the same LeftTuple (MDP)
                         removeMatch(accNode, accumulate, rightTuple, match, reteEvaluator, am, accctx, true);
 
@@ -840,7 +860,10 @@ public class PhreakAccumulateNode {
             final LeftTuple next = match.getRightParentNext();
 
             final LeftTuple leftTuple = match.getLeftParent();
-            final BaseAccumulation accctx = (BaseAccumulation) leftTuple.getContextObject();
+            BaseAccumulation accctx = (BaseAccumulation) leftTuple.getContextObject();
+            if (accctx == null) {
+                accctx = initAccumulationContext( memory, reteEvaluator, accumulate, leftTuple );
+            }
             removeMatch(accNode,
                         accumulate,
                         rightTuple,


### PR DESCRIPTION
**Thank you for submitting this pull request**

**NOTE!:** Double check the target branch for this PR.
The default is `main` so it will target Drools 8 / Kogito.
If this PR is not strictly related to drools and kogito project in `drools.git`, it should probably target `7.x`as a branch

**Ports** If a forward-port or a backport is needed, paste the forward port PR here

[link](https://www.example.com)

**JIRA**: _(please edit the JIRA link if it exists)_
https://issues.redhat.com/browse/DROOLS-7184

[link](https://www.example.com)

**referenced Pull Requests**: _(please edit the URLs of referenced pullrequests if they exist)_

* paste the link(s) from GitHub here
* link 2
* link 3 etc.

<details>
<summary>
How to replicate CI configuration locally?
</summary>

Build Chain tool does "simple" maven build(s), the builds are just Maven commands, but because the repositories relates and depends on each other and any change in API or class method could affect several of those repositories there is a need to use [build-chain tool](https://github.com/kiegroup/github-action-build-chain) to handle cross repository builds and be sure that we always use latest version of the code for each repository.
 
[build-chain tool](https://github.com/kiegroup/github-action-build-chain) is a build tool which can be used on command line locally or in Github Actions workflow(s), in case you need to change multiple repositories and send multiple dependent pull requests related with a change you can easily reproduce the same build by executing it on Github hosted environment or locally in your development environment. See [local execution](https://github.com/kiegroup/github-action-build-chain#local-execution) details to get more information about it.
</details>

<details>
<summary>
How to retest this PR or trigger a specific build:
</summary>

- for <b>pull request checks</b>  
  Please add comment: <b>Jenkins retest this</b>

- for a <b>specific pull request check</b>  
  Please add comment: <b>Jenkins (re)run [drools|kogito-runtimes|kogito-apps|kogito-examples] tests</b>

- for a <b>full downstream build</b> 
  - for <b>jenkins</b> job: please add comment: <b>Jenkins run fdb</b>
  - for <b>github actions</b> job: add the label `run_fdb`

- <b>a compile downstream build</b> please  add comment: <b>Jenkins run cdb</b>

- <b>a full production downstream build</b> please add comment: <b>Jenkins execute product fdb</b>

- <b>an upstream build</b> please add comment: <b>Jenkins run upstream</b>

- for <b>quarkus branch checks</b>  
  Run checks against Quarkus current used branch  
  Please add comment: <b>Jenkins run quarkus-branch</b>

- for a <b>quarkus branch specific check</b>  
  Run checks against Quarkus current used branch  
  Please add comment: <b>Jenkins (re)run [drools|kogito-runtimes|kogito-apps|kogito-examples] quarkus-branch</b>

- for <b>quarkus main checks</b>  
  Run checks against Quarkus main branch  
  Please add comment: <b>Jenkins run quarkus-main</b>

- for a <b>specific quarkus main check</b>  
  Run checks against Quarkus main branch  
  Please add comment: <b>Jenkins (re)run [drools|kogito-runtimes|kogito-apps|kogito-examples] quarkus-main</b>

- for <b>quarkus lts checks</b>  
  Run checks against Quarkus lts branch  
  Please add comment: <b>Jenkins run quarkus-lts</b>

- for a <b>specific quarkus lts check</b>  
  Run checks against Quarkus lts branch  
  Please add comment: <b>Jenkins (re)run [drools|kogito-runtimes|kogito-apps|kogito-examples] quarkus-lts</b>

- for <b>native checks</b>  
  Run native checks  
  Please add comment: <b>Jenkins run native</b>

- for a <b>specific native check</b>  
  Run native checks 
  Please add comment: <b>Jenkins (re)run [drools|kogito-runtimes|kogito-apps|kogito-examples] native</b>

- for <b>mandrel checks</b>  
  Run native checks against Mandrel image
  Please add comment: <b>Jenkins run mandrel</b>

- for a <b>specific mandrel check</b>  
  Run native checks against Mandrel image  
  Please add comment: <b>Jenkins (re)run [drools|kogito-runtimes|kogito-apps|kogito-examples] mandrel</b>

 - for <b>mandrel lts checks</b>  
  Run native checks against Mandrel image and quarkus lts branch
  Please add comment: <b>Jenkins run mandrel-lts</b>

- for a <b>specific mandrel lts check</b>  
  Run native checks against Mandrel image and quarkus lts branch
  Please add comment: <b>Jenkins (re)run [drools|kogito-runtimes|kogito-apps|kogito-examples] mandrel-lts</b>
</details>
