### PR TITLE
[DROOLS-7239] Unable to build KieBase from Model object with property…

### DIFF
--- a/drools-model/drools-model-codegen/src/test/java/org/drools/model/codegen/execmodel/KieBaseBuilderTest.java
+++ b/drools-model/drools-model-codegen/src/test/java/org/drools/model/codegen/execmodel/KieBaseBuilderTest.java
@@ -1,0 +1,141 @@
+/*
+ * Copyright 2022 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ *
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.drools.model.codegen.execmodel;
+
+import java.lang.reflect.InvocationTargetException;
+import java.util.List;
+import java.util.UUID;
+import java.util.stream.Collectors;
+
+import org.drools.compiler.compiler.io.memory.MemoryFileSystem;
+import org.drools.compiler.kie.builder.impl.KieBuilderImpl;
+import org.drools.model.Model;
+import org.drools.model.codegen.execmodel.domain.Person;
+import org.drools.modelcompiler.KieBaseBuilder;
+import org.junit.Test;
+import org.junit.runners.Parameterized.Parameters;
+import org.kie.api.KieBase;
+import org.kie.api.KieBaseConfiguration;
+import org.kie.api.KieServices;
+import org.kie.api.builder.KieBuilder;
+import org.kie.api.builder.ReleaseId;
+import org.kie.api.builder.model.KieModuleModel;
+import org.kie.api.runtime.KieSession;
+import org.kie.internal.builder.KnowledgeBuilderConfiguration;
+import org.kie.internal.builder.KnowledgeBuilderFactory;
+import org.kie.internal.builder.conf.PropertySpecificOption;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class KieBaseBuilderTest extends BaseModelTest {
+
+    // Only exec-model test
+    @Parameters(name = "{0}")
+    public static Object[] params() {
+        return new Object[]{RUN_TYPE.PATTERN_DSL};
+    }
+
+    public KieBaseBuilderTest(RUN_TYPE testRunType) {
+        super(testRunType);
+    }
+
+    @Test
+    public void createKieBaseWithKnowledgeBuilderConfiguration() {
+        // DROOLS-7239
+        final String str =
+                "import " + Person.class.getCanonicalName() + ";\n" +
+                           "\n" +
+                           "rule R when\n" +
+                           "    $p : Person()\n" +
+                           "then\n" +
+                           "    modify($p) { setAge( $p.getAge()+1 ) };\n" +
+                           "end\n";
+
+        // 1st round: Create a kieBuilder with PropertySpecificOption.DISABLED
+        PropertySpecificOption option = PropertySpecificOption.DISABLED;
+        KieServices ks = KieServices.get();
+        ReleaseId releaseId = ks.newReleaseId("org.kie", "kjar-test-" + UUID.randomUUID(), "1.0");
+        KieModuleModel model = ks.newKieModuleModel();
+        model.setConfigurationProperty(option.getPropertyName(), option.name());
+        KieBuilder kieBuilder = createKieBuilder(ks, model, releaseId, toKieFiles(new String[]{str}));
+
+        // 2nd round: Create a kbase with generated classes and PropertySpecificOption.DISABLED
+        KnowledgeBuilderConfiguration knowledgeBuilderConf = KnowledgeBuilderFactory.newKnowledgeBuilderConfiguration();
+        knowledgeBuilderConf.setOption(option);
+        KieBaseConfiguration kieBaseConf = KieServices.get().newKieBaseConfiguration(); // empty kieBaseConf in this test
+        KieBase kbase = buildKieBaseFromExtractedModel(kieBuilder, kieBaseConf, knowledgeBuilderConf);
+
+        KieSession ksession = kbase.newKieSession();
+
+        Person p = new Person("Mario", 40);
+        ksession.insert(p);
+        int fired = ksession.fireAllRules(10); // intentional loop to test propertySpecific DISABLED
+
+        assertThat(fired).isEqualTo(10);
+    }
+
+    private KieBase buildKieBaseFromExtractedModel(KieBuilder kieBuilder, KieBaseConfiguration kieBaseConf, KnowledgeBuilderConfiguration knowledgeBuilderConf) {
+        MemoryFileSystem trgMfs = ((KieBuilderImpl) kieBuilder).getTrgMfs();
+        TestByteArrayClassLoader cl = new TestByteArrayClassLoader(this.getClass().getClassLoader());
+        List<? extends Class<?>> classes = trgMfs.getMap().entrySet()
+                                                 .stream()
+                                                 .filter(entry -> entry.getKey().endsWith(".class"))
+                                                 .map(entry -> {
+                                                     String fileName = entry.getKey().asString();
+                                                     String className = fileName.replace("/", ".")
+                                                                                .replace(".class", "");
+                                                     return cl.defineClass(className, entry.getValue());
+                                                 }).collect(Collectors.toList());
+
+        return createKieBaseFromModelClass(classes, kieBaseConf, knowledgeBuilderConf);
+    }
+
+    private KieBase createKieBaseFromModelClass(final List<? extends Class<?>> classes, KieBaseConfiguration kieBaseConf, KnowledgeBuilderConfiguration knowledgeBuilderConf) {
+        return classes.stream()
+                      .filter(Model.class::isAssignableFrom)
+                      .findFirst()
+                      .map(c -> {
+                          try {
+                              return c.getDeclaredConstructor();
+                          } catch (NoSuchMethodException e) {
+                              throw new RuntimeException(e);
+                          }
+                      })
+                      .map(c -> {
+                          try {
+                              return c.newInstance();
+                          } catch (InstantiationException | IllegalAccessException | InvocationTargetException e) {
+                              throw new RuntimeException(e);
+                          }
+                      })
+                      .map(Model.class::cast)
+                      .map(model -> KieBaseBuilder.createKieBaseFromModel(model, kieBaseConf, knowledgeBuilderConf))
+                      .orElseThrow(() -> new RuntimeException("No Model class found"));
+    }
+
+    public static class TestByteArrayClassLoader extends ClassLoader {
+
+        public TestByteArrayClassLoader(final ClassLoader parent) {
+            super(parent);
+        }
+
+        public Class<?> defineClass(final String name, final byte[] bytes) {
+            return defineClass(name, bytes, 0, bytes.length, null);
+        }
+    }
+}

--- a/drools-model/drools-model-compiler/src/main/java/org/drools/modelcompiler/KieBaseBuilder.java
+++ b/drools-model/drools-model-compiler/src/main/java/org/drools/modelcompiler/KieBaseBuilder.java
@@ -16,6 +16,7 @@
 
 package org.drools.modelcompiler;
 
+import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
 
@@ -27,6 +28,7 @@ import org.kie.api.KieBaseConfiguration;
 import org.kie.api.KieServices;
 import org.kie.api.builder.model.KieBaseModel;
 import org.kie.api.conf.KieBaseOption;
+import org.kie.internal.builder.KnowledgeBuilderConfiguration;
 
 import static org.drools.compiler.kie.builder.impl.KieBuilderImpl.isPackageInKieBase;
 
@@ -62,6 +64,10 @@ public class KieBaseBuilder {
         return createKieBaseFromModel( Collections.singleton( model ), kieBaseConf );
     }
 
+    public static InternalKnowledgeBase createKieBaseFromModel( Model model, KieBaseConfiguration kieBaseConf, KnowledgeBuilderConfiguration knowledgeBuilderConf) {
+        return createKieBaseFromModel( Collections.singleton( model ), kieBaseConf, knowledgeBuilderConf );
+    }
+
     public static InternalKnowledgeBase createKieBaseFromModel( Collection<Model> models, KieBaseOption... options ) {
         KieBaseConfiguration kieBaseConf = KieServices.get().newKieBaseConfiguration();
         if (options != null) {
@@ -74,6 +80,12 @@ public class KieBaseBuilder {
 
     public static InternalKnowledgeBase createKieBaseFromModel( Collection<Model> models, KieBaseConfiguration kieBaseConf ) {
         KiePackagesBuilder builder = new KiePackagesBuilder(kieBaseConf);
+        models.forEach( builder::addModel );
+        return new KieBaseBuilder(kieBaseConf).createKieBase(builder.build());
+    }
+
+    public static InternalKnowledgeBase createKieBaseFromModel( Collection<Model> models, KieBaseConfiguration kieBaseConf, KnowledgeBuilderConfiguration knowledgeBuilderConf ) {
+        KiePackagesBuilder builder = new KiePackagesBuilder(kieBaseConf, knowledgeBuilderConf, new ArrayList<>());
         models.forEach( builder::addModel );
         return new KieBaseBuilder(kieBaseConf).createKieBase(builder.build());
     }


### PR DESCRIPTION
… specific disabled


**JIRA**: 
https://issues.redhat.com/browse/DROOLS-7239

<details>
<summary>
How to replicate CI configuration locally?
</summary>

Build Chain tool does "simple" maven build(s), the builds are just Maven commands, but because the repositories relates and depends on each other and any change in API or class method could affect several of those repositories there is a need to use [build-chain tool](https://github.com/kiegroup/github-action-build-chain) to handle cross repository builds and be sure that we always use latest version of the code for each repository.
 
[build-chain tool](https://github.com/kiegroup/github-action-build-chain) is a build tool which can be used on command line locally or in Github Actions workflow(s), in case you need to change multiple repositories and send multiple dependent pull requests related with a change you can easily reproduce the same build by executing it on Github hosted environment or locally in your development environment. See [local execution](https://github.com/kiegroup/github-action-build-chain#local-execution) details to get more information about it.
</details>

<details>
<summary>
How to retest this PR or trigger a specific build:
</summary>

- for <b>pull request checks</b>  
  Please add comment: <b>Jenkins retest this</b>

- for a <b>specific pull request check</b>  
  Please add comment: <b>Jenkins (re)run [drools|kogito-runtimes|kogito-apps|kogito-examples] tests</b>

- for a <b>full downstream build</b> 
  - for <b>jenkins</b> job: please add comment: <b>Jenkins run fdb</b>
  - for <b>github actions</b> job: add the label `run_fdb`

- <b>a compile downstream build</b> please  add comment: <b>Jenkins run cdb</b>

- <b>a full production downstream build</b> please add comment: <b>Jenkins execute product fdb</b>

- <b>an upstream build</b> please add comment: <b>Jenkins run upstream</b>

- for <b>quarkus branch checks</b>  
  Run checks against Quarkus current used branch  
  Please add comment: <b>Jenkins run quarkus-branch</b>

- for a <b>quarkus branch specific check</b>  
  Run checks against Quarkus current used branch  
  Please add comment: <b>Jenkins (re)run [drools|kogito-runtimes|kogito-apps|kogito-examples] quarkus-branch</b>

- for <b>quarkus main checks</b>  
  Run checks against Quarkus main branch  
  Please add comment: <b>Jenkins run quarkus-main</b>

- for a <b>specific quarkus main check</b>  
  Run checks against Quarkus main branch  
  Please add comment: <b>Jenkins (re)run [drools|kogito-runtimes|kogito-apps|kogito-examples] quarkus-main</b>

- for <b>quarkus lts checks</b>  
  Run checks against Quarkus lts branch  
  Please add comment: <b>Jenkins run quarkus-lts</b>

- for a <b>specific quarkus lts check</b>  
  Run checks against Quarkus lts branch  
  Please add comment: <b>Jenkins (re)run [drools|kogito-runtimes|kogito-apps|kogito-examples] quarkus-lts</b>

- for <b>native checks</b>  
  Run native checks  
  Please add comment: <b>Jenkins run native</b>

- for a <b>specific native check</b>  
  Run native checks 
  Please add comment: <b>Jenkins (re)run [drools|kogito-runtimes|kogito-apps|kogito-examples] native</b>

- for <b>mandrel checks</b>  
  Run native checks against Mandrel image
  Please add comment: <b>Jenkins run mandrel</b>

- for a <b>specific mandrel check</b>  
  Run native checks against Mandrel image  
  Please add comment: <b>Jenkins (re)run [drools|kogito-runtimes|kogito-apps|kogito-examples] mandrel</b>

 - for <b>mandrel lts checks</b>  
  Run native checks against Mandrel image and quarkus lts branch
  Please add comment: <b>Jenkins run mandrel-lts</b>

- for a <b>specific mandrel lts check</b>  
  Run native checks against Mandrel image and quarkus lts branch
  Please add comment: <b>Jenkins (re)run [drools|kogito-runtimes|kogito-apps|kogito-examples] mandrel-lts</b>
</details>
