### PR TITLE
DROOLS-7228 Prepare to add drools-drl-quarkus-extension to Quarkus Platform

### DIFF
--- a/bom/drools-bom/pom.xml
+++ b/bom/drools-bom/pom.xml
@@ -595,6 +595,30 @@
 
       <dependency>
         <groupId>org.drools</groupId>
+        <artifactId>drools-drl-quarkus-integration-test</artifactId>
+        <version>${project.version}</version>
+        <type>test-jar</type>
+        <scope>test</scope>
+      </dependency>
+
+      <dependency>
+        <groupId>org.drools</groupId>
+        <artifactId>drools-drl-quarkus-integration-test-hotreload</artifactId>
+        <version>${project.version}</version>
+        <type>test-jar</type>
+        <scope>test</scope>
+      </dependency>
+
+      <dependency>
+        <groupId>org.drools</groupId>
+        <artifactId>drools-drl-quarkus-ruleunit-integration-test</artifactId>
+        <version>${project.version}</version>
+        <type>test-jar</type>
+        <scope>test</scope>
+      </dependency>
+
+      <dependency>
+        <groupId>org.drools</groupId>
         <artifactId>drools-alphanetwork-compiler</artifactId>
         <version>${project.version}</version>
       </dependency>


### PR DESCRIPTION
In order to support this, we need to properly publish the integration tests as test jars.

We will also need to automate the pipelines, but I'll probably need @radtriste help there 😅 