### PR TITLE
RHDM-1957 DROOLS-7267 DMN extend rule to catch non-normalized named elements

### DIFF
--- a/kie-dmn/kie-dmn-core/src/main/java/org/kie/dmn/core/util/Msg.java
+++ b/kie-dmn/kie-dmn-core/src/main/java/org/kie/dmn/core/util/Msg.java
@@ -41,6 +41,8 @@ public final class Msg {
     public static final Message2 UNKNOWN_FEEL_TYPE_REF_ON_NODE                       = new Message2( DMNMessageType.TYPE_REF_NOT_FOUND, "Type reference '%s' is not a valid FEEL type reference on node '%s'" );
     public static final Message1 UNKNOWN_OUTPUT_TYPE_FOR_DT_ON_NODE                  = new Message1( DMNMessageType.TYPE_REF_NOT_FOUND, "Unknown output type for decision table on node '%s'" );
     public static final Message2 INVALID_NAME                                        = new Message2( DMNMessageType.INVALID_NAME, "Invalid name '%s': %s" );
+    public static final Message3 NAME_NOT_NORMALIZED                                 = new Message3( DMNMessageType.INVALID_NAME, "Name '%s' contains whitespace which is not normalized for element %s with id '%s'" );
+    public static final Message3 NAME_NOT_TRIMMED                                    = new Message3( DMNMessageType.INVALID_NAME, "Name '%s' is not trimmed for element %s with id '%s'" );
     public static final Message1 INVALID_SYNTAX                                      = new Message1( DMNMessageType.INVALID_SYNTAX, "%s: invalid syntax" );
     public static final Message2 INVALID_SYNTAX2                                     = new Message2( DMNMessageType.INVALID_SYNTAX, "%s: %s" );
     public static final Message1 MISSING_EXPRESSION_FOR_BKM                          = new Message1( DMNMessageType.MISSING_EXPRESSION, "Missing expression for Business Knowledge Model node '%s'" );

--- a/kie-dmn/kie-dmn-legacy-tests/src/test/java/org/kie/dmn/legacy/tests/validation/v1_1/ValidatorTest.java
+++ b/kie-dmn/kie-dmn-legacy-tests/src/test/java/org/kie/dmn/legacy/tests/validation/v1_1/ValidatorTest.java
@@ -240,9 +240,15 @@ public class ValidatorTest extends AbstractValidatorTest {
     @Test
     public void testVARIABLE_LEADING_TRAILING_SPACES() {
         List<DMNMessage> validate = validator.validate( getReader( "VARIABLE_LEADING_TRAILING_SPACES.dmn" ), VALIDATE_SCHEMA, VALIDATE_MODEL, VALIDATE_COMPILATION);
-        assertThat(validate).as(ValidatorUtil.formatMessages(validate)).hasSize(1);
-        assertThat(validate.stream().anyMatch(p -> p.getMessageType().equals(DMNMessageType.INVALID_NAME))).isTrue();
-        assertThat( validate.get(0).getSourceId()).isEqualTo("_dd662d27-7896-42cb-9d14-bd74203bdbec");
+        assertThat(validate).withFailMessage(ValidatorUtil.formatMessages(validate)).isNotEmpty();
+        assertThat(validate).anySatisfy(p -> {
+            assertThat(p.getMessageType()).isEqualTo(DMNMessageType.INVALID_NAME);
+            assertThat(p.getSourceId()).isEqualTo("_dd662d27-7896-42cb-9d14-bd74203bdbec");
+        });
+        assertThat(validate).anySatisfy(p -> {
+            assertThat(p.getMessageType()).isEqualTo(DMNMessageType.INVALID_NAME);
+            assertThat(p.getSourceId()).isEqualTo("_1f54fd51-6805-4280-b576-607450f85edd");
+        });
     }
 
     @Test

--- a/kie-dmn/kie-dmn-validation/src/main/resources/org/kie/dmn/validation/DMNv1x/dmn-validation-rules.drl
+++ b/kie-dmn/kie-dmn-validation/src/main/resources/org/kie/dmn/validation/DMNv1x/dmn-validation-rules.drl
@@ -76,6 +76,20 @@ then
     }
 end
 
+rule NAME_NOT_TRIMMED
+when
+    $ne : NamedElement( name != null, name str[startsWith] " " || name str[endsWith] " " )
+then
+    reporter.report( DMNMessage.Severity.WARN, $ne , Msg.NAME_NOT_TRIMMED, $ne.getName(), $ne.getClass().getSimpleName(), $ne.getId() );
+end
+
+rule NAME_NOT_NORMALIZED
+when
+    $ne : NamedElement( name != null, name contains "  " )
+then
+    reporter.report( DMNMessage.Severity.WARN, $ne , Msg.NAME_NOT_NORMALIZED, $ne.getName(), $ne.getClass().getSimpleName(), $ne.getId() );
+end
+
 rule VARIABLE_LEADING_TRAILING_SPACES
 when
   $ce1 : InformationItem( name != null,

--- a/kie-dmn/kie-dmn-validation/src/test/java/org/kie/dmn/validation/ValidatorTest.java
+++ b/kie-dmn/kie-dmn-validation/src/test/java/org/kie/dmn/validation/ValidatorTest.java
@@ -243,9 +243,29 @@ public class ValidatorTest extends AbstractValidatorTest {
     @Test
     public void testVARIABLE_LEADING_TRAILING_SPACES() {
         List<DMNMessage> validate = validator.validate( getReader( "VARIABLE_LEADING_TRAILING_SPACES.dmn" ), VALIDATE_SCHEMA, VALIDATE_MODEL, VALIDATE_COMPILATION);
-        assertThat(validate).withFailMessage(ValidatorUtil.formatMessages(validate)).hasSize(1);
-        assertThat(validate.stream().anyMatch(p -> p.getMessageType().equals(DMNMessageType.INVALID_NAME))).isTrue();
-        assertThat(validate.get(0).getSourceId()).isEqualTo("_dd662d27-7896-42cb-9d14-bd74203bdbec");
+        assertThat(validate).withFailMessage(ValidatorUtil.formatMessages(validate)).isNotEmpty();
+        assertThat(validate).anySatisfy(p -> {
+            assertThat(p.getMessageType()).isEqualTo(DMNMessageType.INVALID_NAME);
+            assertThat(p.getSourceId()).isEqualTo("_dd662d27-7896-42cb-9d14-bd74203bdbec");
+        });
+        assertThat(validate).anySatisfy(p -> {
+            assertThat(p.getMessageType()).isEqualTo(DMNMessageType.INVALID_NAME);
+            assertThat(p.getSourceId()).isEqualTo("_1f54fd51-6805-4280-b576-607450f85edd");
+        });
+    }
+    
+    @Test
+    public void testNAME_NOT_NORMALIZED() {
+        List<DMNMessage> validate = validator.validate( getReader( "NAME_NOT_NORMALIZED.dmn" ), VALIDATE_SCHEMA, VALIDATE_MODEL, VALIDATE_COMPILATION);
+        assertThat(validate).withFailMessage(ValidatorUtil.formatMessages(validate)).isNotEmpty();
+        assertThat(validate).anySatisfy(p -> {
+            assertThat(p.getMessageType()).isEqualTo(DMNMessageType.INVALID_NAME);
+            assertThat(p.getSourceId()).isEqualTo("_7E95B3C8-9276-46EA-87D4-22FDE87DC039");
+        });
+        assertThat(validate).anySatisfy(p -> {
+            assertThat(p.getMessageType()).isEqualTo(DMNMessageType.INVALID_NAME);
+            assertThat(p.getSourceId()).isEqualTo("_07210027-8B43-4DA0-8C0D-69D3E695D23D");
+        });
     }
 
     @Test

--- a/kie-dmn/kie-dmn-validation/src/test/resources/org/kie/dmn/validation/NAME_NOT_NORMALIZED.dmn
+++ b/kie-dmn/kie-dmn-validation/src/test/resources/org/kie/dmn/validation/NAME_NOT_NORMALIZED.dmn
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<dmn:definitions xmlns:dmn="http://www.omg.org/spec/DMN/20180521/MODEL/" xmlns="https://kiegroup.org/dmn/_20972D0B-9CB3-4A73-A569-C983D1BEC7B5" xmlns:feel="http://www.omg.org/spec/DMN/20180521/FEEL/" xmlns:kie="http://www.drools.org/kie/dmn/1.2" xmlns:dmndi="http://www.omg.org/spec/DMN/20180521/DMNDI/" xmlns:di="http://www.omg.org/spec/DMN/20180521/DI/" xmlns:dc="http://www.omg.org/spec/DMN/20180521/DC/" id="_C5AA6EAF-E151-427A-A53E-E8F12603FD7F" name="NAME_NOT_NORMALIZED" typeLanguage="http://www.omg.org/spec/DMN/20180521/FEEL/" namespace="https://kiegroup.org/dmn/_20972D0B-9CB3-4A73-A569-C983D1BEC7B5">
+  <dmn:extensionElements/>
+  <dmn:inputData id="_063DB141-641F-4820-AF96-3F38978F0A51" name="my input">
+    <dmn:extensionElements/>
+    <dmn:variable id="_12F28EB1-086B-4DC8-9E5D-EF51A3C2EEE7" name="my input" typeRef="Any"/>
+  </dmn:inputData>
+  <!-- introducing manually not-normalized name -->
+  <dmn:decision id="_7E95B3C8-9276-46EA-87D4-22FDE87DC039" name="my  doublespace">
+    <dmn:extensionElements/>
+    <dmn:variable id="_07210027-8B43-4DA0-8C0D-69D3E695D23D" name="my  doublespace" typeRef="Any"/>
+    <dmn:informationRequirement id="_5CDB97B2-13F0-4A39-A0FB-C847459DB81B">
+      <dmn:requiredInput href="#_063DB141-641F-4820-AF96-3F38978F0A51"/>
+    </dmn:informationRequirement>
+    <dmn:literalExpression id="_DD09CEFC-9D02-4142-8E13-0C1AA171E265">
+      <dmn:text>my input</dmn:text>
+    </dmn:literalExpression>
+  </dmn:decision>
+</dmn:definitions>


### PR DESCRIPTION
DROOLS-7267 DMN extend rule to catch non-normalized named elements
align legacy prev xml ser tests

**JIRA**:  https://issues.redhat.com/browse/RHDM-1957

**referenced Pull Requests**: ports:

* https://github.com/kiegroup/drools/pull/4978
* https://github.com/kiegroup/drools/pull/4979
* https://github.com/kiegroup/drools/pull/4980 

<details>
<summary>
How to replicate CI configuration locally?
</summary>

Build Chain tool does "simple" maven build(s), the builds are just Maven commands, but because the repositories relates and depends on each other and any change in API or class method could affect several of those repositories there is a need to use [build-chain tool](https://github.com/kiegroup/github-action-build-chain) to handle cross repository builds and be sure that we always use latest version of the code for each repository.
 
[build-chain tool](https://github.com/kiegroup/github-action-build-chain) is a build tool which can be used on command line locally or in Github Actions workflow(s), in case you need to change multiple repositories and send multiple dependent pull requests related with a change you can easily reproduce the same build by executing it on Github hosted environment or locally in your development environment. See [local execution](https://github.com/kiegroup/github-action-build-chain#local-execution) details to get more information about it.
</details>

<details>
<summary>
How to retest this PR or trigger a specific build:
</summary>

- for <b>pull request checks</b>  
  Please add comment: <b>Jenkins retest this</b>

- for a <b>specific pull request check</b>  
  Please add comment: <b>Jenkins (re)run [drools|kogito-runtimes|kogito-apps|kogito-examples] tests</b>

- for a <b>full downstream build</b> 
  - for <b>jenkins</b> job: please add comment: <b>Jenkins run fdb</b>
  - for <b>github actions</b> job: add the label `run_fdb`

- <b>a compile downstream build</b> please  add comment: <b>Jenkins run cdb</b>

- <b>a full production downstream build</b> please add comment: <b>Jenkins execute product fdb</b>

- <b>an upstream build</b> please add comment: <b>Jenkins run upstream</b>

- for <b>quarkus branch checks</b>  
  Run checks against Quarkus current used branch  
  Please add comment: <b>Jenkins run quarkus-branch</b>

- for a <b>quarkus branch specific check</b>  
  Run checks against Quarkus current used branch  
  Please add comment: <b>Jenkins (re)run [drools|kogito-runtimes|kogito-apps|kogito-examples] quarkus-branch</b>

- for <b>quarkus main checks</b>  
  Run checks against Quarkus main branch  
  Please add comment: <b>Jenkins run quarkus-main</b>

- for a <b>specific quarkus main check</b>  
  Run checks against Quarkus main branch  
  Please add comment: <b>Jenkins (re)run [drools|kogito-runtimes|kogito-apps|kogito-examples] quarkus-main</b>

- for <b>quarkus lts checks</b>  
  Run checks against Quarkus lts branch  
  Please add comment: <b>Jenkins run quarkus-lts</b>

- for a <b>specific quarkus lts check</b>  
  Run checks against Quarkus lts branch  
  Please add comment: <b>Jenkins (re)run [drools|kogito-runtimes|kogito-apps|kogito-examples] quarkus-lts</b>

- for <b>native checks</b>  
  Run native checks  
  Please add comment: <b>Jenkins run native</b>

- for a <b>specific native check</b>  
  Run native checks 
  Please add comment: <b>Jenkins (re)run [drools|kogito-runtimes|kogito-apps|kogito-examples] native</b>

- for <b>mandrel checks</b>  
  Run native checks against Mandrel image
  Please add comment: <b>Jenkins run mandrel</b>

- for a <b>specific mandrel check</b>  
  Run native checks against Mandrel image  
  Please add comment: <b>Jenkins (re)run [drools|kogito-runtimes|kogito-apps|kogito-examples] mandrel</b>

 - for <b>mandrel lts checks</b>  
  Run native checks against Mandrel image and quarkus lts branch
  Please add comment: <b>Jenkins run mandrel-lts</b>

- for a <b>specific mandrel lts check</b>  
  Run native checks against Mandrel image and quarkus lts branch
  Please add comment: <b>Jenkins (re)run [drools|kogito-runtimes|kogito-apps|kogito-examples] mandrel-lts</b>
</details>

<details>
<summary>
How to backport a pull request to a different branch?
</summary>

In order to automatically create a **backporting pull request** please add one or more labels having the following format `backport-<branch-name>`, where `<branch-name>` is the name of the branch where the pull request must be backported to (e.g., `backport-7.67.x` to backport the original PR to the `7.67.x` branch).

> **NOTE**: **backporting** is an action aiming to move a change (usually a commit) from a branch (usually the main one) to another one, which is generally referring to a still maintained release branch. Keeping it simple: it is about to move a specific change or a set of them from one branch to another.

Once the original pull request is successfully merged, the automated action will create one backporting pull request per each label (with the previous format) that has been added.

If something goes wrong, the author will be notified and at this point a manual backporting is needed.

> **NOTE**: this automated backporting is triggered whenever a pull request on `main` branch is labeled or closed, but both conditions must be satisfied to get the new PR created.
</details>