### PR TITLE
[DROOLS-7326] shade fastutil

### DIFF
--- a/drools-core/pom.xml
+++ b/drools-core/pom.xml
@@ -223,6 +223,36 @@
         </configuration>
       </plugin>
 
+      <plugin>
+        <artifactId>maven-shade-plugin</artifactId>
+        <executions>
+          <execution>
+            <phase>package</phase>
+            <goals>
+              <goal>shade</goal>
+            </goals>
+            <configuration>
+              <createSourcesJar>true</createSourcesJar>
+              <minimizeJar>true</minimizeJar>
+              <artifactSet>
+                <includes>
+                  <include>it.unimi.dsi:fastutil</include>
+                </includes>
+              </artifactSet>
+              <relocations>
+                <relocation>
+                  <pattern>it.unimi.dsi.fastutil</pattern>
+                  <shadedPattern>org.drools.core.shade.it.unimi.dsi.fastutil</shadedPattern>
+                </relocation>
+              </relocations>
+              <transformers>
+                <transformer implementation="org.apache.maven.plugins.shade.resource.ServicesResourceTransformer" />
+              </transformers>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
+      
     </plugins>
   </build>
 </project>


### PR DESCRIPTION
**JIRA**: https://issues.redhat.com/browse/DROOLS-7326

This shade allow us to avoid bringing in the whole `fastutil` dependency that is 23Mb big, but still in this way `drools-core` jar goes from the original 1.6Mb to 2.6, which in my opinion is still a bit too much and I'm not sure if it makes sense given the limited (and optional) use that we do of `fastutil` at the moment.