### PR TITLE
DROOLS-7228 Add drools-drl-quarkus-extension to Quarkus Platform

### DIFF
--- a/bom/drools-bom/pom.xml
+++ b/bom/drools-bom/pom.xml
@@ -571,6 +571,12 @@
         <groupId>org.drools</groupId>
         <artifactId>drools-drl-quarkus-deployment</artifactId>
         <version>${project.version}</version>
+        <type>pom</type>
+      </dependency>
+      <dependency>
+        <groupId>org.drools</groupId>
+        <artifactId>drools-drl-quarkus-deployment</artifactId>
+        <version>${project.version}</version>
         <type>test-jar</type>
         <scope>test</scope>
       </dependency>

--- a/drools-drl-quarkus-extension/drools-drl-quarkus-deployment/pom.xml
+++ b/drools-drl-quarkus-extension/drools-drl-quarkus-deployment/pom.xml
@@ -44,8 +44,12 @@
             <groupId>org.drools</groupId>
             <artifactId>drools-model-codegen</artifactId>
         </dependency>
+      <dependency>
+          <groupId>org.kie</groupId>
+          <artifactId>kie-drl-map-input-runtime</artifactId>
+      </dependency>
 
-        <!-- quarkus -->
+      <!-- quarkus -->
         <dependency>
             <groupId>io.quarkus</groupId>
             <artifactId>quarkus-core-deployment</artifactId>
@@ -74,10 +78,6 @@
       <groupId>org.mockito</groupId>
       <artifactId>mockito-core</artifactId>
       <scope>test</scope>
-    </dependency>
-    <dependency>
-      <groupId>org.kie</groupId>
-      <artifactId>kie-drl-map-input-runtime</artifactId>
     </dependency>
 
   </dependencies>

--- a/drools-drl-quarkus-extension/drools-drl-quarkus-integration-test-hotreload/pom.xml
+++ b/drools-drl-quarkus-extension/drools-drl-quarkus-integration-test-hotreload/pom.xml
@@ -51,6 +51,7 @@
         <dependency>
             <groupId>org.drools</groupId>
             <artifactId>drools-drl-quarkus-deployment</artifactId>
+            <type>pom</type>
             <scope>test</scope>
             <exclusions>
                 <exclusion>

--- a/drools-drl-quarkus-extension/drools-drl-quarkus-integration-test/pom.xml
+++ b/drools-drl-quarkus-extension/drools-drl-quarkus-integration-test/pom.xml
@@ -50,6 +50,7 @@
         <dependency>
             <groupId>org.drools</groupId>
             <artifactId>drools-drl-quarkus-deployment</artifactId>
+            <type>pom</type>
             <scope>test</scope>
             <exclusions>
                 <exclusion>

--- a/drools-drl-quarkus-extension/drools-drl-quarkus-integration-test/src/test/java/org/drools/quarkus/test/RuntimeTest.java
+++ b/drools-drl-quarkus-extension/drools-drl-quarkus-integration-test/src/test/java/org/drools/quarkus/test/RuntimeTest.java
@@ -15,15 +15,15 @@
  */
 package org.drools.quarkus.test;
 
-import java.util.List;
-import java.util.stream.Collectors;
-import javax.inject.Inject;
-
 import io.quarkus.test.junit.QuarkusTest;
 import org.junit.jupiter.api.Test;
 import org.kie.api.definition.KiePackage;
-import org.kie.api.runtime.KieSession;
 import org.kie.api.runtime.KieRuntimeBuilder;
+import org.kie.api.runtime.KieSession;
+
+import javax.inject.Inject;
+import java.util.List;
+import java.util.stream.Collectors;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;

--- a/drools-drl-quarkus-extension/drools-drl-quarkus-quickstart-test/pom.xml
+++ b/drools-drl-quarkus-extension/drools-drl-quarkus-quickstart-test/pom.xml
@@ -46,6 +46,7 @@
         <dependency>
             <groupId>org.drools</groupId>
             <artifactId>drools-drl-quarkus-deployment</artifactId>
+            <type>pom</type>
             <scope>test</scope>
             <exclusions>
                 <exclusion>

--- a/drools-drl-quarkus-extension/drools-drl-quarkus-ruleunit-integration-test/pom.xml
+++ b/drools-drl-quarkus-extension/drools-drl-quarkus-ruleunit-integration-test/pom.xml
@@ -49,6 +49,7 @@
         <dependency>
             <groupId>org.drools</groupId>
             <artifactId>drools-drl-quarkus-deployment</artifactId>
+            <type>pom</type>
             <scope>test</scope>
             <exclusions>
                 <exclusion>

--- a/drools-drl-quarkus-extension/drools-drl-quarkus-ruleunit-integration-test/src/test/java/org/drools/quarkus/ruleunit/test/RuntimeDslRuleUnitTest.java
+++ b/drools-drl-quarkus-extension/drools-drl-quarkus-ruleunit-integration-test/src/test/java/org/drools/quarkus/ruleunit/test/RuntimeDslRuleUnitTest.java
@@ -1,11 +1,11 @@
 package org.drools.quarkus.ruleunit.test;
 
-import javax.inject.Inject;
-
 import io.quarkus.test.junit.QuarkusTest;
 import org.drools.ruleunits.api.RuleUnit;
 import org.drools.ruleunits.api.RuleUnitInstance;
 import org.junit.jupiter.api.Test;
+
+import javax.inject.Inject;
 
 import static org.assertj.core.api.Assertions.assertThat;
 

--- a/drools-drl-quarkus-extension/drools-drl-quarkus-ruleunit-integration-test/src/test/java/org/drools/quarkus/ruleunit/test/RuntimeTest.java
+++ b/drools-drl-quarkus-extension/drools-drl-quarkus-ruleunit-integration-test/src/test/java/org/drools/quarkus/ruleunit/test/RuntimeTest.java
@@ -15,12 +15,12 @@
  */
 package org.drools.quarkus.ruleunit.test;
 
-import javax.inject.Inject;
-
 import io.quarkus.test.junit.QuarkusTest;
 import org.drools.ruleunits.api.RuleUnit;
 import org.drools.ruleunits.api.RuleUnitInstance;
 import org.junit.jupiter.api.Test;
+
+import javax.inject.Inject;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 


### PR DESCRIPTION
- ❌ drools-drl-quarkus-integration-test
- ✅ drools-drl-quarkus-integration-test-hotreload
- ✅ drools-drl-quarkus-ruleunit-integration-test

I am disabling those tests in platform for now as the issue seems to be related in how the file is read from the jar in the platform test runner (it doesn't really affect real-world usage)

I'll create a follow-up ticket for that