### PR TITLE
[DROOLS-7361] Add benchmarks for drools-reliability

### DIFF
--- a/drools-reliability/src/main/java/org/drools/reliability/CacheManager.java
+++ b/drools-reliability/src/main/java/org/drools/reliability/CacheManager.java
@@ -27,7 +27,7 @@ import org.kie.api.runtime.conf.PersistedSessionOption;
 import static org.drools.reliability.CacheManagerFactory.DELIMITER;
 import static org.drools.reliability.CacheManagerFactory.SESSION_CACHE_PREFIX;
 
-interface CacheManager {
+public interface CacheManager {
 
     void initCacheManager();
 

--- a/drools-reliability/src/main/java/org/drools/reliability/CacheManagerFactory.java
+++ b/drools-reliability/src/main/java/org/drools/reliability/CacheManagerFactory.java
@@ -15,6 +15,10 @@
 
 package org.drools.reliability;
 
+import org.drools.util.Config;
+
+import static org.drools.util.Config.getConfig;
+
 public enum CacheManagerFactory {
 
     INSTANCE;
@@ -35,7 +39,7 @@ public enum CacheManagerFactory {
     private final CacheManager cacheManager;
 
     CacheManagerFactory() {
-        if ("REMOTE".equalsIgnoreCase(System.getProperty(RELIABILITY_CACHE_MODE))) {
+        if ("REMOTE".equalsIgnoreCase(getConfig(RELIABILITY_CACHE_MODE))) {
             cacheManager = RemoteCacheManager.INSTANCE;
         } else {
             cacheManager = EmbeddedCacheManager.INSTANCE;

--- a/drools-reliability/src/main/java/org/drools/reliability/EmbeddedCacheManager.java
+++ b/drools-reliability/src/main/java/org/drools/reliability/EmbeddedCacheManager.java
@@ -45,7 +45,7 @@ import static org.drools.reliability.CacheManagerFactory.SHARED_CACHE_PREFIX;
 import static org.drools.util.Config.getConfig;
 import static org.drools.util.Config.getOptionalConfig;
 
-class EmbeddedCacheManager implements CacheManager {
+public class EmbeddedCacheManager implements CacheManager {
 
     private static final Logger LOG = LoggerFactory.getLogger(EmbeddedCacheManager.class);
 

--- a/drools-reliability/src/main/java/org/drools/reliability/RemoteCacheManager.java
+++ b/drools-reliability/src/main/java/org/drools/reliability/RemoteCacheManager.java
@@ -35,7 +35,7 @@ import static org.drools.reliability.CacheManagerFactory.SESSION_CACHE_PREFIX;
 import static org.drools.reliability.CacheManagerFactory.SHARED_CACHE_PREFIX;
 import static org.drools.util.Config.getConfig;
 
-class RemoteCacheManager implements CacheManager {
+public class RemoteCacheManager implements CacheManager {
 
     private static final Logger LOG = LoggerFactory.getLogger(RemoteCacheManager.class);
 

--- a/drools-reliability/src/test/java/org/drools/reliability/EmbeddedCacheManagerTest.java
+++ b/drools-reliability/src/test/java/org/drools/reliability/EmbeddedCacheManagerTest.java
@@ -15,20 +15,21 @@
 
 package org.drools.reliability;
 
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
+
 import org.infinispan.manager.DefaultCacheManager;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.condition.DisabledIf;
 import org.junit.jupiter.api.extension.ExtendWith;
 
-import java.util.Map;
-import java.util.Set;
-import java.util.concurrent.ConcurrentHashMap;
-
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.drools.reliability.CacheManagerFactory.RELIABILITY_CACHE_ALLOWED_PACKAGES;
 import static org.drools.reliability.CacheManagerFactory.RELIABILITY_CACHE_MODE;
 import static org.drools.reliability.CacheManagerFactory.SESSION_CACHE_PREFIX;
+import static org.drools.util.Config.getConfig;
 
 /**
  *  This class is a unit test for EmbeddedCacheManager methods with a fake cacheManager instead of Infinispan DefaultCacheManager.
@@ -47,7 +48,7 @@ class EmbeddedCacheManagerTest {
     }
 
     private static boolean isRemote() {
-        return "REMOTE".equalsIgnoreCase(System.getProperty(RELIABILITY_CACHE_MODE));
+        return "REMOTE".equalsIgnoreCase(getConfig(RELIABILITY_CACHE_MODE));
     }
 
     @Test


### PR DESCRIPTION
- Loosen visibility to be used in benchmark
- Minor fix to avoid System.getProperty

**JIRA**: 
https://issues.redhat.com/browse/DROOLS-7361

<details>
<summary>
How to replicate CI configuration locally?
</summary>

Build Chain tool does "simple" maven build(s), the builds are just Maven commands, but because the repositories relates and depends on each other and any change in API or class method could affect several of those repositories there is a need to use [build-chain tool](https://github.com/kiegroup/github-action-build-chain) to handle cross repository builds and be sure that we always use latest version of the code for each repository.
 
[build-chain tool](https://github.com/kiegroup/github-action-build-chain) is a build tool which can be used on command line locally or in Github Actions workflow(s), in case you need to change multiple repositories and send multiple dependent pull requests related with a change you can easily reproduce the same build by executing it on Github hosted environment or locally in your development environment. See [local execution](https://github.com/kiegroup/github-action-build-chain#local-execution) details to get more information about it.
</details>

<details>
<summary>
How to retest this PR or trigger a specific build:
</summary>

- for <b>pull request checks</b>  
  Please add comment: <b>Jenkins retest this</b>

- for a <b>specific pull request check</b>  
  Please add comment: <b>Jenkins (re)run [drools|kogito-runtimes|kogito-apps|kogito-examples] tests</b>

- for a <b>full downstream build</b> 
  - for <b>jenkins</b> job: please add comment: <b>Jenkins run fdb</b>
  - for <b>github actions</b> job: add the label `run_fdb`

- <b>a compile downstream build</b> please  add comment: <b>Jenkins run cdb</b>

- <b>a full production downstream build</b> please add comment: <b>Jenkins execute product fdb</b>

- <b>an upstream build</b> please add comment: <b>Jenkins run upstream</b>

- for <b>quarkus branch checks</b>  
  Run checks against Quarkus current used branch  
  Please add comment: <b>Jenkins run quarkus-branch</b>

- for a <b>quarkus branch specific check</b>  
  Run checks against Quarkus current used branch  
  Please add comment: <b>Jenkins (re)run [drools|kogito-runtimes|kogito-apps|kogito-examples] quarkus-branch</b>

- for <b>quarkus main checks</b>  
  Run checks against Quarkus main branch  
  Please add comment: <b>Jenkins run quarkus-main</b>

- for a <b>specific quarkus main check</b>  
  Run checks against Quarkus main branch  
  Please add comment: <b>Jenkins (re)run [drools|kogito-runtimes|kogito-apps|kogito-examples] quarkus-main</b>

- for <b>quarkus lts checks</b>  
  Run checks against Quarkus lts branch  
  Please add comment: <b>Jenkins run quarkus-lts</b>

- for a <b>specific quarkus lts check</b>  
  Run checks against Quarkus lts branch  
  Please add comment: <b>Jenkins (re)run [drools|kogito-runtimes|kogito-apps|kogito-examples] quarkus-lts</b>

- for <b>native checks</b>  
  Run native checks  
  Please add comment: <b>Jenkins run native</b>

- for a <b>specific native check</b>  
  Run native checks 
  Please add comment: <b>Jenkins (re)run [drools|kogito-runtimes|kogito-apps|kogito-examples] native</b>

 - for <b>native lts checks</b>  
  Run native checks against quarkus lts branch
  Please add comment: <b>Jenkins run native-lts</b>

- for a <b>specific native lts check</b>  
  Run native checks against quarkus lts branch
  Please add comment: <b>Jenkins (re)run [drools|kogito-runtimes|kogito-apps|kogito-examples] native-lts</b>
</details>

<details>
<summary>
How to backport a pull request to a different branch?
</summary>

In order to automatically create a **backporting pull request** please add one or more labels having the following format `backport-<branch-name>`, where `<branch-name>` is the name of the branch where the pull request must be backported to (e.g., `backport-7.67.x` to backport the original PR to the `7.67.x` branch).

> **NOTE**: **backporting** is an action aiming to move a change (usually a commit) from a branch (usually the main one) to another one, which is generally referring to a still maintained release branch. Keeping it simple: it is about to move a specific change or a set of them from one branch to another.

Once the original pull request is successfully merged, the automated action will create one backporting pull request per each label (with the previous format) that has been added.

If something goes wrong, the author will be notified and at this point a manual backporting is needed.

> **NOTE**: this automated backporting is triggered whenever a pull request on `main` branch is labeled or closed, but both conditions must be satisfied to get the new PR created.
</details>