### PR TITLE
[7.67.x-blue] [DROOLS-7085] Rule doesn't match with more than 3 rules of BigDecimal…

### DIFF
--- a/drools-core/src/main/java/org/drools/core/reteoo/CompositeObjectSinkAdapter.java
+++ b/drools-core/src/main/java/org/drools/core/reteoo/CompositeObjectSinkAdapter.java
@@ -42,6 +42,8 @@ import org.drools.core.spi.ReadAccessor;
 import org.drools.core.util.index.AlphaRangeIndex;
 import org.drools.core.util.index.IndexUtil.ConstraintType;
 
+import static org.drools.core.util.index.IndexUtil.isBigDecimalEqualityConstraint;
+
 public class CompositeObjectSinkAdapter implements ObjectSinkPropagator {
 
     //    /** You can override this property via a system property (eg -Ddrools.hashThreshold=4) */
@@ -207,6 +209,7 @@ public class CompositeObjectSinkAdapter implements ObjectSinkPropagator {
     private static boolean isHashable( IndexableConstraint indexableConstraint ) {
         return indexableConstraint.getConstraintType() == ConstraintType.EQUAL && indexableConstraint.getField() != null &&
                 indexableConstraint.getFieldExtractor().getValueType() != ValueType.OBJECT_TYPE &&
+                !isBigDecimalEqualityConstraint(indexableConstraint) &&
                 // our current implementation does not support hashing of deeply nested properties
                 indexableConstraint.getFieldExtractor().getIndex() >= 0;
     }

--- a/drools-core/src/main/java/org/drools/core/util/MathUtils.java
+++ b/drools-core/src/main/java/org/drools/core/util/MathUtils.java
@@ -32,6 +32,8 @@ public class MathUtils {
                 ret = (BigDecimal) value;
             } else if( value instanceof String ) {
                 ret = new BigDecimal( (String) value );
+            } else if( value instanceof Integer ) {
+                ret = new BigDecimal( (Integer) value );
             } else if( value instanceof BigInteger ) {
                 ret = new BigDecimal( (BigInteger) value );
             } else if( value instanceof Number ) {

--- a/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/compiler/integrationtests/IndexingTest.java
+++ b/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/compiler/integrationtests/IndexingTest.java
@@ -16,12 +16,14 @@
 
 package org.drools.compiler.integrationtests;
 
+import java.math.BigDecimal;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
+import org.drools.ancompiler.CompiledNetwork;
 import org.drools.core.base.ClassObjectType;
 import org.drools.core.base.DroolsQuery;
 import org.drools.core.common.DoubleNonIndexSkipBetaConstraints;
@@ -38,6 +40,7 @@ import org.drools.core.reteoo.CompositeObjectSinkAdapter;
 import org.drools.core.reteoo.JoinNode;
 import org.drools.core.reteoo.LeftInputAdapterNode;
 import org.drools.core.reteoo.NotNode;
+import org.drools.core.reteoo.ObjectSinkPropagator;
 import org.drools.core.reteoo.ObjectTypeNode;
 import org.drools.core.reteoo.ReteDumper;
 import org.drools.core.reteoo.RightTuple;
@@ -876,6 +879,146 @@ public class IndexingTest {
             assertTrue(bm.getRightTupleMemory() instanceof TupleIndexHashTable);
         } finally {
             wm.dispose();
+        }
+    }
+
+    @Test
+    public void testAlphaIndexWithBigDecimalCoercion() {
+        final String drl =
+                "package org.drools.compiler.test\n" +
+                        "import " + Person.class.getCanonicalName() + "\n" +
+                        "global java.util.List list\n" +
+                        "rule R1\n" +
+                        "    when\n" +
+                        "        Person( salary == 10 )\n" +
+                        "    then\n" +
+                        "        list.add(\"R1\");\n" +
+                        "end\n" +
+                        "rule R2\n" +
+                        "    when\n" +
+                        "        Person( salary == 20 )\n" +
+                        "    then\n" +
+                        "        list.add(\"R2\");\n" +
+                        "end\n" +
+                        "rule R3\n" +
+                        "    when\n" +
+                        "        Person( salary == 30 )\n" +
+                        "    then\n" +
+                        "        list.add(\"R3\");\n" +
+                        "end";
+
+        final KieBase kbase = KieBaseUtil.getKieBaseFromKieModuleFromDrl("indexing-test", kieBaseTestConfiguration, drl);
+        KieSession ksession = kbase.newKieSession();
+
+        try {
+            // BigDecimal Index is disabled
+            assertAlphaIndex(kbase, Person.class, 0);
+
+            List<String> list = new ArrayList<>();
+            ksession.setGlobal("list", list);
+            Person john = new Person("John");
+            john.setSalary(new BigDecimal("10"));
+            ksession.insert(john);
+            ksession.fireAllRules();
+
+            assertThat(list).containsExactly("R1");
+        } finally {
+            ksession.dispose();
+        }
+    }
+
+    private void assertAlphaIndex(KieBase kbase, Class<?> clazz, int hashedSize) {
+        final ObjectTypeNode otn = KieUtil.getObjectTypeNode(kbase, clazz);
+        assertThat(otn).isNotNull();
+        ObjectSinkPropagator objectSinkPropagator = otn.getObjectSinkPropagator();
+        if (this.kieBaseTestConfiguration.useAlphaNetworkCompiler()) {
+            objectSinkPropagator = ((CompiledNetwork) objectSinkPropagator).getOriginalSinkPropagator();
+        }
+        CompositeObjectSinkAdapter sinkAdapter = (CompositeObjectSinkAdapter) objectSinkPropagator;
+        if (hashedSize == 0) {
+            assertThat(sinkAdapter.getHashedSinkMap()).isNull();
+        } else {
+            assertThat(sinkAdapter.getHashedSinkMap()).isNotNull();
+            assertThat(sinkAdapter.getHashedSinkMap().size()).isEqualTo(hashedSize);
+        }
+    }
+
+    @Test
+    public void testAlphaIndexWithBigDecimalDifferentScale() {
+        final String drl =
+                "package org.drools.compiler.test\n" +
+                        "import " + Person.class.getCanonicalName() + "\n" +
+                        "global java.util.List list\n" +
+                        "rule R1\n" +
+                        "    when\n" +
+                        "        Person( salary == 10 )\n" +
+                        "    then\n" +
+                        "        list.add(\"R1\");\n" +
+                        "end\n" +
+                        "rule R2\n" +
+                        "    when\n" +
+                        "        Person( salary == 20 )\n" +
+                        "    then\n" +
+                        "        list.add(\"R2\");\n" +
+                        "end\n" +
+                        "rule R3\n" +
+                        "    when\n" +
+                        "        Person( salary == 30 )\n" +
+                        "    then\n" +
+                        "        list.add(\"R3\");\n" +
+                        "end";
+
+        final KieBase kbase = KieBaseUtil.getKieBaseFromKieModuleFromDrl("indexing-test", kieBaseTestConfiguration, drl);
+        KieSession ksession = kbase.newKieSession();
+
+        try {
+            // BigDecimal Index is disabled
+            assertAlphaIndex(kbase, Person.class, 0);
+
+            List<String> list = new ArrayList<>();
+            ksession.setGlobal("list", list);
+            Person john = new Person("John");
+            john.setSalary(new BigDecimal("10.00"));
+            ksession.insert(john);
+            ksession.fireAllRules();
+
+            assertThat(list).containsExactly("R1");
+        } finally {
+            ksession.dispose();
+        }
+    }
+
+    @Test
+    public void testBetaIndexWithBigDecimalDifferentScale() {
+        final String drl =
+                "package org.drools.compiler.test\n" +
+                        "import " + Person.class.getCanonicalName() + "\n" +
+                        "global java.util.List list\n" +
+                        "rule R1\n" +
+                        "    when\n" +
+                        "        $p1 : Person( name == \"John\" )\n" +
+                        "        $p2 : Person( name == \"Paul\", salary == $p1.salary )\n" +
+                        "    then\n" +
+                        "        list.add(\"R1\");\n" +
+                        "end";
+
+        final KieBase kbase = KieBaseUtil.getKieBaseFromKieModuleFromDrl("indexing-test", kieBaseTestConfiguration, drl);
+        KieSession ksession = kbase.newKieSession();
+
+        try {
+            List<String> list = new ArrayList<>();
+            ksession.setGlobal("list", list);
+            Person john = new Person("John");
+            john.setSalary(new BigDecimal("10"));
+            Person paul = new Person("Paul");
+            paul.setSalary(new BigDecimal("10.00"));
+            ksession.insert(john);
+            ksession.insert(paul);
+            ksession.fireAllRules();
+
+            assertThat(list).containsExactly("R1");
+        } finally {
+            ksession.dispose();
         }
     }
 }

--- a/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/compiler/integrationtests/SharingTest.java
+++ b/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/compiler/integrationtests/SharingTest.java
@@ -322,8 +322,7 @@ public class SharingTest {
         ObjectTypeNode otn = getObjectTypeNode(kbase, Person.class);
 
         assertSinksSize(otn, 3); // Not shared. For improvement, see DROOLS-6485
-        assertHashableSinksSize(otn, 2);
-        assertNonHashableConstraint(otn, "salary == new BigDecimal(\"1\")");
+        assertHashableSinksSize(otn, 0); // Not indexed, see DROOLS-7085
 
         final KieSession kieSession = kbase.newKieSession();
         try {


### PR DESCRIPTION
…… (#4581)

**Ports** 
This is a backport PR of https://github.com/kiegroup/drools/pull/4581 for 7.67.x-blue

**JIRA**: 
https://issues.redhat.com/browse/RHDM-1944

<details>
<summary>
How to replicate CI configuration locally?
</summary>

Build Chain tool does "simple" maven build(s), the builds are just Maven commands, but because the repositories relates and depends on each other and any change in API or class method could affect several of those repositories there is a need to use [build-chain tool](https://github.com/kiegroup/github-action-build-chain) to handle cross repository builds and be sure that we always use latest version of the code for each repository.
 
[build-chain tool](https://github.com/kiegroup/github-action-build-chain) is a build tool which can be used on command line locally or in Github Actions workflow(s), in case you need to change multiple repositories and send multiple dependent pull requests related with a change you can easily reproduce the same build by executing it on Github hosted environment or locally in your development environment. See [local execution](https://github.com/kiegroup/github-action-build-chain#local-execution) details to get more information about it.
</details>

<details>
<summary>
How to retest this PR or trigger a specific build:
</summary>

- for <b>pull request checks</b>  
  Please add comment: <b>Jenkins retest this</b>

- for a <b>specific pull request check</b>  
  Please add comment: <b>Jenkins (re)run [drools|kogito-runtimes|kogito-apps|kogito-examples] tests</b>

- for a <b>full downstream build</b> 
  - for <b>jenkins</b> job: please add comment: <b>Jenkins run fdb</b>
  - for <b>github actions</b> job: add the label `run_fdb`

- <b>a compile downstream build</b> please  add comment: <b>Jenkins run cdb</b>

- <b>a full production downstream build</b> please add comment: <b>Jenkins execute product fdb</b>

- <b>an upstream build</b> please add comment: <b>Jenkins run upstream</b>

- for <b>quarkus branch checks</b>  
  Run checks against Quarkus current used branch  
  Please add comment: <b>Jenkins run quarkus-branch</b>

- for a <b>quarkus branch specific check</b>  
  Run checks against Quarkus current used branch  
  Please add comment: <b>Jenkins (re)run [drools|kogito-runtimes|kogito-apps|kogito-examples] quarkus-branch</b>

- for <b>quarkus main checks</b>  
  Run checks against Quarkus main branch  
  Please add comment: <b>Jenkins run quarkus-main</b>

- for a <b>specific quarkus main check</b>  
  Run checks against Quarkus main branch  
  Please add comment: <b>Jenkins (re)run [drools|kogito-runtimes|kogito-apps|kogito-examples] quarkus-main</b>

- for <b>quarkus lts checks</b>  
  Run checks against Quarkus lts branch  
  Please add comment: <b>Jenkins run quarkus-lts</b>

- for a <b>specific quarkus lts check</b>  
  Run checks against Quarkus lts branch  
  Please add comment: <b>Jenkins (re)run [drools|kogito-runtimes|kogito-apps|kogito-examples] quarkus-lts</b>

- for <b>native checks</b>  
  Run native checks  
  Please add comment: <b>Jenkins run native</b>

- for a <b>specific native check</b>  
  Run native checks 
  Please add comment: <b>Jenkins (re)run [drools|kogito-runtimes|kogito-apps|kogito-examples] native</b>

- for <b>mandrel checks</b>  
  Run native checks against Mandrel image
  Please add comment: <b>Jenkins run mandrel</b>

- for a <b>specific mandrel check</b>  
  Run native checks against Mandrel image  
  Please add comment: <b>Jenkins (re)run [drools|kogito-runtimes|kogito-apps|kogito-examples] mandrel</b>

 - for <b>mandrel lts checks</b>  
  Run native checks against Mandrel image and quarkus lts branch
  Please add comment: <b>Jenkins run mandrel-lts</b>

- for a <b>specific mandrel lts check</b>  
  Run native checks against Mandrel image and quarkus lts branch
  Please add comment: <b>Jenkins (re)run [drools|kogito-runtimes|kogito-apps|kogito-examples] mandrel-lts</b>
</details>
