### PR TITLE
[DROOLS-7207] make sure that quarkus extensions run with static wiring module

### DIFF
--- a/drools-drl-quarkus-extension/drools-drl-quarkus-deployment/src/main/java/org/drools/drl/quarkus/deployment/DroolsAssetsProcessor.java
+++ b/drools-drl-quarkus-extension/drools-drl-quarkus-deployment/src/main/java/org/drools/drl/quarkus/deployment/DroolsAssetsProcessor.java
@@ -18,7 +18,6 @@ package org.drools.drl.quarkus.deployment;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
-
 import javax.inject.Inject;
 
 import io.quarkus.arc.deployment.GeneratedBeanBuildItem;

--- a/drools-drl-quarkus-extension/drools-drl-quarkus-util-deployment/pom.xml
+++ b/drools-drl-quarkus-extension/drools-drl-quarkus-util-deployment/pom.xml
@@ -25,6 +25,10 @@
             <groupId>org.drools</groupId>
             <artifactId>drools-codegen-common</artifactId>
         </dependency>
+        <dependency>
+            <groupId>org.drools</groupId>
+            <artifactId>drools-wiring-api</artifactId>
+        </dependency>
 
         <!-- quarkus -->
         <dependency>

--- a/drools-drl-quarkus-extension/drools-drl-quarkus-util-deployment/src/main/java/org/drools/drl/quarkus/util/deployment/DroolsQuarkusResourceUtils.java
+++ b/drools-drl-quarkus-extension/drools-drl-quarkus-util-deployment/src/main/java/org/drools/drl/quarkus/util/deployment/DroolsQuarkusResourceUtils.java
@@ -34,8 +34,10 @@ import org.drools.codegen.common.DroolsModelBuildContext;
 import org.drools.codegen.common.GeneratedFile;
 import org.drools.codegen.common.GeneratedFileType;
 import org.drools.codegen.common.context.QuarkusDroolsModelBuildContext;
+import org.drools.wiring.api.ComponentsSupplier;
 import org.jboss.jandex.DotName;
 import org.jboss.jandex.IndexView;
+import org.kie.api.internal.utils.KieService;
 import org.kie.memorycompiler.JavaCompiler;
 import org.kie.memorycompiler.JavaCompilerSettings;
 import org.slf4j.Logger;
@@ -55,6 +57,12 @@ public class DroolsQuarkusResourceUtils {
 
     private DroolsQuarkusResourceUtils() {
         // utility class
+    }
+
+    static {
+        if (!KieService.load(ComponentsSupplier.class).getClass().getSimpleName().equals("StaticComponentsSupplier")) {
+            throw new IllegalStateException("Cannot run quarkus extension with module org.drools:drools-wiring-dynamic. Please remove it from your classpath.");
+        }
     }
 
     private static final Logger LOGGER = LoggerFactory.getLogger(DroolsQuarkusResourceUtils.class);

--- a/drools-engine/pom.xml
+++ b/drools-engine/pom.xml
@@ -38,10 +38,6 @@
     </dependency>
     <dependency>
       <groupId>org.drools</groupId>
-      <artifactId>drools-wiring-dynamic</artifactId>
-    </dependency>
-    <dependency>
-      <groupId>org.drools</groupId>
       <artifactId>drools-kiesession</artifactId>
     </dependency>
     <dependency>

--- a/drools-impact-analysis/drools-impact-analysis-parser/pom.xml
+++ b/drools-impact-analysis/drools-impact-analysis-parser/pom.xml
@@ -24,6 +24,10 @@
     </dependency>
     <dependency>
       <groupId>org.drools</groupId>
+      <artifactId>drools-wiring-dynamic</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.drools</groupId>
       <artifactId>drools-impact-analysis-model</artifactId>
     </dependency>
 

--- a/drools-test-coverage/test-integration-nomvel/pom.xml
+++ b/drools-test-coverage/test-integration-nomvel/pom.xml
@@ -42,6 +42,11 @@
         </dependency>
         <dependency>
             <groupId>org.drools</groupId>
+            <artifactId>drools-wiring-dynamic</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.drools</groupId>
             <artifactId>drools-core</artifactId>
             <type>test-jar</type>
             <scope>test</scope>

--- a/drools-test-coverage/test-integration-noxml/pom.xml
+++ b/drools-test-coverage/test-integration-noxml/pom.xml
@@ -41,6 +41,11 @@
             <scope>test</scope>
         </dependency>
         <dependency>
+            <groupId>org.drools</groupId>
+            <artifactId>drools-wiring-dynamic</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
             <groupId>junit</groupId>
             <artifactId>junit</artifactId>
             <scope>test</scope>

--- a/kie-archetypes/kie-drools-exec-model-archetype/src/main/resources/archetype-resources/pom.xml
+++ b/kie-archetypes/kie-drools-exec-model-archetype/src/main/resources/archetype-resources/pom.xml
@@ -41,6 +41,10 @@
     </dependency>
     <dependency>
       <groupId>org.drools</groupId>
+      <artifactId>drools-wiring-dynamic</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.drools</groupId>
       <artifactId>drools-model-compiler</artifactId>
     </dependency>
     <dependency>

--- a/kie-archetypes/kie-drools-exec-model-archetype/src/test/resources/projects/integrationtestDefaults/reference/pom.xml
+++ b/kie-archetypes/kie-drools-exec-model-archetype/src/test/resources/projects/integrationtestDefaults/reference/pom.xml
@@ -38,6 +38,10 @@
     </dependency>
     <dependency>
       <groupId>org.drools</groupId>
+      <artifactId>drools-wiring-dynamic</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.drools</groupId>
       <artifactId>drools-model-compiler</artifactId>
     </dependency>
     <dependency>


### PR DESCRIPTION
**JIRA**: https://issues.redhat.com/browse/DROOLS-7207

I checked the solution suggested by @danielezonca [here](https://github.com/kiegroup/kogito-runtimes/blob/a86f9979049800a47093a7726bfae6a4976e12f3/quarkus/extensions/kogito-quarkus-serverless-workflow-extension/kogito-quarkus-serverless-workflow-deployment/src/main/java/org/kie/kogito/quarkus/serverless/workflow/rpc/ProtocUtils.java#L139), but it seemed overkilling for my needs and also somewhat misleading. I should have created an implementation of the `CodeGenProvider` service without any code to generate but with the only purpose of getting the `ApplicationModel` from it and check if there is the `drools-wiring-dynamic` module among the dependencies. I also tried to figure out if there was a simpler way to obtain the `ApplicationModel` but couldn't find any.

I'm obtaining the same result in a much simpler way: checking in the static initialization block of the `DroolsQuarkusResourceUtils` class, which is shared and used by both drools and kogito extension if the `ComponentSupplier` loaded by the `KieServices` is the static one as expected. This should make sure that the same check is performed only once and for both our extensions.

Also note that by doing this exercise I found that the dynamic module was still imported by many modules of the quarkus extension (I'm not even sure if and how it worked before in native mode at this point) because it was a dependency of the `drools-engine` so I removed it from there. This implies that now the `drools-wiring-dynamic` module has to be imported explicitly by end users every time they need to do some sort of dynamic classloading. I'm not sure if this is what we want, but I think it's right that the new engine doesn't depend on any sort of the dynamic classloading. Alternatively we could create a `drools-engine-static` module, maybe only for internal purposes, and make the quarkus extensions to depend on it.