### PR TITLE
[7.x] [DROOLS-7195] Modify syntax fails when using executable model, works …

### DIFF
--- a/drools-model/drools-model-compiler/src/test/java/org/drools/modelcompiler/CompilationFailuresTest.java
+++ b/drools-model/drools-model-compiler/src/test/java/org/drools/modelcompiler/CompilationFailuresTest.java
@@ -135,11 +135,12 @@ public class CompilationFailuresTest extends BaseModelTest {
 
 
     @Test
-    public void testModifyOnFactInScope() {
-        // DROOLS-5242
+    public void modify_factInScope_java() {
+        // DROOLS-5242, DROOLS-7195
         String drl =
                 "import " + Person.class.getCanonicalName() + ";" +
-                "rule R1 when\n" +
+                "rule R1\n" +
+                "when\n" +
                 "  $p : Person(name == \"Mario\")\n" +
                 "then\n" +
                 "  modify($p) { $p.setName(\"Mark\") }\n" +
@@ -147,9 +148,89 @@ public class CompilationFailuresTest extends BaseModelTest {
 
         Results results = getCompilationResults(drl);
         assertThat(results.getMessages(Message.Level.ERROR).isEmpty()).isFalse();
+    }
 
-        // RHS error : line = 1 with STANDARD_FROM_DRL (RuleDescr)
-        assertThat(results.getMessages().get(0).getLine()).isEqualTo(1);
+    @Test
+    public void modify_factInScope_mvel() {
+        // DROOLS-5242, DROOLS-7195
+        String drl =
+                "import " + Person.class.getCanonicalName() + ";" +
+                "rule R1\n" +
+                "dialect 'mvel'\n" +
+                "when\n" +
+                "  $p : Person(name == \"Mario\")\n" +
+                "then\n" +
+                "  modify($p) { $p.setName(\"Mark\") }\n" +
+                "end";
+
+        Results results = getCompilationResults(drl);
+        assertThat(results.getMessages(Message.Level.ERROR).isEmpty()).isFalse();
+    }
+
+    @Test
+    public void modify_factInScope_nestedPropertySetter_java() {
+        // DROOLS-5242, DROOLS-7195
+        String drl =
+                "import " + Person.class.getCanonicalName() + ";" +
+                "rule R1\n" +
+                "when\n" +
+                "  $p : Person(name == \"Mario\")\n" +
+                "then\n" +
+                "  modify($p) { $p.address.setCity(\"London\") }\n" +
+                "end";
+
+        Results results = getCompilationResults(drl);
+        assertThat(results.getMessages(Message.Level.ERROR).isEmpty()).isFalse();
+    }
+
+    @Test
+    public void modify_factInScope_nestedPropertySetter_mvel() {
+        // DROOLS-5242, DROOLS-7195
+        String drl =
+                "import " + Person.class.getCanonicalName() + ";" +
+                "rule R1\n" +
+                "dialect 'mvel'\n" +
+                "when\n" +
+                "  $p : Person(name == \"Mario\")\n" +
+                "then\n" +
+                "  modify($p) { $p.address.setCity(\"London\") }\n" +
+                "end";
+
+        Results results = getCompilationResults(drl);
+        assertThat(results.getMessages(Message.Level.ERROR).isEmpty()).isFalse();
+    }
+
+    @Test
+    public void modify_factInScope_nestedPropertyAssign_java() {
+        // DROOLS-5242, DROOLS-7195
+        String drl =
+                "import " + Person.class.getCanonicalName() + ";" +
+                "rule R1\n" +
+                "when\n" +
+                "  $p : Person(name == \"Mario\")\n" +
+                "then\n" +
+                "  modify($p) { $p.address.city = \"London\" }\n" +
+                "end";
+
+        Results results = getCompilationResults(drl);
+        assertThat(results.getMessages(Message.Level.ERROR).isEmpty()).isFalse();
+    }
+
+    @Test
+    public void modify_factInScope_nestedPropertyAssign_mvel() {
+        // DROOLS-5242, DROOLS-7195
+        String drl =
+                "import " + Person.class.getCanonicalName() + ";" +
+                "rule R1\n" +
+                "dialect 'mvel'\n" +
+                "when\n" +
+                "  $p : Person(name == \"Mario\")\n" +
+                "then\n" +
+                "  modify($p) { $p.address.city = \"London\" }\n" +
+                "end";
+
+        Results results = getCompilationResults(drl);
+        assertThat(results.getMessages(Message.Level.ERROR).isEmpty()).isFalse();
     }
 
     @Test

--- a/drools-model/drools-model-compiler/src/test/java/org/drools/modelcompiler/MvelDialectTest.java
+++ b/drools-model/drools-model-compiler/src/test/java/org/drools/modelcompiler/MvelDialectTest.java
@@ -27,6 +27,7 @@ import java.util.Map;
 import java.util.Set;
 
 import org.drools.modelcompiler.domain.Address;
+import org.drools.modelcompiler.domain.Counter;
 import org.drools.modelcompiler.domain.InternationalAddress;
 import org.drools.modelcompiler.domain.Person;
 import org.drools.modelcompiler.domain.ValueHolder;
@@ -1587,5 +1588,135 @@ public class MvelDialectTest extends BaseModelTest {
         ksession.fireAllRules();
 
         assertThat(holder.getWrapperBooleanValue()).isTrue();
+    }
+
+    public void assign_nestedProperty() {
+        // DROOLS-7195
+        String str = "package com.example.reproducer\n" +
+                "import " + Person.class.getCanonicalName() + ";\n" +
+                "rule R\n" +
+                "dialect \"mvel\"\n" +
+                "when\n" +
+                "  $p : Person()\n" +
+                "then\n" +
+                "  $p.address.city = \"Tokyo\";\n" +
+                "end";
+
+        KieSession ksession = getKieSession(str);
+
+        Person p = new Person("John");
+        p.setAddress(new Address("London"));
+        ksession.insert(p);
+        ksession.fireAllRules();
+
+        assertThat(p.getAddress().getCity()).isEqualTo("Tokyo");
+    }
+
+    @Test
+    public void assign_nestedPropertyInModify() {
+        // DROOLS-7195
+        String str = "package com.example.reproducer\n" +
+                "import " + Person.class.getCanonicalName() + ";\n" +
+                "rule R\n" +
+                "dialect \"mvel\"\n" +
+                "when\n" +
+                "  $p : Person(name == \"John\")\n" +
+                "then\n" +
+                "  modify($p) {" +
+                "    address.city = \"Tokyo\";\n" +
+                "  }\n" +
+                "end";
+
+        KieSession ksession = getKieSession(str);
+
+        Person p = new Person("John");
+        p.setAddress(new Address("London"));
+        ksession.insert(p);
+        ksession.fireAllRules();
+
+        assertThat(p.getAddress().getCity()).isEqualTo("Tokyo");
+    }
+
+    @Test
+    public void setter_nestedPropertyInModify() {
+        // DROOLS-7195
+        String str = "package com.example.reproducer\n" +
+                "import " + Person.class.getCanonicalName() + ";\n" +
+                "rule R\n" +
+                "dialect \"mvel\"\n" +
+                "when\n" +
+                "  $p : Person(name == \"John\")\n" +
+                "then\n" +
+                "  modify($p) {" +
+                "    address.setCity(\"Tokyo\");\n" +
+                "  }\n" +
+                "end";
+
+        KieSession ksession = getKieSession(str);
+
+        Person p = new Person("John");
+        p.setAddress(new Address("London"));
+        ksession.insert(p);
+        ksession.fireAllRules();
+
+        assertThat(p.getAddress().getCity()).isEqualTo("Tokyo");
+    }
+
+    @Test
+    public void assign_deepNestedPropertyInModify() {
+        // DROOLS-7195
+        String str = "package com.example.reproducer\n" +
+                "import " + Person.class.getCanonicalName() + ";\n" +
+                "rule R\n" +
+                "dialect \"mvel\"\n" +
+                "when\n" +
+                "  $p : Person(name == \"John\")\n" +
+                "then\n" +
+                "  modify($p) {" +
+                "    address.visitorCounter.value = 1;\n" +
+                "  }\n" +
+                "end";
+
+        KieSession ksession = getKieSession(str);
+
+        Person person = new Person("John");
+        Address address = new Address("London");
+        Counter counter = new Counter();
+        counter.setValue(0);
+        address.setVisitorCounter(counter);
+        person.setAddress(address);
+        ksession.insert(person);
+        ksession.fireAllRules();
+
+        assertThat(person.getAddress().getVisitorCounter().getValue()).isEqualTo(1);
+    }
+
+    @Test
+    public void setter_deepNestedPropertyInModify() {
+        // DROOLS-7195
+        String str = "package com.example.reproducer\n" +
+                "import " + Person.class.getCanonicalName() + ";\n" +
+                "rule R\n" +
+                "dialect \"mvel\"\n" +
+                "when\n" +
+                "  $p : Person(name == \"John\")\n" +
+                "then\n" +
+                "  modify($p) {" +
+                "    address.visitorCounter.setValue(1);\n" +
+                "  }\n" +
+                "end";
+
+        KieSession ksession = getKieSession(str);
+
+        Person person = new Person("John");
+        Address address = new Address("London");
+        Counter counter = new Counter();
+        counter.setValue(0);
+        address.setVisitorCounter(counter);
+        person.setAddress(address);
+        ksession.insert(person);
+        ksession.fireAllRules();
+
+        assertThat(person.getAddress().getVisitorCounter().getValue()).isEqualTo(1);
     }
 }

--- a/drools-model/drools-model-compiler/src/test/java/org/drools/modelcompiler/domain/Address.java
+++ b/drools-model/drools-model-compiler/src/test/java/org/drools/modelcompiler/domain/Address.java
@@ -6,6 +6,7 @@ public class Address {
     private int number;
     private short shortNumber;
     private String city;
+    private Counter visitorCounter = new Counter();
 
     public Address() {
         this("", 0, "");
@@ -56,6 +57,14 @@ public class Address {
 
     public void setShortNumber(short shortNumber) {
         this.shortNumber = shortNumber;
+    }
+
+    public Counter getVisitorCounter() {
+        return visitorCounter;
+    }
+
+    public void setVisitorCounter(Counter visitorCounter) {
+        this.visitorCounter = visitorCounter;
     }
 
     public int hashCode() {

--- a/drools-model/drools-model-compiler/src/test/java/org/drools/modelcompiler/domain/Counter.java
+++ b/drools-model/drools-model-compiler/src/test/java/org/drools/modelcompiler/domain/Counter.java
@@ -1,0 +1,29 @@
+/*
+ * Copyright 2022 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.drools.modelcompiler.domain;
+
+
+public class Counter {
+    private int value;
+
+    public int getValue() {
+        return value;
+    }
+
+    public void setValue(int value) {
+        this.value = value;
+    }
+}

--- a/drools-model/drools-mvel-compiler/src/main/java/org/drools/mvelcompiler/ModifyCompiler.java
+++ b/drools-model/drools-mvel-compiler/src/main/java/org/drools/mvelcompiler/ModifyCompiler.java
@@ -32,7 +32,7 @@ import static com.github.javaparser.ast.NodeList.nodeList;
 // A special case of compiler in which only the modify statements are processed
 public class ModifyCompiler {
 
-    private static final PreprocessPhase preprocessPhase = new PreprocessPhase(true);
+    private static final PreprocessPhase preprocessPhase = new PreprocessPhase();
 
     public CompiledBlockResult compile(String mvelBlock) {
 

--- a/drools-model/drools-mvel-compiler/src/main/java/org/drools/mvelcompiler/MvelCompiler.java
+++ b/drools-model/drools-mvel-compiler/src/main/java/org/drools/mvelcompiler/MvelCompiler.java
@@ -26,7 +26,6 @@ import com.github.javaparser.ast.stmt.BlockStmt;
 import com.github.javaparser.ast.stmt.Statement;
 import org.drools.mvel.parser.MvelParser;
 import org.drools.mvel.parser.ast.expr.ModifyStatement;
-import org.drools.mvel.parser.ast.expr.WithStatement;
 import org.drools.mvelcompiler.ast.TypedExpression;
 import org.drools.mvelcompiler.context.MvelCompilerContext;
 
@@ -56,13 +55,7 @@ public class MvelCompiler {
                 .flatMap(this::transformStatementWithPreprocessing)
                 .collect(toList());
 
-        List<String> withUsedBindings = mvelExpression.findAll(WithStatement.class)
-                .stream()
-                .flatMap(this::transformStatementWithPreprocessing)
-                .collect(toList());
-
         allUsedBindings.addAll(modifyUsedBindings);
-        allUsedBindings.addAll(withUsedBindings);
 
         // Entry point of the compiler
         TypedExpression compiledRoot = mvelExpression.accept(statementVisitor, null);

--- a/drools-model/drools-mvel-compiler/src/test/java/org/drools/mvelcompiler/MvelCompilerTest.java
+++ b/drools-model/drools-mvel-compiler/src/test/java/org/drools/mvelcompiler/MvelCompilerTest.java
@@ -774,29 +774,6 @@ public class MvelCompilerTest implements CompilerTest {
     }
 
     @Test
-    public void testWithSemiColon() {
-        test("{ with( $l = new ArrayList()) { $l.add(2); }; }",
-             "{ java.util.ArrayList $l = new java.util.ArrayList(); $l.add(2); }",
-             result -> assertThat(allUsedBindings(result)).isEmpty());
-    }
-
-    @Test
-    public void testWithWithAssignment() {
-        test(ctx -> ctx.addDeclaration("$p", Person.class),
-             "{ with($p = new Person()) { age = $p.age+1 }; }",
-             "{ org.drools.Person $p = new org.drools.Person(); $p.setAge($p.getAge() + 1); }",
-             result -> assertThat(allUsedBindings(result)).isEmpty());
-    }
-
-    @Test
-    public void testWithInIf() {
-        test(ctx -> ctx.addDeclaration("$p", Person.class),
-             "{ if (true) { with($p = new Person()) { age = $p.age+1 }; } }",
-             "{ if (true) { org.drools.Person $p = new org.drools.Person(); $p.setAge($p.getAge() + 1); } }",
-             result -> assertThat(allUsedBindings(result)).isEmpty());
-    }
-
-    @Test
     public void testAddCastToMapGet() {
         test(ctx -> ctx.addDeclaration("$map", Map.class),
              " { Map pMap = map.get( \"whatever\" ); }",
@@ -841,30 +818,6 @@ public class MvelCompilerTest implements CompilerTest {
                      "  } " +
                      "}",
              result -> assertThat(allUsedBindings(result)).containsExactlyInAnyOrder("$p"));
-    }
-
-    @Test
-    public void testWithOrdering() {
-        test(ctx -> ctx.addDeclaration("$p", Person.class),
-             "{ " +
-                     "        with( s0 = new Person() ) {\n" +
-                     "            age = 0\n" +
-                     "        }\n" +
-                     "        insertLogical(s0);\n" +
-                     "        with( s1 = new Person() ) {\n" +
-                     "            age = 1\n" +
-                     "        }\n" +
-                     "        insertLogical(s1);\n " +
-                     "     }",
-
-             "{ " +
-                     "org.drools.Person s0 = new org.drools.Person(); " +
-                     "s0.setAge(0); " +
-                     "insertLogical(s0);\n" +
-                     "org.drools.Person s1 = new org.drools.Person(); " +
-                     "s1.setAge(1);\n" +
-                     "insertLogical(s1);\n" +
-                     "}");
     }
 
     @Test

--- a/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/compiler/integrationtests/RuleChainingTest.java
+++ b/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/compiler/integrationtests/RuleChainingTest.java
@@ -68,13 +68,11 @@ public class RuleChainingTest {
                 "    dialect \"mvel\"\n" +
                 "    when\n" +
                 "    then\n" +
-                "        with( s0 = new Some() ) {\n" +
-                "            field = 0\n" +
-                "        }\n" +
+                "        Some s0 = new Some();\n" +
+                "        s0.field = 0;\n" +
                 "        insertLogical(s0);\n" +
-                "        with( s1 = new Some() ) {\n" +
-                "            field = 1\n" +
-                "        }\n" +
+                "        Some s1 = new Some();\n" +
+                "        s1.field = 1;\n" +
                 "        insertLogical(s1);\n" +
                 "end\n" +
                 "\n" +


### PR DESCRIPTION
…… (#4846)

* [DROOLS-7195] Modify syntax fails when using executable model, works with mvel runtime (nested properties)

* - Dropping 'with' statement support

**Ports** 
This is a backport PR of https://github.com/kiegroup/drools/pull/4846 for 7.x

**JIRA**: 
https://issues.redhat.com/browse/DROOLS-7195

<details>
<summary>
How to replicate CI configuration locally?
</summary>

Build Chain tool does "simple" maven build(s), the builds are just Maven commands, but because the repositories relates and depends on each other and any change in API or class method could affect several of those repositories there is a need to use [build-chain tool](https://github.com/kiegroup/github-action-build-chain) to handle cross repository builds and be sure that we always use latest version of the code for each repository.
 
[build-chain tool](https://github.com/kiegroup/github-action-build-chain) is a build tool which can be used on command line locally or in Github Actions workflow(s), in case you need to change multiple repositories and send multiple dependent pull requests related with a change you can easily reproduce the same build by executing it on Github hosted environment or locally in your development environment. See [local execution](https://github.com/kiegroup/github-action-build-chain#local-execution) details to get more information about it.
</details>

<details>
<summary>
How to retest this PR or trigger a specific build:
</summary>

- for <b>pull request checks</b>  
  Please add comment: <b>Jenkins retest this</b>

- for a <b>specific pull request check</b>  
  Please add comment: <b>Jenkins (re)run [drools|kogito-runtimes|kogito-apps|kogito-examples] tests</b>

- for a <b>full downstream build</b> 
  - for <b>jenkins</b> job: please add comment: <b>Jenkins run fdb</b>
  - for <b>github actions</b> job: add the label `run_fdb`

- <b>a compile downstream build</b> please  add comment: <b>Jenkins run cdb</b>

- <b>a full production downstream build</b> please add comment: <b>Jenkins execute product fdb</b>

- <b>an upstream build</b> please add comment: <b>Jenkins run upstream</b>

- for <b>quarkus branch checks</b>  
  Run checks against Quarkus current used branch  
  Please add comment: <b>Jenkins run quarkus-branch</b>

- for a <b>quarkus branch specific check</b>  
  Run checks against Quarkus current used branch  
  Please add comment: <b>Jenkins (re)run [drools|kogito-runtimes|kogito-apps|kogito-examples] quarkus-branch</b>

- for <b>quarkus main checks</b>  
  Run checks against Quarkus main branch  
  Please add comment: <b>Jenkins run quarkus-main</b>

- for a <b>specific quarkus main check</b>  
  Run checks against Quarkus main branch  
  Please add comment: <b>Jenkins (re)run [drools|kogito-runtimes|kogito-apps|kogito-examples] quarkus-main</b>

- for <b>quarkus lts checks</b>  
  Run checks against Quarkus lts branch  
  Please add comment: <b>Jenkins run quarkus-lts</b>

- for a <b>specific quarkus lts check</b>  
  Run checks against Quarkus lts branch  
  Please add comment: <b>Jenkins (re)run [drools|kogito-runtimes|kogito-apps|kogito-examples] quarkus-lts</b>

- for <b>native checks</b>  
  Run native checks  
  Please add comment: <b>Jenkins run native</b>

- for a <b>specific native check</b>  
  Run native checks 
  Please add comment: <b>Jenkins (re)run [drools|kogito-runtimes|kogito-apps|kogito-examples] native</b>

- for <b>mandrel checks</b>  
  Run native checks against Mandrel image
  Please add comment: <b>Jenkins run mandrel</b>

- for a <b>specific mandrel check</b>  
  Run native checks against Mandrel image  
  Please add comment: <b>Jenkins (re)run [drools|kogito-runtimes|kogito-apps|kogito-examples] mandrel</b>

 - for <b>mandrel lts checks</b>  
  Run native checks against Mandrel image and quarkus lts branch
  Please add comment: <b>Jenkins run mandrel-lts</b>

- for a <b>specific mandrel lts check</b>  
  Run native checks against Mandrel image and quarkus lts branch
  Please add comment: <b>Jenkins (re)run [drools|kogito-runtimes|kogito-apps|kogito-examples] mandrel-lts</b>
</details>
