### PR TITLE
[DROOLS-7197] Generics work different in executable model than in MVEL

### DIFF
--- a/drools-docs/src/modules/ROOT/pages/migration-guide/_nonexec-model-to-exec-model.adoc
+++ b/drools-docs/src/modules/ROOT/pages/migration-guide/_nonexec-model-to-exec-model.adoc
@@ -92,3 +92,66 @@ then
   $f.setWrapperLong(10L);
 end
 ----
+
+=== Generics return type resolution
+Assuming you have classes below:
+
+.parent class
+[source,java]
+----
+public abstract class Vehicle<TEngine extends Engine> {
+        // ...
+
+	public abstract TEngine getEngine();
+
+	public TEngine getMotor() {
+		return getEngine();
+	}
+----
+
+.sub class
+[source,java]
+----
+public class DieselCar extends Vehicle<DieselEngine> {
+	private final DieselEngine engine;
+
+	public DieselCar(String maker, String model, int kw, boolean adBlueRequired) {
+		super(maker, model);
+		this.engine = new DieselEngine(kw, adBlueRequired);
+	}
+
+	@Override
+	public DieselEngine getEngine() {
+		return engine;
+	}
+}
+----
+
+[source,java]
+----
+public class DieselEngine extends Engine {
+
+	private final boolean adBlueRequired;
+----
+
+.rule
+----
+rule Rule1
+	when
+		$v : DieselCar(motor.adBlueRequired == true)
+	then
+		// do something
+end
+----
+
+`non-executable model` can dynamically resolve that `mortor` is `DieselEngine` so the rule works. However, `executable model` resolves  `mortor` to `TEngine`, so a build error is thrown.
+
+----
+Unknown field adBlueRequired on TEngine
+----
+
+In this case, the rule can be fixed by specifying the subtype with `#` operator. For example,
+----
+	when
+		$v : DieselCar(motor#DieselEngine.adBlueRequired == true)
+----

--- a/drools-docs/src/modules/ROOT/pages/migration-guide/_nonexec-model-to-exec-model.adoc
+++ b/drools-docs/src/modules/ROOT/pages/migration-guide/_nonexec-model-to-exec-model.adoc
@@ -150,7 +150,7 @@ end
 Unknown field adBlueRequired on TEngine
 ----
 
-In this case, the rule can be fixed by specifying the subtype with `#` operator. For example,
+In this case, the rule can be fixed by specifying the subtype with the `#` operator. For example,
 ----
 	when
 		$v : DieselCar(motor#DieselEngine.adBlueRequired == true)

--- a/drools-docs/src/modules/ROOT/pages/migration-guide/_nonexec-model-to-exec-model.adoc
+++ b/drools-docs/src/modules/ROOT/pages/migration-guide/_nonexec-model-to-exec-model.adoc
@@ -144,7 +144,7 @@ rule Rule1
 end
 ----
 
-`non-executable model` can dynamically resolve that `mortor` is `DieselEngine` so the rule works. However, `executable model` resolves  `mortor` to `TEngine`, so a build error is thrown.
+`non-executable model` can dynamically resolve that `motor` is `DieselEngine` so the rule works. However, the `executable model` resolves  `motor` to `TEngine`, so a build error is thrown.
 
 ----
 Unknown field adBlueRequired on TEngine

--- a/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/integrationtests/KnownExecModelDifferenceTest.java
+++ b/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/integrationtests/KnownExecModelDifferenceTest.java
@@ -3,7 +3,7 @@
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
- * 
+ *
  *      http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
@@ -11,13 +11,15 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
-*/
+ */
 
 package org.drools.mvel.integrationtests;
 
 import java.util.Collection;
 
 import org.drools.mvel.integrationtests.facts.VarargsFact;
+import org.drools.mvel.integrationtests.facts.vehicles.DieselCar;
+import org.drools.mvel.integrationtests.facts.vehicles.ElectricCar;
 import org.drools.testcoverage.common.util.KieBaseTestConfiguration;
 import org.drools.testcoverage.common.util.KieBaseUtil;
 import org.drools.testcoverage.common.util.KieUtil;
@@ -55,14 +57,14 @@ public class KnownExecModelDifferenceTest {
         // DROOLS-7196
         // Java doesn't coerce int to Long
         String str = "package com.example.reproducer\n" +
-                     "import " + VarargsFact.class.getCanonicalName() + ";\n" +
-                     "rule R\n" +
-                     "dialect \"mvel\"\n" +
-                     "when\n" +
-                     "  $f : VarargsFact()\n" +
-                     "then\n" +
-                     "  $f.setOneWrapperValue(10);\n" +
-                     "end";
+                "import " + VarargsFact.class.getCanonicalName() + ";\n" +
+                "rule R\n" +
+                "dialect \"mvel\"\n" +
+                "when\n" +
+                "  $f : VarargsFact()\n" +
+                "then\n" +
+                "  $f.setOneWrapperValue(10);\n" +
+                "end";
 
         if (kieBaseTestConfiguration.isExecutableModel()) {
             KieBuilder kieBuilder = KieUtil.getKieBuilderFromDrls(kieBaseTestConfiguration, false, str);
@@ -70,7 +72,6 @@ public class KnownExecModelDifferenceTest {
         } else {
             KieBase kbase = KieBaseUtil.getKieBaseFromKieModuleFromDrl("test", kieBaseTestConfiguration, str);
             KieSession ksession = kbase.newKieSession();
-
             VarargsFact fact = new VarargsFact();
             ksession.insert(fact);
             ksession.fireAllRules();
@@ -84,14 +85,14 @@ public class KnownExecModelDifferenceTest {
         // DROOLS-7196
         // Java coerces int to long
         String str = "package com.example.reproducer\n" +
-                     "import " + VarargsFact.class.getCanonicalName() + ";\n" +
-                     "rule R\n" +
-                     "dialect \"mvel\"\n" +
-                     "when\n" +
-                     "  $f : VarargsFact()\n" +
-                     "then\n" +
-                     "  $f.setOnePrimitiveValue(10);\n" +
-                     "end";
+                "import " + VarargsFact.class.getCanonicalName() + ";\n" +
+                "rule R\n" +
+                "dialect \"mvel\"\n" +
+                "when\n" +
+                "  $f : VarargsFact()\n" +
+                "then\n" +
+                "  $f.setOnePrimitiveValue(10);\n" +
+                "end";
 
         KieBase kbase = KieBaseUtil.getKieBaseFromKieModuleFromDrl("test", kieBaseTestConfiguration, str);
         KieSession ksession = kbase.newKieSession();
@@ -108,14 +109,14 @@ public class KnownExecModelDifferenceTest {
         // DROOLS-7196
         // Java doesn't coerce int to Long. Same for varargs
         String str = "package com.example.reproducer\n" +
-                     "import " + VarargsFact.class.getCanonicalName() + ";\n" +
-                     "rule R\n" +
-                     "dialect \"mvel\"\n" +
-                     "when\n" +
-                     "  $f : VarargsFact()\n" +
-                     "then\n" +
-                     "  $f.setWrapperValues(10, 20);\n" +
-                     "end";
+                "import " + VarargsFact.class.getCanonicalName() + ";\n" +
+                "rule R\n" +
+                "dialect \"mvel\"\n" +
+                "when\n" +
+                "  $f : VarargsFact()\n" +
+                "then\n" +
+                "  $f.setWrapperValues(10, 20);\n" +
+                "end";
 
         if (kieBaseTestConfiguration.isExecutableModel()) {
             KieBuilder kieBuilder = KieUtil.getKieBuilderFromDrls(kieBaseTestConfiguration, false, str);
@@ -137,14 +138,14 @@ public class KnownExecModelDifferenceTest {
         // DROOLS-7196
         // Java coerces int to long. Same for varargs
         String str = "package com.example.reproducer\n" +
-                     "import " + VarargsFact.class.getCanonicalName() + ";\n" +
-                     "rule R\n" +
-                     "dialect \"mvel\"\n" +
-                     "when\n" +
-                     "  $f : VarargsFact()\n" +
-                     "then\n" +
-                     "  $f.setPrimitiveValues(10, 20);\n" +
-                     "end";
+                "import " + VarargsFact.class.getCanonicalName() + ";\n" +
+                "rule R\n" +
+                "dialect \"mvel\"\n" +
+                "when\n" +
+                "  $f : VarargsFact()\n" +
+                "then\n" +
+                "  $f.setPrimitiveValues(10, 20);\n" +
+                "end";
 
         KieBase kbase = KieBaseUtil.getKieBaseFromKieModuleFromDrl("test", kieBaseTestConfiguration, str);
         KieSession ksession = kbase.newKieSession();
@@ -154,5 +155,58 @@ public class KnownExecModelDifferenceTest {
         ksession.fireAllRules();
 
         assertThat(fact.getValueList()).containsExactly(10L, 20L); // Coerced with both cases
+    }
+
+    @Test
+    public void property_subClassMethod_genericsReturnType() {
+        // DROOLS-7197
+        String str = "package com.example.reproducer\n" +
+                "import " + DieselCar.class.getCanonicalName() + ";\n" +
+                "rule R\n" +
+                "dialect \"mvel\"\n" +
+                "when\n" +
+                "  $v : DieselCar(motor.adBlueRequired == true)\n" +
+                "then\n" +
+                "  $v.score = 5;\n" +
+                "end";
+
+        if (kieBaseTestConfiguration.isExecutableModel()) {
+            KieBuilder kieBuilder = KieUtil.getKieBuilderFromDrls(kieBaseTestConfiguration, false, str);
+            assertThat(kieBuilder.getResults().hasMessages(Level.ERROR)).isTrue(); // Fail with exec-model
+        } else {
+            KieBase kbase = KieBaseUtil.getKieBaseFromKieModuleFromDrl("test", kieBaseTestConfiguration, str);
+            KieSession ksession = kbase.newKieSession();
+
+            DieselCar dieselCar = new DieselCar("ABC", "Model 1.6", 85, true);
+
+            ksession.insert(dieselCar);
+            ksession.fireAllRules();
+
+            assertThat(dieselCar.getScore()).isEqualTo(5);
+        }
+    }
+
+    @Test
+    public void property_subClassMethod_explicitReturnType() {
+        // DROOLS-7197
+        String str = "package com.example.reproducer\n" +
+                "import " + ElectricCar.class.getCanonicalName() + ";\n" +
+                "rule R\n" +
+                "dialect \"mvel\"\n" +
+                "when\n" +
+                "  $v : ElectricCar(engine.batterySize > 70)\n" +
+                "then\n" +
+                "  $v.score = 5;\n" +
+                "end";
+
+        KieBase kbase = KieBaseUtil.getKieBaseFromKieModuleFromDrl("test", kieBaseTestConfiguration, str);
+        KieSession ksession = kbase.newKieSession();
+
+        ElectricCar electricCar = new ElectricCar("XYZ", "Model 3", 200, 90);
+
+        ksession.insert(electricCar);
+        ksession.fireAllRules();
+
+        assertThat(electricCar.getScore()).isEqualTo(5); // works for both cases
     }
 }

--- a/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/integrationtests/facts/vehicles/DieselCar.java
+++ b/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/integrationtests/facts/vehicles/DieselCar.java
@@ -1,0 +1,31 @@
+/*
+ * Copyright 2022 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+*/
+package org.drools.mvel.integrationtests.facts.vehicles;
+
+public class DieselCar extends Vehicle<DieselEngine> {
+
+    private final DieselEngine engine;
+
+    public DieselCar(String maker, String model, int kw, boolean adBlueRequired) {
+        super(maker, model);
+        this.engine = new DieselEngine(kw, adBlueRequired);
+    }
+
+    @Override
+    public DieselEngine getEngine() {
+        return engine;
+    }
+
+}

--- a/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/integrationtests/facts/vehicles/DieselEngine.java
+++ b/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/integrationtests/facts/vehicles/DieselEngine.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright 2022 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+*/
+package org.drools.mvel.integrationtests.facts.vehicles;
+
+public class DieselEngine extends Engine {
+
+    private boolean dirty;
+
+    private final boolean adBlueRequired;
+
+    public DieselEngine(int kw, boolean adBlueRequired) {
+        super(kw);
+        this.adBlueRequired = adBlueRequired;
+    }
+
+    public boolean isAdBlueRequired() {
+        return adBlueRequired;
+    }
+
+    @Override
+    boolean isZeroEmissions() {
+        return false;
+    }
+
+    public boolean isDirty() {
+        return dirty;
+    }
+
+    public void setDirty(boolean dirty) {
+        this.dirty = dirty;
+    }
+
+}

--- a/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/integrationtests/facts/vehicles/ElectricCar.java
+++ b/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/integrationtests/facts/vehicles/ElectricCar.java
@@ -1,0 +1,31 @@
+/*
+ * Copyright 2022 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+*/
+package org.drools.mvel.integrationtests.facts.vehicles;
+
+public class ElectricCar extends Vehicle<ElectricEngine> {
+
+    private final ElectricEngine electricEngine;
+
+    public ElectricCar(String maker, String model, int kw, int batterySize) {
+        super(maker, model);
+        this.electricEngine = new ElectricEngine(kw, batterySize);
+    }
+
+    @Override
+    public ElectricEngine getEngine() {
+        return electricEngine;
+    }
+
+}

--- a/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/integrationtests/facts/vehicles/ElectricEngine.java
+++ b/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/integrationtests/facts/vehicles/ElectricEngine.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright 2022 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+*/
+package org.drools.mvel.integrationtests.facts.vehicles;
+
+public class ElectricEngine extends Engine {
+
+    private final int batterySize;
+
+    public ElectricEngine(int kw, int batterySize) {
+        super(kw);
+        this.batterySize = batterySize;
+    }
+
+    @Override
+    boolean isZeroEmissions() {
+        return true;
+    }
+
+    public int getBatterySize() {
+        return batterySize;
+    }
+
+}

--- a/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/integrationtests/facts/vehicles/Engine.java
+++ b/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/integrationtests/facts/vehicles/Engine.java
@@ -1,0 +1,31 @@
+/*
+ * Copyright 2022 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+*/
+package org.drools.mvel.integrationtests.facts.vehicles;
+
+public abstract class Engine {
+
+    private final int kw;
+
+    public Engine(int kw) {
+        this.kw = kw;
+    }
+
+    public int getKw() {
+        return kw;
+    }
+
+    abstract boolean isZeroEmissions();
+
+}

--- a/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/integrationtests/facts/vehicles/Vehicle.java
+++ b/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/integrationtests/facts/vehicles/Vehicle.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright 2022 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+*/
+package org.drools.mvel.integrationtests.facts.vehicles;
+
+import java.util.Objects;
+
+public abstract class Vehicle<TEngine extends Engine> {
+
+    private final String maker;
+    private final String model;
+
+    private int score;
+
+    public Vehicle(String maker, String model) {
+        this.maker = Objects.requireNonNull(maker);
+        this.model = Objects.requireNonNull(model);
+    }
+
+    public String getMaker() {
+        return maker;
+    }
+
+    public String getModel() {
+        return model;
+    }
+
+    public abstract TEngine getEngine();
+
+    public TEngine getMotor() {
+        return getEngine();
+    }
+
+    public int getScore() {
+        return score;
+    }
+
+    public void setScore(int score) {
+        this.score = score;
+    }
+}


### PR DESCRIPTION
- Cannot resolve the type in exec-model
- Added to KnownExecModelDifferenceTest
- Added docs

**JIRA**: 
https://issues.redhat.com/browse/DROOLS-7197

<details>
<summary>
How to replicate CI configuration locally?
</summary>

Build Chain tool does "simple" maven build(s), the builds are just Maven commands, but because the repositories relates and depends on each other and any change in API or class method could affect several of those repositories there is a need to use [build-chain tool](https://github.com/kiegroup/github-action-build-chain) to handle cross repository builds and be sure that we always use latest version of the code for each repository.
 
[build-chain tool](https://github.com/kiegroup/github-action-build-chain) is a build tool which can be used on command line locally or in Github Actions workflow(s), in case you need to change multiple repositories and send multiple dependent pull requests related with a change you can easily reproduce the same build by executing it on Github hosted environment or locally in your development environment. See [local execution](https://github.com/kiegroup/github-action-build-chain#local-execution) details to get more information about it.
</details>

<details>
<summary>
How to retest this PR or trigger a specific build:
</summary>

- for <b>pull request checks</b>  
  Please add comment: <b>Jenkins retest this</b>

- for a <b>specific pull request check</b>  
  Please add comment: <b>Jenkins (re)run [drools|kogito-runtimes|kogito-apps|kogito-examples] tests</b>

- for a <b>full downstream build</b> 
  - for <b>jenkins</b> job: please add comment: <b>Jenkins run fdb</b>
  - for <b>github actions</b> job: add the label `run_fdb`

- <b>a compile downstream build</b> please  add comment: <b>Jenkins run cdb</b>

- <b>a full production downstream build</b> please add comment: <b>Jenkins execute product fdb</b>

- <b>an upstream build</b> please add comment: <b>Jenkins run upstream</b>

- for <b>quarkus branch checks</b>  
  Run checks against Quarkus current used branch  
  Please add comment: <b>Jenkins run quarkus-branch</b>

- for a <b>quarkus branch specific check</b>  
  Run checks against Quarkus current used branch  
  Please add comment: <b>Jenkins (re)run [drools|kogito-runtimes|kogito-apps|kogito-examples] quarkus-branch</b>

- for <b>quarkus main checks</b>  
  Run checks against Quarkus main branch  
  Please add comment: <b>Jenkins run quarkus-main</b>

- for a <b>specific quarkus main check</b>  
  Run checks against Quarkus main branch  
  Please add comment: <b>Jenkins (re)run [drools|kogito-runtimes|kogito-apps|kogito-examples] quarkus-main</b>

- for <b>quarkus lts checks</b>  
  Run checks against Quarkus lts branch  
  Please add comment: <b>Jenkins run quarkus-lts</b>

- for a <b>specific quarkus lts check</b>  
  Run checks against Quarkus lts branch  
  Please add comment: <b>Jenkins (re)run [drools|kogito-runtimes|kogito-apps|kogito-examples] quarkus-lts</b>

- for <b>native checks</b>  
  Run native checks  
  Please add comment: <b>Jenkins run native</b>

- for a <b>specific native check</b>  
  Run native checks 
  Please add comment: <b>Jenkins (re)run [drools|kogito-runtimes|kogito-apps|kogito-examples] native</b>

- for <b>mandrel checks</b>  
  Run native checks against Mandrel image
  Please add comment: <b>Jenkins run mandrel</b>

- for a <b>specific mandrel check</b>  
  Run native checks against Mandrel image  
  Please add comment: <b>Jenkins (re)run [drools|kogito-runtimes|kogito-apps|kogito-examples] mandrel</b>

 - for <b>mandrel lts checks</b>  
  Run native checks against Mandrel image and quarkus lts branch
  Please add comment: <b>Jenkins run mandrel-lts</b>

- for a <b>specific mandrel lts check</b>  
  Run native checks against Mandrel image and quarkus lts branch
  Please add comment: <b>Jenkins (re)run [drools|kogito-runtimes|kogito-apps|kogito-examples] mandrel-lts</b>
</details>
