### PR TITLE
[DROOLS-7237] Revive "Timer and calendar rule attributes is in DRL" s…

### DIFF
--- a/drools-docs/src/modules/ROOT/pages/language-reference/_drl-rules.adoc
+++ b/drools-docs/src/modules/ROOT/pages/language-reference/_drl-rules.adoc
@@ -920,9 +920,11 @@ Example: `activation-group "GroupName"`
 Example: `duration 10000`
 
 |`timer`
-|A string identifying either `int` (interval) or `cron` timer definitions for scheduling the rule.
+|A string identifying either `int` (initialDelay interval) or `cron` timer definitions for scheduling the rule.
 
-Example: `timer ( cron:* 0/15 * * * ? )`  (every 15 minutes)
+Example: `timer ( int: 30s 5m )`  (every 5 minutes after a 30-second delay)
+
+         `timer ( cron:* 0/15 * * * ? )`  (every 15 minutes)
 
 |`calendar`
 |A http://www.quartz-scheduler.org/[Quartz] calendar definition for scheduling the rule.
@@ -945,8 +947,6 @@ Example: `lock-on-active true`
 Example: `dialect "JAVA"`
 |===
 
-////
-//@comment: Undecided for Kogito at this time. (Stetson 6 Apr 2020)
 [id="con-drl-timers-calendars_{context}"]
 === Timer and calendar rule attributes in DRL
 
@@ -995,8 +995,6 @@ rule "Send SMS message every 15 minutes"
     channels[ "sms" ].insert( new Sms( $a.mobileNumber, "The alarm is still on." );
 end
 ----
-
-*<@Edoardo, see these paragraphs about active vs. passive modes (fireAllRules vs fireUntilHalt) and then configuring KIE session. Several other places in the DRL/engine content discusses active vs passive, fireAllRules, etc., so need some direction.>*
 
 Generally, a rule that is controlled by a timer becomes active when the rule is triggered and the rule consequence is executed repeatedly, according to the timer settings. The execution stops when the rule condition no longer matches incoming facts. However, the way the {RULE_ENGINE} handles rules with timers depends on whether the {RULE_ENGINE} is in _active mode_ or in _passive mode_.
 
@@ -1123,7 +1121,6 @@ rule "Weekends are low priority"
     send( "priority low - we have an alarm" );
 end
 ----
-////
 
 [id="con-drl-rules-conditions_{context}"]
 == Rule conditions in DRL


### PR DESCRIPTION
…ection

**JIRA**: 
https://issues.redhat.com/browse/DROOLS-7237

<details>
<summary>
How to replicate CI configuration locally?
</summary>

Build Chain tool does "simple" maven build(s), the builds are just Maven commands, but because the repositories relates and depends on each other and any change in API or class method could affect several of those repositories there is a need to use [build-chain tool](https://github.com/kiegroup/github-action-build-chain) to handle cross repository builds and be sure that we always use latest version of the code for each repository.
 
[build-chain tool](https://github.com/kiegroup/github-action-build-chain) is a build tool which can be used on command line locally or in Github Actions workflow(s), in case you need to change multiple repositories and send multiple dependent pull requests related with a change you can easily reproduce the same build by executing it on Github hosted environment or locally in your development environment. See [local execution](https://github.com/kiegroup/github-action-build-chain#local-execution) details to get more information about it.
</details>

<details>
<summary>
How to retest this PR or trigger a specific build:
</summary>

- for <b>pull request checks</b>  
  Please add comment: <b>Jenkins retest this</b>

- for a <b>specific pull request check</b>  
  Please add comment: <b>Jenkins (re)run [drools|kogito-runtimes|kogito-apps|kogito-examples] tests</b>

- for a <b>full downstream build</b> 
  - for <b>jenkins</b> job: please add comment: <b>Jenkins run fdb</b>
  - for <b>github actions</b> job: add the label `run_fdb`

- <b>a compile downstream build</b> please  add comment: <b>Jenkins run cdb</b>

- <b>a full production downstream build</b> please add comment: <b>Jenkins execute product fdb</b>

- <b>an upstream build</b> please add comment: <b>Jenkins run upstream</b>

- for <b>quarkus branch checks</b>  
  Run checks against Quarkus current used branch  
  Please add comment: <b>Jenkins run quarkus-branch</b>

- for a <b>quarkus branch specific check</b>  
  Run checks against Quarkus current used branch  
  Please add comment: <b>Jenkins (re)run [drools|kogito-runtimes|kogito-apps|kogito-examples] quarkus-branch</b>

- for <b>quarkus main checks</b>  
  Run checks against Quarkus main branch  
  Please add comment: <b>Jenkins run quarkus-main</b>

- for a <b>specific quarkus main check</b>  
  Run checks against Quarkus main branch  
  Please add comment: <b>Jenkins (re)run [drools|kogito-runtimes|kogito-apps|kogito-examples] quarkus-main</b>

- for <b>quarkus lts checks</b>  
  Run checks against Quarkus lts branch  
  Please add comment: <b>Jenkins run quarkus-lts</b>

- for a <b>specific quarkus lts check</b>  
  Run checks against Quarkus lts branch  
  Please add comment: <b>Jenkins (re)run [drools|kogito-runtimes|kogito-apps|kogito-examples] quarkus-lts</b>

- for <b>native checks</b>  
  Run native checks  
  Please add comment: <b>Jenkins run native</b>

- for a <b>specific native check</b>  
  Run native checks 
  Please add comment: <b>Jenkins (re)run [drools|kogito-runtimes|kogito-apps|kogito-examples] native</b>

- for <b>mandrel checks</b>  
  Run native checks against Mandrel image
  Please add comment: <b>Jenkins run mandrel</b>

- for a <b>specific mandrel check</b>  
  Run native checks against Mandrel image  
  Please add comment: <b>Jenkins (re)run [drools|kogito-runtimes|kogito-apps|kogito-examples] mandrel</b>

 - for <b>mandrel lts checks</b>  
  Run native checks against Mandrel image and quarkus lts branch
  Please add comment: <b>Jenkins run mandrel-lts</b>

- for a <b>specific mandrel lts check</b>  
  Run native checks against Mandrel image and quarkus lts branch
  Please add comment: <b>Jenkins (re)run [drools|kogito-runtimes|kogito-apps|kogito-examples] mandrel-lts</b>
</details>
