### PR TITLE
DROOLS-7356 fix shading def for graalvm native-image

### DIFF
--- a/drools-core/pom.xml
+++ b/drools-core/pom.xml
@@ -239,17 +239,32 @@
                 <filter>
                   <artifact>it.unimi.dsi:fastutil</artifact>
                   <includes>
+                    <include>it/unimi/dsi/fastutil/Arrays**</include>
+                    <include>it/unimi/dsi/fastutil/BidirectionalIterator**</include>
+                    <include>it/unimi/dsi/fastutil/BigArrays**</include>
                     <include>it/unimi/dsi/fastutil/Function**</include>
                     <include>it/unimi/dsi/fastutil/Hash**</include>
+                    <include>it/unimi/dsi/fastutil/Pair**</include>
+                    <include>it/unimi/dsi/fastutil/Size64**</include>
+                    <include>it/unimi/dsi/fastutil/Stack**</include>
                     <include>it/unimi/dsi/fastutil/objects/AbstractObjectCollection**</include>
+                    <include>it/unimi/dsi/fastutil/objects/AbstractObjectIterator**</include>
+                    <include>it/unimi/dsi/fastutil/objects/AbstractObjectList**</include>
+                    <include>it/unimi/dsi/fastutil/objects/AbstractObjectSet**</include>
+                    <include>it/unimi/dsi/fastutil/objects/AbstractObjectSpliterator**</include>
                     <include>it/unimi/dsi/fastutil/objects/AbstractObject2Object**</include>
+                    <include>it/unimi/dsi/fastutil/objects/BidirectionalIterator**</include>
                     <include>it/unimi/dsi/fastutil/objects/Object2ObjectMap**</include>
                     <include>it/unimi/dsi/fastutil/objects/Object2ObjectFunction**</include>
                     <include>it/unimi/dsi/fastutil/objects/Object2ObjectOpenCustomHashMap**</include>
+                    <include>it/unimi/dsi/fastutil/objects/ObjectArrays**</include>
+                    <include>it/unimi/dsi/fastutil/objects/ObjectArrayList**</include>
+                    <include>it/unimi/dsi/fastutil/objects/ObjectBidirectionalIterator**</include>
                     <include>it/unimi/dsi/fastutil/objects/ObjectCollection**</include>
                     <include>it/unimi/dsi/fastutil/objects/ObjectSet**</include>
                     <include>it/unimi/dsi/fastutil/objects/ObjectIterable**</include>
                     <include>it/unimi/dsi/fastutil/objects/ObjectIterator**</include>
+                    <include>it/unimi/dsi/fastutil/objects/ObjectList**</include>
                     <include>it/unimi/dsi/fastutil/objects/ObjectSpliterator**</include>
                   </includes>
                 </filter>


### PR DESCRIPTION
the problem with the [native-image build](https://eng-jenkins-csb-business-automation.apps.ocp-c1.prod.psi.redhat.com/job/KIE/job/drools/job/main/job/nightly.native/job/drools.build-and-test/107/display/redirect), is due to unability to resolve _all_ the types from the shaded (drools-core).

E.g.: drools make use of the shaded `Object2ObjectOpenCustomHashMap`.
This class in its iterator has a definition of `ObjectArrayList`
To resolve this type, all the types which `ObjectArrayList` make reference-to must also be resolvable, transitively.

It was _not_ the case that all these types were listed in the shaded definition, per this PR highlights.

Unfortunately, the error reported by Graal native-image is not helpful.

E.g.:
```
Caused by: com.oracle.graal.pointsto.constraints.UnresolvedElementException: Discovered unresolved type during parsing: it.unimi.dsi.fastutil.objects.ObjectArrayList. This error is reported at image build time because class it.unimi.dsi.fastutil.objects.Object2ObjectOpenCustomHashMap$MapIterator is registered for linking at image build time by command line
```

so according to this message, it would _seem like_ what's missing is ObjectArrayList, but it's not the case.

By inspecting the JAR with

```
jar tvf drools-core/target/drools-core-8.36.0-SNAPSHOT.jar
```

the class is there, but what's actually missing are the types referenced in the _definition_ of `ObjectArrayList`.

I was able to "prompt" for it in JVM mode by adding the following snippet to some of the classes of the integration test module, in their constructor (e.g.: Person's constructor) so to be sure it's invoked by JVM mode and NI mode.

```java
it.unimi.dsi.fastutil.objects.ObjectArrayList obj = new it.unimi.dsi.fastutil.objects.ObjectArrayList(3);
obj.add("ciao");
System.out.println(obj.subList(0, 0).spliterator().getClass().getCanonicalName());
```

That way you are given a ClassNotFoundException more accurate than the GraalVM Native Image message.

<details>
<summary>
How to replicate CI configuration locally?
</summary>

Build Chain tool does "simple" maven build(s), the builds are just Maven commands, but because the repositories relates and depends on each other and any change in API or class method could affect several of those repositories there is a need to use [build-chain tool](https://github.com/kiegroup/github-action-build-chain) to handle cross repository builds and be sure that we always use latest version of the code for each repository.
 
[build-chain tool](https://github.com/kiegroup/github-action-build-chain) is a build tool which can be used on command line locally or in Github Actions workflow(s), in case you need to change multiple repositories and send multiple dependent pull requests related with a change you can easily reproduce the same build by executing it on Github hosted environment or locally in your development environment. See [local execution](https://github.com/kiegroup/github-action-build-chain#local-execution) details to get more information about it.
</details>

<details>
<summary>
How to retest this PR or trigger a specific build:
</summary>

- for <b>pull request checks</b>  
  Please add comment: <b>Jenkins retest this</b>

- for a <b>specific pull request check</b>  
  Please add comment: <b>Jenkins (re)run [drools|kogito-runtimes|kogito-apps|kogito-examples] tests</b>

- for a <b>full downstream build</b> 
  - for <b>jenkins</b> job: please add comment: <b>Jenkins run fdb</b>
  - for <b>github actions</b> job: add the label `run_fdb`

- <b>a compile downstream build</b> please  add comment: <b>Jenkins run cdb</b>

- <b>a full production downstream build</b> please add comment: <b>Jenkins execute product fdb</b>

- <b>an upstream build</b> please add comment: <b>Jenkins run upstream</b>

- for <b>quarkus branch checks</b>  
  Run checks against Quarkus current used branch  
  Please add comment: <b>Jenkins run quarkus-branch</b>

- for a <b>quarkus branch specific check</b>  
  Run checks against Quarkus current used branch  
  Please add comment: <b>Jenkins (re)run [drools|kogito-runtimes|kogito-apps|kogito-examples] quarkus-branch</b>

- for <b>quarkus main checks</b>  
  Run checks against Quarkus main branch  
  Please add comment: <b>Jenkins run quarkus-main</b>

- for a <b>specific quarkus main check</b>  
  Run checks against Quarkus main branch  
  Please add comment: <b>Jenkins (re)run [drools|kogito-runtimes|kogito-apps|kogito-examples] quarkus-main</b>

- for <b>quarkus lts checks</b>  
  Run checks against Quarkus lts branch  
  Please add comment: <b>Jenkins run quarkus-lts</b>

- for a <b>specific quarkus lts check</b>  
  Run checks against Quarkus lts branch  
  Please add comment: <b>Jenkins (re)run [drools|kogito-runtimes|kogito-apps|kogito-examples] quarkus-lts</b>

- for <b>native checks</b>  
  Run native checks  
  Please add comment: <b>Jenkins run native</b>

- for a <b>specific native check</b>  
  Run native checks 
  Please add comment: <b>Jenkins (re)run [drools|kogito-runtimes|kogito-apps|kogito-examples] native</b>

 - for <b>native lts checks</b>  
  Run native checks against quarkus lts branch
  Please add comment: <b>Jenkins run native-lts</b>

- for a <b>specific native lts check</b>  
  Run native checks against quarkus lts branch
  Please add comment: <b>Jenkins (re)run [drools|kogito-runtimes|kogito-apps|kogito-examples] native-lts</b>
</details>

<details>
<summary>
How to backport a pull request to a different branch?
</summary>

In order to automatically create a **backporting pull request** please add one or more labels having the following format `backport-<branch-name>`, where `<branch-name>` is the name of the branch where the pull request must be backported to (e.g., `backport-7.67.x` to backport the original PR to the `7.67.x` branch).

> **NOTE**: **backporting** is an action aiming to move a change (usually a commit) from a branch (usually the main one) to another one, which is generally referring to a still maintained release branch. Keeping it simple: it is about to move a specific change or a set of them from one branch to another.

Once the original pull request is successfully merged, the automated action will create one backporting pull request per each label (with the previous format) that has been added.

If something goes wrong, the author will be notified and at this point a manual backporting is needed.

> **NOTE**: this automated backporting is triggered whenever a pull request on `main` branch is labeled or closed, but both conditions must be satisfied to get the new PR created.
</details>