### PR TITLE
[7.67.x] [DROOLS-7366] str operator with bind variable fails after mvel jitting

### DIFF
--- a/drools-core/src/main/java/org/drools/core/base/EvaluatorWrapper.java
+++ b/drools-core/src/main/java/org/drools/core/base/EvaluatorWrapper.java
@@ -212,20 +212,9 @@ public class EvaluatorWrapper
     }
 
     public void loadHandles(InternalFactHandle[] handles, InternalFactHandle rightHandle) {
-        InternalFactHandle localLeftHandle = null;
-        InternalFactHandle localRightHandle = null;
+        InternalFactHandle localLeftHandle = selfLeft ? null : getFactHandle(leftBinding, handles);
 
-        if ( !selfLeft && handles != null) {
-            localLeftHandle = getFactHandle(leftBinding, handles);
-        }
-
-        if (selfRight) {
-            localRightHandle = rightHandle;
-        } else if (handles != null){
-            localRightHandle = getFactHandle(rightBinding, handles);
-        } // @FIXME else? what happens now (mdp) ? Maybe this can never happen?
-
-
+        InternalFactHandle localRightHandle = selfRight ? rightHandle : getFactHandle(rightBinding, handles);
         this.rightLiteral = localRightHandle == null;
 
         if (isTemporal()) {
@@ -257,6 +246,6 @@ public class EvaluatorWrapper
 
     private static InternalFactHandle getFactHandle( Declaration declaration,
                                                     InternalFactHandle[] handles ) {
-        return handles[declaration.getObjectIndex()];
+        return handles != null && handles.length > declaration.getObjectIndex() ? handles[declaration.getObjectIndex()] : null;
     }
 }

--- a/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/compiler/integrationtests/CustomOperatorTest.java
+++ b/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/compiler/integrationtests/CustomOperatorTest.java
@@ -61,12 +61,27 @@ public class CustomOperatorTest {
 
     @Test
     public void testCustomOperatorUsingCollections() {
+        String constraints =
+                "    $alice : Person(name == \"Alice\")\n" +
+                "    $bob : Person(name == \"Bob\", addresses supersetOf $alice.addresses)\n";
+        customOperatorUsingCollections(constraints);
+    }
+
+    @Test
+    public void testCustomOperatorUsingCollectionsInverted() {
+        // DROOLS-6983
+        String constraints =
+                "    $bob : Person(name == \"Bob\")\n" +
+                "    $alice : Person(name == \"Alice\", $bob.addresses supersetOf this.addresses)\n";
+        customOperatorUsingCollections(constraints);
+    }
+
+    private void customOperatorUsingCollections(String constraints) {
         final String drl =
                 "import " + Address.class.getCanonicalName() + ";\n" +
                         "import " + Person.class.getCanonicalName() + ";\n" +
                         "rule R when\n" +
-                        "    $alice : Person(name == \"Alice\")\n" +
-                        "    $bob : Person(name == \"Bob\", addresses supersetOf $alice.addresses)\n" +
+                        constraints +
                         "then\n" +
                         "end\n";
 

--- a/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/integrationtests/JittingTest.java
+++ b/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/integrationtests/JittingTest.java
@@ -352,4 +352,24 @@ public class JittingTest {
         kieSession.insert("CX");
         assertThat(kieSession.fireAllRules()).isEqualTo(1);
     }
+
+    @Test
+    public void strOperator() {
+        // DROOLS-7366
+        String drl =
+                "package test\n" +
+                "import " + Person.class.getCanonicalName() + "\n" +
+                "\n" +
+                "dialect \"mvel\"\n" +
+                "rule R1 when \n" +
+                "    Person( $name : name, $name str[startsWith] \"M\" )\n" +
+                "then \n" +
+                "end";
+
+        final KieModule kieModule = KieUtil.getKieModuleFromDrls("test", kieBaseTestConfiguration, drl);
+        final KieBase kieBase = KieBaseUtil.newKieBaseFromKieModuleWithAdditionalOptions(kieModule, kieBaseTestConfiguration, ConstraintJittingThresholdOption.get(0));
+        KieSession ksession = kieBase.newKieSession();
+        ksession.insert(new Person("Mario"));
+        assertThat(ksession.fireAllRules()).isEqualTo(1);
+    }
 }


### PR DESCRIPTION
This PR contains backport of DROOLS-6983 which actually fixes the issue. Then added one more test to align with DROOLS-7366

**Ports** 
This is a backport PR (plus test) for 7.67.x
for 7.67.x-blue -> https://github.com/kiegroup/drools/pull/5102

**JIRA**: 
https://issues.redhat.com/browse/DROOLS-7366
https://issues.redhat.com/browse/RHDM-1965

<details>
<summary>
How to replicate CI configuration locally?
</summary>

Build Chain tool does "simple" maven build(s), the builds are just Maven commands, but because the repositories relates and depends on each other and any change in API or class method could affect several of those repositories there is a need to use [build-chain tool](https://github.com/kiegroup/github-action-build-chain) to handle cross repository builds and be sure that we always use latest version of the code for each repository.
 
[build-chain tool](https://github.com/kiegroup/github-action-build-chain) is a build tool which can be used on command line locally or in Github Actions workflow(s), in case you need to change multiple repositories and send multiple dependent pull requests related with a change you can easily reproduce the same build by executing it on Github hosted environment or locally in your development environment. See [local execution](https://github.com/kiegroup/github-action-build-chain#local-execution) details to get more information about it.
</details>

<details>
<summary>
How to retest this PR or trigger a specific build:
</summary>

- for <b>pull request checks</b>  
  Please add comment: <b>Jenkins retest this</b>

- for a <b>specific pull request check</b>  
  Please add comment: <b>Jenkins (re)run [drools|kogito-runtimes|kogito-apps|kogito-examples] tests</b>

- for a <b>full downstream build</b> 
  - for <b>jenkins</b> job: please add comment: <b>Jenkins run fdb</b>
  - for <b>github actions</b> job: add the label `run_fdb`

- <b>a compile downstream build</b> please  add comment: <b>Jenkins run cdb</b>

- <b>a full production downstream build</b> please add comment: <b>Jenkins execute product fdb</b>

- <b>an upstream build</b> please add comment: <b>Jenkins run upstream</b>

- for <b>quarkus branch checks</b>  
  Run checks against Quarkus current used branch  
  Please add comment: <b>Jenkins run quarkus-branch</b>

- for a <b>quarkus branch specific check</b>  
  Run checks against Quarkus current used branch  
  Please add comment: <b>Jenkins (re)run [drools|kogito-runtimes|kogito-apps|kogito-examples] quarkus-branch</b>

- for <b>quarkus main checks</b>  
  Run checks against Quarkus main branch  
  Please add comment: <b>Jenkins run quarkus-main</b>

- for a <b>specific quarkus main check</b>  
  Run checks against Quarkus main branch  
  Please add comment: <b>Jenkins (re)run [drools|kogito-runtimes|kogito-apps|kogito-examples] quarkus-main</b>

- for <b>quarkus lts checks</b>  
  Run checks against Quarkus lts branch  
  Please add comment: <b>Jenkins run quarkus-lts</b>

- for a <b>specific quarkus lts check</b>  
  Run checks against Quarkus lts branch  
  Please add comment: <b>Jenkins (re)run [drools|kogito-runtimes|kogito-apps|kogito-examples] quarkus-lts</b>

- for <b>native checks</b>  
  Run native checks  
  Please add comment: <b>Jenkins run native</b>

- for a <b>specific native check</b>  
  Run native checks 
  Please add comment: <b>Jenkins (re)run [drools|kogito-runtimes|kogito-apps|kogito-examples] native</b>

 - for <b>native lts checks</b>  
  Run native checks against quarkus lts branch
  Please add comment: <b>Jenkins run native-lts</b>

- for a <b>specific native lts check</b>  
  Run native checks against quarkus lts branch
  Please add comment: <b>Jenkins (re)run [drools|kogito-runtimes|kogito-apps|kogito-examples] native-lts</b>
</details>

<details>
<summary>
How to backport a pull request to a different branch?
</summary>

In order to automatically create a **backporting pull request** please add one or more labels having the following format `backport-<branch-name>`, where `<branch-name>` is the name of the branch where the pull request must be backported to (e.g., `backport-7.67.x` to backport the original PR to the `7.67.x` branch).

> **NOTE**: **backporting** is an action aiming to move a change (usually a commit) from a branch (usually the main one) to another one, which is generally referring to a still maintained release branch. Keeping it simple: it is about to move a specific change or a set of them from one branch to another.

Once the original pull request is successfully merged, the automated action will create one backporting pull request per each label (with the previous format) that has been added.

If something goes wrong, the author will be notified and at this point a manual backporting is needed.

> **NOTE**: this automated backporting is triggered whenever a pull request on `main` branch is labeled or closed, but both conditions must be satisfied to get the new PR created.
</details>