### PR TITLE
[main] Extract Jandex group id as property

### DIFF
--- a/build-parent/pom.xml
+++ b/build-parent/pom.xml
@@ -396,6 +396,12 @@
         <groupId>io.smallrye</groupId>
         <artifactId>smallrye-open-api-core</artifactId>
         <version>${version.io.smallrye.openapi.core}</version>
+        <exclusions>
+          <exclusion>
+            <groupId>io.smallrye</groupId>
+            <artifactId>jandex</artifactId>
+          </exclusion>
+        </exclusions>
       </dependency>
 
       <dependency>
@@ -1440,59 +1446,6 @@
               </configuration>
             </execution>
             <execution>
-              <id>ban-blacklisted-dependencies</id>
-              <phase>validate</phase>
-              <goals>
-                <goal>enforce</goal>
-              </goals>
-              <configuration>
-                <rules>
-                  <bannedDependencies>
-                    <excludes combine.children="append">
-                      <!-- Ban blacklisted logging deps (we only use SLF4J + Logback) -->
-                      <!-- In case of transitive dependency, exclude it and use 'org.slf4j:jcl-over-slf4j' instead -->
-                      <exclude>commons-logging:commons-log*</exclude>
-
-                      <exclude>log4j:log4j</exclude> <!-- In case of transitive dependency, exclude it and use 'org.slf4j:log4j-over-slf4j' instead -->
-                      <exclude>javassist:javassist</exclude>  <!-- In case of transitive dependency, exclude it and use 'org.javassist:javassist' instead -->
-                      <exclude>org.jboss.weld.se:weld-se</exclude> <!-- Use weld-se-core instead -->
-                      <exclude>org.jboss:jandex</exclude> <!-- Use io.smallrye:jandex instead -->
-                      <exclude>org.jboss.jandex:jandex-maven-plugin</exclude> <!-- Use io.smallrye:jandex-maven-plugin instead -->
-                      <exclude>org.mockito:mockito-all</exclude> <!-- Use mockito-core instead -->
-
-                      <!-- Java EE 8 Spec JARs: Use Jakarta EE 8 instead. -->
-                      <exclude>javax.activation:activation</exclude>
-                      <exclude>javax.annotation:javax.annotation-api</exclude>
-                      <exclude>javax.enterprise:cdi-api</exclude>
-                      <exclude>javax.inject:javax.inject</exclude>
-                      <exclude>javax.interceptor:javax.interceptor-api</exclude>
-                      <exclude>javax.jws:jsr181-api</exclude>
-                      <exclude>javax.persistence:javax.persistence-api</exclude>
-                      <exclude>javax.servlet:javax.servlet-api</exclude>
-                      <exclude>javax.xml.bind:jaxb-api</exclude>
-                      <exclude>javax.xml.soap:javax.xml.soap-api</exclude>
-                      <exclude>javax.xml.ws:javaxws-api</exclude>
-                      <exclude>javax.el:javax.el-api</exclude>
-                      <exclude>javax.ws.rs:jsr311-api</exclude>
-                      <exclude>javax.ws.rs:javax.ws.rs-api</exclude>
-                      <exclude>javax.mail:mail</exclude>
-                      <exclude>javax.xml.stream:stax-api</exclude>
-                      <exclude>org.jboss.spec.javax.*:*</exclude>
-                      <exclude>org.apache.geronimo.specs:geronimo-activation_1.1_spec</exclude>
-                      <exclude>org.apache.geronimo.specs:geronimo-annotation_1.0_spec</exclude>
-                      <exclude>org.apache.geronimo.specs:geronimo-javamail_1.4_spec</exclude>
-                      <exclude>org.apache.geronimo.specs:geronimo-jaxws_2.1_spec</exclude>
-                      <exclude>org.apache.geronimo.specs:geronimo-jta_1.1_spec</exclude>
-                      <exclude>org.apache.geronimo.specs:geronimo-servlet_3.0_spec</exclude>
-                      <exclude>org.apache.geronimo.specs:geronimo-ws-metadata_2.0_spec</exclude>
-                      <!-- End  -->
-                    </excludes>
-                  </bannedDependencies>
-                </rules>
-                <fail>${enforcer.failOnBannedDependencies}</fail>
-              </configuration>
-            </execution>
-            <execution>
               <id>ban-duplicated-classes</id>
               <!-- Using phase=none as we don't want this execution as part of the default build. The phase
                    is specified in the "full" profile and thus the execution will only be activated when using that profile. -->
@@ -2381,7 +2334,75 @@
       </activation>
       <properties>
         <org.kie.productized>true</org.kie.productized>
+        <jandex.group-id>org.jboss</jandex.group-id>
+        <version.io.smallrye.jandex>2.4.3.Final</version.io.smallrye.jandex>
+        <jandex-maven-plugin.group-id>org.jboss.jandex</jandex-maven-plugin.group-id>
+        <version.io.smallrye.jandex-maven-plugin>1.2.3</version.io.smallrye.jandex-maven-plugin>
       </properties>
+      <build>
+        <pluginManagement>
+          <plugins>
+            <plugin>
+              <groupId>org.apache.maven.plugins</groupId>
+              <artifactId>maven-enforcer-plugin</artifactId>
+              <executions>
+                <!-- Productized ban-blacklisted-dependencies: do not ban org.jboss:jandex on productized profile -->
+                <execution>
+                  <id>ban-blacklisted-dependencies</id>
+                  <phase>validate</phase>
+                  <goals>
+                    <goal>enforce</goal>
+                  </goals>
+                  <configuration>
+                    <rules>
+                      <bannedDependencies>
+                        <excludes combine.children="append">
+                          <!-- Ban blacklisted logging deps (we only use SLF4J + Logback) -->
+                          <!-- In case of transitive dependency, exclude it and use 'org.slf4j:jcl-over-slf4j' instead -->
+                          <exclude>commons-logging:commons-log*</exclude>
+
+                          <exclude>log4j:log4j</exclude> <!-- In case of transitive dependency, exclude it and use 'org.slf4j:log4j-over-slf4j' instead -->
+                          <exclude>javassist:javassist</exclude>  <!-- In case of transitive dependency, exclude it and use 'org.javassist:javassist' instead -->
+                          <exclude>org.jboss.weld.se:weld-se</exclude> <!-- Use weld-se-core instead -->
+                          <exclude>org.mockito:mockito-all</exclude> <!-- Use mockito-core instead -->
+
+                          <!-- Java EE 8 Spec JARs: Use Jakarta EE 8 instead. -->
+                          <exclude>javax.activation:activation</exclude>
+                          <exclude>javax.annotation:javax.annotation-api</exclude>
+                          <exclude>javax.enterprise:cdi-api</exclude>
+                          <exclude>javax.inject:javax.inject</exclude>
+                          <exclude>javax.interceptor:javax.interceptor-api</exclude>
+                          <exclude>javax.jws:jsr181-api</exclude>
+                          <exclude>javax.persistence:javax.persistence-api</exclude>
+                          <exclude>javax.servlet:javax.servlet-api</exclude>
+                          <exclude>javax.xml.bind:jaxb-api</exclude>
+                          <exclude>javax.xml.soap:javax.xml.soap-api</exclude>
+                          <exclude>javax.xml.ws:javaxws-api</exclude>
+                          <exclude>javax.el:javax.el-api</exclude>
+                          <exclude>javax.ws.rs:jsr311-api</exclude>
+                          <exclude>javax.ws.rs:javax.ws.rs-api</exclude>
+                          <exclude>javax.mail:mail</exclude>
+                          <exclude>javax.xml.stream:stax-api</exclude>
+                          <exclude>org.jboss.spec.javax.*:*</exclude>
+                          <exclude>org.apache.geronimo.specs:geronimo-activation_1.1_spec</exclude>
+                          <exclude>org.apache.geronimo.specs:geronimo-annotation_1.0_spec</exclude>
+                          <exclude>org.apache.geronimo.specs:geronimo-javamail_1.4_spec</exclude>
+                          <exclude>org.apache.geronimo.specs:geronimo-jaxws_2.1_spec</exclude>
+                          <exclude>org.apache.geronimo.specs:geronimo-jta_1.1_spec</exclude>
+                          <exclude>org.apache.geronimo.specs:geronimo-servlet_3.0_spec</exclude>
+                          <exclude>org.apache.geronimo.specs:geronimo-ws-metadata_2.0_spec</exclude>
+                          <!-- End  -->
+                        </excludes>
+                      </bannedDependencies>
+                    </rules>
+                    <fail>${enforcer.failOnBannedDependencies}</fail>
+                  </configuration>
+                </execution>
+              </executions>
+            </plugin>
+          </plugins>
+        </pluginManagement>
+      </build>
     </profile>
     <!--
       Creates JaCoCo XML reports and invokes the Sonar scanner, which uploads code quality data into the SonarCloud.
@@ -2554,19 +2575,78 @@
       </build>
     </profile>
     <profile>
-      <id>productized</id>
+      <id>default</id>
       <activation>
         <property>
-          <name>productized</name>
+          <name>!productized</name>
         </property>
       </activation>
-      <properties>
-        <jandex.group-id>org.jboss</jandex.group-id>
-        <version.io.smallrye.jandex>2.4.3.Final</version.io.smallrye.jandex>
-        <jandex-maven-plugin.group-id>org.jboss.jandex</jandex-maven-plugin.group-id>
-        <version.io.smallrye.jandex-maven-plugin>1.2.3</version.io.smallrye.jandex-maven-plugin>
-        <enforcer.skip>true</enforcer.skip>
-      </properties>
+      <build>
+        <pluginManagement>
+          <plugins>
+            <plugin>
+              <groupId>org.apache.maven.plugins</groupId>
+              <artifactId>maven-enforcer-plugin</artifactId>
+              <executions>
+                <!-- Default ban-blacklisted-dependencies execution, when productized not enabled -->
+                <execution>
+                  <id>ban-blacklisted-dependencies</id>
+                  <phase>validate</phase>
+                  <goals>
+                    <goal>enforce</goal>
+                  </goals>
+                  <configuration>
+                    <rules>
+                      <bannedDependencies>
+                        <excludes combine.children="append">
+                          <!-- Ban blacklisted logging deps (we only use SLF4J + Logback) -->
+                          <!-- In case of transitive dependency, exclude it and use 'org.slf4j:jcl-over-slf4j' instead -->
+                          <exclude>commons-logging:commons-log*</exclude>
+
+                          <exclude>log4j:log4j</exclude> <!-- In case of transitive dependency, exclude it and use 'org.slf4j:log4j-over-slf4j' instead -->
+                          <exclude>javassist:javassist</exclude>  <!-- In case of transitive dependency, exclude it and use 'org.javassist:javassist' instead -->
+                          <exclude>org.jboss.weld.se:weld-se</exclude> <!-- Use weld-se-core instead -->
+                          <exclude>org.jboss:jandex</exclude> <!-- Use io.smallrye:jandex instead -->
+                          <exclude>org.jboss.jandex:jandex-maven-plugin</exclude> <!-- Use io.smallrye:jandex-maven-plugin instead -->
+                          <exclude>org.mockito:mockito-all</exclude> <!-- Use mockito-core instead -->
+
+                          <!-- Java EE 8 Spec JARs: Use Jakarta EE 8 instead. -->
+                          <exclude>javax.activation:activation</exclude>
+                          <exclude>javax.annotation:javax.annotation-api</exclude>
+                          <exclude>javax.enterprise:cdi-api</exclude>
+                          <exclude>javax.inject:javax.inject</exclude>
+                          <exclude>javax.interceptor:javax.interceptor-api</exclude>
+                          <exclude>javax.jws:jsr181-api</exclude>
+                          <exclude>javax.persistence:javax.persistence-api</exclude>
+                          <exclude>javax.servlet:javax.servlet-api</exclude>
+                          <exclude>javax.xml.bind:jaxb-api</exclude>
+                          <exclude>javax.xml.soap:javax.xml.soap-api</exclude>
+                          <exclude>javax.xml.ws:javaxws-api</exclude>
+                          <exclude>javax.el:javax.el-api</exclude>
+                          <exclude>javax.ws.rs:jsr311-api</exclude>
+                          <exclude>javax.ws.rs:javax.ws.rs-api</exclude>
+                          <exclude>javax.mail:mail</exclude>
+                          <exclude>javax.xml.stream:stax-api</exclude>
+                          <exclude>org.jboss.spec.javax.*:*</exclude>
+                          <exclude>org.apache.geronimo.specs:geronimo-activation_1.1_spec</exclude>
+                          <exclude>org.apache.geronimo.specs:geronimo-annotation_1.0_spec</exclude>
+                          <exclude>org.apache.geronimo.specs:geronimo-javamail_1.4_spec</exclude>
+                          <exclude>org.apache.geronimo.specs:geronimo-jaxws_2.1_spec</exclude>
+                          <exclude>org.apache.geronimo.specs:geronimo-jta_1.1_spec</exclude>
+                          <exclude>org.apache.geronimo.specs:geronimo-servlet_3.0_spec</exclude>
+                          <exclude>org.apache.geronimo.specs:geronimo-ws-metadata_2.0_spec</exclude>
+                          <!-- End  -->
+                        </excludes>
+                      </bannedDependencies>
+                    </rules>
+                    <fail>${enforcer.failOnBannedDependencies}</fail>
+                  </configuration>
+                </execution>
+              </executions>
+            </plugin>
+          </plugins>
+        </pluginManagement>
+      </build>
     </profile>
   </profiles>
 

--- a/build-parent/pom.xml
+++ b/build-parent/pom.xml
@@ -1592,6 +1592,57 @@
                 </rules>
               </configuration>
             </execution>
+            <execution>
+              <id>ban-blacklisted-dependencies</id>
+              <phase>validate</phase>
+              <goals>
+                <goal>enforce</goal>
+              </goals>
+              <configuration>
+                <rules>
+                  <bannedDependencies>
+                    <excludes combine.children="append">
+                      <!-- Ban blacklisted logging deps (we only use SLF4J + Logback) -->
+                      <!-- In case of transitive dependency, exclude it and use 'org.slf4j:jcl-over-slf4j' instead -->
+                      <exclude>commons-logging:commons-log*</exclude>
+
+                      <exclude>log4j:log4j</exclude> <!-- In case of transitive dependency, exclude it and use 'org.slf4j:log4j-over-slf4j' instead -->
+                      <exclude>javassist:javassist</exclude>  <!-- In case of transitive dependency, exclude it and use 'org.javassist:javassist' instead -->
+                      <exclude>org.jboss.weld.se:weld-se</exclude> <!-- Use weld-se-core instead -->
+                      <exclude>org.mockito:mockito-all</exclude> <!-- Use mockito-core instead -->
+
+                      <!-- Java EE 8 Spec JARs: Use Jakarta EE 8 instead. -->
+                      <exclude>javax.activation:activation</exclude>
+                      <exclude>javax.annotation:javax.annotation-api</exclude>
+                      <exclude>javax.enterprise:cdi-api</exclude>
+                      <exclude>javax.inject:javax.inject</exclude>
+                      <exclude>javax.interceptor:javax.interceptor-api</exclude>
+                      <exclude>javax.jws:jsr181-api</exclude>
+                      <exclude>javax.persistence:javax.persistence-api</exclude>
+                      <exclude>javax.servlet:javax.servlet-api</exclude>
+                      <exclude>javax.xml.bind:jaxb-api</exclude>
+                      <exclude>javax.xml.soap:javax.xml.soap-api</exclude>
+                      <exclude>javax.xml.ws:javaxws-api</exclude>
+                      <exclude>javax.el:javax.el-api</exclude>
+                      <exclude>javax.ws.rs:jsr311-api</exclude>
+                      <exclude>javax.ws.rs:javax.ws.rs-api</exclude>
+                      <exclude>javax.mail:mail</exclude>
+                      <exclude>javax.xml.stream:stax-api</exclude>
+                      <exclude>org.jboss.spec.javax.*:*</exclude>
+                      <exclude>org.apache.geronimo.specs:geronimo-activation_1.1_spec</exclude>
+                      <exclude>org.apache.geronimo.specs:geronimo-annotation_1.0_spec</exclude>
+                      <exclude>org.apache.geronimo.specs:geronimo-javamail_1.4_spec</exclude>
+                      <exclude>org.apache.geronimo.specs:geronimo-jaxws_2.1_spec</exclude>
+                      <exclude>org.apache.geronimo.specs:geronimo-jta_1.1_spec</exclude>
+                      <exclude>org.apache.geronimo.specs:geronimo-servlet_3.0_spec</exclude>
+                      <exclude>org.apache.geronimo.specs:geronimo-ws-metadata_2.0_spec</exclude>
+                      <!-- End  -->
+                    </excludes>
+                  </bannedDependencies>
+                </rules>
+                <fail>${enforcer.failOnBannedDependencies}</fail>
+              </configuration>
+            </execution>
           </executions>
         </plugin>
         <plugin>
@@ -2333,70 +2384,6 @@
         <jandex-maven-plugin.group-id>org.jboss.jandex</jandex-maven-plugin.group-id>
         <version.io.smallrye.jandex-maven-plugin>1.2.3</version.io.smallrye.jandex-maven-plugin>
       </properties>
-      <build>
-        <pluginManagement>
-          <plugins>
-            <plugin>
-              <groupId>org.apache.maven.plugins</groupId>
-              <artifactId>maven-enforcer-plugin</artifactId>
-              <executions>
-                <!-- Productized ban-blacklisted-dependencies: do not ban org.jboss:jandex on productized profile -->
-                <execution>
-                  <id>ban-blacklisted-dependencies</id>
-                  <phase>validate</phase>
-                  <goals>
-                    <goal>enforce</goal>
-                  </goals>
-                  <configuration>
-                    <rules>
-                      <bannedDependencies>
-                        <excludes combine.children="append">
-                          <!-- Ban blacklisted logging deps (we only use SLF4J + Logback) -->
-                          <!-- In case of transitive dependency, exclude it and use 'org.slf4j:jcl-over-slf4j' instead -->
-                          <exclude>commons-logging:commons-log*</exclude>
-
-                          <exclude>log4j:log4j</exclude> <!-- In case of transitive dependency, exclude it and use 'org.slf4j:log4j-over-slf4j' instead -->
-                          <exclude>javassist:javassist</exclude>  <!-- In case of transitive dependency, exclude it and use 'org.javassist:javassist' instead -->
-                          <exclude>org.jboss.weld.se:weld-se</exclude> <!-- Use weld-se-core instead -->
-                          <exclude>org.mockito:mockito-all</exclude> <!-- Use mockito-core instead -->
-
-                          <!-- Java EE 8 Spec JARs: Use Jakarta EE 8 instead. -->
-                          <exclude>javax.activation:activation</exclude>
-                          <exclude>javax.annotation:javax.annotation-api</exclude>
-                          <exclude>javax.enterprise:cdi-api</exclude>
-                          <exclude>javax.inject:javax.inject</exclude>
-                          <exclude>javax.interceptor:javax.interceptor-api</exclude>
-                          <exclude>javax.jws:jsr181-api</exclude>
-                          <exclude>javax.persistence:javax.persistence-api</exclude>
-                          <exclude>javax.servlet:javax.servlet-api</exclude>
-                          <exclude>javax.xml.bind:jaxb-api</exclude>
-                          <exclude>javax.xml.soap:javax.xml.soap-api</exclude>
-                          <exclude>javax.xml.ws:javaxws-api</exclude>
-                          <exclude>javax.el:javax.el-api</exclude>
-                          <exclude>javax.ws.rs:jsr311-api</exclude>
-                          <exclude>javax.ws.rs:javax.ws.rs-api</exclude>
-                          <exclude>javax.mail:mail</exclude>
-                          <exclude>javax.xml.stream:stax-api</exclude>
-                          <exclude>org.jboss.spec.javax.*:*</exclude>
-                          <exclude>org.apache.geronimo.specs:geronimo-activation_1.1_spec</exclude>
-                          <exclude>org.apache.geronimo.specs:geronimo-annotation_1.0_spec</exclude>
-                          <exclude>org.apache.geronimo.specs:geronimo-javamail_1.4_spec</exclude>
-                          <exclude>org.apache.geronimo.specs:geronimo-jaxws_2.1_spec</exclude>
-                          <exclude>org.apache.geronimo.specs:geronimo-jta_1.1_spec</exclude>
-                          <exclude>org.apache.geronimo.specs:geronimo-servlet_3.0_spec</exclude>
-                          <exclude>org.apache.geronimo.specs:geronimo-ws-metadata_2.0_spec</exclude>
-                          <!-- End  -->
-                        </excludes>
-                      </bannedDependencies>
-                    </rules>
-                    <fail>${enforcer.failOnBannedDependencies}</fail>
-                  </configuration>
-                </execution>
-              </executions>
-            </plugin>
-          </plugins>
-        </pluginManagement>
-      </build>
     </profile>
     <!--
       Creates JaCoCo XML reports and invokes the Sonar scanner, which uploads code quality data into the SonarCloud.
@@ -2582,58 +2569,20 @@
               <groupId>org.apache.maven.plugins</groupId>
               <artifactId>maven-enforcer-plugin</artifactId>
               <executions>
-                <!-- Default ban-blacklisted-dependencies execution, when productized not enabled -->
+                <!-- Additional ban-blacklisted-dependencies deps to be checked when productized is disabled -->
                 <execution>
                   <id>ban-blacklisted-dependencies</id>
-                  <phase>validate</phase>
-                  <goals>
-                    <goal>enforce</goal>
-                  </goals>
                   <configuration>
                     <rules>
                       <bannedDependencies>
+                        <!-- these banned deps are added to the default list define above -->
                         <excludes combine.children="append">
-                          <!-- Ban blacklisted logging deps (we only use SLF4J + Logback) -->
-                          <!-- In case of transitive dependency, exclude it and use 'org.slf4j:jcl-over-slf4j' instead -->
-                          <exclude>commons-logging:commons-log*</exclude>
-
-                          <exclude>log4j:log4j</exclude> <!-- In case of transitive dependency, exclude it and use 'org.slf4j:log4j-over-slf4j' instead -->
-                          <exclude>javassist:javassist</exclude>  <!-- In case of transitive dependency, exclude it and use 'org.javassist:javassist' instead -->
-                          <exclude>org.jboss.weld.se:weld-se</exclude> <!-- Use weld-se-core instead -->
                           <exclude>org.jboss:jandex</exclude> <!-- Use io.smallrye:jandex instead -->
                           <exclude>org.jboss.jandex:jandex-maven-plugin</exclude> <!-- Use io.smallrye:jandex-maven-plugin instead -->
-                          <exclude>org.mockito:mockito-all</exclude> <!-- Use mockito-core instead -->
-
-                          <!-- Java EE 8 Spec JARs: Use Jakarta EE 8 instead. -->
-                          <exclude>javax.activation:activation</exclude>
-                          <exclude>javax.annotation:javax.annotation-api</exclude>
-                          <exclude>javax.enterprise:cdi-api</exclude>
-                          <exclude>javax.inject:javax.inject</exclude>
-                          <exclude>javax.interceptor:javax.interceptor-api</exclude>
-                          <exclude>javax.jws:jsr181-api</exclude>
-                          <exclude>javax.persistence:javax.persistence-api</exclude>
-                          <exclude>javax.servlet:javax.servlet-api</exclude>
-                          <exclude>javax.xml.bind:jaxb-api</exclude>
-                          <exclude>javax.xml.soap:javax.xml.soap-api</exclude>
-                          <exclude>javax.xml.ws:javaxws-api</exclude>
-                          <exclude>javax.el:javax.el-api</exclude>
-                          <exclude>javax.ws.rs:jsr311-api</exclude>
-                          <exclude>javax.ws.rs:javax.ws.rs-api</exclude>
-                          <exclude>javax.mail:mail</exclude>
-                          <exclude>javax.xml.stream:stax-api</exclude>
-                          <exclude>org.jboss.spec.javax.*:*</exclude>
-                          <exclude>org.apache.geronimo.specs:geronimo-activation_1.1_spec</exclude>
-                          <exclude>org.apache.geronimo.specs:geronimo-annotation_1.0_spec</exclude>
-                          <exclude>org.apache.geronimo.specs:geronimo-javamail_1.4_spec</exclude>
-                          <exclude>org.apache.geronimo.specs:geronimo-jaxws_2.1_spec</exclude>
-                          <exclude>org.apache.geronimo.specs:geronimo-jta_1.1_spec</exclude>
-                          <exclude>org.apache.geronimo.specs:geronimo-servlet_3.0_spec</exclude>
-                          <exclude>org.apache.geronimo.specs:geronimo-ws-metadata_2.0_spec</exclude>
                           <!-- End  -->
                         </excludes>
                       </bannedDependencies>
                     </rules>
-                    <fail>${enforcer.failOnBannedDependencies}</fail>
                   </configuration>
                 </execution>
               </executions>

--- a/build-parent/pom.xml
+++ b/build-parent/pom.xml
@@ -190,7 +190,7 @@
 
     <version.ch.obermuhlner>2.0.1</version.ch.obermuhlner>
     <version.io.smallrye.jandex>3.0.5</version.io.smallrye.jandex>
-    <version.io.smallrye.jandex-maven-plugin>3.0.5</version.io.smallrye.jandex-maven-plugin>
+    <version.io.smallrye.jandex-maven-plugin>${version.io.smallrye.jandex}</version.io.smallrye.jandex-maven-plugin>
     <version.org.eclipse.yasson>1.0.11</version.org.eclipse.yasson>
 
     <version.com.github.javaparser>3.24.2</version.com.github.javaparser>
@@ -209,7 +209,7 @@
 
     <!-- Override with old org.jboss if relying on quarkus 2.13.x or older -->
     <jandex.group-id>io.smallrye</jandex.group-id>
-    <jandex-maven-plugin.group-id>io.smallrye</jandex-maven-plugin.group-id>
+    <jandex-maven-plugin.group-id>${jandex.group-id}</jandex-maven-plugin.group-id>
     
   </properties>
 

--- a/build-parent/pom.xml
+++ b/build-parent/pom.xml
@@ -190,6 +190,7 @@
 
     <version.ch.obermuhlner>2.0.1</version.ch.obermuhlner>
     <version.io.smallrye.jandex>3.0.5</version.io.smallrye.jandex>
+    <version.io.smallrye.jandex-maven-plugin>3.0.5</version.io.smallrye.jandex-maven-plugin>
     <version.org.eclipse.yasson>1.0.11</version.org.eclipse.yasson>
 
     <version.com.github.javaparser>3.24.2</version.com.github.javaparser>
@@ -205,6 +206,10 @@
     <!-- DROOLS-7140 Drools 8 enforce JDK and Maven versions as a rule --> 
     <version.jdk>${maven.compiler.release}</version.jdk>
     <version.maven>${version.org.apache.maven}</version.maven>
+
+    <!-- Override with old org.jboss if relying on quarkus 2.13.x or older -->
+    <jandex.group-id>io.smallrye</jandex.group-id>
+    <jandex-maven-plugin.group-id>io.smallrye</jandex-maven-plugin.group-id>
     
   </properties>
 
@@ -1254,7 +1259,7 @@
 
       <!-- used  by DMN test to ensure NI reflect-conf.json is correctly up-to-date -->
       <dependency>
-        <groupId>io.smallrye</groupId>
+        <groupId>${jandex.group-id}</groupId>
         <artifactId>jandex</artifactId>
         <version>${version.io.smallrye.jandex}</version>
       </dependency>
@@ -1920,9 +1925,9 @@
           <version>1.0</version>
         </plugin>
         <plugin>
-          <groupId>io.smallrye</groupId>
+          <groupId>${jandex-maven-plugin.group-id}</groupId>
           <artifactId>jandex-maven-plugin</artifactId>
-          <version>${version.io.smallrye.jandex}</version>
+          <version>${version.io.smallrye.jandex-maven-plugin}</version>
         </plugin>
         <plugin>
           <groupId>org.asciidoctor</groupId>
@@ -2547,6 +2552,21 @@
           </plugins>
         </pluginManagement>
       </build>
+    </profile>
+    <profile>
+      <id>productized</id>
+      <activation>
+        <property>
+          <name>productized</name>
+        </property>
+      </activation>
+      <properties>
+        <jandex.group-id>org.jboss</jandex.group-id>
+        <version.io.smallrye.jandex>2.4.3.Final</version.io.smallrye.jandex>
+        <jandex-maven-plugin.group-id>org.jboss.jandex</jandex-maven-plugin.group-id>
+        <version.io.smallrye.jandex-maven-plugin>1.2.3</version.io.smallrye.jandex-maven-plugin>
+        <enforcer.skip>true</enforcer.skip>
+      </properties>
     </profile>
   </profiles>
 

--- a/build-parent/pom.xml
+++ b/build-parent/pom.xml
@@ -396,12 +396,6 @@
         <groupId>io.smallrye</groupId>
         <artifactId>smallrye-open-api-core</artifactId>
         <version>${version.io.smallrye.openapi.core}</version>
-        <exclusions>
-          <exclusion>
-            <groupId>io.smallrye</groupId>
-            <artifactId>jandex</artifactId>
-          </exclusion>
-        </exclusions>
       </dependency>
 
       <dependency>

--- a/drools-drl-quarkus-extension/drools-drl-quarkus/pom.xml
+++ b/drools-drl-quarkus-extension/drools-drl-quarkus/pom.xml
@@ -114,7 +114,7 @@
                 </configuration>
             </plugin>
             <plugin>
-                <groupId>io.smallrye</groupId>
+                <groupId>${jandex-maven-plugin.group-id}</groupId>
                 <artifactId>jandex-maven-plugin</artifactId>
             </plugin>
         </plugins>

--- a/drools-persistence/drools-persistence-jpa/pom.xml
+++ b/drools-persistence/drools-persistence-jpa/pom.xml
@@ -168,7 +168,7 @@
       </exclusions>
     </dependency>
     <dependency>
-      <groupId>io.smallrye</groupId>
+      <groupId>${jandex.group-id}</groupId>
       <artifactId>jandex</artifactId>
       <scope>test</scope>
     </dependency>

--- a/drools-traits/pom.xml
+++ b/drools-traits/pom.xml
@@ -154,7 +154,7 @@
       </exclusions>
     </dependency>
     <dependency>
-      <groupId>io.smallrye</groupId>
+      <groupId>${jandex.group-id}</groupId>
       <artifactId>jandex</artifactId>
       <scope>test</scope>
     </dependency>

--- a/kie-dmn/kie-dmn-core/pom.xml
+++ b/kie-dmn/kie-dmn-core/pom.xml
@@ -160,7 +160,7 @@
       <scope>test</scope>
     </dependency>
     <dependency>
-      <groupId>io.smallrye</groupId>
+      <groupId>${jandex.group-id}</groupId>
       <artifactId>jandex</artifactId>
       <scope>test</scope>
     </dependency>

--- a/kie-dmn/kie-dmn-core/pom.xml
+++ b/kie-dmn/kie-dmn-core/pom.xml
@@ -173,6 +173,12 @@
       <groupId>io.smallrye</groupId>
       <artifactId>smallrye-open-api-core</artifactId>
       <scope>test</scope>
+      <exclusions>
+        <exclusion>
+          <groupId>io.smallrye</groupId>
+          <artifactId>jandex</artifactId>
+        </exclusion>
+      </exclusions>
     </dependency>
     <dependency>
       <groupId>io.swagger.core.v3</groupId>

--- a/kie-dmn/kie-dmn-feel/pom.xml
+++ b/kie-dmn/kie-dmn-feel/pom.xml
@@ -92,7 +92,7 @@
       <scope>test</scope>
     </dependency>
     <dependency>
-      <groupId>io.smallrye</groupId>
+      <groupId>${jandex.group-id}</groupId>
       <artifactId>jandex</artifactId>
       <scope>test</scope>
     </dependency>

--- a/kie-dmn/kie-dmn-model/pom.xml
+++ b/kie-dmn/kie-dmn-model/pom.xml
@@ -51,7 +51,7 @@
       <scope>test</scope>
     </dependency>
     <dependency>
-      <groupId>io.smallrye</groupId>
+      <groupId>${jandex.group-id}</groupId>
       <artifactId>jandex</artifactId>
       <scope>test</scope>
     </dependency>


### PR DESCRIPTION
**Thank you for submitting this pull request**

**NOTE!:** Double check the target branch for this PR.
The default is `main` so it will target Drools 8 / Kogito.
If this PR is not strictly related to drools and kogito project in `drools.git`, it should probably target `7.x`as a branch

**Ports** If a forward-port or a backport is needed, paste the forward port PR here

[link](https://www.example.com)

**JIRA**: _(please edit the JIRA link if it exists)_

[link](https://www.example.com)

**referenced Pull Requests**: 

* https://github.com/kiegroup/drools/pull/4908
* https://github.com/kiegroup/drools/pull/4914

This is going to fix the error generated by the maven enforcer when using Quarkus 2.13.x or older, the error thrown is this one:
```
[ERROR] Failed to execute goal org.apache.maven.plugins:maven-enforcer-plugin:3.0.0-M2:enforce (ban-blacklisted-dependencies) on project kie-dmn-core: Some Enforcer rules have failed. Look above for specific messages explaining why the rule failed. -> [Help 1]
[ERROR] Failed to execute goal org.apache.maven.plugins:maven-enforcer-plugin:3.0.0-M2:enforce (ban-blacklisted-dependencies) on project drools-drl-quarkus-util-deployment: Some Enforcer rules have failed. Look above for specific messages explaining why the rule failed. -> [Help 1]

...

[INFO] --- maven-enforcer-plugin:3.0.0-M2:enforce (ban-blacklisted-dependencies) @ drools-drl-quarkus-util-deployment ---
[WARNING] Rule 0: org.apache.maven.plugins.enforcer.BannedDependencies failed with message:
Found Banned Dependency: org.jboss:jandex:jar:2.4.3.Final
```
The issue started appearing since https://github.com/kiegroup/drools/pull/4908. The fix allows to override jandex dependency and skip jandex enforcer rules when enabling productized profile.

The fix aims to extract the jandex group id as a separated property such that it can be overridden when needed to the old `org.jboss` one - this is needed as productized profile relies on Quarkus `2.13.x` which brings older jandex core version breaking the enforcer. 

<details>
<summary>
How to replicate CI configuration locally?
</summary>

Build Chain tool does "simple" maven build(s), the builds are just Maven commands, but because the repositories relates and depends on each other and any change in API or class method could affect several of those repositories there is a need to use [build-chain tool](https://github.com/kiegroup/github-action-build-chain) to handle cross repository builds and be sure that we always use latest version of the code for each repository.
 
[build-chain tool](https://github.com/kiegroup/github-action-build-chain) is a build tool which can be used on command line locally or in Github Actions workflow(s), in case you need to change multiple repositories and send multiple dependent pull requests related with a change you can easily reproduce the same build by executing it on Github hosted environment or locally in your development environment. See [local execution](https://github.com/kiegroup/github-action-build-chain#local-execution) details to get more information about it.
</details>

<details>
<summary>
How to retest this PR or trigger a specific build:
</summary>

- for <b>pull request checks</b>  
  Please add comment: <b>Jenkins retest this</b>

- for a <b>specific pull request check</b>  
  Please add comment: <b>Jenkins (re)run [drools|kogito-runtimes|kogito-apps|kogito-examples] tests</b>

- for a <b>full downstream build</b> 
  - for <b>jenkins</b> job: please add comment: <b>Jenkins run fdb</b>
  - for <b>github actions</b> job: add the label `run_fdb`

- <b>a compile downstream build</b> please  add comment: <b>Jenkins run cdb</b>

- <b>a full production downstream build</b> please add comment: <b>Jenkins execute product fdb</b>

- <b>an upstream build</b> please add comment: <b>Jenkins run upstream</b>

- for <b>quarkus branch checks</b>  
  Run checks against Quarkus current used branch  
  Please add comment: <b>Jenkins run quarkus-branch</b>

- for a <b>quarkus branch specific check</b>  
  Run checks against Quarkus current used branch  
  Please add comment: <b>Jenkins (re)run [drools|kogito-runtimes|kogito-apps|kogito-examples] quarkus-branch</b>

- for <b>quarkus main checks</b>  
  Run checks against Quarkus main branch  
  Please add comment: <b>Jenkins run quarkus-main</b>

- for a <b>specific quarkus main check</b>  
  Run checks against Quarkus main branch  
  Please add comment: <b>Jenkins (re)run [drools|kogito-runtimes|kogito-apps|kogito-examples] quarkus-main</b>

- for <b>quarkus lts checks</b>  
  Run checks against Quarkus lts branch  
  Please add comment: <b>Jenkins run quarkus-lts</b>

- for a <b>specific quarkus lts check</b>  
  Run checks against Quarkus lts branch  
  Please add comment: <b>Jenkins (re)run [drools|kogito-runtimes|kogito-apps|kogito-examples] quarkus-lts</b>

- for <b>native checks</b>  
  Run native checks  
  Please add comment: <b>Jenkins run native</b>

- for a <b>specific native check</b>  
  Run native checks 
  Please add comment: <b>Jenkins (re)run [drools|kogito-runtimes|kogito-apps|kogito-examples] native</b>

- for <b>mandrel checks</b>  
  Run native checks against Mandrel image
  Please add comment: <b>Jenkins run mandrel</b>

- for a <b>specific mandrel check</b>  
  Run native checks against Mandrel image  
  Please add comment: <b>Jenkins (re)run [drools|kogito-runtimes|kogito-apps|kogito-examples] mandrel</b>

 - for <b>mandrel lts checks</b>  
  Run native checks against Mandrel image and quarkus lts branch
  Please add comment: <b>Jenkins run mandrel-lts</b>

- for a <b>specific mandrel lts check</b>  
  Run native checks against Mandrel image and quarkus lts branch
  Please add comment: <b>Jenkins (re)run [drools|kogito-runtimes|kogito-apps|kogito-examples] mandrel-lts</b>
</details>

<details>
<summary>
How to backport a pull request to a different branch?
</summary>

In order to automatically create a **backporting pull request** please add one or more labels having the following format `backport-<branch-name>`, where `<branch-name>` is the name of the branch where the pull request must be backported to (e.g., `backport-7.67.x` to backport the original PR to the `7.67.x` branch).

> **NOTE**: **backporting** is an action aiming to move a change (usually a commit) from a branch (usually the main one) to another one, which is generally referring to a still maintained release branch. Keeping it simple: it is about to move a specific change or a set of them from one branch to another.

Once the original pull request is successfully merged, the automated action will create one backporting pull request per each label (with the previous format) that has been added.

If something goes wrong, the author will be notified and at this point a manual backporting is needed.

> **NOTE**: this automated backporting is triggered whenever a pull request on `main` branch is labeled or closed, but both conditions must be satisfied to get the new PR created.
</details>