### PR TITLE
[DROOLS-7387] allow to configure the folder containing the infinispan…

### DIFF
--- a/build-parent/pom.xml
+++ b/build-parent/pom.xml
@@ -83,6 +83,7 @@
     <version.org.jboss.narayana.tomcat>5.13.1.Final</version.org.jboss.narayana.tomcat>
     <version.org.jboss.transaction.spi>7.6.1.Final</version.org.jboss.transaction.spi>
     <version.org.jboss.weld.weld>3.1.6.Final</version.org.jboss.weld.weld>
+    <version.org.eclipse.microprofile.config>2.0.1</version.org.eclipse.microprofile.config>
     <version.jakarta.enterprise.cdi-api>2.0.2</version.jakarta.enterprise.cdi-api>
     <version.jakarta.activation>1.2.1</version.jakarta.activation>
     <version.jakarta.activation-api>1.2.1</version.jakarta.activation-api>
@@ -1262,6 +1263,11 @@
         <version>${version.it.unimi.dsi.fastutil}</version>
       </dependency>
 
+      <dependency>
+        <groupId>org.eclipse.microprofile.config</groupId>
+        <artifactId>microprofile-config-api</artifactId>
+        <version>${version.org.eclipse.microprofile.config}</version>
+      </dependency>
     </dependencies>
 
   </dependencyManagement>

--- a/drools-compiler/src/main/java/org/drools/compiler/rule/builder/util/ConstraintUtil.java
+++ b/drools-compiler/src/main/java/org/drools/compiler/rule/builder/util/ConstraintUtil.java
@@ -8,11 +8,13 @@ import org.drools.drl.ast.descr.BaseDescr;
 import org.drools.drl.ast.descr.OperatorDescr;
 import org.drools.drl.ast.descr.RelationalExprDescr;
 
+import static org.drools.util.Config.getConfig;
+
 public class ConstraintUtil {
 
     public static final String DROOLS_NORMALIZE_CONSTRAINT = "drools.normalize.constraint";
 
-    static boolean ENABLE_NORMALIZE = Boolean.parseBoolean(System.getProperty(DROOLS_NORMALIZE_CONSTRAINT, "true"));
+    static boolean ENABLE_NORMALIZE = Boolean.parseBoolean(getConfig(DROOLS_NORMALIZE_CONSTRAINT, "true"));
 
     private ConstraintUtil() {}
 

--- a/drools-core/src/main/java/org/drools/core/concurrent/ExecutorProviderImpl.java
+++ b/drools-core/src/main/java/org/drools/core/concurrent/ExecutorProviderImpl.java
@@ -29,6 +29,8 @@ import javax.naming.NamingException;
 
 import org.kie.api.concurrent.KieExecutors;
 
+import static org.drools.util.Config.getConfig;
+
 public class ExecutorProviderImpl implements KieExecutors {
 
     public static final String EXECUTOR_SERVICE_PROPERTY = "drools.executorService";
@@ -41,7 +43,7 @@ public class ExecutorProviderImpl implements KieExecutors {
         private static final ThreadFactory threadFactory;
 
         static {
-            String threadFactoryClass = System.getProperty( THREAD_FACTORY_PROPERTY );
+            String threadFactoryClass = getConfig( THREAD_FACTORY_PROPERTY );
 
             if ( threadFactoryClass == null ) {
                 threadFactory = new DaemonThreadFactory();

--- a/drools-core/src/main/java/org/drools/core/phreak/PhreakBuilder.java
+++ b/drools-core/src/main/java/org/drools/core/phreak/PhreakBuilder.java
@@ -21,6 +21,8 @@ import org.drools.core.common.InternalWorkingMemory;
 import org.drools.core.impl.RuleBase;
 import org.drools.core.reteoo.TerminalNode;
 
+import static org.drools.util.Config.getConfig;
+
 public interface PhreakBuilder {
 
     static PhreakBuilder get() {
@@ -35,7 +37,7 @@ public interface PhreakBuilder {
     void removeRule(TerminalNode tn, Collection<InternalWorkingMemory> wms, RuleBase kBase);
 
     class Holder {
-        private static final boolean EAGER_SEGMENT_CREATION = Boolean.parseBoolean(System.getProperty("drools.useEagerSegmentCreation", "false"));
+        private static final boolean EAGER_SEGMENT_CREATION = Boolean.parseBoolean(getConfig("drools.useEagerSegmentCreation", "false"));
         private static final PhreakBuilder PHREAK_BUILDER = EAGER_SEGMENT_CREATION ? new EagerPhreakBuilder() : new LazyPhreakBuilder();
     }
 }

--- a/drools-core/src/main/java/org/drools/core/util/QueueFactory.java
+++ b/drools-core/src/main/java/org/drools/core/util/QueueFactory.java
@@ -5,6 +5,8 @@ import java.util.Comparator;
 
 import org.drools.core.util.Queue.QueueEntry;
 
+import static org.drools.util.Config.getConfig;
+
 public class QueueFactory {
 
     private static final String BINARY_HEAP_QUEUE = "binaryheap";
@@ -35,7 +37,7 @@ public class QueueFactory {
     private static final QueueType QUEUE_TYPE;
 
     static {
-        QUEUE_TYPE = QueueType.get(System.getProperty("org.drools.queuetype", DEFAULT_QUEUE));
+        QUEUE_TYPE = QueueType.get(getConfig("org.drools.queuetype", DEFAULT_QUEUE));
     }
 
     public static <T extends QueueEntry> Queue<T> createQueue(Comparator<T> comparator) {

--- a/drools-core/src/main/java/org/drools/core/util/index/IndexMemory.java
+++ b/drools-core/src/main/java/org/drools/core/util/index/IndexMemory.java
@@ -4,6 +4,8 @@ import java.lang.reflect.InvocationTargetException;
 
 import org.drools.core.reteoo.TupleMemory;
 
+import static org.drools.util.Config.getConfig;
+
 public class IndexMemory {
 
     private static final String INTERNAL_INDEX = "internal";
@@ -60,8 +62,8 @@ public class IndexMemory {
     private static ComparisonMemoryType COMPARISON_MEMORY_TYPE; // did not set this as final, as some tests need to change this
 
     static {
-        EQUALITY_MEMORY_TYPE = EqualityMemoryType.get(System.getProperty("org.drools.equalitymemory", DEFAULT_INDEX));
-        COMPARISON_MEMORY_TYPE = ComparisonMemoryType.get(System.getProperty("org.drools.comparisonmemory", DEFAULT_INDEX));
+        EQUALITY_MEMORY_TYPE = EqualityMemoryType.get(getConfig("org.drools.equalitymemory", DEFAULT_INDEX));
+        COMPARISON_MEMORY_TYPE = ComparisonMemoryType.get(getConfig("org.drools.comparisonmemory", DEFAULT_INDEX));
     }
 
     public static EqualityMemoryType getEqualityMemoryType() {

--- a/drools-decisiontables/src/main/java/org/drools/decisiontable/parser/xls/ExcelParser.java
+++ b/drools-decisiontables/src/main/java/org/drools/decisiontable/parser/xls/ExcelParser.java
@@ -47,6 +47,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import static java.lang.String.format;
+import static org.drools.util.Config.getConfig;
 
 /**
  * Parse an excel spreadsheet, pushing cell info into the SheetListener interface.
@@ -58,7 +59,7 @@ public class ExcelParser
     private static final Logger log = LoggerFactory.getLogger( ExcelParser.class );
 
     private static void initMinInflateRatio() {
-        String minInflateRatio = System.getProperty( "drools.excelParser.minInflateRatio" );
+        String minInflateRatio = getConfig( "drools.excelParser.minInflateRatio" );
         if (minInflateRatio != null) {
             try {
                 ZipSecureFile.setMinInflateRatio( Double.parseDouble( minInflateRatio ) );

--- a/drools-drl-quarkus-extension/drools-drl-quarkus-util-deployment/src/main/java/org/drools/drl/quarkus/util/deployment/DroolsQuarkusResourceUtils.java
+++ b/drools-drl-quarkus-extension/drools-drl-quarkus-util-deployment/src/main/java/org/drools/drl/quarkus/util/deployment/DroolsQuarkusResourceUtils.java
@@ -48,6 +48,7 @@ import io.quarkus.deployment.builditem.nativeimage.NativeImageResourceBuildItem;
 import io.quarkus.maven.dependency.ResolvedDependency;
 import io.quarkus.vertx.http.deployment.spi.AdditionalStaticResourceBuildItem;
 
+import static org.drools.util.Config.getConfig;
 import static org.kie.memorycompiler.KieMemoryCompiler.compileNoLoad;
 
 /**
@@ -77,8 +78,8 @@ public class DroolsQuarkusResourceUtils {
     private static final GeneratedFileWriter.Builder generatedFileWriterBuilder =
             new GeneratedFileWriter.Builder(
                     "target/classes",
-                    System.getProperty("drools.codegen.sources.directory", "target/generated-sources/drools/"),
-                    System.getProperty("drools.codegen.resources.directory", "target/generated-resources/drools/"),
+                    getConfig("drools.codegen.sources.directory", "target/generated-sources/drools/"),
+                    getConfig("drools.codegen.resources.directory", "target/generated-resources/drools/"),
                     "target/generated-sources/drools/");
 
     public static DroolsModelBuildContext createDroolsBuildContext(Path outputTarget, Iterable<Path> paths, IndexView index) {

--- a/drools-metric/src/main/java/org/drools/metric/util/MetricLogUtils.java
+++ b/drools-metric/src/main/java/org/drools/metric/util/MetricLogUtils.java
@@ -20,16 +20,18 @@ import org.drools.core.common.BaseNode;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import static org.drools.util.Config.getConfig;
+
 public class MetricLogUtils {
 
     private static final Logger logger = LoggerFactory.getLogger(MetricLogUtils.class);
 
     public static final String METRIC_LOGGER_ENABLED = "drools.metric.logger.enabled";
-    private boolean enabled = Boolean.parseBoolean(System.getProperty(METRIC_LOGGER_ENABLED, "false"));
+    private boolean enabled = Boolean.parseBoolean(getConfig(METRIC_LOGGER_ENABLED, "false"));
     private boolean micrometerAvailable = isMicrometerAvailable();
 
     public static final String METRIC_LOGGER_THRESHOLD = "drools.metric.logger.threshold";
-    private int threshold = Integer.parseInt(System.getProperty(METRIC_LOGGER_THRESHOLD, "500")); // microseconds
+    private int threshold = Integer.parseInt(getConfig(METRIC_LOGGER_THRESHOLD, "500")); // microseconds
 
     private final ThreadLocal<NodeStats> nodeStats = new ThreadLocal<>();
 

--- a/drools-reliability/src/main/java/org/drools/reliability/CacheManagerFactory.java
+++ b/drools-reliability/src/main/java/org/drools/reliability/CacheManagerFactory.java
@@ -25,6 +25,7 @@ public enum CacheManagerFactory {
 
     public static final String RELIABILITY_CACHE = "drools.reliability.cache";
     public static final String RELIABILITY_CACHE_ALLOWED_PACKAGES = RELIABILITY_CACHE + ".allowedpackages";
+    public static final String RELIABILITY_CACHE_DIRECTORY = RELIABILITY_CACHE + ".dir";
     public static final String RELIABILITY_CACHE_MODE = RELIABILITY_CACHE + ".mode";
     public static final String RELIABILITY_CACHE_REMOTE_HOST = RELIABILITY_CACHE + ".remote.host";
     public static final String RELIABILITY_CACHE_REMOTE_PORT = RELIABILITY_CACHE + ".remote.port";

--- a/drools-reliability/src/main/java/org/drools/reliability/EmbeddedCacheManager.java
+++ b/drools-reliability/src/main/java/org/drools/reliability/EmbeddedCacheManager.java
@@ -15,9 +15,6 @@
 
 package org.drools.reliability;
 
-import java.io.IOException;
-import java.io.UncheckedIOException;
-import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -42,8 +39,11 @@ import org.slf4j.LoggerFactory;
 import static org.drools.reliability.CacheManager.createCacheId;
 import static org.drools.reliability.CacheManagerFactory.DELIMITER;
 import static org.drools.reliability.CacheManagerFactory.RELIABILITY_CACHE_ALLOWED_PACKAGES;
+import static org.drools.reliability.CacheManagerFactory.RELIABILITY_CACHE_DIRECTORY;
 import static org.drools.reliability.CacheManagerFactory.SESSION_CACHE_PREFIX;
 import static org.drools.reliability.CacheManagerFactory.SHARED_CACHE_PREFIX;
+import static org.drools.util.Config.getConfig;
+import static org.drools.util.Config.getOptionalConfig;
 
 class EmbeddedCacheManager implements CacheManager {
 
@@ -51,15 +51,15 @@ class EmbeddedCacheManager implements CacheManager {
 
     private static final String[] ALLOWED_PACKAGES;
 
+    public static final String GLOBAL_STATE_DIR = getConfig(RELIABILITY_CACHE_DIRECTORY, "global/state");
+
     static {
         List<String> allowList = new ArrayList<>();
         allowList.add("org.kie.*");
         allowList.add("org.drools.*");
         allowList.add("java.*");
-        String additionalPkgs = System.getProperty(RELIABILITY_CACHE_ALLOWED_PACKAGES);
-        if (additionalPkgs != null) {
-            Arrays.stream(additionalPkgs.split(",")).forEach(p -> allowList.add(p + ".*"));
-        }
+        getOptionalConfig(RELIABILITY_CACHE_ALLOWED_PACKAGES)
+                .ifPresent(additionalPkgs -> Arrays.stream(additionalPkgs.split(",")).forEach(p -> allowList.add(p + ".*")));
         ALLOWED_PACKAGES = allowList.toArray(new String[allowList.size()]);
     }
 
@@ -68,7 +68,6 @@ class EmbeddedCacheManager implements CacheManager {
     private DefaultCacheManager embeddedCacheManager;
     private Configuration cacheConfiguration;
 
-    public static final String GLOBAL_STATE_DIR = "global/state";
     public static final String CACHE_DIR = "cache";
 
     private EmbeddedCacheManager() {}

--- a/drools-reliability/src/main/java/org/drools/reliability/RemoteCacheManager.java
+++ b/drools-reliability/src/main/java/org/drools/reliability/RemoteCacheManager.java
@@ -33,6 +33,7 @@ import static org.drools.reliability.CacheManagerFactory.DELIMITER;
 import static org.drools.reliability.CacheManagerFactory.RELIABILITY_CACHE_ALLOWED_PACKAGES;
 import static org.drools.reliability.CacheManagerFactory.SESSION_CACHE_PREFIX;
 import static org.drools.reliability.CacheManagerFactory.SHARED_CACHE_PREFIX;
+import static org.drools.util.Config.getConfig;
 
 class RemoteCacheManager implements CacheManager {
 
@@ -45,7 +46,7 @@ class RemoteCacheManager implements CacheManager {
         allowList.add("org.kie.*");
         allowList.add("org.drools.*");
         allowList.add("java.*");
-        String additionalPkgs = System.getProperty(RELIABILITY_CACHE_ALLOWED_PACKAGES);
+        String additionalPkgs = getConfig(RELIABILITY_CACHE_ALLOWED_PACKAGES);
         if (additionalPkgs != null) {
             Arrays.stream(additionalPkgs.split(",")).forEach(p -> allowList.add(p + ".*"));
         }
@@ -63,10 +64,10 @@ class RemoteCacheManager implements CacheManager {
     public void initCacheManager() {
         // Create a RemoteCacheManager with provided properties
         LOG.info("Using Remote Cache Manager");
-        String host = System.getProperty(CacheManagerFactory.RELIABILITY_CACHE_REMOTE_HOST);
-        String port = System.getProperty(CacheManagerFactory.RELIABILITY_CACHE_REMOTE_PORT);
-        String user = System.getProperty(CacheManagerFactory.RELIABILITY_CACHE_REMOTE_USER);
-        String pass = System.getProperty(CacheManagerFactory.RELIABILITY_CACHE_REMOTE_PASS);
+        String host = getConfig(CacheManagerFactory.RELIABILITY_CACHE_REMOTE_HOST);
+        String port = getConfig(CacheManagerFactory.RELIABILITY_CACHE_REMOTE_PORT);
+        String user = getConfig(CacheManagerFactory.RELIABILITY_CACHE_REMOTE_USER);
+        String pass = getConfig(CacheManagerFactory.RELIABILITY_CACHE_REMOTE_PASS);
         if (host == null || port == null) {
             LOG.info("Remote Cache Manager host '{}' and port '{}' not set. So not creating a default RemoteCacheManager." +
                              " You will need to set a RemoteCacheManager with setRemoteCacheManager() method.", host, port);

--- a/drools-util/pom.xml
+++ b/drools-util/pom.xml
@@ -22,6 +22,10 @@
 
     <dependencies>
         <dependency>
+            <groupId>org.eclipse.microprofile.config</groupId>
+            <artifactId>microprofile-config-api</artifactId>
+        </dependency>
+        <dependency>
             <groupId>junit</groupId>
             <artifactId>junit</artifactId>
             <scope>test</scope>

--- a/drools-util/src/main/java/org/drools/util/Config.java
+++ b/drools-util/src/main/java/org/drools/util/Config.java
@@ -1,0 +1,94 @@
+/*
+ * Copyright 2023 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.drools.util;
+
+import java.util.Optional;
+
+import org.eclipse.microprofile.config.ConfigProvider;
+
+public class Config {
+
+    public static String getConfig(String propertyName) {
+        return ConfigResolverHolder.CONFIG_RESOLVER.getConfig(propertyName);
+    }
+
+    public static String getConfig(String propertyName, String defaultValue) {
+        return ConfigResolverHolder.CONFIG_RESOLVER.getConfig(propertyName, defaultValue);
+    }
+
+    public static Optional<String> getOptionalConfig(String propertyName) {
+        return ConfigResolverHolder.CONFIG_RESOLVER.getOptionalConfig(propertyName);
+    }
+
+    interface ConfigResolver {
+        String getConfig(String propertyName);
+        String getConfig(String propertyName, String defaultValue);
+        Optional<String> getOptionalConfig(String propertyName);
+    }
+
+    private static class ConfigResolverHolder {
+        private static final ConfigResolver CONFIG_RESOLVER = createConfigResolver();
+
+        private static ConfigResolver createConfigResolver() {
+            try {
+                return new MicroprofileConfigResolver(ConfigProvider.getConfig());
+            } catch (Exception e) {
+                return new SystemPropertyConfigResolver();
+            }
+        }
+    }
+
+    private static class MicroprofileConfigResolver implements ConfigResolver {
+        private final org.eclipse.microprofile.config.Config config;
+
+        private MicroprofileConfigResolver(org.eclipse.microprofile.config.Config config) {
+            this.config = config;
+        }
+
+        @Override
+        public String getConfig(String propertyName) {
+            return getConfig(propertyName, null);
+        }
+
+        @Override
+        public String getConfig(String propertyName, String defaultValue) {
+            return getOptionalConfig(propertyName).orElse(defaultValue);
+        }
+
+        @Override
+        public Optional<String> getOptionalConfig(String propertyName) {
+            return config.getOptionalValue(propertyName, String.class);
+        }
+    }
+
+    private static class SystemPropertyConfigResolver implements ConfigResolver {
+        @Override
+        public String getConfig(String propertyName) {
+            return System.getProperty(propertyName);
+        }
+
+        @Override
+        public String getConfig(String propertyName, String defaultValue) {
+            return System.getProperty(propertyName, defaultValue);
+        }
+
+        @Override
+        public Optional<String> getOptionalConfig(String propertyName) {
+            return Optional.ofNullable( getConfig(propertyName) );
+        }
+    }
+}

--- a/drools-util/src/main/java/org/drools/util/DateUtils.java
+++ b/drools-util/src/main/java/org/drools/util/DateUtils.java
@@ -22,6 +22,8 @@ import java.text.SimpleDateFormat;
 import java.util.Date;
 import java.util.Locale;
 
+import static org.drools.util.Config.getConfig;
+
 public class DateUtils {
 
     private static final long serialVersionUID = 510l;
@@ -39,7 +41,7 @@ public class DateUtils {
     });
 
     private static String getDefaultLanguage() {
-        String fmt = System.getProperty("drools.defaultlanguage");
+        String fmt = getConfig("drools.defaultlanguage");
         if (fmt == null) {
             fmt = DEFAULT_LANGUAGE;
         }
@@ -47,7 +49,7 @@ public class DateUtils {
     }
 
     private static String getDefaultContry() {
-        String fmt = System.getProperty("drools.defaultcountry");
+        String fmt = getConfig("drools.defaultcountry");
         if (fmt == null) {
             fmt = DEFAULT_COUNTRY;
         }
@@ -91,7 +93,7 @@ public class DateUtils {
 
     /** Check for the system property override, if it exists */
     public static String getDateFormatMask() {
-        String fmt = System.getProperty("drools.dateformat");
+        String fmt = getConfig("drools.dateformat");
         if (fmt == null) {
             fmt = DEFAULT_FORMAT_MASK;
         }

--- a/drools-verifier/drools-verifier-drl/src/main/java/org/drools/verifier/components/LiteralRestriction.java
+++ b/drools-verifier/drools-verifier-drl/src/main/java/org/drools/verifier/components/LiteralRestriction.java
@@ -21,6 +21,8 @@ import java.util.Locale;
 
 import org.drools.verifier.report.components.Cause;
 
+import static org.drools.util.Config.getConfig;
+
 public abstract class LiteralRestriction extends Restriction
     implements
     Cause {
@@ -69,7 +71,7 @@ public abstract class LiteralRestriction extends Restriction
 
         try {
             // TODO: Get this from config.
-            String fmt = System.getProperty( "drools.dateformat" );
+            String fmt = getConfig( "drools.dateformat" );
             if ( fmt == null ) {
                 fmt = "dd-MMM-yyyy";
             }

--- a/drools-verifier/drools-verifier-drl/src/main/java/org/drools/verifier/doc/DroolsDocsBuilder.java
+++ b/drools-verifier/drools-verifier-drl/src/main/java/org/drools/verifier/doc/DroolsDocsBuilder.java
@@ -31,6 +31,8 @@ import com.lowagie.text.HeaderFooter;
 import com.lowagie.text.Phrase;
 import com.lowagie.text.pdf.PdfWriter;
 
+import static org.drools.util.Config.getConfig;
+
 public class DroolsDocsBuilder {
 
     protected final String currentDate = getFormatter().format( new Date() );
@@ -101,7 +103,7 @@ public class DroolsDocsBuilder {
     }
 
     public static String getDateFormatMask() {
-        String fmt = System.getProperty( "drools.dateformat" );
+        String fmt = getConfig( "drools.dateformat" );
         if ( fmt == null ) {
             fmt = "dd-MMM-yyyy";
         }

--- a/drools-verifier/drools-verifier-drl/src/main/java/org/drools/verifier/report/components/MissingNumberPattern.java
+++ b/drools-verifier/drools-verifier-drl/src/main/java/org/drools/verifier/report/components/MissingNumberPattern.java
@@ -26,6 +26,8 @@ import org.drools.verifier.components.Field;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import static org.drools.util.Config.getConfig;
+
 public class MissingNumberPattern extends MissingRange
     implements
     Comparable<MissingRange> {
@@ -67,7 +69,7 @@ public class MissingNumberPattern extends MissingRange
             return Boolean.valueOf( value );
         } else if ( valueType.equals(Field.DATE) ) {
             try {
-                String fmt = System.getProperty( "drools.dateformat" );
+                String fmt = getConfig( "drools.dateformat" );
                 if ( fmt == null ) {
                     fmt = "dd-MMM-yyyy";
                 }

--- a/drools-wiring/drools-wiring-api/src/main/java/org/drools/wiring/api/classloader/ProjectClassLoader.java
+++ b/drools-wiring/drools-wiring-api/src/main/java/org/drools/wiring/api/classloader/ProjectClassLoader.java
@@ -40,12 +40,13 @@ import org.kie.memorycompiler.StoreClassLoader;
 import org.kie.memorycompiler.WritableClassLoader;
 
 import static org.drools.util.ClassUtils.findParentClassLoader;
+import static org.drools.util.Config.getConfig;
 
 public abstract class ProjectClassLoader extends ClassLoader implements KieTypeResolver, StoreClassLoader, WritableClassLoader {
 
     static final boolean CACHE_NON_EXISTING_CLASSES = true;
 
-    private static boolean enableStoreFirst = Boolean.valueOf(System.getProperty("drools.projectClassLoader.enableStoreFirst", "true"));
+    private static boolean enableStoreFirst = Boolean.valueOf(getConfig("drools.projectClassLoader.enableStoreFirst", "true"));
 
     static {
         registerAsParallelCapable();


### PR DESCRIPTION
… cache file used by the reliable session

**JIRA**: https://issues.redhat.com/browse/DROOLS-7387

@tkobayas In general I changed how we read configuration properties. Instead of using `System.getProperty` I introduced a level of indirection trying to read from the `microprofile-config-api` if there is an available implementation on the classpath or falling back to `System.getProperty` otherwise. In this way properties can be configured also via Quarkus `application.properties` file. I know that I'm just scratching the surface for now and in particular what I've done here should be harmonized with the (infamous) `ChainedProperties` class (which could be probably simplified a lot, especially now that we dropped OSGi support), but in future I think that we should always read configuration properties via the new `Config` class.