### PR TITLE
[DROOLS-6994] KieContainer.verify() doesn't work with exec-model with…

### DIFF
--- a/drools-compiler/src/main/java/org/drools/compiler/kie/builder/impl/InternalKieModule.java
+++ b/drools-compiler/src/main/java/org/drools/compiler/kie/builder/impl/InternalKieModule.java
@@ -242,4 +242,8 @@ public interface InternalKieModule extends KieModule, Serializable {
     final class LocalLogger {
         private static final Logger logger = LoggerFactory.getLogger(InternalKieModule.class);
     }
+
+    default boolean isVerifiable() {
+        return true;
+    }
 }

--- a/drools-model/drools-model-compiler/src/main/java/org/drools/modelcompiler/CanonicalKieModule.java
+++ b/drools-model/drools-model-compiler/src/main/java/org/drools/modelcompiler/CanonicalKieModule.java
@@ -897,4 +897,9 @@ public class CanonicalKieModule implements InternalKieModule {
     public ReleaseId getReleaseId() {
         return internalKieModule.getReleaseId();
     }
+
+    @Override
+    public boolean isVerifiable() {
+        return false;
+    }
 }

--- a/drools-test-coverage/test-integration-nomvel/src/test/java/org/drools/compiler/integrationtests/nomvel/VerifyTest.java
+++ b/drools-test-coverage/test-integration-nomvel/src/test/java/org/drools/compiler/integrationtests/nomvel/VerifyTest.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright (c) 2022. Red Hat, Inc. and/or its affiliates.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.drools.compiler.integrationtests.nomvel;
+
+import org.drools.testcoverage.common.model.Person;
+import org.junit.Test;
+import org.kie.api.builder.Results;
+import org.kie.api.runtime.KieContainer;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.drools.compiler.integrationtests.nomvel.TestUtil.getKieContainer;
+
+public class VerifyTest {
+
+    @Test
+    public void verify_kieContainer_executableModel() throws Exception {
+        String drl =
+                "import " + Person.class.getCanonicalName() + " \n" +
+                     "rule R1\n" +
+                     "when\n" +
+                     " Person()\n" +
+                     "then\n" +
+                     "end";
+
+        final KieContainer kieContainer = getKieContainer(null, drl);
+
+        Results results = kieContainer.verify();
+        assertThat(results.getMessages().size()).isEqualTo(0);
+
+        Results resultsWithKieBaseName = kieContainer.verify("defaultKieBase");
+        assertThat(resultsWithKieBaseName.getMessages().size()).isEqualTo(0);
+    }
+}

--- a/drools-test-coverage/test-integration-nomvel/src/test/resources/logback-test.xml
+++ b/drools-test-coverage/test-integration-nomvel/src/test/resources/logback-test.xml
@@ -25,6 +25,7 @@
 
     <logger name="org.kie" level="warn"/>
     <logger name="org.drools" level="warn"/>
+    <logger name="org.drools.compiler.kie.builder.impl" level="info"/>
 
 <!--     <logger name="org.drools.core.management" level="debug"/> -->
 <!--    <logger name="org.drools.modelcompiler.builder" level="debug"/>-->


### PR DESCRIPTION
…out drools-mvel

**JIRA**: 
https://issues.redhat.com/browse/DROOLS-6994

This is a simplified version of https://github.com/kiegroup/drools/pull/4425

<details>
<summary>
How to replicate CI configuration locally?
</summary>

Build Chain tool does "simple" maven build(s), the builds are just Maven commands, but because the repositories relates and depends on each other and any change in API or class method could affect several of those repositories there is a need to use [build-chain tool](https://github.com/kiegroup/github-action-build-chain) to handle cross repository builds and be sure that we always use latest version of the code for each repository.
 
[build-chain tool](https://github.com/kiegroup/github-action-build-chain) is a build tool which can be used on command line locally or in Github Actions workflow(s), in case you need to change multiple repositories and send multiple dependent pull requests related with a change you can easily reproduce the same build by executing it on Github hosted environment or locally in your development environment. See [local execution](https://github.com/kiegroup/github-action-build-chain#local-execution) details to get more information about it.
</details>

<details>
<summary>
How to retest this PR or trigger a specific build:
</summary>

- for <b>pull request checks</b>  
  Please add comment: <b>Jenkins retest this</b>

- for a <b>specific pull request check</b>  
  Please add comment: <b>Jenkins (re)run [drools|kogito-runtimes|kogito-apps|kogito-examples] tests</b>

- for a <b>full downstream build</b> 
  - for <b>jenkins</b> job: please add comment: <b>Jenkins run fdb</b>
  - for <b>github actions</b> job: add the label `run_fdb`

- <b>a compile downstream build</b> please  add comment: <b>Jenkins run cdb</b>

- <b>a full production downstream build</b> please add comment: <b>Jenkins execute product fdb</b>

- <b>an upstream build</b> please add comment: <b>Jenkins run upstream</b>

- for <b>quarkus branch checks</b>  
  Run checks against Quarkus current used branch  
  Please add comment: <b>Jenkins run quarkus-branch</b>

- for a <b>quarkus branch specific check</b>  
  Run checks against Quarkus current used branch  
  Please add comment: <b>Jenkins (re)run [drools|kogito-runtimes|kogito-apps|kogito-examples] quarkus-branch</b>

- for <b>quarkus main checks</b>  
  Run checks against Quarkus main branch  
  Please add comment: <b>Jenkins run quarkus-main</b>

- for a <b>specific quarkus main check</b>  
  Run checks against Quarkus main branch  
  Please add comment: <b>Jenkins (re)run [drools|kogito-runtimes|kogito-apps|kogito-examples] quarkus-main</b>

- for <b>quarkus lts checks</b>  
  Run checks against Quarkus lts branch  
  Please add comment: <b>Jenkins run quarkus-lts</b>

- for a <b>specific quarkus lts check</b>  
  Run checks against Quarkus lts branch  
  Please add comment: <b>Jenkins (re)run [drools|kogito-runtimes|kogito-apps|kogito-examples] quarkus-lts</b>

- for <b>native checks</b>  
  Run native checks  
  Please add comment: <b>Jenkins run native</b>

- for a <b>specific native check</b>  
  Run native checks 
  Please add comment: <b>Jenkins (re)run [drools|kogito-runtimes|kogito-apps|kogito-examples] native</b>

- for <b>mandrel checks</b>  
  Run native checks against Mandrel image
  Please add comment: <b>Jenkins run mandrel</b>

- for a <b>specific mandrel check</b>  
  Run native checks against Mandrel image  
  Please add comment: <b>Jenkins (re)run [drools|kogito-runtimes|kogito-apps|kogito-examples] mandrel</b>

 - for <b>mandrel lts checks</b>  
  Run native checks against Mandrel image and quarkus lts branch
  Please add comment: <b>Jenkins run mandrel-lts</b>

- for a <b>specific mandrel lts check</b>  
  Run native checks against Mandrel image and quarkus lts branch
  Please add comment: <b>Jenkins (re)run [drools|kogito-runtimes|kogito-apps|kogito-examples] mandrel-lts</b>
</details>

<details>
<summary>
How to backport a pull request to a different branch?
</summary>

In order to automatically create a **backporting pull request** please add one or more labels having the following format `backport-<branch-name>`, where `<branch-name>` is the name of the branch where the pull request must be backported to (e.g., `backport-7.67.x` to backport the original PR to the `7.67.x` branch).

> **NOTE**: **backporting** is an action aiming to move a change (usually a commit) from a branch (usually the main one) to another one, which is generally referring to a still maintained release branch. Keeping it simple: it is about to move a specific change or a set of them from one branch to another.

Once the original pull request is successfully merged, the automated action will create one backporting pull request per each label (with the previous format) that has been added.

If something goes wrong, the author will be notified and at this point a manual backporting is needed.

> **NOTE**: this automated backporting is triggered whenever a pull request on `main` branch is labeled or closed, but both conditions must be satisfied to get the new PR created.
</details>