### PR TITLE
DROOLS-6884 Reduce surface of the TypeDeclarationContext facade

### DIFF
--- a/drools-compiler/src/main/java/org/drools/compiler/builder/impl/DefaultTypeDeclarationBuilderFactory.java
+++ b/drools-compiler/src/main/java/org/drools/compiler/builder/impl/DefaultTypeDeclarationBuilderFactory.java
@@ -20,6 +20,6 @@ public class DefaultTypeDeclarationBuilderFactory implements TypeDeclarationBuil
 
     @Override
     public TypeDeclarationBuilder createTypeDeclarationBuilder(KnowledgeBuilderImpl kbuilder) {
-        return new TypeDeclarationBuilder(kbuilder);
+        return new TypeDeclarationBuilder(kbuilder, kbuilder);
     }
 }

--- a/drools-compiler/src/main/java/org/drools/compiler/builder/impl/KnowledgeBuilderImpl.java
+++ b/drools-compiler/src/main/java/org/drools/compiler/builder/impl/KnowledgeBuilderImpl.java
@@ -98,7 +98,7 @@ import org.slf4j.LoggerFactory;
 
 import static java.util.Arrays.asList;
 
-public class KnowledgeBuilderImpl implements InternalKnowledgeBuilder, TypeDeclarationContext, GlobalVariableContext {
+public class KnowledgeBuilderImpl implements InternalKnowledgeBuilder, TypeDeclarationContext, BuildResultCollector, GlobalVariableContext {
 
     protected static final transient Logger logger = LoggerFactory.getLogger(KnowledgeBuilderImpl.class);
 

--- a/drools-compiler/src/main/java/org/drools/compiler/builder/impl/TypeDeclarationCache.java
+++ b/drools-compiler/src/main/java/org/drools/compiler/builder/impl/TypeDeclarationCache.java
@@ -46,10 +46,12 @@ import static org.drools.core.util.Drools.hasMvel;
 public class TypeDeclarationCache {
 
     private final TypeDeclarationContext context;
+    private final BuildResultCollector results;
     private final Map<String, TypeDeclaration> cacheTypes = new HashMap<>();
 
-    TypeDeclarationCache( TypeDeclarationContext context ) {
+    TypeDeclarationCache(TypeDeclarationContext context, BuildResultCollector results) {
         this.context = context;
+        this.results = results;
         if ( hasMvel() ) {
             initBuiltinTypeDeclarations();
         }
@@ -213,12 +215,12 @@ public class TypeDeclarationCache {
             Position pos = fld.getAnnotation(Position.class);
             if (pos != null) {
                 if (pos.value() < 0 || pos.value() >= fields.size()) {
-                    context.addBuilderResult(new TypeDeclarationError(typeDeclaration,
+                    results.addBuilderResult(new TypeDeclarationError(typeDeclaration,
                                                                        "Out of range position " + pos.value() + " for field '" + fld.getName() + "' on class " + cls.getName()));
                     continue;
                 }
                 if (orderedFields[pos.value()] != null) {
-                    context.addBuilderResult(new TypeDeclarationError(typeDeclaration,
+                    results.addBuilderResult(new TypeDeclarationError(typeDeclaration,
                                                                        "Duplicated position " + pos.value() + " for field '" + fld.getName() + "' on class " + cls.getName()));
                     continue;
                 }
@@ -245,7 +247,7 @@ public class TypeDeclarationCache {
         String namespace = ClassUtils.getPackage( cls );
         PackageRegistry pkgRegistry = context.getOrCreatePackageRegistry( new PackageDescr(namespace) );
 
-        processMvelBasedAccessors(context, pkgRegistry, annotated, typeDeclaration );
+        processMvelBasedAccessors(context, results, pkgRegistry, annotated, typeDeclaration );
         return typeDeclaration;
     }
 

--- a/drools-compiler/src/main/java/org/drools/compiler/builder/impl/TypeDeclarationContext.java
+++ b/drools-compiler/src/main/java/org/drools/compiler/builder/impl/TypeDeclarationContext.java
@@ -29,7 +29,6 @@ import java.util.List;
  */
 public interface TypeDeclarationContext extends
         RootClassLoaderProvider,
-        BuildResultCollector,
         BuilderConfigurationProvider,
         PackageRegistryManager,
         InternalKnowledgeBaseProvider,

--- a/drools-compiler/src/main/java/org/drools/compiler/builder/impl/TypeDeclarationContextImpl.java
+++ b/drools-compiler/src/main/java/org/drools/compiler/builder/impl/TypeDeclarationContextImpl.java
@@ -36,7 +36,6 @@ public class TypeDeclarationContextImpl implements TypeDeclarationContext {
     private KnowledgeBuilderConfigurationImpl configuration;
     private final PackageRegistryManager packageRegistryManager;
     private GlobalVariableContext globalVariableContext;
-    private final BuildResultCollectorImpl buildResultAccumulator = new BuildResultCollectorImpl();
 
     private TypeDeclarationManagerImpl typeDeclarationManager;
 
@@ -114,32 +113,6 @@ public class TypeDeclarationContextImpl implements TypeDeclarationContext {
     @Override
     public ClassLoader getRootClassLoader() {
         return configuration.getClassLoader();
-    }
-
-    @Override
-    public void addBuilderResult(KnowledgeBuilderResult result) {
-        buildResultAccumulator.addBuilderResult(result);
-    }
-
-    @Override
-    public boolean hasErrors() {
-        return buildResultAccumulator.hasErrors();
-    }
-
-    public PackageBuilderErrors getErrors() {
-        // this is not really used by TypeDeclarationContext!!
-        return buildResultAccumulator.getErrors();
-    }
-
-    @Override
-    public KnowledgeBuilderResults getResults(ResultSeverity... severities) {
-        // this is not really used by TypeDeclarationContext!!
-        return buildResultAccumulator.getResults(severities);
-    }
-
-    @Override
-    public boolean hasResults(ResultSeverity... problemTypes) {
-        return buildResultAccumulator.hasResults(problemTypes);
     }
 
     @Override

--- a/drools-compiler/src/main/java/org/drools/compiler/builder/impl/TypeDeclarationNameResolver.java
+++ b/drools-compiler/src/main/java/org/drools/compiler/builder/impl/TypeDeclarationNameResolver.java
@@ -34,9 +34,11 @@ import org.drools.drl.ast.descr.TypeFieldDescr;
 public class TypeDeclarationNameResolver {
 
     private final TypeDeclarationContext context;
+    private final BuildResultCollector results;
 
-    public TypeDeclarationNameResolver(TypeDeclarationContext context) {
+    public TypeDeclarationNameResolver(TypeDeclarationContext context, BuildResultCollector results) {
         this.context = context;
+        this.results = results;
     }
 
     public void resolveTypes(Collection<? extends PackageDescr> packageDescrs,
@@ -158,7 +160,7 @@ public class TypeDeclarationNameResolver {
             if (resolved != null) {
                 qname.setName(resolved);
             } else {
-                context.addBuilderResult(new TypeDeclarationError(typeDescr,
+                results.addBuilderResult(new TypeDeclarationError(typeDescr,
                                                                    "Cannot resolve supertype '" + declaredSuperType +
                                                                            " for declared type " + typeDescr.getTypeName()));
             }
@@ -173,7 +175,7 @@ public class TypeDeclarationNameResolver {
         for (TypeFieldDescr field : typeDescr.getFields().values()) {
             GenericTypeDefinition typeDef = GenericTypeDefinition.parseType(field.getPattern().getObjectType(), type -> resolveName(type, typeDescr, packageDescr, typeResolver, unresolvedTypes, true) );
             if (typeDef == null) {
-                context.addBuilderResult(new TypeDeclarationError(typeDescr,
+                results.addBuilderResult(new TypeDeclarationError(typeDescr,
                                                                    "Cannot resolve type '" + field.getPattern().getObjectType() + " for field " + field.getFieldName() +
                                                                            " in declared type " + typeDescr.getTypeName()));
             } else {

--- a/drools-impact-analysis/drools-impact-analysis-parser/src/main/java/org/drools/impact/analysis/parser/impl/ImpactAnalysisRuleContext.java
+++ b/drools-impact-analysis/drools-impact-analysis-parser/src/main/java/org/drools/impact/analysis/parser/impl/ImpactAnalysisRuleContext.java
@@ -28,7 +28,7 @@ public class ImpactAnalysisRuleContext extends RuleContext {
     private Map<String, Object> bindVariableLiteralMap = new HashMap<>();
 
     public ImpactAnalysisRuleContext(KnowledgeBuilderImpl kbuilder, PackageModel packageModel, TypeResolver typeResolver, RuleDescr ruleDescr) {
-        super(kbuilder, packageModel, typeResolver, ruleDescr);
+        super(kbuilder, kbuilder, packageModel, typeResolver, ruleDescr);
     }
 
     public Map<String, Object> getBindVariableLiteralMap() {

--- a/drools-model/drools-model-codegen/src/main/java/org/drools/model/codegen/execmodel/PackageModel.java
+++ b/drools-model/drools-model-codegen/src/main/java/org/drools/model/codegen/execmodel/PackageModel.java
@@ -58,7 +58,9 @@ import com.github.javaparser.ast.stmt.ReturnStmt;
 import com.github.javaparser.ast.type.ClassOrInterfaceType;
 import com.github.javaparser.ast.type.Type;
 import org.drools.codegen.common.DroolsModelBuildContext;
+import org.drools.compiler.builder.impl.BuildResultCollector;
 import org.drools.compiler.builder.impl.KnowledgeBuilderConfigurationImpl;
+import org.drools.compiler.builder.impl.KnowledgeBuilderImpl;
 import org.drools.compiler.builder.impl.TypeDeclarationContext;
 import org.drools.compiler.builder.impl.TypeDeclarationUtils;
 import org.drools.compiler.compiler.DialectCompiletimeRegistry;
@@ -200,14 +202,17 @@ public class PackageModel {
                 .orElse(new PackageModel(releaseId, pkgName, configuration, pkgRegistry.getDialectCompiletimeRegistry(), exprIdGenerator));
     }
 
-    public static void initPackageModel(TypeDeclarationContext kbuilder, InternalKnowledgePackage pkg, TypeResolver typeResolver, PackageDescr packageDescr, PackageModel packageModel ) {
+    public static void initPackageModel(KnowledgeBuilderImpl kbuilder, InternalKnowledgePackage pkg, TypeResolver typeResolver, PackageDescr packageDescr, PackageModel packageModel ) {
+        initPackageModel(kbuilder, kbuilder, pkg, typeResolver, packageDescr, packageModel);
+    }
+    public static void initPackageModel(TypeDeclarationContext typeDeclarationContext, BuildResultCollector results, InternalKnowledgePackage pkg, TypeResolver typeResolver, PackageDescr packageDescr, PackageModel packageModel ) {
         packageModel.addImports( pkg.getImports().keySet());
         packageModel.addStaticImports( pkg.getStaticImports());
         packageModel.addEntryPoints( packageDescr.getEntryPointDeclarations());
         packageModel.addGlobals( pkg );
         packageModel.setAccumulateFunctions( pkg.getAccumulateFunctions());
         packageModel.setInternalKnowledgePackage( pkg );
-        new WindowReferenceGenerator( packageModel, typeResolver ).addWindowReferences( kbuilder, packageDescr.getWindowDeclarations());
+        new WindowReferenceGenerator( packageModel, typeResolver ).addWindowReferences( typeDeclarationContext, results, packageDescr.getWindowDeclarations());
         packageModel.addAllFunctions( packageDescr.getFunctions().stream().map(FunctionGenerator::toFunction).collect(toList()));
     }
 

--- a/drools-model/drools-model-codegen/src/main/java/org/drools/model/codegen/execmodel/processors/ModelGeneratorPhase.java
+++ b/drools-model/drools-model-codegen/src/main/java/org/drools/model/codegen/execmodel/processors/ModelGeneratorPhase.java
@@ -17,6 +17,8 @@
 
 package org.drools.model.codegen.execmodel.processors;
 
+import org.drools.compiler.builder.impl.BuildResultCollector;
+import org.drools.compiler.builder.impl.BuildResultCollectorImpl;
 import org.drools.compiler.builder.impl.TypeDeclarationContext;
 import org.drools.compiler.builder.impl.processors.AbstractPackageCompilationPhase;
 import org.drools.compiler.compiler.PackageRegistry;
@@ -30,22 +32,24 @@ import static org.drools.model.codegen.execmodel.generator.ModelGenerator.genera
 
 public class ModelGeneratorPhase extends AbstractPackageCompilationPhase {
     private final TypeDeclarationContext typeDeclarationContext;
+    private final BuildResultCollectorImpl buildResultCollector;
     private final PackageModel packageModel;
 
     public ModelGeneratorPhase(PackageRegistry pkgRegistry, PackageDescr packageDescr, PackageModel packageModel, TypeDeclarationContext typeDeclarationContext) {
         super(pkgRegistry, packageDescr);
-        this.packageModel = packageModel;
         this.typeDeclarationContext = typeDeclarationContext;
+        this.buildResultCollector = new BuildResultCollectorImpl();
+        this.packageModel = packageModel;
     }
 
     @Override
     public void process() {
-        PackageModel.initPackageModel(typeDeclarationContext, pkgRegistry.getPackage(), pkgRegistry.getTypeResolver(), packageDescr, packageModel );
-        generateModel(typeDeclarationContext, pkgRegistry.getPackage(), packageDescr, packageModel);
+        PackageModel.initPackageModel(typeDeclarationContext, buildResultCollector, pkgRegistry.getPackage(), pkgRegistry.getTypeResolver(), packageDescr, packageModel );
+        generateModel(typeDeclarationContext, buildResultCollector, pkgRegistry.getPackage(), packageDescr, packageModel);
     }
 
     @Override
     public Collection<? extends KnowledgeBuilderResult> getResults() {
-        return typeDeclarationContext.getAllResults();
+        return buildResultCollector.getAllResults();
     }
 }

--- a/drools-model/drools-model-codegen/src/test/java/org/drools/model/codegen/execmodel/generator/ExpressionTyperTest.java
+++ b/drools-model/drools-model-codegen/src/test/java/org/drools/model/codegen/execmodel/generator/ExpressionTyperTest.java
@@ -52,7 +52,7 @@ public class ExpressionTyperTest {
         imports = new HashSet<>();
         packageModel = new PackageModel("", "", null, null, new DRLIdGenerator());
         typeResolver = new ClassTypeResolver(imports, getClass().getClassLoader());
-        ruleContext = new RuleContext(knowledgeBuilder, packageModel, typeResolver, ruleDescr);
+        ruleContext = new RuleContext(knowledgeBuilder, knowledgeBuilder, packageModel, typeResolver, ruleDescr);
         imports.add(Person.class.getCanonicalName());
     }
 

--- a/drools-model/drools-model-codegen/src/test/java/org/drools/model/codegen/execmodel/generator/drlxparse/ConstraintParserTest.java
+++ b/drools-model/drools-model-codegen/src/test/java/org/drools/model/codegen/execmodel/generator/drlxparse/ConstraintParserTest.java
@@ -43,7 +43,7 @@ public class ConstraintParserTest {
         Set<String> imports = new HashSet<>();
         imports.add(Person.class.getCanonicalName());
         TypeResolver typeResolver = new ClassTypeResolver(imports, getClass().getClassLoader());
-        RuleContext context = new RuleContext(null, packageModel, typeResolver, null, 0);
+        RuleContext context = new RuleContext(null, null, packageModel, typeResolver, null, 0);
         parser = ConstraintParser.defaultConstraintParser(context, packageModel);
     }
 

--- a/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/compiler/integrationtests/phases/ExplicitCompilerTest.java
+++ b/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/compiler/integrationtests/phases/ExplicitCompilerTest.java
@@ -88,7 +88,7 @@ public class ExplicitCompilerTest {
 
         TypeDeclarationContextImpl typeDeclarationContext =
                 new TypeDeclarationContextImpl(configuration, packageRegistryManager, globalVariableContext);
-        TypeDeclarationBuilder typeBuilder = new TypeDeclarationBuilder(typeDeclarationContext);
+        TypeDeclarationBuilder typeBuilder = new TypeDeclarationBuilder(typeDeclarationContext, results);
         typeDeclarationContext.setTypeDeclarationManager(new TypeDeclarationManagerImpl(typeBuilder, kBase));
 
 

--- a/drools-traits/src/main/java/org/drools/traits/compiler/builder/impl/TraitsTypeDeclarationBuilderImpl.java
+++ b/drools-traits/src/main/java/org/drools/traits/compiler/builder/impl/TraitsTypeDeclarationBuilderImpl.java
@@ -37,7 +37,7 @@ import org.drools.traits.core.factmodel.TraitRegistryImpl;
 public class TraitsTypeDeclarationBuilderImpl extends TypeDeclarationBuilder {
 
     TraitsTypeDeclarationBuilderImpl(KnowledgeBuilderImpl kbuilder) {
-        super(kbuilder);
+        super(kbuilder, kbuilder);
     }
 
     @Override
@@ -72,7 +72,7 @@ public class TraitsTypeDeclarationBuilderImpl extends TypeDeclarationBuilder {
                     Class<?> resolvedType = reg.getTypeResolver().resolveType(availableName);
                     if (!Thing.class.isAssignableFrom(resolvedType)) {
                         if ( ! resolvedType.isInterface() ) {
-                            context.addBuilderResult(new TypeDeclarationError(typeDescr, "Unable to redeclare concrete class " + resolvedType.getName() + " as a trait." ) );
+                            results.addBuilderResult(new TypeDeclarationError(typeDescr, "Unable to redeclare concrete class " + resolvedType.getName() + " as a trait." ) );
                             return;
                         }
                         updateTraitDefinition(type,
@@ -120,7 +120,7 @@ public class TraitsTypeDeclarationBuilderImpl extends TypeDeclarationBuilder {
                                                    tempDef );
 
                         } catch (ClassNotFoundException cnfe) {
-                            context.addBuilderResult(new TypeDeclarationError(typeDescr,
+                            results.addBuilderResult(new TypeDeclarationError(typeDescr,
                                                                                "Internal Trait extension Class '" + target +
                                                                                         "' could not be generated correctly'" ) );
                         } finally {


### PR DESCRIPTION
org.drools.compiler.builder.impl.TypeDeclarationContext has been created as part of [DROOLS-6881](https://issues.redhat.com/browse/DROOLS-6881). The API surface was good enough for a first round; however it is implementing some redundant interfaces.

For instance, `BuildResultCollector` should be a separate concern. This PR removes `BuildResultCollector` from `TypeDeclarationContext` and wires a `BuildResultCollector` instead.

This should also allow #4740 to be easily fixed.