### PR TITLE
[7.67.x-blue] [DROOLS-7088] Property reactivity discrepancy between executable mode…

### DIFF
--- a/drools-model/drools-model-compiler/src/test/java/org/drools/modelcompiler/PropertyReactivityTest.java
+++ b/drools-model/drools-model-compiler/src/test/java/org/drools/modelcompiler/PropertyReactivityTest.java
@@ -27,6 +27,7 @@ import org.drools.modelcompiler.domain.Address;
 import org.drools.modelcompiler.domain.Person;
 import org.drools.modelcompiler.domain.Pet;
 import org.drools.modelcompiler.domain.Result;
+import org.drools.modelcompiler.domain.VariousCasePropFact;
 import org.junit.Test;
 import org.kie.api.builder.KieBuilder;
 import org.kie.api.builder.Message.Level;
@@ -34,6 +35,7 @@ import org.kie.api.definition.type.Modifies;
 import org.kie.api.runtime.KieSession;
 import org.kie.api.runtime.rule.FactHandle;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
@@ -1572,5 +1574,69 @@ public class PropertyReactivityTest extends BaseModelTest {
 
         assertEquals(41, p.getAge());
         assertEquals(1, ksession.getObjects((Object object) -> object.equals("ok")).size());
+    }
+
+    @Test
+    public void testOnlyFirstLetterIsUpperCaseProperty() {
+        // See JavaBeans 1.01 spec : 8.8 Capitalization of inferred names
+        // “FooBah” becomes “fooBah”
+        testVariousCasePropFact("modify($f) { MyTarget = \"123\" };", "R1", "R2"); // Actually, this modifies "myTarget" property (backed by private "MyTarget" field). This shouldn't react R1
+    }
+
+    @Test
+    public void testTwoFirstLettersAreUpperCaseProperty() {
+        // See JavaBeans 1.01 spec : 8.8 Capitalization of inferred names
+        // “URL” becomes “URL”
+        testVariousCasePropFact("modify($f) { URL = \"123\" };", "R1", "R2"); // This shouldn't react R1
+    }
+
+    @Test
+    public void testFirstLetterIsMultibyteProperty() {
+        // Multibyte is not mentioned in JavaBeans spec
+        testVariousCasePropFact("modify($f) { 名前 = \"123\" };", "R1", "R2"); // This shouldn't react R1
+    }
+
+    @Test
+    public void testOnlyFirstLetterIsUpperCaseAndMultibyteProperty() {
+        // Multibyte is not mentioned in JavaBeans spec
+        testVariousCasePropFact("modify($f) { My名前 = \"123\" };", "R1", "R2"); // Actually, this modifies "my名前" property (backed by private "My名前" field). This shouldn't react R1
+    }
+
+    @Test
+    public void testOnlyFirstLetterIsUpperCasePublicFieldProperty() {
+        testVariousCasePropFact("modify($f) { MyPublicTarget = \"123\" };", "R1", "R2"); // this modifies "MyPublicTarget" public field directly. This shouldn't react R1
+    }
+
+    private void testVariousCasePropFact(String modifyStatement, String... expectedResults) {
+        final String str =
+                "import " + VariousCasePropFact.class.getCanonicalName() + ";\n" +
+                           "dialect \"mvel\"\n" +
+                           "global java.util.List results;\n" +
+                           "rule R1\n" +
+                           "salience 100\n" +
+                           "when\n" +
+                           "    $f : VariousCasePropFact( value == \"A\" )\n" +
+                           "then\n" +
+                           "    results.add(\"R1\")\n" +
+                           "end\n" +
+                           "rule R2\n" +
+                           "no-loop\n" +
+                           "when\n" +
+                           "    $f : VariousCasePropFact( value == \"A\" )\n" +
+                           "then\n" +
+                           "    results.add(\"R2\");\n" +
+                           modifyStatement + "\n" +
+                           "end\n";
+
+        KieSession ksession = getKieSession(str);
+        List<String> results = new ArrayList<>();
+        ksession.setGlobal("results", results);
+
+        VariousCasePropFact fact = new VariousCasePropFact();
+        fact.setValue("A");
+        ksession.insert(fact);
+        ksession.fireAllRules();
+
+        assertThat(results).containsExactly(expectedResults);
     }
 }

--- a/drools-model/drools-model-compiler/src/test/java/org/drools/modelcompiler/domain/VariousCasePropFact.java
+++ b/drools-model/drools-model-compiler/src/test/java/org/drools/modelcompiler/domain/VariousCasePropFact.java
@@ -1,0 +1,68 @@
+/*
+ * Copyright 2022 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.drools.modelcompiler.domain;
+
+public class VariousCasePropFact {
+
+    private String value; // lower only
+    private String MyTarget; // upper + lower
+    private String URL; // upper + upper
+    private String 名前; // multibyte
+    private String My名前; // upper + lower + multibyte
+    public String MyPublicTarget; // public field : upper + lower
+
+    public String getValue() {
+        return value;
+    }
+
+    public void setValue(String value) {
+        this.value = value;
+    }
+
+    public String getMyTarget() {
+        return MyTarget;
+    }
+
+    public void setMyTarget(String myTarget) {
+        MyTarget = myTarget;
+    }
+
+    public String getURL() {
+        return URL;
+    }
+
+    public void setURL(String uRL) {
+        URL = uRL;
+    }
+
+    public String get名前() {
+        return 名前;
+    }
+
+    public void set名前(String 名前) {
+        this.名前 = 名前;
+    }
+
+    public String getMy名前() {
+        return My名前;
+    }
+
+    public void setMy名前(String my名前) {
+        My名前 = my名前;
+    }
+
+}


### PR DESCRIPTION
…… (#4585)

**Ports** 
This is a backport PR of https://github.com/kiegroup/drools/pull/4585 for 7.67.x-blue

**JIRA**: 
https://issues.redhat.com/browse/RHDM-1945

<details>
<summary>
How to replicate CI configuration locally?
</summary>

Build Chain tool does "simple" maven build(s), the builds are just Maven commands, but because the repositories relates and depends on each other and any change in API or class method could affect several of those repositories there is a need to use [build-chain tool](https://github.com/kiegroup/github-action-build-chain) to handle cross repository builds and be sure that we always use latest version of the code for each repository.
 
[build-chain tool](https://github.com/kiegroup/github-action-build-chain) is a build tool which can be used on command line locally or in Github Actions workflow(s), in case you need to change multiple repositories and send multiple dependent pull requests related with a change you can easily reproduce the same build by executing it on Github hosted environment or locally in your development environment. See [local execution](https://github.com/kiegroup/github-action-build-chain#local-execution) details to get more information about it.
</details>

<details>
<summary>
How to retest this PR or trigger a specific build:
</summary>

- for <b>pull request checks</b>  
  Please add comment: <b>Jenkins retest this</b>

- for a <b>specific pull request check</b>  
  Please add comment: <b>Jenkins (re)run [drools|kogito-runtimes|kogito-apps|kogito-examples] tests</b>

- for a <b>full downstream build</b> 
  - for <b>jenkins</b> job: please add comment: <b>Jenkins run fdb</b>
  - for <b>github actions</b> job: add the label `run_fdb`

- <b>a compile downstream build</b> please  add comment: <b>Jenkins run cdb</b>

- <b>a full production downstream build</b> please add comment: <b>Jenkins execute product fdb</b>

- <b>an upstream build</b> please add comment: <b>Jenkins run upstream</b>

- for <b>quarkus branch checks</b>  
  Run checks against Quarkus current used branch  
  Please add comment: <b>Jenkins run quarkus-branch</b>

- for a <b>quarkus branch specific check</b>  
  Run checks against Quarkus current used branch  
  Please add comment: <b>Jenkins (re)run [drools|kogito-runtimes|kogito-apps|kogito-examples] quarkus-branch</b>

- for <b>quarkus main checks</b>  
  Run checks against Quarkus main branch  
  Please add comment: <b>Jenkins run quarkus-main</b>

- for a <b>specific quarkus main check</b>  
  Run checks against Quarkus main branch  
  Please add comment: <b>Jenkins (re)run [drools|kogito-runtimes|kogito-apps|kogito-examples] quarkus-main</b>

- for <b>quarkus lts checks</b>  
  Run checks against Quarkus lts branch  
  Please add comment: <b>Jenkins run quarkus-lts</b>

- for a <b>specific quarkus lts check</b>  
  Run checks against Quarkus lts branch  
  Please add comment: <b>Jenkins (re)run [drools|kogito-runtimes|kogito-apps|kogito-examples] quarkus-lts</b>

- for <b>native checks</b>  
  Run native checks  
  Please add comment: <b>Jenkins run native</b>

- for a <b>specific native check</b>  
  Run native checks 
  Please add comment: <b>Jenkins (re)run [drools|kogito-runtimes|kogito-apps|kogito-examples] native</b>

- for <b>mandrel checks</b>  
  Run native checks against Mandrel image
  Please add comment: <b>Jenkins run mandrel</b>

- for a <b>specific mandrel check</b>  
  Run native checks against Mandrel image  
  Please add comment: <b>Jenkins (re)run [drools|kogito-runtimes|kogito-apps|kogito-examples] mandrel</b>

 - for <b>mandrel lts checks</b>  
  Run native checks against Mandrel image and quarkus lts branch
  Please add comment: <b>Jenkins run mandrel-lts</b>

- for a <b>specific mandrel lts check</b>  
  Run native checks against Mandrel image and quarkus lts branch
  Please add comment: <b>Jenkins (re)run [drools|kogito-runtimes|kogito-apps|kogito-examples] mandrel-lts</b>
</details>
