### PR TITLE
stores only reliable session to support updates and deletes

### DIFF
--- a/drools-core/src/main/java/org/drools/core/common/MapObjectStore.java
+++ b/drools-core/src/main/java/org/drools/core/common/MapObjectStore.java
@@ -31,7 +31,7 @@ import static java.util.stream.Collectors.toList;
 
 public abstract class MapObjectStore implements Externalizable, ObjectStore {
 
-    private Map<Object, InternalFactHandle> fhMap;
+    protected Map<Object, InternalFactHandle> fhMap;
 
     protected MapObjectStore(Map<Object, InternalFactHandle> fhMap) {
         this.fhMap = fhMap;

--- a/drools-reliability/src/main/java/org/drools/reliability/ReliableSessionInitializer.java
+++ b/drools-reliability/src/main/java/org/drools/reliability/ReliableSessionInitializer.java
@@ -1,0 +1,108 @@
+/*
+ * Copyright 2023 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.drools.reliability;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import org.drools.core.SessionConfiguration;
+import org.drools.core.WorkingMemoryEntryPoint;
+import org.drools.core.common.InternalFactHandle;
+import org.drools.core.common.InternalWorkingMemory;
+import org.drools.core.phreak.PropagationEntry;
+import org.kie.api.event.rule.ObjectDeletedEvent;
+import org.kie.api.event.rule.ObjectInsertedEvent;
+import org.kie.api.event.rule.ObjectUpdatedEvent;
+import org.kie.api.event.rule.RuleRuntimeEventListener;
+import org.kie.api.runtime.conf.PersistedSessionOption;
+import org.kie.api.runtime.rule.EntryPoint;
+
+public class ReliableSessionInitializer {
+
+    private static final Map<PersistedSessionOption.Strategy, SessionInitializer> initializersMap = Map.of(
+            PersistedSessionOption.Strategy.STORES_ONLY, new StoresOnlySessionInitializer(),
+            PersistedSessionOption.Strategy.FULL, new FullReliableSessionInitializer());
+
+    static InternalWorkingMemory initReliableSession(SessionConfiguration sessionConfig, InternalWorkingMemory session) {
+        return initializersMap.get(sessionConfig.getPersistedSessionOption().getStrategy()).init(session);
+    }
+
+    interface SessionInitializer {
+        InternalWorkingMemory init(InternalWorkingMemory session);
+    }
+
+    private static class StoresOnlySessionInitializer implements SessionInitializer {
+
+        @Override
+        public InternalWorkingMemory init(InternalWorkingMemory session) {
+            // re-propagate objects from the cache to the new session
+            populateSessionFromCache(session);
+
+            session.setWorkingMemoryActionListener(entry -> onWorkingMemoryAction(session, entry));
+            session.getRuleRuntimeEventSupport().addEventListener(new SimpleStoreRuntimeEventListener(session));
+
+            return session;
+        }
+
+        private void onWorkingMemoryAction(InternalWorkingMemory session, PropagationEntry entry) {
+            if (entry instanceof PropagationEntry.Insert) {
+                InternalFactHandle fh = ((PropagationEntry.Insert) entry).getHandle();
+                WorkingMemoryEntryPoint ep = fh.getEntryPoint(session);
+                ((SimpleReliableObjectStore) ep.getObjectStore()).putIntoPersistedCache(fh.getObject(), true);
+            }
+        }
+
+        private void populateSessionFromCache(InternalWorkingMemory session) {
+            Map<EntryPoint, List<Object>> notPropagatedByEntryPoint = new HashMap<>();
+
+            for (EntryPoint ep : session.getEntryPoints()) {
+                SimpleReliableObjectStore store = (SimpleReliableObjectStore) ((WorkingMemoryEntryPoint) ep).getObjectStore();
+                notPropagatedByEntryPoint.put(ep, store.reInit(session, ep));
+            }
+
+            notPropagatedByEntryPoint.forEach((ep, objects) -> objects.forEach(ep::insert));
+        }
+
+        static class SimpleStoreRuntimeEventListener implements RuleRuntimeEventListener {
+
+            private final InternalWorkingMemory session;
+
+            SimpleStoreRuntimeEventListener(InternalWorkingMemory session) {
+                this.session = session;
+            }
+
+            public void objectInserted(ObjectInsertedEvent ev) {
+            }
+
+            public void objectDeleted(ObjectDeletedEvent ev) {
+            }
+
+            public void objectUpdated(ObjectUpdatedEvent ev) {
+                SimpleReliableObjectStore store = (SimpleReliableObjectStore) ((InternalFactHandle) ev.getFactHandle()).getEntryPoint(session).getObjectStore();
+                store.putIntoPersistedCache(ev.getObject(), false);
+            }
+        }
+    }
+
+    private static class FullReliableSessionInitializer implements SessionInitializer {
+
+        @Override
+        public InternalWorkingMemory init(InternalWorkingMemory session) {
+            return session;
+        }
+    }
+}

--- a/drools-reliability/src/main/java/org/drools/reliability/SimpleReliableObjectStore.java
+++ b/drools-reliability/src/main/java/org/drools/reliability/SimpleReliableObjectStore.java
@@ -1,18 +1,37 @@
+/*
+ * Copyright 2023 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.drools.reliability;
 
+import java.io.Serializable;
 import java.util.ArrayList;
 import java.util.List;
-import java.util.Map;
 
 import org.drools.core.common.IdentityObjectStore;
 import org.drools.core.common.InternalFactHandle;
+import org.drools.core.common.InternalWorkingMemory;
 import org.infinispan.Cache;
+import org.kie.api.runtime.rule.EntryPoint;
 
 public class SimpleReliableObjectStore extends IdentityObjectStore {
 
-    private final Cache<Object, Boolean> cache;
+    private final Cache<Long, PropagatedObject> cache;
 
-    public SimpleReliableObjectStore(Cache<Object, Boolean> cache) {
+    private boolean reInitPropagated = false;
+
+    public SimpleReliableObjectStore(Cache<Long, PropagatedObject> cache) {
         super();
         this.cache = cache;
     }
@@ -20,26 +39,55 @@ public class SimpleReliableObjectStore extends IdentityObjectStore {
     @Override
     public void addHandle(InternalFactHandle handle, Object object) {
         super.addHandle(handle, object);
-        cache.put(object, handle.hasMatches());
+        putIntoPersistedCache(object, handle.hasMatches());
     }
 
     @Override
     public void removeHandle(InternalFactHandle handle) {
+        removeFromPersistedCache(handle.getObject());
         super.removeHandle(handle);
-        cache.remove(handle.getObject());
     }
 
-    Map<Boolean, List<Object>> takeObjectsGroupedByPropagation() {
+    List<Object> reInit(InternalWorkingMemory session, EntryPoint ep) {
+        reInitPropagated = true;
         List<Object> propagated = new ArrayList<>();
         List<Object> notPropagated = new ArrayList<>();
-        for (Map.Entry<Object, Boolean> entry : cache.entrySet()) {
-            if (entry.getValue()) {
-                propagated.add(entry.getKey());
+        for (PropagatedObject entry : cache.values()) {
+            if (entry.propagated) {
+                propagated.add(entry.object);
             } else {
-                notPropagated.add(entry.getKey());
+                notPropagated.add(entry.object);
             }
         }
         cache.clear();
-        return Map.of(true, propagated, false, notPropagated);
+
+        // fact handles with a match have been already propagated in the original session, so they shouldn't fire
+        propagated.forEach(ep::insert);
+        session.fireAllRules(match -> false);
+        reInitPropagated = false;
+
+        // fact handles without any match have never been propagated in the original session, so they should fire
+        return notPropagated;
+    }
+
+    void putIntoPersistedCache(Object object, boolean propagated) {
+        cache.put(fhMap.get(object).getId(), new PropagatedObject(object, reInitPropagated || propagated));
+    }
+
+    void removeFromPersistedCache(Object object) {
+        InternalFactHandle fh = fhMap.get(object);
+        if (fh != null) {
+            cache.remove(fh.getId());
+        }
+    }
+
+    private static class PropagatedObject implements Serializable {
+        private final Object object;
+        private final boolean propagated;
+
+        private PropagatedObject(Object object, boolean propagated) {
+            this.object = object;
+            this.propagated = propagated;
+        }
     }
 }


### PR DESCRIPTION
This pull request makes the stores only strategy to also support updates and deletes. The main problem that was necessary to solve to do so was having an immutable and stable key for the persisted cache, instead of using directly the users domain objects that are generally mutable. I figured out that I didn't need to introduce another map to do so but I could reuse the `IdentityMap` that the `SimpleReliableObjectStore` inherits from the `IdentityObjectStore` and use as key for the persisted cache the `FactHandle`'s id.