### PR TITLE
[KOGITO-8183] Add mutable jar builder for AppPath

### DIFF
--- a/drools-drl-quarkus-extension/drools-drl-quarkus-util-deployment/src/main/java/org/drools/drl/quarkus/util/deployment/DroolsQuarkusResourceUtils.java
+++ b/drools-drl-quarkus-extension/drools-drl-quarkus-util-deployment/src/main/java/org/drools/drl/quarkus/util/deployment/DroolsQuarkusResourceUtils.java
@@ -25,12 +25,6 @@ import java.util.Map;
 import java.util.UUID;
 import java.util.stream.Collectors;
 
-import io.quarkus.arc.deployment.GeneratedBeanBuildItem;
-import io.quarkus.deployment.annotations.BuildProducer;
-import io.quarkus.deployment.builditem.GeneratedResourceBuildItem;
-import io.quarkus.deployment.builditem.nativeimage.NativeImageResourceBuildItem;
-import io.quarkus.maven.dependency.ResolvedDependency;
-import io.quarkus.vertx.http.deployment.spi.AdditionalStaticResourceBuildItem;
 import org.drools.codegen.common.AppPaths;
 import org.drools.codegen.common.DroolsModelBuildContext;
 import org.drools.codegen.common.GeneratedFile;
@@ -46,6 +40,13 @@ import org.kie.memorycompiler.JavaCompiler;
 import org.kie.memorycompiler.JavaCompilerSettings;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+
+import io.quarkus.arc.deployment.GeneratedBeanBuildItem;
+import io.quarkus.deployment.annotations.BuildProducer;
+import io.quarkus.deployment.builditem.GeneratedResourceBuildItem;
+import io.quarkus.deployment.builditem.nativeimage.NativeImageResourceBuildItem;
+import io.quarkus.maven.dependency.ResolvedDependency;
+import io.quarkus.vertx.http.deployment.spi.AdditionalStaticResourceBuildItem;
 
 import static org.kie.memorycompiler.KieMemoryCompiler.compileNoLoad;
 
@@ -83,7 +84,7 @@ public class DroolsQuarkusResourceUtils {
     public static DroolsModelBuildContext createDroolsBuildContext(Path outputTarget, Iterable<Path> paths, IndexView index) {
         // scan and parse paths
         AppPaths.BuildTool buildTool = AppPaths.BuildTool.findBuildTool();
-        AppPaths appPaths = AppPaths.fromQuarkus(outputTarget, paths, buildTool);
+        AppPaths appPaths = QuarkusAppPaths.from(outputTarget, paths, buildTool);
         ClassLoader classLoader = Thread.currentThread().getContextClassLoader();
         DroolsModelBuildContext context = QuarkusDroolsModelBuildContext.builder()
                 .withClassLoader(classLoader)
@@ -140,8 +141,8 @@ public class DroolsQuarkusResourceUtils {
         }
     }
 
-    public static Collection<GeneratedBeanBuildItem> compileGeneratedSources( DroolsModelBuildContext context, Collection<ResolvedDependency> dependencies,
-                                                                              Collection<GeneratedFile> generatedFiles, boolean useDebugSymbols) {
+    public static Collection<GeneratedBeanBuildItem> compileGeneratedSources(DroolsModelBuildContext context, Collection<ResolvedDependency> dependencies,
+            Collection<GeneratedFile> generatedFiles, boolean useDebugSymbols) {
         Map<String, String> sourcesMap = getSourceMap(generatedFiles);
         if (sourcesMap.isEmpty()) {
             LOGGER.info("No Java source to compile");
@@ -150,7 +151,7 @@ public class DroolsQuarkusResourceUtils {
 
         JavaCompilerSettings compilerSettings = createJavaCompilerSettings(context, dependencies, useDebugSymbols);
         ClassLoader classLoader = Thread.currentThread().getContextClassLoader();
-        return makeBuildItems( compileNoLoad(sourcesMap, classLoader, compilerSettings) );
+        return makeBuildItems(compileNoLoad(sourcesMap, classLoader, compilerSettings));
     }
 
     private static JavaCompilerSettings createJavaCompilerSettings(DroolsModelBuildContext context, Collection<ResolvedDependency> dependencies, boolean useDebugSymbols) {
@@ -222,19 +223,19 @@ public class DroolsQuarkusResourceUtils {
 
     private static final String RULE_UNIT_DEF_PRODUCER =
             "import javax.enterprise.context.Dependent;\n" +
-            "import javax.enterprise.inject.Produces;\n" +
-            "\n" +
-            "import org.drools.ruleunits.api.RuleUnit;\n" +
-            "import org.drools.ruleunits.api.RuleUnitProvider;\n" +
-            "\n" +
-            "@Dependent\n" +
-            "public class $RULE_UNIT_NAME$Producer {\n" +
-            "\n" +
-            "    @Produces\n" +
-            "    public RuleUnit<$RULE_UNIT_NAME$> produceRuleUnit() {\n" +
-            "        return RuleUnitProvider.get().getRuleUnit(new $RULE_UNIT_NAME$());\n" +
-            "    }\n" +
-            "}\n";
+                    "import javax.enterprise.inject.Produces;\n" +
+                    "\n" +
+                    "import org.drools.ruleunits.api.RuleUnit;\n" +
+                    "import org.drools.ruleunits.api.RuleUnitProvider;\n" +
+                    "\n" +
+                    "@Dependent\n" +
+                    "public class $RULE_UNIT_NAME$Producer {\n" +
+                    "\n" +
+                    "    @Produces\n" +
+                    "    public RuleUnit<$RULE_UNIT_NAME$> produceRuleUnit() {\n" +
+                    "        return RuleUnitProvider.get().getRuleUnit(new $RULE_UNIT_NAME$());\n" +
+                    "    }\n" +
+                    "}\n";
 
     private static GeneratedFile generateRuleUnitDefProducerSource(DotName ruleUnitDefName) {
         String source = "package " + ruleUnitDefName.packagePrefix() + ";\n\n" +

--- a/drools-drl-quarkus-extension/drools-drl-quarkus-util-deployment/src/main/java/org/drools/drl/quarkus/util/deployment/QuarkusAppPaths.java
+++ b/drools-drl-quarkus-extension/drools-drl-quarkus-util-deployment/src/main/java/org/drools/drl/quarkus/util/deployment/QuarkusAppPaths.java
@@ -1,0 +1,108 @@
+/*
+ * Copyright 2023 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.drools.drl.quarkus.util.deployment;
+
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.LinkedHashSet;
+import java.util.Set;
+
+import org.drools.codegen.common.AppPaths;
+
+import io.quarkus.deployment.pkg.steps.JarResultBuildStep;
+
+/**
+ * {@link AppPaths}'s extension in Quarkus context.
+ */
+public class QuarkusAppPaths extends AppPaths {
+
+    private static final Path MUTABLE_JAR_PATH = Paths.get("dev", "app");
+    private static final Path CLASSES_PATH = Paths.get(TARGET_DIR, "classes");
+    private static final Path TEST_CLASSES_PATH = Paths.get(TARGET_DIR, "test-classes");
+
+    private enum PathType {
+        CLASSES,
+        TEST_CLASSES,
+        JAR,
+        /**
+         * Augmentation Mode from Quarkus. The app is deployed at "target/quarkus-app/dev/app" and behaves as an "exploded" jar.
+         * Every resource is in this root path, so all the generated code must also be generated in this very same path.
+         *
+         * @see <a href=""https://quarkus.io/guides/maven-tooling#remote-development-mode>Remote Development Mode</a>
+         */
+        MUTABLE_JAR,
+        UNKNOWN
+    }
+
+    protected QuarkusAppPaths(Set<Path> projectPaths, Collection<Path> classesPaths, boolean isJar, BuildTool bt, Path outputTarget) {
+        super(projectPaths, classesPaths, isJar, bt, JarResultBuildStep.MAIN, outputTarget);
+    }
+
+    public static AppPaths from(Path outputTarget, Iterable<Path> paths, AppPaths.BuildTool bt) {
+        final Set<Path> projectPaths = new LinkedHashSet<>();
+        final Collection<Path> classesPaths = new ArrayList<>();
+        boolean isJar = false;
+        for (Path path : paths) {
+            PathType pathType = getPathType(path);
+            switch (pathType) {
+                case CLASSES:
+                    classesPaths.add(path);
+                    projectPaths.add(path.getParent().getParent());
+                    break;
+                case TEST_CLASSES:
+                    projectPaths.add(path.getParent().getParent());
+                    break;
+                case JAR:
+                    isJar = true;
+                    classesPaths.add(path);
+                    projectPaths.add(path.getParent().getParent());
+                    break;
+                case MUTABLE_JAR:
+                    // project, class, and target are all the same.
+                    // also, we don't need any prefix (see constructor), hence passing GRADLE as the build tool
+                    return new QuarkusAppPaths(Collections.singleton(path), Collections.singleton(path), false, BuildTool.GRADLE, path);
+                case UNKNOWN:
+                    classesPaths.add(path);
+                    projectPaths.add(path);
+                    break;
+            }
+        }
+        return new QuarkusAppPaths(projectPaths, classesPaths, isJar, bt, outputTarget);
+    }
+
+    private static PathType getPathType(Path archiveLocation) {
+        if (archiveLocation.endsWith(MUTABLE_JAR_PATH)) {
+            return PathType.MUTABLE_JAR;
+        }
+        if (archiveLocation.endsWith(CLASSES_PATH)) {
+            return PathType.CLASSES;
+        }
+        if (archiveLocation.endsWith(TEST_CLASSES_PATH)) {
+            return PathType.TEST_CLASSES;
+        }
+        // Quarkus generates a file with extension .jar.original when doing a native compilation of a uberjar
+        // TODO replace ".jar.original" with constant JarResultBuildStep.RENAMED_JAR_EXTENSION when it will be avialable in Quakrus 1.7
+        if (archiveLocation.toString().toLowerCase().endsWith(".jar") || archiveLocation.toString().toLowerCase().endsWith(".jar.original")) {
+            return PathType.JAR;
+        }
+        return PathType.UNKNOWN;
+    }
+
+}

--- a/drools-model/drools-codegen-common/src/main/java/org/drools/codegen/common/AppPaths.java
+++ b/drools-model/drools-codegen-common/src/main/java/org/drools/codegen/common/AppPaths.java
@@ -45,6 +45,24 @@ public class AppPaths {
     private final Path resourcesPath;
     private final Path outputTarget;
 
+    /**
+     * Augmentation Mode from Quarkus. The app is deployed at "target/quarkus-app/dev/app" and behaves as an "exploded" jar.
+     * Every resource is in this root path, so all the generated code must also be generated in this very same path.
+     *
+     * @param targetPath The path as defined by the Quarkus deployment model
+     * @see <a href=""https://quarkus.io/guides/maven-tooling#remote-development-mode>Remote Development Mode</a>
+     * @return the app path
+     */
+    public static AppPaths fromMutableJar(Path targetPath) {
+        // we force GRADLE as the build tool since our resources' directory doesn't need a prefix.
+        return new AppPaths(Collections.singleton(targetPath),
+                Collections.singleton(targetPath),
+                false,
+                BuildTool.GRADLE,
+                "",
+                targetPath);
+    }
+
     public static AppPaths fromProjectDir(Path projectDir, Path outputTarget) {
         return new AppPaths(Collections.singleton(projectDir), Collections.emptyList(), false, BuildTool.MAVEN, "main", outputTarget);
     }
@@ -118,7 +136,7 @@ public class AppPaths {
      * @param resourcesBasePath "main" or "test"
      */
     private AppPaths(Set<Path> projectPaths, Collection<Path> classesPaths, boolean isJar, BuildTool bt,
-                     String resourcesBasePath, Path outputTarget) {
+            String resourcesBasePath, Path outputTarget) {
         this.isJar = isJar;
         this.projectPaths.addAll(projectPaths);
         this.classesPaths.addAll(classesPaths);


### PR DESCRIPTION
Signed-off-by: Ricardo Zanini <zanini@redhat.com>

In this PR we are moving all related Quarkus code from the `AppPaths` class in the common codegen module to a utils package in the extension.

Additionally, we fix a bug that applications won't generate any code in mutable JAR form.

See the context here: https://issues.redhat.com/browse/KOGITO-8183

**Thank you for submitting this pull request**

**NOTE!:** Double check the target branch for this PR.
The default is `main` so it will target Drools 8 / Kogito.
If this PR is not strictly related to drools and kogito project in `drools.git`, it should probably target `7.x`as a branch

**Ports** If a forward-port or a backport is needed, paste the forward port PR here

[link](https://www.example.com)

**JIRA**: _(please edit the JIRA link if it exists)_

[Quarkus remote dev mode mutable jar startUp failed](https://issues.redhat.com/browse/KOGITO-8183)

**referenced Pull Requests**: _(please edit the URLs of referenced pullrequests if they exist)_

* https://github.com/kiegroup/kogito-runtimes/pull/2714

<details>
<summary>
How to replicate CI configuration locally?
</summary>

Build Chain tool does "simple" maven build(s), the builds are just Maven commands, but because the repositories relates and depends on each other and any change in API or class method could affect several of those repositories there is a need to use [build-chain tool](https://github.com/kiegroup/github-action-build-chain) to handle cross repository builds and be sure that we always use latest version of the code for each repository.
 
[build-chain tool](https://github.com/kiegroup/github-action-build-chain) is a build tool which can be used on command line locally or in Github Actions workflow(s), in case you need to change multiple repositories and send multiple dependent pull requests related with a change you can easily reproduce the same build by executing it on Github hosted environment or locally in your development environment. See [local execution](https://github.com/kiegroup/github-action-build-chain#local-execution) details to get more information about it.
</details>

<details>
<summary>
How to retest this PR or trigger a specific build:
</summary>

- for <b>pull request checks</b>  
  Please add comment: <b>Jenkins retest this</b>

- for a <b>specific pull request check</b>  
  Please add comment: <b>Jenkins (re)run [drools|kogito-runtimes|kogito-apps|kogito-examples] tests</b>

- for a <b>full downstream build</b> 
  - for <b>jenkins</b> job: please add comment: <b>Jenkins run fdb</b>
  - for <b>github actions</b> job: add the label `run_fdb`

- <b>a compile downstream build</b> please  add comment: <b>Jenkins run cdb</b>

- <b>a full production downstream build</b> please add comment: <b>Jenkins execute product fdb</b>

- <b>an upstream build</b> please add comment: <b>Jenkins run upstream</b>

- for <b>quarkus branch checks</b>  
  Run checks against Quarkus current used branch  
  Please add comment: <b>Jenkins run quarkus-branch</b>

- for a <b>quarkus branch specific check</b>  
  Run checks against Quarkus current used branch  
  Please add comment: <b>Jenkins (re)run [drools|kogito-runtimes|kogito-apps|kogito-examples] quarkus-branch</b>

- for <b>quarkus main checks</b>  
  Run checks against Quarkus main branch  
  Please add comment: <b>Jenkins run quarkus-main</b>

- for a <b>specific quarkus main check</b>  
  Run checks against Quarkus main branch  
  Please add comment: <b>Jenkins (re)run [drools|kogito-runtimes|kogito-apps|kogito-examples] quarkus-main</b>

- for <b>quarkus lts checks</b>  
  Run checks against Quarkus lts branch  
  Please add comment: <b>Jenkins run quarkus-lts</b>

- for a <b>specific quarkus lts check</b>  
  Run checks against Quarkus lts branch  
  Please add comment: <b>Jenkins (re)run [drools|kogito-runtimes|kogito-apps|kogito-examples] quarkus-lts</b>

- for <b>native checks</b>  
  Run native checks  
  Please add comment: <b>Jenkins run native</b>

- for a <b>specific native check</b>  
  Run native checks 
  Please add comment: <b>Jenkins (re)run [drools|kogito-runtimes|kogito-apps|kogito-examples] native</b>

- for <b>mandrel checks</b>  
  Run native checks against Mandrel image
  Please add comment: <b>Jenkins run mandrel</b>

- for a <b>specific mandrel check</b>  
  Run native checks against Mandrel image  
  Please add comment: <b>Jenkins (re)run [drools|kogito-runtimes|kogito-apps|kogito-examples] mandrel</b>

 - for <b>mandrel lts checks</b>  
  Run native checks against Mandrel image and quarkus lts branch
  Please add comment: <b>Jenkins run mandrel-lts</b>

- for a <b>specific mandrel lts check</b>  
  Run native checks against Mandrel image and quarkus lts branch
  Please add comment: <b>Jenkins (re)run [drools|kogito-runtimes|kogito-apps|kogito-examples] mandrel-lts</b>
</details>

<details>
<summary>
How to backport a pull request to a different branch?
</summary>

In order to automatically create a **backporting pull request** please add one or more labels having the following format `backport-<branch-name>`, where `<branch-name>` is the name of the branch where the pull request must be backported to (e.g., `backport-7.67.x` to backport the original PR to the `7.67.x` branch).

> **NOTE**: **backporting** is an action aiming to move a change (usually a commit) from a branch (usually the main one) to another one, which is generally referring to a still maintained release branch. Keeping it simple: it is about to move a specific change or a set of them from one branch to another.

Once the original pull request is successfully merged, the automated action will create one backporting pull request per each label (with the previous format) that has been added.

If something goes wrong, the author will be notified and at this point a manual backporting is needed.

> **NOTE**: this automated backporting is triggered whenever a pull request on `main` branch is labeled or closed, but both conditions must be satisfied to get the new PR created.
</details>