### PR TITLE
[FIX_EFESTO_FIRST_CACHE_POPULATION] Fix initialization of firstLevelCache

### DIFF
--- a/efesto/efesto-core/efesto-runtime-manager/efesto-runtime-manager-core/src/main/java/org/kie/efesto/runtimemanager/core/service/RuntimeManagerUtils.java
+++ b/efesto/efesto-core/efesto-runtime-manager/efesto-runtime-manager-core/src/main/java/org/kie/efesto/runtimemanager/core/service/RuntimeManagerUtils.java
@@ -16,6 +16,7 @@
 package org.kie.efesto.runtimemanager.core.service;
 
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -57,7 +58,7 @@ public class RuntimeManagerUtils {
                                         final Map<EfestoClassKey, List<KieRuntimeService>> toPopulate) {
         discoveredKieRuntimeServices.forEach(kieRuntimeService -> {
             EfestoClassKey efestoClassKey = kieRuntimeService.getEfestoClassKeyIdentifier();
-            toPopulate.merge(efestoClassKey, List.of(kieRuntimeService), (previous,
+            toPopulate.merge(efestoClassKey, new ArrayList<>(Collections.singletonList(kieRuntimeService)), (previous,
                                                                           toAdd) -> {
                 List<KieRuntimeService> toReturn = new ArrayList<>();
                 toReturn.addAll(previous);
@@ -122,14 +123,18 @@ public class RuntimeManagerUtils {
         Optional<KieRuntimeService> retrieved = getKieRuntimeServiceFromEfestoRuntimeContext(input, context);
         if (retrieved.isPresent()) {
             KieRuntimeService toAdd = retrieved.get();
-            List<KieRuntimeService> stored = firstLevelCache.get(input.getFirstLevelCacheKey());
-            if (stored == null) {
-                stored = new ArrayList<>();
-                firstLevelCache.put(input.getFirstLevelCacheKey(), stored);
-            }
-            stored.add(toAdd);
+            addKieRuntimeServiceToFirstLevelCache(toAdd, input.getFirstLevelCacheKey());
         }
         return retrieved;
+    }
+
+    static void addKieRuntimeServiceToFirstLevelCache(KieRuntimeService toAdd, EfestoClassKey firstLevelClassKey) {
+        List<KieRuntimeService> stored = firstLevelCache.get(firstLevelClassKey);
+        if (stored == null) {
+            stored = new ArrayList<>();
+            firstLevelCache.put(firstLevelClassKey, stored);
+        }
+        stored.add(toAdd);
     }
 
     static Optional<EfestoOutput> getOptionalOutput(EfestoRuntimeContext context, EfestoInput input) {

--- a/efesto/efesto-core/efesto-runtime-manager/efesto-runtime-manager-core/src/test/java/org/kie/efesto/runtimemanager/core/service/RuntimeManagerUtilsTest.java
+++ b/efesto/efesto-core/efesto-runtime-manager/efesto-runtime-manager-core/src/test/java/org/kie/efesto/runtimemanager/core/service/RuntimeManagerUtilsTest.java
@@ -54,6 +54,8 @@ class RuntimeManagerUtilsTest {
     private static KieRuntimeService kieRuntimeServiceB;
     private static KieRuntimeService kieRuntimeServiceC;
 
+    private static KieRuntimeService kieRuntimeServiceA_cloned;
+
     private static EfestoClassKey efestoClassKeyA;
     private static EfestoClassKey efestoClassKeyB;
     private static EfestoClassKey efestoClassKeyC;
@@ -76,6 +78,8 @@ class RuntimeManagerUtilsTest {
         kieRuntimeServiceC = mock(KieRuntimeService.class);
         efestoClassKeyC = new EfestoClassKey(List.class, String.class);
         when(kieRuntimeServiceC.getEfestoClassKeyIdentifier()).thenReturn(efestoClassKeyC);
+        kieRuntimeServiceA_cloned = mock(KieRuntimeService.class);
+        when(kieRuntimeServiceA_cloned.getEfestoClassKeyIdentifier()).thenReturn(efestoClassKeyA);
 
         // setup
         String path = "/example/some-id/instances/some-instance-id";
@@ -89,7 +93,8 @@ class RuntimeManagerUtilsTest {
     @Test
     void populateFirstLevelCache() {
         List<KieRuntimeService> discoveredKieRuntimeServices = Arrays.asList(kieRuntimeServiceA, kieRuntimeServiceB,
-                                                                             kieRuntimeServiceC);
+                                                                             kieRuntimeServiceC,
+                                                                             kieRuntimeServiceA_cloned);
         final Map<EfestoClassKey, List<KieRuntimeService>> toPopulate = new HashMap<>();
         RuntimeManagerUtils.populateFirstLevelCache(discoveredKieRuntimeServices, toPopulate);
         assertThat(toPopulate).hasSize(2);
@@ -97,10 +102,27 @@ class RuntimeManagerUtilsTest {
         List<KieRuntimeService> servicesA = toPopulate.get(efestoClassKeyA);
         List<KieRuntimeService> servicesB = toPopulate.get(efestoClassKeyB);
         assertThat(servicesA).isEqualTo(servicesB);
-        assertThat(servicesA).hasSize(2);
-        assertThat(servicesA).contains(kieRuntimeServiceA, kieRuntimeServiceB);
+        assertThat(servicesA).hasSize(3);
+        assertThat(servicesA).contains(kieRuntimeServiceA, kieRuntimeServiceB, kieRuntimeServiceA_cloned);
         List<KieRuntimeService> servicesC = toPopulate.get(efestoClassKeyC);
         assertThat(servicesC).containsExactly(kieRuntimeServiceC);
+    }
+
+    @Test
+    void addKieRuntimeServiceToFirstLevelCache() {
+        List<KieRuntimeService> discoveredKieRuntimeServices = Arrays.asList(kieRuntimeServiceA);
+        final Map<EfestoClassKey, List<KieRuntimeService>> toPopulate = new HashMap<>();
+        RuntimeManagerUtils.populateFirstLevelCache(discoveredKieRuntimeServices, toPopulate);
+        assertThat(toPopulate).hasSize(1);
+        assertThat(toPopulate).containsKeys(efestoClassKeyA);
+        List<KieRuntimeService> servicesA = toPopulate.get(efestoClassKeyA);
+        assertThat(servicesA).containsExactly(kieRuntimeServiceA);
+
+        RuntimeManagerUtils.firstLevelCache.putAll(toPopulate);
+        RuntimeManagerUtils.addKieRuntimeServiceToFirstLevelCache(kieRuntimeServiceA_cloned, efestoClassKeyA);
+        servicesA = RuntimeManagerUtils.firstLevelCache.get(efestoClassKeyA);
+        assertThat(servicesA).containsExactly(kieRuntimeServiceA, kieRuntimeServiceA_cloned);
+
     }
 
     @Test


### PR DESCRIPTION
@danielezonca @pibizza 

Before this fix, if only one kieruntimeservice was found for a given efestokey, the first levelCache was initialized with an immutable list, that lead to exception if a kieruntimeservice had to be add later. 
The original method has been split in two for sake of testing.

**referenced Pull Requests**: _(please edit the URLs of referenced pullrequests if they exist)_

* paste the link(s) from GitHub here
* link 2
* link 3 etc.

<details>
<summary>
How to replicate CI configuration locally?
</summary>

Build Chain tool does "simple" maven build(s), the builds are just Maven commands, but because the repositories relates and depends on each other and any change in API or class method could affect several of those repositories there is a need to use [build-chain tool](https://github.com/kiegroup/github-action-build-chain) to handle cross repository builds and be sure that we always use latest version of the code for each repository.
 
[build-chain tool](https://github.com/kiegroup/github-action-build-chain) is a build tool which can be used on command line locally or in Github Actions workflow(s), in case you need to change multiple repositories and send multiple dependent pull requests related with a change you can easily reproduce the same build by executing it on Github hosted environment or locally in your development environment. See [local execution](https://github.com/kiegroup/github-action-build-chain#local-execution) details to get more information about it.
</details>

<details>
<summary>
How to retest this PR or trigger a specific build:
</summary>

- for <b>pull request checks</b>  
  Please add comment: <b>Jenkins retest this</b>

- for a <b>specific pull request check</b>  
  Please add comment: <b>Jenkins (re)run [drools|kogito-runtimes|kogito-apps|kogito-examples] tests</b>

- for a <b>full downstream build</b> 
  - for <b>jenkins</b> job: please add comment: <b>Jenkins run fdb</b>
  - for <b>github actions</b> job: add the label `run_fdb`

- <b>a compile downstream build</b> please  add comment: <b>Jenkins run cdb</b>

- <b>a full production downstream build</b> please add comment: <b>Jenkins execute product fdb</b>

- <b>an upstream build</b> please add comment: <b>Jenkins run upstream</b>

- for <b>quarkus branch checks</b>  
  Run checks against Quarkus current used branch  
  Please add comment: <b>Jenkins run quarkus-branch</b>

- for a <b>quarkus branch specific check</b>  
  Run checks against Quarkus current used branch  
  Please add comment: <b>Jenkins (re)run [drools|kogito-runtimes|kogito-apps|kogito-examples] quarkus-branch</b>

- for <b>quarkus main checks</b>  
  Run checks against Quarkus main branch  
  Please add comment: <b>Jenkins run quarkus-main</b>

- for a <b>specific quarkus main check</b>  
  Run checks against Quarkus main branch  
  Please add comment: <b>Jenkins (re)run [drools|kogito-runtimes|kogito-apps|kogito-examples] quarkus-main</b>

- for <b>quarkus lts checks</b>  
  Run checks against Quarkus lts branch  
  Please add comment: <b>Jenkins run quarkus-lts</b>

- for a <b>specific quarkus lts check</b>  
  Run checks against Quarkus lts branch  
  Please add comment: <b>Jenkins (re)run [drools|kogito-runtimes|kogito-apps|kogito-examples] quarkus-lts</b>

- for <b>native checks</b>  
  Run native checks  
  Please add comment: <b>Jenkins run native</b>

- for a <b>specific native check</b>  
  Run native checks 
  Please add comment: <b>Jenkins (re)run [drools|kogito-runtimes|kogito-apps|kogito-examples] native</b>

- for <b>mandrel checks</b>  
  Run native checks against Mandrel image
  Please add comment: <b>Jenkins run mandrel</b>

- for a <b>specific mandrel check</b>  
  Run native checks against Mandrel image  
  Please add comment: <b>Jenkins (re)run [drools|kogito-runtimes|kogito-apps|kogito-examples] mandrel</b>

 - for <b>mandrel lts checks</b>  
  Run native checks against Mandrel image and quarkus lts branch
  Please add comment: <b>Jenkins run mandrel-lts</b>

- for a <b>specific mandrel lts check</b>  
  Run native checks against Mandrel image and quarkus lts branch
  Please add comment: <b>Jenkins (re)run [drools|kogito-runtimes|kogito-apps|kogito-examples] mandrel-lts</b>
</details>
