### PR TITLE
DROOLS-7369: refactor ReliabilityTest to extend ReliabilityTestBasics

### DIFF
--- a/drools-reliability/src/test/java/org/drools/reliability/ReliabilityTestBasics.java
+++ b/drools-reliability/src/test/java/org/drools/reliability/ReliabilityTestBasics.java
@@ -53,13 +53,11 @@ public abstract class ReliabilityTestBasics {
     }
 
     protected FactHandle insertString(String str) {
-        session.insert(str);
-        return null;
+        return session.insert(str);
     }
 
     protected FactHandle insertInteger(Integer number) {
-        session.insert(number);
-        return null;
+        return session.insert(number);
     }
 
     protected FactHandle insertMatchingPerson(String name, Integer age) {


### PR DESCRIPTION
refactor ReliabilityTest to extend ReliabilityTestBasics class so that all ReliabilityTest* classes will use the same supporting methods (insertString, etc).