### PR TITLE
[DROOLS-7214] non-executable-model doesn't react to bind-only Map pro…

### DIFF
--- a/drools-compiler/src/main/java/org/drools/compiler/rule/builder/PatternBuilder.java
+++ b/drools-compiler/src/main/java/org/drools/compiler/rule/builder/PatternBuilder.java
@@ -108,6 +108,8 @@ import org.kie.internal.builder.ResultSeverity;
 import static org.drools.compiler.rule.builder.util.PatternBuilderUtil.getNormalizeDate;
 import static org.drools.compiler.rule.builder.util.PatternBuilderUtil.normalizeEmptyKeyword;
 import static org.drools.compiler.rule.builder.util.PatternBuilderUtil.normalizeStringOperator;
+import static org.drools.core.util.StringUtils.doesFirstPropHaveListMapAccessor;
+import static org.drools.core.util.StringUtils.extractFirstIdentifier;
 import static org.drools.core.util.StringUtils.isIdentifier;
 
 /**
@@ -1398,8 +1400,12 @@ public class PatternBuilder
 
         declr.setReadAccessor(extractor);
 
-        if (!declr.isFromXpathChunk() && typeDeclaration != null && extractor instanceof ClassFieldReader) {
-            addFieldToPatternWatchlist(pattern, typeDeclaration, ((ClassFieldReader) extractor).getFieldName());
+        if (!declr.isFromXpathChunk() && typeDeclaration != null) {
+            if (extractor instanceof ClassFieldReader) {
+                addFieldToPatternWatchlist(pattern, typeDeclaration, ((ClassFieldReader) extractor).getFieldName());
+            } else if (doesFirstPropHaveListMapAccessor(fieldBindingDescr.getBindingField())) {
+                addFieldToPatternWatchlist(pattern, typeDeclaration, extractFirstIdentifier(fieldBindingDescr.getBindingField(), 0)); // extractor is MVELObjectClassFieldReader
+            }
         }
     }
 

--- a/drools-core/src/main/java/org/drools/core/util/StringUtils.java
+++ b/drools-core/src/main/java/org/drools/core/util/StringUtils.java
@@ -1377,4 +1377,22 @@ public class StringUtils {
     public static String uuid() {
         return "x" + UUID.randomUUID().toString().replace( '-', 'x' );
     }
+
+    public static boolean doesFirstPropHaveListMapAccessor(String expression) {
+        StringBuilder propertyNameBuilder = new StringBuilder();
+        int cursor = extractFirstIdentifier(expression, propertyNameBuilder, 0);
+        Character nextChar = lookAheadIgnoringSpaces(expression, cursor);
+        return nextChar != null && nextChar.equals('[');
+    }
+
+    public static Character lookAheadIgnoringSpaces(String expression, int cursor) {
+        while (cursor < expression.length()) {
+            char c = expression.charAt(cursor);
+            if (!Character.isWhitespace(c)) {
+                return c;
+            }
+            cursor++;
+        }
+        return null;
+    }
 }

--- a/drools-model/drools-model-compiler/src/test/java/org/drools/modelcompiler/PropertyReactivityTest.java
+++ b/drools-model/drools-model-compiler/src/test/java/org/drools/modelcompiler/PropertyReactivityTest.java
@@ -1639,4 +1639,96 @@ public class PropertyReactivityTest extends BaseModelTest {
 
         assertThat(results).containsExactly(expectedResults);
     }
+
+    @Test
+    public void bindOnlyPropertyReacts() {
+        // DROOLS-7214
+        final String str =
+                "import " + Person.class.getCanonicalName() + ";\n" +
+                           "dialect \"mvel\"\n" +
+                           "rule R when\n" +
+                           "    $p : Person( name == \"Mario\", $age : age )\n" +
+                           "then\n" +
+                           "    modify($p) { age = $age + 1 };\n" +
+                           "end\n";
+
+        KieSession ksession = getKieSession(str);
+
+        Person p = new Person("Mario", 40);
+        ksession.insert(p);
+        int fired = ksession.fireAllRules(10); // intentional loop
+
+        assertThat(fired).isEqualTo(10);
+    }
+
+    @Test
+    public void bindOnlyMapPropertyReacts() {
+        // DROOLS-7214
+        final String str =
+                "import " + Person.class.getCanonicalName() + ";\n" +
+                           "dialect \"mvel\"\n" +
+                           "rule R when\n" +
+                           "    $p : Person( name == \"Mario\", $map : itemsString )\n" +
+                           "then\n" +
+                           "    $p.itemsString[\"B\"] = \"itemB\";\n" +
+                           "    modify($p) { itemsString = $p.itemsString };\n" +
+                           "end\n";
+
+        KieSession ksession = getKieSession(str);
+
+        Person p = new Person("Mario", 40);
+        p.getItemsString().put("A", "itemA");
+        ksession.insert(p);
+        int fired = ksession.fireAllRules(10); // intentional loop
+
+        assertThat(fired).isEqualTo(10);
+    }
+
+    @Test
+    public void bindOnlyMapPropertyWithAccessOperatorReacts() {
+        // DROOLS-7214
+        final String str =
+                "import " + Person.class.getCanonicalName() + ";\n" +
+                           "dialect \"mvel\"\n" +
+                           "rule R when\n" +
+                           "    $p : Person( name == \"Mario\", $mapDataA : itemsString[\"A\"] )\n" +
+                           "then\n" +
+                           "    $p.itemsString[\"B\"] = \"itemB\";\n" +
+                           "    modify($p) { itemsString = $p.itemsString };\n" +
+                           "end\n";
+
+        KieSession ksession = getKieSession(str);
+
+        Person p = new Person("Mario", 40);
+        p.getItemsString().put("A", "itemA");
+        ksession.insert(p);
+        int fired = ksession.fireAllRules(10); // intentional loop
+
+        assertThat(fired).isEqualTo(10);
+    }
+
+    @Test
+    public void bindOnlyListPropertyWithAccessOperatorReacts() {
+        // DROOLS-7214
+        final String str =
+                "import " + Person.class.getCanonicalName() + ";\n" +
+                           "import " + Address.class.getCanonicalName() + ";\n" +
+                           "dialect \"mvel\"\n" +
+                           "rule R when\n" +
+                           "    $p : Person( name == \"Mario\", $listData0 : addresses[0] )\n" +
+                           "then\n" +
+                           "    $p.addresses.add(new Address(\"C\"));\n" +
+                           "    modify($p) { addresses = $p.addresses };\n" +
+                           "end\n";
+
+        KieSession ksession = getKieSession(str);
+
+        Person p = new Person("Mario", 40);
+        p.getAddresses().add(new Address("A"));
+        p.getAddresses().add(new Address("B"));
+        ksession.insert(p);
+        int fired = ksession.fireAllRules(10); // intentional loop
+
+        assertThat(fired).isEqualTo(10);
+    }
 }

--- a/drools-mvel/src/main/java/org/drools/mvel/MVELConstraint.java
+++ b/drools-mvel/src/main/java/org/drools/mvel/MVELConstraint.java
@@ -89,6 +89,7 @@ import static org.drools.core.util.MessageUtils.defaultToEmptyString;
 import static org.drools.core.util.StringUtils.codeAwareIndexOf;
 import static org.drools.core.util.StringUtils.equalsIgnoreSpaces;
 import static org.drools.core.util.StringUtils.extractFirstIdentifier;
+import static org.drools.core.util.StringUtils.lookAheadIgnoringSpaces;
 import static org.drools.core.util.StringUtils.skipBlanks;
 
 public class MVELConstraint extends MutableTypeConstraint implements IndexableConstraint, AcceptsReadAccessor {
@@ -534,8 +535,8 @@ public class MVELConstraint extends MutableTypeConstraint implements IndexableCo
         }
 
         if (!isAccessor) {
-            String lookAhead = lookAheadIgnoringSpaces(expression, cursor);
-            boolean isMethodInvocation = lookAhead != null && lookAhead.equals("(");
+            Character lookAhead = lookAheadIgnoringSpaces(expression, cursor);
+            boolean isMethodInvocation = lookAhead != null && lookAhead.equals('(');
             if (isMethodInvocation) {
                 return nextPropertyName(expression, names, cursor);
             }
@@ -545,17 +546,6 @@ public class MVELConstraint extends MutableTypeConstraint implements IndexableCo
             names.add(propertyName);
         }
         return skipOperator(expression, cursor);
-    }
-
-    private String lookAheadIgnoringSpaces(String expression, int cursor) {
-        while (cursor < expression.length()) {
-            char c = expression.charAt(cursor);
-            if (!Character.isWhitespace(c)) {
-                return "" + c;
-            }
-            cursor++;
-        }
-        return null;
     }
 
     private int skipOperator(String expression, int cursor) {


### PR DESCRIPTION
…… (#4771)

**Ports** 
This is a backport PR of https://github.com/kiegroup/drools/pull/4771 for 7.67.x-blue

**JIRA**:
https://issues.redhat.com/browse/RHDM-1952

<details>
<summary>
How to replicate CI configuration locally?
</summary>

Build Chain tool does "simple" maven build(s), the builds are just Maven commands, but because the repositories relates and depends on each other and any change in API or class method could affect several of those repositories there is a need to use [build-chain tool](https://github.com/kiegroup/github-action-build-chain) to handle cross repository builds and be sure that we always use latest version of the code for each repository.
 
[build-chain tool](https://github.com/kiegroup/github-action-build-chain) is a build tool which can be used on command line locally or in Github Actions workflow(s), in case you need to change multiple repositories and send multiple dependent pull requests related with a change you can easily reproduce the same build by executing it on Github hosted environment or locally in your development environment. See [local execution](https://github.com/kiegroup/github-action-build-chain#local-execution) details to get more information about it.
</details>

<details>
<summary>
How to retest this PR or trigger a specific build:
</summary>

- for <b>pull request checks</b>  
  Please add comment: <b>Jenkins retest this</b>

- for a <b>specific pull request check</b>  
  Please add comment: <b>Jenkins (re)run [drools|kogito-runtimes|kogito-apps|kogito-examples] tests</b>

- for a <b>full downstream build</b> 
  - for <b>jenkins</b> job: please add comment: <b>Jenkins run fdb</b>
  - for <b>github actions</b> job: add the label `run_fdb`

- <b>a compile downstream build</b> please  add comment: <b>Jenkins run cdb</b>

- <b>a full production downstream build</b> please add comment: <b>Jenkins execute product fdb</b>

- <b>an upstream build</b> please add comment: <b>Jenkins run upstream</b>

- for <b>quarkus branch checks</b>  
  Run checks against Quarkus current used branch  
  Please add comment: <b>Jenkins run quarkus-branch</b>

- for a <b>quarkus branch specific check</b>  
  Run checks against Quarkus current used branch  
  Please add comment: <b>Jenkins (re)run [drools|kogito-runtimes|kogito-apps|kogito-examples] quarkus-branch</b>

- for <b>quarkus main checks</b>  
  Run checks against Quarkus main branch  
  Please add comment: <b>Jenkins run quarkus-main</b>

- for a <b>specific quarkus main check</b>  
  Run checks against Quarkus main branch  
  Please add comment: <b>Jenkins (re)run [drools|kogito-runtimes|kogito-apps|kogito-examples] quarkus-main</b>

- for <b>quarkus lts checks</b>  
  Run checks against Quarkus lts branch  
  Please add comment: <b>Jenkins run quarkus-lts</b>

- for a <b>specific quarkus lts check</b>  
  Run checks against Quarkus lts branch  
  Please add comment: <b>Jenkins (re)run [drools|kogito-runtimes|kogito-apps|kogito-examples] quarkus-lts</b>

- for <b>native checks</b>  
  Run native checks  
  Please add comment: <b>Jenkins run native</b>

- for a <b>specific native check</b>  
  Run native checks 
  Please add comment: <b>Jenkins (re)run [drools|kogito-runtimes|kogito-apps|kogito-examples] native</b>

- for <b>mandrel checks</b>  
  Run native checks against Mandrel image
  Please add comment: <b>Jenkins run mandrel</b>

- for a <b>specific mandrel check</b>  
  Run native checks against Mandrel image  
  Please add comment: <b>Jenkins (re)run [drools|kogito-runtimes|kogito-apps|kogito-examples] mandrel</b>

 - for <b>mandrel lts checks</b>  
  Run native checks against Mandrel image and quarkus lts branch
  Please add comment: <b>Jenkins run mandrel-lts</b>

- for a <b>specific mandrel lts check</b>  
  Run native checks against Mandrel image and quarkus lts branch
  Please add comment: <b>Jenkins (re)run [drools|kogito-runtimes|kogito-apps|kogito-examples] mandrel-lts</b>
</details>
