### PR TITLE
[7.x] [DROOLS-7250] executable-model fails with mvel boolean property assig…

### DIFF
--- a/drools-model/drools-model-compiler/src/test/java/org/drools/modelcompiler/MvelDialectTest.java
+++ b/drools-model/drools-model-compiler/src/test/java/org/drools/modelcompiler/MvelDialectTest.java
@@ -29,6 +29,7 @@ import java.util.Set;
 import org.drools.modelcompiler.domain.Address;
 import org.drools.modelcompiler.domain.InternationalAddress;
 import org.drools.modelcompiler.domain.Person;
+import org.drools.modelcompiler.domain.ValueHolder;
 
 import org.junit.Test;
 import org.kie.api.builder.Message;
@@ -1540,5 +1541,51 @@ public class MvelDialectTest extends BaseModelTest {
         assertThat(p.getAge()).isEqualTo(20);
         assertThat(p.getAddresses().size()).isEqualTo(0);
         assertThat(fired).isEqualTo(1);
+    }
+
+    @Test
+    public void assign_primitiveBooleanProperty() {
+        // DROOLS-7250
+        String str = "package com.example.reproducer\n" +
+                     "import " + ValueHolder.class.getCanonicalName() + ";\n" +
+                     "rule R\n" +
+                     "dialect \"mvel\"\n" +
+                     "when\n" +
+                     "  $holder : ValueHolder()\n" +
+                     "then\n" +
+                     "  $holder.primitiveBooleanValue = true;\n" +
+                     "end";
+
+        KieSession ksession = getKieSession(str);
+
+        ValueHolder holder = new ValueHolder();
+        holder.setPrimitiveBooleanValue(false);
+        ksession.insert(holder);
+        ksession.fireAllRules();
+
+        assertThat(holder.isPrimitiveBooleanValue()).isTrue();
+    }
+
+    @Test
+    public void assign_wrapperBooleanProperty() {
+        // DROOLS-7250
+        String str = "package com.example.reproducer\n" +
+                     "import " + ValueHolder.class.getCanonicalName() + ";\n" +
+                     "rule R\n" +
+                     "dialect \"mvel\"\n" +
+                     "when\n" +
+                     "  $holder : ValueHolder()\n" +
+                     "then\n" +
+                     "  $holder.wrapperBooleanValue = true;\n" +
+                     "end";
+
+        KieSession ksession = getKieSession(str);
+
+        ValueHolder holder = new ValueHolder();
+        holder.setWrapperBooleanValue(false);
+        ksession.insert(holder);
+        ksession.fireAllRules();
+
+        assertThat(holder.getWrapperBooleanValue()).isTrue();
     }
 }

--- a/drools-model/drools-model-compiler/src/test/java/org/drools/modelcompiler/domain/ValueHolder.java
+++ b/drools-model/drools-model-compiler/src/test/java/org/drools/modelcompiler/domain/ValueHolder.java
@@ -25,6 +25,9 @@ public class ValueHolder {
     private BigDecimal bdValue;
     private Object objValue;
 
+    private boolean primitiveBooleanValue;
+    private Boolean wrapperBooleanValue;
+
     public ValueHolder() {}
 
     public int getIntValue() {
@@ -59,4 +62,19 @@ public class ValueHolder {
         this.objValue = objValue;
     }
 
+    public boolean isPrimitiveBooleanValue() {
+        return primitiveBooleanValue;
+    }
+
+    public void setPrimitiveBooleanValue(boolean primitiveBooleanValue) {
+        this.primitiveBooleanValue = primitiveBooleanValue;
+    }
+
+    public Boolean getWrapperBooleanValue() {
+        return wrapperBooleanValue;
+    }
+
+    public void setWrapperBooleanValue(Boolean wrapperBooleanValue) {
+        this.wrapperBooleanValue = wrapperBooleanValue;
+    }
 }

--- a/drools-model/drools-mvel-compiler/src/main/java/org/drools/mvelcompiler/RHSPhase.java
+++ b/drools-model/drools-mvel-compiler/src/main/java/org/drools/mvelcompiler/RHSPhase.java
@@ -29,6 +29,7 @@ import com.github.javaparser.ast.body.VariableDeclarator;
 import com.github.javaparser.ast.expr.ArrayAccessExpr;
 import com.github.javaparser.ast.expr.AssignExpr;
 import com.github.javaparser.ast.expr.BinaryExpr;
+import com.github.javaparser.ast.expr.BooleanLiteralExpr;
 import com.github.javaparser.ast.expr.CastExpr;
 import com.github.javaparser.ast.expr.CharLiteralExpr;
 import com.github.javaparser.ast.expr.EnclosedExpr;
@@ -57,6 +58,7 @@ import org.drools.mvelcompiler.ast.BigDecimalArithmeticExprT;
 import org.drools.mvelcompiler.ast.BigDecimalConvertedExprT;
 import org.drools.mvelcompiler.ast.BigIntegerConvertedExprT;
 import org.drools.mvelcompiler.ast.BinaryExprT;
+import org.drools.mvelcompiler.ast.BooleanLiteralExpressionT;
 import org.drools.mvelcompiler.ast.CastExprT;
 import org.drools.mvelcompiler.ast.CharacterLiteralExpressionT;
 import org.drools.mvelcompiler.ast.FieldAccessTExpr;
@@ -313,6 +315,11 @@ public class RHSPhase implements DrlGenericVisitor<TypedExpression, RHSPhase.Con
     @Override
     public TypedExpression visit(LongLiteralExpr n, Context arg) {
         return new LongLiteralExpressionT(n);
+    }
+
+    @Override
+    public TypedExpression visit(BooleanLiteralExpr n, Context arg) {
+        return new BooleanLiteralExpressionT(n);
     }
 
     @Override

--- a/drools-model/drools-mvel-compiler/src/main/java/org/drools/mvelcompiler/ast/BooleanLiteralExpressionT.java
+++ b/drools-model/drools-mvel-compiler/src/main/java/org/drools/mvelcompiler/ast/BooleanLiteralExpressionT.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright 2022 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.drools.mvelcompiler.ast;
+
+import java.lang.reflect.Type;
+import java.util.Optional;
+
+import com.github.javaparser.ast.Node;
+import com.github.javaparser.ast.expr.BooleanLiteralExpr;
+
+public class BooleanLiteralExpressionT implements TypedExpression {
+
+    private final BooleanLiteralExpr booleanLiteralExpr;
+
+    public BooleanLiteralExpressionT(BooleanLiteralExpr booleanLiteralExpr) {
+        this.booleanLiteralExpr = booleanLiteralExpr;
+    }
+
+    @Override
+    public Optional<Type> getType() {
+        return Optional.of(boolean.class);
+    }
+
+    @Override
+    public Node toJavaExpression() {
+        return booleanLiteralExpr;
+    }
+
+    @Override
+    public String toString() {
+        return "BooleanLiteralExpressionT{" +
+               "originalExpression=" + booleanLiteralExpr +
+               '}';
+    }
+}


### PR DESCRIPTION
…nment in RHS (#4844)

**Ports** 
This is a backport PR of https://github.com/kiegroup/drools/pull/4844 for 7.x

**JIRA**: 
https://issues.redhat.com/browse/DROOLS-7250

<details>
<summary>
How to replicate CI configuration locally?
</summary>

Build Chain tool does "simple" maven build(s), the builds are just Maven commands, but because the repositories relates and depends on each other and any change in API or class method could affect several of those repositories there is a need to use [build-chain tool](https://github.com/kiegroup/github-action-build-chain) to handle cross repository builds and be sure that we always use latest version of the code for each repository.
 
[build-chain tool](https://github.com/kiegroup/github-action-build-chain) is a build tool which can be used on command line locally or in Github Actions workflow(s), in case you need to change multiple repositories and send multiple dependent pull requests related with a change you can easily reproduce the same build by executing it on Github hosted environment or locally in your development environment. See [local execution](https://github.com/kiegroup/github-action-build-chain#local-execution) details to get more information about it.
</details>

<details>
<summary>
How to retest this PR or trigger a specific build:
</summary>

- for <b>pull request checks</b>  
  Please add comment: <b>Jenkins retest this</b>

- for a <b>specific pull request check</b>  
  Please add comment: <b>Jenkins (re)run [drools|kogito-runtimes|kogito-apps|kogito-examples] tests</b>

- for a <b>full downstream build</b> 
  - for <b>jenkins</b> job: please add comment: <b>Jenkins run fdb</b>
  - for <b>github actions</b> job: add the label `run_fdb`

- <b>a compile downstream build</b> please  add comment: <b>Jenkins run cdb</b>

- <b>a full production downstream build</b> please add comment: <b>Jenkins execute product fdb</b>

- <b>an upstream build</b> please add comment: <b>Jenkins run upstream</b>

- for <b>quarkus branch checks</b>  
  Run checks against Quarkus current used branch  
  Please add comment: <b>Jenkins run quarkus-branch</b>

- for a <b>quarkus branch specific check</b>  
  Run checks against Quarkus current used branch  
  Please add comment: <b>Jenkins (re)run [drools|kogito-runtimes|kogito-apps|kogito-examples] quarkus-branch</b>

- for <b>quarkus main checks</b>  
  Run checks against Quarkus main branch  
  Please add comment: <b>Jenkins run quarkus-main</b>

- for a <b>specific quarkus main check</b>  
  Run checks against Quarkus main branch  
  Please add comment: <b>Jenkins (re)run [drools|kogito-runtimes|kogito-apps|kogito-examples] quarkus-main</b>

- for <b>quarkus lts checks</b>  
  Run checks against Quarkus lts branch  
  Please add comment: <b>Jenkins run quarkus-lts</b>

- for a <b>specific quarkus lts check</b>  
  Run checks against Quarkus lts branch  
  Please add comment: <b>Jenkins (re)run [drools|kogito-runtimes|kogito-apps|kogito-examples] quarkus-lts</b>

- for <b>native checks</b>  
  Run native checks  
  Please add comment: <b>Jenkins run native</b>

- for a <b>specific native check</b>  
  Run native checks 
  Please add comment: <b>Jenkins (re)run [drools|kogito-runtimes|kogito-apps|kogito-examples] native</b>

- for <b>mandrel checks</b>  
  Run native checks against Mandrel image
  Please add comment: <b>Jenkins run mandrel</b>

- for a <b>specific mandrel check</b>  
  Run native checks against Mandrel image  
  Please add comment: <b>Jenkins (re)run [drools|kogito-runtimes|kogito-apps|kogito-examples] mandrel</b>

 - for <b>mandrel lts checks</b>  
  Run native checks against Mandrel image and quarkus lts branch
  Please add comment: <b>Jenkins run mandrel-lts</b>

- for a <b>specific mandrel lts check</b>  
  Run native checks against Mandrel image and quarkus lts branch
  Please add comment: <b>Jenkins (re)run [drools|kogito-runtimes|kogito-apps|kogito-examples] mandrel-lts</b>
</details>
