### PR TITLE
first implementation of persisted stores only strategy

### DIFF
--- a/drools-core/src/main/java/org/drools/core/SessionConfiguration.java
+++ b/drools-core/src/main/java/org/drools/core/SessionConfiguration.java
@@ -202,6 +202,10 @@ public class SessionConfiguration extends BaseConfiguration<KieSessionOption, Si
         return this.keepReference;
     }
 
+    public boolean hasPersistedSessionOption() {
+        return this.persistedSessionOption != null;
+    }
+
     public PersistedSessionOption getPersistedSessionOption() {
         return this.persistedSessionOption;
     }

--- a/drools-core/src/main/java/org/drools/core/common/AgendaGroupQueueImpl.java
+++ b/drools-core/src/main/java/org/drools/core/common/AgendaGroupQueueImpl.java
@@ -28,7 +28,6 @@ import org.drools.core.marshalling.MarshallerReaderContext;
 import org.drools.core.phreak.PropagationEntry;
 import org.drools.core.phreak.RuleAgendaItem;
 import org.drools.core.util.ArrayQueue;
-import org.drools.core.util.BinaryHeapQueue;
 import org.drools.core.util.Queue;
 import org.drools.core.util.QueueFactory;
 
@@ -120,7 +119,7 @@ public class AgendaGroupQueueImpl
         }
 
         @Override
-        public void execute( ReteEvaluator reteEvaluator ) {
+        public void internalExecute(ReteEvaluator reteEvaluator ) {
             ((InternalAgenda) reteEvaluator.getActivationsManager()).clearAndCancelAgendaGroup(this.name);
         }
     }
@@ -138,7 +137,7 @@ public class AgendaGroupQueueImpl
         }
 
         @Override
-        public void execute( ReteEvaluator reteEvaluator ) {
+        public void internalExecute(ReteEvaluator reteEvaluator ) {
             ((InternalAgenda) reteEvaluator.getActivationsManager()).setFocus(this.name);
         }
 
@@ -284,7 +283,7 @@ public class AgendaGroupQueueImpl
             this.ruleFlowGroup = (InternalRuleFlowGroup) context.getWorkingMemory().getAgenda().getRuleFlowGroup( context.readUTF() );
         }
 
-        public void execute(ReteEvaluator reteEvaluator) {
+        public void internalExecute(ReteEvaluator reteEvaluator) {
             // check whether ruleflow group is still empty first
             if ( this.ruleFlowGroup.isEmpty() ) {
                 // deactivate ruleflow group

--- a/drools-core/src/main/java/org/drools/core/common/NetworkNode.java
+++ b/drools-core/src/main/java/org/drools/core/common/NetworkNode.java
@@ -16,6 +16,8 @@
 
 package org.drools.core.common;
 
+import java.io.Serializable;
+
 import org.drools.core.reteoo.TerminalNode;
 import org.kie.api.definition.rule.Rule;
 
@@ -23,7 +25,7 @@ import org.kie.api.definition.rule.Rule;
  * Interface used to expose generic information on Rete nodes outside of he package. It is used
  * for exposing information events.
  */
-public interface NetworkNode {
+public interface NetworkNode extends Serializable {
 
     /**
      * Returns the unique id that represents the node in the Rete network

--- a/drools-core/src/main/java/org/drools/core/common/ObjectTypeConfigurationRegistry.java
+++ b/drools-core/src/main/java/org/drools/core/common/ObjectTypeConfigurationRegistry.java
@@ -36,7 +36,7 @@ public class ObjectTypeConfigurationRegistry implements Serializable {
 
     private final Map<Object, ObjectTypeConf> typeConfMap = new ConcurrentHashMap<>();
 
-    private final RuleBase ruleBase;
+    private final transient RuleBase ruleBase;
 
     public ObjectTypeConfigurationRegistry(RuleBase ruleBase) {
         this.ruleBase = ruleBase;

--- a/drools-core/src/main/java/org/drools/core/common/ReteEvaluator.java
+++ b/drools-core/src/main/java/org/drools/core/common/ReteEvaluator.java
@@ -18,6 +18,7 @@ package org.drools.core.common;
 
 import java.util.Collection;
 import java.util.Collections;
+import java.util.function.Consumer;
 
 import org.drools.core.RuleSessionConfiguration;
 import org.drools.core.SessionConfiguration;
@@ -138,4 +139,19 @@ public interface ReteEvaluator {
     int fireAllRules(int max);
     int fireAllRules(AgendaFilter agendaFilter);
     int fireAllRules(AgendaFilter agendaFilter, int max);
+
+    default void setWorkingMemoryActionListener(Consumer<PropagationEntry> listener) {
+        throw new UnsupportedOperationException();
+    }
+
+    default Consumer<PropagationEntry> getWorkingMemoryActionListener() {
+        return null;
+    }
+
+    default void onWorkingMemoryAction(PropagationEntry entry) {
+        Consumer<PropagationEntry> listener = getWorkingMemoryActionListener();
+        if (listener != null) {
+            listener.accept(entry);
+        }
+    }
 }

--- a/drools-core/src/main/java/org/drools/core/impl/WorkingMemoryReteExpireAction.java
+++ b/drools-core/src/main/java/org/drools/core/impl/WorkingMemoryReteExpireAction.java
@@ -71,7 +71,7 @@ public class WorkingMemoryReteExpireAction
         this.node = (ObjectTypeNode) context.getSinks().get(nodeId);
     }
 
-    public void execute(ReteEvaluator reteEvaluator) {
+    public void internalExecute(ReteEvaluator reteEvaluator) {
         if (!factHandle.isValid()) {
             return;
         }
@@ -127,7 +127,7 @@ public class WorkingMemoryReteExpireAction
         }
 
         @Override
-        public void execute( ReteEvaluator reteEvaluator ) {
+        public void internalExecute(ReteEvaluator reteEvaluator ) {
             if (!factHandle.isValid()) {
                 return;
             }

--- a/drools-core/src/main/java/org/drools/core/phreak/PhreakTimerNode.java
+++ b/drools-core/src/main/java/org/drools/core/phreak/PhreakTimerNode.java
@@ -379,7 +379,7 @@ public class PhreakTimerNode {
         }
 
         @Override
-        public void execute(final ReteEvaluator reteEvaluator) {
+        public void internalExecute(final ReteEvaluator reteEvaluator) {
             execute( reteEvaluator, false );
         }
 

--- a/drools-core/src/main/java/org/drools/core/phreak/PropagationEntry.java
+++ b/drools-core/src/main/java/org/drools/core/phreak/PropagationEntry.java
@@ -46,7 +46,12 @@ import static org.drools.core.rule.TypeDeclaration.NEVER_EXPIRES;
 
 public interface PropagationEntry {
 
-    void execute(ReteEvaluator reteEvaluator);
+    default void execute(ReteEvaluator reteEvaluator) {
+        internalExecute(reteEvaluator);
+        reteEvaluator.onWorkingMemoryAction(this);
+    }
+
+    void internalExecute(ReteEvaluator reteEvaluator);
 
     PropagationEntry getNext();
     void setNext(PropagationEntry next);
@@ -151,7 +156,7 @@ public interface PropagationEntry {
         }
 
         @Override
-        public void execute( ReteEvaluator reteEvaluator ) {
+        public void internalExecute(ReteEvaluator reteEvaluator ) {
             QueryTerminalNode[] tnodes = reteEvaluator.getKnowledgeBase().getReteooBuilder().getTerminalNodesForQuery( queryName );
             if ( tnodes == null ) {
                 throw new RuntimeException( "Query '" + queryName + "' does not exist" );
@@ -229,7 +234,7 @@ public interface PropagationEntry {
             return !handle.hasMatches() && !reteEvaluator.getKnowledgeBase().getKieBaseConfiguration().isMutabilityEnabled();
         }
 
-        public void execute( ReteEvaluator reteEvaluator ) {
+        public void internalExecute(ReteEvaluator reteEvaluator ) {
             propagate( handle, context, reteEvaluator, objectTypeConf );
         }
 
@@ -276,6 +281,10 @@ public interface PropagationEntry {
         public String toString() {
             return "Insert of " + handle.getObject();
         }
+
+        public InternalFactHandle getHandle() {
+            return handle;
+        }
     }
 
     class Update extends AbstractPropagationEntry {
@@ -289,7 +298,7 @@ public interface PropagationEntry {
             this.objectTypeConf = objectTypeConf;
         }
 
-        public void execute(ReteEvaluator reteEvaluator) {
+        public void internalExecute(ReteEvaluator reteEvaluator) {
             execute(handle, context, objectTypeConf, reteEvaluator);
         }
 
@@ -334,7 +343,7 @@ public interface PropagationEntry {
             this.objectTypeConf = objectTypeConf;
         }
 
-        public void execute(ReteEvaluator reteEvaluator) {
+        public void internalExecute(ReteEvaluator reteEvaluator) {
             ModifyPreviousTuples modifyPreviousTuples = new ModifyPreviousTuples( handle.detachLinkedTuplesForPartition(partition) );
             ObjectTypeNode[] cachedNodes = objectTypeConf.getObjectTypeNodes();
             for ( int i = 0, length = cachedNodes.length; i < length; i++ ) {
@@ -369,7 +378,7 @@ public interface PropagationEntry {
             this.objectTypeConf = objectTypeConf;
         }
 
-        public void execute(ReteEvaluator reteEvaluator) {
+        public void internalExecute(ReteEvaluator reteEvaluator) {
             epn.propagateRetract(handle, context, objectTypeConf, reteEvaluator);
         }
 
@@ -401,7 +410,7 @@ public interface PropagationEntry {
             this.objectTypeConf = objectTypeConf;
         }
 
-        public void execute(ReteEvaluator reteEvaluator) {
+        public void internalExecute(ReteEvaluator reteEvaluator) {
             ObjectTypeNode[] cachedNodes = objectTypeConf.getObjectTypeNodes();
 
             if ( cachedNodes == null ) {

--- a/drools-core/src/main/java/org/drools/core/phreak/ReactiveObjectUtil.java
+++ b/drools-core/src/main/java/org/drools/core/phreak/ReactiveObjectUtil.java
@@ -78,7 +78,7 @@ public class ReactiveObjectUtil {
         }
 
         @Override
-        public void execute( ReteEvaluator reteEvaluator ) {
+        public void internalExecute(ReteEvaluator reteEvaluator ) {
             if ( leftTuple.resetModificationState( object ) == ModificationType.NONE ) {
                 return;
             }

--- a/drools-core/src/main/java/org/drools/core/reteoo/AsyncReceiveNode.java
+++ b/drools-core/src/main/java/org/drools/core/reteoo/AsyncReceiveNode.java
@@ -119,7 +119,7 @@ public class AsyncReceiveNode extends LeftTupleSource
         }
 
         @Override
-        public void execute( final ReteEvaluator reteEvaluator ) {
+        public void internalExecute(final ReteEvaluator reteEvaluator ) {
             AsyncReceiveMemory memory = reteEvaluator.getNodeMemory( asyncReceiveNode );
             memory.addMessage( object );
             memory.setNodeDirtyWithoutNotify();

--- a/drools-core/src/main/java/org/drools/core/reteoo/BaseTuple.java
+++ b/drools-core/src/main/java/org/drools/core/reteoo/BaseTuple.java
@@ -36,7 +36,7 @@ public abstract class BaseTuple implements Tuple {
     private Tuple   previous;
     private Tuple   next;
 
-    protected Sink  sink;
+    protected Sink sink;
 
     protected Tuple handlePrevious;
     protected Tuple handleNext;

--- a/drools-core/src/main/java/org/drools/core/reteoo/BetaNode.java
+++ b/drools-core/src/main/java/org/drools/core/reteoo/BetaNode.java
@@ -50,7 +50,6 @@ import org.drools.core.util.bitmask.AllSetBitMask;
 import org.drools.core.util.bitmask.BitMask;
 import org.drools.core.util.bitmask.EmptyBitMask;
 import org.drools.core.util.index.IndexUtil;
-import org.kie.api.KieBaseConfiguration;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -98,7 +97,7 @@ public abstract class BetaNode extends LeftTupleSource
 
     private boolean rightInputIsPassive;
 
-    private KieBaseConfiguration config;
+    private boolean indexable;
 
     // ------------------------------------------------------------
     // Constructors
@@ -139,9 +138,9 @@ public abstract class BetaNode extends LeftTupleSource
 
         setStreamMode( context.isStreamMode() && getObjectTypeNode(context).getObjectType().isEvent() );
 
-        hashcode = calculateHashCode();
+        this.hashcode = calculateHashCode();
 
-        config = context.getRuleBase().getConfiguration();
+        this.indexable = this.constraints.getConstraints().length > 0 && IndexUtil.isIndexable(this.constraints.getConstraints()[0], getType(), context.getRuleBase().getConfiguration());
     }
 
     private ObjectTypeNode getObjectTypeNode(BuildContext context) {
@@ -229,7 +228,7 @@ public abstract class BetaNode extends LeftTupleSource
         BetaNodeFieldConstraint[] betaCconstraints = this.constraints.getConstraints();
         if ( betaCconstraints.length > 0 ) {
             BetaNodeFieldConstraint c = betaCconstraints[0];
-            if ( IndexUtil.isIndexable(c, getType(), config) && ((IndexableConstraint) c).isUnification() ) {
+            if ( indexable && ((IndexableConstraint) c).isUnification() ) {
                 if ( this.constraints instanceof SingleBetaConstraints ) {
                     setConstraints( new SingleNonIndexSkipBetaConstraints( (SingleBetaConstraints) this.constraints ) );
                 } else if ( this.constraints instanceof DoubleBetaConstraints ) {

--- a/drools-core/src/main/java/org/drools/core/reteoo/ClassObjectTypeConf.java
+++ b/drools-core/src/main/java/org/drools/core/reteoo/ClassObjectTypeConf.java
@@ -52,7 +52,8 @@ public class ClassObjectTypeConf
     private static final long          serialVersionUID = 510l;
 
     private Class<?> cls;
-    private transient RuleBase ruleBase;
+
+    private Rete rete;
     private ObjectTypeNode[] objectTypeNodes;
 
     private ObjectType objectType;
@@ -75,7 +76,6 @@ public class ClassObjectTypeConf
                                final Class< ? > clazz,
                                final RuleBase ruleBase) {
         this.cls = (InternalMatch.class.isAssignableFrom(clazz) ) ? ClassObjectType.Match_ObjectType.getClassType() : clazz;
-        this.ruleBase = ruleBase;
         this.entryPoint = entryPoint;
 
         this.typeDecl = ruleBase.getTypeDeclaration( clazz );
@@ -98,13 +98,12 @@ public class ClassObjectTypeConf
         }
 
         this.objectType = ruleBase.getClassFieldAccessorCache().getClassObjectType( new ClassObjectType( clazz, isEvent ), false );
-
-        this.concreteObjectTypeNode = ruleBase.getRete().getObjectTypeNodes( entryPoint ).get( objectType );
+        this.rete = ruleBase.getRete();
+        this.concreteObjectTypeNode = this.rete.getObjectTypeNodes( entryPoint ).get( objectType );
     }
 
-    public void readExternal(ObjectInput stream) throws IOException,
-                                                ClassNotFoundException {
-        ruleBase = (RuleBase) stream.readObject();
+    public void readExternal(ObjectInput stream) throws IOException, ClassNotFoundException {
+        rete = (Rete) stream.readObject();
         cls = (Class<?>) stream.readObject();
         objectTypeNodes = (ObjectTypeNode[]) stream.readObject();
         objectType = (ObjectType) stream.readObject();
@@ -116,7 +115,7 @@ public class ClassObjectTypeConf
     }
 
     public void writeExternal(ObjectOutput stream) throws IOException {
-        stream.writeObject( ruleBase );
+        stream.writeObject( rete );
         stream.writeObject( cls );
         stream.writeObject( objectTypeNodes );
         stream.writeObject( objectType );
@@ -157,7 +156,7 @@ public class ClassObjectTypeConf
 
     public ObjectTypeNode getConcreteObjectTypeNode() {
         if (concreteObjectTypeNode == null) {
-            concreteObjectTypeNode = ruleBase.getRete().getObjectTypeNodes( entryPoint ).get( objectType );
+            concreteObjectTypeNode = rete.getObjectTypeNodes( entryPoint ).get( objectType );
         }
         return concreteObjectTypeNode;
     }
@@ -194,7 +193,7 @@ public class ClassObjectTypeConf
     private ObjectTypeNode[] getMatchingObjectTypes(final Class<?> clazz) {
         final List<ObjectTypeNode> cache = new ArrayList<>();
 
-        for ( ObjectTypeNode node : ruleBase.getRete().getObjectTypeNodes( this.entryPoint ).values() ) {
+        for ( ObjectTypeNode node : rete.getObjectTypeNodes( this.entryPoint ).values() ) {
             if ( clazz == DroolsQuery.class ) {
                 // for query objects only add direct matches
                 if ( ((ClassObjectType)node.getObjectType()).getClassType() == clazz ) {

--- a/drools-core/src/main/java/org/drools/core/reteoo/CompositePartitionAwareObjectSinkAdapter.java
+++ b/drools-core/src/main/java/org/drools/core/reteoo/CompositePartitionAwareObjectSinkAdapter.java
@@ -137,7 +137,7 @@ public class CompositePartitionAwareObjectSinkAdapter implements ObjectSinkPropa
         }
 
         @Override
-        public void execute( ReteEvaluator reteEvaluator ) {
+        public void internalExecute(ReteEvaluator reteEvaluator ) {
             propagator.propagateAssertObject( factHandle, context, reteEvaluator );
         }
 
@@ -160,7 +160,7 @@ public class CompositePartitionAwareObjectSinkAdapter implements ObjectSinkPropa
         }
 
         @Override
-        public void execute( ReteEvaluator reteEvaluator ) {
+        public void internalExecute(ReteEvaluator reteEvaluator ) {
             sink.getObjectSinkPropagator().propagateAssertObject( factHandle, context, reteEvaluator );
         }
 

--- a/drools-core/src/main/java/org/drools/core/reteoo/RuntimeComponentFactory.java
+++ b/drools-core/src/main/java/org/drools/core/reteoo/RuntimeComponentFactory.java
@@ -41,7 +41,7 @@ public interface RuntimeComponentFactory extends KieService {
 
     String NO_RUNTIME = "Missing runtime. Please add the module org.drools:drools-kiesession to your classpath.";
 
-    AgendaFactory getAgendaFactory();
+    AgendaFactory getAgendaFactory(SessionConfiguration config);
 
     AgendaGroupFactory getAgendaGroupFactory();
 

--- a/drools-core/src/main/java/org/drools/core/rule/Declaration.java
+++ b/drools-core/src/main/java/org/drools/core/rule/Declaration.java
@@ -127,7 +127,11 @@ public class Declaration implements Externalizable, AcceptsReadAccessor, TupleVa
     public void readExternal(ObjectInput in) throws IOException,
                                             ClassNotFoundException {
         identifier = (String) in.readObject();
-        ( (DroolsObjectInputStream) in ).readExtractor( this::setReadAccessor );
+        if (in instanceof DroolsObjectInputStream) {
+            ((DroolsObjectInputStream) in).readExtractor(this::setReadAccessor);
+        } else {
+            readAccessor = (ReadAccessor) in.readObject();
+        }
         pattern = (Pattern) in.readObject();
         internalFact = in.readBoolean();
         bindingName = (String) in.readObject();

--- a/drools-core/src/main/java/org/drools/core/rule/SlidingTimeWindow.java
+++ b/drools-core/src/main/java/org/drools/core/rule/SlidingTimeWindow.java
@@ -387,7 +387,7 @@ public class SlidingTimeWindow
         }
 
         @Override
-        public void execute(ReteEvaluator reteEvaluator) {
+        public void internalExecute(ReteEvaluator reteEvaluator) {
             this.behavior.expireFacts( context, null, reteEvaluator );
         }
     }

--- a/drools-core/src/main/java/org/drools/core/time/EnqueuedSelfRemovalJobContext.java
+++ b/drools-core/src/main/java/org/drools/core/time/EnqueuedSelfRemovalJobContext.java
@@ -31,7 +31,7 @@ public class EnqueuedSelfRemovalJobContext extends SelfRemovalJobContext {
     public void remove() {
         getReteEvaluator().addPropagation( new PropagationEntry.AbstractPropagationEntry() {
             @Override
-            public void execute(ReteEvaluator reteEvaluator) {
+            public void internalExecute(ReteEvaluator reteEvaluator) {
                 timerInstances.remove( jobContext.getJobHandle().getId() );
             }
         } );

--- a/drools-core/src/test/java/org/drools/core/time/impl/JDKTimerServiceTest.java
+++ b/drools-core/src/test/java/org/drools/core/time/impl/JDKTimerServiceTest.java
@@ -40,7 +40,6 @@ import org.drools.core.time.TimerService;
 import org.drools.core.time.TimerServiceFactory;
 import org.drools.core.time.Trigger;
 import org.junit.Test;
-import org.kie.api.runtime.conf.ClockTypeOption;
 
 import static org.assertj.core.api.Assertions.assertThat;
 

--- a/drools-kiesession/src/main/java/org/drools/kiesession/agenda/CompositeDefaultAgenda.java
+++ b/drools-kiesession/src/main/java/org/drools/kiesession/agenda/CompositeDefaultAgenda.java
@@ -272,8 +272,8 @@ public class CompositeDefaultAgenda implements Externalizable, InternalAgenda {
         }
 
         @Override
-        public void execute( ReteEvaluator reteEvaluator ) {
-            super.execute( reteEvaluator );
+        public void internalExecute(ReteEvaluator reteEvaluator ) {
+            super.internalExecute( reteEvaluator );
             compositeAgenda.notifyWaitOnRest();
         }
     }

--- a/drools-kiesession/src/main/java/org/drools/kiesession/agenda/DefaultAgenda.java
+++ b/drools-kiesession/src/main/java/org/drools/kiesession/agenda/DefaultAgenda.java
@@ -832,7 +832,7 @@ public class DefaultAgenda implements Externalizable, InternalAgenda {
         }
 
         @Override
-        public void execute( ReteEvaluator reteEvaluator ) {
+        public void internalExecute(ReteEvaluator reteEvaluator ) {
             executionStateMachine.internalHalt();
         }
 

--- a/drools-kiesession/src/main/java/org/drools/kiesession/factory/RuntimeComponentFactoryImpl.java
+++ b/drools-kiesession/src/main/java/org/drools/kiesession/factory/RuntimeComponentFactoryImpl.java
@@ -69,7 +69,7 @@ public class RuntimeComponentFactoryImpl implements Serializable, RuntimeCompone
         return propagationFactory;
     }
 
-    public AgendaFactory getAgendaFactory() {
+    public AgendaFactory getAgendaFactory(SessionConfiguration config) {
         return agendaFactory;
     }
 

--- a/drools-kiesession/src/main/java/org/drools/kiesession/session/StatefulKnowledgeSessionImpl.java
+++ b/drools-kiesession/src/main/java/org/drools/kiesession/session/StatefulKnowledgeSessionImpl.java
@@ -35,6 +35,7 @@ import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicLong;
 import java.util.concurrent.locks.Lock;
 import java.util.concurrent.locks.ReentrantLock;
+import java.util.function.Consumer;
 
 import org.drools.core.FlowSessionConfiguration;
 import org.drools.core.QueryResultsImpl;
@@ -242,6 +243,8 @@ public class StatefulKnowledgeSessionImpl extends AbstractRuntime
 
     private NamedEntryPointsManager entryPointsManager;
 
+    private Consumer<PropagationEntry> workingMemoryActionListener;
+
     // ------------------------------------------------------------
     // Constructors
     // ------------------------------------------------------------
@@ -256,14 +259,14 @@ public class StatefulKnowledgeSessionImpl extends AbstractRuntime
         this(id,
              kBase,
              true,
-             kBase.getSessionConfiguration(),
+             (SessionConfiguration) kBase.getSessionConfiguration(),
              EnvironmentFactory.newEnvironment());
     }
 
     public StatefulKnowledgeSessionImpl(final long id,
                                         final InternalKnowledgeBase kBase,
                                         boolean initInitFactHandle,
-                                        final KieSessionConfiguration config,
+                                        final SessionConfiguration config,
                                         final Environment environment) {
         this(id,
              kBase,
@@ -282,7 +285,7 @@ public class StatefulKnowledgeSessionImpl extends AbstractRuntime
                                         final InternalKnowledgeBase kBase,
                                         final FactHandleFactory handleFactory,
                                         final long propagationContext,
-                                        final KieSessionConfiguration config,
+                                        final SessionConfiguration config,
                                         final InternalAgenda agenda,
                                         final Environment environment) {
         this(id,
@@ -304,7 +307,7 @@ public class StatefulKnowledgeSessionImpl extends AbstractRuntime
                                          final FactHandleFactory handleFactory,
                                          final boolean initInitFactHandle,
                                          final long propagationContext,
-                                         final KieSessionConfiguration config,
+                                         final SessionConfiguration config,
                                          final Environment environment,
                                          final RuleRuntimeEventSupport workingMemoryEventSupport,
                                          final AgendaEventSupport agendaEventSupport,
@@ -326,7 +329,7 @@ public class StatefulKnowledgeSessionImpl extends AbstractRuntime
         RuleBaseConfiguration conf = kBase.getRuleBaseConfiguration();
         this.pctxFactory = RuntimeComponentFactory.get().getPropagationContextFactory();
 
-        this.agenda = agenda != null ? agenda : RuntimeComponentFactory.get().getAgendaFactory().createAgenda(kBase);
+        this.agenda = agenda != null ? agenda : RuntimeComponentFactory.get().getAgendaFactory( config ).createAgenda(kBase);
         this.agenda.setWorkingMemory(this);
 
         this.entryPointsManager = (NamedEntryPointsManager) RuntimeComponentFactory.get().getEntryPointFactory().createEntryPointsManager(this);
@@ -458,6 +461,16 @@ public class StatefulKnowledgeSessionImpl extends AbstractRuntime
     @Override
     public KieBase getKieBase() {
         return this.kBase;
+    }
+
+    @Override
+    public Consumer<PropagationEntry> getWorkingMemoryActionListener() {
+        return workingMemoryActionListener;
+    }
+
+    @Override
+    public void setWorkingMemoryActionListener(Consumer<PropagationEntry> workingMemoryActionListener) {
+        this.workingMemoryActionListener = workingMemoryActionListener;
     }
 
     StatefulKnowledgeSessionImpl fromPool(StatefulSessionPool pool) {
@@ -749,7 +762,7 @@ public class StatefulKnowledgeSessionImpl extends AbstractRuntime
         }
 
         @Override
-        public void execute( ReteEvaluator reteEvaluator ) {
+        public void internalExecute(ReteEvaluator reteEvaluator ) {
             LeftInputAdapterNode lian = factHandle.getFirstLeftTuple().getTupleSource();
             LeftInputAdapterNode.LiaNodeMemory lmem = getNodeMemory(lian);
             SegmentMemory lsmem = lmem.getSegmentMemory();
@@ -1236,7 +1249,7 @@ public class StatefulKnowledgeSessionImpl extends AbstractRuntime
     public void submit(AtomicAction action) {
         agenda.addPropagation( new PropagationEntry.AbstractPropagationEntry() {
             @Override
-            public void execute( ReteEvaluator reteEvaluator ) {
+            public void internalExecute(ReteEvaluator reteEvaluator ) {
                 action.execute( (KieSession)reteEvaluator );
             }
         } );

--- a/drools-kiesession/src/test/java/org/drools/kiesession/ReteooWorkingMemoryTest.java
+++ b/drools-kiesession/src/test/java/org/drools/kiesession/ReteooWorkingMemoryTest.java
@@ -204,7 +204,7 @@ public class ReteooWorkingMemoryTest {
             implements WorkingMemoryAction {
         // I am using AtomicInteger just as an int wrapper... nothing to do with concurrency here
         public AtomicInteger counter = new AtomicInteger(0);
-        public void execute(ReteEvaluator reteEvaluator) {
+        public void internalExecute(ReteEvaluator reteEvaluator) {
             // the reentrant action must be executed completely
             // before any of the final actions is executed
             assertThat(counter.get()).isEqualTo(0);

--- a/drools-mvel/src/main/java/org/drools/mvel/MVELConstraint.java
+++ b/drools-mvel/src/main/java/org/drools/mvel/MVELConstraint.java
@@ -33,8 +33,8 @@ import java.util.concurrent.Executor;
 import java.util.concurrent.atomic.AtomicInteger;
 
 import org.drools.compiler.rule.builder.EvaluatorWrapper;
-import org.drools.core.RuleBaseConfiguration;
 import org.drools.core.base.DroolsQuery;
+import org.drools.core.base.ObjectType;
 import org.drools.core.common.DroolsObjectInputStream;
 import org.drools.core.common.InternalFactHandle;
 import org.drools.core.common.ReteEvaluator;
@@ -42,20 +42,18 @@ import org.drools.core.definitions.InternalKnowledgePackage;
 import org.drools.core.definitions.rule.impl.RuleImpl;
 import org.drools.core.impl.RuleBase;
 import org.drools.core.reteoo.PropertySpecificUtil;
+import org.drools.core.reteoo.Tuple;
 import org.drools.core.reteoo.builder.BuildContext;
 import org.drools.core.rule.ContextEntry;
 import org.drools.core.rule.Declaration;
 import org.drools.core.rule.IndexableConstraint;
 import org.drools.core.rule.MutableTypeConstraint;
 import org.drools.core.rule.accessor.AcceptsReadAccessor;
-import org.drools.core.rule.constraint.Constraint;
 import org.drools.core.rule.accessor.FieldValue;
 import org.drools.core.rule.accessor.ReadAccessor;
-import org.drools.core.base.ObjectType;
-import org.drools.core.reteoo.Tuple;
 import org.drools.core.rule.accessor.TupleValueExtractor;
+import org.drools.core.rule.constraint.Constraint;
 import org.drools.core.util.AbstractHashTable.FieldIndex;
-import org.drools.core.util.MemoryUtil;
 import org.drools.core.util.bitmask.BitMask;
 import org.drools.core.util.index.IndexUtil;
 import org.drools.mvel.ConditionAnalyzer.CombinedCondition;
@@ -83,9 +81,9 @@ import static org.drools.core.reteoo.PropertySpecificUtil.allSetBitMask;
 import static org.drools.core.reteoo.PropertySpecificUtil.allSetButTraitBitMask;
 import static org.drools.core.reteoo.PropertySpecificUtil.getEmptyPropertyReactiveMask;
 import static org.drools.core.reteoo.PropertySpecificUtil.setPropertyOnMask;
-import static org.drools.util.ClassUtils.getter2property;
 import static org.drools.core.util.Drools.isJmxAvailable;
 import static org.drools.core.util.MessageUtils.defaultToEmptyString;
+import static org.drools.util.ClassUtils.getter2property;
 import static org.drools.util.StringUtils.codeAwareIndexOf;
 import static org.drools.util.StringUtils.equalsIgnoreSpaces;
 import static org.drools.util.StringUtils.extractFirstIdentifier;
@@ -650,7 +648,13 @@ public class MVELConstraint extends MutableTypeConstraint implements IndexableCo
         super.readExternal(in);
         packageNames = (Set<String>) in.readObject();
         expression = (String) in.readObject();
-        ((DroolsObjectInputStream) in).readExtractor(this::setReadAccessor);
+
+        if (in instanceof DroolsObjectInputStream) {
+            ((DroolsObjectInputStream) in).readExtractor(this::setReadAccessor);
+        } else {
+            extractor = (ReadAccessor) in.readObject();
+        }
+
         indexingDeclaration = (Declaration) in.readObject();
         declarations = (Declaration[]) in.readObject();
         constraintType = (IndexUtil.ConstraintType) in.readObject();

--- a/drools-reliability/src/main/java/org/drools/reliability/CacheManager.java
+++ b/drools-reliability/src/main/java/org/drools/reliability/CacheManager.java
@@ -49,7 +49,9 @@ public enum CacheManager implements AutoCloseable {
         global.serialization()
                 .marshaller(new JavaSerializationMarshaller())
                 .allowList()
-                .addRegexps("org.drools."); // TODO: need to be configurable
+                .addRegexps("org.kie.*") // TODO: need to be configurable
+                .addRegexps("org.drools.*") // TODO: need to be configurable
+                .addRegexps("java.*"); // TODO: why is this necessary?
         global.transport().defaultTransport();
 
         // Initialize the default Cache Manager.

--- a/drools-reliability/src/main/java/org/drools/reliability/ReliableRuntimeComponentFactoryImpl.java
+++ b/drools-reliability/src/main/java/org/drools/reliability/ReliableRuntimeComponentFactoryImpl.java
@@ -15,21 +15,27 @@
 
 package org.drools.reliability;
 
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
 import java.util.concurrent.atomic.AtomicLong;
+import java.util.stream.Collectors;
 
 import org.drools.core.SessionConfiguration;
+import org.drools.core.WorkingMemoryEntryPoint;
 import org.drools.core.common.AgendaFactory;
 import org.drools.core.common.EntryPointFactory;
+import org.drools.core.common.InternalFactHandle;
 import org.drools.core.common.InternalWorkingMemory;
 import org.drools.core.impl.RuleBase;
+import org.drools.core.phreak.PropagationEntry;
 import org.drools.kiesession.factory.RuntimeComponentFactoryImpl;
 import org.drools.kiesession.rulebase.InternalKnowledgeBase;
-import org.drools.kiesession.session.StatefulKnowledgeSessionImpl;
 import org.kie.api.runtime.Environment;
+import org.kie.api.runtime.conf.PersistedSessionOption;
+import org.kie.api.runtime.rule.EntryPoint;
 
 public class ReliableRuntimeComponentFactoryImpl extends RuntimeComponentFactoryImpl {
-
-    public static final ReliableRuntimeComponentFactoryImpl DEFAULT = new ReliableRuntimeComponentFactoryImpl();
 
     private static final AtomicLong RELIABLE_SESSIONS_COUNTER = new AtomicLong(0);
 
@@ -42,32 +48,63 @@ public class ReliableRuntimeComponentFactoryImpl extends RuntimeComponentFactory
 
     @Override
     public InternalWorkingMemory createStatefulSession(RuleBase ruleBase, Environment environment, SessionConfiguration sessionConfig, boolean fromPool) {
+        if (!sessionConfig.hasPersistedSessionOption()) {
+            return super.createStatefulSession(ruleBase, environment, sessionConfig, fromPool);
+        }
+
         InternalKnowledgeBase kbase = (InternalKnowledgeBase) ruleBase;
         if (fromPool || kbase.getSessionPool() == null) {
-            StatefulKnowledgeSessionImpl session = (StatefulKnowledgeSessionImpl) getWorkingMemoryFactory()
-                    .createWorkingMemory(RELIABLE_SESSIONS_COUNTER.getAndIncrement(), kbase, sessionConfig, environment);
+            InternalWorkingMemory session = getWorkingMemoryFactory().createWorkingMemory(RELIABLE_SESSIONS_COUNTER.getAndIncrement(), kbase, sessionConfig, environment);
             return internalInitSession(kbase, sessionConfig, session);
         }
         return (InternalWorkingMemory) kbase.getSessionPool().newKieSession(sessionConfig);
     }
 
-    private StatefulKnowledgeSessionImpl internalInitSession(InternalKnowledgeBase kbase, SessionConfiguration sessionConfig, StatefulKnowledgeSessionImpl session) {
+    private InternalWorkingMemory internalInitSession(InternalKnowledgeBase kbase, SessionConfiguration sessionConfig, InternalWorkingMemory session) {
         if (sessionConfig.isKeepReference()) {
             kbase.addStatefulSession(session);
         }
 
+        session.setWorkingMemoryActionListener(entry -> onWorkingMemoryAction(session, entry));
+
         // re-propagate objects from the cache to the new session
-//        updateFactsWithCache(session);
+        populateSessionFromCache(session, sessionConfig);
         return session;
     }
 
-    private void updateFactsWithCache(StatefulKnowledgeSessionImpl session) {
-        session.getFactHandles().forEach(factHandle -> {
-            session.update(factHandle, session.getObject(factHandle));
-        });
+    private void onWorkingMemoryAction(InternalWorkingMemory session, PropagationEntry entry) {
+        if (entry instanceof PropagationEntry.Insert) {
+            InternalFactHandle fh = ((PropagationEntry.Insert) entry).getHandle();
+            WorkingMemoryEntryPoint ep = fh.getEntryPoint(session);
+            ep.getObjectStore().updateHandle(fh, fh.getObject());
+        }
     }
 
-    public AgendaFactory getAgendaFactory() {
+    private void populateSessionFromCache(InternalWorkingMemory session, SessionConfiguration sessionConfig) {
+        if (sessionConfig.getPersistedSessionOption().getStrategy() == PersistedSessionOption.Strategy.STORES_ONLY) {
+            session.getEntryPoints().forEach( ep -> populateEntryPointFromCache(session, ep));
+        }
+    }
+
+    private void populateEntryPointFromCache(InternalWorkingMemory session, EntryPoint ep) {
+        Map<Boolean, List<InternalFactHandle>> map = ep.getFactHandles().stream()
+                .map(InternalFactHandle.class::cast)
+                .collect(Collectors.groupingBy(InternalFactHandle::hasMatches));
+
+        ((WorkingMemoryEntryPoint) ep).getObjectStore().clear();
+
+        // fact handles with a match have been already propagated in the original session, so they shouldn't fire
+        map.getOrDefault(true, Collections.emptyList()).forEach(fh -> session.insert( fh.getObject() ) );
+        session.fireAllRules(match -> false);
+
+        // fact handles without any match have never been propagated in the original session, so they should fire
+        map.getOrDefault(false, Collections.emptyList()).forEach( fh -> session.insert( fh.getObject() ) );
+    }
+
+    public AgendaFactory getAgendaFactory(SessionConfiguration sessionConfig) {
+        if (!sessionConfig.hasPersistedSessionOption() || sessionConfig.getPersistedSessionOption().getStrategy() == PersistedSessionOption.Strategy.STORES_ONLY) {
+            return super.getAgendaFactory(sessionConfig);
+        }
         return agendaFactory;
     }
 

--- a/drools-serialization-protobuf/src/main/java/org/drools/serialization/protobuf/ProtobufInputMarshaller.java
+++ b/drools-serialization-protobuf/src/main/java/org/drools/serialization/protobuf/ProtobufInputMarshaller.java
@@ -180,7 +180,7 @@ public class ProtobufInputMarshaller {
         session.reset( _session.getRuleData().getLastId(),
                        _session.getRuleData().getLastRecency(),
                        1 );
-        InternalAgenda agenda = (InternalAgenda) session.getAgenda();
+        InternalAgenda agenda = session.getAgenda();
 
         readAgenda( context,
                     _session.getRuleData(),
@@ -196,7 +196,7 @@ public class ProtobufInputMarshaller {
         FactHandleFactory handleFactory = context.getKnowledgeBase().newFactHandleFactory( _session.getRuleData().getLastId(),
                                                                                  _session.getRuleData().getLastRecency() );
 
-        InternalAgenda agenda = RuntimeComponentFactory.get().getAgendaFactory().createAgenda( context.getKnowledgeBase(), false );
+        InternalAgenda agenda = RuntimeComponentFactory.get().getAgendaFactory(config).createAgenda( context.getKnowledgeBase(), false );
 
         StatefulKnowledgeSessionImpl session = ( StatefulKnowledgeSessionImpl ) PhreakWorkingMemoryFactory.getInstance()
                 .createWorkingMemory( id, context.getKnowledgeBase(), handleFactory,

--- a/drools-serialization-protobuf/src/main/java/org/drools/serialization/protobuf/WorkingMemoryReteAssertAction.java
+++ b/drools-serialization-protobuf/src/main/java/org/drools/serialization/protobuf/WorkingMemoryReteAssertAction.java
@@ -60,7 +60,7 @@ public class WorkingMemoryReteAssertAction
         }
     }
 
-    public void execute(ReteEvaluator reteEvaluator) {
+    public void internalExecute(ReteEvaluator reteEvaluator) {
         PropagationContextFactory pctxFactory = RuntimeComponentFactory.get().getPropagationContextFactory();
 
         final PropagationContext context = pctxFactory.createPropagationContext(reteEvaluator.getNextPropagationIdCounter(), PropagationContext.Type.INSERTION,

--- a/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/compiler/command/PropagationListTest.java
+++ b/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/compiler/command/PropagationListTest.java
@@ -135,7 +135,7 @@ public class PropagationListTest {
         }
 
         @Override
-        public void execute(final ReteEvaluator reteEvaluator) {
+        public void internalExecute(final ReteEvaluator reteEvaluator) {
             checker.check(this);
         }
 

--- a/drools-tms/src/main/java/org/drools/tms/beliefsystem/simple/BeliefSystemLogicalCallback.java
+++ b/drools-tms/src/main/java/org/drools/tms/beliefsystem/simple/BeliefSystemLogicalCallback.java
@@ -78,7 +78,7 @@ public class BeliefSystemLogicalCallback extends PropagationEntry.AbstractPropag
         this.fullyRetract = fullyRetract;
     }
 
-    public void execute(ReteEvaluator reteEvaluator) {
+    public void internalExecute(ReteEvaluator reteEvaluator) {
         NamedEntryPoint nep = (NamedEntryPoint) handle.getEntryPoint(reteEvaluator) ;
 
         BeliefSet bs = ((TruthMaintenanceSystemEqualityKey)handle.getEqualityKey()).getBeliefSet();

--- a/kie-api/src/main/java/org/kie/api/runtime/conf/PersistedSessionOption.java
+++ b/kie-api/src/main/java/org/kie/api/runtime/conf/PersistedSessionOption.java
@@ -24,6 +24,10 @@ import java.util.Objects;
  */
 public class PersistedSessionOption implements SingleValueKieSessionOption {
 
+    public enum Strategy {
+        FULL, STORES_ONLY
+    }
+
     /**
      * The property name for the clock type configuration
      */
@@ -31,20 +35,39 @@ public class PersistedSessionOption implements SingleValueKieSessionOption {
 
     private final long sessionId;
 
+    private final Strategy strategy;
+
     private PersistedSessionOption() {
         this(-1L);
     }
 
     private PersistedSessionOption(long sessionId) {
+        this(sessionId, Strategy.FULL);
+    }
+
+    private PersistedSessionOption(Strategy strategy) {
+        this(-1, strategy);
+    }
+
+    private PersistedSessionOption(long sessionId, Strategy strategy) {
         this.sessionId = sessionId;
+        this.strategy = strategy;
     }
 
     public static PersistedSessionOption newSession() {
         return new PersistedSessionOption();
     }
 
+    public static PersistedSessionOption newSession(Strategy strategy) {
+        return new PersistedSessionOption(strategy);
+    }
+
     public static PersistedSessionOption fromSession(long sessionId) {
         return new PersistedSessionOption(sessionId);
+    }
+
+    public static PersistedSessionOption fromSession(long sessionId, Strategy strategy) {
+        return new PersistedSessionOption(sessionId, strategy);
     }
 
     /**
@@ -56,6 +79,10 @@ public class PersistedSessionOption implements SingleValueKieSessionOption {
 
     public long getSessionId() {
         return sessionId;
+    }
+
+    public Strategy getStrategy() {
+        return strategy;
     }
 
     public boolean isNewSession() {


### PR DESCRIPTION
This pull request is a first implemetation of lightweight reliable session that only relies on persistance of object store. It includes:

- Fix to serialization of `FactHandle`s.
- A mechanism to [listen when a working memory action is performed](https://github.com/kiegroup/drools/pull/5065/files#diff-f120d1c752fce374911be2ae53336d91edfad7132e83535cd654445a1d158317R151). This is necessary to [refresh the cache](https://github.com/kiegroup/drools/pull/5065/files#diff-0ddb008ecafa6fd81b44ca5e3ea5e1372a21dca06f80b761d102d66d43d78c9bR76) when a `FactHandle` is modified. At the moment this is acting only on the Insert action, but it will need to be extended to many other actions.
- A mechanism to [flush the objects from the persisted object stores](https://github.com/kiegroup/drools/pull/5065/files#diff-0ddb008ecafa6fd81b44ca5e3ea5e1372a21dca06f80b761d102d66d43d78c9bR89) to the new empty session. It distinguishes between facts that have been already propagated, that shouldn't cause the firing of a consequence and others not yet propagated, for which the consequence should fire at the first explicit `fireAllRules` invocation.

The following is instead still outstanding:

- A mechanism to also persist and restore `global`s.
- Something also dealing with timers (more in general we are not considering CEP yet and I'm afraid that this will be tricky).
- A lighter persisted object store specific for this use case: for this scenario it is not necessary to persist the whole `FactHandle`s, also because [they are all discarded](https://github.com/kiegroup/drools/pull/5065/files#diff-0ddb008ecafa6fd81b44ca5e3ea5e1372a21dca06f80b761d102d66d43d78c9bR94) and recreated. It will be enough to keep track of only the objects present in a store in a given moment.

As first improvement I will concentrate on this last point (light persisted object store) with a subsequent pull request.