### PR TITLE
KOGITO-8400 Setup Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,95 @@
+mvn_opts=
+mvn_cmd=mvn $(mvn_opts)
+
+build_chain_branch=$(shell git branch --show-current)
+build_chain_file='https://raw.githubusercontent.com/kiegroup/drools/main/.ci/pull-request-config.yaml'
+build_chain_group='kiegroup'
+build_chain_project='kiegroup/drools'
+
+default: help
+
+.PHONY: build
+## Build the project
+build:
+	$(mvn_cmd) clean install
+
+.PHONY: build-quickly
+## Perform a quick build of the project
+build-quickly:
+	$(mvn_cmd) clean install -Dquickly
+
+.PHONY: build-upstream
+## Build (build-chain) upstream projects from the same branch. If needed, you can modify the `build_chain_file`, `build_chain_group` and `build_chain_branch` if needed.
+build-upstream: build-chain
+	export BUILD_MVN_OPTS="${mvn_opts}" && build-chain build cross_pr -f ${build_chain_file} -o /tmp/bc -p ${build_chain_project} -b ${build_chain_branch} -g ${build_chain_group} --skipParallelCheckout --skipProjectExecution kiegroup/drools --skipProjectCheckout kiegroup/drools
+
+.PHONY: build-pr
+pr_link=
+## Build (build-chain) projects from a given `pr_link` argument. If needed, you can also modify the `build_chain_file` and `build_chain_project` if needed.
+build-pr: build-chain
+	$(if $(pr_link),,$(error Please provide the 'pr_link' argument))
+	export BUILD_MVN_OPTS=${mvn_opts} && build-chain build cross_pr -f ${build_chain_file} -o /tmp/bc -p ${build_chain_project} -u ${pr_link} --skipParallelCheckout
+
+.PHONY: test
+## Launch full testing
+test:
+	$(mvn_cmd) clean verify
+
+.PHONY: quick-test
+## Launch unit testing
+quick-test:
+	$(mvn_cmd) clean verify -DquickTests
+
+.PHONY: deploy
+## Deploy the project
+deploy:
+	$(mvn_cmd) deploy
+
+.PHONY: clean
+## Clean the project
+clean:
+	$(mvn_cmd) clean
+
+.PHONY: mvn
+## Execute a Maven command with project configuration. Needs the `cmd` argument set
+mvn:
+	$(mvn_cmd) ${cmd}
+
+## Update the quarkus version. Needs the `quarkus_version` argument set
+update-quarkus:
+	export BUILD_MVN_OPTS=${mvn_opts} && .ci/environments/common/update_quarkus.sh ${quarkus_version}
+	$(MAKE) show-diff
+
+## Prepare the repository for a specific environment. Needs the `environment` argument set
+prepare-env:
+    export BUILD_MVN_OPTS=${mvn_opts} && .ci/environments/update.sh ${environment}
+
+## Show project dependencies
+tree:
+	$(mvn_cmd) dependency:tree
+
+## Show Git diff
+show-diff:
+	git status
+	git diff
+
+## This help screen
+help:
+	@printf "Available targets:\n\n"
+	@awk '/^[a-zA-Z\-_0-9%:\\]+/ { \
+		helpMessage = match(lastLine, /^## (.*)/); \
+		if (helpMessage) { \
+			helpCommand = $$1; \
+			helpMessage = substr(lastLine, RSTART + 3, RLENGTH); \
+			gsub("\\\\", "", helpCommand); \
+			gsub(":+$$", "", helpCommand); \
+			printf "  \x1b[32;01m%-35s\x1b[0m %s\n", helpCommand, helpMessage; \
+		} \
+	} \
+	{ lastLine = $$0 }' $(MAKEFILE_LIST)
+	@printf "\n"
+	@printf "All Maven commands can include some maven options via the \`mvn_opts\` argument !"
+	@printf "\n"
+
+build-chain:
+	which build-chain || npm i @kie/build-chain-action -g || printf "\nERROR: Cannot install build-chain. Please run \`npm i @kie/build-chain-action -g\` as sudo user\n"

--- a/README.md
+++ b/README.md
@@ -26,8 +26,8 @@ There are two ways to activate such profile during maven build:
 
 The following two commands will execute tests on machine with locale different than _en_US_:
 
-1. `mvn clean verify -Ptest-en`
-2. `mvn clean verify -DTestEn`
+1. `make test -Ptest-en`
+2. `make test -DTestEn`
 
 
 


### PR DESCRIPTION
https://issues.redhat.com/browse/KOGITO-8400

```
$ make help
Available targets:

  build                               Build the project
  quick-build                         Perform a quick build of the project
  test                                Launch full testing
  quick-test                          Launch unit testing
  deploy                              Deploy the project
  clean                               Clean the project
  mvn                                 Execute a Maven command. Needs the `cmd` argument set
  update-quarkus                      Update the quarkus version. Needs the `quarkus_version` argument set
  prepare-env                         Prepare the repository for a specific environment. Needs the `environment` argument set
  tree                                Show project dependencies
  show-diff                           Show Git diff
  help                                This help screen

All Maven commands can include some maven options via the `mvn_opts` argument !
```