### PR TITLE
DROOLS-7205 - Increase coverage for efesto-common-api module

### DIFF
--- a/efesto/efesto-core/efesto-common-api/src/main/java/org/kie/efesto/common/api/utils/CollectionUtils.java
+++ b/efesto/efesto-core/efesto-common-api/src/main/java/org/kie/efesto/common/api/utils/CollectionUtils.java
@@ -3,7 +3,6 @@ package org.kie.efesto.common.api.utils;
 import java.util.Optional;
 import java.util.function.BiFunction;
 import java.util.function.Predicate;
-import java.util.function.Supplier;
 
 public class CollectionUtils {
 
@@ -23,7 +22,4 @@ public class CollectionUtils {
         return Optional.ofNullable(result);
     }
 
-    public static <T, X extends RuntimeException> T findExactlyOne(Iterable<T> collection, Predicate<T> filter, BiFunction<T, T, X> multipleValuesExceptionSupplier, Supplier<X> missingValueExceptionSupplier) {
-        return findAtMostOne(collection, filter, multipleValuesExceptionSupplier).orElseThrow(missingValueExceptionSupplier);
-    }
 }

--- a/efesto/efesto-core/efesto-common-api/src/test/java/org/kie/efesto/common/api/utils/CollectionUtilsTest.java
+++ b/efesto/efesto-core/efesto-common-api/src/test/java/org/kie/efesto/common/api/utils/CollectionUtilsTest.java
@@ -1,0 +1,68 @@
+package org.kie.efesto.common.api.utils;
+
+import java.util.Optional;
+import java.util.function.BiFunction;
+import java.util.function.Predicate;
+
+import org.junit.jupiter.api.Test;
+import org.kie.efesto.common.api.exceptions.KieEfestoCommonException;
+
+import static java.util.Arrays.asList;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
+import static org.kie.efesto.common.api.utils.CollectionUtils.findAtMostOne;
+
+public class CollectionUtilsTest {
+	
+	private Optional<Integer> result;
+
+	@Test
+	public void findAtMostOne_emptyCollection() throws Exception {
+		result = findAtMostOne(asList(), matchAll(), exceptionProvider());
+		
+		assertThat(result).isNotPresent();
+	}
+
+	@Test
+	public void findAtMostOne_oneElementNoFilter() throws Exception {
+		result = findAtMostOne(asList(1), matchAll(), exceptionProvider());
+		
+		assertThat(result).isPresent().hasValue(1);
+	}
+
+	@Test
+	public void findAtMostOne_oneElement_filterFails() throws Exception {
+		result = findAtMostOne(asList(1), match(2), exceptionProvider());
+		
+		assertThat(result).isNotPresent();
+	}
+
+	
+	@Test
+	public void findAtMostOne_oneElement_filterSuccess() throws Exception {
+		result = findAtMostOne(asList(2), match(2), exceptionProvider());
+		
+		assertThat(result).isPresent().hasValue(2);
+	}
+	
+	@Test
+	public void findAtMostOne_twoIdenticalElements_exception() throws Exception {
+		assertThatExceptionOfType(KieEfestoCommonException.class).isThrownBy(
+				() -> findAtMostOne(asList(1, 1), matchAll(), exceptionProvider()));
+	}
+	
+	private Predicate<Integer> matchAll() {
+		return x -> true;
+	}
+
+	private Predicate<Integer> match(int value) {
+		return x -> x.equals(value);
+	}
+
+	private BiFunction<Integer, Integer, KieEfestoCommonException> exceptionProvider() {
+		return (x, t) -> new KieEfestoCommonException();
+	}
+	
+
+
+}

--- a/efesto/efesto-core/efesto-common-api/src/test/java/org/kie/efesto/common/api/utils/FileNameUtilsTest.java
+++ b/efesto/efesto-core/efesto-common-api/src/test/java/org/kie/efesto/common/api/utils/FileNameUtilsTest.java
@@ -17,30 +17,51 @@ package org.kie.efesto.common.api.utils;
 
 import org.junit.jupiter.api.Test;
 
-import java.io.File;
 
+import static java.io.File.separator;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.kie.efesto.common.api.utils.FileNameUtils.getFileName;
+import static org.kie.efesto.common.api.utils.FileNameUtils.getSuffix;
+import static org.kie.efesto.common.api.utils.FileNameUtils.removeSuffix;
 
 class FileNameUtilsTest {
 
 
     @Test
-    void getFileName() {
-        String fileName = "file_name.txt";
-        String source = fileName;
-        assertThat(FileNameUtils.getFileName(source)).isEqualTo(fileName);
-        source = File.separator + "dir" + File.separator + fileName;
-        assertThat(FileNameUtils.getFileName(source)).isEqualTo(fileName);
+    void getFileName_noDirectories() {
+        assertThat(getFileName("file_name.txt")).isEqualTo("file_name.txt");
+    }
+    
+    @Test
+    void getFileName_oneDirectory() {
+        assertThat(getFileName("dir" + separator + "file_name.txt")).isEqualTo("file_name.txt");
+    }
+
+    
+    @Test
+    void getFileName_manyDirectories() {
+        assertThat(getFileName("dir" + separator + "dir" + separator + "file_name.txt")).isEqualTo("file_name.txt");
     }
 
     @Test
-    void getSuffix() {
-        String fileName = "file_name.model_json";
-        String expected = "model_json";
-        String source = fileName;
-        assertThat(FileNameUtils.getSuffix(source)).isEqualTo(expected);
-        source = File.separator + "dir" + File.separator + fileName;
-        assertThat(FileNameUtils.getSuffix(source)).isEqualTo(expected);
+    void getSuffix_noSuffix() {
+        assertThat(getSuffix("file_name")).isEqualTo("file_name");
     }
 
+    @Test
+    void getSuffix_withSuffix() {
+        assertThat(getSuffix("file_name.model_json")).isEqualTo("model_json");
+    }
+    
+    @Test
+    void getSuffix_pathIsIrrelevant() {
+        assertThat(getSuffix("dir" + separator + "file_name.model_json")).isEqualTo("model_json");
+    }
+
+    @Test
+    void removeSuffix_noSuffix() {
+        assertThat(removeSuffix("file_name.model_json")).isEqualTo("file_name");
+    }
+
+    
 }


### PR DESCRIPTION
First step to increase test coverage and testability in efesto-common-api

This PR is about:
- clarifying tests in util package by splitting them
- adding tests for the CollectionUtils class

**JIRA**: [DROOLS-7205](https://issues.redhat.com/browse/DROOLS-7205)

<details>
<summary>
How to replicate CI configuration locally?
</summary>

Build Chain tool does "simple" maven build(s), the builds are just Maven commands, but because the repositories relates and depends on each other and any change in API or class method could affect several of those repositories there is a need to use [build-chain tool](https://github.com/kiegroup/github-action-build-chain) to handle cross repository builds and be sure that we always use latest version of the code for each repository.
 
[build-chain tool](https://github.com/kiegroup/github-action-build-chain) is a build tool which can be used on command line locally or in Github Actions workflow(s), in case you need to change multiple repositories and send multiple dependent pull requests related with a change you can easily reproduce the same build by executing it on Github hosted environment or locally in your development environment. See [local execution](https://github.com/kiegroup/github-action-build-chain#local-execution) details to get more information about it.
</details>

<details>
<summary>
How to retest this PR or trigger a specific build:
</summary>

- for <b>pull request checks</b>  
  Please add comment: <b>Jenkins retest this</b>

- for a <b>specific pull request check</b>  
  Please add comment: <b>Jenkins (re)run [drools|kogito-runtimes|kogito-apps|kogito-examples] tests</b>

- for a <b>full downstream build</b> 
  - for <b>jenkins</b> job: please add comment: <b>Jenkins run fdb</b>
  - for <b>github actions</b> job: add the label `run_fdb`

- <b>a compile downstream build</b> please  add comment: <b>Jenkins run cdb</b>

- <b>a full production downstream build</b> please add comment: <b>Jenkins execute product fdb</b>

- <b>an upstream build</b> please add comment: <b>Jenkins run upstream</b>

- for <b>quarkus branch checks</b>  
  Run checks against Quarkus current used branch  
  Please add comment: <b>Jenkins run quarkus-branch</b>

- for a <b>quarkus branch specific check</b>  
  Run checks against Quarkus current used branch  
  Please add comment: <b>Jenkins (re)run [drools|kogito-runtimes|kogito-apps|kogito-examples] quarkus-branch</b>

- for <b>quarkus main checks</b>  
  Run checks against Quarkus main branch  
  Please add comment: <b>Jenkins run quarkus-main</b>

- for a <b>specific quarkus main check</b>  
  Run checks against Quarkus main branch  
  Please add comment: <b>Jenkins (re)run [drools|kogito-runtimes|kogito-apps|kogito-examples] quarkus-main</b>

- for <b>quarkus lts checks</b>  
  Run checks against Quarkus lts branch  
  Please add comment: <b>Jenkins run quarkus-lts</b>

- for a <b>specific quarkus lts check</b>  
  Run checks against Quarkus lts branch  
  Please add comment: <b>Jenkins (re)run [drools|kogito-runtimes|kogito-apps|kogito-examples] quarkus-lts</b>

- for <b>native checks</b>  
  Run native checks  
  Please add comment: <b>Jenkins run native</b>

- for a <b>specific native check</b>  
  Run native checks 
  Please add comment: <b>Jenkins (re)run [drools|kogito-runtimes|kogito-apps|kogito-examples] native</b>

- for <b>mandrel checks</b>  
  Run native checks against Mandrel image
  Please add comment: <b>Jenkins run mandrel</b>

- for a <b>specific mandrel check</b>  
  Run native checks against Mandrel image  
  Please add comment: <b>Jenkins (re)run [drools|kogito-runtimes|kogito-apps|kogito-examples] mandrel</b>

 - for <b>mandrel lts checks</b>  
  Run native checks against Mandrel image and quarkus lts branch
  Please add comment: <b>Jenkins run mandrel-lts</b>

- for a <b>specific mandrel lts check</b>  
  Run native checks against Mandrel image and quarkus lts branch
  Please add comment: <b>Jenkins (re)run [drools|kogito-runtimes|kogito-apps|kogito-examples] mandrel-lts</b>
</details>
