### PR TITLE
Link cach name to PersistedSessionOption.sessionId

### DIFF
--- a/drools-reliability/src/test/java/org/drools/reliability/Person.java
+++ b/drools-reliability/src/test/java/org/drools/reliability/Person.java
@@ -46,4 +46,32 @@ public class Person implements Serializable {
     public String toString() {
         return "Person [name=" + name + ", age=" + age + "]@" + Integer.toHexString(System.identityHashCode(this));
     }
+
+    @Override
+    public int hashCode() {
+        final int prime = 31;
+        int result = 1;
+        result = prime * result + age;
+        result = prime * result + ((name == null) ? 0 : name.hashCode());
+        return result;
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        if (this == obj)
+            return true;
+        if (obj == null)
+            return false;
+        if (getClass() != obj.getClass())
+            return false;
+        Person other = (Person) obj;
+        if (age != other.age)
+            return false;
+        if (name == null) {
+            if (other.name != null)
+                return false;
+        } else if (!name.equals(other.name))
+            return false;
+        return true;
+    }
 }


### PR DESCRIPTION
changes in this PR:
- a PersistedSessionOption is created from a sessionId. If it's a new session we initiate sessionId to the working memory counter.
- SessionConfiguration updated to include the option PersistedSessionOption
- a cache is created as "cacheSession_sessionId"
- ReliabilityTest was revised to test the functionality of creating three sessions: first-session is new, second-session is created from the first-session, third-session is new. At the end of this test we expect to have only two cache folders on the disk, cacheSession_0 and cacheSession_2.
