### PR TITLE
[DROOLS-7384] Persist RELIABLE_SESSIONS_COUNTER in cache

### DIFF
--- a/drools-reliability/pom.xml
+++ b/drools-reliability/pom.xml
@@ -177,7 +177,7 @@
             <artifactId>maven-surefire-plugin</artifactId>
             <configuration>
               <systemPropertyVariables>
-                <drools.reliability.cache.manager.mode>REMOTE</drools.reliability.cache.manager.mode>
+                <drools.reliability.cache.mode>REMOTE</drools.reliability.cache.mode>
               </systemPropertyVariables>
             </configuration>
           </plugin>

--- a/drools-reliability/src/main/java/org/drools/reliability/CacheManager.java
+++ b/drools-reliability/src/main/java/org/drools/reliability/CacheManager.java
@@ -33,6 +33,8 @@ interface CacheManager {
 
     <k, V> BasicCache<k, V> getOrCreateCacheForSession(ReteEvaluator reteEvaluator, String cacheName);
 
+    <k, V> BasicCache<k, V> getOrCreateSharedCache(String cacheName);
+
     void close();
 
     void removeCache(String cacheName);

--- a/drools-reliability/src/main/java/org/drools/reliability/CacheManagerFactory.java
+++ b/drools-reliability/src/main/java/org/drools/reliability/CacheManagerFactory.java
@@ -20,6 +20,7 @@ public enum CacheManagerFactory {
     INSTANCE;
 
     public static final String SESSION_CACHE_PREFIX = "session_";
+    public static final String SHARED_CACHE_PREFIX = "shared_";
     public static final String DELIMITER = "_";
 
     public static final String RELIABILITY_CACHE = "drools.reliability.cache";
@@ -33,8 +34,7 @@ public enum CacheManagerFactory {
     private final CacheManager cacheManager;
 
     CacheManagerFactory() {
-        String modeValue = System.getProperty(RELIABILITY_CACHE_MODE, "EMBEDDED");
-        if (modeValue.equalsIgnoreCase("REMOTE")) {
+        if ("REMOTE".equalsIgnoreCase(System.getProperty(RELIABILITY_CACHE_MODE))) {
             cacheManager = RemoteCacheManager.INSTANCE;
         } else {
             cacheManager = EmbeddedCacheManager.INSTANCE;

--- a/drools-reliability/src/test/java/org/drools/reliability/BeforeAllMethodExtension.java
+++ b/drools-reliability/src/test/java/org/drools/reliability/BeforeAllMethodExtension.java
@@ -15,12 +15,19 @@
 
 package org.drools.reliability;
 
+import java.nio.file.Path;
+
+import org.drools.util.FileUtils;
 import org.junit.jupiter.api.extension.BeforeAllCallback;
 import org.junit.jupiter.api.extension.ExtensionContext;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import static org.drools.reliability.CacheManagerFactory.RELIABILITY_CACHE_ALLOWED_PACKAGES;
 
 public class BeforeAllMethodExtension implements BeforeAllCallback {
+
+    private static final Logger LOG = LoggerFactory.getLogger(BeforeAllMethodExtension.class);
 
     // note: cache directory is shared, so we must not run junit 5 with multi-thread (e.g. ExecutionMode.CONCURRENT)
     // nor surefire-plugin with fork > 1
@@ -28,7 +35,7 @@ public class BeforeAllMethodExtension implements BeforeAllCallback {
     private static boolean initialized = false;
 
     @Override
-    public void beforeAll(ExtensionContext context) throws Exception {
+    public void beforeAll(ExtensionContext context) {
         // This method will be called before the first test method of all test classes
         // So it makes sure to clean up even if we terminate a process while debugging
         if (initialized) {
@@ -36,8 +43,7 @@ public class BeforeAllMethodExtension implements BeforeAllCallback {
         }
         initialized = true;
         System.setProperty(RELIABILITY_CACHE_ALLOWED_PACKAGES, "org.test.domain");
-        if (!CacheManagerFactory.INSTANCE.getCacheManager().isRemote()) {
-            EmbeddedCacheManager.cleanUpGlobalStateAndFileStore();
-        }
+        FileUtils.deleteDirectory(Path.of(EmbeddedCacheManager.GLOBAL_STATE_DIR));
+        LOG.info("### Deleted directory {}", EmbeddedCacheManager.GLOBAL_STATE_DIR);
     }
 }

--- a/drools-reliability/src/test/java/org/drools/reliability/EmbeddedCacheManagerTest.java
+++ b/drools-reliability/src/test/java/org/drools/reliability/EmbeddedCacheManagerTest.java
@@ -19,6 +19,7 @@ import org.infinispan.manager.DefaultCacheManager;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.condition.DisabledIf;
+import org.junit.jupiter.api.extension.ExtendWith;
 
 import java.util.Map;
 import java.util.Set;
@@ -26,9 +27,15 @@ import java.util.concurrent.ConcurrentHashMap;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.drools.reliability.CacheManagerFactory.RELIABILITY_CACHE_ALLOWED_PACKAGES;
+import static org.drools.reliability.CacheManagerFactory.RELIABILITY_CACHE_MODE;
 import static org.drools.reliability.CacheManagerFactory.SESSION_CACHE_PREFIX;
 
-class CacheManagerFactoryTest {
+/**
+ *  This class is a unit test for EmbeddedCacheManager methods with a fake cacheManager instead of Infinispan DefaultCacheManager.
+ */
+@DisabledIf("isRemote")
+@ExtendWith(BeforeAllMethodExtension.class)
+class EmbeddedCacheManagerTest {
 
     static {
         System.setProperty(RELIABILITY_CACHE_ALLOWED_PACKAGES, "org.test.domain");
@@ -39,11 +46,10 @@ class CacheManagerFactoryTest {
         CacheManagerFactory.INSTANCE.getCacheManager().restart(); // make sure that FakeCacheManager is removed
     }
 
-    private boolean isRemote() {
-        return CacheManagerFactory.INSTANCE.getCacheManager().isRemote();
+    private static boolean isRemote() {
+        return "REMOTE".equalsIgnoreCase(System.getProperty(RELIABILITY_CACHE_MODE));
     }
 
-    @DisabledIf("isRemote")
     @Test
     void removeAllSessionCaches_shouldLeaveNonSessionCache() {
         CacheManagerFactory.INSTANCE.getCacheManager().setEmbeddedCacheManager(new FakeCacheManager());
@@ -56,7 +62,6 @@ class CacheManagerFactoryTest {
         assertThat(CacheManagerFactory.INSTANCE.getCacheManager().getCacheNames()).containsExactly("METADATA_0");
     }
 
-    @DisabledIf("isRemote")
     @Test
     void removeCachesBySessionId_shouldRemoveSpecifiedCacheOnly() {
         CacheManagerFactory.INSTANCE.getCacheManager().setEmbeddedCacheManager(new FakeCacheManager());

--- a/drools-reliability/src/test/java/org/drools/reliability/ReliabilityTestBasics.java
+++ b/drools-reliability/src/test/java/org/drools/reliability/ReliabilityTestBasics.java
@@ -79,7 +79,6 @@ public abstract class ReliabilityTestBasics {
             // clean up embedded Infinispan including GlobalState and FireStore so that test methods can be isolated
             CacheManagerFactory.INSTANCE.getCacheManager().restartWithCleanUp();
         }
-
         ReliableRuntimeComponentFactoryImpl.resetCounter();
     }
 
@@ -93,7 +92,7 @@ public abstract class ReliabilityTestBasics {
         } else {
             CacheManagerFactory.INSTANCE.getCacheManager().restart(); // restart embedded infinispan cacheManager. GlobalState and FireStore are kept
         }
-        ReliableRuntimeComponentFactoryImpl.resetCounter();
+        ReliableRuntimeComponentFactoryImpl.refreshCounterUsingCache();
     }
 
     protected FactHandle insertString(String str) {

--- a/drools-reliability/src/test/java/org/drools/reliability/example/RemoteCacheManagerExample.java
+++ b/drools-reliability/src/test/java/org/drools/reliability/example/RemoteCacheManagerExample.java
@@ -14,6 +14,8 @@ import org.kie.api.runtime.KieSessionConfiguration;
 import org.kie.api.runtime.conf.PersistedSessionOption;
 import org.kie.internal.utils.KieHelper;
 
+import static org.drools.reliability.CacheManagerFactory.RELIABILITY_CACHE_ALLOWED_PACKAGES;
+
 /**
  * Example class to demonstrate how to use RemoteCacheManager.
  * <p>
@@ -58,6 +60,8 @@ public class RemoteCacheManagerExample {
         System.setProperty(CacheManagerFactory.RELIABILITY_CACHE_REMOTE_PORT, "11222");
         System.setProperty(CacheManagerFactory.RELIABILITY_CACHE_REMOTE_USER, "admin");
         System.setProperty(CacheManagerFactory.RELIABILITY_CACHE_REMOTE_PASS, "secret");
+
+        System.setProperty(RELIABILITY_CACHE_ALLOWED_PACKAGES, "org.test.domain");
 
         KieBase kbase = new KieHelper().addContent(BASIC_RULE, ResourceType.DRL).build();
         KieSessionConfiguration conf = KieServices.get().newKieSessionConfiguration();

--- a/drools-util/src/main/java/org/drools/util/FileUtils.java
+++ b/drools-util/src/main/java/org/drools/util/FileUtils.java
@@ -19,8 +19,10 @@ import java.io.File;
 import java.io.FileInputStream;
 import java.io.IOException;
 import java.io.InputStream;
+import java.io.UncheckedIOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.util.Comparator;
 import java.util.Optional;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
@@ -87,5 +89,23 @@ public class FileUtils {
      */
     public static Optional<InputStream> getInputStreamFromFileNameAndClassLoader(String fileName, ClassLoader classLoader) {
         return Optional.ofNullable(classLoader.getResourceAsStream(fileName));
+    }
+
+    /**
+     * delete a directory and all its content
+     * @param path path to the directory to delete
+     */
+    public static void deleteDirectory(Path path) {
+        try {
+            if (Files.exists(path)) {
+                try (Stream<Path> walk = Files.walk(path)) {
+                    walk.sorted(Comparator.reverseOrder())
+                            .map(Path::toFile)
+                            .forEach(File::delete);
+                }
+            }
+        } catch (IOException e) {
+            throw new UncheckedIOException(e);
+        }
     }
 }

--- a/drools-util/src/test/java/org/drools/util/FileUtilsTest.java
+++ b/drools-util/src/test/java/org/drools/util/FileUtilsTest.java
@@ -20,6 +20,8 @@ import java.io.File;
 import java.io.FileInputStream;
 import java.io.IOException;
 import java.io.InputStream;
+import java.nio.file.Files;
+import java.nio.file.Path;
 import java.util.Optional;
 
 import org.junit.Test;
@@ -66,5 +68,14 @@ public class FileUtilsTest {
     public void getInputStreamFromFileNameNotExisting() {
         Optional<InputStream> retrieved = FileUtils.getInputStreamFromFileNameAndClassLoader(NOT_EXISTING_FILE, FileUtilsTest.class.getClassLoader());
         assertThat(retrieved).isNotPresent();
+    }
+
+    @Test
+    public void deleteDirectory() throws IOException {
+        final Path tempDirectory = Files.createTempDirectory("temp");
+        final Path tempFile = Files.createTempFile(tempDirectory, "temp", "temp");
+        FileUtils.deleteDirectory(tempDirectory);
+        assertThat(Files.exists(tempDirectory)).isFalse();
+        assertThat(Files.exists(tempFile)).isFalse();
     }
 }


### PR DESCRIPTION
**JIRA**: 
https://issues.redhat.com/browse/DROOLS-7384

If a client forgets to dispose a ksession, its cache will be left. It's unavoidable because we cannot distinguish whether the client will try to fail-over or just forget. (We may introduce a clean-up feature based on timeout in the future). However, the cache should not be reused by another new ksession. It means `RELIABLE_SESSIONS_COUNTER` should keep incrementing (like database sequence) even after fail-over. so `RELIABLE_SESSIONS_COUNTER` has to be stored in the cache.

<details>
<summary>
How to replicate CI configuration locally?
</summary>

Build Chain tool does "simple" maven build(s), the builds are just Maven commands, but because the repositories relates and depends on each other and any change in API or class method could affect several of those repositories there is a need to use [build-chain tool](https://github.com/kiegroup/github-action-build-chain) to handle cross repository builds and be sure that we always use latest version of the code for each repository.
 
[build-chain tool](https://github.com/kiegroup/github-action-build-chain) is a build tool which can be used on command line locally or in Github Actions workflow(s), in case you need to change multiple repositories and send multiple dependent pull requests related with a change you can easily reproduce the same build by executing it on Github hosted environment or locally in your development environment. See [local execution](https://github.com/kiegroup/github-action-build-chain#local-execution) details to get more information about it.
</details>

<details>
<summary>
How to retest this PR or trigger a specific build:
</summary>

- for <b>pull request checks</b>  
  Please add comment: <b>Jenkins retest this</b>

- for a <b>specific pull request check</b>  
  Please add comment: <b>Jenkins (re)run [drools|kogito-runtimes|kogito-apps|kogito-examples] tests</b>

- for a <b>full downstream build</b> 
  - for <b>jenkins</b> job: please add comment: <b>Jenkins run fdb</b>
  - for <b>github actions</b> job: add the label `run_fdb`

- <b>a compile downstream build</b> please  add comment: <b>Jenkins run cdb</b>

- <b>a full production downstream build</b> please add comment: <b>Jenkins execute product fdb</b>

- <b>an upstream build</b> please add comment: <b>Jenkins run upstream</b>

- for <b>quarkus branch checks</b>  
  Run checks against Quarkus current used branch  
  Please add comment: <b>Jenkins run quarkus-branch</b>

- for a <b>quarkus branch specific check</b>  
  Run checks against Quarkus current used branch  
  Please add comment: <b>Jenkins (re)run [drools|kogito-runtimes|kogito-apps|kogito-examples] quarkus-branch</b>

- for <b>quarkus main checks</b>  
  Run checks against Quarkus main branch  
  Please add comment: <b>Jenkins run quarkus-main</b>

- for a <b>specific quarkus main check</b>  
  Run checks against Quarkus main branch  
  Please add comment: <b>Jenkins (re)run [drools|kogito-runtimes|kogito-apps|kogito-examples] quarkus-main</b>

- for <b>quarkus lts checks</b>  
  Run checks against Quarkus lts branch  
  Please add comment: <b>Jenkins run quarkus-lts</b>

- for a <b>specific quarkus lts check</b>  
  Run checks against Quarkus lts branch  
  Please add comment: <b>Jenkins (re)run [drools|kogito-runtimes|kogito-apps|kogito-examples] quarkus-lts</b>

- for <b>native checks</b>  
  Run native checks  
  Please add comment: <b>Jenkins run native</b>

- for a <b>specific native check</b>  
  Run native checks 
  Please add comment: <b>Jenkins (re)run [drools|kogito-runtimes|kogito-apps|kogito-examples] native</b>

 - for <b>native lts checks</b>  
  Run native checks against quarkus lts branch
  Please add comment: <b>Jenkins run native-lts</b>

- for a <b>specific native lts check</b>  
  Run native checks against quarkus lts branch
  Please add comment: <b>Jenkins (re)run [drools|kogito-runtimes|kogito-apps|kogito-examples] native-lts</b>
</details>

<details>
<summary>
How to backport a pull request to a different branch?
</summary>

In order to automatically create a **backporting pull request** please add one or more labels having the following format `backport-<branch-name>`, where `<branch-name>` is the name of the branch where the pull request must be backported to (e.g., `backport-7.67.x` to backport the original PR to the `7.67.x` branch).

> **NOTE**: **backporting** is an action aiming to move a change (usually a commit) from a branch (usually the main one) to another one, which is generally referring to a still maintained release branch. Keeping it simple: it is about to move a specific change or a set of them from one branch to another.

Once the original pull request is successfully merged, the automated action will create one backporting pull request per each label (with the previous format) that has been added.

If something goes wrong, the author will be notified and at this point a manual backporting is needed.

> **NOTE**: this automated backporting is triggered whenever a pull request on `main` branch is labeled or closed, but both conditions must be satisfied to get the new PR created.
</details>