### PR TITLE
Restored BinaryHeap, but kept getAll improvement and moved it to Arra…

### DIFF
--- a/drools-core/src/main/java/org/drools/core/common/VisitedAgendaGroup.java
+++ b/drools-core/src/main/java/org/drools/core/common/VisitedAgendaGroup.java
@@ -159,4 +159,14 @@ public class VisitedAgendaGroup implements Activation {
     public Object getDeclarationValue(String s) {
         return null;
     }
+
+    @Override
+    public int getQueueIndex() {
+        return 0;
+    }
+
+    @Override
+    public void setQueueIndex(int index) {
+
+    }
 }

--- a/drools-core/src/main/java/org/drools/core/phreak/RuleAgendaItem.java
+++ b/drools-core/src/main/java/org/drools/core/phreak/RuleAgendaItem.java
@@ -72,6 +72,8 @@ public class RuleAgendaItem implements LinkedListNode<RuleAgendaItem>, AgendaIte
      * The activation number
      */
     private           long                                           activationNumber;
+
+    private           int                                            index;
     private           boolean                                        queued;
     private transient InternalAgendaGroup                            agendaGroup;
     private           ActivationGroupNode                            activationGroupNode;
@@ -102,6 +104,7 @@ public class RuleAgendaItem implements LinkedListNode<RuleAgendaItem>, AgendaIte
         this.salience = salience;
         this.rtn = rtn;
         this.activationNumber = activationNumber;
+        this.index = -1;
         this.matched = true;
         this.agendaGroup = agendaGroup;
     }
@@ -220,6 +223,16 @@ public class RuleAgendaItem implements LinkedListNode<RuleAgendaItem>, AgendaIte
     @Override
     public String toString() {
         return "[Activation rule=" + this.rtn.getRule().getName() + ", act#=" + this.activationNumber + ", salience=" + this.salience + ", tuple=" + this.tuple + "]";
+    }
+
+    @Override
+    public void setQueueIndex(final int index) {
+        this.index = index;
+    }
+
+    @Override
+    public int getQueueIndex() {
+        return this.index;
     }
 
     @Override

--- a/drools-core/src/main/java/org/drools/core/reteoo/RuleTerminalNodeLeftTuple.java
+++ b/drools-core/src/main/java/org/drools/core/reteoo/RuleTerminalNodeLeftTuple.java
@@ -45,6 +45,9 @@ public class RuleTerminalNodeLeftTuple extends BaseLeftTuple implements AgendaIt
      * The activation number
      */
     private           long                                           activationNumber;
+
+    private           int                                            queueIndex;
+
     private           boolean                                        queued;
     private transient InternalAgendaGroup                            agendaGroup;
     private           ActivationGroupNode                            activationGroupNode;
@@ -118,6 +121,7 @@ public class RuleTerminalNodeLeftTuple extends BaseLeftTuple implements AgendaIt
         setPropagationContext(pctx);
         this.salience = salience;
         this.activationNumber = activationNumber;
+        this.queueIndex = -1;
         this.matched = true;
         this.ruleAgendaItem = ruleAgendaItem;
         this.agendaGroup = agendaGroup;
@@ -191,6 +195,14 @@ public class RuleTerminalNodeLeftTuple extends BaseLeftTuple implements AgendaIt
         if (queued) {
             setActive(true);
         }
+    }
+
+    public void setQueueIndex(final int queueIndex) {
+        this.queueIndex = queueIndex;
+    }
+
+    public int getQueueIndex() {
+        return this.queueIndex;
     }
 
     public void dequeue() {

--- a/drools-core/src/main/java/org/drools/core/util/BinaryHeapQueue.java
+++ b/drools-core/src/main/java/org/drools/core/util/BinaryHeapQueue.java
@@ -20,27 +20,52 @@ import java.io.Externalizable;
 import java.io.IOException;
 import java.io.ObjectInput;
 import java.io.ObjectOutput;
+import java.lang.reflect.Array;
+import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Comparator;
+import java.util.List;
+import java.util.NoSuchElementException;
 import java.util.Objects;
-import java.util.TreeSet;
 import java.util.stream.Stream;
-
 import org.drools.core.util.Queue.QueueEntry;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import static java.util.stream.Collectors.toList;
 
-public class BinaryHeapQueue<T extends QueueEntry> implements Queue<T>, Externalizable {
+public class BinaryHeapQueue<T extends QueueEntry>
+        implements
+        Queue<T>,
+        Externalizable {
+    protected static final transient Logger log = LoggerFactory.getLogger(BinaryHeapQueue.class);
 
-    protected static final Logger log = LoggerFactory.getLogger(BinaryHeapQueue.class);
+    /** The default capacity for a binary heap. */
+    private static final int DEFAULT_CAPACITY = 13;
+
+    /** The comparator used to order the elements */
+    private Comparator<T> comparator;
+
+    /** The number of elements currently in this heap. */
+    private int size;
 
     /** The elements in this heap. */
-    private TreeSet<T> elements;
+    private ArrayList<T> elements;
 
     public BinaryHeapQueue() {
 
+    }
+
+    /**
+     * Constructs a new <code>BinaryHeap</code> that will use the given
+     * comparator to order its elements.
+     *
+     * @param comparator the comparator used to order the elements, null
+     *                   means use natural order
+     */
+    public BinaryHeapQueue(final Comparator<T> comparator) {
+        this(comparator,
+             BinaryHeapQueue.DEFAULT_CAPACITY);
     }
 
     /**
@@ -48,31 +73,41 @@ public class BinaryHeapQueue<T extends QueueEntry> implements Queue<T>, External
      *
      * @param comparator the comparator used to order the elements, null
      *                   means use natural order
+     * @param capacity   the initial capacity for the heap
+     * @throws IllegalArgumentException if <code>capacity</code> is &lt;= <code>0</code>
      */
-    public BinaryHeapQueue(final Comparator<T> comparator) {
-        this.elements = new TreeSet<>(comparator);
+    public BinaryHeapQueue(final Comparator<T> comparator,
+                           final int capacity) {
+        if (capacity <= 0) {
+            throw new IllegalArgumentException("invalid capacity");
+        }
+
+        //+1 as 0 is noop
+        this.elements = new ArrayList<>(capacity +1);
+        this.elements.add(null); // root is always null
+        this.comparator = comparator;
     }
 
     //-----------------------------------------------------------------------
     public void readExternal(ObjectInput in) throws IOException, ClassNotFoundException {
-        elements = (TreeSet<T>) in.readObject();
+        comparator = (Comparator) in.readObject();
+        elements = (ArrayList<T>) in.readObject();
+        size = in.readInt();
     }
 
     public void writeExternal(ObjectOutput out) throws IOException {
+        out.writeObject(comparator);
         out.writeObject(elements);
+        out.writeInt(size);
     }
 
     /**
      * Clears all elements from queue.
      */
-    @Override
     public void clear() {
-        this.elements.clear();
-    }
-
-    @Override
-    public Collection<T> getAll() {
-        return elements;
+        this.elements.clear(); ; // for gc
+        this.elements.add(null); // 0 must be null;
+        this.size = 0;
     }
 
     /**
@@ -81,9 +116,19 @@ public class BinaryHeapQueue<T extends QueueEntry> implements Queue<T>, External
      * @return <code>true</code> if queue is empty; <code>false</code>
      *         otherwise.
      */
-    @Override
     public boolean isEmpty() {
-        return this.elements.isEmpty();
+        return this.size == 0;
+    }
+
+    /**
+     * Tests if queue is full.
+     *
+     * @return <code>true</code> if queue is full; <code>false</code>
+     *         otherwise.
+     */
+    public  boolean isFull() {
+        //+1 as Queueable 0 is noop
+        return this.elements.size() == this.size + 1;
     }
 
     /**
@@ -91,14 +136,12 @@ public class BinaryHeapQueue<T extends QueueEntry> implements Queue<T>, External
      *
      * @return the number of elements in this heap
      */
-    @Override
     public int size() {
-        return this.elements.size();
+        return size;
     }
 
-    @Override
     public T peek() {
-        return isEmpty() ? null : elements.last();
+        return size > 0 ? this.elements.get(1) : null;
     }
 
     /**
@@ -106,13 +149,16 @@ public class BinaryHeapQueue<T extends QueueEntry> implements Queue<T>, External
      *
      * @param element the Queueable to be inserted
      */
-    @Override
     public void enqueue(final T element) {
-        elements.add( element );
+        if ( isFull() ) {
+            grow();
+        }
+
+        percolateUpMaxHeap( element );
         element.setQueued(true);
 
         if ( log.isTraceEnabled() ) {
-            log.trace( "Queue Added {}", element);
+            log.trace( "Queue Added {} {}", element.getQueueIndex(), element);
         }
     }
 
@@ -120,15 +166,158 @@ public class BinaryHeapQueue<T extends QueueEntry> implements Queue<T>, External
      * Returns the Queueable on top of heap and remove it.
      *
      * @return the Queueable at top of heap
+     * @throws NoSuchElementException if <code>isEmpty() == true</code>
      */
-    @Override
     public T dequeue() {
-        return elements.pollLast();
+        if ( isEmpty() ) {
+            return null;
+        }
+
+        final T result = this.elements.get(1);
+        dequeue(result.getQueueIndex());
+
+        return result;
     }
 
-    @Override
     public void dequeue(T activation) {
-        elements.remove(activation);
+        dequeue(activation.getQueueIndex());
+    }
+
+    T dequeue(final int index) {
+        if ( index < 1 || index > this.size ) {
+            return null;
+        }
+
+
+        final T result = this.elements.get(index);
+        if ( log.isTraceEnabled() ) {
+            log.trace( "Queue Removed {} {}", result.getQueueIndex(), result);
+        }
+
+        setElement( index,
+                    this.elements.get(this.size) );
+        this.elements.set(this.size, null);
+        this.size--;
+        if ( this.size != 0 && index <= this.size ) {
+            int compareToParent = 0;
+            if ( index > 1 ) {
+                compareToParent = compare( this.elements.get(index),
+                                           this.elements.get(index / 2) );
+            }
+            if ( index > 1 && compareToParent > 0 ) {
+                percolateUpMaxHeap( index );
+            } else {
+                percolateDownMaxHeap( index );
+            }
+        }
+
+        result.setQueued(false);
+        result.setQueueIndex(-1);
+
+        return result;
+    }
+
+    /**
+     * Percolates element down heap from the position given by the index.
+     * <p>
+     * Assumes it is a maximum heap.
+     *
+     * @param index the index of the element
+     */
+    protected void percolateDownMaxHeap(final int index) {
+        final T element = elements.get(index);
+        int hole = index;
+
+        while ((hole * 2) <= size) {
+            int child = hole * 2;
+
+            // if we have a right child and that child can not be percolated
+            // up then move onto other child
+            if (child != size && compare(elements.get(child + 1), elements.get(child)) > 0) {
+                child++;
+            }
+
+            // if we found resting place of bubble then terminate search
+            if (compare(elements.get(child), element) <= 0) {
+                break;
+            }
+
+            setElement( hole, elements.get(child) );
+            hole = child;
+        }
+
+        setElement( hole, element);
+    }
+
+
+    /**
+     * Percolates element up heap from the position given by the index.
+     * <p>
+     * Assume it is a maximum heap.
+     *
+     * @param index the index of the element to be percolated up
+     */
+    protected void percolateUpMaxHeap(final int index) {
+        int hole = index;
+        T element = elements.get(hole);
+
+        while (hole > 1 && compare(element, elements.get(hole / 2)) > 0) {
+            // save element that is being pushed down
+            // as the element "bubble" is percolated up
+            final int next = hole / 2;
+            setElement( hole, elements.get(next) );
+            hole = next;
+        }
+
+        setElement( hole, element );
+    }
+
+    /**
+     * Percolates a new element up heap from the bottom.
+     * <p>
+     * Assume it is a maximum heap.
+     *
+     * @param element the element
+     */
+    protected void percolateUpMaxHeap(final T element) {
+        if (isFull()) {
+            elements.add(element);
+            element.setQueueIndex(++size);
+        } else {
+            elements.set(++size, element);
+            element.setQueueIndex(size);
+        }
+
+        percolateUpMaxHeap(size);
+    }
+
+    /**
+     * Compares two objects using the comparator if specified, or the
+     * natural order otherwise.
+     *
+     * @param a the first object
+     * @param b the second object
+     * @return -ve if a less than b, 0 if they are equal, +ve if a greater than b
+     */
+    private int compare(final T a, final T b) {
+        return comparator.compare( a, b );
+    }
+
+    /**
+     * Increases the size of the heap to support additional elements
+     */
+    private void grow() {
+        elements.ensureCapacity(elements.size() * 2);
+    }
+
+    private void setElement(final int index,
+                            final T element) {
+        elements.set(index, element);
+        element.setQueueIndex(index);
+    }
+
+    public Collection<T> getAll() {
+        return elements.subList(1, size+1);
     }
 
     @Override

--- a/drools-core/src/main/java/org/drools/core/util/Queue.java
+++ b/drools-core/src/main/java/org/drools/core/util/Queue.java
@@ -40,6 +40,10 @@ public interface Queue<T extends QueueEntry> {
 
         void setQueued(boolean b);
 
+        int getQueueIndex();
+
+        void setQueueIndex(int index);
+
         void dequeue();
 
         boolean isQueued();

--- a/drools-core/src/test/java/org/drools/core/util/BinaryHeapPriorityQueueTest.java
+++ b/drools-core/src/test/java/org/drools/core/util/BinaryHeapPriorityQueueTest.java
@@ -30,7 +30,8 @@ public class BinaryHeapPriorityQueueTest {
         final Random random = new Random();
         final List<QueueEntry> items = new ArrayList<>();
 
-        final BinaryHeapQueue<QueueEntry> queue = new BinaryHeapQueue<>( NaturalComparator.INSTANCE );
+        final BinaryHeapQueue queue = new BinaryHeapQueue( NaturalComparator.INSTANCE,
+                                                           100000 );
 
         for ( int i = 0; i < 100000; ++i ) {
             items.add( new LongQueueable( queue, random.nextLong() ) );
@@ -93,14 +94,24 @@ public class BinaryHeapPriorityQueueTest {
 
         private BinaryHeapQueue queue;
 
+        private int   index;
+
         public LongQueueable(BinaryHeapQueue queue,
                              final long value) {
             this.queue = queue;
             this.value = Long.valueOf( value );
         }
 
+        public void setQueueIndex(final int index) {
+            this.index = index;
+        }
+
+        public int getQueueIndex() {
+            return this.index;
+        }
+
         public void dequeue() {
-            this.queue.dequeue();
+            this.queue.dequeue( this.index );
         }
 
         public boolean isQueued() {

--- a/drools-core/src/test/java/org/drools/core/util/BinaryHeapQueueTest.java
+++ b/drools-core/src/test/java/org/drools/core/util/BinaryHeapQueueTest.java
@@ -17,6 +17,7 @@ package org.drools.core.util;
 
 import java.util.ArrayList;
 import java.util.Collection;
+import java.util.Collections;
 import java.util.List;
 
 import org.drools.core.common.ActivationGroupNode;
@@ -32,7 +33,10 @@ import org.drools.core.rule.consequence.Activation;
 import org.drools.core.rule.consequence.ConflictResolver;
 import org.drools.core.rule.consequence.Consequence;
 import org.junit.Before;
+import org.junit.Test;
 import org.kie.api.runtime.rule.FactHandle;
+
+import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
 
 /**
  * Thes test class uses auxiliary test classes in org.kie.util:
@@ -65,6 +69,39 @@ public class BinaryHeapQueueTest {
             a[lim - 1] = h;
             shuffle( a,
                      lim - 1 );
+        }
+    }
+
+    @Test
+    public void testShuffled() {
+
+        for ( Integer[] perm : perms ) {
+            Group group = new Group( "group" );
+
+            for ( Integer i : perm ) {
+                Item item = new Item( group,
+                                      i );
+                group.add( item );
+            }
+
+            Activation[] elems = group.getQueue().toArray( new Activation[0]);
+            for (Activation elem : elems ) {
+                Item item = (Item) elem;
+                //        System.out.print( " " + item.getSalience() + "/"  + item.getActivationNumber() + "/" + item.getQueueIndex() );
+                if ( item.getQueueIndex() % 2 == 0 ) {
+                    group.remove( item );
+                    group.add( item );
+                }
+            }
+            boolean ok = true;
+            StringBuilder sb = new StringBuilder( "queue:" );
+            for ( int i = max - 1; i >= 0; i-- ) {
+                int sal = group.getNext().getSalience();
+                sb.append( " " ).append( sal );
+                if ( sal != i ) ok = false;
+            }
+            assertThat(ok).as("incorrect order in " + sb.toString()).isTrue();
+            //      System.out.println( sb.toString() );
         }
     }
 
@@ -169,6 +206,7 @@ public class BinaryHeapQueueTest {
 
         private static int actNo = 1;
 
+        private int   index;
         private long  activationNumber;
         private Group group;
         private int   salience;
@@ -184,6 +222,15 @@ public class BinaryHeapQueueTest {
             if (this.group != null) {
                 this.group.remove(this);
             }
+            this.index = -1;
+        }
+
+        public void setQueueIndex(int index) {
+            this.index = index;
+        }
+
+        public int getQueueIndex() {
+            return index;
         }
 
         public int getSalience() {

--- a/drools-kiesession/src/test/java/org/drools/kiesession/MockActivation.java
+++ b/drools-kiesession/src/test/java/org/drools/kiesession/MockActivation.java
@@ -146,4 +146,14 @@ public class MockActivation implements Activation {
     @Override
     public void dequeue() {
     }
+
+    @Override
+    public int getQueueIndex() {
+        return 0;
+    }
+
+    @Override
+    public void setQueueIndex(int index) {
+
+    }
 }

--- a/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/compiler/builder/impl/KnowledgeBuilderTest.java
+++ b/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/compiler/builder/impl/KnowledgeBuilderTest.java
@@ -1407,6 +1407,16 @@ public class KnowledgeBuilderTest extends DroolsTestCase {
         @Override
         public void dequeue() {
         }
+
+        @Override
+        public int getQueueIndex() {
+            return 0;
+        }
+
+        @Override
+        public void setQueueIndex(int index) {
+
+        }
     }
 
     class MockTuple

--- a/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/compiler/testframework/RuleCoverageListenerTest.java
+++ b/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/compiler/testframework/RuleCoverageListenerTest.java
@@ -188,4 +188,13 @@ class MockActivation implements Activation {
     public void dequeue() {
     }
 
+    @Override
+    public int getQueueIndex() {
+        return 0;
+    }
+
+    @Override
+    public void setQueueIndex(int index) {
+
+    }
 }


### PR DESCRIPTION
This restores the binary heap. However it is now an ArrayList, so Kogito keeps working with Quarkus. It also keeps the getAll() method to avoid the array copying.