### PR TITLE
[KOGITO-8436] raise a compile time error if a rule belonging to a rul…

### DIFF
--- a/drools-compiler/src/main/java/org/drools/compiler/builder/impl/processors/RuleValidator.java
+++ b/drools-compiler/src/main/java/org/drools/compiler/builder/impl/processors/RuleValidator.java
@@ -59,6 +59,15 @@ public class RuleValidator extends AbstractPackageCompilationPhase {
                 }
             }
             names.add(name);
+
+            if (rule.getUnit() != null &&
+                    (rule.getAttributes().get("agenda-group") != null || rule.getAttributes().get("ruleflow-group") != null)) {
+                this.results.add(new ParserError(rule.getResource(),
+                        "Rule " + rule.getName() + " belongs to unit " + rule.getUnit().getTarget() + " and cannot have an agenda-group or a ruleflow-group",
+                        rule.getLine(),
+                        rule.getColumn(),
+                        packageDescr.getNamespace()));
+            }
         }
     }
 

--- a/drools-ruleunits/drools-ruleunits-impl/src/test/java/org/drools/ruleunits/impl/AgendaGroupUnit.java
+++ b/drools-ruleunits/drools-ruleunits-impl/src/test/java/org/drools/ruleunits/impl/AgendaGroupUnit.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright 2022 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.drools.ruleunits.impl;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.drools.ruleunits.api.DataSource;
+import org.drools.ruleunits.api.DataStore;
+import org.drools.ruleunits.api.RuleUnitData;
+
+public class AgendaGroupUnit implements RuleUnitData {
+    private final DataStore<String> strings;
+    private final List<String> results = new ArrayList<>();
+
+    public AgendaGroupUnit() {
+        this(DataSource.createStore());
+    }
+
+    public AgendaGroupUnit(DataStore<String> strings) {
+        this.strings = strings;
+    }
+
+    public DataStore<String> getStrings() {
+        return strings;
+    }
+
+    public List<String> getResults() {
+        return results;
+    }
+}

--- a/drools-ruleunits/drools-ruleunits-impl/src/test/java/org/drools/ruleunits/impl/RuleUnitProviderImplTest.java
+++ b/drools-ruleunits/drools-ruleunits-impl/src/test/java/org/drools/ruleunits/impl/RuleUnitProviderImplTest.java
@@ -101,6 +101,19 @@ public class RuleUnitProviderImplTest {
     }
 
     @Test
+    public void agendaGroup() {
+        try {
+            RuleUnitProvider.get().createRuleUnitInstance(new AgendaGroupUnit());
+            fail("Compilation should fail");
+        } catch (CompilationErrorsException e) {
+            assertThat(
+                    e.getErrorMessages().stream().map(Objects::toString)
+                            .anyMatch( s -> s.contains("Rule RuleInGroup belongs to unit AgendaGroupUnit and cannot have an agenda-group or a ruleflow-group"))
+            ).isTrue();
+        }
+    }
+
+    @Test
     public void addEventListeners() {
         TestAgendaEventListener testAgendaEventListener = new TestAgendaEventListener();
         TestRuleRuntimeEventListener testRuleRuntimeEventListener = new TestRuleRuntimeEventListener();

--- a/drools-ruleunits/drools-ruleunits-impl/src/test/resources/org/drools/ruleunits/impl/AgendaGroupUnit.drl
+++ b/drools-ruleunits/drools-ruleunits-impl/src/test/resources/org/drools/ruleunits/impl/AgendaGroupUnit.drl
@@ -1,0 +1,33 @@
+/**
+ * Copyright 2019 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.drools.ruleunits.impl;
+unit AgendaGroupUnit;
+
+rule HelloWorld
+when
+    /strings [ this == "Hello World" ]
+then
+    drools.setFocus("process");
+    results.add("it worked!");
+end
+
+rule RuleInGroup
+agenda-group "process"
+when
+    /strings [ this == "Hello World" ]
+then
+    results.add("it worked!");
+end


### PR DESCRIPTION
…e unit also declares an agenda-group

**JIRA**: https://issues.redhat.com/browse/KOGITO-8436

As clarified [here](https://kie.zulipchat.com/#narrow/stream/232676-kogito/topic/Atypical.20deployment.20pattern.20for.20Kogito), agenda-groups are a way to partition a rule base exactly in the same way as rule units do, so it doesn't make sense to use agenda-groups AND rule units in the same rule base, they both have the same purpose. For this reason I decided to raise a compile time error if a rule belonging to a rule unit also declares an agenda group.