### PR TITLE
DSL: Update GH token credentials id

### DIFF
--- a/.ci/jenkins/config/branch.yaml
+++ b/.ci/jenkins/config/branch.yaml
@@ -63,7 +63,7 @@ git:
   author:
     name: kiegroup
     credentials_id: kie-ci
-    token_credentials_id: kie-ci3-token
+    token_credentials_id: kie-ci4-token
   bot_author:
     name: bsig-gh-bot
     credentials_id: bsig-gh-bot


### PR DESCRIPTION
This should limit the rate limit issues.
Each project (Drools, Kogito. OptaPlanner) will have its own token.