### PR TITLE
Quarkus-3: Update scripts

### DIFF
--- a/.ci/environments/quarkus-3/quarkus3.yml
+++ b/.ci/environments/quarkus-3/quarkus3.yml
@@ -23,11 +23,8 @@ tags:
   - jakarta
 recipeList:
   - org.openrewrite.maven.ChangePropertyValue:
-      key: quarkus.platform.version
-      newValue: 3.0.0.Alpha3
-  - org.openrewrite.maven.ChangePropertyValue:
-      key: quarkus.version
-      newValue: 3.0.0.Alpha3
+      key: version.io.quarkus
+      newValue: {QUARKUS_VERSION}
   - org.openrewrite.java.migrate.JavaxMigrationToJakarta
   - org.kie.openrewrite.recipe.jpmml.JPMMLRecipe
 ---


### PR DESCRIPTION
- Set specific `quarkus-3-SNAPSHOT` version for artifacts and avoid to use external maven local repo
- `fail-at-end` the openrewrite so we can have a global overview