### PR TITLE
DROOLS-7363 refactor tests

### DIFF
--- a/drools-reliability/src/test/java/org/drools/reliability/ReliabilityTestBasics.java
+++ b/drools-reliability/src/test/java/org/drools/reliability/ReliabilityTestBasics.java
@@ -1,0 +1,111 @@
+/*
+ * Copyright 2023 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.drools.reliability;
+
+import org.drools.core.ClassObjectFilter;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.kie.api.KieBase;
+import org.kie.api.KieServices;
+import org.kie.api.io.ResourceType;
+import org.kie.api.runtime.KieSession;
+import org.kie.api.runtime.KieSessionConfiguration;
+import org.kie.api.runtime.conf.PersistedSessionOption;
+import org.kie.api.runtime.rule.FactHandle;
+import org.kie.internal.utils.KieHelper;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+import java.util.stream.Stream;
+
+@ExtendWith(BeforeAllMethodExtension.class)
+public abstract class ReliabilityTestBasics {
+
+    protected long savedSessionId;
+    protected KieSession session;
+
+    static Stream<PersistedSessionOption.Strategy> strategyProvider() {
+        return Stream.of(PersistedSessionOption.Strategy.STORES_ONLY, PersistedSessionOption.Strategy.FULL);
+    }
+
+    static Stream<PersistedSessionOption.Strategy> strategyProviderStoresOnly() {
+        return Stream.of(PersistedSessionOption.Strategy.STORES_ONLY);
+    }
+
+    @AfterEach
+    public void tearDown() {
+        // We can remove this when we implement ReliableSession.dispose() to call CacheManager.removeCachesBySessionId(id)
+        CacheManager.INSTANCE.removeAllSessionCaches();
+    }
+
+    protected FactHandle insertString(String str) {
+        session.insert(str);
+        return null;
+    }
+
+    protected FactHandle insertInteger(Integer number) {
+        session.insert(number);
+        return null;
+    }
+
+    protected FactHandle insertMatchingPerson(String name, Integer age) {
+        return session.insert(new Person(name, age));
+    }
+
+    protected void updateWithMatchingPerson(FactHandle nonMatching, Object matching){
+        session.update(nonMatching,matching);
+    }
+
+    protected  void updateWithNonMatchingPerson(FactHandle matching, Object nonMatching){
+        session.update(matching, nonMatching);
+    }
+
+    protected FactHandle insertNonMatchingPerson(String name, Integer age) {
+        return session.insert(new Person(name, age));
+    }
+
+    protected List<Object> getResults() {
+        return (List<Object>) session.getGlobal("results");
+    }
+
+    protected KieSession createSession(String drl, PersistedSessionOption.Strategy strategy) {
+        return getKieSession(drl, PersistedSessionOption.newSession(strategy));
+    }
+
+    protected KieSession restoreSession(String drl, PersistedSessionOption.Strategy strategy) {
+        return getKieSession(drl, PersistedSessionOption.fromSession(savedSessionId, strategy));
+    }
+
+    protected KieSession getKieSession(String drl, PersistedSessionOption option) {
+        KieBase kbase = new KieHelper().addContent(drl, ResourceType.DRL).build();
+        KieSessionConfiguration conf = KieServices.get().newKieSessionConfiguration();
+        conf.setOption(option);
+        session = kbase.newKieSession(conf, null);
+        savedSessionId = session.getIdentifier();
+        List<Object> results = new ArrayList<>();
+        session.setGlobal("results", results);
+        return session;
+    }
+
+    protected Optional<Person> getPersonByName(KieSession kieSession, String name) {
+        return kieSession.getObjects(new ClassObjectFilter(Person.class))
+                .stream()
+                .map(Person.class::cast)
+                .filter(p -> p.getName().equals(name) ).findFirst();
+    }
+}
+

--- a/drools-reliability/src/test/java/org/drools/reliability/ReliabilityTestBasics.java
+++ b/drools-reliability/src/test/java/org/drools/reliability/ReliabilityTestBasics.java
@@ -83,7 +83,9 @@ public abstract class ReliabilityTestBasics {
     }
 
     protected KieSession createSession(String drl, PersistedSessionOption.Strategy strategy) {
-        return getKieSession(drl, PersistedSessionOption.newSession(strategy));
+        getKieSession(drl, PersistedSessionOption.newSession(strategy));
+        savedSessionId = session.getIdentifier();
+        return session;
     }
 
     protected KieSession restoreSession(String drl, PersistedSessionOption.Strategy strategy) {
@@ -95,7 +97,6 @@ public abstract class ReliabilityTestBasics {
         KieSessionConfiguration conf = KieServices.get().newKieSessionConfiguration();
         conf.setOption(option);
         session = kbase.newKieSession(conf, null);
-        savedSessionId = session.getIdentifier();
         List<Object> results = new ArrayList<>();
         session.setGlobal("results", results);
         return session;

--- a/drools-reliability/src/test/java/org/drools/reliability/ReliabilityTestUpdateInDrl.java
+++ b/drools-reliability/src/test/java/org/drools/reliability/ReliabilityTestUpdateInDrl.java
@@ -1,0 +1,81 @@
+/*
+ * Copyright 2023 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.drools.reliability;
+
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
+import org.kie.api.runtime.conf.PersistedSessionOption;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.drools.reliability.ReliabilityTestUtils.failover;
+
+@ExtendWith(BeforeAllMethodExtension.class)
+public class ReliabilityTestUpdateInDrl extends ReliabilityTestBasics {
+
+    private static final String RULE_UPDATE =
+            "import " + Person.class.getCanonicalName() + ";" +
+                    "global java.util.List results;" +
+                    "rule X when\n" +
+                    "  $s: String()\n" +
+                    "  $p: Person( getName().startsWith($s), getAge()>17 )\n" +
+                    "then\n" +
+                    "  results.add( $p.getAge() );\n" +
+                    "end\n" +
+                    "rule Birthday when\n" +
+                    "  $a: Integer()\n" +
+                    "  $p: Person( getAge() == $a )\n" +
+                    "then\n" +
+                    "  $p.setAge( $a + 1 );\n" +
+                    "  update($p);\n" +
+                    "end";
+
+    @Disabled("fails in the 2nd assertion, will run successfully after PR#5093 is merged ")
+    @ParameterizedTest
+    @MethodSource("strategyProviderStoresOnly")
+    void updateInRHS_insertFireFailoverFire_shouldMatchUpdatesFromFirstSession(PersistedSessionOption.Strategy strategy){
+
+        createSession(RULE_UPDATE, strategy);
+
+        insertString("M");
+        insertMatchingPerson("Mike",22);
+        insertNonMatchingPerson("Eleven", 17);
+        insertInteger(17); // person with age=17 will change to 18 (17+1)
+
+        assertThat(session.fireAllRules()).isEqualTo(2); // person with name that starts with M and has age>17 will be added to the results list
+        assertThat(getResults()).containsExactlyInAnyOrder(22);
+
+        failover();
+
+        restoreSession(RULE_UPDATE, strategy);
+
+        insertString("E"); // NonMatchingPerson will match rule X
+
+        assertThat(session.fireAllRules()).isEqualTo(1);
+        assertThat(getResults()).containsExactlyInAnyOrder(18);
+
+        failover();
+
+        restoreSession(RULE_UPDATE, strategy);
+
+        assertThat(session.fireAllRules()).isEqualTo(0);
+        assertThat(getResults()).isEmpty();
+    }
+
+}
+
+


### PR DESCRIPTION
the PR introduces a new class for testing with a 2-rule drl, the basic rule plus one that updates a fact under conditions.
the PR also suggests the introduction of the abstract class ReliabilityTestBasics for the common functions the various test classes will share.