### PR TITLE
[DROOLS-7363] demonstrate SyntheticRuleUnit reuse

### DIFF
--- a/drools-ruleunits/drools-ruleunits-dsl/src/test/java/org/drools/ruleunits/dsl/SyntheticRuleUnitsTest.java
+++ b/drools-ruleunits/drools-ruleunits-dsl/src/test/java/org/drools/ruleunits/dsl/SyntheticRuleUnitsTest.java
@@ -107,6 +107,32 @@ public class SyntheticRuleUnitsTest {
         unitInstance.close();
     }
 
+    @Test
+    public void syntheticRuleUnitDefinitionReuse() {
+        // DROOLS-7363
+        SyntheticRuleUnit unit = createSyntheticRuleUnit();
+        RuleUnitInstance<SyntheticRuleUnit> unitInstance = RuleUnitProvider.get().createRuleUnitInstance(unit);
+
+        unit.getDataStore("strings", String.class).add("Hello World");
+
+        assertThat(unitInstance.fire()).isEqualTo(2);
+        assertThat(unit.getGlobal("results", List.class)).containsExactlyInAnyOrder("it worked!", "it also worked with HELLO WORLD");
+
+        SyntheticRuleUnit unit2 = createSyntheticRuleUnit();
+        RuleUnitInstance<SyntheticRuleUnit> unitInstance2 = RuleUnitProvider.get().createRuleUnitInstance(unit2);
+
+        unit2.getDataStore("strings", String.class).add("Hello World");
+        unitInstance2.fire();
+        unit2.getGlobal("results", List.class).clear();
+
+        unit2.getDataStore("ints", Integer.class).add(11);
+        assertThat(unitInstance2.fire()).isEqualTo(1);
+        assertThat(unit2.getGlobal("results", List.class)).containsExactly("String 'Hello World' is 11 characters long");
+
+        unitInstance.close();
+        unitInstance2.close();
+    }
+
     private SyntheticRuleUnit createSyntheticRuleUnit() {
         DataStore<String> strings = DataSource.createStore();
         DataStore<Integer> ints = DataSource.createStore();


### PR DESCRIPTION
**JIRA**: https://issues.redhat.com/browse/DROOLS-7363

@tarilabs With this PR I'm just adding a test case demonstrating how to reuse the definition of a synthetic rule unit. In this case I don't think that it is possible to create multiple `RuleUnitInstance` from the same `RuleUnit`, because the `DataSource`s are inherently bound to the `RuleUnit` itself. Also note that this is consistent with what happens for non-synthetic `RuleUnit`s defined through the Java DSL, see https://github.com/kiegroup/drools/blob/f41aa536dd47263fb83b737153122739fc074438/drools-ruleunits/drools-ruleunits-dsl/src/test/java/org/drools/ruleunits/dsl/RuleUnitsTest.java#L276

Please let me know if this is ok for your use case and if you have any suggestion to improve this implementation.