### PR TITLE
Review scope of maven-model to be provided

### DIFF
--- a/build-parent/pom.xml
+++ b/build-parent/pom.xml
@@ -676,6 +676,7 @@
         <groupId>org.apache.maven</groupId>
         <artifactId>maven-model</artifactId>
         <version>${version.org.apache.maven}</version>
+        <scope>provided</scope>
       </dependency>
       <dependency>
         <groupId>org.apache.maven</groupId>


### PR DESCRIPTION
Fixes the following waring during build

```
Some dependencies of Maven Plugins are expected to be in provided scope.
Please make sure that dependencies listed below declared in POM
have set '<scope>provided</scope>' as well.

The following dependencies are in wrong scope:
 * org.apache.maven:maven-model:jar:3.8.6:compile
```