### PR TITLE
Split openrewrite execution

### DIFF
--- a/.ci/environments/README.md
+++ b/.ci/environments/README.md
@@ -1,3 +1,29 @@
 # Environments CI scripts
 
 This folder contains update scripts which would be called for a specific environments.
+
+
+Updating branch.
+================
+
+The `.ci/environments/update.sh` script is responsible to execute the update/migration.
+
+It expect at least one parameter, namely the "environment" and optionally a second one, when the rewrite execution is required.
+
+The first parameter defines which folder will be executed (e.g. *quarkus-3*, *quarkus-main*, etc).
+The second parameter, if provided and equals to *rewrite*, fires the **rewrite** execution.
+
+The process of define the migration changes is split in two parts
+
+1. rewrite execution: this is done manually, since rewrite execution take a lot of time; after successfully execution, the changes must be saved as *patches*
+2. patches apply: this is done automatically, and all *patches* found in the `${environment}/patches` are applied
+3. if executed, rewrite runs ***BEFORE*** the patch apply
+
+To execute migration in the *quarkus-3* ***WITHOUT*** rewrite
+
+`.ci/environments/update.sh quarkus-3`
+
+To execute migration in the *quarkus-3* ***WITH*** rewrite
+
+`.ci/environments/update.sh quarkus-3 rewrite`
+

--- a/.ci/environments/quarkus-3/before.sh
+++ b/.ci/environments/quarkus-3/before.sh
@@ -9,6 +9,8 @@ quarkus_version=${QUARKUS_VERSION:-3.0.0.Alpha5}
 quarkus_file="${script_dir_path}/quarkus3.yml"
 project_version='quarkus-3-SNAPSHOT'
 
+export MAVEN_OPTS="-Xmx16192m -XX:MaxPermSize=512m"
+
 echo "Update project with Quarkus version ${quarkus_version}"
 
 set -x
@@ -27,7 +29,7 @@ ${mvn_cmd} -e -N -Dfull -DnewVersion=${project_version} -DallowSnapshots=true -D
 ${mvn_cmd} clean install -Dquickly
 
 # Launch Quarkus 3 Openrewrite
-${mvn_cmd} org.openrewrite.maven:rewrite-maven-plugin:4.41.1:run \
+${mvn_cmd} org.openrewrite.maven:rewrite-maven-plugin:4.42.0:run \
     -Drewrite.configLocation="${quarkus_file}" \
     -DactiveRecipes=io.quarkus.openrewrite.Quarkus3 \
     -Drewrite.recipeArtifactCoordinates=org.kie:jpmml-migration-recipe:"${project_version}" \

--- a/.ci/environments/update.sh
+++ b/.ci/environments/update.sh
@@ -5,6 +5,16 @@ script_dir_path=$(cd `dirname "${BASH_SOURCE[0]}"`; pwd -P)
 
 environment=$1
 
+if [[ "$#" -eq 2 ]]; then
+   echo "Rewrite parameter set";
+   rewrite=$2
+else
+   echo "Rewrite parameter not set";
+   rewrite="none"
+fi
+
+echo "rewrite "${rewrite}
+
 if [ -z "${environment}" ]; then
     echo "No environment given as first argument"
     exit 1
@@ -19,8 +29,8 @@ fi
 echo "Update project for environment '${environment}'"
 
 # If update script is present, apply it
-if [ -f "${env_path}/before.sh" ]; then
-    echo "Run before script"
+if [ -f "${env_path}/before.sh" ] && [ "rewrite" == ${rewrite} ]; then
+    echo "Run before script for rewrite operation"
     ${env_path}/before.sh
 fi
 

--- a/efesto/pom.xml
+++ b/efesto/pom.xml
@@ -17,7 +17,7 @@
   <description>New model container framework</description>
 
   <properties>
-    <rewrite.maven.plugin.version>4.41.1</rewrite.maven.plugin.version>
+    <rewrite.maven.plugin.version>4.42.0</rewrite.maven.plugin.version>
     <rewrite.testing.frameworks.version>1.22.0</rewrite.testing.frameworks.version>
     <archunit.maven.plugin.version>2.9.1</archunit.maven.plugin.version>
     <jdepend.maven.plugin.version>2.0</jdepend.maven.plugin.version>

--- a/kie-pmml-trusty/pom.xml
+++ b/kie-pmml-trusty/pom.xml
@@ -17,7 +17,7 @@
   <description>Support for PMML-Encoded Predictive Models</description>
 
   <properties>
-    <rewrite.maven.plugin.version>4.41.1</rewrite.maven.plugin.version>
+    <rewrite.maven.plugin.version>4.42.0</rewrite.maven.plugin.version>
     <rewrite.testing.frameworks.version>1.22.0</rewrite.testing.frameworks.version>
     <archunit.maven.plugin.version>2.9.1</archunit.maven.plugin.version>
   </properties>

--- a/pom.xml
+++ b/pom.xml
@@ -227,7 +227,7 @@
           <plugin>
             <groupId>org.openrewrite.maven</groupId>
             <artifactId>rewrite-maven-plugin</artifactId>
-            <version>4.41.1</version>
+            <version>4.42.0</version>
             <configuration>
               <activeRecipes>
                 <!--                <recipe>org.drools.rewrite.PrintStackTraceToLogError</recipe>-->


### PR DESCRIPTION
Fixes https://github.com/kiegroup/kie-issues/issues/150

@mariofusco @danielezonca  @baldimir @pibizza @radtriste 

This PR 
1. upgrade rewrite maven plugin to 4.42.0
2. split update execution: patches are always applied; rewrite only on demand
3. see Readme file for info

<details>
<summary>
How to replicate CI configuration locally?
</summary>

Build Chain tool does "simple" maven build(s), the builds are just Maven commands, but because the repositories relates and depends on each other and any change in API or class method could affect several of those repositories there is a need to use [build-chain tool](https://github.com/kiegroup/github-action-build-chain) to handle cross repository builds and be sure that we always use latest version of the code for each repository.
 
[build-chain tool](https://github.com/kiegroup/github-action-build-chain) is a build tool which can be used on command line locally or in Github Actions workflow(s), in case you need to change multiple repositories and send multiple dependent pull requests related with a change you can easily reproduce the same build by executing it on Github hosted environment or locally in your development environment. See [local execution](https://github.com/kiegroup/github-action-build-chain#local-execution) details to get more information about it.
</details>

<details>
<summary>
How to retest this PR or trigger a specific build:
</summary>

- for <b>pull request checks</b>  
  Please add comment: <b>Jenkins retest this</b>

- for a <b>specific pull request check</b>  
  Please add comment: <b>Jenkins (re)run [drools|kogito-runtimes|kogito-apps|kogito-examples] tests</b>

- for a <b>full downstream build</b> 
  - for <b>jenkins</b> job: please add comment: <b>Jenkins run fdb</b>
  - for <b>github actions</b> job: add the label `run_fdb`

- <b>a compile downstream build</b> please  add comment: <b>Jenkins run cdb</b>

- <b>a full production downstream build</b> please add comment: <b>Jenkins execute product fdb</b>

- <b>an upstream build</b> please add comment: <b>Jenkins run upstream</b>

- for <b>quarkus branch checks</b>  
  Run checks against Quarkus current used branch  
  Please add comment: <b>Jenkins run quarkus-branch</b>

- for a <b>quarkus branch specific check</b>  
  Run checks against Quarkus current used branch  
  Please add comment: <b>Jenkins (re)run [drools|kogito-runtimes|kogito-apps|kogito-examples] quarkus-branch</b>

- for <b>quarkus main checks</b>  
  Run checks against Quarkus main branch  
  Please add comment: <b>Jenkins run quarkus-main</b>

- for a <b>specific quarkus main check</b>  
  Run checks against Quarkus main branch  
  Please add comment: <b>Jenkins (re)run [drools|kogito-runtimes|kogito-apps|kogito-examples] quarkus-main</b>

- for <b>quarkus lts checks</b>  
  Run checks against Quarkus lts branch  
  Please add comment: <b>Jenkins run quarkus-lts</b>

- for a <b>specific quarkus lts check</b>  
  Run checks against Quarkus lts branch  
  Please add comment: <b>Jenkins (re)run [drools|kogito-runtimes|kogito-apps|kogito-examples] quarkus-lts</b>

- for <b>native checks</b>  
  Run native checks  
  Please add comment: <b>Jenkins run native</b>

- for a <b>specific native check</b>  
  Run native checks 
  Please add comment: <b>Jenkins (re)run [drools|kogito-runtimes|kogito-apps|kogito-examples] native</b>

 - for <b>native lts checks</b>  
  Run native checks against quarkus lts branch
  Please add comment: <b>Jenkins run native-lts</b>

- for a <b>specific native lts check</b>  
  Run native checks against quarkus lts branch
  Please add comment: <b>Jenkins (re)run [drools|kogito-runtimes|kogito-apps|kogito-examples] native-lts</b>
</details>

<details>
<summary>
How to backport a pull request to a different branch?
</summary>

In order to automatically create a **backporting pull request** please add one or more labels having the following format `backport-<branch-name>`, where `<branch-name>` is the name of the branch where the pull request must be backported to (e.g., `backport-7.67.x` to backport the original PR to the `7.67.x` branch).

> **NOTE**: **backporting** is an action aiming to move a change (usually a commit) from a branch (usually the main one) to another one, which is generally referring to a still maintained release branch. Keeping it simple: it is about to move a specific change or a set of them from one branch to another.

Once the original pull request is successfully merged, the automated action will create one backporting pull request per each label (with the previous format) that has been added.

If something goes wrong, the author will be notified and at this point a manual backporting is needed.

> **NOTE**: this automated backporting is triggered whenever a pull request on `main` branch is labeled or closed, but both conditions must be satisfied to get the new PR created.
</details>