### PR TITLE
DSL: Quarkus branch should have version env

### DIFF
--- a/.ci/jenkins/config/branch.yaml
+++ b/.ci/jenkins/config/branch.yaml
@@ -24,6 +24,8 @@ environments:
   quarkus-branch:
     env_vars:
       QUARKUS_BRANCH: '2.16'
+      # Due to https://github.com/quarkusio/quarkus/pull/30860
+      QUARKUS_VERSION: 2.16.999-SNAPSHOT
     ids:
     - quarkus
   quarkus-lts:


### PR DESCRIPTION
Due to https://github.com/quarkusio/quarkus/pull/30860

- https://github.com/kiegroup/kogito-pipelines/pull/830
- https://github.com/kiegroup/drools/pull/4982
- https://github.com/kiegroup/optaplanner/pull/2578