### PR TITLE
first reliable propagation list implementation

### DIFF
--- a/drools-core/src/main/java/org/drools/core/phreak/PropagationEntry.java
+++ b/drools-core/src/main/java/org/drools/core/phreak/PropagationEntry.java
@@ -15,6 +15,7 @@
 
 package org.drools.core.phreak;
 
+import java.io.Serializable;
 import java.util.concurrent.CountDownLatch;
 
 import org.drools.core.base.DroolsQuery;
@@ -190,7 +191,7 @@ public interface PropagationEntry {
         }
     }
 
-    class Insert extends AbstractPropagationEntry {
+    class Insert extends AbstractPropagationEntry implements Serializable {
         private static final ObjectTypeNode.ExpireJob job = new ObjectTypeNode.ExpireJob();
 
         private final InternalFactHandle handle;

--- a/drools-core/src/main/java/org/drools/core/phreak/SynchronizedPropagationList.java
+++ b/drools-core/src/main/java/org/drools/core/phreak/SynchronizedPropagationList.java
@@ -23,7 +23,7 @@ import org.slf4j.LoggerFactory;
 
 public class SynchronizedPropagationList implements PropagationList {
 
-    protected static final transient Logger log                = LoggerFactory.getLogger( SynchronizedPropagationList.class );
+    protected static final Logger log = LoggerFactory.getLogger( SynchronizedPropagationList.class );
 
     protected final ReteEvaluator reteEvaluator;
 

--- a/drools-kiesession/src/main/java/org/drools/kiesession/agenda/DefaultAgenda.java
+++ b/drools-kiesession/src/main/java/org/drools/kiesession/agenda/DefaultAgenda.java
@@ -222,7 +222,7 @@ public class DefaultAgenda implements Externalizable, InternalAgenda {
         this.propagationList = createPropagationList();
     }
 
-    private PropagationList createPropagationList() {
+    protected PropagationList createPropagationList() {
         if (!workingMemory.getSessionConfiguration().isThreadSafe()) {
             return new ThreadUnsafePropagationList( workingMemory );
         }

--- a/drools-reliability/src/main/java/org/drools/reliability/ReliableAgenda.java
+++ b/drools-reliability/src/main/java/org/drools/reliability/ReliableAgenda.java
@@ -1,0 +1,38 @@
+package org.drools.reliability;
+
+import org.drools.core.common.InternalWorkingMemory;
+import org.drools.core.impl.RuleBase;
+import org.drools.core.phreak.PropagationList;
+import org.drools.kiesession.agenda.DefaultAgenda;
+import org.infinispan.Cache;
+
+public class ReliableAgenda extends DefaultAgenda {
+
+    public ReliableAgenda() { }
+
+    public ReliableAgenda(RuleBase kBase) {
+        super( kBase );
+    }
+
+    public ReliableAgenda(RuleBase kBase, boolean initMain) {
+        super( kBase, initMain );
+    }
+
+    @Override
+    public void setWorkingMemory(InternalWorkingMemory workingMemory) {
+        super.setWorkingMemory(workingMemory);
+    }
+
+    @Override
+    protected PropagationList createPropagationList() {
+        Cache<String, Object> componentsCache = CacheManager.INSTANCE.getOrCreateCacheForSession(workingMemory, "components");
+        ReliablePropagationList propagationList = (ReliablePropagationList) componentsCache.get("PropagationList");
+        if (propagationList == null) {
+            propagationList = new ReliablePropagationList(workingMemory);
+            componentsCache.put("PropagationList", propagationList);
+        } else {
+            propagationList = new ReliablePropagationList(workingMemory, propagationList);
+        }
+        return propagationList;
+    }
+}

--- a/drools-reliability/src/main/java/org/drools/reliability/ReliableAgendaFactory.java
+++ b/drools-reliability/src/main/java/org/drools/reliability/ReliableAgendaFactory.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright 2010 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.drools.reliability;
+
+
+import java.io.Serializable;
+
+import org.drools.core.common.AgendaFactory;
+import org.drools.core.common.InternalAgenda;
+import org.drools.core.impl.RuleBase;
+
+public class ReliableAgendaFactory implements AgendaFactory, Serializable {
+
+    private static final AgendaFactory INSTANCE = new ReliableAgendaFactory();
+
+    public static AgendaFactory getInstance() {
+        return INSTANCE;
+    }
+
+    private ReliableAgendaFactory() { }
+
+    public InternalAgenda createAgenda(RuleBase kBase, boolean initMain) {
+        return new ReliableAgenda( kBase, initMain );
+    }
+
+    public InternalAgenda createAgenda(RuleBase kBase) {
+        return new ReliableAgenda( kBase );
+    }
+}

--- a/drools-reliability/src/main/java/org/drools/reliability/ReliableNamedEntryPoint.java
+++ b/drools-reliability/src/main/java/org/drools/reliability/ReliableNamedEntryPoint.java
@@ -20,7 +20,6 @@ import org.drools.core.common.ReteEvaluator;
 import org.drools.core.reteoo.EntryPointNode;
 import org.drools.core.rule.EntryPointId;
 import org.drools.kiesession.entrypoints.NamedEntryPoint;
-import org.kie.api.runtime.conf.PersistedSessionOption;
 
 public class ReliableNamedEntryPoint extends NamedEntryPoint {
 
@@ -32,18 +31,6 @@ public class ReliableNamedEntryPoint extends NamedEntryPoint {
 
     @Override
     protected void initObjectStore(EntryPointId entryPoint, RuleBaseConfiguration conf, ReteEvaluator reteEvaluator) {
-        String cacheName;
-        PersistedSessionOption persistedSessionOption = reteEvaluator.getSessionConfiguration().getPersistedSessionOption();
-        if (persistedSessionOption != null) {
-            if (persistedSessionOption.isNewSession()) {
-                // Use sessionId of the first session
-                cacheName = "cacheSession_" + reteEvaluator.getIdentifier();
-            } else {
-                cacheName = "cacheSession_" + persistedSessionOption.getSessionId();
-            }
-        } else {
-            throw new ReliabilityConfigurationException("PersistedSessionOption has to be configured when drools-reliability is used");
-        }
-        this.objectStore = new ReliableObjectStore(CacheManager.INSTANCE.getOrCreateCache(cacheName));
+        this.objectStore = new ReliableObjectStore(CacheManager.INSTANCE.getOrCreateCacheForSession(reteEvaluator, "ep" + getEntryPointId()));
     }
 }

--- a/drools-reliability/src/main/java/org/drools/reliability/ReliablePropagationList.java
+++ b/drools-reliability/src/main/java/org/drools/reliability/ReliablePropagationList.java
@@ -1,0 +1,18 @@
+package org.drools.reliability;
+
+import java.io.Serializable;
+
+import org.drools.core.common.ReteEvaluator;
+import org.drools.core.phreak.SynchronizedPropagationList;
+
+public class ReliablePropagationList extends SynchronizedPropagationList implements Serializable {
+    public ReliablePropagationList(ReteEvaluator reteEvaluator) {
+        super(reteEvaluator);
+    }
+
+    public ReliablePropagationList(ReteEvaluator reteEvaluator, ReliablePropagationList originalList) {
+        super(reteEvaluator);
+        this.head = originalList.head;
+        this.tail = originalList.tail;
+    }
+}

--- a/drools-reliability/src/test/java/org/drools/reliability/ReliabilityTest.java
+++ b/drools-reliability/src/test/java/org/drools/reliability/ReliabilityTest.java
@@ -62,13 +62,13 @@ public class ReliabilityTest {
         conf2.setOption(PersistedSessionOption.fromSession(id));
         KieSession secondSession = kbase.newKieSession(conf2, null);
 
-        try{
+        try {
             secondSession.insert(new Person("Edson", 35));
             secondSession.insert(new Person("Mario", 40));
 
             assertThat(secondSession.fireAllRules()).isEqualTo(2);
 
-        }finally {
+        } finally {
             secondSession.dispose();
         }
     }
@@ -77,12 +77,12 @@ public class ReliabilityTest {
     public void testReliableObjectStore() {
         String drl =
                 "import " + Person.class.getCanonicalName() + ";" +
-                        "rule X when\n" +
-                        "  $s: String()\n" +
-                        "  $p: Person( getName().startsWith($s) )\n" +
-                        "then\n" +
-                        "  System.out.println( $p.getAge() );\n" +
-                        "end";
+                "rule X when\n" +
+                "  $s: String()\n" +
+                "  $p: Person( getName().startsWith($s) )\n" +
+                "then\n" +
+                "  System.out.println( $p.getAge() );\n" +
+                "end";
 
         KieBase kbase = new KieHelper().addContent(drl, ResourceType.DRL).build();
         KieSessionConfiguration conf = KieServices.get().newKieSessionConfiguration();


### PR DESCRIPTION
With this PR I'm implementing a first version of a reliable propagation list. In this way it is no longer necessary to repropagate the objects from the object store into the persisted session created from an existing one (and I commented out the invocation of that method). However consider that now the existing test case works only because when the first session is replaced we never called a fireAllRules on it yet and then all the inserted objects are still in the propagation queue. I expect that the test fails if you issue a first fireAllRules before moving to the second session. I will add one more test for this scenarion and this will be fixed when also the other necessary data structures will be persisted.

Just a couple of notes:

1. I found that normally the session id is only unique per kbase, but we need an universally unique id, that's why I reimplemented the generation in the reliable components.
2. At the moment I'm putting in the infinispan cache the whole propagation queue which is a modifiable object and just letting infinispan to deal with the changes on it. I'm not sure if this is a correct way to use infinispan though. 