### PR TITLE
[KOGITO-8220] isolate globals and entry-points by rule units

### DIFF
--- a/drools-drl-quarkus-extension/drools-drl-quarkus-examples/drools-drl-quarkus-examples-multiunit/pom.xml
+++ b/drools-drl-quarkus-extension/drools-drl-quarkus-examples/drools-drl-quarkus-examples-multiunit/pom.xml
@@ -1,0 +1,136 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+  <parent>
+    <groupId>org.drools</groupId>
+    <artifactId>drools-drl-quarkus-examples</artifactId>
+    <version>8.31.0-SNAPSHOT</version>
+  </parent>
+
+  <name>Drools :: Quarkus Extension :: Examples :: Reactive</name>
+  <artifactId>drools-drl-quarkus-examples-multiunit</artifactId>
+
+  <dependencies>
+    <dependency>
+      <groupId>org.drools</groupId>
+      <artifactId>drools-drl-quarkus</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.drools</groupId>
+      <artifactId>drools-ruleunits-engine</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>io.quarkus</groupId>
+      <artifactId>quarkus-core</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.assertj</groupId>
+      <artifactId>assertj-core</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>io.quarkus</groupId>
+      <artifactId>quarkus-junit5</artifactId>
+      <scope>test</scope>
+    </dependency>
+
+    <!-- this is used implicitly by quarkus tests so let's make Maven aware 
+      of it -->
+    <dependency>
+      <groupId>org.drools</groupId>
+      <artifactId>drools-drl-quarkus-deployment</artifactId>
+      <scope>test</scope>
+      <exclusions>
+        <exclusion>
+          <groupId>*</groupId>
+          <artifactId>*</artifactId>
+        </exclusion>
+      </exclusions>
+    </dependency>
+
+  </dependencies>
+
+  <build>
+    <pluginManagement>
+      <plugins>
+        <plugin>
+          <groupId>io.quarkus</groupId>
+          <artifactId>quarkus-maven-plugin</artifactId>
+          <version>${version.io.quarkus}</version>
+          <configuration>
+            <noDeps>true</noDeps>
+            <skip>${skipTests}</skip>
+          </configuration>
+        </plugin>
+      </plugins>
+    </pluginManagement>
+
+    <plugins>
+      <plugin>
+        <groupId>io.quarkus</groupId>
+        <artifactId>quarkus-maven-plugin</artifactId>
+        <executions>
+          <execution>
+            <goals>
+              <goal>build</goal>
+            </goals>
+          </execution>
+        </executions>
+      </plugin>
+      <plugin>
+        <artifactId>maven-failsafe-plugin</artifactId>
+        <configuration>
+          <useModulePath>false</useModulePath>
+          <includes>
+            <include>**/*IT.java</include>
+          </includes>
+          <excludes>
+            <exclude>**/*Test.java</exclude>
+            <exclude>**/Native*</exclude>
+          </excludes>
+          <argLine>-Xmx2048m -Xmx4g</argLine>
+          <systemPropertyVariables>
+            <maven.repo.local>${session.request.localRepositoryPath.path}</maven.repo.local>
+            <maven.settings>${session.request.userSettingsFile.path}</maven.settings>
+          </systemPropertyVariables>
+        </configuration>
+      </plugin>
+    </plugins>
+  </build>
+
+  <profiles>
+    <profile>
+      <id>native</id>
+      <activation>
+        <property>
+          <name>native</name>
+        </property>
+      </activation>
+      <properties>
+        <quarkus.package.type>native</quarkus.package.type>
+      </properties>
+      <build>
+        <plugins>
+          <plugin>
+            <groupId>org.apache.maven.plugins</groupId>
+            <artifactId>maven-failsafe-plugin</artifactId>
+            <executions>
+              <execution>
+                <goals>
+                  <goal>integration-test</goal>
+                  <goal>verify</goal>
+                </goals>
+                <configuration>
+                  <systemProperties>
+                    <native.image.path>${project.build.directory}/${project.build.finalName}-runner</native.image.path>
+                  </systemProperties>
+                </configuration>
+              </execution>
+            </executions>
+          </plugin>
+        </plugins>
+      </build>
+    </profile>
+  </profiles>
+</project>

--- a/drools-drl-quarkus-extension/drools-drl-quarkus-examples/drools-drl-quarkus-examples-multiunit/src/main/java/org/drools/quarkus/ruleunit/examples/multiunit/FirstUnit.java
+++ b/drools-drl-quarkus-extension/drools-drl-quarkus-examples/drools-drl-quarkus-examples-multiunit/src/main/java/org/drools/quarkus/ruleunit/examples/multiunit/FirstUnit.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright 2022 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.drools.quarkus.ruleunit.examples.multiunit;
+
+import org.drools.ruleunits.api.DataSource;
+import org.drools.ruleunits.api.DataStream;
+import org.drools.ruleunits.api.RuleUnitData;
+
+public class FirstUnit implements RuleUnitData {
+
+    private final DataStream<RuleInput> input = DataSource.createStream();
+    private final DataStream<RuleOutput1> output = DataSource.createStream();
+
+    public DataStream<RuleInput> getInput() {
+        return input;
+    }
+
+    public DataStream<RuleOutput1> getOutput() {
+        return output;
+    }
+}

--- a/drools-drl-quarkus-extension/drools-drl-quarkus-examples/drools-drl-quarkus-examples-multiunit/src/main/java/org/drools/quarkus/ruleunit/examples/multiunit/RuleInput.java
+++ b/drools-drl-quarkus-extension/drools-drl-quarkus-examples/drools-drl-quarkus-examples-multiunit/src/main/java/org/drools/quarkus/ruleunit/examples/multiunit/RuleInput.java
@@ -1,0 +1,31 @@
+/*
+ * Copyright 2022 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.drools.quarkus.ruleunit.examples.multiunit;
+
+import org.drools.ruleunits.api.RuleUnitData;
+
+public class RuleInput implements RuleUnitData {
+
+    private final String text;
+
+    public RuleInput(String text) {
+        this.text = text;
+    }
+
+    public String getText() {
+        return text;
+    }
+}

--- a/drools-drl-quarkus-extension/drools-drl-quarkus-examples/drools-drl-quarkus-examples-multiunit/src/main/java/org/drools/quarkus/ruleunit/examples/multiunit/RuleOutput1.java
+++ b/drools-drl-quarkus-extension/drools-drl-quarkus-examples/drools-drl-quarkus-examples-multiunit/src/main/java/org/drools/quarkus/ruleunit/examples/multiunit/RuleOutput1.java
@@ -1,0 +1,29 @@
+/*
+ * Copyright 2022 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.drools.quarkus.ruleunit.examples.multiunit;
+
+public class RuleOutput1 {
+
+    private final String text;
+
+    public RuleOutput1(String text) {
+        this.text = text;
+    }
+
+    public String getText() {
+        return text;
+    }
+}

--- a/drools-drl-quarkus-extension/drools-drl-quarkus-examples/drools-drl-quarkus-examples-multiunit/src/main/java/org/drools/quarkus/ruleunit/examples/multiunit/RuleOutput2.java
+++ b/drools-drl-quarkus-extension/drools-drl-quarkus-examples/drools-drl-quarkus-examples-multiunit/src/main/java/org/drools/quarkus/ruleunit/examples/multiunit/RuleOutput2.java
@@ -1,0 +1,28 @@
+/*
+ * Copyright 2022 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.drools.quarkus.ruleunit.examples.multiunit;
+
+public class RuleOutput2 {
+    private final String text;
+
+    public RuleOutput2(String text) {
+        this.text = text;
+    }
+
+    public String getText() {
+        return text;
+    }
+}

--- a/drools-drl-quarkus-extension/drools-drl-quarkus-examples/drools-drl-quarkus-examples-multiunit/src/main/java/org/drools/quarkus/ruleunit/examples/multiunit/SecondUnit.java
+++ b/drools-drl-quarkus-extension/drools-drl-quarkus-examples/drools-drl-quarkus-examples-multiunit/src/main/java/org/drools/quarkus/ruleunit/examples/multiunit/SecondUnit.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright 2022 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.drools.quarkus.ruleunit.examples.multiunit;
+
+import org.drools.ruleunits.api.DataSource;
+import org.drools.ruleunits.api.DataStream;
+import org.drools.ruleunits.api.RuleUnitData;
+
+public class SecondUnit implements RuleUnitData {
+
+    private final DataStream<RuleInput> input = DataSource.createStream();
+    private final DataStream<RuleOutput2> output = DataSource.createStream();
+
+    public DataStream<RuleInput> getInput() {
+        return input;
+    }
+
+    public DataStream<RuleOutput2> getOutput() {
+        return output;
+    }
+}

--- a/drools-drl-quarkus-extension/drools-drl-quarkus-examples/drools-drl-quarkus-examples-multiunit/src/main/resources/org/drools/quarkus/ruleunit/examples/multiunit/First.drl
+++ b/drools-drl-quarkus-extension/drools-drl-quarkus-examples/drools-drl-quarkus-examples-multiunit/src/main/resources/org/drools/quarkus/ruleunit/examples/multiunit/First.drl
@@ -1,0 +1,15 @@
+package org.drools.quarkus.ruleunit.examples.multiunit;
+
+unit FirstUnit;
+
+import org.drools.ruleunits.api.DataSource;
+import org.drools.ruleunits.api.DataStream;
+import org.drools.ruleunits.api.RuleUnitData;
+
+rule "Test1"
+when
+    /input [ text == "Hello" ];
+then
+    System.out.println("Hi 1");
+    output.append(new RuleOutput1("Hi 1"));
+end

--- a/drools-drl-quarkus-extension/drools-drl-quarkus-examples/drools-drl-quarkus-examples-multiunit/src/main/resources/org/drools/quarkus/ruleunit/examples/multiunit/Second.drl
+++ b/drools-drl-quarkus-extension/drools-drl-quarkus-examples/drools-drl-quarkus-examples-multiunit/src/main/resources/org/drools/quarkus/ruleunit/examples/multiunit/Second.drl
@@ -1,0 +1,14 @@
+package org.drools.quarkus.ruleunit.examples.multiunit;
+
+unit SecondUnit;
+
+import org.drools.ruleunits.api.DataSource;
+import org.drools.ruleunits.api.DataStream;
+import org.drools.ruleunits.api.RuleUnitData;
+
+rule "Test2"
+when
+    /input [ text == "Hello" ];
+then
+    output.append(new RuleOutput2("Hi 2"));
+end

--- a/drools-drl-quarkus-extension/drools-drl-quarkus-examples/drools-drl-quarkus-examples-multiunit/src/test/java/org/drools/quarkus/ruleunit/examples/multiunit/RuntimeTest.java
+++ b/drools-drl-quarkus-extension/drools-drl-quarkus-examples/drools-drl-quarkus-examples-multiunit/src/test/java/org/drools/quarkus/ruleunit/examples/multiunit/RuntimeTest.java
@@ -1,0 +1,103 @@
+/*
+ * Copyright 2021 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.drools.quarkus.ruleunit.examples.multiunit;
+
+import java.util.concurrent.atomic.AtomicReference;
+import javax.inject.Inject;
+
+import io.quarkus.test.junit.QuarkusTest;
+import org.drools.ruleunits.api.DataHandle;
+import org.drools.ruleunits.api.DataProcessor;
+import org.drools.ruleunits.api.RuleUnit;
+import org.drools.ruleunits.api.RuleUnitInstance;
+import org.junit.jupiter.api.Test;
+import org.kie.api.runtime.rule.FactHandle;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+@QuarkusTest
+public class RuntimeTest {
+
+    @Inject
+    RuleUnit<FirstUnit> firstUnit;
+
+    @Inject
+    RuleUnit<SecondUnit> secondUnit;
+
+    @Test
+    public void testFirst() {
+        FirstUnit first = new FirstUnit();
+        RuleUnitInstance<FirstUnit> instance = firstUnit.createInstance(first);
+
+        AtomicReference<RuleOutput1> output = new AtomicReference<>();
+
+        first.getOutput().subscribe(new DataProcessor<RuleOutput1>() {
+            @Override
+            public FactHandle insert(DataHandle handle, RuleOutput1 object) {
+                output.set(object);
+                return null;
+            }
+
+            @Override
+            public void update(DataHandle handle, RuleOutput1 object) {
+
+            }
+
+            @Override
+            public void delete(DataHandle handle) {
+
+            }
+        });
+
+        first.getInput().append(new RuleInput("Hello"));
+
+        instance.fire();
+
+        assertEquals("Hi 1", output.get().getText());
+    }
+
+    @Test
+    public void testSecond() {
+        SecondUnit second = new SecondUnit();
+        RuleUnitInstance<SecondUnit> instance = secondUnit.createInstance(second);
+
+        AtomicReference<RuleOutput2> output = new AtomicReference<>();
+
+        second.getOutput().subscribe(new DataProcessor<RuleOutput2>() {
+            @Override
+            public FactHandle insert(DataHandle handle, RuleOutput2 object) {
+                output.set(object);
+                return null;
+            }
+
+            @Override
+            public void update(DataHandle handle, RuleOutput2 object) {
+
+            }
+
+            @Override
+            public void delete(DataHandle handle) {
+
+            }
+        });
+
+        second.getInput().append(new RuleInput("Hello"));
+
+        instance.fire();
+
+        assertEquals("Hi 2", output.get().getText());
+    }
+}

--- a/drools-drl-quarkus-extension/drools-drl-quarkus-examples/pom.xml
+++ b/drools-drl-quarkus-extension/drools-drl-quarkus-examples/pom.xml
@@ -15,5 +15,6 @@
 
     <modules>
       <module>drools-drl-quarkus-examples-reactive</module>
+      <module>drools-drl-quarkus-examples-multiunit</module>
     </modules>
 </project>

--- a/drools-impact-analysis/drools-impact-analysis-parser/src/main/java/org/drools/impact/analysis/parser/impl/RhsParser.java
+++ b/drools-impact-analysis/drools-impact-analysis-parser/src/main/java/org/drools/impact/analysis/parser/impl/RhsParser.java
@@ -61,7 +61,7 @@ public class RhsParser {
 
     public void parse( RuleDescr ruleDescr, RuleContext context, Rule rule ) {
         BlockStmt ruleVariablesBlock = new BlockStmt();
-        MethodCallExpr consequenceExpr = new Consequence(context).createCall( ruleDescr, ruleDescr.getConsequence().toString(), ruleVariablesBlock, false );
+        MethodCallExpr consequenceExpr = new Consequence(context).createCall( ruleDescr.getConsequence().toString(), ruleVariablesBlock, false );
 
         consequenceExpr.findAll(MethodCallExpr.class).stream()
                 .filter( m -> m.getScope().map( s -> s.toString().equals( "drools" ) ).orElse( false ) )

--- a/drools-model/drools-model-codegen/src/main/java/org/drools/model/codegen/execmodel/PackageModel.java
+++ b/drools-model/drools-model-codegen/src/main/java/org/drools/model/codegen/execmodel/PackageModel.java
@@ -906,10 +906,6 @@ public class PackageModel {
         this.accumulateFunctions = accumulateFunctions;
     }
 
-    public boolean hasDeclaration(String id) {
-        return globals.get(id) != null;
-    }
-
     public boolean registerDomainClass(Class<?> domainClass) {
         if (!domainClass.isPrimitive() && !domainClass.isArray()) {
             synchronized (domainClasses) {

--- a/drools-model/drools-model-codegen/src/main/java/org/drools/model/codegen/execmodel/PackageModel.java
+++ b/drools-model/drools-model-codegen/src/main/java/org/drools/model/codegen/execmodel/PackageModel.java
@@ -91,12 +91,12 @@ import org.drools.util.TypeResolver;
 import org.kie.api.builder.ReleaseId;
 import org.kie.api.runtime.rule.AccumulateFunction;
 import org.kie.internal.ruleunit.RuleUnitDescription;
+import org.kie.internal.ruleunit.RuleUnitVariable;
 
 import static com.github.javaparser.StaticJavaParser.parseBodyDeclaration;
 import static com.github.javaparser.ast.Modifier.finalModifier;
 import static com.github.javaparser.ast.Modifier.publicModifier;
 import static com.github.javaparser.ast.Modifier.staticModifier;
-import static java.util.Optional.ofNullable;
 import static java.util.stream.Collectors.joining;
 import static java.util.stream.Collectors.toList;
 import static org.drools.kiesession.session.StatefulKnowledgeSessionImpl.DEFAULT_RULE_UNIT;
@@ -133,7 +133,7 @@ public class PackageModel {
 
     private final Map<String, java.lang.reflect.Type> globals = new HashMap<>();
 
-    private final Map<String, Map<Integer, MethodDeclaration>> ruleMethods = new ConcurrentHashMap<>();
+    private final Map<String, RuleUnitMembers> ruleUnitMembers = new ConcurrentHashMap<>();
 
     private final Set<String> queryNames = new HashSet<>();
     private final Map<String, MethodDeclaration> queryMethods = new ConcurrentHashMap<>();
@@ -287,12 +287,13 @@ public class PackageModel {
         entryPoints.stream().map( EntryPointDeclarationDescr::getEntryPointId ).forEach( this.entryPoints::add );
     }
 
-    public void addEntryPoint(String name) {
-        entryPoints.add( name );
-    }
-
     public boolean hasEntryPoint(String name) {
         return entryPoints.contains( name );
+    }
+
+    public boolean hasEntryPointForUnit(String name, String unitName) {
+        RuleUnitMembers unitMembers = ruleUnitMembers.get(unitName);
+        return unitMembers != null && unitMembers.entryPoints.contains( name );
     }
 
     public Collection<String> getStaticImports() {
@@ -345,16 +346,26 @@ public class PackageModel {
         return staticMethods;
     }
 
+    public void addRuleUnitVariable(String unitName, RuleUnitVariable unitVar) {
+        RuleUnitMembers unitMembers = ruleUnitMembers.computeIfAbsent(unitName, k -> new RuleUnitMembers());
+        String unitVarName = unitVar.getName();
+        unitMembers.globals.put( unitVarName, unitVar.getType() );
+        if ( unitVar.isDataSource() ) {
+            unitMembers.entryPoints.add( unitVarName );
+        }
+    }
+
     public void addGlobals(InternalKnowledgePackage pkg) {
         globals.putAll( pkg.getGlobals() );
     }
 
-    public void addGlobal(String name, java.lang.reflect.Type type) {
-        globals.put( name, type );
-    }
-
     public Map<String, java.lang.reflect.Type> getGlobals() {
         return globals;
+    }
+
+    public Map<String, java.lang.reflect.Type> getGlobalsForUnit(String unitName) {
+        RuleUnitMembers unitMembers = ruleUnitMembers.get(unitName);
+        return unitMembers == null ? Collections.emptyMap() : unitMembers.globals;
     }
 
     public void addTypeMetaDataExpressions(Expression typeMetaDataExpression) {
@@ -362,11 +373,11 @@ public class PackageModel {
     }
 
     public void putRuleMethod(String unitName, MethodDeclaration ruleMethod, int ruleIndex) {
-        ruleMethods.computeIfAbsent(unitName, k -> Collections.synchronizedMap( new TreeMap<>() )).put( ruleIndex, ruleMethod );
+        ruleUnitMembers.computeIfAbsent(unitName, k -> new RuleUnitMembers()).ruleMethods.put( ruleIndex, ruleMethod );
     }
 
     public void putRuleUnit(String unitName) {
-        ruleMethods.computeIfAbsent(unitName, k -> Collections.synchronizedMap( new TreeMap<>() ));
+        ruleUnitMembers.computeIfAbsent(unitName, k -> new RuleUnitMembers());
         executableRulesClasses.remove(executableRulesClass);
         String toAdd = executableRulesClass + "_"  + unitName;
         executableRulesClasses.add(toAdd);
@@ -519,9 +530,6 @@ public class PackageModel {
 
         ClassOrInterfaceDeclaration rulesClass = cu.addClass(rulesFileName);
         rulesClass.addImplementedType(Model.class.getCanonicalName());
-        if (hasRuleUnit) {
-            rulesClass.addModifier( Modifier.Keyword.ABSTRACT );
-        }
 
         BodyDeclaration<?> dateFormatter = parseBodyDeclaration(
                 "public final static java.time.format.DateTimeFormatter " + DATE_TIME_FORMATTER_FIELD +
@@ -535,18 +543,6 @@ public class PackageModel {
                 "    }\n"
                 );
         rulesClass.addMember(getNameMethod);
-
-        String entryPointsBuilder = entryPoints.isEmpty() ?
-                "java.util.Collections.emptyList()" :
-                "java.util.Arrays.asList(D.entryPoint(\"" + entryPoints.stream().collect( joining("\"), D.entryPoint(\"") ) + "\"))";
-
-        BodyDeclaration<?> getEntryPointsMethod = parseBodyDeclaration(
-                "    @Override\n" +
-                "    public java.util.List<org.drools.model.EntryPoint> getEntryPoints() {\n" +
-                "        return " + entryPointsBuilder + ";\n" +
-                "    }\n"
-                );
-        rulesClass.addMember(getEntryPointsMethod);
 
         BodyDeclaration<?> getGlobalsMethod = parseBodyDeclaration(
                 "    @Override\n" +
@@ -574,10 +570,6 @@ public class PackageModel {
             f.getVariables().get(0).setInitializer(windowReference.getValue());
         }
 
-        for ( Map.Entry<String, java.lang.reflect.Type> g : getGlobals().entrySet() ) {
-            addGlobalField(rulesClass, getName(), g.getKey(), g.getValue());
-        }
-
         for(Map.Entry<String, QueryGenerator.QueryDefWithType> queryDef: queryDefWithType.entrySet()) {
             FieldDeclaration field = rulesClass.addField(queryDef.getValue().getQueryType(), queryDef.getKey(), publicModifier().getKeyword(), staticModifier().getKeyword(), finalModifier().getKeyword());
             field.getVariables().get(0).setInitializer(queryDef.getValue().getMethodCallExpr());
@@ -589,7 +581,11 @@ public class PackageModel {
         BlockStmt rulesListInitializerBody = new BlockStmt();
         rulesListInitializer.setBody(rulesListInitializerBody);
 
-        buildArtifactsDeclaration( getGlobals().keySet(), rulesClass, rulesListInitializerBody, "org.drools.model.Global", "globals", true );
+        for ( Map.Entry<String, java.lang.reflect.Type> g : globals.entrySet() ) {
+            addGlobalField(rulesClass, rulesListInitializerBody, getName(), g.getKey(), g.getValue());
+        }
+
+        rulesClass.addMember( generateListField("org.drools.model.Global", "globals", globals.isEmpty() && !hasRuleUnit) );
 
         if ( !typeMetaDataExpressions.isEmpty() ) {
             BodyDeclaration<?> typeMetaDatasList = parseBodyDeclaration("java.util.List<org.drools.model.TypeMetaData> typeMetaDatas = new java.util.ArrayList<>();");
@@ -607,16 +603,24 @@ public class PackageModel {
         RuleSourceResult results = new RuleSourceResult(cu);
 
         if (hasRuleUnit) {
-            ruleMethods.keySet().forEach( unitName -> {
+            rulesClass.addModifier( Modifier.Keyword.ABSTRACT );
+
+            ruleUnitMembers.forEach( (unitName, unitMembers) -> {
                 String className = rulesFileName + "_" + unitName;
-                ClassOrInterfaceDeclaration unitClass = createClass( className, results);
+                ClassOrInterfaceDeclaration unitClass = createCompilationUnit(results).addClass(className);
                 unitClass.addExtendedType( rulesFileName );
 
                 InitializerDeclaration unitInitializer = new InitializerDeclaration();
                 BlockStmt unitInitializerBody = new BlockStmt();
                 unitInitializer.setBody(unitInitializerBody);
 
-                generateRulesInUnit( unitName, unitInitializerBody, results, unitClass );
+                generateRulesInUnit( unitName, unitMembers, unitInitializerBody, results, unitClass );
+
+                unitClass.addMember(generateGetEntryPointsMethod(unitMembers.entryPoints));
+
+                for ( Map.Entry<String, java.lang.reflect.Type> g : unitMembers.globals.entrySet() ) {
+                    addGlobalField(unitClass, unitInitializerBody, getName(), g.getKey(), g.getValue());
+                }
 
                 Set<QueryModel> queries = queriesByRuleUnit.get( unitName );
                 Collection<String> queryNames = queries == null ? Collections.emptyList() : queries.stream()
@@ -632,8 +636,9 @@ public class PackageModel {
            } );
 
         } else {
-            generateRulesInUnit( DEFAULT_RULE_UNIT, rulesListInitializerBody, results, rulesClass );
+            generateRulesInUnit( DEFAULT_RULE_UNIT, ruleUnitMembers.get(DEFAULT_RULE_UNIT), rulesListInitializerBody, results, rulesClass );
             generateQueriesInUnit( rulesClass, rulesListInitializerBody, queryMethods.keySet(), queryMethods.values() );
+            rulesClass.addMember(generateGetEntryPointsMethod(entryPoints));
         }
 
         if (!rulesListInitializerBody.getStatements().isEmpty()) {
@@ -641,6 +646,20 @@ public class PackageModel {
         }
 
         return results;
+    }
+
+    private BodyDeclaration<?> generateGetEntryPointsMethod(Set<String> entryPoints) {
+        String entryPointsBuilder = entryPoints.isEmpty() ?
+                "java.util.Collections.emptyList()" :
+                "java.util.Arrays.asList(D.entryPoint(\"" + entryPoints.stream().collect( joining("\"), D.entryPoint(\"") ) + "\"))";
+
+        BodyDeclaration<?> getEntryPointsMethod = parseBodyDeclaration(
+                "    @Override\n" +
+                "    public java.util.List<org.drools.model.EntryPoint> getEntryPoints() {\n" +
+                "        return " + entryPointsBuilder + ";\n" +
+                "    }\n"
+                );
+        return getEntryPointsMethod;
     }
 
     private void generateQueriesInUnit( ClassOrInterfaceDeclaration rulesClass, BlockStmt initializerBody, Collection<String> queryNames, Collection<MethodDeclaration> queryImpls ) {
@@ -670,12 +689,13 @@ public class PackageModel {
         buildArtifactsDeclaration( queryNames, rulesClass, initializerBody, "org.drools.model.Query", "queries", false );
     }
 
-    private void generateRulesInUnit( String ruleUnitName, BlockStmt rulesListInitializerBody, RuleSourceResult results,
+    private void generateRulesInUnit( String ruleUnitName, RuleUnitMembers ruleUnitMembers,
+                                      BlockStmt rulesListInitializerBody, RuleSourceResult results,
                                       ClassOrInterfaceDeclaration rulesClass ) {
 
         results.withModel( name + "." + ruleUnitName, name + "." + rulesClass.getNameAsString() );
 
-        Collection<MethodDeclaration> ruleMethodsInUnit = ofNullable(ruleMethods.get(ruleUnitName)).map(Map::values).orElse(null);
+        Collection<MethodDeclaration> ruleMethodsInUnit = ruleUnitMembers != null ? ruleUnitMembers.ruleMethods.values() : null;
         if (ruleMethodsInUnit == null || ruleMethodsInUnit.isEmpty()) {
             BodyDeclaration<?> getQueriesMethod = parseBodyDeclaration(
                     "    @Override\n" +
@@ -738,7 +758,9 @@ public class PackageModel {
             String methodName = ruleMethod.getNameAsString();
             ClassOrInterfaceDeclaration rulesMethodClass = splitted.computeIfAbsent(++count / rulesPerClass, i -> {
                 String className = rulesClass.getNameAsString() + (oneClassPerRule ? "_" + methodName : "RuleMethods" + i);
-                return createClass( className, results );
+                CompilationUnit cu = createCompilationUnit(results);
+                cu.getImports().add(new ImportDeclaration(new Name(name + "." + rulesClass.getNameAsString()), true, true));
+                return cu.addClass(className);
             });
             rulesMethodClass.addMember(ruleMethod);
 
@@ -784,30 +806,30 @@ public class PackageModel {
         getRulesMethod.setComment(exprIdComment);
     }
 
-    private ClassOrInterfaceDeclaration createClass( String className, RuleSourceResult results ) {
+    private CompilationUnit createCompilationUnit(RuleSourceResult results ) {
         CompilationUnit cuRulesMethod = new CompilationUnit();
         results.withClass(cuRulesMethod);
         cuRulesMethod.setPackageDeclaration(name);
         manageImportForCompilationUnit(cuRulesMethod);
         cuRulesMethod.getImports().add(new ImportDeclaration(new Name(name + "." + rulesFileName), true, true));
-        return cuRulesMethod.addClass(className);
+        return cuRulesMethod;
     }
 
     private void buildArtifactsDeclaration( Collection<String> artifacts, ClassOrInterfaceDeclaration rulesClass,
                                             BlockStmt rulesListInitializerBody, String type, String fieldName, boolean needsToVar ) {
-        if (!artifacts.isEmpty()) {
-            BodyDeclaration<?> queriesList = parseBodyDeclaration("java.util.List<" + type + "> " + fieldName + " = new java.util.ArrayList<>();");
-            rulesClass.addMember(queriesList);
-            for (String name : artifacts) {
-                addInitStatement( rulesListInitializerBody, new NameExpr( needsToVar ? toVar(name) : name ), fieldName );
-            }
-        } else {
-            BodyDeclaration<?> queriesList = parseBodyDeclaration("java.util.List<" + type + "> " + fieldName + " = java.util.Collections.emptyList();");
-            rulesClass.addMember(queriesList);
+        rulesClass.addMember( generateListField(type, fieldName, artifacts.isEmpty()) );
+        for (String name : artifacts) {
+            addInitStatement( rulesListInitializerBody, new NameExpr( needsToVar ? toVar(name) : name ), fieldName );
         }
     }
 
-    private void addInitStatement( BlockStmt rulesListInitializerBody, Expression expr, String fieldName ) {
+    private BodyDeclaration<?> generateListField(String type, String fieldName, boolean empty) {
+        return empty ?
+                parseBodyDeclaration("protected java.util.List<" + type + "> " + fieldName + " = java.util.Collections.emptyList();") :
+                parseBodyDeclaration("protected java.util.List<" + type + "> " + fieldName + " = new java.util.ArrayList<>();");
+    }
+
+    private static void addInitStatement( BlockStmt rulesListInitializerBody, Expression expr, String fieldName ) {
         NameExpr rulesFieldName = new NameExpr( fieldName );
         MethodCallExpr add = new MethodCallExpr( rulesFieldName, "add" );
         add.addArgument( expr );
@@ -853,7 +875,7 @@ public class PackageModel {
         }
     }
 
-    private static void addGlobalField(ClassOrInterfaceDeclaration classDeclaration, String packageName, String globalName, java.lang.reflect.Type globalType) {
+    private static void addGlobalField(ClassOrInterfaceDeclaration classDeclaration, BlockStmt rulesListInitializerBody, String packageName, String globalName, java.lang.reflect.Type globalType) {
         ClassOrInterfaceType varType = toClassOrInterfaceType(Global.class);
         MethodCallExpr declarationOfCall = createDslTopLevelMethod(GLOBAL_OF_CALL);
 
@@ -876,6 +898,8 @@ public class PackageModel {
         FieldDeclaration field = classDeclaration.addField(varType, toVar(globalName), publicModifier().getKeyword(), staticModifier().getKeyword(), finalModifier().getKeyword());
 
         field.getVariables().get(0).setInitializer(declarationOfCall);
+
+        addInitStatement( rulesListInitializerBody, new NameExpr( toVar(globalName) ), "globals" );
     }
 
     public void setAccumulateFunctions(Map<String, AccumulateFunction> accumulateFunctions) {
@@ -978,5 +1002,11 @@ public class PackageModel {
 
     public DroolsModelBuildContext getContext() {
         return context;
+    }
+
+    private static class RuleUnitMembers {
+        final Map<Integer, MethodDeclaration> ruleMethods = Collections.synchronizedMap( new TreeMap<>() );
+        final Map<String, java.lang.reflect.Type> globals = new HashMap<>();
+        final Set<String> entryPoints = new HashSet<>();
     }
 }

--- a/drools-model/drools-model-codegen/src/main/java/org/drools/model/codegen/execmodel/generator/Consequence.java
+++ b/drools-model/drools-model-codegen/src/main/java/org/drools/model/codegen/execmodel/generator/Consequence.java
@@ -51,7 +51,6 @@ import com.github.javaparser.ast.type.Type;
 import org.drools.compiler.compiler.MissingDependencyError;
 import org.drools.core.common.TruthMaintenanceSystemFactory;
 import org.drools.core.factmodel.ClassDefinition;
-import org.drools.drl.ast.descr.RuleDescr;
 import org.drools.model.BitMask;
 import org.drools.model.bitmask.AllSetButLastBitMask;
 import org.drools.model.codegen.execmodel.PackageModel;
@@ -137,7 +136,7 @@ public class Consequence {
         this.packageModel = context.getPackageModel();
     }
 
-    public MethodCallExpr createCall(RuleDescr ruleDescr, String consequenceString, BlockStmt ruleVariablesBlock, boolean isBreaking) {
+    public MethodCallExpr createCall(String consequenceString, BlockStmt ruleVariablesBlock, boolean isBreaking) {
         BlockStmt ruleConsequence = null;
 
         if (context.getRuleDialect() == RuleContext.RuleDialect.JAVA) {
@@ -255,7 +254,7 @@ public class Consequence {
     private Set<String> extractUsedDeclarations(BlockStmt ruleConsequence, String consequenceString) {
         Set<String> existingDecls = new HashSet<>();
         existingDecls.addAll(context.getAvailableBindings());
-        existingDecls.addAll(packageModel.getGlobals().keySet());
+        existingDecls.addAll(context.getGlobals().keySet());
         if (context.getRuleUnitDescr() != null) {
             existingDecls.addAll(context.getRuleUnitDescr().getUnitVars());
         }

--- a/drools-model/drools-model-codegen/src/main/java/org/drools/model/codegen/execmodel/generator/ModelGenerator.java
+++ b/drools-model/drools-model-codegen/src/main/java/org/drools/model/codegen/execmodel/generator/ModelGenerator.java
@@ -263,7 +263,7 @@ public class ModelGenerator {
         createVariables(ruleVariablesBlock, packageModel, context);
         ruleMethod.setBody(ruleVariablesBlock);
 
-        MethodCallExpr executeCall = new Consequence(context).createCall(ruleDescr, ruleDescr.getConsequence().toString(), ruleVariablesBlock, false );
+        MethodCallExpr executeCall = new Consequence(context).createCall(ruleDescr.getConsequence().toString(), ruleVariablesBlock, false );
         buildCall.addArgument( executeCall );
 
         ruleVariablesBlock.addStatement(new AssignExpr(ruleVar, buildCall, AssignExpr.Operator.ASSIGN));
@@ -467,7 +467,7 @@ public class ModelGenerator {
     public static void createVariables(BlockStmt block, PackageModel packageModel, RuleContext context) {
         for (DeclarationSpec decl : context.getAllDeclarations()) {
             boolean domainClass = packageModel.registerDomainClass( decl.getDeclarationClass() );
-            if (!packageModel.getGlobals().containsKey(decl.getBindingId()) && !context.getQueryParameterByName(decl.getBindingId()).isPresent()) {
+            if (!context.getGlobals().containsKey(decl.getBindingId()) && !context.getQueryParameterByName(decl.getBindingId()).isPresent()) {
                 addVariable(block, decl, context, domainClass);
             }
         }

--- a/drools-model/drools-model-codegen/src/main/java/org/drools/model/codegen/execmodel/generator/RuleContext.java
+++ b/drools-model/drools-model-codegen/src/main/java/org/drools/model/codegen/execmodel/generator/RuleContext.java
@@ -253,7 +253,8 @@ public class RuleContext {
     }
 
     public boolean hasDeclaration(String id) {
-        return getDeclaration( id ) != null;
+        return getDeclaration( id ) != null || packageModel.getGlobals().get(id) != null ||
+                (ruleUnitDescr != null && packageModel.getGlobalsForUnit(ruleUnitDescr.getSimpleName()).get(id)  != null);
     }
 
     private DeclarationSpec getDeclaration(String id) {

--- a/drools-model/drools-model-codegen/src/main/java/org/drools/model/codegen/execmodel/generator/expressiontyper/ExpressionTyper.java
+++ b/drools-model/drools-model-codegen/src/main/java/org/drools/model/codegen/execmodel/generator/expressiontyper/ExpressionTyper.java
@@ -61,9 +61,6 @@ import com.github.javaparser.ast.stmt.BlockStmt;
 import com.github.javaparser.ast.type.ClassOrInterfaceType;
 import com.github.javaparser.ast.type.ReferenceType;
 import com.github.javaparser.ast.type.Type;
-import org.drools.util.TypeResolver;
-import org.drools.util.MethodUtils;
-import org.drools.model.codegen.execmodel.PackageModel;
 import org.drools.model.codegen.execmodel.errors.InvalidExpressionErrorResult;
 import org.drools.model.codegen.execmodel.errors.ParseExpressionErrorResult;
 import org.drools.model.codegen.execmodel.generator.DeclarationSpec;
@@ -93,14 +90,14 @@ import org.drools.mvel.parser.ast.expr.OOPathExpr;
 import org.drools.mvel.parser.ast.expr.PointFreeExpr;
 import org.drools.mvel.parser.printer.PrintUtil;
 import org.drools.mvelcompiler.util.BigDecimalArgumentCoercion;
+import org.drools.util.MethodUtils;
+import org.drools.util.TypeResolver;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import static com.github.javaparser.ast.NodeList.nodeList;
 import static java.util.Optional.empty;
 import static java.util.Optional.of;
-import static org.drools.util.ClassUtils.extractGenericType;
-import static org.drools.util.ClassUtils.getter2property;
 import static org.drools.model.codegen.execmodel.generator.DrlxParseUtil.THIS_PLACEHOLDER;
 import static org.drools.model.codegen.execmodel.generator.DrlxParseUtil.findRootNodeViaParent;
 import static org.drools.model.codegen.execmodel.generator.DrlxParseUtil.getClassFromContext;
@@ -122,15 +119,16 @@ import static org.drools.modelcompiler.util.ClassUtil.getTypeArgument;
 import static org.drools.modelcompiler.util.ClassUtil.toRawClass;
 import static org.drools.mvel.parser.MvelParser.parseType;
 import static org.drools.mvel.parser.printer.PrintUtil.printNode;
+import static org.drools.util.ClassUtils.extractGenericType;
+import static org.drools.util.ClassUtils.getter2property;
 import static org.kie.internal.ruleunit.RuleUnitUtil.isDataSource;
 
 public class ExpressionTyper {
 
     private final RuleContext ruleContext;
-    private final PackageModel packageModel;
-    private Class<?> patternType;
-    private String bindingId;
-    private boolean isPositional;
+    private final Class<?> patternType;
+    private final String bindingId;
+    private final boolean isPositional;
     private final ExpressionTyperContext context;
 
     private static final Logger logger          = LoggerFactory.getLogger(ExpressionTyper.class);
@@ -146,7 +144,6 @@ public class ExpressionTyper {
 
     public ExpressionTyper(RuleContext ruleContext, Class<?> patternType, String bindingId, boolean isPositional, ExpressionTyperContext context) {
         this.ruleContext = ruleContext;
-        packageModel = ruleContext.getPackageModel();
         this.patternType = patternType;
         this.bindingId = bindingId;
         this.isPositional = isPositional;
@@ -213,7 +210,7 @@ public class ExpressionTyper {
             Optional<TypedExpression> optLeft = toTypedExpressionRec(binaryExpr.getLeft());
             Optional<TypedExpression> optRight = toTypedExpressionRec(binaryExpr.getRight());
 
-            if (!optLeft.isPresent() || !optRight.isPresent()) {
+            if (optLeft.isEmpty() || optRight.isEmpty()) {
                 return empty();
             }
 
@@ -410,7 +407,7 @@ public class ExpressionTyper {
     }
 
     private boolean isEval(String nameAsString, Optional<Expression> scope, NodeList<Expression> arguments) {
-        return nameAsString.equals("eval") && !scope.isPresent() && arguments.size() == 1;
+        return nameAsString.equals("eval") && scope.isEmpty() && arguments.size() == 1;
     }
 
     private Optional<TypedExpression> createArrayAccessExpression(Expression index, Expression scope) {
@@ -540,7 +537,7 @@ public class ExpressionTyper {
             addReactOnProperty(me.getNameAsString(), me.getArguments());
         }
 
-        if(!teCursor.isPresent()) {
+        if(teCursor.isEmpty()) {
             return new TypedExpressionResult(empty(), context);
         }
 
@@ -643,11 +640,10 @@ public class ExpressionTyper {
         } catch(RuntimeException e) {
             return empty();
         }
-        String field = name;
 
         final Object staticValue;
         try {
-            staticValue = clazz.getDeclaredField(field).get(null);
+            staticValue = clazz.getDeclaredField(name).get(null);
         } catch (IllegalAccessException | NoSuchFieldException e) {
             return empty();
         }
@@ -718,7 +714,7 @@ public class ExpressionTyper {
             result = processFirstNode( drlxExpr, childNodes, (( EnclosedExpr ) firstNode).getInner(), isInLineCast, originalTypeCursor);
 
         } else if (firstNode instanceof CastExpr) {
-            result = castExpr( ( CastExpr ) firstNode, drlxExpr, childNodes, isInLineCast, originalTypeCursor );
+            result = castExpr( ( CastExpr ) firstNode, isInLineCast );
 
         } else if (firstNode instanceof ArrayCreationExpr) {
             result = of(arrayCreationExpr( (( ArrayCreationExpr ) firstNode) ));
@@ -801,7 +797,7 @@ public class ExpressionTyper {
         return leftType;
     }
 
-    private Optional<TypedExpressionCursor> castExpr( CastExpr firstNode, Expression drlxExpr, List<Node> childNodes, boolean isInLineCast, java.lang.reflect.Type originalTypeCursor ) {
+    private Optional<TypedExpressionCursor> castExpr( CastExpr firstNode, boolean isInLineCast ) {
         try {
             Type type = firstNode.getType();
             Class<?> typeClass = ruleContext.getTypeResolver().resolveType( type.toString() );
@@ -921,7 +917,7 @@ public class ExpressionTyper {
         int genericPos = 0;
         for (TypeVariable typeVar : rawClassCursor.getTypeParameters()) {
             if (typeVar.equals( genericReturnType )) {
-                return (( ParameterizedType ) originalTypeCursor).getActualTypeArguments()[genericPos];
+                return originalTypeCursor.getActualTypeArguments()[genericPos];
             }
             genericPos++;
         }
@@ -1051,9 +1047,8 @@ public class ExpressionTyper {
 
     private TypedExpressionCursor fieldAccessExpr(java.lang.reflect.Type originalTypeCursor, SimpleName firstNodeName) {
         TypedExpressionCursor teCursor;
-        final java.lang.reflect.Type tc4 = originalTypeCursor;
         String firstName = firstNodeName.getIdentifier();
-        Method firstAccessor = DrlxParseUtil.getAccessor(toRawClass(tc4), firstName, ruleContext);
+        Method firstAccessor = DrlxParseUtil.getAccessor(toRawClass(originalTypeCursor), firstName, ruleContext);
         if (firstAccessor != null) {
             context.addReactOnProperties(firstName);
             teCursor = new TypedExpressionCursor(new MethodCallExpr(new NameExpr(THIS_PLACEHOLDER), firstAccessor.getName()), firstAccessor.getGenericReturnType());

--- a/drools-model/drools-model-codegen/src/main/java/org/drools/model/codegen/execmodel/generator/expressiontyper/ExpressionTyper.java
+++ b/drools-model/drools-model-codegen/src/main/java/org/drools/model/codegen/execmodel/generator/expressiontyper/ExpressionTyper.java
@@ -453,10 +453,10 @@ public class ExpressionTyper {
             context.addUsedDeclarations(name);
             return of(new TypedExpression(new NameExpr(name)));
 
-        } else if(packageModel.getGlobals().containsKey(name)){
+        } else if (ruleContext.getGlobals().containsKey(name)){
             Expression plusThis = new NameExpr(name);
             context.addUsedDeclarations(name);
-            return of(new TypedExpression(plusThis, packageModel.getGlobals().get(name)));
+            return of(new TypedExpression(plusThis, ruleContext.getGlobals().get(name)));
 
         } else if (isPositional || ruleContext.isQuery()) {
             String unificationVariable = ruleContext.getOrCreateUnificationId(name);
@@ -1133,9 +1133,9 @@ public class ExpressionTyper {
             return of(new TypedExpressionCursor(new NameExpr(firstName), typeCursor));
         }
 
-        if (packageModel.getGlobals().containsKey(firstName)) {
+        if (ruleContext.getGlobals().containsKey(firstName)) {
             context.addUsedDeclarations(firstName);
-            return of(new TypedExpressionCursor(new NameExpr(firstName), packageModel.getGlobals().get(firstName)));
+            return of(new TypedExpressionCursor(new NameExpr(firstName), ruleContext.getGlobals().get(firstName)));
         }
 
         final Optional<Node> rootNode = findRootNodeViaParent(drlxExpr);

--- a/drools-model/drools-model-codegen/src/main/java/org/drools/model/codegen/execmodel/generator/visitor/FromVisitor.java
+++ b/drools-model/drools-model-codegen/src/main/java/org/drools/model/codegen/execmodel/generator/visitor/FromVisitor.java
@@ -35,7 +35,6 @@ import com.github.javaparser.ast.expr.ObjectCreationExpr;
 import com.github.javaparser.ast.stmt.ExpressionStmt;
 import org.drools.drl.ast.descr.FromDescr;
 import org.drools.drl.ast.descr.PatternSourceDescr;
-import org.drools.model.codegen.execmodel.PackageModel;
 import org.drools.model.codegen.execmodel.errors.InvalidExpressionErrorResult;
 import org.drools.model.codegen.execmodel.generator.DeclarationSpec;
 import org.drools.model.codegen.execmodel.generator.DrlxParseUtil;
@@ -52,7 +51,6 @@ import org.drools.mvel.parser.printer.PrintUtil;
 import static java.util.Optional.of;
 import static java.util.Optional.ofNullable;
 import static org.drools.core.rule.Pattern.isCompatibleWithFromReturnType;
-import static org.drools.util.StringUtils.splitArgumentsList;
 import static org.drools.model.codegen.execmodel.generator.DrlxParseUtil.findViaScopeWithPredicate;
 import static org.drools.model.codegen.execmodel.generator.DrlxParseUtil.generateLambdaWithoutParameters;
 import static org.drools.model.codegen.execmodel.generator.DrlxParseUtil.toStringLiteral;
@@ -60,16 +58,15 @@ import static org.drools.model.codegen.execmodel.generator.DrlxParseUtil.toVar;
 import static org.drools.model.codegen.execmodel.generator.DslMethodNames.ENTRY_POINT_CALL;
 import static org.drools.model.codegen.execmodel.generator.DslMethodNames.FROM_CALL;
 import static org.drools.model.codegen.execmodel.generator.DslMethodNames.createDslTopLevelMethod;
+import static org.drools.util.StringUtils.splitArgumentsList;
 
 public class FromVisitor {
 
     private final RuleContext context;
-    private final PackageModel packageModel;
     private final Class<?> patternType;
 
-    public FromVisitor(RuleContext context, PackageModel packageModel, Class<?> patternType) {
+    public FromVisitor(RuleContext context, Class<?> patternType) {
         this.context = context;
-        this.packageModel = packageModel;
         this.patternType = patternType;
     }
 
@@ -146,7 +143,7 @@ public class FromVisitor {
 
         for (Expression argument : parsedExpression.getArguments()) {
             final String argumentName = PrintUtil.printNode(argument);
-            if (contextHasDeclaration(argumentName)) {
+            if (context.hasDeclaration(argumentName)) {
                 bindingIds.add(argumentName);
                 fromCall.addArgument( context.getVarExpr(argumentName));
             }
@@ -177,7 +174,7 @@ public class FromVisitor {
         if ( context.hasEntryPoint( bindingId ) ) {
             return of( createEntryPointCall(bindingId) );
         }
-        if ( contextHasDeclaration( bindingId ) ) {
+        if ( context.hasDeclaration( bindingId ) ) {
             return of( createFromCall(expression, bindingId, optContainsBinding.isPresent(), null) );
         }
         return of(createUnitDataCall(bindingId));
@@ -229,16 +226,12 @@ public class FromVisitor {
         final Expression sanitizedMethodCallExpr = DrlxParseUtil.transformDrlNameExprToNameExpr(expr);
         return findViaScopeWithPredicate(sanitizedMethodCallExpr, e -> {
             if (e instanceof NameExpr) {
-                return contextHasDeclaration(((NameExpr) e).getName().toString());
+                return context.hasDeclaration(((NameExpr) e).getName().toString());
             }
             return false;
         })
         .filter( Expression::isNameExpr )
         .map( e -> createFromCall(expression, e.asNameExpr().toString(), true, expr) );
-    }
-
-    private boolean contextHasDeclaration(String name) {
-        return context.hasDeclaration(name) || packageModel.hasDeclaration(name);
     }
 
     private Expression createEntryPointCall( String bindingId ) {
@@ -278,7 +271,7 @@ public class FromVisitor {
             DeclarationSpec declarationSpec = context.getDeclarationById( bindingId ).orElseThrow( RuntimeException::new );
             Class<?> clazz = declarationSpec.getDeclarationClass();
 
-            DrlxParseResult drlxParseResult = ConstraintParser.withoutVariableValidationConstraintParser(context, packageModel)
+            DrlxParseResult drlxParseResult = ConstraintParser.withoutVariableValidationConstraintParser(context, context.getPackageModel())
                     .drlxParse(clazz, bindingId, expression);
 
             return drlxParseResult.acceptWithReturnValue( drlxParseSuccess -> {

--- a/drools-model/drools-model-codegen/src/main/java/org/drools/model/codegen/execmodel/generator/visitor/FromVisitor.java
+++ b/drools-model/drools-model-codegen/src/main/java/org/drools/model/codegen/execmodel/generator/visitor/FromVisitor.java
@@ -174,7 +174,7 @@ public class FromVisitor {
         if (staticField.isPresent()) {
             return of( createSupplier(parsedExpression) );
         }
-        if ( packageModel.hasEntryPoint( bindingId ) ) {
+        if ( context.hasEntryPoint( bindingId ) ) {
             return of( createEntryPointCall(bindingId) );
         }
         if ( contextHasDeclaration( bindingId ) ) {

--- a/drools-model/drools-model-codegen/src/main/java/org/drools/model/codegen/execmodel/generator/visitor/NamedConsequenceVisitor.java
+++ b/drools-model/drools-model-codegen/src/main/java/org/drools/model/codegen/execmodel/generator/visitor/NamedConsequenceVisitor.java
@@ -144,7 +144,7 @@ public class NamedConsequenceVisitor {
         }
         BlockStmt ruleVariablesBlock = context.getRuleVariablesBlock();
         createVariables(ruleVariablesBlock, packageModel, context);
-        return new Consequence(context).createCall(null, namedConsequenceString, ruleVariablesBlock, namedConsequence.isBreaking() );
+        return new Consequence(context).createCall(namedConsequenceString, ruleVariablesBlock, namedConsequence.isBreaking() );
     }
 
     static class InvalidNamedConsequenceException extends RuntimeException {


### PR DESCRIPTION
**JIRA**: https://issues.redhat.com/browse/KOGITO-8220

At the moment globals and entry-points are always defined in the general package level model. This causes a name clash if 2 rule units in the same package has 2 data sources with the same name. The purpose of this PR is isolating the globals and entry-points definitions in the model of the single rule units.