### PR TITLE
Drools 7362 [SimpleReliableStore: test fact updates]

### DIFF
--- a/drools-reliability/src/test/java/org/drools/reliability/StoresOnlyStrategyTest.java
+++ b/drools-reliability/src/test/java/org/drools/reliability/StoresOnlyStrategyTest.java
@@ -59,11 +59,12 @@ public class StoresOnlyStrategyTest {
             firstSession.insert("M");
             firstSession.insert(new Person("Matteo", 41));
             Person pMark = new Person("_Mark", 47);
-            FactHandle fhMark = firstSession.insert(pMark);
+            FactHandle fhMark = firstSession.insert(new Person("_Mark", 47));
 
             assertThat(firstSession.fireAllRules()).isEqualTo(1);
             assertThat(results).containsExactlyInAnyOrder(41);
 
+            //Person pMark = (Person) firstSession.getObject(fhMark);
             pMark.setName("Mark");
             firstSession.update(fhMark, pMark);
         }

--- a/drools-reliability/src/test/java/org/drools/reliability/StoresOnlyStrategyTest.java
+++ b/drools-reliability/src/test/java/org/drools/reliability/StoresOnlyStrategyTest.java
@@ -1,0 +1,178 @@
+package org.drools.reliability;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.kie.api.KieBase;
+import org.kie.api.KieServices;
+import org.kie.api.io.ResourceType;
+import org.kie.api.runtime.KieSession;
+import org.kie.api.runtime.KieSessionConfiguration;
+import org.kie.api.runtime.conf.PersistedSessionOption;
+import org.kie.api.runtime.rule.FactHandle;
+import org.kie.internal.utils.KieHelper;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.drools.reliability.ReliabilityTestUtils.failover;
+
+@ExtendWith(BeforeAllMethodExtension.class)
+public class StoresOnlyStrategyTest {
+
+    private static final String BASIC_RULE =
+            "import " + Person.class.getCanonicalName() + ";" +
+                    "global java.util.List results;" +
+                    "rule X when\n" +
+                    "  $s: String()\n" +
+                    "  $p: Person( getName().startsWith($s) )\n" +
+                    "then\n" +
+                    "  results.add( $p.getAge() );\n" +
+                    "end";
+
+    @AfterEach
+    public void tearDown() {
+        // We can remove this when we implement ReliableSession.dispose() to call CacheManager.removeCachesBySessionId(id)
+        CacheManager.INSTANCE.removeAllSessionCaches();
+    }
+
+    private KieSession getKieSession(String drl, PersistedSessionOption option) {
+        KieBase kbase = new KieHelper().addContent(drl, ResourceType.DRL).build();
+        KieSessionConfiguration conf = KieServices.get().newKieSessionConfiguration();
+        conf.setOption(option);
+        return kbase.newKieSession(conf, null);
+    }
+
+    @Test
+    void insertFireUpdateFailover_RePropagateUpdates() {
+        long id;
+
+        // 1st round
+        {
+            KieSession firstSession = getKieSession(BASIC_RULE, PersistedSessionOption.newSession(PersistedSessionOption.Strategy.STORES_ONLY));
+            List<Integer> results = new ArrayList<>();
+            firstSession.setGlobal("results", results);
+
+            id = firstSession.getIdentifier();
+
+            firstSession.insert("M");
+            firstSession.insert(new Person("Matteo", 41));
+            Person pMark = new Person("_Mark", 47);
+            FactHandle fhMark = firstSession.insert(pMark);
+
+            assertThat(firstSession.fireAllRules()).isEqualTo(1);
+            assertThat(results).containsExactlyInAnyOrder(41);
+
+            pMark.setName("Mark");
+            firstSession.update(fhMark, pMark);
+        }
+
+        failover();
+
+        // 2nd round
+        {
+            KieSession secondSession = getKieSession(BASIC_RULE, PersistedSessionOption.fromSession(id, PersistedSessionOption.Strategy.STORES_ONLY));
+            List<Integer> results = new ArrayList<>();
+            secondSession.setGlobal("results", results);
+
+            try {
+                secondSession.insert(new Person("Toshiya", 45));
+                secondSession.insert(new Person("Mario", 49));
+
+                assertThat(secondSession.fireAllRules()).isEqualTo(2);
+                assertThat(results).containsExactlyInAnyOrder(49,47);
+            } finally {
+                secondSession.dispose();
+            }
+        }
+    }
+
+    @Test
+    void insertUpdateFireFailover_CacheImmutableKey() {
+        long id;
+
+        // 1st round
+        {
+            KieSession firstSession = getKieSession(BASIC_RULE, PersistedSessionOption.newSession(PersistedSessionOption.Strategy.STORES_ONLY));
+            List<Integer> results = new ArrayList<>();
+            firstSession.setGlobal("results", results);
+
+            id = firstSession.getIdentifier();
+
+            firstSession.insert("M");
+            firstSession.insert(new Person("Matteo", 41));
+
+            Person pMark = new Person("Mark", 47);
+            FactHandle fhMark = firstSession.insert(new Person("Mark", 47));
+            pMark.setName("_Mark");
+            firstSession.update(fhMark, pMark);
+
+            assertThat(firstSession.fireAllRules()).isEqualTo(1);
+            assertThat(results).containsExactlyInAnyOrder(41);
+        }
+
+        failover();
+
+        // 2nd round
+        {
+            KieSession secondSession = getKieSession(BASIC_RULE, PersistedSessionOption.fromSession(id, PersistedSessionOption.Strategy.STORES_ONLY));
+            List<Integer> results = new ArrayList<>();
+            secondSession.setGlobal("results", results);
+
+            try {
+                secondSession.insert(new Person("Toshiya", 45));
+                secondSession.insert(new Person("Mario", 49));
+
+                assertThat(secondSession.fireAllRules()).isEqualTo(1);
+                assertThat(results).containsExactlyInAnyOrder(49);
+            } finally {
+                secondSession.dispose();
+            }
+        }
+    }
+
+    @Test
+    void fireInsertUpdateFailover_CacheImmutableKey() {
+        long id;
+
+        // 1st round
+        {
+            KieSession firstSession = getKieSession(BASIC_RULE, PersistedSessionOption.newSession(PersistedSessionOption.Strategy.STORES_ONLY));
+            List<Integer> results = new ArrayList<>();
+            firstSession.setGlobal("results", results);
+
+            id = firstSession.getIdentifier();
+
+            firstSession.insert("M");
+            firstSession.insert(new Person("Matteo", 41));
+
+            assertThat(firstSession.fireAllRules()).isEqualTo(1);
+            assertThat(results).containsExactlyInAnyOrder(41);
+
+            Person pMark = new Person("Mark", 47);
+            FactHandle fhMark = firstSession.insert(new Person("Mark", 47));
+            pMark.setName("_Mark");
+            firstSession.update(fhMark, pMark);
+        }
+
+        failover();
+
+        // 2nd round
+        {
+            KieSession secondSession = getKieSession(BASIC_RULE, PersistedSessionOption.fromSession(id, PersistedSessionOption.Strategy.STORES_ONLY));
+            List<Integer> results = new ArrayList<>();
+            secondSession.setGlobal("results", results);
+
+            try {
+                secondSession.insert(new Person("Toshiya", 45));
+                secondSession.insert(new Person("Mario", 49));
+
+                assertThat(secondSession.fireAllRules()).isEqualTo(1);
+                assertThat(results).containsExactlyInAnyOrder(49);
+            } finally {
+                secondSession.dispose();
+            }
+        }
+    }
+}


### PR DESCRIPTION
Testing SimpleReliableObjectStore when creating a new session from a persisted store that contains fact updates not processed (propagated).

The PR also contains two basic tests to ensure that infinispan cache immutable key limitation is not causing any issues (insertUpdateFireFailover_CacheImmutableKey(), fireInsertUpdateFailover_CacheImmutableKey).

With regards to fact updates and creating a session from a persisted store,
I noticed that depending on how we update facts, that we have previously inserted into the wm, affects the way a fact is populated into a new session (fireUpdateFactByFactHandleFailover(), fireUpdateFactWithNewObjectFailover()).
Please see jira  [DROOLS-7362](https://issues.redhat.com/browse/DROOLS-7362).


