### PR TITLE
[fix_javax_transaction] Renaming javax.transaction -> jakarta.transaction

### DIFF
--- a/.ci/environments/quarkus-3/patches/replace_javax_jakarta_transaction
+++ b/.ci/environments/quarkus-3/patches/replace_javax_jakarta_transaction
@@ -1,0 +1,19 @@
+Subject: [PATCH] [fix_javax_transaction] Renaming javax.transaction -> jakarta.transaction
+---
+Index: drools-persistence/drools-persistence-api/src/main/java/org/drools/persistence/jta/JtaTransactionManager.java
+IDEA additional info:
+Subsystem: com.intellij.openapi.diff.impl.patch.CharsetEP
+<+>UTF-8
+===================================================================
+diff --git a/drools-persistence/drools-persistence-api/src/main/java/org/drools/persistence/jta/JtaTransactionManager.java b/drools-persistence/drools-persistence-api/src/main/java/org/drools/persistence/jta/JtaTransactionManager.java
+--- a/drools-persistence/drools-persistence-api/src/main/java/org/drools/persistence/jta/JtaTransactionManager.java	(revision 5ddd9980b2e98acb2d318dc07cad6f0f4f88a227)
++++ b/drools-persistence/drools-persistence-api/src/main/java/org/drools/persistence/jta/JtaTransactionManager.java	(date 1678880528477)
+@@ -47,7 +47,7 @@
+      */
+     public static final String           DEFAULT_TRANSACTION_SYNCHRONIZATION_REGISTRY_NAME = "java:comp/TransactionSynchronizationRegistry";
+
+-    private static final String          TRANSACTION_SYNCHRONIZATION_REGISTRY_CLASS_NAME   = "javax.transaction.TransactionSynchronizationRegistry";
++    private static final String          TRANSACTION_SYNCHRONIZATION_REGISTRY_CLASS_NAME   = "jakarta.transaction.TransactionSynchronizationRegistry";
+
+     private static Class< ? >            transactionSynchronizationRegistryClass;
+


### PR DESCRIPTION
Fixes https://github.com/kiegroup/kie-issues/issues/148

@mariofusco @baldimir @radtriste 

This PR broken tests of `drools-persistence-jpa`.
The issue is present inside `JtaTransactionManager` and related to the `TRANSACTION_SYNCHRONIZATION_REGISTRY_CLASS_NAME` that in hte quarkus version should point to `jakarta.transaction.TransactionSynchronizationRegistry` to instantiate `transactionSynchronizationRegistryClass`.
IF `transactionSynchronizationRegistryClass` is `null` the transaction system does not work properly, as demonstrated by the failing tests.

@mariofusco As side note, I noticed that snippet

`try {
        transactionSynchronizationRegistryClass = cl.loadClass( TRANSACTION_SYNCHRONIZATION_REGISTRY_CLASS_NAME );
        } catch ( ClassNotFoundException e ) {
            // JTA 1.1 API not available... simply proceed the JTA 1.0 way.
}`

that silently swallop up failure of `transactionSynchronizationRegistryClass` instantiation. But without that instance, the transaction mechanism is broken: should not this be managed differently ?


<details>
<summary>
How to replicate CI configuration locally?
</summary>

Build Chain tool does "simple" maven build(s), the builds are just Maven commands, but because the repositories relates and depends on each other and any change in API or class method could affect several of those repositories there is a need to use [build-chain tool](https://github.com/kiegroup/github-action-build-chain) to handle cross repository builds and be sure that we always use latest version of the code for each repository.
 
[build-chain tool](https://github.com/kiegroup/github-action-build-chain) is a build tool which can be used on command line locally or in Github Actions workflow(s), in case you need to change multiple repositories and send multiple dependent pull requests related with a change you can easily reproduce the same build by executing it on Github hosted environment or locally in your development environment. See [local execution](https://github.com/kiegroup/github-action-build-chain#local-execution) details to get more information about it.
</details>

<details>
<summary>
How to retest this PR or trigger a specific build:
</summary>

- for <b>pull request checks</b>  
  Please add comment: <b>Jenkins retest this</b>

- for a <b>specific pull request check</b>  
  Please add comment: <b>Jenkins (re)run [drools|kogito-runtimes|kogito-apps|kogito-examples] tests</b>

- for a <b>full downstream build</b> 
  - for <b>jenkins</b> job: please add comment: <b>Jenkins run fdb</b>
  - for <b>github actions</b> job: add the label `run_fdb`

- <b>a compile downstream build</b> please  add comment: <b>Jenkins run cdb</b>

- <b>a full production downstream build</b> please add comment: <b>Jenkins execute product fdb</b>

- <b>an upstream build</b> please add comment: <b>Jenkins run upstream</b>

- for <b>quarkus branch checks</b>  
  Run checks against Quarkus current used branch  
  Please add comment: <b>Jenkins run quarkus-branch</b>

- for a <b>quarkus branch specific check</b>  
  Run checks against Quarkus current used branch  
  Please add comment: <b>Jenkins (re)run [drools|kogito-runtimes|kogito-apps|kogito-examples] quarkus-branch</b>

- for <b>quarkus main checks</b>  
  Run checks against Quarkus main branch  
  Please add comment: <b>Jenkins run quarkus-main</b>

- for a <b>specific quarkus main check</b>  
  Run checks against Quarkus main branch  
  Please add comment: <b>Jenkins (re)run [drools|kogito-runtimes|kogito-apps|kogito-examples] quarkus-main</b>

- for <b>quarkus lts checks</b>  
  Run checks against Quarkus lts branch  
  Please add comment: <b>Jenkins run quarkus-lts</b>

- for a <b>specific quarkus lts check</b>  
  Run checks against Quarkus lts branch  
  Please add comment: <b>Jenkins (re)run [drools|kogito-runtimes|kogito-apps|kogito-examples] quarkus-lts</b>

- for <b>native checks</b>  
  Run native checks  
  Please add comment: <b>Jenkins run native</b>

- for a <b>specific native check</b>  
  Run native checks 
  Please add comment: <b>Jenkins (re)run [drools|kogito-runtimes|kogito-apps|kogito-examples] native</b>

 - for <b>native lts checks</b>  
  Run native checks against quarkus lts branch
  Please add comment: <b>Jenkins run native-lts</b>

- for a <b>specific native lts check</b>  
  Run native checks against quarkus lts branch
  Please add comment: <b>Jenkins (re)run [drools|kogito-runtimes|kogito-apps|kogito-examples] native-lts</b>
</details>

<details>
<summary>
How to backport a pull request to a different branch?
</summary>

In order to automatically create a **backporting pull request** please add one or more labels having the following format `backport-<branch-name>`, where `<branch-name>` is the name of the branch where the pull request must be backported to (e.g., `backport-7.67.x` to backport the original PR to the `7.67.x` branch).

> **NOTE**: **backporting** is an action aiming to move a change (usually a commit) from a branch (usually the main one) to another one, which is generally referring to a still maintained release branch. Keeping it simple: it is about to move a specific change or a set of them from one branch to another.

Once the original pull request is successfully merged, the automated action will create one backporting pull request per each label (with the previous format) that has been added.

If something goes wrong, the author will be notified and at this point a manual backporting is needed.

> **NOTE**: this automated backporting is triggered whenever a pull request on `main` branch is labeled or closed, but both conditions must be satisfied to get the new PR created.
</details>