### PR TITLE
[DROOLS-7207] ensure that quarkus extensions use the static wiring module when running in native mode

### DIFF
--- a/drools-drl-quarkus-extension/drools-drl-quarkus-util-deployment/pom.xml
+++ b/drools-drl-quarkus-extension/drools-drl-quarkus-util-deployment/pom.xml
@@ -23,6 +23,10 @@
         </dependency>
         <dependency>
             <groupId>org.drools</groupId>
+            <artifactId>drools-core</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.drools</groupId>
             <artifactId>drools-codegen-common</artifactId>
         </dependency>
 

--- a/drools-drl-quarkus-extension/drools-drl-quarkus-util-deployment/src/main/java/org/drools/drl/quarkus/util/deployment/DroolsQuarkusResourceUtils.java
+++ b/drools-drl-quarkus-extension/drools-drl-quarkus-util-deployment/src/main/java/org/drools/drl/quarkus/util/deployment/DroolsQuarkusResourceUtils.java
@@ -34,8 +34,11 @@ import org.drools.codegen.common.DroolsModelBuildContext;
 import org.drools.codegen.common.GeneratedFile;
 import org.drools.codegen.common.GeneratedFileType;
 import org.drools.codegen.common.context.QuarkusDroolsModelBuildContext;
+import org.drools.core.util.Drools;
+import org.drools.wiring.api.ComponentsSupplier;
 import org.jboss.jandex.DotName;
 import org.jboss.jandex.IndexView;
+import org.kie.api.internal.utils.KieService;
 import org.kie.memorycompiler.JavaCompiler;
 import org.kie.memorycompiler.JavaCompilerSettings;
 import org.slf4j.Logger;
@@ -58,6 +61,12 @@ public class DroolsQuarkusResourceUtils {
     }
 
     private static final Logger LOGGER = LoggerFactory.getLogger(DroolsQuarkusResourceUtils.class);
+
+    static {
+        if (Drools.isNativeImage() && !KieService.load(ComponentsSupplier.class).getClass().getSimpleName().equals("StaticComponentsSupplier")) {
+            throw new IllegalStateException("Cannot run quarkus extension in native mode with module org.drools:drools-wiring-dynamic. Please remove it from your classpath.");
+        }
+    }
 
     // since quarkus-maven-plugin is later phase of maven-resources-plugin,
     // need to manually late-provide the resource in the expected location for quarkus:dev phase --so not: writeGeneratedFile( f, resourcePath );


### PR DESCRIPTION
**JIRA**: https://issues.redhat.com/browse/DROOLS-7207