### PR TITLE
[DROOLS-7238] Rete Buildtime Segmentation

### DIFF
--- a/drools-core/src/main/java/org/drools/core/common/BaseNode.java
+++ b/drools-core/src/main/java/org/drools/core/common/BaseNode.java
@@ -219,10 +219,6 @@ public abstract class BaseNode
         return associatedTerminals.containsKey(terminalNode.getId());
     }
 
-    public Map<Integer, TerminalNode> getAssociatedTerminals() {
-        return associatedTerminals;
-    }
-
     @Override
     public final int hashCode() {
         return hashcode;

--- a/drools-core/src/main/java/org/drools/core/common/BaseNode.java
+++ b/drools-core/src/main/java/org/drools/core/common/BaseNode.java
@@ -219,6 +219,10 @@ public abstract class BaseNode
         return associatedTerminals.containsKey(terminalNode.getId());
     }
 
+    public Map<Integer, TerminalNode> getAssociatedTerminals() {
+        return associatedTerminals;
+    }
+
     @Override
     public final int hashCode() {
         return hashcode;

--- a/drools-core/src/main/java/org/drools/core/common/Memory.java
+++ b/drools-core/src/main/java/org/drools/core/common/Memory.java
@@ -32,7 +32,7 @@ public interface Memory extends LinkedListNode<Memory> {
     default SegmentMemory getOrCreateSegmentMemory( LeftTupleSource tupleSource, ReteEvaluator reteEvaluator ) {
         SegmentMemory smem = getSegmentMemory();
         if (smem == null) {
-            smem = RuntimeSegmentUtilities.getOrCreateSegmentMemory(tupleSource, reteEvaluator);
+            smem = RuntimeSegmentUtilities.getOrCreateSegmentMemory(this, tupleSource, reteEvaluator);
         }
         return smem;
     }

--- a/drools-core/src/main/java/org/drools/core/common/NetworkNode.java
+++ b/drools-core/src/main/java/org/drools/core/common/NetworkNode.java
@@ -19,8 +19,6 @@ package org.drools.core.common;
 import org.drools.core.reteoo.TerminalNode;
 import org.kie.api.definition.rule.Rule;
 
-import java.util.Map;
-
 /**
  * Interface used to expose generic information on Rete nodes outside of he package. It is used
  * for exposing information events.
@@ -47,7 +45,6 @@ public interface NetworkNode {
     void removeAssociatedTerminal(TerminalNode terminalNode);
 
     int getAssociatedTerminalsSize();
-    //Map<Integer, TerminalNode> getAssociatedTerminals();
 
     boolean hasAssociatedTerminal(NetworkNode terminalNode);
 

--- a/drools-core/src/main/java/org/drools/core/common/NetworkNode.java
+++ b/drools-core/src/main/java/org/drools/core/common/NetworkNode.java
@@ -19,6 +19,8 @@ package org.drools.core.common;
 import org.drools.core.reteoo.TerminalNode;
 import org.kie.api.definition.rule.Rule;
 
+import java.util.Map;
+
 /**
  * Interface used to expose generic information on Rete nodes outside of he package. It is used
  * for exposing information events.
@@ -43,7 +45,10 @@ public interface NetworkNode {
 
     void addAssociatedTerminal(TerminalNode terminalNode);
     void removeAssociatedTerminal(TerminalNode terminalNode);
+
     int getAssociatedTerminalsSize();
+    //Map<Integer, TerminalNode> getAssociatedTerminals();
+
     boolean hasAssociatedTerminal(NetworkNode terminalNode);
 
     NetworkNode[] getSinks();

--- a/drools-core/src/main/java/org/drools/core/impl/KnowledgeBaseImpl.java
+++ b/drools-core/src/main/java/org/drools/core/impl/KnowledgeBaseImpl.java
@@ -57,7 +57,6 @@ import org.drools.core.reteoo.LeftTupleNode;
 import org.drools.core.reteoo.LeftTupleSource;
 import org.drools.core.reteoo.ObjectSinkPropagator;
 import org.drools.core.reteoo.ObjectTypeNode;
-import org.drools.core.reteoo.PathEndNode;
 import org.drools.core.reteoo.Rete;
 import org.drools.core.reteoo.ReteooBuilder;
 import org.drools.core.reteoo.RuntimeComponentFactory;
@@ -91,8 +90,6 @@ import org.kie.api.internal.io.ResourceTypePackage;
 import org.kie.api.internal.utils.KieService;
 import org.kie.api.internal.weaver.KieWeavers;
 import org.kie.api.io.Resource;
-import org.kie.api.runtime.KieSession;
-import org.kie.api.runtime.KieSessionConfiguration;
 import org.kie.internal.conf.CompositeBaseConfiguration;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -924,11 +921,6 @@ public class KnowledgeBaseImpl implements RuleBase {
     }
 
     @Override
-    public Map<Integer,SegmentPrototype> getSegmentPrototypes() {
-        return segmentProtos;
-    }
-
-    @Override
     public SegmentMemory createSegmentFromPrototype(ReteEvaluator reteEvaluator, LeftTupleSource tupleSource) {
         SegmentPrototype proto = segmentProtos.get(tupleSource.getId());
         return createSegmentFromPrototype(reteEvaluator, proto);
@@ -1034,7 +1026,6 @@ public class KnowledgeBaseImpl implements RuleBase {
     }
 
     public void kBaseInternal_addRules(Collection<? extends Rule> rules, Collection<InternalWorkingMemory> wms ) {
-        List<PathEndNode> endNodes = new ArrayList<>();
         List<TerminalNode> terminalNodes = new ArrayList<>(rules.size() * 2);
 
         for (Rule r : rules) {
@@ -1044,7 +1035,7 @@ public class KnowledgeBaseImpl implements RuleBase {
             terminalNodes.addAll(this.reteooBuilder.addRule(rule, wms));
         }
 
-        if (PhreakBuilder.isEagerSegmentCreation() && getSegmentPrototypes().isEmpty()) {
+        if (PhreakBuilder.isEagerSegmentCreation() && !hasSegmentPrototypes()) {
             // All Protos must be created, before inserting objects.
             for (TerminalNode tn : terminalNodes) {
                 tn.getPathMemSpec();

--- a/drools-core/src/main/java/org/drools/core/impl/RuleBase.java
+++ b/drools-core/src/main/java/org/drools/core/impl/RuleBase.java
@@ -26,7 +26,6 @@ import java.util.concurrent.Future;
 
 import org.drools.core.KieBaseConfigurationImpl;
 import org.drools.core.RuleBaseConfiguration;
-import org.drools.core.SessionConfiguration;
 import org.drools.core.base.ClassFieldAccessorCache;
 import org.drools.core.common.InternalWorkingMemory;
 import org.drools.core.common.ReteEvaluator;
@@ -43,8 +42,8 @@ import org.drools.core.reteoo.SegmentMemory;
 import org.drools.core.reteoo.SegmentMemory.SegmentPrototype;
 import org.drools.core.rule.InvalidPatternException;
 import org.drools.core.rule.TypeDeclaration;
-import org.drools.core.ruleunit.RuleUnitDescriptionRegistry;
 import org.drools.core.rule.accessor.FactHandleFactory;
+import org.drools.core.ruleunit.RuleUnitDescriptionRegistry;
 import org.kie.api.KieBaseConfiguration;
 import org.kie.api.builder.ReleaseId;
 import org.kie.api.definition.KiePackage;
@@ -174,6 +173,4 @@ public interface RuleBase {
     }
 
     void registerSegmentPrototype(LeftTupleNode tupleSource, SegmentPrototype smem);
-
-    Map<Integer,SegmentPrototype> getSegmentPrototypes();
 }

--- a/drools-core/src/main/java/org/drools/core/impl/RuleBase.java
+++ b/drools-core/src/main/java/org/drools/core/impl/RuleBase.java
@@ -174,4 +174,6 @@ public interface RuleBase {
     }
 
     void registerSegmentPrototype(LeftTupleNode tupleSource, SegmentPrototype smem);
+
+    Map<Integer,SegmentPrototype> getSegmentPrototypes();
 }

--- a/drools-core/src/main/java/org/drools/core/phreak/BuildtimeSegmentUtilities.java
+++ b/drools-core/src/main/java/org/drools/core/phreak/BuildtimeSegmentUtilities.java
@@ -15,8 +15,11 @@
 
 package org.drools.core.phreak;
 
+import java.nio.file.Path;
 import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 
 import org.drools.core.common.NetworkNode;
 import org.drools.core.impl.RuleBase;
@@ -35,6 +38,7 @@ import org.drools.core.reteoo.LeftTupleSource;
 import org.drools.core.reteoo.NodeTypeEnums;
 import org.drools.core.reteoo.NotNode;
 import org.drools.core.reteoo.PathEndNode;
+import org.drools.core.reteoo.PathEndNode.PathMemSpec;
 import org.drools.core.reteoo.QueryElementNode;
 import org.drools.core.reteoo.ReactiveFromNode;
 import org.drools.core.reteoo.RightInputAdapterNode;
@@ -58,6 +62,29 @@ import org.drools.core.reteoo.TimerNode;
 
 public class BuildtimeSegmentUtilities {
 
+    public static void updateSegmentEndNodes(PathEndNode endNode) {
+        SegmentPrototype smproto = endNode.getSegmentPrototypes()[endNode.getSegmentPrototypes().length-1];
+        if (smproto.getPathEndNodes() != null) {
+            // This is a special check, for shared subnetwork paths. It ensure it's initallysed only once,
+            // even though the rian is shared with different TNs.
+            return;
+        }
+
+        for ( int i = 0; i < endNode.getSegmentPrototypes().length; i++) {
+            smproto = endNode.getSegmentPrototypes()[i];
+
+            if ( smproto.getPathEndNodes() != null) {
+                PathEndNode[] existingNodes = smproto.getPathEndNodes();
+                PathEndNode[] newNodes = new PathEndNode[existingNodes.length+1];
+                System.arraycopy(existingNodes, 0, newNodes, 0, existingNodes.length);
+                newNodes[newNodes.length-1] = endNode;
+                smproto.setPathEndNodes(newNodes);
+            } else {
+                smproto.setPathEndNodes( new PathEndNode[]{endNode});
+            }
+        }
+    }
+
     public static void createPathProtoMemories(TerminalNode tn, TerminalNode removingTn, RuleBase rbase) {
         // Will initialise all segments in a path
         SegmentPrototype[] smems;
@@ -74,13 +101,34 @@ public class BuildtimeSegmentUtilities {
         List<SegmentPrototype> eager = new ArrayList<>();
         for (SegmentPrototype smem : smems) {
             // The segments before the start of a subnetwork, will be null for a rian path.
-            if (smem != null && requiresAnEagerSegment(smem.getNodeTypesInSegment())) {
+            if (smem != null && smem.requiresEager()) {
                 eager.add(smem);
             }
         }
         endNode.setEagerSegmentPrototypes(eager.toArray(new SegmentPrototype[eager.size()]));
 
+        long allLinkedMaskTest = getPathAllLinkedMaskTest(smems, endNode);
+
+        endNode.setPathMemSpec(new PathMemSpec(allLinkedMaskTest, smems.length));
+
         endNode.setSegmentPrototypes(smems);
+
+        updateSegmentEndNodes(endNode);
+    }
+
+    public static long getPathAllLinkedMaskTest(SegmentPrototype[] smems, PathEndNode endNode) {
+        long allLinkedMaskTest = 0;
+        for (int i = smems.length - 1; i >= 0; i--) {
+            SegmentPrototype smem = smems[i];
+
+            if (EagerPhreakBuilder.isInsideSubnetwork(endNode, smem) && smem.getAllLinkedMaskTest() > 0) {
+                allLinkedMaskTest = allLinkedMaskTest | 1;
+            }
+            if (i > 0) {
+                allLinkedMaskTest = nextNodePosMask(allLinkedMaskTest);
+            }
+        }
+        return allLinkedMaskTest;
     }
 
     // notes, looking into if/why I need stopNode
@@ -88,7 +136,11 @@ public class BuildtimeSegmentUtilities {
         LeftTupleNode segmentRoot = lts;
         LeftTupleNode segmentTip = lts;
         List<SegmentPrototype> smems = new ArrayList<>();
-        boolean inside = true; // as it starts at the terminal or ria node, we know that it starts inside.
+        int start = 0;
+
+        LeftTupleNode firstConditional = getFirstConditionalBranchNode(lts);
+        int recordBefore = firstConditional == null  ? Integer.MAX_VALUE : firstConditional.getPathIndex();  // nodes after a branch CE can notify, but they cannot impact linking
+
         do {
             // iterate to find the actual segment root
             while (!BuildtimeSegmentUtilities.isRootNode(segmentRoot, removingTn)) {
@@ -96,12 +148,12 @@ public class BuildtimeSegmentUtilities {
             }
 
             // Store all nodes for the main path in reverse order (we're starting from the terminal node).
-            // If this is a subnetwork, only store nodes inside of it.
-            smems.add( 0, inside ? createSegmentMemory(segmentRoot, segmentTip, removingTn, rbase) : null );
-
-            if ( inside && segmentRoot.getLeftTupleSource() == stopNode) {
-                inside = false;
+            SegmentPrototype smem = rbase.getSegmentPrototype(segmentRoot);
+            if (smem == null) {
+                start = segmentRoot.getPathIndex(); // we want counter to start from the new segment proto only
+                smem = createSegmentMemory(segmentRoot, segmentTip, recordBefore, removingTn, rbase);
             }
+            smems.add(0, smem);
 
             // this is the new segment so set both to same, and it iterates for the actual segmentRoot next loop.
             segmentRoot = segmentRoot.getLeftTupleSource();
@@ -110,10 +162,14 @@ public class BuildtimeSegmentUtilities {
 
         // reset to find the next segments and set their position and their bit mask
         int ruleSegmentPosMask = 1;
-        for (int counter = 0; counter < smems.size(); counter++) {
-            if ( smems.get(counter) != null) { // The segments before the start of a subnetwork, will be null for a rian path.
-                smems.get(counter).setPos(counter);
-                smems.get(counter).setSegmentPosMaskBit(ruleSegmentPosMask);
+        for (int i = 0; i < smems.size(); i++) {
+            if ( start >= 0 && smems.get(i) != null) { // The segments before the start of a subnetwork, will be null for a rian path.
+                smems.get(i).setPos(i);
+                if (smems.get(i).getAllLinkedMaskTest() > 0) {
+                    smems.get(i).setSegmentPosMaskBit(ruleSegmentPosMask);
+                } else {
+                    smems.get(i).setSegmentPosMaskBit(0);
+                }
             }
             ruleSegmentPosMask = ruleSegmentPosMask << 1;
         }
@@ -121,10 +177,21 @@ public class BuildtimeSegmentUtilities {
         return smems.toArray(new SegmentPrototype[smems.size()]);
     }
 
+    static LeftTupleNode getFirstConditionalBranchNode(LeftTupleNode tupleSource) {
+        LeftTupleNode conditionalBranch = null;
+        while (  tupleSource.getType() != NodeTypeEnums.LeftInputAdapterNode ) {
+            if ( tupleSource.getType() == NodeTypeEnums.ConditionalBranchNode ) {
+                conditionalBranch = tupleSource;
+            }
+            tupleSource = tupleSource.getLeftTupleSource();
+        }
+        return conditionalBranch;
+    }
+
     /**
      * Initialises the NodeSegment memory for all nodes in the segment.
      */
-    public static SegmentPrototype createSegmentMemory(LeftTupleNode segmentRoot, LeftTupleNode segmentTip, TerminalNode removingTn, RuleBase rbase) {
+    public static SegmentPrototype createSegmentMemory(LeftTupleNode segmentRoot, LeftTupleNode segmentTip, int recordBefore, TerminalNode removingTn, RuleBase rbase) {
         LeftTupleNode node = segmentRoot;
         int nodeTypesInSegment = 0;
 
@@ -136,12 +203,13 @@ public class BuildtimeSegmentUtilities {
         // allLinkedTestMask is the resulting mask used to test if all nodes are linked in
         long nodePosMask = 1;
         long allLinkedTestMask = 0;
-        boolean updateNodeBit = true;  // nodes after a branch CE can notify, but they cannot impact linking
+        boolean updateNodeBit = true;
 
         while (true) {
             nodeTypesInSegment = updateNodeTypesMask(node, nodeTypesInSegment);
             if (NodeTypeEnums.isBetaNode(node)) {
-                allLinkedTestMask = processBetaNode((BetaNode)node, smem, memories, nodes, nodePosMask, allLinkedTestMask, updateNodeBit, removingTn, rbase);
+                boolean updateAllLinked = node.getPathIndex() < recordBefore && updateNodeBit;
+                allLinkedTestMask = processBetaNode((BetaNode)node, smem, memories, nodes, nodePosMask, allLinkedTestMask, updateAllLinked, removingTn, rbase);
             } else {
                 switch (node.getType()) {
                     case NodeTypeEnums.LeftInputAdapterNode:
@@ -149,7 +217,6 @@ public class BuildtimeSegmentUtilities {
                         break;
                     case NodeTypeEnums.ConditionalBranchNode:
                         processConditionalBranchNode((ConditionalBranchNode) node, memories, nodes);
-                        updateNodeBit = false;
                         break;
                     case NodeTypeEnums.FromNode:
                         processFromNode((FromNode) node, memories, nodes);
@@ -192,12 +259,8 @@ public class BuildtimeSegmentUtilities {
         }
         smem.setAllLinkedMaskTest(allLinkedTestMask);
 
-        List<PathEndNode> endNodes = new ArrayList<>();
-        collectPathEndNodes(segmentTip, endNodes, removingTn);
-
         smem.setNodesInSegment(nodes.toArray( new LeftTupleNode[nodes.size()]));
         smem.setMemories(memories.toArray( new MemoryPrototype[memories.size()]));
-        smem.setPathEndNodes(endNodes.toArray( new PathEndNode[endNodes.size()]));
         smem.setNodeTypesInSegment(nodeTypesInSegment);
 
         rbase.registerSegmentPrototype(segmentRoot, smem);
@@ -212,31 +275,30 @@ public class BuildtimeSegmentUtilities {
              !isSet(nodeTypesInSegment, REACTIVE_EXISTS_NODE_BIT);
     }
 
-    private static void collectPathEndNodes(LeftTupleNode lt,
-                                            List<PathEndNode> endNodes,
-                                            TerminalNode removingTn) {
-        if (removingTn != null & !NodeTypeEnums.isTerminalNode(lt) && !sinkNotExclusivelyAssociatedWithTerminal(removingTn, lt)) {
-            // ignore this path, it unique to the removing tn
-            return;
+    public static class PathCacheEntry {
+        private LeftTupleNode node;
+        private List<PathEndNode> endNodes;
+
+        public PathCacheEntry(LeftTupleNode node, List<PathEndNode> endNodes) {
+            this.node = node;
+            this.endNodes = endNodes;
         }
 
-         if (NodeTypeEnums.isTerminalNode(lt)) {
-            endNodes.add((PathEndNode) lt);
-        } else if (NodeTypeEnums.RightInputAdapterNode == lt.getType()) {
-            endNodes.add( (PathEndNode) lt );
+        public LeftTupleNode node() {
+            return node;
         }
 
-        for (LeftTupleSinkNode sink = lt.getSinkPropagator().getLastLeftTupleSink(); sink != null; sink = sink.getPreviousLeftTupleSinkNode()) {
-            collectPathEndNodes(sink, endNodes, removingTn);
+        public List<PathEndNode> endNodes() {
+            return endNodes;
         }
     }
 
-    public static long nextNodePosMask(long nodePosMask) {
+    public static long nextNodePosMask(long posMask) {
         // prevent overflow of segment and path memories masks when a segment has 64 or more nodes or a path has 64 or more segments
         // in this extreme case all the items after the 64th will be all mapped by the same bit and then the linking of one of them
         // will be enough to consider all those item linked
-        long nextNodePosMask = nodePosMask << 1;
-        return nextNodePosMask > 0 ? nextNodePosMask : nodePosMask;
+        long nextNodePosMask = posMask << 1;
+        return nextNodePosMask > 0 ? nextNodePosMask : posMask;
     }
 
     private static boolean processQueryNode(QueryElementNode queryNode, List<MemoryPrototype> memories, List<LeftTupleNode> nodes, long nodePosMask) {
@@ -317,7 +379,7 @@ public class BuildtimeSegmentUtilities {
             // there is a subnetwork, so create all it's segment memory prototypes
             riaNode = (RightInputAdapterNode) betaNode.getRightInput();
 
-            SegmentPrototype[] smems = createPathProtoMemories(riaNode, riaNode.getStartTupleSource(), removingTn, rbase);
+            SegmentPrototype[] smems = createPathProtoMemories(riaNode, riaNode.getStartTupleSource().getLeftTupleSource(), removingTn, rbase);
             setSegments(riaNode, smems);
 
             if (updateNodeBit && canBeDisabled(betaNode) && riaNode.getPathMemSpec().allLinkedTestMask() > 0) {
@@ -361,8 +423,8 @@ public class BuildtimeSegmentUtilities {
      * The result should discount any removingRule. That means it gives you the result as
      * if the rule had already been removed from the network.
      */
-    public static boolean isRootNode(LeftTupleNode node, TerminalNode removingTN) {
-        return node.getType() == NodeTypeEnums.LeftInputAdapterNode || isTipNode( node.getLeftTupleSource(), removingTN );
+    public static boolean isRootNode(LeftTupleNode node, TerminalNode ignoreTn) {
+        return node.getType() == NodeTypeEnums.LeftInputAdapterNode || isTipNode( node.getLeftTupleSource(), ignoreTn );
     }
 
     /**
@@ -413,6 +475,8 @@ public class BuildtimeSegmentUtilities {
     public static final int REACTIVE_EXISTS_NODE_BIT   = 1 << 2;
     public static final int PASSIVE_EXISTS_NODE_BIT    = 1 << 3;
 
+    public static final int CONDITIONAL_BRANCH_BIT = 1 << 4;
+
     public static int updateNodeTypesMask(NetworkNode node, int mask) {
         if (node != null) {
             switch ( node.getType() ) {
@@ -429,6 +493,9 @@ public class BuildtimeSegmentUtilities {
                 case NodeTypeEnums.NotNode:
                     mask |= NOT_NODE_BIT;
                     break;
+                case NodeTypeEnums.ConditionalBranchNode:
+                    mask |= CONDITIONAL_BRANCH_BIT;
+                    break;
             }
         }
         return mask;
@@ -438,14 +505,14 @@ public class BuildtimeSegmentUtilities {
         return (mask & bit) == bit;
     }
 
-    public static LeftTupleNode findSegmentRoot(LeftTupleNode tupleSource) {
-        while (!BuildtimeSegmentUtilities.isRootNode(tupleSource, null)) {
+    public static LeftTupleNode findSegmentRoot(LeftTupleNode tupleSource, TerminalNode ignoreTn) {
+        while (!BuildtimeSegmentUtilities.isRootNode(tupleSource, ignoreTn)) {
             tupleSource = tupleSource.getLeftTupleSource();
         }
         return tupleSource;
     }
 
     public static boolean isAssociatedWith(NetworkNode node, TerminalNode tn) {
-        return tn.isTerminalNodeOf((LeftTupleNode) node);
+        return node.hasAssociatedTerminal(tn);
     }
 }

--- a/drools-core/src/main/java/org/drools/core/phreak/EagerPhreakBuilder.java
+++ b/drools-core/src/main/java/org/drools/core/phreak/EagerPhreakBuilder.java
@@ -18,25 +18,25 @@ package org.drools.core.phreak;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
-import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Iterator;
 import java.util.List;
-import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
+import java.util.stream.Collectors;
 
+import org.drools.core.WorkingMemory;
 import org.drools.core.common.EventFactHandle;
 import org.drools.core.common.InternalAgenda;
 import org.drools.core.common.InternalFactHandle;
 import org.drools.core.common.InternalWorkingMemory;
 import org.drools.core.common.Memory;
 import org.drools.core.common.MemoryFactory;
+import org.drools.core.common.NetworkNode;
 import org.drools.core.common.PropagationContext;
 import org.drools.core.common.PropagationContextFactory;
 import org.drools.core.common.TupleSets;
 import org.drools.core.impl.RuleBase;
-import org.drools.core.reteoo.AbstractTerminalNode;
 import org.drools.core.reteoo.AccumulateNode.AccumulateContext;
 import org.drools.core.reteoo.AccumulateNode.AccumulateMemory;
 import org.drools.core.reteoo.AlphaTerminalNode;
@@ -47,22 +47,23 @@ import org.drools.core.reteoo.LeftInputAdapterNode;
 import org.drools.core.reteoo.LeftInputAdapterNode.RightTupleSinkAdapter;
 import org.drools.core.reteoo.LeftTuple;
 import org.drools.core.reteoo.LeftTupleNode;
-import org.drools.core.reteoo.LeftTupleSink;
 import org.drools.core.reteoo.LeftTupleSinkNode;
-import org.drools.core.reteoo.LeftTupleSource;
 import org.drools.core.reteoo.NodeTypeEnums;
 import org.drools.core.reteoo.ObjectSink;
 import org.drools.core.reteoo.ObjectSource;
 import org.drools.core.reteoo.ObjectTypeNode;
 import org.drools.core.reteoo.ObjectTypeNode.ObjectTypeNodeMemory;
 import org.drools.core.reteoo.PathEndNode;
+import org.drools.core.reteoo.PathEndNode.PathMemSpec;
 import org.drools.core.reteoo.PathMemory;
 import org.drools.core.reteoo.QueryElementNode;
 import org.drools.core.reteoo.RightInputAdapterNode;
 import org.drools.core.reteoo.RightTuple;
 import org.drools.core.reteoo.RuntimeComponentFactory;
 import org.drools.core.reteoo.SegmentMemory;
+import org.drools.core.reteoo.SegmentMemory.MemoryPrototype;
 import org.drools.core.reteoo.SegmentMemory.SegmentPrototype;
+import org.drools.core.reteoo.SegmentNodeMemory;
 import org.drools.core.reteoo.TerminalNode;
 import org.drools.core.reteoo.Tuple;
 import org.drools.core.reteoo.TupleMemory;
@@ -72,10 +73,8 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import static org.drools.core.phreak.BuildtimeSegmentUtilities.isAssociatedWith;
-import static org.drools.core.phreak.BuildtimeSegmentUtilities.isRootNode;
-import static org.drools.core.phreak.TupleEvaluationUtil.forceFlushLeftTuple;
 
-class EagerPhreakBuilder implements PhreakBuilder {
+public class EagerPhreakBuilder implements PhreakBuilder {
 
     private static final Logger log = LoggerFactory.getLogger(EagerPhreakBuilder.class);
 
@@ -89,77 +88,35 @@ class EagerPhreakBuilder implements PhreakBuilder {
             log.trace("Adding Rule {}", tn.getRule().getName());
         }
 
-        Set<LeftTupleNode> splitNodes = new HashSet<>();
-        Arrays.stream(tn.getPathEndNodes()).forEach(n -> addNetworkSplitPoint(n, splitNodes));
-
-        PathEndNodes pathEndNodes = getPathEndNodes(tn, splitNodes);
-
-        pathEndNodes.nodesToInvalidate.forEach(kBase::invalidateSegmentPrototype);
-
-        // reset the node/segment masks and protos for the subject and other impact
-        tn.resetPathMemSpec(null);
-        BuildtimeSegmentUtilities.createPathProtoMemories(tn, null, kBase);
-
-        // reset first, to avoid resetting stuff already recalculated - in the case of shares.
-        resetPaths(null, kBase, pathEndNodes);
-
-        // Insert the facts for the new paths. This will iterate each new path from EndNode to the splitStart - but will not process the splitStart itself (as tha already exist).
-        // It does not matter that the prior segments have not yet been processed for splitting, as this will only apply for branches of paths that did not exist before
-
         for (InternalWorkingMemory wm : wms) {
             wm.flushPropagations();
-
-            PathEndNodeMemories tnms = getPathEndMemories(wm, pathEndNodes);
-
-            if (tn.getPathNodes()[0].getAssociatedTerminalsSize() == 1) {
-                // rule added with no sharing, so populate it's lian
-                insertLiaFacts(tn.getPathNodes()[0], wm);
-            } else if (tnms.subjectPmem != null) {
-                // If the subject PathMemories are not yet initialized (by the flush) there are no Segments or tuples to process
-                Map<PathMemory, SegmentMemory[]> prevSmemsLookup = reInitPathMemories(tnms.otherPmems);
-
-                // must collect all visited SegmentMemories, for link notification
-                handleExistingPaths(tn, prevSmemsLookup, tnms.otherPmems, wm, ExistingPathStrategy.ADD_STRATEGY);
-
-                addNewPaths(wm, tnms.subjectPmems);
-
-                pathEndNodes.subjectSplits.forEach( n -> processLeftTuples(n, wm, true, tn));
-            }
-
-            addExistingSegmentMemories(pathEndNodes, wm);
-
-            insertFacts(pathEndNodes, wm);
-
-            notifySegments(tnms, wm);
         }
-    }
 
-    private static void addExistingSegmentMemories(PathEndNodes pathEndNodes, InternalWorkingMemory wm) {
-        // Iterates the path to find existing SegmentMemories that can be added to the PathMemory
-        pathEndNodes.subjectEndNodes.forEach(endNode -> {
-            Arrays.stream(endNode.getSegmentPrototypes()).forEach( proto -> {
-                if (proto == null) { // ths proto is before the start of the subnetwork
-                    return;
-                }
+        Set<SegmentMemoryPair> smemsToNotify = new HashSet<>();
 
-                LeftTupleNode node = proto.getRootNode();
-                Memory mem = wm.getNodeMemories().peekNodeMemory(node);
+        Set<Integer> visited = new HashSet<>();
+        if (tn.getPathNodes()[0].getAssociatedTerminalsSize() == 1) {
+            BuildtimeSegmentUtilities.createPathProtoMemories(tn, null, kBase);
 
-                if (mem != null && mem.getSegmentMemory() != null) {
-                    SegmentMemory smem = mem.getSegmentMemory();
+            // rule added with no sharing, so populate it's lian
+            wms.stream().forEach( wm -> Add.insertLiaFacts(tn.getPathNodes()[0], wm, visited, false));
+        } else {
+            List<Pair> exclBranchRoots = getExclusiveBranchRoots(tn);
 
-                    PathMemory pmem = (PathMemory) wm.getNodeMemories().peekNodeMemory(endNode);
-                    if (pmem == null) {
-                        pmem = RuntimeSegmentUtilities.initializePathMemory(wm, endNode);
-                    }
-                    if (pmem.getSegmentMemories()[proto.getPos()] == null) {
-                        // we check null, as this might have been fixed due to eager initialisation
-                        pmem.setSegmentMemory(smem.getPos(), smem);
-                        smem.addPathMemory(pmem);
-                    }
-                }
-            });
-        });
+            // Process existing branches from the split  points
+            exclBranchRoots.forEach(pair -> Add.processSplit(pair.parent, kBase, wms, smemsToNotify));
+
+            Add.addNewPaths(exclBranchRoots, tn, wms, kBase, smemsToNotify);
+
+            exclBranchRoots.forEach(pair -> processLeftTuples(pair.parent, true, tn, wms));
+        }
+
+        for (InternalWorkingMemory wm : wms) {
+            Add.addExistingSegmentMemories(Arrays.asList(tn.getPathEndNodes()), wm);
+            Add.insertFacts(tn, wm, visited, false);
+        }
+
+        smemsToNotify.stream().forEach( pair -> pair.sm.notifyRuleLinkSegment(pair.wm));
     }
 
     /**
@@ -174,432 +131,590 @@ class EagerPhreakBuilder implements PhreakBuilder {
             log.trace("Removing Rule {}", tn.getRule().getName());
         }
 
-        Set<LeftTupleNode> splitNodes = new HashSet<>();
-        Arrays.stream(tn.getPathEndNodes()).forEach(n -> addNetworkSplitPoint(n, splitNodes));
-
-        PathEndNodes pathEndNodes = getPathEndNodes(tn, splitNodes);
-
-        PathEndNodeMemories[] tnmsList = new PathEndNodeMemories[wms.size()];
-        int i = 0;
         for (InternalWorkingMemory wm : wms) {
             wm.flushPropagations();
-
-            PathEndNodeMemories tnms = getPathEndMemories(wm, pathEndNodes);
-            tnmsList[i++]  = tnms;
-
-            if (!tnms.subjectPmems.isEmpty()) {
-                if (tn.getPathNodes()[0].getAssociatedTerminalsSize() == 1 &&
-                    tnms.subjectPmem != null) {
-                    pathEndNodes.subjectSplits.forEach(n -> flushStagedTuples(n, tnms.subjectPmem, wm));
-                } else {
-                    flushStagedTuples(tn, tnms.subjectPmem, pathEndNodes, wm);
-                }
-                pathEndNodes.subjectSplits.forEach( n -> processLeftTuples(n, wm, false, tn));
-
-            }
         }
 
-        pathEndNodes.nodesToInvalidate.forEach(kBase::invalidateSegmentPrototype);
+        Set<SegmentMemoryPair> smemsToNotify = new HashSet<>();
 
-        resetPaths(tn, kBase, pathEndNodes);
+        List<Pair> exclBranchRoots = getExclusiveBranchRoots(tn);
 
-        i = 0;
         for (InternalWorkingMemory wm : wms) {
-            PathEndNodeMemories tnms = tnmsList[i++];
-
-            if (!tnms.subjectPmems.isEmpty()) {
-                removeNewPaths(wm, tnms.subjectPmems);
-                if (tn.getPathNodes()[0].getAssociatedTerminalsSize() > 1 ) {
-                    Map<PathMemory, SegmentMemory[]> prevSmemsLookup = reInitPathMemories(tnms.otherPmems);
-
-                    // must collect all visited SegmentMemories, for link notification
-                    handleExistingPaths(tn, prevSmemsLookup, tnms.otherPmems, wm, ExistingPathStrategy.REMOVE_STRATEGY);
-
-                    notifySegments(tnms, wm);
-                }
-            }
-
-            if (tnms.subjectPmem != null && tnms.subjectPmem.isInitialized() && tnms.subjectPmem.getRuleAgendaItem().isQueued()) {
-                // SubjectPmem can be null, if it was never initialized
-                tnms.subjectPmem.getRuleAgendaItem().dequeue();
-            }
-        }
-    }
-
-    private static void resetPaths(TerminalNode tn, RuleBase kBase, PathEndNodes pathEndNodes) {
-        // reset first, to avoid resetting stuff already relculated - in the case of shares.
-        pathEndNodes.otherTermNodes.forEach(other -> other.resetPathMemSpec(tn));
-        pathEndNodes.otherTermNodes.forEach(other -> BuildtimeSegmentUtilities.createPathProtoMemories(other, tn, kBase));
-    }
-
-    static void adjustSegment(InternalWorkingMemory wm, SegmentMemory smem) {
-        smem.unlinkSegment(wm);
-        SegmentPrototype proto = wm.getKnowledgeBase().getSegmentPrototype(smem.getRootNode());
-
-        // need to preserve the current LinkedNodeMask, during update, so it can be restored.
-        long currentLinkedNodeMask = smem.getLinkedNodeMask();
-        proto.updateSegmentMemory(smem,wm);
-        smem.setLinkedNodeMask(currentLinkedNodeMask);
-    }
-
-    interface ExistingPathStrategy {
-        ExistingPathStrategy ADD_STRATEGY = new AddExistingPaths();
-        ExistingPathStrategy REMOVE_STRATEGY = new RemoveExistingPaths();
-
-        SegmentMemory[] getSegmenMemories(PathMemory pmem);
-
-        void handleSplit(PathMemory pmem, SegmentMemory[] prevSmems, SegmentMemory[] smems, int smemIndex, int prevSmemIndex,
-                         LeftTupleNode parentNode, LeftTupleNode node, TerminalNode tn,
-                         Set<Integer> visited, Map<LeftTupleNode, SegmentMemory> nodeToSegmentMap,
-                         InternalWorkingMemory wm);
-
-        void processSegmentMemories(SegmentMemory[] smems, PathMemory pmem);
-
-        int incSmemIndex1(int smemIndex);
-        int incSmemIndex2(int smemIndex);
-
-        int incPrevSmemIndex1(int prevSmemIndex);
-        int incPrevSmemIndex2(int prevSmemIndex);
-    }
-
-    static class AddExistingPaths implements ExistingPathStrategy {
-
-        @Override
-        public SegmentMemory[] getSegmenMemories(PathMemory pmem) {
-            return pmem.getSegmentMemories();
-        }
-
-        @Override
-        public void handleSplit(PathMemory pmem, SegmentMemory[] prevSmems, SegmentMemory[] smems, int smemIndex, int prevSmemIndex,
-                                LeftTupleNode parentNode, LeftTupleNode node, TerminalNode tn,
-                                Set<Integer> visited, Map<LeftTupleNode, SegmentMemory> nodeToSegmentMap,
-                                InternalWorkingMemory wm) {
-            if (smems[smemIndex - 1] != null) {
-                SegmentMemory sm2 = nodeToSegmentMap.get(node);
-                if (sm2 == null) {
-                    SegmentMemory sm1 = smems[smemIndex - 1];
-                    correctMemoryOnSplitsChanged(parentNode, null, wm);
-                    sm2 = splitSegment(wm, sm1, parentNode, wm.getKnowledgeBase());
-                    nodeToSegmentMap.put(node, sm2);
-                }
-
-                smems[smemIndex] = sm2;
+            PathMemory pmem = (PathMemory) wm.getNodeMemories().peekNodeMemory(tn);
+            if (pmem != null) {
+                List<LeftTupleNode> splits = exclBranchRoots.stream().map( pair -> pair.parent).filter(Objects::nonNull).collect(Collectors.toList());
+                LazyPhreakBuilder.flushStagedTuples(tn, pmem, splits, wm);
             }
         }
 
-        @Override
-        public void processSegmentMemories(SegmentMemory[] smems, PathMemory pmem) {
+        if (exclBranchRoots.isEmpty()) {
+            LeftTupleNode lian = tn.getPathNodes()[0];
+            processLeftTuples(lian, false, tn, wms);
+            Remove.removeExistingPaths(exclBranchRoots, tn, wms, kBase, smemsToNotify);
+        } else {
+            exclBranchRoots.forEach(pair -> processLeftTuples(pair.parent, false, tn, wms));
+            Remove.removeExistingPaths(exclBranchRoots, tn, wms, kBase, smemsToNotify);
 
+            // Process existing branches from the split  points
+            Set<Integer> visited = new HashSet<>();
+            exclBranchRoots.forEach(pair -> Remove.processMerges(pair.parent, tn, kBase, wms, visited, smemsToNotify));
         }
 
-        @Override
-        public int incSmemIndex1(int smemIndex) {
-            return smemIndex+1;
+        for (InternalWorkingMemory wm : wms) {
+            PathMemory pmem = (PathMemory) wm.getNodeMemories().peekNodeMemory(tn);
+
+            if (pmem!= null && pmem.isInitialized() && pmem.getRuleAgendaItem().isQueued()) {
+                // pmem can be null, if it was never initialized
+                pmem.getRuleAgendaItem().dequeue();
+            }
         }
 
+        smemsToNotify.stream().forEach( pair -> pair.sm.notifyRuleLinkSegment(pair.wm));
+    }
 
-        @Override
-        public int incPrevSmemIndex1(int prevSmemIndex) {
-            return prevSmemIndex;
-        }
-
-        @Override
-        public int incSmemIndex2(int smemIndex) {
-            return smemIndex;
-        }
-
-        @Override
-        public int incPrevSmemIndex2(int prevSmemIndex) {
-            return prevSmemIndex+1;
+    public static void notifyImpactedSegments(SegmentMemory smem, InternalWorkingMemory wm, Set<SegmentMemoryPair> segmentsToNotify) {
+        if (smem.getAllLinkedMaskTest() > 0) {
+            segmentsToNotify.add(new SegmentMemoryPair(smem, wm));
         }
     }
 
-    static class RemoveExistingPaths implements ExistingPathStrategy {
+    public static class SegmentMemoryPair {
+        public SegmentMemory sm;
 
-        @Override
-        public SegmentMemory[] getSegmenMemories(PathMemory pmem) {
-            return new SegmentMemory[ pmem.getSegmentMemories().length ];
+        public InternalWorkingMemory wm;
+
+        public int nodeId;
+        public long sessionId;
+
+        public SegmentMemoryPair(SegmentMemory sm, InternalWorkingMemory wm) {
+            this.sm = sm;
+            this.wm = wm;
+            this.nodeId = sm.getRootNode().getId();
+            this.sessionId = wm.getIdentifier();
         }
 
         @Override
-        public void handleSplit(PathMemory pmem, SegmentMemory[] prevSmems, SegmentMemory[] smems, int smemIndex, int prevSmemIndex,
-                                LeftTupleNode parentNode, LeftTupleNode node, TerminalNode tn,
-                                Set<Integer> visited, Map<LeftTupleNode, SegmentMemory> nodeToSegmentMap,
-                                InternalWorkingMemory wm) {
-            if (visited.contains(node.getId())) {
+        public boolean equals(Object o) {
+            if (this == o) {
+                return true;
+            }
+            if (getClass() != o.getClass()) {
+                return false;
+            }
+            SegmentMemoryPair that = (SegmentMemoryPair) o;
+            return nodeId == that.nodeId && sessionId == that.sessionId;
+        }
+
+        @Override
+        public int hashCode() {
+            return Objects.hash(nodeId, sessionId);
+        }
+    }
+
+    public static class Pair {
+        public final LeftTupleNode parent;
+        public final LeftTupleNode child;
+
+        public Pair(LeftTupleNode parent, LeftTupleNode child) {
+            this.parent = parent;
+            this.child = child;
+        }
+
+        @Override
+        public String toString() {
+            return "Pair{" +
+                   "parent=" + parent +
+                   ", child=" + child +
+                   '}';
+        }
+    }
+
+    public static List<Pair> getExclusiveBranchRoots(TerminalNode tn) {
+        List<Pair> exclbranchRoots = new ArrayList<>();
+        Set<Integer> visited = new HashSet<>(); // PathEndNodes may havde the same root exclusive branch node.
+        Arrays.stream(tn.getPathEndNodes()).forEach(endNode -> {
+            LeftTupleNode node = endNode;
+            if (node.getAssociatedTerminalsSize() > 1) {
+                // this can happen if the whole subnetwork is shared.
                 return;
             }
 
-            correctMemoryOnSplitsChanged(parentNode, tn, wm);
-
-            SegmentMemory sm1 = smems[smemIndex];
-            SegmentMemory sm2 = prevSmems[prevSmemIndex];
-
-            // if both are null, there is nothing to do.
-            if (sm1 == null && sm2 == null) {
-                return;
-            }
-
-            // Temporarily remove the terminal node of the rule to be removed from the rete network to avoid that
-            // its path memory could be added to an existing segment memory during the merge of 2 segments
-            LeftTupleSource removedTerminalSource = tn.getLeftTupleSource();
-            removedTerminalSource.removeTupleSink( tn );
-
-            // sm1 cannot be null, if they re to merge
-            if (sm1 == null) {
-                sm1 = RuntimeSegmentUtilities.createChildSegment(wm, parentNode);
-                smems[smemIndex] = sm1;
-                sm1.add(sm2);
-            }
-
-            // merge in sm2, if it is null
-            if (sm2 != null) {
-                mergeSegment(sm1, sm2, wm.getKnowledgeBase(), wm);
-                sm2.unlinkSegment(wm);
-            } else {
-                SegmentPrototype proto = wm.getKnowledgeBase().getSegmentPrototype(sm1.getRootNode());
-                proto.updateSegmentMemory(sm1, wm);
-                long currentLinkedNodeMask = sm1.getLinkedNodeMask();
-                proto.updateSegmentMemory(sm1,wm);
-                sm1.setLinkedNodeMask(currentLinkedNodeMask);
-            }
-
-            sm1.unlinkSegment(wm);
-            visited.add(node.getId());
-
-            // Add back the the terminal node of the rule to be removed into the rete network to permit the network
-            // traversal up from it and the removal of all the nodes exclusively belonging to the removed rule
-            removedTerminalSource.addTupleSink( tn );
-        }
-
-        @Override
-        public void processSegmentMemories(SegmentMemory[] smems, PathMemory pmem) {
-            for (int i = 0; i < smems.length; i++) {
-                if (smems[i] != null) {
-                    pmem.setSegmentMemory( smems[i].getPos(), smems[i] );
+            while (node.getLeftTupleSource()  != null) {
+                if (NodeTypeEnums.isBetaNodeWithRian(node) && ((BetaNode)node).getRightInput().getAssociatedTerminalsSize() > 1) {
+                    exclbranchRoots.add( new Pair((LeftTupleNode) ((BetaNode)node).getRightInput(), node));
                 }
+
+                if (node.getLeftTupleSource().getAssociatedTerminalsSize()> 1) {
+                    if (visited.add(node.getId())) {
+                        exclbranchRoots.add( new Pair(node.getLeftTupleSource(), node));
+                    }
+                    return;
+                }
+                node = node.getLeftTupleSource();
             }
-        }
-
-        @Override
-        public int incSmemIndex1(int smemIndex) {
-            return smemIndex;
-        }
-
-        @Override
-        public int incPrevSmemIndex1(int prevSmemIndex) {
-            return prevSmemIndex+1;
-        }
-
-        @Override
-        public int incSmemIndex2(int smemIndex) {
-            return smemIndex+1;
-        }
-
-        @Override
-        public int incPrevSmemIndex2(int prevSmemIndex) {
-            return prevSmemIndex;
-        }
+        });
+        return exclbranchRoots;
     }
 
-    private static void handleExistingPaths(TerminalNode tn, Map<PathMemory, SegmentMemory[]> prevSmemsLookup,
-                                                          List<PathMemory> pmems, InternalWorkingMemory wm, ExistingPathStrategy strategy) {
-        Set<SegmentMemory>                visitedSegments  = new HashSet<>();
-        Set<Integer> visitedNodes = new HashSet<>();
-        Map<LeftTupleNode, SegmentMemory> nodeToSegmentMap = new HashMap<>();
+    public static class Add {
 
-        for (PathMemory pmem : pmems) {
-            LeftTupleNode[] nodes = pmem.getPathEndNode().getPathNodes();
+        public static void insertLiaFacts(LeftTupleNode startNode, InternalWorkingMemory wm, Set<Integer> visited, boolean allBranches) {
+            // rule added with no sharing
+            PropagationContextFactory pctxFactory = RuntimeComponentFactory.get().getPropagationContextFactory();
+            final PropagationContext  pctx        = pctxFactory.createPropagationContext(wm.getNextPropagationIdCounter(), PropagationContext.Type.RULE_ADDITION, null, null, null);
+            LeftInputAdapterNode      lian        = (LeftInputAdapterNode) startNode;
+            if (allBranches && visited.add(lian.getId()) || lian.getAssociatedTerminalsSize() == 1 ) {
+                RightTupleSinkAdapter liaAdapter = new RightTupleSinkAdapter(lian);
+                lian.getObjectSource().updateSink(liaAdapter, pctx, wm);
+            }
+        }
 
-            SegmentMemory[] prevSmems = prevSmemsLookup.get(pmem);
-            SegmentMemory[] smems     = strategy.getSegmenMemories(pmem);
-
-            if (prevSmems.length == 0 && smems.length == 0) {
-                continue;
+        public static SegmentPrototype processSplit(LeftTupleNode splitNode, RuleBase kbase, Collection<InternalWorkingMemory> wms, Set<SegmentMemoryPair> smemsToNotify) {
+            LeftTupleNode segmentRoot = BuildtimeSegmentUtilities.findSegmentRoot(splitNode, null);
+            SegmentPrototype proto1 = kbase.getSegmentPrototype(segmentRoot);
+            if ( proto1.getTipNode() != splitNode) {
+                // split does not already exist, add it.
+                SegmentPrototype proto2 = splitSegment(proto1, splitNode, kbase, wms, smemsToNotify);
+                return proto2;
             }
 
-            LeftTupleNode node;
-            int prevSmemIndex = 0;
-            int smemIndex = 0;
-            int nodeIndex = 0;
-            boolean firstSplit = true;
-
-            // excluding the rule just added iterate while not split (i.e. find the next split, prior to this rule being added)
-            // note it's checking for when the parent is the split, and thus node is the next root root.
-
-            smems[smemIndex] = prevSmems[prevSmemIndex];
-            do {
-                node = nodes[nodeIndex++];
-                LeftTupleSource parentNode = node.getLeftTupleSource();
-                if (isSplit(parentNode)) {
-                    smemIndex = strategy.incSmemIndex1(smemIndex);
-                    prevSmemIndex = strategy.incPrevSmemIndex1(prevSmemIndex);
-                    if (isSplit(parentNode, tn)) { // check if the split is there even without the processed rule
-                        smemIndex = strategy.incSmemIndex2(smemIndex);
-                        prevSmemIndex = strategy.incPrevSmemIndex2(prevSmemIndex);
-                        smems[smemIndex] = prevSmems[prevSmemIndex];
-                        if ( smems[smemIndex] != null && !firstSplit && visitedSegments.add(smems[smemIndex])) {
-                            adjustSegment( wm, smems[smemIndex] );
-                        }
-                    } else {
-                        strategy.handleSplit(pmem, prevSmems, smems, smemIndex, prevSmemIndex,
-                                             parentNode, node, tn, visitedNodes,
-                                             nodeToSegmentMap, wm);
-                        firstSplit = false;
-                    }
-                }
-            } while (!NodeTypeEnums.isEndNode(node));
-
-            strategy.processSegmentMemories(smems, pmem);
-
-
+            // split already exists, add it.
+            return null;
         }
-    }
 
-    private static void addNewPaths(InternalWorkingMemory wm, List<PathMemory> pmems) {
-        for (PathMemory pmem : pmems) {
-            LeftTupleSink tipNode = pmem.getPathEndNode();
-
-            LeftTupleNode child  = tipNode;
-            LeftTupleNode parent = tipNode.getLeftTupleSource();
-
-            while (true) {
-                if ( parent != null && parent.getAssociatedTerminalsSize() != 1 && child.getAssociatedTerminalsSize() == 1 ) {
-                    // This is the split point that the new path enters an existing path.
-                    // If the parent has other child SegmentMemorys then it must create a new child SegmentMemory
-                    // If the parent is a query node, then it's internal data structure needs changing
-                    // all right input data must be propagated
-                    Memory mem = wm.getNodeMemories().peekNodeMemory( parent );
-                    if ( mem != null && mem.getSegmentMemory() != null ) {
-                        SegmentMemory sm = mem.getSegmentMemory();
-                        if ( sm.getFirst() != null && sm.size() < parent.getSinkPropagator().size()) {
-                            LeftTupleSink[] sinks = parent.getSinkPropagator().getSinks();
-                            for (int i = sm.size(); i < sinks.length; i++) {
-                                SegmentMemory childSmem = RuntimeSegmentUtilities.createChildSegment(wm, sinks[i]);
-                                sm.add(childSmem);
-                            }
-                        }
-                        correctMemoryOnSplitsChanged( parent, null, wm );
+        private static void addExistingSegmentMemories(Collection<PathEndNode> pathEndNodes, InternalWorkingMemory wm) {
+            // Iterates the path to find existing SegmentMemories that can be added to the new PathMemory
+            pathEndNodes.forEach(endNode -> {
+                Arrays.stream(endNode.getSegmentPrototypes()).forEach( proto -> {
+                    if (!isInsideSubnetwork(endNode, proto)) { // ths proto is before the start of the subnetwork
+                        return;
                     }
-                } else {
-                    Memory mem = wm.getNodeMemories().peekNodeMemory( child );
-                    // The root of each segment
-                    if ( mem != null ) {
-                        SegmentMemory sm = mem.getSegmentMemory();
 
-                        // make sure there is a proto  in that slot. If it's null, its a subnetwork and the node is before it's start.
-                        if ( sm != null &&
-                             pmem.getPathEndNode().getSegmentPrototypes()[sm.getPos()] != null &&
-                             !sm.getPathMemories().contains( pmem ) ) {
-                            sm.addPathMemory( pmem );
-                            pmem.setSegmentMemory( sm.getPos(), sm );
+                    LeftTupleNode node = proto.getRootNode();
+                    Memory mem = wm.getNodeMemories().peekNodeMemory(node);
+
+                    if (mem != null && mem.getSegmentMemory() != null) {
+                        SegmentMemory smem = mem.getSegmentMemory();
+
+                        PathMemory pmem = (PathMemory) wm.getNodeMemories().peekNodeMemory(endNode);
+                        if (pmem == null) {
+                            pmem = RuntimeSegmentUtilities.initializePathMemory(wm, endNode);
+                        }
+                        if (pmem.getSegmentMemories()[proto.getPos()] == null) {
+                            // we check null, as this might have been fixed due to eager initialisation
+                            RuntimeSegmentUtilities.addSegmentToPathMemory(pmem, smem);
+                        }
+                    }
+                });
+            });
+        }
+
+        public static void insertFacts(TerminalNode tn, InternalWorkingMemory wm, Set<Integer> visited, boolean allBranches) {
+            for ( PathEndNode endNode : tn.getPathEndNodes() ) {
+                LeftTupleNode[]  nodes = endNode.getPathNodes();
+
+                // Iterate each PathEnd of the TerminalNode. Stop at either the path branch start (to avoid processing nodes twice), or
+                // when the path is no longer uniquely associated with the terminal node.
+                for ( int i = nodes.length-1;
+                      i > 0 &&
+                      nodes[i].getPathIndex() >= endNode.getStartTupleSource().getPathIndex() &&
+                      (allBranches && visited.add(nodes[i].getId()) || nodes[i].getAssociatedTerminalsSize() == 1 );
+                      i-- ) {
+                    LeftTupleNode node = nodes[i];
+                    if  ( NodeTypeEnums.isBetaNode(node) ) {
+                        BetaNode bn = (BetaNode) node;
+
+                        if (!bn.isRightInputIsRiaNode()) {
+                            PropagationContextFactory pctxFactory = RuntimeComponentFactory.get().getPropagationContextFactory();
+                            final PropagationContext pctx = pctxFactory.createPropagationContext(wm.getNextPropagationIdCounter(), PropagationContext.Type.RULE_ADDITION, null, null, null);
+                            bn.getRightInput().updateSink(bn, pctx, wm);
                         }
                     }
                 }
-
-                if (parent == null) {
-                    break;
-                }
-
-                child = parent;
-                parent = parent.getLeftTupleSource();
             }
         }
-    }
 
+        public static SegmentMemory splitSegment(InternalWorkingMemory wm, SegmentMemory sm1, SegmentPrototype proto1, SegmentPrototype proto2, RuleBase kbase,
+                                                 Set<SegmentMemoryPair> smemsToNotify) {
+            Memory[] origMemories = sm1.getNodeMemories();
 
-    private static void removeNewPaths(InternalWorkingMemory wm, List<PathMemory> pmems) {
-        Set<Integer> visitedNodes = new HashSet<>();
-        for (PathMemory pmem : pmems) {
-            LeftTupleSink tipNode = pmem.getPathEndNode();
+            // create new segment, starting after split
+            SegmentMemory sm2 = proto2.shallowNewSegmentMemory(wm); // we know there is only one sink
 
-            LeftTupleNode child  = tipNode;
-            LeftTupleNode parent = tipNode.getLeftTupleSource();
-
-            while (true) {
-                if (child.getAssociatedTerminalsSize() == 1 && NodeTypeEnums.isBetaNode(child)) {
-                    // If this is a beta node, it'll delete all the right input data
-                    deleteRightInputData((LeftTupleSink) child, wm);
+            // Move the children of sm1 to sm2
+            if (sm1.getFirst() != null) {
+                for (SegmentMemory sm = sm1.getFirst(); sm != null; ) {
+                    SegmentMemory next = sm.getNext();
+                    sm1.remove(sm);
+                    sm2.add(sm);
+                    sm = next;
                 }
+            }
 
-                if (parent != null && parent.getAssociatedTerminalsSize() != 1 && child.getAssociatedTerminalsSize() == 1) {
-                    // This is the split point that the new path enters an existing path.
-                    // If the parent has other child SegmentMemorys then it must create a new child SegmentMemory
-                    // If the parent is a query node, then it's internal data structure needs changing
-                    // all right input data must be propagated
-                    if (!visitedNodes.contains( child.getId() )) {
-                        Memory mem = wm.getNodeMemories().peekNodeMemory( parent );
-                        if ( mem != null && mem.getSegmentMemory() != null ) {
+            sm1.add(sm2);
+
+            sm2.mergePathMemories(sm1);
+
+            // preserve values that get changed updateSegmentMemory, for split
+            long currentLinkedNodeMask  = sm1.getLinkedNodeMask();
+            proto1.shallowUpdateSegmentMemory(sm1,wm);
+
+            if (sm1.getTipNode().getType() == NodeTypeEnums.LeftInputAdapterNode) {
+                if (!sm1.getStagedLeftTuples().isEmpty()) {
+                    // Segments with only LiaNode's cannot have staged LeftTuples, so move them down to the new Segment
+                    sm2.getStagedLeftTuples().addAll(sm1.getStagedLeftTuples());
+                }
+            }
+
+            splitBitMasks(sm1, sm2, currentLinkedNodeMask);
+
+            Memory[] mem1 = new Memory[proto1.getMemories().length];
+            Memory[] mem2 = new Memory[proto2.getMemories().length];
+
+            System.arraycopy(origMemories, 0, mem1, 0, mem1.length);
+
+            // As the segmentMemory needs updating, no point in a separate arraycopy
+            for (int i = 0; i < mem2.length; i++) {
+                Memory mem = origMemories[mem1.length + i];
+                mem2[i] = mem;
+                mem.setSegmentMemory(sm2);
+                if (mem instanceof SegmentNodeMemory) {
+                    ((SegmentNodeMemory) mem).setNodePosMaskBit(proto2.getMemories()[i].getNodePosMaskBit());
+                }
+            }
+
+            // break the references, between segments
+            mem1[mem1.length-1].setNext(null);
+            mem2[0].setPrevious(null);
+
+            sm1.setNodeMemories(mem1);
+            sm2.setNodeMemories(mem2);
+
+            notifyImpactedSegments(sm1, wm, smemsToNotify);
+            notifyImpactedSegments(sm2, wm, smemsToNotify);
+
+            return sm2;
+        }
+
+        public static SegmentPrototype splitSegment(SegmentPrototype proto1, LeftTupleNode splitNode, RuleBase kbase, Collection<InternalWorkingMemory> wms, Set<SegmentMemoryPair> smemsToNotify) {
+            boolean proto1WasEager = proto1.requiresEager();
+
+            // Create the new segment proto
+            LeftTupleNode proto2RootNode = splitNode.getSinkPropagator().getFirstLeftTupleSink();
+            SegmentPrototype proto2 = new SegmentPrototype(proto2RootNode, proto1.getTipNode());
+            kbase.registerSegmentPrototype(proto2RootNode, proto2);
+            proto2.setPos(proto1.getPos()+1);
+
+            // Split the nodes across proto1 and proto2
+            splitProtos(proto1, proto2, splitNode);
+
+            // now split any existing Segments, using the updated Protos
+            for (InternalWorkingMemory wm : wms) {
+                Memory mem = wm.getNodeMemories().peekNodeMemory(proto1.getRootNode());
+                if ( mem != null && mem.getSegmentMemory() != null) {
+                    splitSegment(wm, mem.getSegmentMemory(), proto1, proto2, kbase, smemsToNotify);
+                }
+            }
+
+            // Paths need updating, update the protos and the smems
+            PathEndNode[] endNodes = proto1.getPathEndNodes();
+            for (PathEndNode endNode : endNodes) {
+                // process eager changes
+                splitEagerProtos(proto1, proto1WasEager, proto2, endNode);
+
+                proto2.setPathEndNodes(proto1.getPathEndNodes());
+
+                // insert the new proto into the segment list
+                SegmentPrototype[] oldList = endNode.getSegmentPrototypes();
+                SegmentPrototype[] newList = new SegmentPrototype[oldList.length + 1];
+                System.arraycopy(oldList, 0, newList, 0, proto1.getPos()+1);
+                newList[proto2.getPos()] = proto2;
+
+                // If the proto isn't end, copy over the remaining protos and adjust their pos and bit pos
+                if ( proto2.getPos()+1 != newList.length) {
+                    for (int i = proto2.getPos()+1; i <newList.length; i++) {
+                        newList[i] = oldList[i-1];
+                        newList[i].setPos(i);
+                        newList[i].setSegmentPosMaskBit(1 << i);
+                    }
+                }
+                endNode.setSegmentPrototypes(newList);
+
+                updatePaths(proto1, wms, endNode, newList);
+            }
+
+            return proto2;
+        }
+
+        private static void splitProtos(SegmentPrototype proto1, SegmentPrototype proto2, LeftTupleNode splitNode) {
+            LeftTupleNode proto1TipNode = splitNode;
+            proto1.setTipNode(proto1TipNode);
+
+            LeftTupleNode[] nodes = proto1.getNodesInSegment();
+
+            MemoryPrototype[] mems = proto1.getMemories();
+
+            int arraySplit = splitNode.getPathIndex() - proto1.getRootNode().getPathIndex() + 1;
+            LeftTupleNode[] proto1Nodes = new LeftTupleNode[arraySplit];
+            LeftTupleNode[] proto2Nodes = new LeftTupleNode[nodes.length - arraySplit];
+            System.arraycopy(nodes, 0, proto1Nodes, 0, proto1Nodes.length);
+            System.arraycopy(nodes, arraySplit, proto2Nodes, 0, proto2Nodes.length);
+            proto1.setNodesInSegment(proto1Nodes);
+            proto2.setNodesInSegment(proto2Nodes);
+
+            setNodeTypes(proto1, proto1Nodes);
+            setNodeTypes(proto2, proto2Nodes);
+
+            // Split the memory protos across proto1 and proto2
+            MemoryPrototype[] proto1Mems = new MemoryPrototype[proto1Nodes.length];
+            MemoryPrototype[] proto2Mems = new MemoryPrototype[proto2Nodes.length];
+            System.arraycopy(mems, 0, proto1Mems, 0, proto1Mems.length);
+            proto1.setMemories(proto1Mems);
+
+            // proto2Mems needs updating, no point in arraycopy, so just use standard for loop to copy
+            int bitPos = 1;
+            for (int i = 0; i < proto2Mems.length; i++ ) {
+                proto2Mems[i] = mems[i+arraySplit];
+                proto2Mems[i].setNodePosMaskBit(bitPos);
+                bitPos = bitPos << 1;
+            }
+
+            proto2.setMemories(proto2Mems);
+            splitBitMasks(proto1, proto2);
+        }
+
+        private static void splitEagerProtos(SegmentPrototype proto1, boolean proto1WasEager, SegmentPrototype proto2, PathEndNode endNode) {
+            SegmentPrototype[] eager = endNode.getEagerSegmentPrototypes();
+            if (proto1WasEager) { // if it wasn't eager before, nothing can be eager after
+                if (proto1.requiresEager() && proto2.requiresEager()) {
+                    // keep proto1 and add proto2
+                    SegmentPrototype[] newEager = new SegmentPrototype[eager.length+1];
+                    System.arraycopy(eager, 0, newEager, 0, eager.length);
+                    newEager[newEager.length-1] = proto2; // I don't think order matters, so just add to the end
+                } else if (proto2.requiresEager()) {
+                    // proto2 is no longer eager, find proto1 and swap proto1 with proto2
+                    for ( int i = 0; i < eager.length; i++){
+                        if (eager[i] == proto1) {
+                            eager[i] = proto2;
+                            break;
+                        }
+                    }
+                } // else if ( proto1.requiresEager() && !proto2.requiresEager()) do nothing as proto1 already in the array
+            }
+        }
+
+        private static void splitBitMasks(SegmentMemory sm1, SegmentMemory sm2, long currentLinkedNodeMask) {
+            // @TODO Haven't made this work for more than 64 nodes, as per SegmentUtilities.nextNodePosMask (mdp)
+            int  splitPos              = sm1.getSegmentPrototype().getNodesInSegment().length; // +1 as zero based
+            long currentDirtyNodeMask  = sm1.getDirtyNodeMask();
+            long splitMask         =  ((1L << (splitPos)) - 1);
+
+            sm1.setDirtyNodeMask(currentDirtyNodeMask & splitMask);
+            sm1.setLinkedNodeMask(currentLinkedNodeMask & splitMask);
+
+            sm2.setLinkedNodeMask(currentLinkedNodeMask >> splitPos);
+            sm2.setDirtyNodeMask(currentDirtyNodeMask >> splitPos);
+        }
+
+        private static void splitBitMasks(SegmentPrototype sm1, SegmentPrototype sm2) {
+            // @TODO Haven't made this work for more than 64 nodes, as per SegmentUtilities.nextNodePosMask (mdp)
+            int  splitPos          = sm1.getNodesInSegment().length; // +1 as zero based
+            long splitMask         = ((1L << (splitPos)) - 1);
+
+            long currentLinkedNodeMask = sm1.getLinkedNodeMask();
+            long currentAllLinkedMaskTest = sm1.getAllLinkedMaskTest();
+
+            sm1.setLinkedNodeMask(currentLinkedNodeMask & splitMask);
+            sm1.setAllLinkedMaskTest(currentAllLinkedMaskTest & splitMask);
+
+            sm2.setLinkedNodeMask(currentLinkedNodeMask >> splitPos);
+            sm2.setAllLinkedMaskTest(currentAllLinkedMaskTest >> splitPos);
+
+            sm2.setSegmentPosMaskBit(sm1.getSegmentPosMaskBit() << 1);
+        }
+
+
+        private static void addNewPaths(List<Pair> exclBranchRoots, TerminalNode tn,
+                                        Collection<InternalWorkingMemory> wms, RuleBase kBase,
+                                        Set<SegmentMemoryPair> smemsToNotify) {
+            // create protos
+            BuildtimeSegmentUtilities.createPathProtoMemories(tn, null, kBase);
+
+            // update SegmentProtos with new EndNodes
+            for ( PathEndNode endNode : tn.getPathEndNodes() ) {
+                BuildtimeSegmentUtilities.updateSegmentEndNodes(endNode);
+            }
+
+            // Process the root nodes of each new branch. Not it's important to do this in order of inner subnetwork first.
+            for (InternalWorkingMemory wm : wms) {
+                for (PathEndNode endNode : tn.getPathEndNodes() ) {
+                    if (endNode.getAssociatedTerminalsSize() > 1) {
+                        // can only happen on rians, and we need to notify, incase they are already linked in
+                        Memory mem = wm.getNodeMemories().peekNodeMemory(endNode);
+                        if (mem != null && mem.getSegmentMemory() != null) {
                             SegmentMemory sm = mem.getSegmentMemory();
-                            if ( sm.getFirst() != null ) {
-                                SegmentMemory childSm = wm.getNodeMemories().peekNodeMemory( child ).getSegmentMemory();
-                                sm.remove( childSm );
+
+                            notifyImpactedSegments(sm, wm, smemsToNotify);
+                        }
+
+                        break; // skip this EndNode, it was not new, it already existed
+                    }
+
+                    PathMemory pmem = null; // lazy create this on demand, only if there are existing segments
+
+                    for (SegmentPrototype sproto : endNode.getSegmentPrototypes() ) {
+                        if (!isInsideSubnetwork(endNode, sproto)) {
+                            continue;
+                        }
+                        if (sproto.getRootNode() != endNode) {
+                            Memory mem = wm.getNodeMemories().peekNodeMemory(sproto.getRootNode());
+                            if (mem != null && mem.getSegmentMemory() != null) {
+                                if (pmem == null) {
+                                    pmem = RuntimeSegmentUtilities.initializePathMemory(wm, endNode);
+                                }
+                                SegmentMemory sm = mem.getSegmentMemory();
+                                pmem.getSegmentMemories()[sproto.getPos()] = sm;
+                                sm.getPathMemories().add(pmem);
+                                notifyImpactedSegments(sm, wm, smemsToNotify);
+                            }
+                        } else if (pmem != null) {
+                            // segment with just the PathEndNode, so create
+                            SegmentMemory sm = sproto.shallowNewSegmentMemory(wm);
+                            sm.setNodeMemories( new Memory[]{pmem});
+                            pmem.setSegmentMemory(sm);
+                            RuntimeSegmentUtilities.addSegmentToPathMemory(pmem, sm);
+                            notifyImpactedSegments(sm, wm, smemsToNotify);
+                        }
+                    }
+                }
+
+                // If the parent has other child SegmentMemories then it must create a new child SegmentMemory
+                // If the parent is a query node, then it's internal data structure needs changing
+                // all right input data must be propagated
+                Set<Integer> visited = new HashSet<>();
+                for (int i = exclBranchRoots.size()-1; i >= 0; i--)  { // last is the most inner
+                    LeftTupleNode child = exclBranchRoots.get(i).child;
+                    LeftTupleNode parent = exclBranchRoots.get(i).parent;
+
+                    Memory parentMem = wm.getNodeMemories().peekNodeMemory(parent);
+
+                    // If the parent has propagations to existing child, then add it to the parent's child smem list
+                    if (parentMem != null && parentMem.getSegmentMemory() != null &&
+                        !parentMem.getSegmentMemory().isEmpty()) {
+                        SegmentMemory sm = parentMem.getSegmentMemory();
+                        SegmentMemory childSmem = RuntimeSegmentUtilities.createChildSegment(wm, child);
+                        sm.add(childSmem);
+                        sm.notifyRuleLinkSegment(wm);
+                        notifyImpactedSegments(sm, wm, smemsToNotify);
+                        notifyImpactedSegments(childSmem, wm, smemsToNotify);
+                    }
+
+                    if (visited.add(parent.getId())) {
+                        // only vist the same parent node once, i.e. in case of subnetwork splits.
+                        correctMemoryOnSplitsChanged(parent, null, wm);
+                    }
+
+
+                }
+            }
+        }
+    }
+
+    public static boolean isInsideSubnetwork(PathEndNode endNode, SegmentPrototype smproto) {
+        return smproto.getRootNode().getPathIndex() >= endNode.getStartTupleSource().getPathIndex();
+    }
+
+    public static class Remove {
+        private static void removeExistingPaths(List<Pair> exclBranchRoots, TerminalNode tn, Collection<InternalWorkingMemory> wms, RuleBase kbase, Set<SegmentMemoryPair> smemsToNotify) {
+            // update existing SegmentProtos (before removing path branch root) to remove EndNodes
+            // for nodes after, just remove them from the cache
+            for ( PathEndNode endNode : tn.getPathEndNodes() ) {
+                if (endNode.getAssociatedTerminalsSize() > 1) {
+                    // do nothing, this whole subnetwork is still shared
+                    continue;
+                }
+                for ( int i = 0; i < endNode.getSegmentPrototypes().length; i++) {
+                    SegmentPrototype smproto = endNode.getSegmentPrototypes()[i];
+                    if (smproto.getRootNode().getAssociatedTerminalsSize() > 1) {
+                        // update the segments before the branch being removed.
+                        PathEndNode[] existingNodes = smproto.getPathEndNodes();
+                        PathEndNode[] newNodes = new PathEndNode[existingNodes.length - 1];
+                        for (int j = 0, k = 0; j < existingNodes.length; j++) {
+                            if (existingNodes[j] == endNode) {
+                                // this forces the skipping of the node, j will increase, k will not
+                                continue;
+                            }
+                            newNodes[k] = existingNodes[j];
+                            k++;
+                        }
+                        smproto.setPathEndNodes(newNodes);
+                    } else {
+                        // unregister the segments exclusive to the branch being used
+                        kbase.getSegmentPrototypes().remove(smproto.getRootNode().getId());
+                    }
+                }
+            }
+
+            for (InternalWorkingMemory wm : wms) {
+                // iterate in reverse, to do the most inner network first.
+                Set<Integer> visited = new HashSet<>();
+                for (int i = exclBranchRoots.size() - 1; i >= 0; i--) { // last is the most inner
+                    LeftTupleNode child = exclBranchRoots.get(i).child;
+                    LeftTupleNode parent = exclBranchRoots.get(i).parent;
+                    if (parent.getType() == NodeTypeEnums.RightInputAdapterNode) {
+                        continue; // A RIAN as it's also a PathEnd doesn't have a child segment
+                    }
+
+                    // If it exists, remove the child segment memory for the path being removed.
+                    if (visited.add(child.getId())) {
+                        Memory mem = wm.getNodeMemories().peekNodeMemory(parent);
+                        if (mem != null && mem.getSegmentMemory() != null) {
+                            SegmentMemory sm = mem.getSegmentMemory();
+                            if (sm.getFirst() != null) {
+                                SegmentMemory childSm = wm.getNodeMemories().peekNodeMemory(child).getSegmentMemory();
+                                sm.remove(childSm);
                             }
                         }
                     }
-                } else {
-                    Memory mem = wm.getNodeMemories().peekNodeMemory(child);
-                    // The root of each segment
-                    if (mem != null) {
-                        SegmentMemory sm = mem.getSegmentMemory();
-                        if (sm != null && sm.getPathMemories().contains( pmem )) {
-                            mem.getSegmentMemory().removePathMemory(pmem);
-                        }
+
+                    if (parent != null && visited.add(parent.getId())) {
+                        // only vist the same parent node once, i.e. in case of subnetwork splits.
+                        correctMemoryOnSplitsChanged(parent, null, wm);
                     }
                 }
 
-                if (parent == null) {
-                    break;
-                }
+                for (PathEndNode endNode : tn.getPathEndNodes()) {
+                    PathMemory pmem = (PathMemory) wm.getNodeMemories().peekNodeMemory(endNode);
 
-                visitedNodes.add(child.getId());
-                child = parent;
-                parent = parent.getLeftTupleSource();
-            }
-        }
-    }
+                    // Iterate from root to tip.
+                    // For non-exclusive, remove the PathMemory.
+                    // For exclusive delete the right inputs and clear up the node memories also clean up node memories
+                    for (SegmentPrototype smproto : endNode.getSegmentPrototypes()) {
+                        if (!isInsideSubnetwork(endNode, smproto)) {
+                            // While SegmentPrototypes are added for entire path, for traversal reasons.
+                            // SegmenrMemory's themselves are only added to the PathMemory for path or subpath the are part of.
+                            continue;
+                        }
 
-    private static boolean isSplit(LeftTupleNode node) {
-        return isSplit(node, null);
-    }
-
-    private static boolean isSplit(LeftTupleNode node, TerminalNode removingTN) {
-        return node != null && BuildtimeSegmentUtilities.isTipNode(node, removingTN);
-    }
-
-    public static class Flushed {
-        SegmentMemory segmentMemory;
-        PathMemory pathMemory;
-
-        public Flushed(SegmentMemory segmentMemory, PathMemory pathMemory) {
-            this.segmentMemory = segmentMemory;
-            this.pathMemory = pathMemory;
-        }
-    }
-
-    private static void flushStagedTuples(TerminalNode tn, PathMemory pmem, PathEndNodes pathEndNodes, InternalWorkingMemory wm) {
-        // first flush the subject rule, then flush any staging lists that are part of a merge
-        if ( pmem.isInitialized() ) {
-            RuleNetworkEvaluator.INSTANCE.evaluateNetwork(pmem, pmem.getRuleAgendaItem().getRuleExecutor(), wm);
-        }
-
-        // With the removing rules being flushed, we need to check any splits that will be merged, to see if they need flushing
-        // Beware that flushing a higher up node, might again cause lower nodes to have more staged items. So track flushed items
-        // incase they need to be reflushed
-        List<Flushed> flushed = new ArrayList<>();
-
-        for ( LeftTupleNode node : pathEndNodes.subjectSplits ) {
-            if (!isSplit(node, tn)) { // check if the split is there even without the processed rule
-                Memory mem = wm.getNodeMemories().peekNodeMemory(node);
-                if ( mem != null) {
-                    SegmentMemory smem = mem.getSegmentMemory();
-
-                    if ( !smem.isEmpty() ) {
-                        for ( SegmentMemory childSmem = smem.getFirst(); childSmem != null; childSmem = childSmem.getNext() ) {
-                            if ( !childSmem.getStagedLeftTuples().isEmpty() ) {
-                                PathMemory childPmem = childSmem.getPathMemories().get(0);
-                                flushed.add( new Flushed(childSmem, childPmem));
-                                forceFlushLeftTuple(childPmem, childSmem, wm, childSmem.getStagedLeftTuples().takeAll());
+                        if (smproto.getRootNode().getAssociatedTerminalsSize() > 1) {
+                            if (pmem != null) {
+                                Memory mem = wm.getNodeMemories().peekNodeMemory(smproto.getRootNode());
+                                // The root of each segment
+                                if (mem != null) {
+                                    SegmentMemory sm = mem.getSegmentMemory();
+                                    if (sm != null) {
+                                        sm.removePathMemory(pmem);
+                                    }
+                                }
+                            }
+                        } else {
+                            // This is exclusive to the branch being removed, so it'll need right inputs cleaned up
+                            for (int i = 0; i < smproto.getNodesInSegment().length; i++) {
+                                LeftTupleNode n = smproto.getNodesInSegment()[i];
+                                Memory mem = wm.getNodeMemories().peekNodeMemory(n);
+                                if (mem != null && NodeTypeEnums.isBetaNode(n)) {
+                                    deleteRightInputData(n, mem, wm);
+                                }
                             }
                         }
                     }
@@ -607,132 +722,245 @@ class EagerPhreakBuilder implements PhreakBuilder {
             }
         }
 
-        int flushCount = 1; // need to ensure that there is one full iteration, without any flushing. To avoid one flush causing populat of another already flushed segment
-        while (!flushed.isEmpty() && flushCount != 0) {
-            flushCount = 0;
-            for (Flushed path : flushed) {
-                if ( !path.segmentMemory.getStagedLeftTuples().isEmpty() ) {
-                    flushCount++;
-                    forceFlushLeftTuple(pmem, path.segmentMemory, wm, path.segmentMemory.getStagedLeftTuples().takeAll());
-                }
+
+        private static void processMerges(LeftTupleNode splitNode, TerminalNode tn, RuleBase kBase, Collection<InternalWorkingMemory> wms, Set<Integer> visited, Set<SegmentMemoryPair> smemsToNotify) {
+            // it's possible for a rule to have multiple exclBranches, pointing to the same parent. So need to ensure it's processed once.
+            if ( !visited.add(splitNode.getId())) {
+                return;
             }
-        }
-    }
 
-    private static void flushStagedTuples(LeftTupleNode splitStartNode, PathMemory pmem, InternalWorkingMemory wm) {
-        if ( !pmem.isInitialized() ) {
-            // The rule has never been linked in and evaluated, so there will be nothing to flush.
-            return;
-        }
-        if ( pmem.getSegmentMemories().length == 0) {
-            // this is a AlphaTerminalNode, so ignore.
-            return;
-        }
+            if ( !BuildtimeSegmentUtilities.isTipNode(splitNode, tn)) {
+                // with the tn ignored, it's no longer a semgnet tip so it's segment is ready to merge
+                LeftTupleNode segmentRoot = BuildtimeSegmentUtilities.findSegmentRoot(splitNode, tn);
 
-        int             smemIndex = getSegmentPos(splitStartNode); // index before the segments are merged
-        SegmentMemory[] smems     = pmem.getSegmentMemories();
+                SegmentPrototype proto1 = kBase.getSegmentPrototype(segmentRoot);
 
-        SegmentMemory   sm        = null;
-
-        // If there is no sharing, then there will not be any staged tuples in later segemnts, and thus no need to search for them if the current sm is empty.
-        int length = smems.length;
-        if ( splitStartNode.getAssociatedTerminalsSize() == 1 ) {
-            length = 1;
-        }
-
-        while (smemIndex < length) {
-            sm = smems[smemIndex];
-            if (sm != null && !sm.getStagedLeftTuples().isEmpty()) {
-                break;
-            }
-            smemIndex++;
-        }
-
-        if ( smemIndex < length ) {
-            // it only found a SM that needed flushing, if smemIndex < length
-            forceFlushLeftTuple(pmem, sm, wm, sm.getStagedLeftTuples().takeAll());
-        }
-    }
-
-    private static Map<PathMemory, SegmentMemory[]> reInitPathMemories(List<PathMemory> pathMems) {
-        Map<PathMemory, SegmentMemory[]> previousSmems = new HashMap<>();
-        for (PathMemory pmem : pathMems) {
-            // Re initialise all the PathMemories
-            previousSmems.put(pmem, pmem.getSegmentMemories());
-
-            PathEndNode pathEndNode = pmem.getPathEndNode();
-            AbstractTerminalNode.initPathMemory(pathEndNode, pmem);
-        }
-        return previousSmems;
-    }
-
-    private static void notifySegments(PathEndNodeMemories tnms, InternalWorkingMemory wm) {
-        tnms.otherPmems.stream().flatMap( pmem -> Arrays.stream(pmem.getSegmentMemories())).filter(Objects::nonNull).forEach( sm -> sm.notifyRuleLinkSegment(wm));
-        tnms.subjectPmems.stream().flatMap( pmem -> Arrays.stream(pmem.getSegmentMemories())).filter(Objects::nonNull).forEach( sm -> sm.notifyRuleLinkSegment(wm));
-    }
-
-    private static void correctMemoryOnSplitsChanged(LeftTupleNode splitStart, TerminalNode removingTN, InternalWorkingMemory wm) {
-        if (splitStart.getType() == NodeTypeEnums.UnificationNode) {
-            QueryElementNode.QueryElementNodeMemory mem = (QueryElementNode.QueryElementNodeMemory) wm.getNodeMemories().peekNodeMemory(splitStart);
-            if (mem != null) {
-                mem.correctMemoryOnSinksChanged(removingTN);
-            }
-        }
-    }
-
-
-
-    private static int getSegmentPos(LeftTupleNode lts) {
-        int counter = 0;
-        while (lts.getType() != NodeTypeEnums.LeftInputAdapterNode) {
-            lts = lts.getLeftTupleSource();
-            if (BuildtimeSegmentUtilities.isTipNode(lts, null)) {
-                counter++;
-            }
-        }
-        return counter;
-    }
-
-    private static void insertLiaFacts(LeftTupleNode startNode, InternalWorkingMemory wm) {
-        // rule added with no sharing
-        PropagationContextFactory pctxFactory = RuntimeComponentFactory.get().getPropagationContextFactory();
-        final PropagationContext  pctx        = pctxFactory.createPropagationContext(wm.getNextPropagationIdCounter(), PropagationContext.Type.RULE_ADDITION, null, null, null);
-        LeftInputAdapterNode      lian        = (LeftInputAdapterNode) startNode;
-        RightTupleSinkAdapter     liaAdapter  = new RightTupleSinkAdapter(lian);
-        lian.getObjectSource().updateSink(liaAdapter, pctx, wm);
-    }
-
-    private static void insertFacts(PathEndNodes endNodes, InternalWorkingMemory wm) {
-        Set<Integer> visited = new HashSet<>();
-
-        for ( PathEndNode endNode : endNodes.subjectEndNodes ) {
-            LeftTupleNode[]  nodes = endNode.getPathNodes();
-            for ( int i = 0; i < nodes.length; i++ ) {
-                LeftTupleNode node = nodes[i];
-                if  ( NodeTypeEnums.isBetaNode(node) && node.getAssociatedTerminalsSize() == 1 ) {
-                    if (!visited.add( node.getId() )) {
-                        continue;// this is to avoid rentering a path, and processing nodes twice. This can happen for nested subnetworks.
-                    }
-                    BetaNode bn = (BetaNode) node;
-
-                    if (!bn.isRightInputIsRiaNode()) {
-                        PropagationContextFactory pctxFactory = RuntimeComponentFactory.get().getPropagationContextFactory();
-                        final PropagationContext pctx = pctxFactory.createPropagationContext(wm.getNextPropagationIdCounter(), PropagationContext.Type.RULE_ADDITION, null, null, null);
-                        bn.getRightInput().updateSink(bn, pctx, wm);
+                // find the remaining child and get it's proto
+                LeftTupleNode ltn = null;
+                for (NetworkNode n : splitNode.getSinks()) {
+                    if (n.getAssociatedTerminalsSize() == 1 && n.hasAssociatedTerminal(tn)) {
+                        continue;
+                    } else {
+                        ltn = (LeftTupleNode) n;
+                        break;
                     }
                 }
+                if ( ltn == null) {
+                    // the excl branch is being removed, but there is no merge. For example see AddRemoveRulesTest.testInsertRemoveFireWith2Nots
+                    //return;
+                    throw new RuntimeException();
+                }
+
+                SegmentPrototype proto2 = kBase.getSegmentPrototype(ltn);
+
+                mergeSegments(proto1, proto2, kBase, wms);
+
+                notifyImpactedSegments(wms, proto1, null, smemsToNotify);
             }
         }
-    }
 
-    private static void deleteRightInputData(LeftTupleSink node, InternalWorkingMemory wm) {
-        if (wm.getNodeMemories().peekNodeMemory(node) != null) {
+        public static void mergeSegments(SegmentPrototype proto1, SegmentPrototype proto2, RuleBase kbase, Collection<InternalWorkingMemory> wms) {
+            boolean proto2WasEager = proto2.requiresEager();
+
+            LeftTupleNode[] origNodes = proto1.getNodesInSegment();
+
+            mergeProtos(proto1, proto2, origNodes);
+
+            // Now merge any existing Segments, using the updated Protos
+            for (InternalWorkingMemory wm : wms) {
+                Memory mem1 = wm.getNodeMemories().peekNodeMemory(proto1.getRootNode());
+                Memory mem2 = wm.getNodeMemories().peekNodeMemory(proto2.getRootNode());
+                mergeSegment(proto1, mem1, proto2, origNodes, mem2, kbase, wm);
+            }
+
+            // Paths need updating, update the protos and the smems
+            PathEndNode[] endNodes = proto1.getPathEndNodes();
+            for (PathEndNode endNode : endNodes) {
+                // process eager changes
+                mergeEagerProtos(proto1, proto2, proto2WasEager, endNode);
+                proto1.setPathEndNodes(proto2.getPathEndNodes());
+
+                // insert the new proto into the segment list
+                SegmentPrototype[] newList = new SegmentPrototype[endNode.getSegmentPrototypes().length - 1];
+                copyWithRemoval(endNode.getSegmentPrototypes(), newList, proto2);
+
+                // If the proto isn't end, copy over the remaining protos and adjust their pos and bit pos
+                if ( proto1.getPos()+1 != newList.length) {
+                    for (int i = proto1.getPos()+1; i <newList.length; i++) {
+                        newList[i].setPos(i);
+                        newList[i].setSegmentPosMaskBit(1 << i);
+                    }
+                }
+                endNode.setSegmentPrototypes(newList);
+
+                updatePaths(proto1, wms, endNode, newList);
+            }
+
+            kbase.getSegmentPrototypes().remove(proto2.getRootNode().getId());
+        }
+
+
+        private static void mergeProtos(SegmentPrototype proto1, SegmentPrototype proto2, LeftTupleNode[] origNodes) {
+            proto1.setTipNode(proto2.getTipNode());
+            LeftTupleNode[] nodes = new LeftTupleNode[proto1.getNodesInSegment().length + proto2.getNodesInSegment().length];
+
+            System.arraycopy(proto1.getNodesInSegment(), 0, nodes,
+                             0, proto1.getNodesInSegment().length);
+
+            System.arraycopy(proto2.getNodesInSegment(), 0, nodes,
+                             proto1.getNodesInSegment().length, proto2.getNodesInSegment().length);
+
+            proto1.setNodesInSegment(nodes);
+
+            MemoryPrototype[] protoMems = new MemoryPrototype[proto1.getMemories().length + proto2.getMemories().length];
+
+            System.arraycopy(proto1.getMemories(), 0, protoMems,
+                             0, proto1.getMemories().length);
+
+            System.arraycopy(proto2.getMemories(), 0, protoMems,
+                             proto1.getMemories().length, proto2.getMemories().length);
+
+            proto1.setNodesInSegment(nodes);
+            proto1.setMemories(protoMems);
+
+            int bitPos = 1;
+            for (int i = 0; i < protoMems.length; i++ ) {
+                protoMems[i].setNodePosMaskBit(bitPos);
+                bitPos = bitPos << 1;
+            }
+            setNodeTypes(proto1, nodes);
+
+            mergeBitMasks(proto1, proto2, origNodes);
+        }
+
+
+        private static void mergeSegment(SegmentPrototype proto1, Memory m1, SegmentPrototype proto2, LeftTupleNode[] origNodes, Memory m2, RuleBase kbase, InternalWorkingMemory wm) {
+            SegmentMemory sm1 = (m1 != null) ? m1.getSegmentMemory() : null;
+            SegmentMemory sm2 = (m2 != null) ? m2.getSegmentMemory() : null;
+            if ( sm1 == null && sm2 == null) {
+                return;
+            }
+
+            if ( sm1 == null) {
+                // To be able to merge sm1 must exist
+                sm1 = RuntimeSegmentUtilities.getOrCreateSegmentMemory(proto1.getRootNode(), wm);
+            }
+
+            if ( sm2 == null) {
+                // To be able to merge sm2 must exist
+                sm2 = RuntimeSegmentUtilities.getOrCreateSegmentMemory(proto2.getRootNode(), wm);
+            }
+
+            // merge the memories and reassign back to sm1
+            Memory[] mems1 = sm1.getNodeMemories();
+            Memory[] mems2 = sm2.getNodeMemories();
+
+            Memory[] mems = new Memory[mems1.length + mems2.length];
+            System.arraycopy(mems1, 0, mems,
+                             0, mems1.length);
+
+            // As the segmentMemory needs updating, no point in a separate arraycopy
+            for (int i = 0; i < mems2.length; i++) {
+                Memory mem = mems2[i];
+                mems[mems1.length + i] = mem;
+                mem.setSegmentMemory(sm1);
+
+                // make sure all the mems still reference each other
+                mem.setPrevious(mems[mems1.length + i -1]);
+                mems[mems1.length + i -1].setNext(mem);
+
+                if (mem instanceof SegmentNodeMemory) {
+                    ((SegmentNodeMemory) mem).setNodePosMaskBit(proto2.getMemories()[i].getNodePosMaskBit());
+                }
+            }
+
+            sm1.setNodeMemories(mems);
+
+            mergeSegment(sm1, sm2, proto1, origNodes, kbase, wm);
+        }
+
+        private static void mergeSegment(SegmentMemory sm1, SegmentMemory sm2, SegmentPrototype proto1, LeftTupleNode[] origNodes, RuleBase kbase, InternalWorkingMemory wm) {
+            if (sm1.getTipNode().getType() == NodeTypeEnums.LeftInputAdapterNode && !sm2.getStagedLeftTuples().isEmpty()) {
+                // If a rule has not been linked, lia can still have child segments with staged tuples that did not get flushed
+                // these are safe to just move to the parent SegmentMemory
+                sm1.getStagedLeftTuples().addAll(sm2.getStagedLeftTuples());
+            }
+
+            // sm1 may not be linked yet to sm2 because sm2 has been just created
+            if (sm1.contains(sm2)) {
+                sm1.remove(sm2);
+            }
+
+            // add all child sms
+            if (sm2.getFirst() != null) {
+                for (SegmentMemory sm = sm2.getFirst(); sm != null; ) {
+                    SegmentMemory next = sm.getNext();
+                    sm2.remove(sm);
+                    sm1.add(sm);
+                    sm = next;
+                }
+            }
+
+            // preserve values that get changed updateSegmentMemory, for merge
+            long currentLinkedNodeMask = sm1.getLinkedNodeMask();
+            proto1.shallowUpdateSegmentMemory(sm1, wm);
+
+            mergeBitMasks(sm1, sm2, origNodes, currentLinkedNodeMask);
+        }
+
+        private static void mergeBitMasks(SegmentPrototype sm1, SegmentPrototype sm2, LeftTupleNode[] origNodes) {
+            // @TODO Haven't made this work for more than 64 nodes, as per SegmentUtilities.nextNodePosMask (mdp)
+            int shiftBits = origNodes.length;
+
+            long currentLinkedNodeMask = sm1.getLinkedNodeMask();
+            long currentAllLinkedMaskTest = sm1.getAllLinkedMaskTest();
+
+            long linkedBitsToAdd = sm2.getLinkedNodeMask() << shiftBits;
+            long allBitsToAdd = sm2.getAllLinkedMaskTest() << shiftBits;
+
+            sm1.setLinkedNodeMask(linkedBitsToAdd | currentLinkedNodeMask);
+            sm1.setAllLinkedMaskTest(allBitsToAdd | currentAllLinkedMaskTest);
+        }
+
+        private static void mergeBitMasks(SegmentMemory sm1, SegmentMemory sm2, LeftTupleNode[] origNodes, long currentLinkedNodeMask) {
+            // @TODO Haven't made this work for more than 64 nodes, as per SegmentUtilities.nextNodePosMask (mdp)
+            int shiftBits = origNodes.length;
+
+            long linkedBitsToAdd = sm2.getLinkedNodeMask() << shiftBits;
+            long dirtyBitsToAdd = sm2.getDirtyNodeMask() << shiftBits;
+            sm1.setLinkedNodeMask(linkedBitsToAdd | currentLinkedNodeMask);
+            sm1.setDirtyNodeMask(dirtyBitsToAdd | sm1.getDirtyNodeMask());
+        }
+
+        private static void mergeEagerProtos(SegmentPrototype proto1, SegmentPrototype proto2, boolean proto2WasEager, PathEndNode endNode) {
+            if (!proto1.requiresEager() && !proto2.requiresEager()) {
+                return;
+            }
+
+            SegmentPrototype[] eager = endNode.getEagerSegmentPrototypes();
+            if (proto1.requiresEager() && proto2.requiresEager()) {
+                // keep proto1 and remove proto2
+                SegmentPrototype[] newEager = new SegmentPrototype[eager.length-1];
+                copyWithRemoval(eager, newEager, proto2);
+                endNode.setEagerSegmentPrototypes(newEager);
+            }  else if (proto1.requiresEager() && proto2WasEager) {
+                // find proto2 and swap proto2 with proto1
+                for ( int i = 0; i < eager.length; i++){
+                    if (eager[i] == proto2) {
+                        eager[i] = proto1;
+                        break;
+                    }
+                }
+            } // else if ( proto1.requiresEager() && !proto2.requiresEager()) do nothing as proto1 already in the array
+        }
+
+        private static void deleteRightInputData(LeftTupleNode node, Memory m, InternalWorkingMemory wm) {
             BetaNode   bn = (BetaNode) node;
             BetaMemory bm;
             if (bn.getType() == NodeTypeEnums.AccumulateNode) {
-                bm = ((AccumulateMemory) wm.getNodeMemory(bn)).getBetaMemory();
+                bm = ((AccumulateMemory) m).getBetaMemory();
             } else {
-                bm = (BetaMemory) wm.getNodeMemory(bn);
+                bm = (BetaMemory) m;
             }
 
             TupleMemory  rtm = bm.getRightTupleMemory();
@@ -755,30 +983,52 @@ class EagerPhreakBuilder implements PhreakBuilder {
 
             deleteFactsFromRightInput(bn, wm);
         }
-    }
 
-    private static void deleteFactsFromRightInput(BetaNode bn, InternalWorkingMemory wm) {
-        ObjectSource source = bn.getRightInput();
-        if (source instanceof WindowNode) {
-            WindowNode.WindowMemory memory = wm.getNodeMemory(((WindowNode) source));
-            for (EventFactHandle factHandle : memory.getFactHandles()) {
-                factHandle.forEachRightTuple( rt -> {
-                    if (source.equals(rt.getTupleSink())) {
-                        rt.unlinkFromRightParent();
+        private static void deleteFactsFromRightInput(BetaNode bn, InternalWorkingMemory wm) {
+            ObjectSource source = bn.getRightInput();
+            if (source instanceof WindowNode) {
+                WindowNode.WindowMemory memory = (WindowNode.WindowMemory) wm.getNodeMemories().peekNodeMemory(source);
+                if (memory != null) {
+                    for (EventFactHandle factHandle : memory.getFactHandles()) {
+                        factHandle.forEachRightTuple(rt -> {
+                            if (source.equals(rt.getTupleSink())) {
+                                rt.unlinkFromRightParent();
+                            }
+                        });
                     }
-                });
+                }
+            }
+        }
+
+        private static void unlinkRightTuples(RightTuple rightTuple) {
+            for (RightTuple rt = rightTuple; rt != null; ) {
+                RightTuple next = rt.getStagedNext();
+                // this RightTuple could have been already unlinked by the former cycle
+                if (rt.getFactHandle() != null) {
+                    rt.unlinkFromRightParent();
+                }
+                rt = next;
+            }
+        }
+
+        private static void copyWithRemoval(SegmentPrototype[] orinalProtos, SegmentPrototype[] newProtos, SegmentPrototype protoToRemove) {
+            for (int i = 0, j = 0; i < orinalProtos.length; i++) {
+                if (orinalProtos[i] == protoToRemove) {
+                    // j is not increased here.
+                    continue;
+                }
+                newProtos[j] = orinalProtos[i];
+                j++;
             }
         }
     }
 
-    private static void unlinkRightTuples(RightTuple rightTuple) {
-        for (RightTuple rt = rightTuple; rt != null; ) {
-            RightTuple next = rt.getStagedNext();
-            // this RightTuple could have been already unlinked by the former cycle
-            if (rt.getFactHandle() != null) {
-                rt.unlinkFromRightParent();
+    private static void correctMemoryOnSplitsChanged(LeftTupleNode splitStart, TerminalNode removingTN, InternalWorkingMemory wm) {
+        if (splitStart.getType() == NodeTypeEnums.UnificationNode) {
+            QueryElementNode.QueryElementNodeMemory mem = (QueryElementNode.QueryElementNodeMemory) wm.getNodeMemories().peekNodeMemory(splitStart);
+            if (mem != null) {
+                mem.correctMemoryOnSinksChanged(removingTN);
             }
-            rt = next;
         }
     }
 
@@ -787,88 +1037,94 @@ class EagerPhreakBuilder implements PhreakBuilder {
      * It traverses to the LiaNode's ObjectTypeNode. It then iterates the LeftTuple chains, where an existing LeftTuple is staged
      * as delete. Or a new LeftTuple is created and staged as an insert.
      */
-    private static void processLeftTuples(LeftTupleNode node, InternalWorkingMemory wm, boolean insert, TerminalNode tn) {
-        // *** if you make a fix here, it most likely needs to be in PhreakActivationIteratorToo ***
+    private static void processLeftTuples(LeftTupleNode node, boolean insert, TerminalNode tn, Collection<InternalWorkingMemory> wms) {
+        for (InternalWorkingMemory wm : wms) {
+            // this visited is here due to subnetworks causing potential parent revisiting.
+            Set<LeftTupleNode> visited = new HashSet<>();
 
-        // Must iterate up until a node with memory is found, this can be followed to find the LeftTuples
-        // which provide the potential peer of the tuple being added or removed
 
-        if ( node instanceof AlphaTerminalNode ) {
-            processLeftTuplesOnLian( wm, insert, tn, (LeftInputAdapterNode) node );
-            return;
-        }
+            // *** if you make a fix here, it most likely needs to be in PhreakActivationIteratorToo ***
 
-        Memory memory = wm.getNodeMemories().peekNodeMemory(node);
-        if (memory == null || memory.getSegmentMemory() == null) {
-            // segment has never been initialized, which means the rule(s) have never been linked and thus no Tuples to fix
-            return;
-        }
-        SegmentMemory sm = memory.getSegmentMemory();
+            // Must iterate up until a node with memory is found, this can be followed to find the LeftTuples
+            // which provide the potential peer of the tuple being added or removed
 
-        while (NodeTypeEnums.LeftInputAdapterNode != node.getType()) {
+            if (node instanceof AlphaTerminalNode) {
+                processLeftTuplesOnLian(wm, insert, tn, (LeftInputAdapterNode) node, visited);
+                return;
+            }
 
-            if (NodeTypeEnums.isBetaNode(node)) {
-                BetaMemory    bm;
-                if (NodeTypeEnums.AccumulateNode == node.getType()) {
-                    AccumulateMemory am = (AccumulateMemory) memory;
-                    bm = am.getBetaMemory();
-                    FastIterator it = bm.getLeftTupleMemory().fullFastIterator();
-                    Tuple        lt = BetaNode.getFirstTuple(bm.getLeftTupleMemory(), it);
-                    for (; lt != null; lt = (LeftTuple) it.next(lt)) {
-                        AccumulateContext accctx = (AccumulateContext) lt.getContextObject();
-                        visitChild(accctx.getResultLeftTuple(), insert, wm, tn);
-                    }
-                } else if (NodeTypeEnums.ExistsNode == node.getType() &&
-                           !((BetaNode)node).isRightInputIsRiaNode()) { // do not process exists with subnetworks
-                    // If there is a subnetwork, then there is no populated RTM, but the LTM is populated,
-                    // so this would be procsssed in the "else".
+            Memory memory = wm.getNodeMemories().peekNodeMemory(node);
+            if (memory == null || memory.getSegmentMemory() == null) {
+                // segment has never been initialized, which means the rule(s) have never been linked and thus no Tuples to fix
+                return;
+            }
 
-                    bm = (BetaMemory) wm.getNodeMemory((MemoryFactory) node);
-                    FastIterator it = bm.getRightTupleMemory().fullFastIterator(); // done off the RightTupleMemory, as exists only have unblocked tuples on the left side
-                    RightTuple   rt = (RightTuple) BetaNode.getFirstTuple(bm.getRightTupleMemory(), it);
-                    for (; rt != null; rt = (RightTuple) it.next(rt)) {
-                        for (LeftTuple lt = rt.getBlocked(); lt != null; lt = lt.getBlockedNext()) {
-                            visitChild(wm, insert, tn, it, lt);
+            while (NodeTypeEnums.LeftInputAdapterNode != node.getType()) {
+                if (!visited.add(node)) {
+                    return;
+                }
+                if (NodeTypeEnums.isBetaNode(node)) {
+                    BetaMemory bm;
+                    if (NodeTypeEnums.AccumulateNode == node.getType()) {
+                        AccumulateMemory am = (AccumulateMemory) memory;
+                        bm = am.getBetaMemory();
+                        FastIterator it = bm.getLeftTupleMemory().fullFastIterator();
+                        Tuple lt = BetaNode.getFirstTuple(bm.getLeftTupleMemory(), it);
+                        for (; lt != null; lt = (LeftTuple) it.next(lt)) {
+                            AccumulateContext accctx = (AccumulateContext) lt.getContextObject();
+                            visitChild(accctx.getResultLeftTuple(), insert, wm, tn, visited);
+                        }
+                    } else if (NodeTypeEnums.ExistsNode == node.getType() &&
+                               !((BetaNode) node).isRightInputIsRiaNode()) { // do not process exists with subnetworks
+                        // If there is a subnetwork, then there is no populated RTM, but the LTM is populated,
+                        // so this would be procsssed in the "else".
+
+                        bm = (BetaMemory) wm.getNodeMemories().peekNodeMemory(node);
+                        if (bm != null) {
+                            FastIterator it = bm.getRightTupleMemory().fullFastIterator(); // done off the RightTupleMemory, as exists only have unblocked tuples on the left side
+                            RightTuple rt = (RightTuple) BetaNode.getFirstTuple(bm.getRightTupleMemory(), it);
+                            for (; rt != null; rt = (RightTuple) it.next(rt)) {
+                                for (LeftTuple lt = rt.getBlocked(); lt != null; lt = lt.getBlockedNext()) {
+                                    visitChild(wm, insert, tn, it, lt, visited);
+                                }
+                            }
+                        }
+                    } else {
+                        bm = (BetaMemory) wm.getNodeMemories().peekNodeMemory(node);
+                        if (bm != null) {
+                            FastIterator it = bm.getLeftTupleMemory().fullFastIterator();
+                            Tuple lt = BetaNode.getFirstTuple(bm.getLeftTupleMemory(), it);
+                            visitChild(wm, insert, tn, it, lt, visited);
                         }
                     }
-                } else {
-                    bm = (BetaMemory) wm.getNodeMemory((MemoryFactory) node);
-                    FastIterator it = bm.getLeftTupleMemory().fullFastIterator();
-                    Tuple        lt = BetaNode.getFirstTuple(bm.getLeftTupleMemory(), it);
-                    visitChild(wm, insert, tn, it, lt);
+                    return;
+                } else if (NodeTypeEnums.FromNode == node.getType()) {
+                    FromMemory fm = (FromMemory) wm.getNodeMemories().peekNodeMemory(node);
+                    if (fm != null) {
+                        TupleMemory ltm = fm.getBetaMemory().getLeftTupleMemory();
+                        FastIterator it = ltm.fullFastIterator();
+                        for (LeftTuple lt = (LeftTuple) ltm.getFirst(null); lt != null; lt = (LeftTuple) it.next(lt)) {
+                            visitChild(lt, insert, wm, tn, visited);
+                        }
+                    }
+                    return;
                 }
-                return;
-            } else if (NodeTypeEnums.FromNode == node.getType()) {
-                FromMemory   fm  = (FromMemory) wm.getNodeMemory((MemoryFactory) node);
-                TupleMemory  ltm = fm.getBetaMemory().getLeftTupleMemory();
-                FastIterator it  = ltm.fullFastIterator();
-                for (LeftTuple lt = (LeftTuple) ltm.getFirst(null); lt != null; lt = (LeftTuple) it.next(lt)) {
-                    visitChild(lt, insert, wm, tn);
-                }
-                return;
+                node = node.getLeftTupleSource();
             }
-            if (sm.getRootNode() == node) {
-                sm = wm.getNodeMemory((MemoryFactory<Memory>) node.getLeftTupleSource()).getSegmentMemory();
-            }
-            node = node.getLeftTupleSource();
-        }
 
-        // No beta or from nodes, so must retrieve LeftTuples from the LiaNode.
-        // This is done by scanning all the LeftTuples referenced from the FactHandles in the ObjectTypeNode
-        processLeftTuplesOnLian( wm, insert, tn, (LeftInputAdapterNode) node );
+            // No beta or from nodes, so must retrieve LeftTuples from the LiaNode.
+            // This is done by scanning all the LeftTuples referenced from the FactHandles in the ObjectTypeNode
+            processLeftTuplesOnLian(wm, insert, tn, (LeftInputAdapterNode) node, visited);
+        }
     }
 
-    private static void processLeftTuplesOnLian( InternalWorkingMemory wm, boolean insert, TerminalNode tn, LeftInputAdapterNode lian ) {
+    private static void processLeftTuplesOnLian( InternalWorkingMemory wm, boolean insert, TerminalNode tn, LeftInputAdapterNode lian, Set<LeftTupleNode> visited ) {
         ObjectSource os = lian.getObjectSource();
         while (os.getType() != NodeTypeEnums.ObjectTypeNode) {
             os = os.getParentObjectSource();
         }
         ObjectTypeNode otn  = (ObjectTypeNode) os;
-        final ObjectTypeNodeMemory omem = wm.getNodeMemory(otn);
-        if (omem == null) {
-            // no OTN memory yet, i.e. no inserted matching objects, so no Tuples to process
-            return;
-        }
+        final ObjectTypeNodeMemory omem = wm.getNodeMemory(otn); // For some reason cannot move this to peek, as TruthMaintenanceTEst.testLogicalInsertionsDynamicRule fails
 
         Iterator<InternalFactHandle> it = omem.iterator();
         while (it.hasNext()) {
@@ -878,7 +1134,7 @@ class EagerPhreakBuilder implements PhreakBuilder {
 
                 // Each lt is for a different lian, skip any lian not associated with the rule. Need to use lt parent (souce) not child to check the lian.
                 if (isAssociatedWith(lt.getTupleSource(), tn)) {
-                    visitChild(lt, insert, wm, tn);
+                    visitChild(lt, insert, wm, tn, visited);
 
                     if (lt.getHandlePrevious() != null) {
                         lt.getHandlePrevious().setHandleNext( nextLt );
@@ -891,30 +1147,29 @@ class EagerPhreakBuilder implements PhreakBuilder {
         }
     }
 
-    private static void visitChild(InternalWorkingMemory wm, boolean insert, TerminalNode tn, FastIterator it, Tuple lt) {
+    private static void visitChild(InternalWorkingMemory wm, boolean insert, TerminalNode tn, FastIterator it, Tuple lt, Set<LeftTupleNode> visited) {
         for (; lt != null; lt = (LeftTuple) it.next(lt)) {
             LeftTuple childLt = lt.getFirstChild();
             while (childLt != null) {
                 LeftTuple nextLt = childLt.getHandleNext();
-                visitChild(childLt, insert, wm, tn);
+                visitChild(childLt, insert, wm, tn, visited);
                 childLt = nextLt;
             }
         }
     }
 
-    private static void visitChild(LeftTuple lt, boolean insert, InternalWorkingMemory wm, TerminalNode tn) {
+    private static void visitChild(LeftTuple lt, boolean insert, InternalWorkingMemory wm, TerminalNode tn, Set<LeftTupleNode> visited) {
         LeftTuple prevLt = null;
         LeftTupleSinkNode sink = lt.getTupleSink();
 
         for ( ; sink != null; sink = sink.getNextLeftTupleSinkNode() ) {
-
             if ( lt != null ) {
                 if (isAssociatedWith(lt.getTupleSink(), tn)) {
 
                     if (lt.getTupleSink().getAssociatedTerminalsSize() > 1) {
                         if (lt.getFirstChild() != null) {
                             for ( LeftTuple child = lt.getFirstChild(); child != null; child =  child.getHandleNext() ) {
-                                visitChild(child, insert, wm, tn);
+                                visitChild(child, insert, wm, tn, visited);
                             }
                         } else if (lt.getTupleSink().getType() == NodeTypeEnums.RightInputAdapterNode) {
                             insertPeerRightTuple(lt, wm, tn, insert);
@@ -957,10 +1212,12 @@ class EagerPhreakBuilder implements PhreakBuilder {
                 prevLt = lt;
                 lt = lt.getPeer();
             } else if (insert) {
-                BetaMemory bm = (BetaMemory) wm.getNodeMemory( (BetaNode) sink );
-                prevLt = rian.createPeer( prevLt );
-                bm.linkNode( (BetaNode) sink, wm );
-                bm.getStagedRightTuples().addInsert((RightTuple)prevLt);
+                BetaMemory bm = (BetaMemory) wm.getNodeMemories().peekNodeMemory( sink );
+                if (bm != null) {
+                    prevLt = rian.createPeer(prevLt);
+                    bm.linkNode((BetaNode) sink, wm);
+                    bm.getStagedRightTuples().addInsert((RightTuple) prevLt);
+                }
             }
         }
     }
@@ -983,7 +1240,7 @@ class EagerPhreakBuilder implements PhreakBuilder {
 
         LeftInputAdapterNode.LiaNodeMemory liaMem = null;
         if ( node.getLeftTupleSource().getType() == NodeTypeEnums.LeftInputAdapterNode ) {
-            liaMem = wm.getNodeMemory(((LeftInputAdapterNode) node.getLeftTupleSource()));
+            liaMem = (LeftInputAdapterNode.LiaNodeMemory) wm.getNodeMemories().peekNodeMemory(node.getLeftTupleSource());
         }
 
         Memory memory = wm.getNodeMemories().peekNodeMemory(node);
@@ -1123,233 +1380,77 @@ class EagerPhreakBuilder implements PhreakBuilder {
         }
     }
 
-    private static void addNetworkSplitPoint(LeftTupleNode node, Set<LeftTupleNode> splitNodes) {
-        // It's ok to add nodes that are predecessors of existing nodes in the network.
-        // due to subnetworks, both may need their LTs processing.
-        while (node.getLeftTupleSource()  != null) {
-            if (node.getLeftTupleSource().getAssociatedTerminalsSize() != 1) {
-                if ( node.getAssociatedTerminalsSize() == 1) {
-                    splitNodes.add(node.getLeftTupleSource());
-                }
-                return;
-            }
-            node = node.getLeftTupleSource();
-        }
+    private static void updatePaths(SegmentPrototype proto, Collection<InternalWorkingMemory> wms, PathEndNode endNode, SegmentPrototype[] newList) {
+        PathMemSpec spec = endNode.getPathMemSpec();
+        spec.update(BuildtimeSegmentUtilities.getPathAllLinkedMaskTest(endNode.getSegmentPrototypes(), endNode),
+                    endNode.getSegmentPrototypes().length);
 
-        // this only happens if it reaches the Lian, which we need to return if nothing else is reached.
-        splitNodes.add(node);
-    }
+        // Now update the PathMemories array of SegmentMemories.
+        // Also update all SegmentMemory after the split.
+        for (WorkingMemory wm : wms) {
+            PathMemory pmem = (PathMemory) wm.getNodeMemories().peekNodeMemory(endNode);
 
-    public static SegmentMemory splitSegment(InternalWorkingMemory wm, SegmentMemory sm1, LeftTupleNode splitNode, RuleBase kbase) {
-        // create new segment, starting after split
-        LeftTupleNode childNode = splitNode.getSinkPropagator().getFirstLeftTupleSink();
-        SegmentPrototype proto2 = kbase.getSegmentPrototype(childNode);
-        SegmentMemory sm2 = proto2.newSegmentMemory(wm); // we know there is only one sink
-        wm.getNodeMemories().peekNodeMemory( childNode ).setSegmentMemory( sm2 );
-
-        // Move the children of sm1 to sm2
-        if (sm1.getFirst() != null) {
-            for (SegmentMemory sm = sm1.getFirst(); sm != null; ) {
-                SegmentMemory next = sm.getNext();
-                sm1.remove(sm);
-                sm2.add(sm);
-                sm = next;
-            }
-        }
-
-        sm1.add(sm2);
-
-        sm2.mergePathMemories(sm1);
-
-        // preserve values that get changed updateSegmentMemory, for split
-        long currentLinkedNodeMask  = sm1.getLinkedNodeMask();
-        SegmentPrototype proto1 = kbase.getSegmentPrototype(sm1.getRootNode());
-        proto1.updateSegmentMemory(sm1, wm);
-
-        if (sm1.getTipNode().getType() == NodeTypeEnums.LeftInputAdapterNode) {
-            if (!sm1.getStagedLeftTuples().isEmpty()) {
-                // Segments with only LiaNode's cannot have staged LeftTuples, so move them down to the new Segment
-                sm2.getStagedLeftTuples().addAll(sm1.getStagedLeftTuples());
-            }
-        }
-
-        splitBitMasks(sm1, sm2, currentLinkedNodeMask);
-
-        return sm2;
-    }
-
-    private static void mergeSegment(SegmentMemory sm1, SegmentMemory sm2, RuleBase kbase, InternalWorkingMemory wm) {
-        if (sm1.getTipNode().getType() == NodeTypeEnums.LeftInputAdapterNode && !sm2.getStagedLeftTuples().isEmpty()) {
-            // If a rule has not been linked, lia can still have child segments with staged tuples that did not get flushed
-            // these are safe to just move to the parent SegmentMemory
-            sm1.getStagedLeftTuples().addAll(sm2.getStagedLeftTuples());
-        }
-
-        // sm1 may not be linked yet to sm2 because sm2 has been just created
-        if (sm1.contains(sm2)) {
-            sm1.remove(sm2);
-        }
-
-        if (sm2.getFirst() != null) {
-            for (SegmentMemory sm = sm2.getFirst(); sm != null; ) {
-                SegmentMemory next = sm.getNext();
-                sm2.remove(sm);
-                sm1.add(sm);
-                sm = next;
-            }
-        }
-
-        // preserve values that get changed updateSegmentMemory, for merge
-        long currentLinkedNodeMask = sm1.getLinkedNodeMask();
-        SegmentPrototype proto1 = kbase.getSegmentPrototype(sm1.getRootNode());
-        proto1.updateSegmentMemory(sm1, wm);
-
-        mergeBitMasks(sm1, sm2, currentLinkedNodeMask);
-
-
-    }
-
-    private static void splitBitMasks(SegmentMemory sm1, SegmentMemory sm2, long currentLinkedNodeMask) {
-        // @TODO Haven't made this work for more than 64 nodes, as per SegmentUtilities.nextNodePosMask (mdp)
-        int  splitPos              = sm1.getSegmentPrototype().getNodesInSegment().length; // +1 as zero based
-        long currentDirtyNodeMask  = sm1.getDirtyNodeMask();
-        long splitAsBinary         = (1L << splitPos) - 1;
-
-        sm1.setDirtyNodeMask(currentDirtyNodeMask & splitAsBinary);
-        sm1.setLinkedNodeMask(currentLinkedNodeMask& sm1.getAllLinkedMaskTest());
-
-        sm2.setLinkedNodeMask(currentLinkedNodeMask >> splitPos);
-        sm2.setDirtyNodeMask(currentDirtyNodeMask >> splitPos);
-    }
-
-    private static void mergeBitMasks(SegmentMemory sm1, SegmentMemory sm2, long currentLinkedNodeMask) {
-        int shiftBits = 0;
-        for (LeftTupleNode node : sm1.getSegmentPrototype().getNodesInSegment()) {
-            if (node == sm2.getRootNode()) {
-                break;
-            }
-            shiftBits++;
-        }
-        long linkedBitsToAdd = sm2.getLinkedNodeMask() << shiftBits;
-        long dirtyBitsToAdd = sm2.getLinkedNodeMask() << shiftBits;
-        sm1.setLinkedNodeMask(linkedBitsToAdd | currentLinkedNodeMask);
-        sm1.setDirtyNodeMask(dirtyBitsToAdd | sm1.getDirtyNodeMask());
-
-    }
-
-    private static PathEndNodeMemories getPathEndMemories(InternalWorkingMemory wm,
-                                                          PathEndNodes pathEndNodes) {
-        PathEndNodeMemories tnMems = new PathEndNodeMemories();
-
-        for (LeftTupleNode node : pathEndNodes.otherEndNodes) {
-            PathMemory pmem = (PathMemory) wm.getNodeMemories().peekNodeMemory(node);
             if (pmem != null) {
-                tnMems.otherPmems.add(pmem);
-            }
-        }
+                pmem.setAllLinkedMaskTest(spec.allLinkedTestMask());
 
-        tnMems.subjectPmem = (PathMemory) wm.getNodeMemories().peekNodeMemory(pathEndNodes.subjectTermNode);
-        if (tnMems.subjectPmem == null && !tnMems.otherPmems.isEmpty()) {
-            // If "other pmem's are initialized, then the subject needs to be initialized too.
-            tnMems.subjectPmem = RuntimeSegmentUtilities.initializePathMemory(wm, pathEndNodes.subjectTermNode);
-        }
+                // @TODO alphaterminalnodes shouldn't really have segments created?
+                SegmentMemory[] newSmems = new SegmentMemory[newList.length];
+                for (int i = 0; i < newList.length; i++) {
+                    SegmentPrototype smproto = newList[i];
+                    if (!isInsideSubnetwork(endNode, smproto)) {
+                        continue;
+                    }
+                    Memory mem = wm.getNodeMemories().peekNodeMemory(smproto.getRootNode());
+                    if (mem != null && mem.getSegmentMemory() != null) {
+                        SegmentMemory sm = mem.getSegmentMemory();
+                        newSmems[i] = sm;
 
-        for (PathEndNode node : pathEndNodes.subjectEndNodes) {
-            PathMemory pmem = (PathMemory) wm.getNodeMemories().peekNodeMemory(node);
-            if (pmem == null && !tnMems.otherPmems.isEmpty()) {
-                pmem = RuntimeSegmentUtilities.initializePathMemory(wm, node);
-            }
-            if (pmem != null) {
-                tnMems.subjectPmems.add(pmem);
-            }
-        }
-
-        return tnMems;
-    }
-
-    private static class PathEndNodeMemories {
-        PathMemory subjectPmem;
-        List<PathMemory> subjectPmems = new ArrayList<>();
-        List<PathMemory> otherPmems = new ArrayList<>();
-    }
-
-    private static PathEndNodes getPathEndNodes(TerminalNode tn,
-                                                Set<LeftTupleNode> splitNodes) {
-        PathEndNodes endNodes = new PathEndNodes();
-        endNodes.subjectTermNode = tn;
-        endNodes.subjectEndNodes.add(tn);
-        endNodes.subjectSplits.addAll(splitNodes);
-
-        Set<Integer> visited = new HashSet<>();
-        if (!endNodes.subjectSplits.isEmpty()) {
-            // first the root node of the segment that is being split
-            endNodes.subjectSplits.forEach(n -> invalidateRootNode(n, endNodes));
-
-            // collect all the PathEndNodes frmo the split point
-            endNodes.subjectSplits.forEach(n -> collectPathEndNodes(n, endNodes, tn,visited));
-        }
-
-        return endNodes;
-    }
-
-    private static void collectPathEndNodes(LeftTupleNode lt,
-                                            PathEndNodes endNodes,
-                                            TerminalNode tn,
-                                            Set<Integer> visited) {
-        // Traverses the sinks in reverse order in order to collect PathEndNodes so that
-        // the outermost (sub)network are evaluated before the innermost one
-        for (LeftTupleSinkNode sink = lt.getSinkPropagator().getLastLeftTupleSink(); sink != null; sink = sink.getPreviousLeftTupleSinkNode()) {
-            if (!visited.add(sink.getId())) {
-                // do not visit this node, if it's already in the visited set
-                continue;
-            }
-            if ( isRootNode( sink, null )) {
-                endNodes.nodesToInvalidate.add(sink);
-            }
-
-            if (NodeTypeEnums.isLeftTupleSource(sink)) {
-                collectPathEndNodes(sink, endNodes, tn, visited);
-            } else if (NodeTypeEnums.isTerminalNode(sink)) {
-                if (sink != tn) {
-                    endNodes.otherTermNodes.add((TerminalNode) sink);
-                    endNodes.otherEndNodes.add((TerminalNode) sink);
-                }
-            } else if (NodeTypeEnums.RightInputAdapterNode == sink.getType()) {
-                if (BuildtimeSegmentUtilities.sinkNotExclusivelyAssociatedWithTerminal(tn, sink)) {
-                    // Add every terminal node in it's PathEndNodes array. The set removes duplicates.
-                    // This is a bit brute force heavy, but the code isn't currently smart enough to do this partially, so it'll always just start from all assocaited tns.
-                    Arrays.stream(((PathEndNode) sink).getPathEndNodes()).filter(NodeTypeEnums::isTerminalNode).forEach(endNode -> {
-                        if ( endNode != tn) {
-                            endNodes.otherTermNodes.add((TerminalNode) endNode);
+                        // only update segment after proto
+                        if (i > proto.getPos()) {
+                            long currentLinkedNodeMask  = sm.getLinkedNodeMask();
+                            smproto.shallowUpdateSegmentMemory(sm,wm);
+                            sm.setLinkedNodeMask(currentLinkedNodeMask);
                         }
-                    });
-                    endNodes.otherEndNodes.add( (PathEndNode) sink );
-                } else {
-                    endNodes.subjectEndNodes.add( (PathEndNode) sink );
+
+                        // update link mask status on pmem for all segments from proto1 onwards
+                        if (i >= proto.getPos()) {
+                            if (sm.getAllLinkedMaskTest() > 0 && sm.isSegmentLinked() ) {
+                                pmem.setLinkedSegmentMask(pmem.getLinkedSegmentMask() | sm.getSegmentPosMaskBit());
+                            } else {
+                                pmem.setLinkedSegmentMask(pmem.getLinkedSegmentMask() & ~sm.getSegmentPosMaskBit());
+                            }
+                        }
+                    } else {
+                        // ensure the pmem is unset for this position, can happen if the segment that set this before shifted up
+                        pmem.setLinkedSegmentMask(pmem.getLinkedSegmentMask() & ~(1 << i ));
+                    }
                 }
-            } else {
-                if (!(NodeTypeEnums.isTerminalNode(sink) && isAssociatedWith(sink, tn))) {
-                    throw new RuntimeException("Error: Unknown Node. Defensive programming test..");
+                pmem.setSegmentMemories(newSmems);
+            }
+        }
+    }
+
+    private static void notifyImpactedSegments(Collection<InternalWorkingMemory> wms, SegmentPrototype proto1, SegmentPrototype proto2, Set<SegmentMemoryPair> smemsToNotify) {
+        // any impacted segments must be notified for potential linking
+        for (InternalWorkingMemory wm : wms) {
+            Memory mem1 = wm.getNodeMemories().peekNodeMemory(proto1.getRootNode());
+            if (mem1 != null && mem1.getSegmentMemory() != null) {
+                // there was a split segment, both need notifying.
+                notifyImpactedSegments(mem1.getSegmentMemory(), wm, smemsToNotify);
+                if (proto2 != null) {
+                    Memory mem2 = wm.getNodeMemories().peekNodeMemory(proto2.getRootNode());
+                    notifyImpactedSegments(mem2.getSegmentMemory(), wm, smemsToNotify);
                 }
             }
         }
     }
 
-    private static void invalidateRootNode( LeftTupleNode lt, PathEndNodes endNodes ) {
-        while (!isRootNode( lt, null )) {
-            lt = lt.getLeftTupleSource();
+    private static void setNodeTypes(SegmentPrototype proto, LeftTupleNode[] protoNodes) {
+        int nodeTypesInSegment = 0;
+        for ( LeftTupleNode node : protoNodes) {
+            nodeTypesInSegment = BuildtimeSegmentUtilities.updateNodeTypesMask(node, nodeTypesInSegment);
         }
-        endNodes.nodesToInvalidate.add(lt);
+        proto.setNodeTypesInSegment(nodeTypesInSegment);
     }
 
-    private static class PathEndNodes {
-        TerminalNode   subjectTermNode;
-        private final Set<PathEndNode>   subjectEndNodes = new HashSet<>();
-        private final Set<LeftTupleNode> subjectSplits   = new HashSet<>();
-        private final Set<PathEndNode>   otherEndNodes   = new HashSet<>();
-
-        private final Set<TerminalNode>   otherTermNodes   = new HashSet<>();
-
-        private final Set<LeftTupleNode> nodesToInvalidate = new HashSet<>();
-    }
 }

--- a/drools-core/src/main/java/org/drools/core/phreak/LazyPhreakBuilder.java
+++ b/drools-core/src/main/java/org/drools/core/phreak/LazyPhreakBuilder.java
@@ -17,6 +17,7 @@ package org.drools.core.phreak;
 
 
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collection;
 import java.util.HashMap;
 import java.util.HashSet;
@@ -98,6 +99,10 @@ import static org.drools.core.phreak.TupleEvaluationUtil.forceFlushLeftTuple;
 class LazyPhreakBuilder implements PhreakBuilder {
 
     private static final Logger log = LoggerFactory.getLogger(LazyPhreakBuilder.class);
+
+    public LazyPhreakBuilder() {
+         //throw new UnsupportedOperationException("DIE!!!!!");
+    }
 
     /**
      * This method is called after the rule nodes have been added to the network
@@ -195,7 +200,7 @@ class LazyPhreakBuilder implements PhreakBuilder {
 
                     removeNewPaths(wm, tnms.subjectPmems);
                 } else {
-                    flushStagedTuples(tn, tnms.subjectPmem, pathEndNodes, wm);
+                    flushStagedTuples(tn, tnms.subjectPmem, pathEndNodes.subjectSplits, wm);
 
                     processLeftTuples(firstSplit, wm, false, tn.getRule());
 
@@ -482,8 +487,7 @@ class LazyPhreakBuilder implements PhreakBuilder {
                         if ( mem != null ) {
                             SegmentMemory sm = mem.getSegmentMemory();
                             if ( sm != null && !sm.getPathMemories().contains( pmem ) ) {
-                                sm.addPathMemory( pmem );
-                                pmem.setSegmentMemory( sm.getPos(), sm );
+                                RuntimeSegmentUtilities.addSegmentToPathMemory(pmem, sm);
                                 sm.notifyRuleLinkSegment( wm, pmem );
                             }
                         }
@@ -575,7 +579,7 @@ class LazyPhreakBuilder implements PhreakBuilder {
         }
     }
 
-    private static void flushStagedTuples(TerminalNode tn, PathMemory pmem, PathEndNodes pathEndNodes, InternalWorkingMemory wm) {
+    public static void flushStagedTuples(TerminalNode tn, PathMemory pmem, List<LeftTupleNode> splits, InternalWorkingMemory wm) {
         // first flush the subject rule, then flush any staging lists that are part of a merge
         if ( pmem.isInitialized() ) {
             RuleNetworkEvaluator.INSTANCE.evaluateNetwork(pmem, pmem.getRuleAgendaItem().getRuleExecutor(), wm);
@@ -586,7 +590,7 @@ class LazyPhreakBuilder implements PhreakBuilder {
         // incase they need to be reflushed
         List<Flushed> flushed = new ArrayList<>();
 
-        for ( LeftTupleNode node : pathEndNodes.subjectSplits ) {
+        for (LeftTupleNode node : splits) {
             if (!isSplit(node, tn)) { // check if the split is there even without the processed rule
                 Memory mem = wm.getNodeMemories().peekNodeMemory(node);
                 if ( mem != null) {
@@ -617,7 +621,7 @@ class LazyPhreakBuilder implements PhreakBuilder {
         }
     }
 
-    private static void flushStagedTuples(LeftTupleNode splitStartNode, PathMemory pmem, InternalWorkingMemory wm) {
+    public static void flushStagedTuples(LeftTupleNode splitStartNode, PathMemory pmem, InternalWorkingMemory wm) {
         if ( !pmem.isInitialized() ) {
             // The rule has never been linked in and evaluated, so there will be nothing to flush.
             return;
@@ -655,7 +659,7 @@ class LazyPhreakBuilder implements PhreakBuilder {
 
             PathEndNode pathEndNode = pmem.getPathEndNode();
             pathEndNode.resetPathMemSpec(removingTN); // re-initialise the PathMemory
-            AbstractTerminalNode.initPathMemory(pathEndNode, pmem);
+            AbstractTerminalNode.initPathMemory(pathEndNode, pmem, removingTN);
         }
         return previousSmems;
     }
@@ -1231,18 +1235,18 @@ class LazyPhreakBuilder implements PhreakBuilder {
     }
 
     private static void mergeBitMasks(SegmentMemory sm1, SegmentMemory sm2) {
-        List<Memory> smNodeMemories2 = sm2.getNodeMemories();
+        Memory[] smNodeMemories2 = sm2.getNodeMemories();
 
-        long mask = sm2.getAllLinkedMaskTest() << smNodeMemories2.size();
+        long mask = sm2.getAllLinkedMaskTest() << smNodeMemories2.length;
         sm1.setAllLinkedMaskTest(mask & sm1.getAllLinkedMaskTest());
 
-        mask = sm2.getAllLinkedMaskTest() << smNodeMemories2.size();
+        mask = sm2.getAllLinkedMaskTest() << smNodeMemories2.length;
         sm1.setLinkedNodeMask(mask & sm1.getLinkedNodeMask());
     }
 
     private static void splitNodeMemories(SegmentMemory sm1, SegmentMemory sm2, int pos) {
-        List<Memory> smNodeMemories1 = sm1.getNodeMemories();
-        List<Memory> smNodeMemories2 = sm2.getNodeMemories();
+        List<Memory> smNodeMemories1 = new ArrayList<>(Arrays.asList(sm1.getNodeMemories()));
+        List<Memory> smNodeMemories2 = new ArrayList<>();
 
         Memory mem = smNodeMemories1.get(0);
         long nodePosMask = 1;
@@ -1261,11 +1265,13 @@ class LazyPhreakBuilder implements PhreakBuilder {
             }
             mem = next;
         }
+        sm1.setNodeMemories(smNodeMemories1.toArray(new Memory[smNodeMemories1.size()]));
+        sm2.setNodeMemories(smNodeMemories2.toArray(new Memory[smNodeMemories2.size()]));
     }
 
     private static void mergeNodeMemories(SegmentMemory sm1, SegmentMemory sm2) {
-        List<Memory> smNodeMemories1 = sm1.getNodeMemories();
-        List<Memory> smNodeMemories2 = sm2.getNodeMemories();
+        List<Memory> smNodeMemories1 = Arrays.asList(sm1.getNodeMemories());
+        List<Memory> smNodeMemories2 = Arrays.asList(sm2.getNodeMemories());
 
         int nodePosMask = 1;
         for (int i = 0, length = smNodeMemories1.size(); i < length; i++) {
@@ -1285,6 +1291,7 @@ class LazyPhreakBuilder implements PhreakBuilder {
             nodePosMask = nodePosMask >> 1;
             mem = next;
         }
+        sm1.setNodeMemories(smNodeMemories1.toArray(new Memory[smNodeMemories1.size()]));
     }
 
     private static void addToMemoryList(List<Memory> smNodeMemories, Memory mem) {
@@ -1327,7 +1334,7 @@ class LazyPhreakBuilder implements PhreakBuilder {
         tnMems.subjectPmem = (PathMemory) wm.getNodeMemories().peekNodeMemory(pathEndNodes.subjectEndNode);
         if (tnMems.subjectPmem == null && !tnMems.otherPmems.isEmpty()) {
             // If "other pmem's are initialized, then the subject needs to be initialized too.
-            tnMems.subjectPmem = (PathMemory) wm.getNodeMemory((MemoryFactory<Memory>) pathEndNodes.subjectEndNode);
+            tnMems.subjectPmem = wm.getNodeMemory( pathEndNodes.subjectEndNode);
         }
 
         for (LeftTupleNode node : pathEndNodes.subjectEndNodes) {
@@ -1466,15 +1473,14 @@ class LazyPhreakBuilder implements PhreakBuilder {
 
     private static SegmentMemory createChildSegmentForTerminalNode( LeftTupleNode node, Memory memory ) {
         SegmentMemory childSmem = new SegmentMemory( node ); // rtns or riatns don't need a queue
-        PathMemory pmem = NodeTypeEnums.isTerminalNode( node ) ? (PathMemory) memory : (RightInputAdapterNode.RiaPathMemory) memory;
+        PathMemory pmem = (PathMemory) memory;
 
         childSmem.setPos( pmem.getSegmentMemories().length - 1 );
-        pmem.setSegmentMemory(childSmem.getPos(), childSmem);
         pmem.setSegmentMemory(childSmem);
-        childSmem.addPathMemory( pmem );
+        RuntimeSegmentUtilities.addSegmentToPathMemory(pmem, childSmem);
 
         childSmem.setTipNode(node);
-        childSmem.addNodeMemory(memory);
+        childSmem.setNodeMemories(new Memory[] {memory});
         return childSmem;
     }
 
@@ -1489,38 +1495,39 @@ class LazyPhreakBuilder implements PhreakBuilder {
         boolean updateNodeBit = true;  // nodes after a branch CE can notify, but they cannot impact linking
 
         int nodeTypesInSegment = 0;
+        List<Memory> memories = new ArrayList<>();
         while (true) {
             nodeTypesInSegment = updateNodeTypesMask(tupleSource, nodeTypesInSegment);
             if (NodeTypeEnums.isBetaNode(tupleSource)) {
-                allLinkedTestMask = processBetaNode((BetaNode)tupleSource, reteEvaluator, smem, nodePosMask, allLinkedTestMask, updateNodeBit);
+                allLinkedTestMask = processBetaNode((BetaNode)tupleSource, reteEvaluator, smem, memories, nodePosMask, allLinkedTestMask, updateNodeBit);
             } else {
                 switch (tupleSource.getType()) {
                     case NodeTypeEnums.LeftInputAdapterNode:
-                        allLinkedTestMask = processLiaNode((LeftInputAdapterNode) tupleSource, reteEvaluator, smem, nodePosMask, allLinkedTestMask);
+                        allLinkedTestMask = processLiaNode((LeftInputAdapterNode) tupleSource, reteEvaluator, smem, memories, nodePosMask, allLinkedTestMask);
                         break;
                     case NodeTypeEnums.EvalConditionNode:
-                        processEvalNode((EvalConditionNode) tupleSource, reteEvaluator, smem);
+                        processEvalNode((EvalConditionNode) tupleSource, reteEvaluator, smem, memories);
                         break;
                     case NodeTypeEnums.ConditionalBranchNode:
-                        updateNodeBit = processBranchNode((ConditionalBranchNode) tupleSource, reteEvaluator, smem);
+                        updateNodeBit = processBranchNode((ConditionalBranchNode) tupleSource, reteEvaluator, smem, memories);
                         break;
                     case NodeTypeEnums.FromNode:
-                        processFromNode((FromNode) tupleSource, reteEvaluator, smem);
+                        processFromNode((FromNode) tupleSource, reteEvaluator, smem, memories);
                         break;
                     case NodeTypeEnums.ReactiveFromNode:
-                        processReactiveFromNode((MemoryFactory) tupleSource, reteEvaluator, smem, nodePosMask);
+                        processReactiveFromNode((MemoryFactory) tupleSource, reteEvaluator, smem, memories, nodePosMask);
                         break;
                     case NodeTypeEnums.TimerConditionNode:
-                        processTimerNode((TimerNode) tupleSource, reteEvaluator, smem, nodePosMask);
+                        processTimerNode((TimerNode) tupleSource, reteEvaluator, smem, memories, nodePosMask);
                         break;
                     case NodeTypeEnums.AsyncSendNode:
-                        processAsyncSendNode((AsyncSendNode) tupleSource, reteEvaluator, smem);
+                        processAsyncSendNode((AsyncSendNode) tupleSource, reteEvaluator, smem, memories);
                         break;
                     case NodeTypeEnums.AsyncReceiveNode:
-                        processAsyncReceiveNode((AsyncReceiveNode) tupleSource, reteEvaluator, smem, nodePosMask);
+                        processAsyncReceiveNode((AsyncReceiveNode) tupleSource, reteEvaluator, smem, memories, nodePosMask);
                         break;
                     case NodeTypeEnums.QueryElementNode:
-                        updateNodeBit = processQueryNode((QueryElementNode) tupleSource, reteEvaluator, segmentRoot, smem, nodePosMask);
+                        updateNodeBit = processQueryNode((QueryElementNode) tupleSource, reteEvaluator, segmentRoot, smem, memories, nodePosMask);
                         break;
                 }
             }
@@ -1538,7 +1545,7 @@ class LazyPhreakBuilder implements PhreakBuilder {
                     Memory memory = reteEvaluator.getNodeMemory((MemoryFactory) sink);
                     if (sink.getType() == NodeTypeEnums.RightInputAdapterNode) {
                         PathMemory riaPmem = (RightInputAdapterNode.RiaPathMemory)memory;
-                        smem.addNodeMemory( riaPmem );
+                        memories.add( riaPmem );
 
                         RightInputAdapterNode rian = ( RightInputAdapterNode ) sink;
                         ObjectSink[] nodes = rian.getObjectSinkPropagator().getSinks();
@@ -1548,7 +1555,7 @@ class LazyPhreakBuilder implements PhreakBuilder {
                             }
                         }
                     } else if (NodeTypeEnums.isTerminalNode(sink)) {
-                        smem.addNodeMemory( memory );
+                        memories.add( memory );
                     }
                     memory.setSegmentMemory(smem);
                     smem.setTipNode(sink);
@@ -1561,6 +1568,17 @@ class LazyPhreakBuilder implements PhreakBuilder {
             }
         }
         smem.setAllLinkedMaskTest(allLinkedTestMask);
+        smem.setNodeMemories(memories.toArray(new Memory[memories.size()]));
+
+        // Update the memory linked references
+        Memory lastMem = null;
+        for (Memory mem : memories) {
+            if (lastMem != null) {
+                mem.setPrevious(lastMem);
+                lastMem.setNext(mem);
+            }
+            lastMem = mem;
+        }
 
         // iterate to find root and determine the SegmentNodes position in the RuleSegment
         LeftTupleSource pathRoot = segmentRoot;
@@ -1585,66 +1603,87 @@ class LazyPhreakBuilder implements PhreakBuilder {
         return smem;
     }
 
-    private static boolean processQueryNode(QueryElementNode queryNode, ReteEvaluator reteEvaluator, LeftTupleSource segmentRoot, SegmentMemory smem, long nodePosMask) {
+    private static boolean processQueryNode(QueryElementNode queryNode, ReteEvaluator reteEvaluator, LeftTupleSource segmentRoot, SegmentMemory smem, List<Memory> memories, long nodePosMask) {
         // Initialize the QueryElementNode and have it's memory reference the actual query SegmentMemory
         SegmentMemory querySmem = getQuerySegmentMemory(reteEvaluator, segmentRoot, queryNode);
         QueryElementNode.QueryElementNodeMemory queryNodeMem = smem.createNodeMemory(queryNode, reteEvaluator);
         queryNodeMem.setNodePosMaskBit(nodePosMask);
         queryNodeMem.setQuerySegmentMemory(querySmem);
         queryNodeMem.setSegmentMemory(smem);
+        memories.add(queryNodeMem);
         return ! queryNode.getQueryElement().isAbductive();
     }
 
-    private static void processFromNode(MemoryFactory tupleSource, ReteEvaluator reteEvaluator, SegmentMemory smem) {
-        smem.createNodeMemory(tupleSource, reteEvaluator).setSegmentMemory(smem);
+    private static void processFromNode(MemoryFactory tupleSource, ReteEvaluator reteEvaluator, SegmentMemory smem, List<Memory> memories) {
+        Memory mem = smem.createNodeMemory(tupleSource, reteEvaluator);
+        memories.add(mem);
+        mem.setSegmentMemory(smem);
     }
 
-    private static void processAsyncSendNode(MemoryFactory tupleSource, ReteEvaluator reteEvaluator, SegmentMemory smem) {
-        smem.createNodeMemory(tupleSource, reteEvaluator).setSegmentMemory(smem);
+    private static void processAsyncSendNode(MemoryFactory tupleSource, ReteEvaluator reteEvaluator, SegmentMemory smem, List<Memory> memories) {
+        Memory mem = smem.createNodeMemory(tupleSource, reteEvaluator);
+        mem.setSegmentMemory(smem);
+        memories.add(mem);
     }
 
-    private static void processAsyncReceiveNode(AsyncReceiveNode tupleSource, ReteEvaluator reteEvaluator, SegmentMemory smem, long nodePosMask) {
+    private static void processAsyncReceiveNode(AsyncReceiveNode tupleSource, ReteEvaluator reteEvaluator, SegmentMemory smem, List<Memory> memories, long nodePosMask) {
         AsyncReceiveNode.AsyncReceiveMemory tnMem = smem.createNodeMemory( tupleSource, reteEvaluator );
+        memories.add(tnMem);
         tnMem.setNodePosMaskBit(nodePosMask);
         tnMem.setSegmentMemory(smem);
     }
 
-    private static void processReactiveFromNode(MemoryFactory tupleSource, ReteEvaluator reteEvaluator, SegmentMemory smem, long nodePosMask) {
+    private static void processReactiveFromNode(MemoryFactory tupleSource, ReteEvaluator reteEvaluator, SegmentMemory smem, List<Memory> memories, long nodePosMask) {
         FromNode.FromMemory mem = ((FromNode.FromMemory) smem.createNodeMemory(tupleSource, reteEvaluator));
+        memories.add(mem);
         mem.setSegmentMemory(smem);
         mem.setNodePosMaskBit(nodePosMask);
     }
 
-    private static boolean processBranchNode(ConditionalBranchNode tupleSource, ReteEvaluator reteEvaluator, SegmentMemory smem) {
+    private static boolean processBranchNode(ConditionalBranchNode tupleSource, ReteEvaluator reteEvaluator, SegmentMemory smem, List<Memory> memories) {
         ConditionalBranchNode.ConditionalBranchMemory branchMem = smem.createNodeMemory(tupleSource, reteEvaluator);
+        memories.add(branchMem);
         branchMem.setSegmentMemory(smem);
         // nodes after a branch CE can notify, but they cannot impact linking
         return false;
     }
 
-    private static void processEvalNode(EvalConditionNode tupleSource, ReteEvaluator reteEvaluator, SegmentMemory smem) {
+    private static void processEvalNode(EvalConditionNode tupleSource, ReteEvaluator reteEvaluator, SegmentMemory smem, List<Memory> memories) {
         EvalConditionNode.EvalMemory evalMem = smem.createNodeMemory(tupleSource, reteEvaluator);
+        memories.add(evalMem);
         evalMem.setSegmentMemory(smem);
     }
 
-    private static void processTimerNode(TimerNode tupleSource, ReteEvaluator reteEvaluator, SegmentMemory smem, long nodePosMask) {
+    private static void processTimerNode(TimerNode tupleSource, ReteEvaluator reteEvaluator, SegmentMemory smem, List<Memory> memories, long nodePosMask) {
         TimerNode.TimerNodeMemory tnMem = smem.createNodeMemory( tupleSource, reteEvaluator );
+        memories.add(tnMem);
         tnMem.setNodePosMaskBit(nodePosMask);
         tnMem.setSegmentMemory(smem);
     }
 
-    private static long processLiaNode(LeftInputAdapterNode tupleSource, ReteEvaluator reteEvaluator, SegmentMemory smem, long nodePosMask, long allLinkedTestMask) {
+    private static long processLiaNode(LeftInputAdapterNode tupleSource, ReteEvaluator reteEvaluator, SegmentMemory smem, List<Memory> memories, long nodePosMask, long allLinkedTestMask) {
         LeftInputAdapterNode.LiaNodeMemory liaMemory = smem.createNodeMemory(tupleSource, reteEvaluator);
+        memories.add(liaMemory);
         liaMemory.setSegmentMemory(smem);
         liaMemory.setNodePosMaskBit(nodePosMask);
         allLinkedTestMask = allLinkedTestMask | nodePosMask;
         return allLinkedTestMask;
     }
 
-    private static long processBetaNode(BetaNode betaNode, ReteEvaluator reteEvaluator, SegmentMemory smem, long nodePosMask, long allLinkedTestMask, boolean updateNodeBit) {
-        BetaMemory bm = NodeTypeEnums.AccumulateNode == betaNode.getType() ?
-                ((AccumulateNode.AccumulateMemory) smem.createNodeMemory(betaNode, reteEvaluator)).getBetaMemory() :
-                (BetaMemory) smem.createNodeMemory(betaNode, reteEvaluator);
+    private static long processBetaNode(BetaNode betaNode, ReteEvaluator reteEvaluator, SegmentMemory smem, List<Memory> memories, long nodePosMask, long allLinkedTestMask, boolean updateNodeBit) {
+        BetaMemory bm;
+        if (NodeTypeEnums.AccumulateNode == betaNode.getType()) {
+            AccumulateNode.AccumulateMemory accMemory = ((AccumulateNode.AccumulateMemory) smem.createNodeMemory(betaNode, reteEvaluator));
+            memories.add(accMemory);
+            accMemory.setSegmentMemory(smem);
+
+            bm = accMemory.getBetaMemory();
+        } else {
+            bm = (BetaMemory) smem.createNodeMemory(betaNode, reteEvaluator);
+            memories.add(bm);
+        }
+
+        bm.setSegmentMemory(smem);
 
         // this must be set first, to avoid recursion as sub networks can be initialised multiple ways
         // and bm.getSegmentMemory == null check can be used to avoid recursion.
@@ -1653,8 +1692,8 @@ class LazyPhreakBuilder implements PhreakBuilder {
         if (betaNode.isRightInputIsRiaNode()) {
             RightInputAdapterNode riaNode = createRiaSegmentMemory( betaNode, reteEvaluator );
 
-            RightInputAdapterNode.RiaPathMemory riaMem = reteEvaluator.getNodeMemory(riaNode);
-            bm.setRiaRuleMemory(riaMem);
+            PathMemory riaMem = reteEvaluator.getNodeMemory(riaNode);
+            bm.setRiaRuleMemory((RiaPathMemory) riaMem);
             if (updateNodeBit && canBeDisabled(betaNode) && riaMem.getAllLinkedMaskTest() > 0) {
                 // only ria's with reactive subnetworks can be disabled and thus need checking
                 allLinkedTestMask = allLinkedTestMask | nodePosMask;
@@ -1723,8 +1762,7 @@ class LazyPhreakBuilder implements PhreakBuilder {
             }
 
             if (pmem != null && smem.getPos() < pmem.getSegmentMemories().length) {
-                smem.addPathMemory( pmem );
-                pmem.setSegmentMemory( smem.getPos(), smem );
+                RuntimeSegmentUtilities.addSegmentToPathMemory(pmem, smem);
                 if (smem.isSegmentLinked()) {
                     // not's can cause segments to be linked, and the rules need to be notified for evaluation
                     smem.notifyRuleLinkSegment(reteEvaluator);
@@ -1759,14 +1797,14 @@ class LazyPhreakBuilder implements PhreakBuilder {
      * and before the rianode.
      */
     private static boolean inSubNetwork(RightInputAdapterNode riaNode, LeftTupleSource leftTupleSource) {
-        LeftTupleSource startTupleSource = riaNode.getStartTupleSource();
-        LeftTupleSource parent = riaNode.getLeftTupleSource();
+        LeftTupleSource startTupleSource = riaNode.getStartTupleSource().getLeftTupleSource();
+        LeftTupleSource current = riaNode.getLeftTupleSource();
 
-        while (parent != startTupleSource) {
-            if (parent == leftTupleSource) {
+        while (current != startTupleSource) {
+            if (current == leftTupleSource) {
                 return true;
             }
-            parent = parent.getLeftTupleSource();
+            current = current.getLeftTupleSource();
         }
 
         return false;

--- a/drools-core/src/main/java/org/drools/core/phreak/PhreakBuilder.java
+++ b/drools-core/src/main/java/org/drools/core/phreak/PhreakBuilder.java
@@ -35,7 +35,7 @@ public interface PhreakBuilder {
     void removeRule(TerminalNode tn, Collection<InternalWorkingMemory> wms, RuleBase kBase);
 
     class Holder {
-        private static final boolean EAGER_SEGMENT_CREATION = Boolean.parseBoolean(System.getProperty("drools.useEagerSegmentCreation", "true"));
+        private static final boolean EAGER_SEGMENT_CREATION = Boolean.parseBoolean(System.getProperty("drools.useEagerSegmentCreation", "false"));
         private static final PhreakBuilder PHREAK_BUILDER = EAGER_SEGMENT_CREATION ? new EagerPhreakBuilder() : new LazyPhreakBuilder();
     }
 }

--- a/drools-core/src/main/java/org/drools/core/phreak/PhreakBuilder.java
+++ b/drools-core/src/main/java/org/drools/core/phreak/PhreakBuilder.java
@@ -35,7 +35,7 @@ public interface PhreakBuilder {
     void removeRule(TerminalNode tn, Collection<InternalWorkingMemory> wms, RuleBase kBase);
 
     class Holder {
-        private static final boolean EAGER_SEGMENT_CREATION = true; //System.getProperty("drools.useEagerSegmentCreation") != null;
+        private static final boolean EAGER_SEGMENT_CREATION = Boolean.parseBoolean(System.getProperty("drools.useEagerSegmentCreation", "true"));
         private static final PhreakBuilder PHREAK_BUILDER = EAGER_SEGMENT_CREATION ? new EagerPhreakBuilder() : new LazyPhreakBuilder();
     }
 }

--- a/drools-core/src/main/java/org/drools/core/phreak/PhreakBuilder.java
+++ b/drools-core/src/main/java/org/drools/core/phreak/PhreakBuilder.java
@@ -35,7 +35,7 @@ public interface PhreakBuilder {
     void removeRule(TerminalNode tn, Collection<InternalWorkingMemory> wms, RuleBase kBase);
 
     class Holder {
-        private static final boolean EAGER_SEGMENT_CREATION = System.getProperty("drools.useEagerSegmentCreation") != null;
+        private static final boolean EAGER_SEGMENT_CREATION = true; //System.getProperty("drools.useEagerSegmentCreation") != null;
         private static final PhreakBuilder PHREAK_BUILDER = EAGER_SEGMENT_CREATION ? new EagerPhreakBuilder() : new LazyPhreakBuilder();
     }
 }

--- a/drools-core/src/main/java/org/drools/core/phreak/PhreakQueryNode.java
+++ b/drools-core/src/main/java/org/drools/core/phreak/PhreakQueryNode.java
@@ -71,7 +71,7 @@ public class PhreakQueryNode {
                                                              stackEntry.getSink(), reteEvaluator);
 
             LeftInputAdapterNode lian = (LeftInputAdapterNode) qmem.getQuerySegmentMemory().getRootNode();
-            LiaNodeMemory lm = (LiaNodeMemory) qmem.getQuerySegmentMemory().getNodeMemories().get(0);
+            LiaNodeMemory lm = (LiaNodeMemory) qmem.getQuerySegmentMemory().getNodeMemories()[0];
             LeftInputAdapterNode.doInsertObject(handle, pCtx, lian, reteEvaluator, lm, false, dquery.isOpen());
 
             leftTuple.clearStaged();
@@ -92,7 +92,7 @@ public class PhreakQueryNode {
 
             SegmentMemory qsmem = qmem.getQuerySegmentMemory();
             LeftInputAdapterNode lian = (LeftInputAdapterNode) qsmem.getRootNode();
-            LiaNodeMemory lmem = (LiaNodeMemory) qsmem.getNodeMemories().get(0);
+            LiaNodeMemory lmem = (LiaNodeMemory) qsmem.getNodeMemories()[0];
             if (dquery.isOpen()) {
                 LeftTuple childLeftTuple = fh.getFirstLeftTuple(); // there is only one, all other LTs are peers
                 LeftInputAdapterNode.doUpdateObject(childLeftTuple, childLeftTuple.getPropagationContext(), reteEvaluator, lian, false, lmem, qmem.getQuerySegmentMemory());
@@ -100,7 +100,7 @@ public class PhreakQueryNode {
                 if (fh.getFirstLeftTuple() != null) {
                     throw new RuntimeException("defensive programming while testing"); // @TODO remove later (mdp)
                 }
-                LiaNodeMemory lm = (LiaNodeMemory) qmem.getQuerySegmentMemory().getNodeMemories().get(0);
+                LiaNodeMemory lm = (LiaNodeMemory) qmem.getQuerySegmentMemory().getNodeMemories()[0];
                 LeftInputAdapterNode.doInsertObject(fh, leftTuple.getPropagationContext(), lian, reteEvaluator, lm, false, dquery.isOpen());
             }
 
@@ -121,7 +121,7 @@ public class PhreakQueryNode {
             DroolsQuery dquery = (DroolsQuery) fh.getObject();
             if (dquery.isOpen()) {
                 LeftInputAdapterNode lian = (LeftInputAdapterNode) qmem.getQuerySegmentMemory().getRootNode();
-                LiaNodeMemory lm = (LiaNodeMemory) qmem.getQuerySegmentMemory().getNodeMemories().get(0);
+                LiaNodeMemory lm = (LiaNodeMemory) qmem.getQuerySegmentMemory().getNodeMemories()[0];
                 LeftTuple childLeftTuple = fh.getFirstLeftTuple(); // there is only one, all other LTs are peers
                 LeftInputAdapterNode.doDeleteObject(childLeftTuple, childLeftTuple.getPropagationContext(), qmem.getQuerySegmentMemory(), reteEvaluator, lian, false, lm);
             } else {

--- a/drools-core/src/main/java/org/drools/core/phreak/PropagationEntry.java
+++ b/drools-core/src/main/java/org/drools/core/phreak/PropagationEntry.java
@@ -170,7 +170,7 @@ public interface PropagationEntry {
             LeftInputAdapterNode lian = (LeftInputAdapterNode) lts;
             LeftInputAdapterNode.LiaNodeMemory lmem = reteEvaluator.getNodeMemory( lian );
             if ( lmem.getSegmentMemory() == null ) {
-                RuntimeSegmentUtilities.getOrCreateSegmentMemory(lts, reteEvaluator);
+                RuntimeSegmentUtilities.getOrCreateSegmentMemory(lmem, lts, reteEvaluator);
             }
 
             LeftInputAdapterNode.doInsertObject( handle, pCtx, lian, reteEvaluator, lmem, false, queryObject.isOpen() );

--- a/drools-core/src/main/java/org/drools/core/phreak/RuleNetworkEvaluator.java
+++ b/drools-core/src/main/java/org/drools/core/phreak/RuleNetworkEvaluator.java
@@ -109,6 +109,7 @@ public class RuleNetworkEvaluator {
     public void evaluateNetwork(PathMemory pmem, RuleExecutor executor, ActivationsManager activationsManager) {
         SegmentMemory[] smems = pmem.getSegmentMemories();
 
+
         SegmentMemory smem = smems[0];
         if (smem == null) {
             // if there's no first smem it's a pure alpha firing and then doesn't require any furthe evaluation
@@ -127,11 +128,11 @@ public class RuleNetworkEvaluator {
             // nothing is staged in the liaNode, so skip to next segment
             smem = smems[1];
             node = smem.getRootNode();
-            nodeMem = smem.getNodeMemories().get(0);
+            nodeMem = smem.getNodeMemories()[0];
         } else {
             // lia is in shared segment, so point to next node
             node = liaNode.getSinkPropagator().getFirstLeftTupleSink();
-            nodeMem = smem.getNodeMemories().get(1); // skip the liaNode memory
+            nodeMem = smem.getNodeMemories()[1]; // skip the liaNode memory
         }
 
         TupleSets<LeftTuple> srcTuples = smem.getStagedLeftTuples();
@@ -233,7 +234,7 @@ public class RuleNetworkEvaluator {
                 smem = smems[++smemIndex];
                 trgTuples = smem.getStagedLeftTuples().takeAll();
                 node = smem.getRootNode();
-                nodeMem = smem.getNodeMemories().get(0);
+                nodeMem = smem.getNodeMemories()[0];
                 bit = 1; // update bit to start of new segment
             }
         }
@@ -289,7 +290,7 @@ public class RuleNetworkEvaluator {
                         srcTuples = smem.getStagedLeftTuples().takeAll();
                         emptySrcTuples = srcTuples.isEmpty();
                         node = smem.getRootNode();
-                        nodeMem = smem.getNodeMemories().get(0);
+                        nodeMem = smem.getNodeMemories()[0];
                         if ( !emptySrcTuples ||
                              smem.getDirtyNodeMask() != 0 ||
                              (NodeTypeEnums.isBetaNode(node) && ((BetaNode)node).isRightInputIsRiaNode() )) {
@@ -368,7 +369,7 @@ public class RuleNetworkEvaluator {
                     log.trace("{} Segment {}", indent(offset), smemIndex);
                 }
                 node = smem.getRootNode();
-                nodeMem = smem.getNodeMemories().get(0);
+                nodeMem = smem.getNodeMemories()[0];
             }
             processRian = true; //  make sure it's reset, so ria nodes are processed
         }
@@ -509,12 +510,12 @@ public class RuleNetworkEvaluator {
                     // nothing is staged in the liaNode, so skip to next segment
                     smem = smems[++smemIndex]; // 1
                     node = smem.getRootNode();
-                    nodeMem = smem.getNodeMemories().get(0);
+                    nodeMem = smem.getNodeMemories()[0];
                     bit = 1;
                 } else {
                     // lia is in shared segment, so point to next node
                     node = liaNode.getSinkPropagator().getFirstLeftTupleSink();
-                    nodeMem = smem.getNodeMemories().get(1); // skip the liaNode memory
+                    nodeMem = smem.getNodeMemories()[1]; // skip the liaNode memory
                     bit = 2;
                 }
 
@@ -630,7 +631,7 @@ public class RuleNetworkEvaluator {
         TupleSets<LeftTuple> subLts = subSmem.getStagedLeftTuples().takeAll();
         // node is first in the segment, so bit is 1
         innerEval( pathMem, subSmem.getRootNode(), 1,
-                   subSmem.getNodeMemories().get(0),
+                   subSmem.getNodeMemories()[0],
                    subnetworkSmems, subSmem.getPos(),
                    subLts, activationsManager, stack, true, executor );
     }

--- a/drools-core/src/main/java/org/drools/core/phreak/RuntimeSegmentUtilities.java
+++ b/drools-core/src/main/java/org/drools/core/phreak/RuntimeSegmentUtilities.java
@@ -60,7 +60,7 @@ public class RuntimeSegmentUtilities {
         }
 
         // find segment root
-        LeftTupleNode segmentRoot = BuildtimeSegmentUtilities.findSegmentRoot(node, null);
+        LeftTupleNode segmentRoot = BuildtimeSegmentUtilities.findSegmentRoot(node);
 
         smem = restoreSegmentFromPrototype(reteEvaluator, segmentRoot);
         if ( smem != null ) {

--- a/drools-core/src/main/java/org/drools/core/phreak/RuntimeSegmentUtilities.java
+++ b/drools-core/src/main/java/org/drools/core/phreak/RuntimeSegmentUtilities.java
@@ -39,19 +39,28 @@ import org.drools.core.reteoo.SegmentMemory;
 import org.drools.core.reteoo.SegmentMemory.SegmentPrototype;
 import org.drools.core.rule.constraint.QueryNameConstraint;
 
+import static org.drools.core.phreak.EagerPhreakBuilder.isInsideSubnetwork;
+
 public class RuntimeSegmentUtilities {
 
     /**
      * Initialises the NodeSegment memory for all nodes in the segment.
      */
     public static SegmentMemory getOrCreateSegmentMemory(LeftTupleNode node, ReteEvaluator reteEvaluator) {
-        SegmentMemory smem = reteEvaluator.getNodeMemory((MemoryFactory) node).getSegmentMemory();
+        return getOrCreateSegmentMemory(reteEvaluator.getNodeMemory((MemoryFactory<? extends Memory>) node), node, reteEvaluator);
+    }
+
+    /**
+     * Initialises the NodeSegment memory for all nodes in the segment.
+     */
+    public static SegmentMemory getOrCreateSegmentMemory(Memory memory, LeftTupleNode node, ReteEvaluator reteEvaluator) {
+        SegmentMemory smem = memory.getSegmentMemory();
         if ( smem != null ) {
             return smem;
         }
 
         // find segment root
-        LeftTupleNode segmentRoot = BuildtimeSegmentUtilities.findSegmentRoot(node);
+        LeftTupleNode segmentRoot = BuildtimeSegmentUtilities.findSegmentRoot(node, null);
 
         smem = restoreSegmentFromPrototype(reteEvaluator, segmentRoot);
         if ( smem != null ) {
@@ -61,6 +70,7 @@ public class RuntimeSegmentUtilities {
             return smem;
         }
 
+        // it should not be possible to reach here, for BuildTimeSegmentProtos
         return LazyPhreakBuilder.createSegmentMemory(reteEvaluator, segmentRoot);
     }
 
@@ -71,8 +81,6 @@ public class RuntimeSegmentUtilities {
         }
 
         LeftTupleNode lastNode = proto.getNodesInSegment()[proto.getNodesInSegment().length-1];
-        SegmentMemory smem = null;
-
 
         if (NodeTypeEnums.isTerminalNode(lastNode)) {
             // If the last node is a tn and it's pmem does not exist, instantiate it separately to avoid a recursive smem/pmem creation.
@@ -82,15 +90,13 @@ public class RuntimeSegmentUtilities {
                 pmem = initializePathMemory(reteEvaluator, (PathEndNode) lastNode);
             }
 
-            smem = pmem.getSegmentMemories()[proto.getPos()];
+            SegmentMemory smem = pmem.getSegmentMemories()[proto.getPos()];
+            if (smem != null) {
+                return smem;
+            }
         }
 
-
-        if (smem == null) {
-            // Note eager smems mean this smem may have been created by this initializePathMemory,
-            // so check and use that to avoid duplicate creation.
-            smem = reteEvaluator.getKnowledgeBase().createSegmentFromPrototype(reteEvaluator, proto);
-        }
+        SegmentMemory smem = reteEvaluator.getKnowledgeBase().createSegmentFromPrototype(reteEvaluator, proto);
 
         updateRiaAndTerminalMemory(smem, proto, reteEvaluator);
 
@@ -102,7 +108,7 @@ public class RuntimeSegmentUtilities {
         LiaNodeMemory liam = reteEvaluator.getNodeMemory(liaNode);
         SegmentMemory querySmem = liam.getSegmentMemory();
         if (querySmem == null) {
-            querySmem = getOrCreateSegmentMemory(liaNode, reteEvaluator);
+            querySmem = getOrCreateSegmentMemory(liam, liaNode, reteEvaluator);
         }
         return querySmem;
     }
@@ -110,16 +116,13 @@ public class RuntimeSegmentUtilities {
     static RightInputAdapterNode createRiaSegmentMemory( BetaNode betaNode, ReteEvaluator reteEvaluator ) {
         RightInputAdapterNode riaNode = (RightInputAdapterNode) betaNode.getRightInput();
 
-        LeftTupleSource subnetworkLts = riaNode.getLeftTupleSource();
-        while (subnetworkLts.getLeftTupleSource() != riaNode.getStartTupleSource()) {
-            subnetworkLts = subnetworkLts.getLeftTupleSource();
-        }
+        LeftTupleSource subnetworkLts = riaNode.getStartTupleSource();
 
         Memory rootSubNetwokrMem = reteEvaluator.getNodeMemory( (MemoryFactory) subnetworkLts );
         SegmentMemory subNetworkSegmentMemory = rootSubNetwokrMem.getSegmentMemory();
         if (subNetworkSegmentMemory == null) {
             // we need to stop recursion here
-            getOrCreateSegmentMemory(subnetworkLts, reteEvaluator);
+            getOrCreateSegmentMemory(rootSubNetwokrMem, subnetworkLts, reteEvaluator);
         }
         return riaNode;
     }
@@ -139,7 +142,7 @@ public class RuntimeSegmentUtilities {
     public static SegmentMemory createChildSegment(ReteEvaluator reteEvaluator, LeftTupleNode node) {
         Memory memory = reteEvaluator.getNodeMemory((MemoryFactory) node);
         if (memory.getSegmentMemory() == null) {
-            getOrCreateSegmentMemory(node, reteEvaluator);
+            getOrCreateSegmentMemory(memory, node, reteEvaluator);
         }
         return memory.getSegmentMemory();
     }
@@ -153,33 +156,42 @@ public class RuntimeSegmentUtilities {
      * it sets the bit of node it is the right input for.
      */
     private static void updateRiaAndTerminalMemory(SegmentMemory smem,
-                                                 SegmentPrototype proto,
-                                                 ReteEvaluator reteEvaluator) {
-        for (PathEndNode pathEndNode : proto.getPathEndNodes()) {
-            if (pathEndNode.getSegmentPrototypes()[proto.getPos()] == null) {
-                // this is a rian path, and the smem is before the subnetwork, so skip.
+                                                   SegmentPrototype proto,
+                                                   ReteEvaluator reteEvaluator) {
+        for (PathEndNode endNode : proto.getPathEndNodes()) {
+            if (!isInsideSubnetwork(endNode, proto)) {
+                // While SegmentPrototypes are added for entire path, for traversal reasons.
+                // SegmenrMemory's themselves are only added to the PathMemory for path or subpath the are part of.
                 continue;
             }
 
-            PathMemory pmem = (PathMemory) reteEvaluator.getNodeMemories().peekNodeMemory(pathEndNode);
+            PathMemory pmem = (PathMemory) reteEvaluator.getNodeMemories().peekNodeMemory(endNode);
             if (pmem != null) {
-                pmem.setSegmentMemory( smem.getPos(), smem );
+                RuntimeSegmentUtilities.addSegmentToPathMemory(pmem, smem);
             } else {
-                pmem = reteEvaluator.getNodeMemories().getNodeMemory((MemoryFactory<? extends PathMemory>) pathEndNode, reteEvaluator);
-                pmem.setSegmentMemory( smem.getPos(), smem ); // this needs to be set before init, to avoid recursion during eager segment initialisation
-                initializePathMemory(reteEvaluator, pathEndNode, pmem);
+                pmem = reteEvaluator.getNodeMemories().getNodeMemory((MemoryFactory<? extends PathMemory>) endNode, reteEvaluator);
+                RuntimeSegmentUtilities.addSegmentToPathMemory(pmem, smem);  // this needs to be set before init, to avoid recursion during eager segment initialisation
+                pmem.setSegmentMemory( smem.getPos(), smem );
+                initializePathMemory(reteEvaluator, endNode, pmem);
             }
 
-            smem.addPathMemory( pmem );
-            if (smem.isSegmentLinked()) {
+            if (smem.getAllLinkedMaskTest() > 0 && smem.isSegmentLinked()) {
                 // not's can cause segments to be linked, and the rules need to be notified for evaluation
                 smem.notifyRuleLinkSegment(reteEvaluator);
             }
         }
     }
 
+    public static void addSegmentToPathMemory(PathMemory pmem, SegmentMemory smem) {
+        if (smem.getRootNode().getPathIndex() >= pmem.getPathEndNode().getStartTupleSource().getPathIndex()) {
+            smem.addPathMemory(pmem);
+            pmem.setSegmentMemory(smem.getPos(), smem);
+        }
+
+    }
+
     public static PathMemory initializePathMemory(ReteEvaluator reteEvaluator, PathEndNode pathEndNode) {
-        PathMemory pmem = reteEvaluator.getNodeMemories().getNodeMemory((MemoryFactory<PathMemory>) pathEndNode, reteEvaluator);
+        PathMemory pmem = reteEvaluator.getNodeMemories().getNodeMemory(pathEndNode, reteEvaluator);
         initializePathMemory(reteEvaluator, pathEndNode, pmem);
         return pmem;
     }

--- a/drools-core/src/main/java/org/drools/core/phreak/TupleEvaluationUtil.java
+++ b/drools-core/src/main/java/org/drools/core/phreak/TupleEvaluationUtil.java
@@ -115,11 +115,11 @@ public class TupleEvaluationUtil {
         if ( sm.getRootNode().getType() == NodeTypeEnums.LeftInputAdapterNode && sm.getTipNode().getType() != NodeTypeEnums.LeftInputAdapterNode) {
             // The segment is the first and it has the lian shared with other nodes, the lian must be skipped, so adjust the bit and sink
             node =  sm.getRootNode().getSinkPropagator().getFirstLeftTupleSink();
-            mem = sm.getNodeMemories().get(1);
+            mem = sm.getNodeMemories()[1];
             bit = 2; // adjust bit to point to next node
         } else {
             node =  sm.getRootNode();
-            mem = sm.getNodeMemories().get(0);
+            mem = sm.getNodeMemories()[0];
         }
 
         PathMemory rtnPmem = NodeTypeEnums.isTerminalNode(pmem.getPathEndNode()) ?

--- a/drools-core/src/main/java/org/drools/core/reteoo/AbstractTerminalNode.java
+++ b/drools-core/src/main/java/org/drools/core/reteoo/AbstractTerminalNode.java
@@ -131,7 +131,7 @@ public abstract class AbstractTerminalNode extends BaseNode implements TerminalN
             n.setSegmentPrototypes(null);
             n.setEagerSegmentPrototypes(null);}
         );
-        pathMemSpec = calculatePathMemSpec( startTupleSource, removingTN );
+        pathMemSpec = removingTN == null ? null : calculatePathMemSpec( startTupleSource, removingTN );
     }
 
     public RuleImpl getRule() {
@@ -244,10 +244,10 @@ public abstract class AbstractTerminalNode extends BaseNode implements TerminalN
     }
 
     public PathMemory createMemory(RuleBaseConfiguration config, ReteEvaluator reteEvaluator) {
-        return initPathMemory( this, new PathMemory(this, reteEvaluator), null );
+        return initPathMemory( this, new PathMemory(this, reteEvaluator) );
     }
 
-    public static PathMemory initPathMemory( PathEndNode pathEndNode, PathMemory pmem, TerminalNode removingTN ) {
+    public static PathMemory initPathMemory( PathEndNode pathEndNode, PathMemory pmem ) {
         PathMemSpec pathMemSpec = pathEndNode.getPathMemSpec();
         pmem.setAllLinkedMaskTest(pathMemSpec.allLinkedTestMask );
         pmem.setSegmentMemories( new SegmentMemory[pathEndNode.getPathMemSpec().smemCount()] );
@@ -397,8 +397,8 @@ public abstract class AbstractTerminalNode extends BaseNode implements TerminalN
     }
 
     public void visitLeftTupleNodes(Consumer<LeftTupleNode> func) {
-        for(PathEndNode endNode : getPathEndNodes()) {
-            for(int i = endNode.getPathNodes().length-1; i >= 0; i--) {
+        for (PathEndNode endNode : getPathEndNodes()) {
+            for (int i = endNode.getPathNodes().length-1; i >= 0; i--) {
                 LeftTupleNode node = endNode.getPathNodes()[i];
                 func.accept(node);
                 if (endNode.getStartTupleSource() == node) {

--- a/drools-core/src/main/java/org/drools/core/reteoo/BetaMemory.java
+++ b/drools-core/src/main/java/org/drools/core/reteoo/BetaMemory.java
@@ -118,8 +118,8 @@ public class BetaMemory extends AbstractBaseLinkedListNode<Memory>
         return nodePosMaskBit;
     }
 
-    public void setNodePosMaskBit(long segmentPos) {
-        this.nodePosMaskBit = segmentPos;
+    public void setNodePosMaskBit(long nodePosMaskBit) {
+        this.nodePosMaskBit = nodePosMaskBit;
     }
 
     public int getCounter() {

--- a/drools-core/src/main/java/org/drools/core/reteoo/BetaNode.java
+++ b/drools-core/src/main/java/org/drools/core/reteoo/BetaNode.java
@@ -416,7 +416,7 @@ public abstract class BetaNode extends LeftTupleSource
         LeftTupleSource startTupleSource = (( RightInputAdapterNode ) getRightInput()).getStartTupleSource();
 
         // Iterate find start
-        while (lt.getIndex() != startTupleSource.getPathIndex()) {
+        while (lt.getIndex() != startTupleSource.getPathIndex()-1) { // -1 as it needs the split node, not the start of the branch
             lt = lt.getLeftParent();
         }
 

--- a/drools-core/src/main/java/org/drools/core/reteoo/NodeTypeEnums.java
+++ b/drools-core/src/main/java/org/drools/core/reteoo/NodeTypeEnums.java
@@ -89,6 +89,10 @@ public class NodeTypeEnums {
         return node.getType() > NodeTypeEnums.BetaNode;
     }
 
+    public static boolean isBetaNodeWithRian(NetworkNode node) {
+        return node.getType() > NodeTypeEnums.BetaNode && ((org.drools.core.reteoo.BetaNode)node).isRightInputIsRiaNode();
+    }
+
     public static boolean isTerminalNode(NetworkNode node) {
         return node.getType() == QueryTerminalNode || node.getType() == RuleTerminalNode;
     }

--- a/drools-core/src/main/java/org/drools/core/reteoo/NotNode.java
+++ b/drools-core/src/main/java/org/drools/core/reteoo/NotNode.java
@@ -131,13 +131,14 @@ public class NotNode extends BetaNode {
 
         boolean stagedInsertWasEmpty = memory.getStagedRightTuples().addInsert( rightTuple );
 
-        if (  memory.getAndIncCounter() == 0 && isEmptyBetaConstraints()  ) {
+        if (memory.getAndIncCounter() == 0 && isEmptyBetaConstraints()  ) {
             // strangely we link here, this is actually just to force a network evaluation
             // The assert is then processed and the rule unlinks then.
             // This is because we need the first RightTuple to link with it's blocked
             if ( stagedInsertWasEmpty ) {
                 memory.setNodeDirtyWithoutNotify();
             }
+
             // NotNodes can only be unlinked, if they have no variable constraints
             memory.linkNode( this, reteEvaluator );
         } else if ( stagedInsertWasEmpty ) {

--- a/drools-core/src/main/java/org/drools/core/reteoo/PathMemory.java
+++ b/drools-core/src/main/java/org/drools/core/reteoo/PathMemory.java
@@ -31,7 +31,6 @@ import org.slf4j.LoggerFactory;
 public class PathMemory extends AbstractBaseLinkedListNode<Memory>
         implements
         Serializable, Memory {
-    //public static SegmentMemory[] NOT_INITIALZED = new SegmentMemory[0];
 
     protected static final Logger log = LoggerFactory.getLogger(PathMemory.class);
     protected static final boolean isLogTraceEnabled = log.isTraceEnabled();

--- a/drools-core/src/main/java/org/drools/core/reteoo/PathMemory.java
+++ b/drools-core/src/main/java/org/drools/core/reteoo/PathMemory.java
@@ -76,6 +76,10 @@ public class PathMemory extends AbstractBaseLinkedListNode<Memory>
         return linkedSegmentMask;
     }
 
+    public void setLinkedSegmentMask(long mask) {
+        this.linkedSegmentMask = mask;
+    }
+
     public long getAllLinkedMaskTest() {
         return allLinkedMaskTest;
     }
@@ -175,7 +179,7 @@ public class PathMemory extends AbstractBaseLinkedListNode<Memory>
 
     public void unlinkedSegment(long mask, ReteEvaluator reteEvaluator) {
         boolean linkedRule =  isRuleLinked();
-        linkedSegmentMask ^= mask;
+        linkedSegmentMask &= ~mask;
         if (isLogTraceEnabled) {
             log.trace("  UnlinkSegment smask={} rmask={} name={}", mask, linkedSegmentMask, this);
         }

--- a/drools-core/src/main/java/org/drools/core/reteoo/ReteooBuilder.java
+++ b/drools-core/src/main/java/org/drools/core/reteoo/ReteooBuilder.java
@@ -92,18 +92,17 @@ public class ReteooBuilder
         this.ruleBuilder = new ReteooRuleBuilder();
     }
 
-// ------------------------------------------------------------
+    // ------------------------------------------------------------
     // Instance methods
     // ------------------------------------------------------------
 
     /**
      * Add a <code>Rule</code> to the network.
      *
-     * @param rule
-     *            The rule to add.
+     * @param rule     The rule to add.
      * @throws InvalidPatternException
      */
-    public synchronized void addRule(final RuleImpl rule, Collection<InternalWorkingMemory> workingMemories) {
+    public synchronized List<TerminalNode> addRule(final RuleImpl rule, Collection<InternalWorkingMemory> workingMemories) {
         final List<TerminalNode> terminals = this.ruleBuilder.addRule( rule, this.kBase, workingMemories );
 
         TerminalNode[] nodes = terminals.toArray( new TerminalNode[terminals.size()] );
@@ -111,6 +110,8 @@ public class ReteooBuilder
         if (rule.isQuery()) {
             this.queries.put( rule.getName(), terminals.toArray( new QueryTerminalNode[terminals.size()] ) );
         }
+
+        return terminals;
     }
 
     public void addEntryPoint( String id, Collection<InternalWorkingMemory> workingMemories ) {
@@ -248,7 +249,6 @@ public class ReteooBuilder
 
         if (removed) {
             stillInUse.remove( node.getId() );
-            // phreak must clear node memories, although this should ideally be pushed into AddRemoveRule
             for (InternalWorkingMemory workingMemory : wms) {
                 workingMemory.clearNodeMemory((MemoryFactory) node);
             }

--- a/drools-core/src/main/java/org/drools/core/reteoo/RightInputAdapterNode.java
+++ b/drools-core/src/main/java/org/drools/core/reteoo/RightInputAdapterNode.java
@@ -22,20 +22,18 @@ import java.util.List;
 import java.util.Set;
 
 import org.drools.core.RuleBaseConfiguration;
+import org.drools.core.base.ObjectType;
 import org.drools.core.common.ActivationsManager;
 import org.drools.core.common.InternalFactHandle;
 import org.drools.core.common.InternalWorkingMemory;
 import org.drools.core.common.Memory;
-import org.drools.core.common.MemoryFactory;
 import org.drools.core.common.NetworkNode;
+import org.drools.core.common.PropagationContext;
 import org.drools.core.common.ReteEvaluator;
 import org.drools.core.common.UpdateContext;
 import org.drools.core.definitions.rule.impl.RuleImpl;
-import org.drools.core.reteoo.RightInputAdapterNode.RiaPathMemory;
 import org.drools.core.reteoo.SegmentMemory.SegmentPrototype;
 import org.drools.core.reteoo.builder.BuildContext;
-import org.drools.core.base.ObjectType;
-import org.drools.core.common.PropagationContext;
 import org.drools.core.util.bitmask.BitMask;
 import org.kie.api.definition.rule.Rule;
 
@@ -188,7 +186,7 @@ public class RightInputAdapterNode extends ObjectSource
      * Creates and return the node memory
      */    
     public RiaPathMemory createMemory(final RuleBaseConfiguration config, ReteEvaluator reteEvaluator) {
-        return (RiaPathMemory) AbstractTerminalNode.initPathMemory( this, new RiaPathMemory(this, reteEvaluator), null );
+        return (RiaPathMemory) AbstractTerminalNode.initPathMemory( this, new RiaPathMemory(this, reteEvaluator) );
     }
     
     public SubnetworkTuple createPeer(LeftTuple original) {

--- a/drools-core/src/main/java/org/drools/core/reteoo/RightInputAdapterNode.java
+++ b/drools-core/src/main/java/org/drools/core/reteoo/RightInputAdapterNode.java
@@ -47,13 +47,15 @@ import org.kie.api.definition.rule.Rule;
 public class RightInputAdapterNode extends ObjectSource
     implements
     LeftTupleSinkNode,
-    PathEndNode,
-    MemoryFactory<RiaPathMemory> {
+    PathEndNode {
 
     private static final long serialVersionUID = 510l;
 
     private LeftTupleSource   tupleSource;
-    
+
+    /**
+     * This is first node inside of the subnetwork. The split, with two outs, would be the parent node.
+     */
     private LeftTupleSource   startTupleSource;
 
     private boolean           tupleMemoryEnabled;
@@ -126,6 +128,17 @@ public class RightInputAdapterNode extends ObjectSource
     }
 
     @Override
+    public void setPathMemSpec(PathMemSpec pathMemSpec) {
+        this.pathMemSpec = pathMemSpec;
+    }
+
+    @Override
+    public void resetPathMemSpec(TerminalNode removingTN) {
+        nullPathMemSpec();
+        pathMemSpec = getPathMemSpec(removingTN);
+    }
+
+    @Override
     public void setSegmentPrototypes(SegmentPrototype[] smems) {
         this.segmentPrototypes = smems;
     }
@@ -175,7 +188,7 @@ public class RightInputAdapterNode extends ObjectSource
      * Creates and return the node memory
      */    
     public RiaPathMemory createMemory(final RuleBaseConfiguration config, ReteEvaluator reteEvaluator) {
-        return (RiaPathMemory) AbstractTerminalNode.initPathMemory( this, new RiaPathMemory(this, reteEvaluator) );
+        return (RiaPathMemory) AbstractTerminalNode.initPathMemory( this, new RiaPathMemory(this, reteEvaluator), null );
     }
     
     public SubnetworkTuple createPeer(LeftTuple original) {
@@ -462,8 +475,4 @@ public class RightInputAdapterNode extends ObjectSource
         return result;
     }
 
-    @Override
-    public void resetPathMemSpec(TerminalNode removingTN) {
-        pathMemSpec = removingTN == null ? null : calculatePathMemSpec(null, removingTN);
-    }
 }

--- a/drools-core/src/main/java/org/drools/core/reteoo/SegmentMemory.java
+++ b/drools-core/src/main/java/org/drools/core/reteoo/SegmentMemory.java
@@ -23,7 +23,6 @@ import java.util.List;
 
 import org.drools.core.common.Memory;
 import org.drools.core.common.MemoryFactory;
-import org.drools.core.common.NetworkNode;
 import org.drools.core.common.ReteEvaluator;
 import org.drools.core.common.TupleSets;
 import org.drools.core.common.TupleSetsImpl;
@@ -47,19 +46,18 @@ public class SegmentMemory extends LinkedList<SegmentMemory>
     protected static final Logger log = LoggerFactory.getLogger(SegmentMemory.class);
     protected static final boolean IS_LOG_TRACE_ENABLED = log.isTraceEnabled();
 
-    private          SegmentPrototype   proto;
-//    private          List<Memory>       nodeMemories = new ArrayList<>();
-    private          Memory[]       nodeMemories;
-    private          List<PathMemory>   pathMemories = new ArrayList<>(1);;
-    private          TupleSets<LeftTuple> stagedLeftTuples = new TupleSetsImpl<>();
-    private          long               linkedNodeMask;
-    private          long               dirtyNodeMask;
-    private          long               allLinkedMaskTest;
-    private          long               segmentPosMaskBit;
-    private          int                pos = -1;
-    private          boolean            active;
-    private          SegmentMemory      previous;
-    private          SegmentMemory      next;
+    private SegmentPrototype   proto;
+    private Memory[]       nodeMemories;
+    private final List<PathMemory>   pathMemories = new ArrayList<>(1);;
+    private final TupleSets<LeftTuple> stagedLeftTuples = new TupleSetsImpl<>();
+    private long linkedNodeMask;
+    private long dirtyNodeMask;
+    private long allLinkedMaskTest;
+    private long segmentPosMaskBit;
+    private int pos = -1;
+    private boolean active;
+    private SegmentMemory previous;
+    private SegmentMemory next;
 
     private transient List<PathMemory>  dataDrivenPathMemories;
 
@@ -73,10 +71,8 @@ public class SegmentMemory extends LinkedList<SegmentMemory>
         this.proto = new SegmentPrototype(rootNode, null);
     }
 
-    public <T extends Memory> T createNodeMemory(MemoryFactory<T> memoryFactory,
-                                                 ReteEvaluator reteEvaluator) {
-        T memory = reteEvaluator.getNodeMemory(memoryFactory);
-        return memory;
+    public <T extends Memory> T createNodeMemory(MemoryFactory<T> memoryFactory, ReteEvaluator reteEvaluator) {
+        return reteEvaluator.getNodeMemory(memoryFactory);
     }
 
     public LeftTupleNode getRootNode() {
@@ -456,13 +452,13 @@ public class SegmentMemory extends LinkedList<SegmentMemory>
             return smem;
         }
 
-        public SegmentMemory shallowNewSegmentMemory(ReteEvaluator reteEvaluator) {
+        public SegmentMemory shallowNewSegmentMemory() {
             SegmentMemory smem = new SegmentMemory();
-            shallowUpdateSegmentMemory(smem, reteEvaluator);
+            shallowUpdateSegmentMemory(smem);
             return smem;
         }
 
-        public void shallowUpdateSegmentMemory(SegmentMemory smem, ReteEvaluator reteEvaluator) {
+        public void shallowUpdateSegmentMemory(SegmentMemory smem) {
             smem.proto = this;
             smem.allLinkedMaskTest = this.allLinkedMaskTest;
             smem.segmentPosMaskBit = this.segmentPosMaskBit;
@@ -471,7 +467,7 @@ public class SegmentMemory extends LinkedList<SegmentMemory>
         }
 
         public void updateSegmentMemory(SegmentMemory smem, ReteEvaluator reteEvaluator) {
-            shallowUpdateSegmentMemory(smem, reteEvaluator);
+            shallowUpdateSegmentMemory(smem);
             Memory[] nodeMemories = new Memory[getNodesInSegment().length];
             for ( int i = 0; i < memories.length; i++) {
                 Memory mem = reteEvaluator.getNodeMemory((MemoryFactory) getNodesInSegment()[i]);
@@ -506,10 +502,6 @@ public class SegmentMemory extends LinkedList<SegmentMemory>
             return rootNode;
         }
 
-        public void setRootNode(LeftTupleNode rootNode) {
-            this.rootNode = rootNode;
-        }
-
         public LeftTupleNode getTipNode() {
             return tipNode;
         }
@@ -520,7 +512,7 @@ public class SegmentMemory extends LinkedList<SegmentMemory>
 
         public void linkNode(long mask) {
             linkedNodeMask |= mask;
-        };
+        }
 
         public long getLinkedNodeMask() {
             return linkedNodeMask;

--- a/drools-core/src/main/java/org/drools/core/reteoo/SegmentMemory.java
+++ b/drools-core/src/main/java/org/drools/core/reteoo/SegmentMemory.java
@@ -27,6 +27,7 @@ import org.drools.core.common.NetworkNode;
 import org.drools.core.common.ReteEvaluator;
 import org.drools.core.common.TupleSets;
 import org.drools.core.common.TupleSetsImpl;
+import org.drools.core.phreak.BuildtimeSegmentUtilities;
 import org.drools.core.phreak.RuntimeSegmentUtilities;
 import org.drools.core.reteoo.AsyncReceiveNode.AsyncReceiveMemory;
 import org.drools.core.reteoo.QueryElementNode.QueryElementNodeMemory;
@@ -47,7 +48,8 @@ public class SegmentMemory extends LinkedList<SegmentMemory>
     protected static final boolean IS_LOG_TRACE_ENABLED = log.isTraceEnabled();
 
     private          SegmentPrototype   proto;
-    private          List<Memory>       nodeMemories = new ArrayList<>();
+//    private          List<Memory>       nodeMemories = new ArrayList<>();
+    private          Memory[]       nodeMemories;
     private          List<PathMemory>   pathMemories = new ArrayList<>(1);;
     private          TupleSets<LeftTuple> stagedLeftTuples = new TupleSetsImpl<>();
     private          long               linkedNodeMask;
@@ -74,7 +76,6 @@ public class SegmentMemory extends LinkedList<SegmentMemory>
     public <T extends Memory> T createNodeMemory(MemoryFactory<T> memoryFactory,
                                                  ReteEvaluator reteEvaluator) {
         T memory = reteEvaluator.getNodeMemory(memoryFactory);
-        addNodeMemory(memory);
         return memory;
     }
 
@@ -98,17 +99,12 @@ public class SegmentMemory extends LinkedList<SegmentMemory>
         return (LeftTupleSink) proto.getRootNode();
     }
 
-    public List<Memory> getNodeMemories() {
+    public Memory[] getNodeMemories() {
         return nodeMemories;
     }
 
-    public void addNodeMemory(Memory memory) {
-        if (!nodeMemories.isEmpty()) {
-            Memory last = nodeMemories.get(nodeMemories.size() - 1);
-            last.setNext(memory);
-            memory.setPrevious(last);
-        }
-        nodeMemories.add(memory);
+    public void setNodeMemories(Memory[] nodeMemories) {
+        this.nodeMemories = nodeMemories;
     }
 
     public long getLinkedNodeMask() {
@@ -212,7 +208,7 @@ public class SegmentMemory extends LinkedList<SegmentMemory>
         boolean dataDrivePmemLinked = false;
         boolean linked = isSegmentLinked();
         // some node unlinking does not unlink the segment, such as nodes after a Branch CE
-        linkedNodeMask ^= mask;
+        linkedNodeMask &= ~mask;
         dirtyNodeMask |= mask;
 
         if (IS_LOG_TRACE_ENABLED) {
@@ -247,7 +243,7 @@ public class SegmentMemory extends LinkedList<SegmentMemory>
     }
 
     public void unlinkNodeWithoutRuleNotify(long mask) {
-        linkedNodeMask ^= mask;
+        linkedNodeMask &= ~mask;
         if (IS_LOG_TRACE_ENABLED) {
             log.trace("UnlinkNode notify=false nmask={} smask={} spos={} rules={}", mask, linkedNodeMask, pos, getRuleNames());
         }
@@ -270,8 +266,12 @@ public class SegmentMemory extends LinkedList<SegmentMemory>
     }
 
     public void addPathMemory(PathMemory pathMemory) {
+        if (pathMemories.contains(pathMemory)) {
+            System.out.println("!!!");
+        }
+
         pathMemories.add(pathMemory);
-        if (isSegmentLinked()) {
+        if (getAllLinkedMaskTest() > 0 && isSegmentLinked()) {
             pathMemory.linkSegmentWithoutRuleNotify(segmentPosMaskBit);
         }
         if (pathMemory.isDataDriven()) {
@@ -330,8 +330,8 @@ public class SegmentMemory extends LinkedList<SegmentMemory>
         return segmentPosMaskBit;
     }
 
-    public void setSegmentPosMaskBit(long nodeSegmenMask) {
-        this.segmentPosMaskBit = nodeSegmenMask;
+    public void setSegmentPosMaskBit(long segmentPosMaskBit) {
+        this.segmentPosMaskBit = segmentPosMaskBit;
     }
 
     public boolean isActive() {
@@ -386,6 +386,9 @@ public class SegmentMemory extends LinkedList<SegmentMemory>
 
     public void setNext(SegmentMemory next) {
         this.next = next;
+        if ( this.next == this) {
+            throw new RuntimeException();
+        }
     }
 
     public SegmentMemory getPrevious() {
@@ -425,12 +428,16 @@ public class SegmentMemory extends LinkedList<SegmentMemory>
     }
 
     public static class SegmentPrototype {
-        private final LeftTupleNode rootNode;
+        private LeftTupleNode rootNode;
         private LeftTupleNode tipNode;
         long linkedNodeMask;
         long allLinkedMaskTest;
         long segmentPosMaskBit;
         int pos;
+
+        boolean requiresEager;
+
+        int nodeTypesInSegment = 0;
 
         MemoryPrototype[] memories;
 
@@ -438,14 +445,8 @@ public class SegmentMemory extends LinkedList<SegmentMemory>
 
         PathEndNode[] pathEndNodes;
 
-        int nodeTypesInSegment = 0;
-
         public SegmentPrototype(LeftTupleNode rootNode, LeftTupleNode tipNode) {
             this.rootNode = rootNode;
-            this.tipNode = tipNode;
-        }
-
-        public void setTipNode(LeftTupleNode tipNode) {
             this.tipNode = tipNode;
         }
 
@@ -455,24 +456,37 @@ public class SegmentMemory extends LinkedList<SegmentMemory>
             return smem;
         }
 
-        public void updateSegmentMemory(SegmentMemory smem, ReteEvaluator reteEvaluator) {
+        public SegmentMemory shallowNewSegmentMemory(ReteEvaluator reteEvaluator) {
+            SegmentMemory smem = new SegmentMemory();
+            shallowUpdateSegmentMemory(smem, reteEvaluator);
+            return smem;
+        }
+
+        public void shallowUpdateSegmentMemory(SegmentMemory smem, ReteEvaluator reteEvaluator) {
             smem.proto = this;
-            smem.allLinkedMaskTest = allLinkedMaskTest;
-            smem.segmentPosMaskBit = segmentPosMaskBit;
-            smem.linkedNodeMask = linkedNodeMask;
-            smem.pos = pos;
-            smem.nodeMemories.clear();
-            int i = 0;
-            for (NetworkNode node : getNodesInSegment()) {
-                Memory mem = reteEvaluator.getNodeMemory((MemoryFactory) node);
+            smem.allLinkedMaskTest = this.allLinkedMaskTest;
+            smem.segmentPosMaskBit = this.segmentPosMaskBit;
+            smem.linkedNodeMask = this.linkedNodeMask;
+            smem.pos = this.pos;
+        }
+
+        public void updateSegmentMemory(SegmentMemory smem, ReteEvaluator reteEvaluator) {
+            shallowUpdateSegmentMemory(smem, reteEvaluator);
+            Memory[] nodeMemories = new Memory[getNodesInSegment().length];
+            for ( int i = 0; i < memories.length; i++) {
+                Memory mem = reteEvaluator.getNodeMemory((MemoryFactory) getNodesInSegment()[i]);
+                if (i > 0) {
+                    mem.setPrevious(nodeMemories[i-1]);
+                    nodeMemories[i-1].setNext(mem);
+                }
+                nodeMemories[i] = mem;
                 mem.setSegmentMemory(smem);
-                smem.addNodeMemory(mem);
                 MemoryPrototype proto = memories[i];
                 if (proto != null) {
                     proto.populateMemory(reteEvaluator, mem);
                 }
-                i++;
             }
+            smem.setNodeMemories(nodeMemories);
         }
 
         public SegmentPrototype initFromSegmentMemory(SegmentMemory smem) {
@@ -481,7 +495,7 @@ public class SegmentMemory extends LinkedList<SegmentMemory>
             this.segmentPosMaskBit = smem.segmentPosMaskBit;
             this.pos = smem.pos;
             int i = 0;
-            memories = new MemoryPrototype[smem.nodeMemories.size()];
+            memories = new MemoryPrototype[smem.nodeMemories.length];
             for (Memory mem : smem.nodeMemories) {
                 memories[i++] = MemoryPrototype.get(mem);
             }
@@ -492,20 +506,44 @@ public class SegmentMemory extends LinkedList<SegmentMemory>
             return rootNode;
         }
 
+        public void setRootNode(LeftTupleNode rootNode) {
+            this.rootNode = rootNode;
+        }
+
         public LeftTupleNode getTipNode() {
             return tipNode;
+        }
+
+        public void setTipNode(LeftTupleNode tipNode) {
+            this.tipNode = tipNode;
         }
 
         public void linkNode(long mask) {
             linkedNodeMask |= mask;
         };
 
+        public long getLinkedNodeMask() {
+            return linkedNodeMask;
+        }
+
+        public void setLinkedNodeMask(long linkedNodeMask) {
+            this.linkedNodeMask = linkedNodeMask;
+        }
+
         public void setAllLinkedMaskTest(long allLinkedMaskTest) {
             this.allLinkedMaskTest = allLinkedMaskTest;
         }
 
+        public long getAllLinkedMaskTest() {
+            return allLinkedMaskTest;
+        }
+
         public void setSegmentPosMaskBit(long segmentPosMaskBit) {
             this.segmentPosMaskBit = segmentPosMaskBit;
+        }
+
+        public long getSegmentPosMaskBit() {
+            return segmentPosMaskBit;
         }
 
         public int getPos() {
@@ -538,6 +576,11 @@ public class SegmentMemory extends LinkedList<SegmentMemory>
 
         public void setNodeTypesInSegment(int nodeTypesInSegment) {
             this.nodeTypesInSegment = nodeTypesInSegment;
+            requiresEager = BuildtimeSegmentUtilities.requiresAnEagerSegment(nodeTypesInSegment);
+        }
+
+        public boolean requiresEager() {
+            return requiresEager;
         }
 
         public PathEndNode[] getPathEndNodes() {
@@ -558,13 +601,17 @@ public class SegmentMemory extends LinkedList<SegmentMemory>
             sbuilder.append("pos " + pos + ", ");
             sbuilder.append("nodeTypesInSegment " + nodeTypesInSegment + " ");
             sbuilder.append("nodes ");
-            Arrays.stream(nodesInSegment).forEach( n -> sbuilder.append(n));
+            if (nodesInSegment != null) {
+                Arrays.stream(nodesInSegment).forEach(n -> sbuilder.append(n));
+            }
             sbuilder.append("]");
             return sbuilder.toString();
         }
     }
 
     public abstract static class MemoryPrototype {
+        protected long nodePosMaskBit;
+
         public static MemoryPrototype get(Memory memory) {
             if (memory instanceof BetaMemory) {
                 BetaMemory betaMemory = (BetaMemory)memory;
@@ -591,11 +638,17 @@ public class SegmentMemory extends LinkedList<SegmentMemory>
         }
 
         public abstract void populateMemory(ReteEvaluator reteEvaluator, Memory memory);
+
+        public void setNodePosMaskBit(long nodePosMaskBit) {
+            this.nodePosMaskBit = nodePosMaskBit;
+        }
+
+        public long getNodePosMaskBit() {
+            return nodePosMaskBit;
+        }
     }
 
     public static class BetaMemoryPrototype extends MemoryPrototype {
-
-        private final long nodePosMaskBit;
         private final RightInputAdapterNode riaNode;
 
         public BetaMemoryPrototype(long nodePosMaskBit, RightInputAdapterNode riaNode) {
@@ -618,9 +671,6 @@ public class SegmentMemory extends LinkedList<SegmentMemory>
     }
 
     public static class LiaMemoryPrototype extends MemoryPrototype {
-
-        private final long nodePosMaskBit;
-
         public LiaMemoryPrototype(long nodePosMaskBit) {
             this.nodePosMaskBit = nodePosMaskBit;
         }
@@ -632,9 +682,6 @@ public class SegmentMemory extends LinkedList<SegmentMemory>
     }
 
     public static class ReactiveFromMemoryPrototype extends MemoryPrototype {
-
-        private final long nodePosMaskBit;
-
         public ReactiveFromMemoryPrototype(long nodePosMaskBit) {
             this.nodePosMaskBit = nodePosMaskBit;
         }
@@ -697,8 +744,6 @@ public class SegmentMemory extends LinkedList<SegmentMemory>
     }
 
     public static class QueryMemoryPrototype extends MemoryPrototype {
-
-        private final long nodePosMaskBit;
         private final QueryElementNode queryNode;
 
         public QueryMemoryPrototype(long nodePosMaskBit, QueryElementNode queryNode) {
@@ -716,8 +761,6 @@ public class SegmentMemory extends LinkedList<SegmentMemory>
     }
 
     public static class TimerMemoryPrototype extends MemoryPrototype {
-
-        private final long nodePosMaskBit;
 
         public TimerMemoryPrototype(long nodePosMaskBit) {
             this.nodePosMaskBit = nodePosMaskBit;
@@ -741,8 +784,6 @@ public class SegmentMemory extends LinkedList<SegmentMemory>
     }
 
     public static class AsyncReceiveMemoryPrototype extends MemoryPrototype {
-
-        private final long nodePosMaskBit;
 
         public AsyncReceiveMemoryPrototype(long nodePosMaskBit) {
             this.nodePosMaskBit = nodePosMaskBit;

--- a/drools-core/src/main/java/org/drools/core/reteoo/TerminalNode.java
+++ b/drools-core/src/main/java/org/drools/core/reteoo/TerminalNode.java
@@ -30,7 +30,7 @@ import org.drools.core.util.bitmask.BitMask;
  */
 public interface TerminalNode
     extends
-    NetworkNode, Sink, PathEndNode, MemoryFactory<PathMemory> {
+    NetworkNode, Sink, PathEndNode {
 
     LeftTupleSource getLeftTupleSource();
     

--- a/drools-core/src/main/java/org/drools/core/reteoo/builder/PhreakNodeFactory.java
+++ b/drools-core/src/main/java/org/drools/core/reteoo/builder/PhreakNodeFactory.java
@@ -99,7 +99,12 @@ public class PhreakNodeFactory implements NodeFactory, Serializable {
         return new EvalConditionNode( id, tupleSource, eval, context );
     }
 
-    public RightInputAdapterNode buildRightInputNode( int id, LeftTupleSource leftInput, LeftTupleSource startTupleSource, BuildContext context ) {
+    public RightInputAdapterNode buildRightInputNode( int id, LeftTupleSource leftInput, LeftTupleSource splitStart, BuildContext context ) {
+        LeftTupleSource startTupleSource = leftInput;
+
+        while (startTupleSource.getLeftTupleSource() != splitStart) {
+            startTupleSource = startTupleSource.getLeftTupleSource();
+        }
         return new RightInputAdapterNode( id, leftInput, startTupleSource, context );
     }
 

--- a/drools-core/src/main/java/org/drools/core/reteoo/builder/ReteooRuleBuilder.java
+++ b/drools-core/src/main/java/org/drools/core/reteoo/builder/ReteooRuleBuilder.java
@@ -117,7 +117,6 @@ public class ReteooRuleBuilder implements RuleBuilder {
         final GroupElement[] subrules = rule.getTransformedLhs( LogicTransformer.getInstance(), kBase.getGlobals() );
 
         for (int i = 0; i < subrules.length; i++) {
-
             // creates a clean build context for each subrule
             final BuildContext context = new BuildContext( kBase, workingMemories );
             context.setRule( rule );
@@ -218,7 +217,10 @@ public class ReteooRuleBuilder implements RuleBuilder {
 
         setPathEndNodes(context, terminalNode);
 
-        PhreakBuilder.get().addRule(terminalNode, context.getWorkingMemories(), context.getRuleBase());
+        if (!PhreakBuilder.isEagerSegmentCreation() || !context.getRuleBase().getSegmentPrototypes().isEmpty()) {
+            // only need to process this, if segment protos exist
+            PhreakBuilder.get().addRule(terminalNode, context.getWorkingMemories(), context.getRuleBase());
+        }
     }
 
     private static void setPathEndNodes(BuildContext context, TerminalNode terminalNode) {

--- a/drools-core/src/main/java/org/drools/core/reteoo/builder/ReteooRuleBuilder.java
+++ b/drools-core/src/main/java/org/drools/core/reteoo/builder/ReteooRuleBuilder.java
@@ -217,7 +217,7 @@ public class ReteooRuleBuilder implements RuleBuilder {
 
         setPathEndNodes(context, terminalNode);
 
-        if (!PhreakBuilder.isEagerSegmentCreation() || !context.getRuleBase().getSegmentPrototypes().isEmpty()) {
+        if (!PhreakBuilder.isEagerSegmentCreation() || context.getRuleBase().hasSegmentPrototypes()) {
             // only need to process this, if segment protos exist
             PhreakBuilder.get().addRule(terminalNode, context.getWorkingMemories(), context.getRuleBase());
         }

--- a/drools-docs/src/modules/ROOT/pages/KIE/BuildDeployUtilizeAndRun/_KIERunning-section.adoc
+++ b/drools-docs/src/modules/ROOT/pages/KIE/BuildDeployUtilizeAndRun/_KIERunning-section.adoc
@@ -513,15 +513,15 @@ For a quick start, here is the programmatic approach:
 ====
 [source,java]
 ----
-PoolingDataSource ds = new PoolingDataSource();
-ds.setUniqueName( "jdbc/BitronixJTADataSource" );
-ds.setClassName( "org.h2.jdbcx.JdbcDataSource" );
-ds.setMaxPoolSize( 3 );
-ds.setAllowLocalTransactions( true );
-ds.getDriverProperties().put( "user", "sa" );
-ds.getDriverProperties().put( "password", "sasa" );
-ds.getDriverProperties().put( "URL", "jdbc:h2:mem:mydb" );
-ds.init();
+PoolingDataSource fs = new PoolingDataSource();
+fs.setUniqueName( "jdbc/BitronixJTADataSource" );
+fs.setClassName( "org.h2.jdbcx.JdbcDataSource" );
+fs.setMaxPoolSize( 3 );
+fs.setAllowLocalTransactions( true );
+fs.getDriverProperties().put( "user", "sa" );
+fs.getDriverProperties().put( "password", "sasa" );
+fs.getDriverProperties().put( "URL", "jdbc:h2:mem:mydb" );
+fs.init();
 ----
 ====
 

--- a/drools-impact-analysis/drools-impact-analysis-itests/src/test/java/org/drools/impact/analysis/example/ExampleUsageTest.java
+++ b/drools-impact-analysis/drools-impact-analysis-itests/src/test/java/org/drools/impact/analysis/example/ExampleUsageTest.java
@@ -32,6 +32,7 @@ import org.drools.impact.analysis.integrationtests.RuleExecutionHelper;
 import org.drools.impact.analysis.model.AnalysisModel;
 import org.drools.impact.analysis.parser.internal.ImpactAnalysisKieModule;
 import org.drools.impact.analysis.parser.internal.ImpactAnalysisProject;
+import org.junit.Ignore;
 import org.junit.Test;
 import org.kie.api.KieServices;
 import org.kie.api.builder.KieBuilder;
@@ -46,7 +47,7 @@ import org.kie.api.runtime.KieSession;
  */
 public class ExampleUsageTest {
 
-    @Test
+    @Test @Ignore
     public void testExampleUsage() throws IOException {
 
         KieServices ks = KieServices.Factory.get();

--- a/drools-impact-analysis/drools-impact-analysis-itests/src/test/java/org/drools/impact/analysis/example/ExampleUsageTest.java
+++ b/drools-impact-analysis/drools-impact-analysis-itests/src/test/java/org/drools/impact/analysis/example/ExampleUsageTest.java
@@ -32,7 +32,6 @@ import org.drools.impact.analysis.integrationtests.RuleExecutionHelper;
 import org.drools.impact.analysis.model.AnalysisModel;
 import org.drools.impact.analysis.parser.internal.ImpactAnalysisKieModule;
 import org.drools.impact.analysis.parser.internal.ImpactAnalysisProject;
-import org.junit.Ignore;
 import org.junit.Test;
 import org.kie.api.KieServices;
 import org.kie.api.builder.KieBuilder;
@@ -47,7 +46,7 @@ import org.kie.api.runtime.KieSession;
  */
 public class ExampleUsageTest {
 
-    @Test @Ignore
+    @Test
     public void testExampleUsage() throws IOException {
 
         KieServices ks = KieServices.Factory.get();

--- a/drools-kiesession/src/main/java/org/drools/kiesession/rulebase/SessionsAwareKnowledgeBase.java
+++ b/drools-kiesession/src/main/java/org/drools/kiesession/rulebase/SessionsAwareKnowledgeBase.java
@@ -62,7 +62,6 @@ import org.drools.core.rule.TypeDeclaration;
 import org.drools.core.rule.accessor.FactHandleFactory;
 import org.drools.core.ruleunit.RuleUnitDescriptionRegistry;
 import org.kie.api.KieBaseConfiguration;
-import org.kie.api.KieServices;
 import org.kie.api.builder.ReleaseId;
 import org.kie.api.definition.KiePackage;
 import org.kie.api.definition.process.Process;
@@ -510,11 +509,6 @@ public class SessionsAwareKnowledgeBase implements InternalKnowledgeBase {
     @Override
     public SegmentPrototype getSegmentPrototype(SegmentMemory segment) {
         return delegate.getSegmentPrototype(segment);
-    }
-
-    @Override
-    public Map<Integer, SegmentPrototype> getSegmentPrototypes() {
-        return delegate.getSegmentPrototypes();
     }
 
     @Override

--- a/drools-kiesession/src/main/java/org/drools/kiesession/rulebase/SessionsAwareKnowledgeBase.java
+++ b/drools-kiesession/src/main/java/org/drools/kiesession/rulebase/SessionsAwareKnowledgeBase.java
@@ -513,6 +513,11 @@ public class SessionsAwareKnowledgeBase implements InternalKnowledgeBase {
     }
 
     @Override
+    public Map<Integer, SegmentPrototype> getSegmentPrototypes() {
+        return delegate.getSegmentPrototypes();
+    }
+
+    @Override
     public TypeDeclaration getExactTypeDeclaration(Class<?> clazz) {
         return delegate.getExactTypeDeclaration(clazz);
     }

--- a/drools-kiesession/src/test/java/org/drools/kiesession/NodeSegmentUnlinkingTest.java
+++ b/drools-kiesession/src/test/java/org/drools/kiesession/NodeSegmentUnlinkingTest.java
@@ -238,13 +238,13 @@ public class NodeSegmentUnlinkingTest {
         n5.attach(buildContext);
 
         StatefulKnowledgeSessionImpl ksession = (StatefulKnowledgeSessionImpl)kBase.newKieSession();
-        SegmentPrototype[] protos = BuildtimeSegmentUtilities.createPathProtoMemories(n3, null, null, kBase);
+        SegmentPrototype[] protos = BuildtimeSegmentUtilities.createLeftTupleNodeProtoMemories(n3, null, kBase);
         Arrays.stream(protos).forEach( p -> p.setPathEndNodes( new PathEndNode[0]));
 
-        protos = BuildtimeSegmentUtilities.createPathProtoMemories(n4, null, null, kBase);
+        protos = BuildtimeSegmentUtilities.createLeftTupleNodeProtoMemories(n4, null, kBase);
         Arrays.stream(protos).forEach( p -> p.setPathEndNodes( new PathEndNode[0]));
 
-        protos = BuildtimeSegmentUtilities.createPathProtoMemories(n5, null, null, kBase);
+        protos = BuildtimeSegmentUtilities.createLeftTupleNodeProtoMemories(n5, null, kBase);
         Arrays.stream(protos).forEach( p -> p.setPathEndNodes( new PathEndNode[0]));
         createSegmentMemory( n2, ksession );
 

--- a/drools-kiesession/src/test/java/org/drools/kiesession/NodeSegmentUnlinkingTest.java
+++ b/drools-kiesession/src/test/java/org/drools/kiesession/NodeSegmentUnlinkingTest.java
@@ -15,6 +15,7 @@
 
 package org.drools.kiesession;
 
+import java.util.Arrays;
 import java.util.Collections;
 
 import org.drools.core.base.ClassObjectType;
@@ -27,6 +28,7 @@ import org.drools.core.common.PropagationContextFactory;
 import org.drools.core.definitions.rule.impl.RuleImpl;
 import org.drools.core.phreak.BuildtimeSegmentUtilities;
 import org.drools.core.reteoo.PathEndNode;
+import org.drools.core.reteoo.SegmentMemory.SegmentPrototype;
 import org.drools.core.reteoo.TerminalNode;
 import org.drools.kiesession.rulebase.InternalKnowledgeBase;
 import org.drools.core.phreak.PhreakNotNode;
@@ -236,9 +238,14 @@ public class NodeSegmentUnlinkingTest {
         n5.attach(buildContext);
 
         StatefulKnowledgeSessionImpl ksession = (StatefulKnowledgeSessionImpl)kBase.newKieSession();
-        BuildtimeSegmentUtilities.createPathProtoMemories(n3, null, null, kBase);
-        BuildtimeSegmentUtilities.createPathProtoMemories(n4, null, null, kBase);
-        BuildtimeSegmentUtilities.createPathProtoMemories(n5, null, null, kBase);
+        SegmentPrototype[] protos = BuildtimeSegmentUtilities.createPathProtoMemories(n3, null, null, kBase);
+        Arrays.stream(protos).forEach( p -> p.setPathEndNodes( new PathEndNode[0]));
+
+        protos = BuildtimeSegmentUtilities.createPathProtoMemories(n4, null, null, kBase);
+        Arrays.stream(protos).forEach( p -> p.setPathEndNodes( new PathEndNode[0]));
+
+        protos = BuildtimeSegmentUtilities.createPathProtoMemories(n5, null, null, kBase);
+        Arrays.stream(protos).forEach( p -> p.setPathEndNodes( new PathEndNode[0]));
         createSegmentMemory( n2, ksession );
 
         BetaMemory bm = (BetaMemory) ksession.getNodeMemory( n1 );

--- a/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/compiler/integrationtests/incrementalcompilation/AddRemoveRulesTest.java
+++ b/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/compiler/integrationtests/incrementalcompilation/AddRemoveRulesTest.java
@@ -831,7 +831,7 @@ public class AddRemoveRulesTest {
                 " list.add('R2'); \n" +
                 "end";
 
-        AddRemoveTestCases.insertFactsRemoveFire(base, rule1, rule2, null, TestUtil.getDefaultFacts());
+        AddRemoveTestCases. insertFactsRemoveFire(base, rule1, rule2, null, TestUtil.getDefaultFacts());
     }
 
     @Test
@@ -1638,7 +1638,7 @@ public class AddRemoveRulesTest {
         additionalGlobals.put("globalInt", new AtomicInteger(0));
 
         AddRemoveTestCases.runAllTestCases(base, rule1, rule2, rule1Name, rule2Name, additionalGlobals,1, 2, "1");
-//        AddRemoveTestCases.runAllTestCases(base, rule2, rule1, rule2Name, rule1Name, additionalGlobals,1, 2, "1");
+        AddRemoveTestCases.runAllTestCases(base, rule2, rule1, rule2Name, rule1Name, additionalGlobals,1, 2, "1");
     }
 
     @Test

--- a/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/compiler/integrationtests/incrementalcompilation/AddRemoveTestCases.java
+++ b/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/compiler/integrationtests/incrementalcompilation/AddRemoveTestCases.java
@@ -45,20 +45,20 @@ public final class AddRemoveTestCases {
                                        final Object... facts) {
         
         insertFactsFireRulesRemoveRules1(originalKnowledgeBase, rule1, rule2, rule1Name, rule2Name, additionalGlobals,facts);
-//        insertFactsFireRulesRemoveRules2(originalKnowledgeBase, rule1, rule2, rule1Name, rule2Name, additionalGlobals, facts);
-//        insertFactsFireRulesRemoveRules3(originalKnowledgeBase, rule1, rule2, rule1Name, rule2Name, additionalGlobals, facts);
-//
-//        fireRulesInsertFactsFireRulesRemoveRules1(originalKnowledgeBase, rule1, rule2, rule1Name, rule2Name, additionalGlobals, facts);
-//        fireRulesInsertFactsFireRulesRemoveRules2(originalKnowledgeBase, rule1, rule2, rule1Name, rule2Name, additionalGlobals, facts);
-//        fireRulesInsertFactsFireRulesRemoveRules3(originalKnowledgeBase, rule1, rule2, rule1Name, rule2Name, additionalGlobals, facts);
-//
-//        insertFactsRemoveRulesFireRulesRemoveRules1(originalKnowledgeBase, rule1, rule2, rule1Name, rule2Name, additionalGlobals, facts);
-//        insertFactsRemoveRulesFireRulesRemoveRules2(originalKnowledgeBase, rule1, rule2, rule1Name, rule2Name, additionalGlobals, facts);
-//        insertFactsRemoveRulesFireRulesRemoveRules3(originalKnowledgeBase, rule1, rule2, rule1Name, rule2Name, additionalGlobals, facts);
-//
-//        insertFactsFireRulesRemoveRulesReinsertRules1(originalKnowledgeBase, rule1, rule2, rule1Name, rule2Name, additionalGlobals, facts);
-//        insertFactsFireRulesRemoveRulesReinsertRules2(originalKnowledgeBase, rule1, rule2, rule1Name, rule2Name, additionalGlobals, facts);
-//        insertFactsFireRulesRemoveRulesReinsertRules3(originalKnowledgeBase, rule1, rule2, rule1Name, rule2Name, additionalGlobals, facts);
+        insertFactsFireRulesRemoveRules2(originalKnowledgeBase, rule1, rule2, rule1Name, rule2Name, additionalGlobals, facts);
+        insertFactsFireRulesRemoveRules3(originalKnowledgeBase, rule1, rule2, rule1Name, rule2Name, additionalGlobals, facts);
+
+        fireRulesInsertFactsFireRulesRemoveRules1(originalKnowledgeBase, rule1, rule2, rule1Name, rule2Name, additionalGlobals, facts);
+        fireRulesInsertFactsFireRulesRemoveRules2(originalKnowledgeBase, rule1, rule2, rule1Name, rule2Name, additionalGlobals, facts);
+        fireRulesInsertFactsFireRulesRemoveRules3(originalKnowledgeBase, rule1, rule2, rule1Name, rule2Name, additionalGlobals, facts);
+
+        insertFactsRemoveRulesFireRulesRemoveRules1(originalKnowledgeBase, rule1, rule2, rule1Name, rule2Name, additionalGlobals, facts);
+        insertFactsRemoveRulesFireRulesRemoveRules2(originalKnowledgeBase, rule1, rule2, rule1Name, rule2Name, additionalGlobals, facts);
+        insertFactsRemoveRulesFireRulesRemoveRules3(originalKnowledgeBase, rule1, rule2, rule1Name, rule2Name, additionalGlobals, facts);
+
+        insertFactsFireRulesRemoveRulesReinsertRules1(originalKnowledgeBase, rule1, rule2, rule1Name, rule2Name, additionalGlobals, facts);
+        insertFactsFireRulesRemoveRulesReinsertRules2(originalKnowledgeBase, rule1, rule2, rule1Name, rule2Name, additionalGlobals, facts);
+        insertFactsFireRulesRemoveRulesReinsertRules3(originalKnowledgeBase, rule1, rule2, rule1Name, rule2Name, additionalGlobals, facts);
     }
 
     public static void insertFactsFireRulesRemoveRules1(final String rule1,
@@ -549,7 +549,7 @@ public final class AddRemoveTestCases {
 
             TestUtil.addRules(kieSession, true, rule2);
             kieSession.fireAllRules();
-            assertThat(resultsList).containsOnly(rule1Name, rule2Name);
+            assertThat(resultsList).containsOnly(rule2Name);
         } finally {
             kieSession.dispose();
         }

--- a/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/compiler/integrationtests/incrementalcompilation/AddRuleTest.java
+++ b/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/compiler/integrationtests/incrementalcompilation/AddRuleTest.java
@@ -43,6 +43,7 @@ public class AddRuleTest {
     private final KieBaseTestConfiguration kieBaseTestConfiguration;
 
     public AddRuleTest(final KieBaseTestConfiguration kieBaseTestConfiguration) {
+        System.setProperty("drools.useEagerSegmentCreation", "true");
         this.kieBaseTestConfiguration = kieBaseTestConfiguration;
     }
 
@@ -53,6 +54,7 @@ public class AddRuleTest {
 
     @Test
     public void testMemoriesCCEWhenAddRemoveAddRule() {
+        //System.setProperty("drools.useEagerSegmentCreation", "false");
         // JBRULES-3656
         final String rule1 = "import " + AddRuleTest.class.getCanonicalName() + ".*\n" +
                 "import java.util.Date\n" +

--- a/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/compiler/integrationtests/incrementalcompilation/AddRuleTest.java
+++ b/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/compiler/integrationtests/incrementalcompilation/AddRuleTest.java
@@ -43,7 +43,6 @@ public class AddRuleTest {
     private final KieBaseTestConfiguration kieBaseTestConfiguration;
 
     public AddRuleTest(final KieBaseTestConfiguration kieBaseTestConfiguration) {
-        System.setProperty("drools.useEagerSegmentCreation", "true");
         this.kieBaseTestConfiguration = kieBaseTestConfiguration;
     }
 
@@ -54,7 +53,6 @@ public class AddRuleTest {
 
     @Test
     public void testMemoriesCCEWhenAddRemoveAddRule() {
-        //System.setProperty("drools.useEagerSegmentCreation", "false");
         // JBRULES-3656
         final String rule1 = "import " + AddRuleTest.class.getCanonicalName() + ".*\n" +
                 "import java.util.Date\n" +

--- a/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/compiler/integrationtests/incrementalcompilation/TestUtil.java
+++ b/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/compiler/integrationtests/incrementalcompilation/TestUtil.java
@@ -45,11 +45,12 @@ public final class TestUtil {
         for (final String drl : drls) {
             final KnowledgeBuilder kBuilder;
             if (reuseKieBaseWhenAddingRules) {
-                kBuilder = createKnowledgeBuilder(session.getKieBase(), drl);
+                // packages are added live to the target kbase, no need to re-add them again.
+                createKnowledgeBuilder(session.getKieBase(), drl);
             } else {
                 kBuilder = createKnowledgeBuilder(null, drl);
+                ((InternalKnowledgeBase)session.getKieBase()).addPackages(kBuilder.getKnowledgePackages());
             }
-            ((InternalKnowledgeBase)session.getKieBase()).addPackages(kBuilder.getKnowledgePackages());
         }
     }
 

--- a/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/compiler/MemoryLeakTest.java
+++ b/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/compiler/MemoryLeakTest.java
@@ -206,7 +206,7 @@ public class MemoryLeakTest {
                 System.out.println( memory );
                 LeftTuple deleteFirst = memory.getSegmentMemory().getStagedLeftTuples().getDeleteFirst();
                 if ( segmentMemory.getRootNode() instanceof JoinNode ) {
-                    BetaMemory bm = (BetaMemory) segmentMemory.getNodeMemories().get(0);
+                    BetaMemory bm = (BetaMemory) segmentMemory.getNodeMemories()[0];
                     assertThat(bm.getLeftTupleMemory().size()).isEqualTo(0);
                 }
                 System.out.println( deleteFirst );

--- a/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/integrationtests/LinkingTest.java
+++ b/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/integrationtests/LinkingTest.java
@@ -718,8 +718,8 @@ public class LinkingTest {
         BetaMemory fMem = ( BetaMemory )   wm.getNodeMemory( fNode );
         BetaMemory gMem = ( BetaMemory )   wm.getNodeMemory( gNode );
 
-        RiaPathMemory riaMem1 = wm.getNodeMemory(riaNode1);
-        RiaPathMemory riaMem2 = wm.getNodeMemory(riaNode2);
+        RiaPathMemory riaMem1 = (RiaPathMemory) wm.getNodeMemory(riaNode1);
+        RiaPathMemory riaMem2 = (RiaPathMemory) wm.getNodeMemory(riaNode2);
 
         PathMemory rs = wm.getNodeMemory(rtn);
 

--- a/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/integrationtests/SegmentCreationTest.java
+++ b/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/integrationtests/SegmentCreationTest.java
@@ -22,6 +22,7 @@ import java.util.List;
 import org.drools.core.base.ClassObjectType;
 import org.drools.core.common.InternalWorkingMemory;
 import org.drools.core.impl.RuleBase;
+import org.drools.core.phreak.PhreakBuilder;
 import org.drools.core.reteoo.BetaMemory;
 import org.drools.core.reteoo.ConditionalBranchNode;
 import org.drools.core.reteoo.InitialFactImpl;
@@ -464,7 +465,7 @@ public class SegmentCreationTest {
 
         PathMemory pmemr2 = wm.getNodeMemory(rtn2);
         assertThat(pmemr2.getAllLinkedMaskTest()).isEqualTo(1);
-        assertThat(pmemr2.getLinkedSegmentMask()).isEqualTo(0);
+        assertThat(pmemr2.getLinkedSegmentMask()).isEqualTo(PhreakBuilder.isEagerSegmentCreation() ? 0 : 2);
         assertThat(pmemr2.getSegmentMemories().length).isEqualTo(3);
         assertThat(pmemr2.isRuleLinked()).isFalse();
 
@@ -476,7 +477,7 @@ public class SegmentCreationTest {
         BetaMemory cNodeBm = ( BetaMemory ) wm.getNodeMemory( cNode );
         SegmentMemory cNodeSmem = cNodeBm.getSegmentMemory();
 
-        assertThat(cNodeSmem.getAllLinkedMaskTest()).isEqualTo(0);
+        assertThat(cNodeSmem.getAllLinkedMaskTest()).isEqualTo(PhreakBuilder.isEagerSegmentCreation() ? 0 : 1);
         assertThat(cNodeSmem.getLinkedNodeMask()).isEqualTo(1);
 
         wm.insert(new LinkingTest.X());
@@ -490,10 +491,10 @@ public class SegmentCreationTest {
         wm.delete(cFh); // retract C does not unlink the rule
         wm.flushPropagations();
 
-        assertThat(pmemr2.getLinkedSegmentMask()).isEqualTo(1); // b segment never unlinks, as it has no impact on path unlinking anyway
+        assertThat(pmemr2.getLinkedSegmentMask()).isEqualTo(PhreakBuilder.isEagerSegmentCreation() ? 1 : 3); // b segment never unlinks, as it has no impact on path unlinking anyway
         assertThat(pmemr2.isRuleLinked()).isTrue();
 
-        assertThat(pmemr3.getLinkedSegmentMask()).isEqualTo(1); // b segment never unlinks, as it has no impact on path unlinking anyway
+        assertThat(pmemr3.getLinkedSegmentMask()).isEqualTo(PhreakBuilder.isEagerSegmentCreation() ? 1 : 3); // b segment never unlinks, as it has no impact on path unlinking anyway
         assertThat(pmemr3.isRuleLinked()).isTrue();
     }
 

--- a/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/integrationtests/phreak/AddRuleTest.java
+++ b/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/integrationtests/phreak/AddRuleTest.java
@@ -16,25 +16,45 @@
 package org.drools.mvel.integrationtests.phreak;
 
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collection;
+import java.util.Collections;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.List;
+import java.util.Map;
 
 import org.drools.core.base.ClassObjectType;
+import org.drools.core.common.BaseNode;
 import org.drools.core.common.InternalWorkingMemory;
+import org.drools.core.common.Memory;
+import org.drools.core.definitions.rule.impl.RuleImpl;
 import org.drools.core.impl.RuleBase;
+import org.drools.core.phreak.EagerPhreakBuilder;
+import org.drools.core.phreak.EagerPhreakBuilder.Pair;
+import org.drools.core.phreak.BuildtimeSegmentUtilities;
+import org.drools.core.phreak.EagerPhreakBuilder.Add;
 import org.drools.core.phreak.PhreakBuilder;
 import org.drools.core.reteoo.BetaMemory;
+import org.drools.core.reteoo.BetaNode;
 import org.drools.core.reteoo.EvalConditionNode;
+import org.drools.core.reteoo.ExistsNode;
 import org.drools.core.reteoo.JoinNode;
 import org.drools.core.reteoo.LeftInputAdapterNode;
 import org.drools.core.reteoo.LeftInputAdapterNode.LiaNodeMemory;
+import org.drools.core.reteoo.LeftTupleNode;
+import org.drools.core.reteoo.NodeTypeEnums;
 import org.drools.core.reteoo.ObjectTypeNode;
+import org.drools.core.reteoo.PathEndNode;
 import org.drools.core.reteoo.PathMemory;
 import org.drools.core.reteoo.Rete;
 import org.drools.core.reteoo.RuleTerminalNode;
 import org.drools.core.reteoo.SegmentMemory;
+import org.drools.core.reteoo.SegmentMemory.SegmentPrototype;
+import org.drools.core.reteoo.TerminalNode;
 import org.drools.core.reteoo.Tuple;
+import org.drools.core.reteoo.builder.BuildContext;
+import org.drools.core.rule.GroupElement;
 import org.drools.kiesession.rulebase.InternalKnowledgeBase;
 import org.drools.testcoverage.common.util.KieBaseTestConfiguration;
 import org.drools.testcoverage.common.util.KieBaseUtil;
@@ -51,15 +71,15 @@ import org.kie.api.definition.KiePackage;
 import org.kie.api.runtime.KieContainer;
 import org.kie.api.runtime.rule.Match;
 
-import static org.assertj.core.api.Assertions.assertThat;
 import static java.util.Arrays.asList;
+import static org.assertj.core.api.Assertions.assertThat;
 
 @RunWith(Parameterized.class)
 public class AddRuleTest {
-
     private final KieBaseTestConfiguration kieBaseTestConfiguration;
 
     public AddRuleTest(KieBaseTestConfiguration kieBaseTestConfiguration) {
+        System.setProperty("drools.useEagerSegmentCreation", "true");
         this.kieBaseTestConfiguration = kieBaseTestConfiguration;
     }
 
@@ -67,6 +87,460 @@ public class AddRuleTest {
     public static Collection<Object[]> getParameters() {
         return TestParametersUtil.getKieBaseCloudConfigurations(true);
     }
+
+
+
+    @Test
+    public void testAddThenSplitProtoAllJoins() {
+        InternalKnowledgeBase kbase1 = buildKnowledgeBase("r1", "   a : A() B() C() X() E()\n");
+        InternalWorkingMemory wm = (InternalWorkingMemory) kbase1.newKieSession();
+        ObjectTypeNode aotn = getObjectTypeNode(kbase1.getRete(), A.class);
+        ObjectTypeNode cotn = getObjectTypeNode(kbase1.getRete(), C.class);
+
+        LeftInputAdapterNode lian = (LeftInputAdapterNode) aotn.getSinks()[0];
+        BetaNode cbeta = (BetaNode) cotn.getSinks()[0];
+
+        Map<Integer, SegmentPrototype> protos = kbase1.getSegmentPrototypes();
+
+        insertAndFlush(wm);
+
+        SegmentPrototype smemProto0 = protos.get(lian.getId());
+        PathEndNode endNode = smemProto0.getPathEndNodes()[0];
+
+        assertSegmentsLengthAndPos(endNode, 1, wm);
+        assertThat(endNode.getSegmentPrototypes()[0]).isSameAs(smemProto0);
+        assertThat(endNode.getEagerSegmentPrototypes().length).isEqualTo(0);
+        assertThat(smemProto0.getNodesInSegment().length).isEqualTo(6);
+        LeftTupleNode[] nodes = smemProto0.getNodesInSegment();
+        // the last RTN node is not part of the mask
+        assertThat(smemProto0.getAllLinkedMaskTest()).isEqualTo(31);
+        assertThat(smemProto0.getLinkedNodeMask()).isEqualTo(0);
+        assertThat(smemProto0.getNodeTypesInSegment()).isEqualTo(BuildtimeSegmentUtilities.JOIN_NODE_BIT);
+
+        SegmentPrototype[] oldSmemProtos = endNode.getSegmentPrototypes();
+        SegmentPrototype smemProto1 = Add.processSplit(cbeta, kbase1, Collections.singletonList(wm), new HashSet<>());
+
+        assertSegmentsLengthAndPos(endNode, 2, oldSmemProtos, smemProto1, wm);
+        assertThat(endNode.getSegmentPrototypes()[0]).isSameAs(smemProto0);
+        assertThat(endNode.getSegmentPrototypes()[1]).isSameAs(smemProto1);
+        assertThat(endNode.getEagerSegmentPrototypes().length).isEqualTo(0);
+        assertThat(smemProto0.getAllLinkedMaskTest()).isEqualTo(7);
+        assertThat(smemProto0.getLinkedNodeMask()).isEqualTo(0);
+        assertThat(smemProto0.getNodeTypesInSegment()).isEqualTo(BuildtimeSegmentUtilities.JOIN_NODE_BIT);
+        assertThat(smemProto0.getNodesInSegment().length).isEqualTo(3);
+        assertThat(nodes[0]).isSameAs(smemProto0.getNodesInSegment()[0]);
+        assertThat(nodes[1]).isSameAs(smemProto0.getNodesInSegment()[1]);
+        assertThat(nodes[2]).isSameAs(smemProto0.getNodesInSegment()[2]);
+
+        assertThat(endNode).isSameAs(smemProto1.getPathEndNodes()[0]);
+        assertThat(smemProto1.getAllLinkedMaskTest()).isEqualTo(3);
+        assertThat(smemProto1.getLinkedNodeMask()).isEqualTo(0);
+        assertThat(smemProto1.getNodeTypesInSegment()).isEqualTo(BuildtimeSegmentUtilities.JOIN_NODE_BIT);
+        assertThat(smemProto1.getNodesInSegment().length).isEqualTo(3);
+        assertThat(nodes[3]).isSameAs(smemProto1.getNodesInSegment()[0]);
+        assertThat(nodes[4]).isSameAs(smemProto1.getNodesInSegment()[1]);
+        assertThat(nodes[5]).isSameAs(smemProto1.getNodesInSegment()[2]);
+    }
+
+    @Test
+    public void testAddThenSplitProtoWithNot() {
+        // This only really checks that the linkedNodeMask is set, for the 'not' bits
+        InternalKnowledgeBase kbase1 = buildKnowledgeBase("r1", "   a : A() not B() C() not X() E()\n");
+        InternalWorkingMemory wm = (InternalWorkingMemory) kbase1.newKieSession();
+        ObjectTypeNode aotn = getObjectTypeNode(kbase1.getRete(), A.class);
+        ObjectTypeNode cotn = getObjectTypeNode(kbase1.getRete(), C.class);
+
+        LeftInputAdapterNode lian = (LeftInputAdapterNode) aotn.getSinks()[0];
+        BetaNode cbeta = (BetaNode) cotn.getSinks()[0];
+
+        Map<Integer, SegmentPrototype> protos = kbase1.getSegmentPrototypes();
+
+        insertAndFlush(wm);
+
+        SegmentMemory smemLian = wm.getNodeMemories().getNodeMemory(lian, wm).getSegmentMemory();
+        SegmentPrototype smemProto0 = protos.get(lian.getId());
+        assertThat(smemLian.getSegmentPrototype()).isSameAs(smemProto0);
+
+        assertThat(smemProto0.getNodesInSegment().length).isEqualTo(6);
+        assertThat(smemProto0.getAllLinkedMaskTest()).isEqualTo(31);
+        assertThat(smemProto0.getLinkedNodeMask()).isEqualTo(10); // nots must be linked in
+        assertThat(smemProto0.getNodeTypesInSegment()).isEqualTo(BuildtimeSegmentUtilities.JOIN_NODE_BIT | BuildtimeSegmentUtilities.NOT_NODE_BIT);
+        SegmentPrototype smemProto1 = Add.processSplit(cbeta, kbase1, Collections.singletonList(wm), new HashSet<>());
+
+        assertThat(smemProto0.getAllLinkedMaskTest()).isEqualTo(7);
+        assertThat(smemProto0.getLinkedNodeMask()).isEqualTo(2);
+        assertThat(smemProto0.getNodeTypesInSegment()).isEqualTo(BuildtimeSegmentUtilities.JOIN_NODE_BIT | BuildtimeSegmentUtilities.NOT_NODE_BIT);
+
+        assertThat(smemProto1.getAllLinkedMaskTest()).isEqualTo(3);
+        assertThat(smemProto1.getLinkedNodeMask()).isEqualTo(1);
+        assertThat(smemProto1.getNodeTypesInSegment()).isEqualTo(BuildtimeSegmentUtilities.JOIN_NODE_BIT | BuildtimeSegmentUtilities.NOT_NODE_BIT);
+    }
+    @Test
+    public void testAddWithSplitThenCreateThirdSplit() {
+        InternalKnowledgeBase kbase1 = buildKnowledgeBase("r",
+                                                          "   a : A() B() C() E(1;) E(2;) E(3;) E(4;)\n",
+                                                          "   A() B() C() X()\n");
+
+        InternalWorkingMemory wm = (InternalWorkingMemory) kbase1.newKieSession();
+        ObjectTypeNode aotn = getObjectTypeNode(kbase1.getRete(), A.class);
+        ObjectTypeNode eotn = getObjectTypeNode(kbase1.getRete(), E.class);
+        ObjectTypeNode xotn = getObjectTypeNode(kbase1.getRete(), X.class);
+
+        LeftInputAdapterNode lian = (LeftInputAdapterNode) aotn.getSinks()[0];
+        BetaNode ebeta = (BetaNode) eotn.getSinks()[0].getSinks()[0];
+        BetaNode ebeta3 = (BetaNode) eotn.getSinks()[2].getSinks()[0];
+        BetaNode xbeta = (BetaNode) xotn.getSinks()[0];
+
+        Map<Integer, SegmentPrototype> protos = kbase1.getSegmentPrototypes();
+
+        insertAndFlush(wm);
+
+        SegmentMemory smem = wm.getNodeMemories().getNodeMemory(lian, wm).getSegmentMemory();
+        SegmentPrototype smemProto0 = protos.get(lian.getId());
+        assertThat(smem.getSegmentPrototype()).isSameAs(smemProto0);
+        PathEndNode endNode0 = smemProto0.getPathEndNodes()[0];
+        PathEndNode endNode1 = smemProto0.getPathEndNodes()[1];
+        assertSegmentsLengthAndPos(endNode0, 2, wm);
+        assertSegmentsLengthAndPos(endNode1, 2, wm);
+
+        SegmentPrototype smemProtoE = protos.get(ebeta.getId());
+        assertThat(smemProtoE.getNodesInSegment().length).isEqualTo(5);
+        assertThat(smemProtoE.getPos()).isEqualTo(1);
+        SegmentPrototype smemProtoX = protos.get(xbeta.getId());
+        assertThat(smemProtoX.getPos()).isEqualTo(1);
+
+        SegmentPrototype[] oldSmemProtos = endNode1.getSegmentPrototypes();
+        SegmentPrototype smemProtoE2 = Add.processSplit(ebeta3, kbase1, Collections.singletonList(wm), new HashSet<>());
+        assertSegmentsLengthAndPos(endNode0, 3, wm);
+        assertSegmentsLengthAndPos(endNode1, 2, oldSmemProtos, smemProtoE2, wm);
+
+        assertThat(endNode0.getSegmentPrototypes()[0]).isSameAs(smemProto0);
+        assertThat(endNode0.getSegmentPrototypes()[1]).isSameAs(smemProtoE);
+        assertThat(endNode0.getSegmentPrototypes()[2]).isSameAs(smemProtoE2);
+
+        assertThat(smemProtoE.getNodesInSegment().length).isEqualTo(3);
+        assertThat(smemProtoE2.getNodesInSegment().length).isEqualTo(2);
+
+        assertThat(smemProtoE.getPos()).isEqualTo(1);
+        assertThat(smemProtoE2.getPos()).isEqualTo(2);
+
+        assertThat(smemProtoE.getSegmentPosMaskBit()).isEqualTo(2);
+        assertThat(smemProtoE2.getSegmentPosMaskBit()).isEqualTo(4);
+
+        assertThat(smemProtoE.getAllLinkedMaskTest()).isEqualTo(7);
+        assertThat(smemProtoE2.getAllLinkedMaskTest()).isEqualTo(1);
+    }
+
+    @Test
+    public void testAddWithSplitThenCreateThirdSplitInSamePos() {
+        InternalKnowledgeBase kbase1 = buildKnowledgeBase("r",
+                                                          "   a : A() B() C() E(1;) E(2;) E(3;) E(4;)\n",
+                                                          "   A() B() C() X() Y()\n");
+
+        InternalWorkingMemory wm = (InternalWorkingMemory) kbase1.newKieSession();
+        ObjectTypeNode aotn = getObjectTypeNode(kbase1.getRete(), A.class);
+        ObjectTypeNode eotn = getObjectTypeNode(kbase1.getRete(), E.class);
+        ObjectTypeNode cotn = getObjectTypeNode(kbase1.getRete(), C.class);
+        ObjectTypeNode xotn = getObjectTypeNode(kbase1.getRete(), X.class);
+        ObjectTypeNode yotn = getObjectTypeNode(kbase1.getRete(), Y.class);
+
+        LeftInputAdapterNode lian = (LeftInputAdapterNode) aotn.getSinks()[0];
+        BetaNode ebeta = (BetaNode) eotn.getSinks()[0].getSinks()[0];
+        BetaNode cbeta = (BetaNode) cotn.getSinks()[0];
+        BetaNode ebeta3 = (BetaNode) eotn.getSinks()[2].getSinks()[0];
+        BetaNode xbeta = (BetaNode) xotn.getSinks()[0];
+
+        Map<Integer, SegmentPrototype> protos = kbase1.getSegmentPrototypes();
+
+        insertAndFlush(wm);
+        wm.fireAllRules();
+
+        SegmentMemory smem = wm.getNodeMemories().getNodeMemory(lian, wm).getSegmentMemory();
+        SegmentPrototype smemProto0 = protos.get(lian.getId());
+        assertThat(smem.getSegmentPrototype()).isSameAs(smemProto0);
+        PathEndNode endNode0 = smemProto0.getPathEndNodes()[0];
+        PathEndNode endNode1 = smemProto0.getPathEndNodes()[1];
+        assertSegmentsLengthAndPos(endNode0, 2, wm);
+        assertSegmentsLengthAndPos(endNode1, 2, wm);
+
+        // processSplit should return null, as it's alreayd split and this does nothing.
+        assertThat(Add.processSplit(cbeta, kbase1, Collections.singletonList(wm), new HashSet<>())).isNull();
+
+        // now add a rule at the given split, so we can check paths were all updated correctly
+        addRuleAtGivenSplit(kbase1, wm, cbeta, yotn);
+
+        BetaNode jbeta = (BetaNode) yotn.getSinks()[1];
+        assertThat(((ClassObjectType)jbeta.getObjectTypeNode().getObjectType()).getClassType()).isSameAs(Y.class);
+        assertThat(jbeta.getLeftTupleSource()).isSameAs(cbeta);
+
+        endNode0 = smemProto0.getPathEndNodes()[0];
+        endNode1 = smemProto0.getPathEndNodes()[1];
+        PathEndNode endNode2 = smemProto0.getPathEndNodes()[2];
+        assertSegmentsLengthAndPos(endNode0, 2, wm);
+        assertSegmentsLengthAndPos(endNode1, 2, wm);
+        assertSegmentsLengthAndPos(endNode2, 2, wm);
+    }
+
+    private static void addRuleAtGivenSplit(InternalKnowledgeBase kbase1, InternalWorkingMemory wm, BetaNode cbeta, ObjectTypeNode yotn) {
+        RuleImpl rule = new RuleImpl("newrule1");
+        BuildContext buildContext = new BuildContext(kbase1, Collections.emptyList() );
+
+        JoinNode joinNode = (JoinNode) BetaNodeBuilder.create(NodeTypeEnums.JoinNode, buildContext)
+                                             .setLeftType( C.class )
+                                             .setBinding( "object", "$object" )
+                                             .setRightType( Y.class )
+                                             .setConstraint( "object", "!=", "$object" ).build(cbeta, yotn);
+
+        joinNode.doAttach(buildContext);
+
+        RuleTerminalNode rtn = new RuleTerminalNode(buildContext.getNextNodeId(), joinNode, rule, new GroupElement(), 0, buildContext);
+        rtn.setPathEndNodes(new PathEndNode[]{rtn});
+        rtn.doAttach(buildContext);
+        Arrays.stream(rtn.getPathNodes()).forEach( n -> {n.addAssociatedTerminal(rtn); ((BaseNode)n).addAssociation(rule);});
+        new EagerPhreakBuilder().addRule(rtn, Collections.singletonList(wm), kbase1);
+    }
+
+    @Test
+    public void testAddWithSplitAndEvalThenCreateThirdSplit() {
+        InternalKnowledgeBase kbase1 = buildKnowledgeBase("r",
+                                                          "   a : A() B() C() eval(1==1) eval(2==2) E(3;) E(4;)\n",
+                                                          "   A() B() C() X()\n");
+
+        InternalWorkingMemory wm = (InternalWorkingMemory) kbase1.newKieSession();
+        ObjectTypeNode aotn = getObjectTypeNode(kbase1.getRete(), A.class);
+        ObjectTypeNode cotn = getObjectTypeNode(kbase1.getRete(), C.class);
+        ObjectTypeNode eotn = getObjectTypeNode(kbase1.getRete(), E.class);
+
+        LeftInputAdapterNode lian = (LeftInputAdapterNode) aotn.getSinks()[0];
+        BetaNode cbeta = (BetaNode) cotn.getSinks()[0];
+        BetaNode ebeta3 = (BetaNode) eotn.getSinks()[0].getSinks()[0];
+        EvalConditionNode evnode = (EvalConditionNode)  cbeta.getSinks()[0];
+
+        Map<Integer, SegmentPrototype> protos = kbase1.getSegmentPrototypes();
+
+        insertAndFlush(wm);
+
+        SegmentMemory smem = wm.getNodeMemories().getNodeMemory(lian, wm).getSegmentMemory();
+        SegmentPrototype smemProto0 = protos.get(lian.getId());
+        PathEndNode endNode1 = smemProto0.getPathEndNodes()[1];
+        assertSegmentsLengthAndPos(endNode1, 2, wm);
+
+        SegmentPrototype smemProtoEV = protos.get(evnode.getId());
+        assertThat(smemProtoEV.getNodesInSegment().length).isEqualTo(5);
+        assertThat(smemProtoEV.getPos()).isEqualTo(1);
+        assertThat(smemProtoEV.getAllLinkedMaskTest()).isEqualTo(12); // first two are evals, so each is 0
+
+        SegmentPrototype[] oldSmemProtos = endNode1.getSegmentPrototypes();
+        SegmentPrototype smemProtoE4 = Add.processSplit(ebeta3, kbase1, Collections.singletonList(wm), new HashSet<>());
+
+        assertSegmentsLengthAndPos(endNode1, 2, oldSmemProtos, smemProtoE4, wm);
+
+
+        assertThat(smemProtoEV.getSegmentPosMaskBit()).isEqualTo(2);
+        assertThat(smemProtoE4.getSegmentPosMaskBit()).isEqualTo(4);
+
+        assertThat(smemProtoEV.getAllLinkedMaskTest()).isEqualTo(4);
+        assertThat(smemProtoE4.getAllLinkedMaskTest()).isEqualTo(1);
+    }
+
+    @Test
+    public void testChildProtosPosAndEndNodeSegmentsUpdated() {
+        InternalKnowledgeBase kbase1 = buildKnowledgeBase("r",
+                                                          "   a : A() B() B(1;) C(1;) X() X(1;) X(2;) E()\n",
+                                                          "   a : A() B() B(1;) C(1;) X() X(1;) X(3;)\n",
+                                                          "   a : A() B() B(1;) C(2;)\n");
+
+        InternalWorkingMemory wm = (InternalWorkingMemory) kbase1.newKieSession();
+        ObjectTypeNode aotn = getObjectTypeNode(kbase1.getRete(), A.class);
+        ObjectTypeNode botn = getObjectTypeNode(kbase1.getRete(), B.class);
+
+        LeftInputAdapterNode lian = (LeftInputAdapterNode) aotn.getSinks()[0];
+        BetaNode bbeta = (BetaNode) botn.getSinks()[0];
+
+        Map<Integer, SegmentPrototype> protos = kbase1.getSegmentPrototypes();
+
+        insertAndFlush(wm);
+
+        SegmentPrototype smemProto0 = protos.get(lian.getId());
+        PathEndNode endNode0 = smemProto0.getPathEndNodes()[0];
+        assertThat(endNode0.getPathMemSpec().allLinkedTestMask()).isEqualTo(7);
+        assertThat(endNode0.getPathMemSpec().smemCount()).isEqualTo(3);
+
+        assertSegmentsLengthAndPos(endNode0, 3, wm);
+
+        SegmentPrototype[] oldSmemProtos = endNode0.getSegmentPrototypes();
+        SegmentPrototype smemProto1 = Add.processSplit(bbeta, kbase1, Collections.singletonList(wm), new HashSet<>());
+
+        assertSegmentsLengthAndPos(endNode0, 4, oldSmemProtos, smemProto1, wm);
+        assertThat(endNode0.getPathMemSpec().allLinkedTestMask()).isEqualTo(15);
+        assertThat(endNode0.getPathMemSpec().smemCount()).isEqualTo(4);
+    }
+
+    /**
+     * This tests that masks and segments are not set, when outside of the subnetwork for a given path.
+     */
+    @Test
+    public void testDataStructuresWithSubnetwork() {
+        InternalKnowledgeBase kbase1 = buildKnowledgeBase("r",
+                                                          "   a : A() B() exists ( C() and C(1;) ) E() X()\n");
+
+        InternalWorkingMemory wm = (InternalWorkingMemory) kbase1.newKieSession();
+        ObjectTypeNode aotn = getObjectTypeNode(kbase1.getRete(), A.class);
+        ObjectTypeNode botn = getObjectTypeNode(kbase1.getRete(), B.class);
+
+        LeftInputAdapterNode lian = (LeftInputAdapterNode) aotn.getSinks()[0];
+
+        Map<Integer, SegmentPrototype> protos = kbase1.getSegmentPrototypes();
+
+        insertAndFlush(wm);
+
+        SegmentPrototype smemProto0 = protos.get(lian.getId());
+
+        PathEndNode endNode0 = smemProto0.getPathEndNodes()[0];
+        assertThat(endNode0.getType()).isEqualTo(NodeTypeEnums.RightInputAdapterNode);
+        assertThat(endNode0.getPathMemSpec().allLinkedTestMask()).isEqualTo(2);
+        assertThat(endNode0.getPathMemSpec().smemCount()).isEqualTo(2);
+
+        PathEndNode endNode1 = smemProto0.getPathEndNodes()[1];
+        assertThat(endNode1.getType()).isEqualTo(NodeTypeEnums.RuleTerminalNode);
+        assertThat(endNode1.getPathMemSpec().allLinkedTestMask()).isEqualTo(3);
+        assertThat(endNode1.getPathMemSpec().smemCount()).isEqualTo(2);
+    }
+
+    @Test
+    public void testFindNewBrancheRootsSimple() {
+        InternalKnowledgeBase kbase1 = buildKnowledgeBase("r",
+                                                          "   a : A() B() C() E()\n",
+                                                          "   a : A() B() X() E()\n");
+
+        ObjectTypeNode cotn = getObjectTypeNode(kbase1.getRete(), C.class);
+        ObjectTypeNode xotn = getObjectTypeNode(kbase1.getRete(), X.class);
+
+        BetaNode cBeta = (BetaNode) cotn.getSinks()[0];
+        BetaNode xBeta = (BetaNode) xotn.getSinks()[0];
+
+        TerminalNode[] tns = kbase1.getReteooBuilder().getTerminalNodes("org.kie.r0");
+        assertThat(tns.length).isEqualTo(1);
+        List<EagerPhreakBuilder.Pair> branchRoots =  EagerPhreakBuilder.getExclusiveBranchRoots(tns[0]);
+        assertThat(branchRoots.size()).isEqualTo(1);
+        assertThat(((Pair)branchRoots.toArray()[0]).child).isSameAs(cBeta);
+
+        tns = kbase1.getReteooBuilder().getTerminalNodes("org.kie.r1");
+        assertThat(tns.length).isEqualTo(1);
+        branchRoots =  EagerPhreakBuilder.getExclusiveBranchRoots(tns[0]);
+        assertThat(branchRoots.size()).isEqualTo(1);
+        assertThat(((Pair)branchRoots.toArray()[0]).child).isSameAs(xBeta);
+    }
+
+    @Test
+    public void testNewBrancheRootsWithSubnetwork() {
+        InternalKnowledgeBase kbase1 = buildKnowledgeBase("r",
+                                                          "   a : A() B(1;) C() E() X()\n",
+                                                          "   a : A() B(1;) C() exists ( E() and F() ) B(2;)\n");
+
+        ObjectTypeNode cotn = getObjectTypeNode(kbase1.getRete(), C.class);
+        ObjectTypeNode fotn = getObjectTypeNode(kbase1.getRete(), F.class);
+        ObjectTypeNode xotn = getObjectTypeNode(kbase1.getRete(), X.class);
+        ObjectTypeNode botn = getObjectTypeNode(kbase1.getRete(), B.class);
+
+        BetaNode fBeta = (BetaNode) fotn.getSinks()[0];
+        BetaNode xBeta = (BetaNode) xotn.getSinks()[0];
+        ExistsNode exists = (ExistsNode) ((LeftTupleNode)botn.getSinks()[1].getSinks()[0]).getLeftTupleSource();
+
+        TerminalNode[] tns = kbase1.getReteooBuilder().getTerminalNodes("org.kie.r0");
+        assertThat(tns.length).isEqualTo(1);
+        List<EagerPhreakBuilder.Pair> branchRoots =  EagerPhreakBuilder.getExclusiveBranchRoots(tns[0]);
+        assertThat(branchRoots.size()).isEqualTo(1);
+        Pair[] pairs = branchRoots.toArray(new Pair[1]);
+        assertThat(pairs[0].child).isSameAs(xBeta);
+
+        tns = kbase1.getReteooBuilder().getTerminalNodes("org.kie.r1");
+        assertThat(tns.length).isEqualTo(1);
+        branchRoots =  EagerPhreakBuilder.getExclusiveBranchRoots(tns[0]);
+        assertThat(branchRoots.size()).isEqualTo(2);
+        assertThat(((Pair)branchRoots.toArray()[0]).child).isSameAs(exists);
+        assertThat(((Pair)branchRoots.toArray()[1]).child).isSameAs(fBeta);
+    }
+
+    private static void insertAndFlush(InternalWorkingMemory wm) {
+        wm.insert(new A(1));
+        wm.insert(new B(1));
+        wm.insert(new B(2));
+        wm.insert(new C(1));
+        wm.insert(new C(2));
+        wm.insert(new E(1));
+        wm.insert(new E(2));
+        wm.insert(new E(3));
+        wm.insert(new E(4));
+        wm.insert(new X(1));
+        wm.insert(new Y(1));
+
+        wm.setGlobal("list", new ArrayList<>());
+        wm.flushPropagations();
+    }
+
+    private static void assertSegmentsLengthAndPos(PathEndNode endNode, int s, InternalWorkingMemory wm) {
+        assertSegmentsLengthAndPos(endNode, s, null, null, wm);
+    }
+
+    private static void assertSegmentsLengthAndPos(PathEndNode endNode, int s, SegmentPrototype[] oldProtos, SegmentPrototype newProto, InternalWorkingMemory wm) {
+        assertThat(endNode.getSegmentPrototypes().length).isEqualTo(s);
+        int smemOffset = 0;
+        int bitPos = 1;
+
+        for (int i = 0; i < endNode.getSegmentPrototypes().length; i++) {
+            assertThat(endNode.getSegmentPrototypes()[i].getPos()).isEqualTo(i);
+            assertThat(endNode.getSegmentPrototypes()[i].getSegmentPosMaskBit()).isEqualTo(bitPos);
+            bitPos = bitPos << 1;
+        }
+
+        if (oldProtos != null) {
+            // if old protos exist, assert the split was done correctly and protos all match as expected
+            for (int i = 0; i < endNode.getSegmentPrototypes().length; i++) {
+                if (i == newProto.getPos()) {
+                    // assert the inserted proto, and set the offset
+                    assertThat(newProto).isSameAs(endNode.getSegmentPrototypes()[newProto.getPos()]);
+                    smemOffset = 1;
+                } else {
+                    assertThat(oldProtos[i - smemOffset]).isSameAs(endNode.getSegmentPrototypes()[i]);
+                }
+            }
+        }
+
+        SegmentPrototype startProto = wm.getKnowledgeBase().getSegmentPrototype(endNode.getStartTupleSource());
+        // ensure all smems are null before start SmemProto. If startProto pos is 0, skip this
+        for (int i = 0; i < startProto.getPos(); i++) {
+            assertThat(endNode.getSegmentPrototypes()[i]).isNull();
+        }
+
+        // assert that all segments contain this path
+        for (int i = 0; i < endNode.getSegmentPrototypes().length; i++) {
+            SegmentPrototype proto = endNode.getSegmentPrototypes()[i];
+            if ( proto != null) { // protos before startTupleSource will be null
+                asList(proto.getPathEndNodes()).contains(endNode);
+            }
+        }
+
+        if ( wm == null ) {
+            return;
+        }
+
+        for (int i = 0; i < endNode.getSegmentPrototypes().length; i++) {
+            SegmentPrototype proto = endNode.getSegmentPrototypes()[i];
+
+            Memory m = wm.getNodeMemories().peekNodeMemory(proto.getRootNode());
+            SegmentMemory sm = m.getSegmentMemory();
+
+            assertThat(sm.getSegmentPrototype()).isSameAs(proto);
+            assertThat(sm.getRootNode()).isSameAs(proto.getRootNode());
+            assertThat(sm.getTipNode()).isSameAs(proto.getTipNode());
+
+            assertThat(sm.getPos()).isEqualTo(proto.getPos());
+            assertThat(sm.getAllLinkedMaskTest()).isEqualTo(proto.getAllLinkedMaskTest());
+            assertThat(sm.getSegmentPosMaskBit()).isEqualTo(proto.getSegmentPosMaskBit());
+        }
+    }
+
 
     @Test
     public void testPopulatedSingleRuleNoSharing() {
@@ -456,10 +930,10 @@ public class AddRuleTest {
         RuleTerminalNode rtn5 = getRtn( "org.kie.r5", kbase1 );
         if (PhreakBuilder.isEagerSegmentCreation()) {
             PathMemory pm5 = (PathMemory) wm.getNodeMemories().peekNodeMemory(rtn5.getMemoryId());
-            assertThat(pm5.getSegmentMemories()).isEqualTo(new SegmentMemory[2]); // this path is not yet initialised, as there is no inserted data
-            assertThat(pm5.getPathEndNode().getSegmentPrototypes().length).isEqualTo(2); // make sure it's proto was created successfully
+            assertThat(pm5).isNull(); // this path is not yet initialised, as there is no inserted data
+            assertThat(rtn5.getSegmentPrototypes().length).isEqualTo(2); // make sure it's proto was created successfully
         } else {
-            PathMemory pm5 = wm.getNodeMemory(rtn5);
+            PathMemory pm5 = (PathMemory) wm.getNodeMemories().peekNodeMemory(rtn5.getMemoryId());
             smems = pm5.getSegmentMemories();
             assertThat(smems.length).isEqualTo(2);
             assertThat(smems[0]).isNull();
@@ -535,10 +1009,10 @@ public class AddRuleTest {
         RuleTerminalNode rtn5 = getRtn( "org.kie.r5", kbase1 );
         if (PhreakBuilder.isEagerSegmentCreation()) {
             PathMemory pm5 = (PathMemory) wm.getNodeMemories().peekNodeMemory(rtn5.getMemoryId());
-            assertThat(pm5.getSegmentMemories()).isEqualTo( new SegmentMemory[2]); // this path is not yet initialised, as there is no inserted data
-            assertThat(pm5.getPathEndNode().getSegmentPrototypes().length).isEqualTo(2); // make sure it's proto was created successfully
+            assertThat(pm5).isNull(); // this path is not yet initialised, as there is no inserted data
+            assertThat(rtn5.getSegmentPrototypes().length).isEqualTo(2); // make sure it's proto was created successfully
         } else {
-            PathMemory pm5 = wm.getNodeMemory(rtn5);
+            PathMemory pm5 =  (PathMemory) wm.getNodeMemories().peekNodeMemory(rtn5.getMemoryId());
             smems = pm5.getSegmentMemories();
             assertThat(smems.length).isEqualTo(2);
             assertThat(smems[0]).isNull();
@@ -615,25 +1089,29 @@ public class AddRuleTest {
         return ( RuleTerminalNode ) ((RuleBase) kbase).getReteooBuilder().getTerminalNodes(ruleName)[0];
     }
 
-    private InternalKnowledgeBase buildKnowledgeBase(String ruleName, String rule) {
+    private InternalKnowledgeBase buildKnowledgeBase(String ruleName, String... rule) {
         return (InternalKnowledgeBase)KieBaseUtil.getKieBaseFromKieModuleFromDrl("test", kieBaseTestConfiguration, buildKnowledgePackageDrl(ruleName, rule));
     }
 
-    private String buildKnowledgePackageDrl(String ruleName, String rule) {
+    private String buildKnowledgePackageDrl(String ruleName, String... rule) {
         String str = "";
         str += "package org.kie \n";
         str += "import " + A.class.getCanonicalName() + "\n";
         str += "import " + B.class.getCanonicalName() + "\n";
         str += "import " + C.class.getCanonicalName() + "\n";
-        str += "import " + X.class.getCanonicalName() + "\n";
         str += "import " + E.class.getCanonicalName() + "\n";
+        str += "import " + F.class.getCanonicalName() + "\n";
+        str += "import " + X.class.getCanonicalName() + "\n";
+        str += "import " + Y.class.getCanonicalName() + "\n";
         str += "global java.util.List list \n";
 
-        str += "rule " + ruleName + "  when \n";
-        str += rule;
-        str += "then \n";
-        str += " list.add( kcontext.getMatch() );\n";
-        str += "end \n";
+        for (int i = 0; i < rule.length; i++) {
+            str += "rule " + (rule.length == 1 ? ruleName : ruleName + i )+ "  when \n";
+            str += rule[i];
+            str += "then \n";
+            str += " list.add( kcontext.getMatch() );\n";
+            str += "end \n";
+        }
 
         return str;
     }

--- a/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/integrationtests/phreak/BetaNodeBuilder.java
+++ b/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/integrationtests/phreak/BetaNodeBuilder.java
@@ -15,6 +15,7 @@
 
 package org.drools.mvel.integrationtests.phreak;
 
+import org.drools.core.reteoo.LeftTupleSource;
 import org.drools.mvel.accessors.ClassFieldAccessorStore;
 import org.drools.core.base.ClassObjectType;
 import org.drools.core.common.BetaConstraints;
@@ -25,7 +26,6 @@ import org.drools.core.reteoo.CoreComponentFactory;
 import org.drools.core.reteoo.EntryPointNode;
 import org.drools.core.reteoo.ExistsNode;
 import org.drools.core.reteoo.JoinNode;
-import org.drools.core.reteoo.LeftInputAdapterNode;
 import org.drools.core.reteoo.NodeTypeEnums;
 import org.drools.core.reteoo.NotNode;
 import org.drools.core.reteoo.ObjectSource;
@@ -83,6 +83,10 @@ public class BetaNodeBuilder {
     }
 
     public BetaNode build() {
+        return build(null, null);
+    }
+
+    public BetaNode build(LeftTupleSource leftInput, ObjectSource rightInput) {
         NodeFactory nFactory = CoreComponentFactory.get().getNodeFactoryService();
 
         EntryPointNode epn = buildContext.getRuleBase().getRete().getEntryPointNodes().values().iterator().next();
@@ -92,12 +96,16 @@ public class BetaNodeBuilder {
                                                           new ClassObjectType(leftType),
                                                           buildContext);
 
-        LeftInputAdapterNode leftInput = nFactory.buildLeftInputAdapterNode(buildContext.getNextNodeId(), otn, buildContext, false);
+        if (leftInput == null) {
+            leftInput = nFactory.buildLeftInputAdapterNode(buildContext.getNextNodeId(), otn, buildContext, false);
+        }
 
-        ObjectSource rightInput = nFactory.buildObjectTypeNode(buildContext.getNextNodeId(),
-                                                               epn,
-                                                               new ClassObjectType(rightType),
-                                                               buildContext);
+        if (rightInput == null) {
+            rightInput = nFactory.buildObjectTypeNode(buildContext.getNextNodeId(),
+                                                      epn,
+                                                      new ClassObjectType(rightType),
+                                                      buildContext);
+        }
 
         ReteTesterHelper reteTesterHelper = new ReteTesterHelper();
 
@@ -124,11 +132,11 @@ public class BetaNodeBuilder {
 
         switch (nodeType) {
             case NodeTypeEnums.JoinNode:
-                return new JoinNode(0, leftInput, rightInput, betaConstraints, buildContext);
+                return new JoinNode(buildContext.getNextNodeId(), leftInput, rightInput, betaConstraints, buildContext);
             case NodeTypeEnums.NotNode:
-                return new NotNode(0, leftInput, rightInput, betaConstraints, buildContext);
+                return new NotNode(buildContext.getNextNodeId(), leftInput, rightInput, betaConstraints, buildContext);
             case NodeTypeEnums.ExistsNode:
-                return new ExistsNode(0, leftInput, rightInput, betaConstraints, buildContext);
+                return new ExistsNode(buildContext.getNextNodeId(), leftInput, rightInput, betaConstraints, buildContext);
         }
         throw new IllegalStateException("Unable to build Node");
     }

--- a/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/integrationtests/phreak/C.java
+++ b/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/integrationtests/phreak/C.java
@@ -27,17 +27,17 @@ public class C {
         this.object = object;
     }
 
-    public static C b(Object object) {
+    public static C c(Object object) {
         return new C( object );
     }
 
-    public static C[] b(Object... objects) {
-        C[] bs = new C[objects.length];
+    public static C[] c(Object... objects) {
+        C[] cs = new C[objects.length];
         int i = 0;
         for ( Object object : objects ) {
-            bs[i++] = new C( object );
+            cs[i++] = new C( object );
         }
-        return bs;
+        return cs;
     }        
 
     public Object getObject() {

--- a/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/integrationtests/phreak/F.java
+++ b/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/integrationtests/phreak/F.java
@@ -17,27 +17,27 @@ package org.drools.mvel.integrationtests.phreak;
 
 import org.kie.api.definition.type.Position;
 
-public class E {
+public class F {
 
     @Position(0)
     Object object;
 
-    public E(Object object) {
+    public F(Object object) {
         super();
         this.object = object;
     }
 
-    public static E e(Object object) {
-        return new E( object );
+    public static F f(Object object) {
+        return new F(object );
     }
 
-    public static E[] e(Object... objects) {
-        E[] es = new E[objects.length];
+    public static F[] f(Object... objects) {
+        F[] fs = new F[objects.length];
         int i = 0;
         for ( Object object : objects ) {
-            es[i++] = new E( object );
+            fs[i++] = new F(object );
         }
-        return es;
+        return fs;
     }        
 
     public Object getObject() {
@@ -61,7 +61,7 @@ public class E {
         if ( this == obj ) return true;
         if ( obj == null ) return false;
         if ( getClass() != obj.getClass() ) return false;
-        E other = (E) obj;
+        F other = (F) obj;
         if ( object == null ) {
             if ( other.object != null ) return false;
         } else if ( !object.equals( other.object ) ) return false;
@@ -70,7 +70,7 @@ public class E {
 
     @Override
     public String toString() {
-        return "E [" + object + "]";
+        return "D [" + object + "]";
     }
 
 }

--- a/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/integrationtests/phreak/PhreakJoinNodeTest.java
+++ b/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/integrationtests/phreak/PhreakJoinNodeTest.java
@@ -230,7 +230,7 @@ public class PhreakJoinNodeTest {
         return new Scenario( phreakNode, joinNode, sinkNode, bm, wm );
     }
 
-    public BuildContext createContext() {
+    public static BuildContext createContext() {
 
         CompositeBaseConfiguration conf = (CompositeBaseConfiguration) RuleBaseFactory.newKnowledgeBaseConfiguration();
 

--- a/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/integrationtests/phreak/RemoveRuleTest.java
+++ b/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/integrationtests/phreak/RemoveRuleTest.java
@@ -54,7 +54,6 @@ public class RemoveRuleTest {
     private final KieBaseTestConfiguration kieBaseTestConfiguration;
 
     public RemoveRuleTest(KieBaseTestConfiguration kieBaseTestConfiguration) {
-        System.setProperty("drools.useEagerSegmentCreation", "true");
         this.kieBaseTestConfiguration = kieBaseTestConfiguration;
     }
 

--- a/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/integrationtests/phreak/RemoveRuleTest.java
+++ b/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/integrationtests/phreak/RemoveRuleTest.java
@@ -54,6 +54,7 @@ public class RemoveRuleTest {
     private final KieBaseTestConfiguration kieBaseTestConfiguration;
 
     public RemoveRuleTest(KieBaseTestConfiguration kieBaseTestConfiguration) {
+        System.setProperty("drools.useEagerSegmentCreation", "true");
         this.kieBaseTestConfiguration = kieBaseTestConfiguration;
     }
 
@@ -90,11 +91,11 @@ public class RemoveRuleTest {
 
         wm.fireAllRules();
 
-        BetaMemory bMem = ( BetaMemory ) sm.getNodeMemories().get(1);
+        BetaMemory bMem = ( BetaMemory ) sm.getNodeMemories()[1];
         assertThat(bMem.getLeftTupleMemory().size()).isEqualTo(1);
         assertThat(bMem.getRightTupleMemory().size()).isEqualTo(1);
 
-        BetaMemory eMem = ( BetaMemory ) sm.getNodeMemories().get(4);
+        BetaMemory eMem = ( BetaMemory ) sm.getNodeMemories()[4];
         assertThat(eMem.getLeftTupleMemory().size()).isEqualTo(1);
         assertThat(eMem.getRightTupleMemory().size()).isEqualTo(1);
 
@@ -640,6 +641,7 @@ public class RemoveRuleTest {
 
     @Test
     public void testPathMemorySizeAfterSegmentMerge() throws Exception {
+        // The two A(1;) are not actually shared, as r2 creates an AlphaTerminalNode
         InternalKnowledgeBase kbase1 = buildKnowledgeBase("r1", "   A(1;) B(1;)\n" );
         kbase1.addPackages( buildKnowledgePackage("r2", "   A(1;)\n") );
         InternalWorkingMemory wm = ((InternalWorkingMemory)kbase1.newKieSession());

--- a/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/integrationtests/phreak/X.java
+++ b/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/integrationtests/phreak/X.java
@@ -27,11 +27,11 @@ public class X {
         this.object = object;
     }
 
-    public static X b(Object object) {
+    public static X x(Object object) {
         return new X(object );
     }
 
-    public static X[] b(Object... objects) {
+    public static X[] x(Object... objects) {
         X[] bs = new X[objects.length];
         int i = 0;
         for ( Object object : objects ) {

--- a/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/integrationtests/phreak/Y.java
+++ b/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/integrationtests/phreak/Y.java
@@ -17,27 +17,27 @@ package org.drools.mvel.integrationtests.phreak;
 
 import org.kie.api.definition.type.Position;
 
-public class E {
+public class Y {
 
     @Position(0)
     Object object;
 
-    public E(Object object) {
+    public Y(Object object) {
         super();
         this.object = object;
     }
 
-    public static E e(Object object) {
-        return new E( object );
+    public static Y y(Object object) {
+        return new Y(object );
     }
 
-    public static E[] e(Object... objects) {
-        E[] es = new E[objects.length];
+    public static Y[] y(Object... objects) {
+        Y[] bs = new Y[objects.length];
         int i = 0;
         for ( Object object : objects ) {
-            es[i++] = new E( object );
+            bs[i++] = new Y(object );
         }
-        return es;
+        return bs;
     }        
 
     public Object getObject() {
@@ -61,7 +61,7 @@ public class E {
         if ( this == obj ) return true;
         if ( obj == null ) return false;
         if ( getClass() != obj.getClass() ) return false;
-        E other = (E) obj;
+        Y other = (Y) obj;
         if ( object == null ) {
             if ( other.object != null ) return false;
         } else if ( !object.equals( other.object ) ) return false;
@@ -70,7 +70,7 @@ public class E {
 
     @Override
     public String toString() {
-        return "E [" + object + "]";
+        return "Y [" + object + "]";
     }
 
 }


### PR DESCRIPTION
QE have benchmarked and Mario has approved. @Ignores no longer present and the EAGER_SEGMENT_CREATION is now correctly settable from a system property. Note These should move to Options as a later PR.
private static final boolean EAGER_SEGMENT_CREATION = Boolean.parseBoolean(System.getProperty("drools.useEagerSegmentCreation", "true"));