### PR TITLE
[DROOLS-7196] Overloaded method resolution is different between mvel …

### DIFF
--- a/.github/workflows/drools-docs-pr.yml
+++ b/.github/workflows/drools-docs-pr.yml
@@ -28,5 +28,6 @@ jobs:
           java-version: ${{ matrix.java-version }}
           maven-version: ${{ matrix.maven-version }}
           cache-key-prefix: ${{ runner.os }}-${{ matrix.java-version }}-maven${{ matrix.maven-version }}
+          allow-snapshots: true
       - name: Build with Maven
         run: mvn -B clean install --file drools-docs/pom.xml

--- a/drools-docs/src/modules/ROOT/pages/migration-guide/_nonexec-model-to-exec-model.adoc
+++ b/drools-docs/src/modules/ROOT/pages/migration-guide/_nonexec-model-to-exec-model.adoc
@@ -67,7 +67,7 @@ end
 ----
 
 === Invalid coercion
-For example, Java allows coercion from `int` to `long`. However, Java doesn't allow coercion from `int` to `Long`. If you have a rule to call `setWrapperLong` method which accepts `Long`,
+For example, Java allows coercion from `int` to `long`. However, Java doesn't allow coercion from `int` to `Long`. If you have the rule to call the `setWrapperLong` method which accepts `Long`.
 
 [source]
 ----

--- a/drools-docs/src/modules/ROOT/pages/migration-guide/_nonexec-model-to-exec-model.adoc
+++ b/drools-docs/src/modules/ROOT/pages/migration-guide/_nonexec-model-to-exec-model.adoc
@@ -80,7 +80,7 @@ then
 end
 ----
 
-`non-executable model` coerces `10` to `Long`, so it doesn't throw an Exception. However, `executable model` throws a build error.
+`non-executable model` coerces `10` to `Long`, so it doesn't throw an Exception. However, the `executable model` throws a build error.
 ----
 The method setWrapperLong(Long) in the type Fact is not applicable for the arguments (int)
 ----

--- a/drools-docs/src/modules/ROOT/pages/migration-guide/_nonexec-model-to-exec-model.adoc
+++ b/drools-docs/src/modules/ROOT/pages/migration-guide/_nonexec-model-to-exec-model.adoc
@@ -65,3 +65,30 @@ then
   }
 end
 ----
+
+=== Invalid coercion
+For example, Java allows coercion from `int` to `long`. However, Java doesn't allow coercion from `int` to `Long`. If you have a rule to call `setWrapperLong` method which accepts `Long`,
+
+[source]
+----
+rule Rule1
+dialect "mvel"
+when
+  $f : Fact()
+then
+  $f.setWrapperLong(10);
+end
+----
+
+`non-executable model` coerces `10` to `Long`, so it doesn't throw an Exception. However, `executable model` throws a build error.
+----
+The method setWrapperLong(Long) in the type Fact is not applicable for the arguments (int)
+----
+
+In this case, the rule can be easily fixed by using valid Java syntax. For example,
+----
+ ...
+then
+  $f.setWrapperLong(10L);
+end
+----

--- a/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/integrationtests/KnownExecModelDifferenceTest.java
+++ b/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/integrationtests/KnownExecModelDifferenceTest.java
@@ -1,0 +1,158 @@
+/*
+ * Copyright 2022 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+*/
+
+package org.drools.mvel.integrationtests;
+
+import java.util.Collection;
+
+import org.drools.mvel.integrationtests.facts.VarargsFact;
+import org.drools.testcoverage.common.util.KieBaseTestConfiguration;
+import org.drools.testcoverage.common.util.KieBaseUtil;
+import org.drools.testcoverage.common.util.KieUtil;
+import org.drools.testcoverage.common.util.TestParametersUtil;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+import org.kie.api.KieBase;
+import org.kie.api.builder.KieBuilder;
+import org.kie.api.builder.Message.Level;
+import org.kie.api.runtime.KieSession;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * This is a place where known behavior differences between exec-model and non-exec-model.
+ * They are not treated as a bug and should be documented in "Migration from non-executable model to executable model" section
+ */
+@RunWith(Parameterized.class)
+public class KnownExecModelDifferenceTest {
+
+    private final KieBaseTestConfiguration kieBaseTestConfiguration;
+
+    public KnownExecModelDifferenceTest(final KieBaseTestConfiguration kieBaseTestConfiguration) {
+        this.kieBaseTestConfiguration = kieBaseTestConfiguration;
+    }
+
+    @Parameterized.Parameters(name = "KieBase type={0}")
+    public static Collection<Object[]> getParameters() {
+        return TestParametersUtil.getKieBaseCloudConfigurations(true);
+    }
+
+    @Test
+    public void setter_intToWrapperLongCoercion() {
+        // DROOLS-7196
+        // Java doesn't coerce int to Long
+        String str = "package com.example.reproducer\n" +
+                     "import " + VarargsFact.class.getCanonicalName() + ";\n" +
+                     "rule R\n" +
+                     "dialect \"mvel\"\n" +
+                     "when\n" +
+                     "  $f : VarargsFact()\n" +
+                     "then\n" +
+                     "  $f.setOneWrapperValue(10);\n" +
+                     "end";
+
+        if (kieBaseTestConfiguration.isExecutableModel()) {
+            KieBuilder kieBuilder = KieUtil.getKieBuilderFromDrls(kieBaseTestConfiguration, false, str);
+            assertThat(kieBuilder.getResults().hasMessages(Level.ERROR)).isTrue(); // Fail with exec-model
+        } else {
+            KieBase kbase = KieBaseUtil.getKieBaseFromKieModuleFromDrl("test", kieBaseTestConfiguration, str);
+            KieSession ksession = kbase.newKieSession();
+
+            VarargsFact fact = new VarargsFact();
+            ksession.insert(fact);
+            ksession.fireAllRules();
+
+            assertThat(fact.getValueList()).containsExactly(10L); // Coerced with non-exec-model
+        }
+    }
+
+    @Test
+    public void setter_intToPrimitiveLongCoercion() {
+        // DROOLS-7196
+        // Java coerces int to long
+        String str = "package com.example.reproducer\n" +
+                     "import " + VarargsFact.class.getCanonicalName() + ";\n" +
+                     "rule R\n" +
+                     "dialect \"mvel\"\n" +
+                     "when\n" +
+                     "  $f : VarargsFact()\n" +
+                     "then\n" +
+                     "  $f.setOnePrimitiveValue(10);\n" +
+                     "end";
+
+        KieBase kbase = KieBaseUtil.getKieBaseFromKieModuleFromDrl("test", kieBaseTestConfiguration, str);
+        KieSession ksession = kbase.newKieSession();
+
+        VarargsFact fact = new VarargsFact();
+        ksession.insert(fact);
+        ksession.fireAllRules();
+
+        assertThat(fact.getValueList()).containsExactly(10L); // Coerced with both cases
+    }
+
+    @Test
+    public void setter_intToWrapperLongCoercionVarargs() {
+        // DROOLS-7196
+        // Java doesn't coerce int to Long. Same for varargs
+        String str = "package com.example.reproducer\n" +
+                     "import " + VarargsFact.class.getCanonicalName() + ";\n" +
+                     "rule R\n" +
+                     "dialect \"mvel\"\n" +
+                     "when\n" +
+                     "  $f : VarargsFact()\n" +
+                     "then\n" +
+                     "  $f.setWrapperValues(10, 20);\n" +
+                     "end";
+
+        if (kieBaseTestConfiguration.isExecutableModel()) {
+            KieBuilder kieBuilder = KieUtil.getKieBuilderFromDrls(kieBaseTestConfiguration, false, str);
+            assertThat(kieBuilder.getResults().hasMessages(Level.ERROR)).isTrue(); // Fail with exec-model
+        } else {
+            KieBase kbase = KieBaseUtil.getKieBaseFromKieModuleFromDrl("test", kieBaseTestConfiguration, str);
+            KieSession ksession = kbase.newKieSession();
+
+            VarargsFact fact = new VarargsFact();
+            ksession.insert(fact);
+            ksession.fireAllRules();
+
+            assertThat(fact.getValueList()).containsExactly(10L, 20L); // Coerced with non-exec-model
+        }
+    }
+
+    @Test
+    public void setter_intToPrimitiveLongCoercionVarargs() {
+        // DROOLS-7196
+        // Java coerces int to long. Same for varargs
+        String str = "package com.example.reproducer\n" +
+                     "import " + VarargsFact.class.getCanonicalName() + ";\n" +
+                     "rule R\n" +
+                     "dialect \"mvel\"\n" +
+                     "when\n" +
+                     "  $f : VarargsFact()\n" +
+                     "then\n" +
+                     "  $f.setPrimitiveValues(10, 20);\n" +
+                     "end";
+
+        KieBase kbase = KieBaseUtil.getKieBaseFromKieModuleFromDrl("test", kieBaseTestConfiguration, str);
+        KieSession ksession = kbase.newKieSession();
+
+        VarargsFact fact = new VarargsFact();
+        ksession.insert(fact);
+        ksession.fireAllRules();
+
+        assertThat(fact.getValueList()).containsExactly(10L, 20L); // Coerced with both cases
+    }
+}

--- a/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/integrationtests/facts/VarargsFact.java
+++ b/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/integrationtests/facts/VarargsFact.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright 2022 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.drools.mvel.integrationtests.facts;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.stream.Collectors;
+
+public class VarargsFact {
+
+    private List<Long> valueList = new ArrayList<>();
+
+    public VarargsFact() {}
+
+    public List<Long> getValueList() {
+        return valueList;
+    }
+
+    public void setWrapperValues(Long... values) {
+        valueList = Arrays.asList(values);
+    }
+
+    public void setPrimitiveValues(long... values) {
+        valueList = Arrays.stream(values).boxed().collect(Collectors.toList());
+    }
+
+    public void setOneWrapperValue(Long value) {
+        valueList = Arrays.asList(new Long[]{value});
+    }
+
+    public void setOnePrimitiveValue(long value) {
+        valueList = Arrays.asList(new Long[]{value});
+    }
+}


### PR DESCRIPTION
…and executable model (varargs)

- Java doesn't coerce int to Long (Wrapper class). It's not a varargs issue
- Documented as known difference
- Added KnownExecModelDifferenceTest for this kind of behavior differences


**JIRA**:
https://issues.redhat.com/browse/DROOLS-7196



<details>
<summary>
How to replicate CI configuration locally?
</summary>

Build Chain tool does "simple" maven build(s), the builds are just Maven commands, but because the repositories relates and depends on each other and any change in API or class method could affect several of those repositories there is a need to use [build-chain tool](https://github.com/kiegroup/github-action-build-chain) to handle cross repository builds and be sure that we always use latest version of the code for each repository.
 
[build-chain tool](https://github.com/kiegroup/github-action-build-chain) is a build tool which can be used on command line locally or in Github Actions workflow(s), in case you need to change multiple repositories and send multiple dependent pull requests related with a change you can easily reproduce the same build by executing it on Github hosted environment or locally in your development environment. See [local execution](https://github.com/kiegroup/github-action-build-chain#local-execution) details to get more information about it.
</details>

<details>
<summary>
How to retest this PR or trigger a specific build:
</summary>

- for <b>pull request checks</b>  
  Please add comment: <b>Jenkins retest this</b>

- for a <b>specific pull request check</b>  
  Please add comment: <b>Jenkins (re)run [drools|kogito-runtimes|kogito-apps|kogito-examples] tests</b>

- for a <b>full downstream build</b> 
  - for <b>jenkins</b> job: please add comment: <b>Jenkins run fdb</b>
  - for <b>github actions</b> job: add the label `run_fdb`

- <b>a compile downstream build</b> please  add comment: <b>Jenkins run cdb</b>

- <b>a full production downstream build</b> please add comment: <b>Jenkins execute product fdb</b>

- <b>an upstream build</b> please add comment: <b>Jenkins run upstream</b>

- for <b>quarkus branch checks</b>  
  Run checks against Quarkus current used branch  
  Please add comment: <b>Jenkins run quarkus-branch</b>

- for a <b>quarkus branch specific check</b>  
  Run checks against Quarkus current used branch  
  Please add comment: <b>Jenkins (re)run [drools|kogito-runtimes|kogito-apps|kogito-examples] quarkus-branch</b>

- for <b>quarkus main checks</b>  
  Run checks against Quarkus main branch  
  Please add comment: <b>Jenkins run quarkus-main</b>

- for a <b>specific quarkus main check</b>  
  Run checks against Quarkus main branch  
  Please add comment: <b>Jenkins (re)run [drools|kogito-runtimes|kogito-apps|kogito-examples] quarkus-main</b>

- for <b>quarkus lts checks</b>  
  Run checks against Quarkus lts branch  
  Please add comment: <b>Jenkins run quarkus-lts</b>

- for a <b>specific quarkus lts check</b>  
  Run checks against Quarkus lts branch  
  Please add comment: <b>Jenkins (re)run [drools|kogito-runtimes|kogito-apps|kogito-examples] quarkus-lts</b>

- for <b>native checks</b>  
  Run native checks  
  Please add comment: <b>Jenkins run native</b>

- for a <b>specific native check</b>  
  Run native checks 
  Please add comment: <b>Jenkins (re)run [drools|kogito-runtimes|kogito-apps|kogito-examples] native</b>

- for <b>mandrel checks</b>  
  Run native checks against Mandrel image
  Please add comment: <b>Jenkins run mandrel</b>

- for a <b>specific mandrel check</b>  
  Run native checks against Mandrel image  
  Please add comment: <b>Jenkins (re)run [drools|kogito-runtimes|kogito-apps|kogito-examples] mandrel</b>

 - for <b>mandrel lts checks</b>  
  Run native checks against Mandrel image and quarkus lts branch
  Please add comment: <b>Jenkins run mandrel-lts</b>

- for a <b>specific mandrel lts check</b>  
  Run native checks against Mandrel image and quarkus lts branch
  Please add comment: <b>Jenkins (re)run [drools|kogito-runtimes|kogito-apps|kogito-examples] mandrel-lts</b>
</details>
