### PR TITLE
[8.36.x] DSL triggers disabled

### DIFF
--- a/.ci/jenkins/config/branch.yaml
+++ b/.ci/jenkins/config/branch.yaml
@@ -48,7 +48,7 @@ environments:
     enabled: false
 productized_branch: false
 disable:
-  triggers: false
+  triggers: true
 repositories:
 - name: drools
   branch: 8.36.x


### PR DESCRIPTION
Generated by https://eng-jenkins-csb-business-automation.apps.ocp-c1.prod.psi.redhat.com/job/KIE/job/drools/job/8.36.x/job/tools/job/toggle-dsl-triggers/1/