### PR TITLE
[DROOLS-7328] fix sliding time window performance problem

### DIFF
--- a/drools-core/pom.xml
+++ b/drools-core/pom.xml
@@ -234,6 +234,25 @@
             <configuration>
               <createSourcesJar>true</createSourcesJar>
               <minimizeJar>true</minimizeJar>
+              <filters>
+                <filter>
+                  <artifact>it.unimi.dsi:fastutil</artifact>
+                  <includes>
+                    <include>it/unimi/dsi/fastutil/Function**</include>
+                    <include>it/unimi/dsi/fastutil/Hash**</include>
+                    <include>it/unimi/dsi/fastutil/objects/AbstractObjectCollection**</include>
+                    <include>it/unimi/dsi/fastutil/objects/AbstractObject2Object**</include>
+                    <include>it/unimi/dsi/fastutil/objects/Object2ObjectMap**</include>
+                    <include>it/unimi/dsi/fastutil/objects/Object2ObjectFunction**</include>
+                    <include>it/unimi/dsi/fastutil/objects/Object2ObjectOpenCustomHashMap**</include>
+                    <include>it/unimi/dsi/fastutil/objects/ObjectCollection**</include>
+                    <include>it/unimi/dsi/fastutil/objects/ObjectSet**</include>
+                    <include>it/unimi/dsi/fastutil/objects/ObjectIterable**</include>
+                    <include>it/unimi/dsi/fastutil/objects/ObjectIterator**</include>
+                    <include>it/unimi/dsi/fastutil/objects/ObjectSpliterator**</include>
+                  </includes>
+                </filter>
+              </filters>
               <artifactSet>
                 <includes>
                   <include>it.unimi.dsi:fastutil</include>


### PR DESCRIPTION
**JIRA**: https://issues.redhat.com/browse/DROOLS-7328

I created a benchmark for this issue here https://github.com/kiegroup/kie-benchmarks/pull/220 and with this improvement performance went from

```
Benchmark                             Mode  Cnt     Score     Error  Units
SlidingTimeWindowBenchmark.benchmark    ss   20  2845.509 ± 106.070  ms/op
```

to

```
Benchmark                             Mode  Cnt     Score    Error  Units
SlidingTimeWindowBenchmark.benchmark    ss   20  1466.830 ± 42.994  ms/op
```