### PR TITLE
[8.37.x] Update project version to 8.37.1-SNAPSHOT

### DIFF
--- a/bom/drools-bom/pom.xml
+++ b/bom/drools-bom/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.kie</groupId>
     <artifactId>kie-core-bom</artifactId>
-    <version>8.37.0.Final</version>
+    <version>8.37.1-SNAPSHOT</version>
     <relativePath>../kie-core-bom/pom.xml</relativePath>
   </parent>
 

--- a/bom/kie-core-bom/pom.xml
+++ b/bom/kie-core-bom/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.kie</groupId>
     <artifactId>drools-parent</artifactId>
-    <version>8.37.0.Final</version>
+    <version>8.37.1-SNAPSHOT</version>
     <relativePath>../../pom.xml</relativePath>
   </parent>
 

--- a/bom/kie-dmn-bom/pom.xml
+++ b/bom/kie-dmn-bom/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.kie</groupId>
     <artifactId>kie-core-bom</artifactId>
-    <version>8.37.0.Final</version>
+    <version>8.37.1-SNAPSHOT</version>
     <relativePath>../kie-core-bom/pom.xml</relativePath>
   </parent>
 

--- a/bom/kie-efesto-bom/pom.xml
+++ b/bom/kie-efesto-bom/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.kie</groupId>
     <artifactId>kie-core-bom</artifactId>
-    <version>8.37.0.Final</version>
+    <version>8.37.1-SNAPSHOT</version>
     <relativePath>../kie-core-bom/pom.xml</relativePath>
   </parent>
 

--- a/bom/kie-pmml-bom/pom.xml
+++ b/bom/kie-pmml-bom/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.kie</groupId>
     <artifactId>kie-core-bom</artifactId>
-    <version>8.37.0.Final</version>
+    <version>8.37.1-SNAPSHOT</version>
     <relativePath>../kie-core-bom/pom.xml</relativePath>
   </parent>
 

--- a/bom/pom.xml
+++ b/bom/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>drools-parent</artifactId>
         <groupId>org.kie</groupId>
-        <version>8.37.0.Final</version>
+        <version>8.37.1-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/build-parent/pom.xml
+++ b/build-parent/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <artifactId>drools-parent</artifactId>
     <groupId>org.kie</groupId>
-    <version>8.37.0.Final</version>
+    <version>8.37.1-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/drools-alphanetwork-compiler/pom.xml
+++ b/drools-alphanetwork-compiler/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.kie</groupId>
     <artifactId>drools-build-parent</artifactId>
-    <version>8.37.0.Final</version>
+    <version>8.37.1-SNAPSHOT</version>
     <relativePath>../build-parent/pom.xml</relativePath>
   </parent>
 

--- a/drools-beliefs/pom.xml
+++ b/drools-beliefs/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.kie</groupId>
     <artifactId>drools-build-parent</artifactId>
-    <version>8.37.0.Final</version>
+    <version>8.37.1-SNAPSHOT</version>
     <relativePath>../build-parent/pom.xml</relativePath>
   </parent>
 

--- a/drools-commands/pom.xml
+++ b/drools-commands/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>org.kie</groupId>
         <artifactId>drools-build-parent</artifactId>
-        <version>8.37.0.Final</version>
+        <version>8.37.1-SNAPSHOT</version>
         <relativePath>../build-parent/pom.xml</relativePath>
     </parent>
 

--- a/drools-compiler/pom.xml
+++ b/drools-compiler/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.kie</groupId>
     <artifactId>drools-build-parent</artifactId>
-    <version>8.37.0.Final</version>
+    <version>8.37.1-SNAPSHOT</version>
     <relativePath>../build-parent/pom.xml</relativePath>
   </parent>
 

--- a/drools-core/pom.xml
+++ b/drools-core/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.kie</groupId>
     <artifactId>drools-build-parent</artifactId>
-    <version>8.37.0.Final</version>
+    <version>8.37.1-SNAPSHOT</version>
     <relativePath>../build-parent/pom.xml</relativePath>
   </parent>
 

--- a/drools-decisiontables/pom.xml
+++ b/drools-decisiontables/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.kie</groupId>
     <artifactId>drools-build-parent</artifactId>
-    <version>8.37.0.Final</version>
+    <version>8.37.1-SNAPSHOT</version>
     <relativePath>../build-parent/pom.xml</relativePath>
   </parent>
 

--- a/drools-distribution/pom.xml
+++ b/drools-distribution/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.kie</groupId>
     <artifactId>drools-build-parent</artifactId>
-    <version>8.37.0.Final</version>
+    <version>8.37.1-SNAPSHOT</version>
     <relativePath>../build-parent/pom.xml</relativePath>
   </parent>
 

--- a/drools-docs/pom.xml
+++ b/drools-docs/pom.xml
@@ -7,7 +7,7 @@
   <parent>
     <groupId>org.kie</groupId>
     <artifactId>drools-build-parent</artifactId>
-    <version>8.37.0.Final</version>
+    <version>8.37.1-SNAPSHOT</version>
     <relativePath>../build-parent/pom.xml</relativePath>
   </parent>
 

--- a/drools-drl-ast/pom.xml
+++ b/drools-drl-ast/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.kie</groupId>
     <artifactId>drools-build-parent</artifactId>
-    <version>8.37.0.Final</version>
+    <version>8.37.1-SNAPSHOT</version>
     <relativePath>../build-parent/pom.xml</relativePath>
   </parent>
 

--- a/drools-drl-extensions/pom.xml
+++ b/drools-drl-extensions/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>org.kie</groupId>
         <artifactId>drools-build-parent</artifactId>
-        <version>8.37.0.Final</version>
+        <version>8.37.1-SNAPSHOT</version>
         <relativePath>../build-parent/pom.xml</relativePath>
     </parent>
 

--- a/drools-drl-parser/pom.xml
+++ b/drools-drl-parser/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>org.kie</groupId>
         <artifactId>drools-build-parent</artifactId>
-        <version>8.37.0.Final</version>
+        <version>8.37.1-SNAPSHOT</version>
         <relativePath>../build-parent/pom.xml</relativePath>
     </parent>
 

--- a/drools-drl-quarkus-extension/drools-drl-quarkus-deployment/pom.xml
+++ b/drools-drl-quarkus-extension/drools-drl-quarkus-deployment/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>org.drools</groupId>
       <artifactId>drools-drl-quarkus-extension</artifactId>
-      <version>8.37.0.Final</version>
+      <version>8.37.1-SNAPSHOT</version>
     </parent>
 
   <name>Drools :: Quarkus Extension :: Deployment</name>

--- a/drools-drl-quarkus-extension/drools-drl-quarkus-examples/drools-drl-quarkus-examples-multiunit/pom.xml
+++ b/drools-drl-quarkus-extension/drools-drl-quarkus-examples/drools-drl-quarkus-examples-multiunit/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.drools</groupId>
     <artifactId>drools-drl-quarkus-examples</artifactId>
-    <version>8.37.0.Final</version>
+    <version>8.37.1-SNAPSHOT</version>
   </parent>
 
   <name>Drools :: Quarkus Extension :: Examples :: Reactive</name>

--- a/drools-drl-quarkus-extension/drools-drl-quarkus-examples/drools-drl-quarkus-examples-reactive/pom.xml
+++ b/drools-drl-quarkus-extension/drools-drl-quarkus-examples/drools-drl-quarkus-examples-reactive/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.drools</groupId>
     <artifactId>drools-drl-quarkus-examples</artifactId>
-    <version>8.37.0.Final</version>
+    <version>8.37.1-SNAPSHOT</version>
   </parent>
 
   <name>Drools :: Quarkus Extension :: Examples :: Reactive</name>

--- a/drools-drl-quarkus-extension/drools-drl-quarkus-examples/pom.xml
+++ b/drools-drl-quarkus-extension/drools-drl-quarkus-examples/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>org.drools</groupId>
         <artifactId>drools-drl-quarkus-extension</artifactId>
-        <version>8.37.0.Final</version>
+        <version>8.37.1-SNAPSHOT</version>
     </parent>
 
     <name>Drools :: Quarkus Extension :: Examples</name>

--- a/drools-drl-quarkus-extension/drools-drl-quarkus-integration-test-hotreload/pom.xml
+++ b/drools-drl-quarkus-extension/drools-drl-quarkus-integration-test-hotreload/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>org.drools</groupId>
         <artifactId>drools-drl-quarkus-extension</artifactId>
-        <version>8.37.0.Final</version>
+        <version>8.37.1-SNAPSHOT</version>
     </parent>
 
     <name>Drools :: Quarkus Extension :: Integration Test :: Hotreload</name>

--- a/drools-drl-quarkus-extension/drools-drl-quarkus-integration-test/pom.xml
+++ b/drools-drl-quarkus-extension/drools-drl-quarkus-integration-test/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>org.drools</groupId>
         <artifactId>drools-drl-quarkus-extension</artifactId>
-        <version>8.37.0.Final</version>
+        <version>8.37.1-SNAPSHOT</version>
     </parent>
 
     <name>Drools :: Quarkus Extension :: Integration Test</name>

--- a/drools-drl-quarkus-extension/drools-drl-quarkus-quickstart-test/pom.xml
+++ b/drools-drl-quarkus-extension/drools-drl-quarkus-quickstart-test/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>org.drools</groupId>
         <artifactId>drools-drl-quarkus-extension</artifactId>
-        <version>8.37.0.Final</version>
+        <version>8.37.1-SNAPSHOT</version>
     </parent>
 
     <name>Drools :: Quarkus Extension :: Quickstart Integration Test</name>

--- a/drools-drl-quarkus-extension/drools-drl-quarkus-ruleunit-integration-test/pom.xml
+++ b/drools-drl-quarkus-extension/drools-drl-quarkus-ruleunit-integration-test/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>org.drools</groupId>
         <artifactId>drools-drl-quarkus-extension</artifactId>
-        <version>8.37.0.Final</version>
+        <version>8.37.1-SNAPSHOT</version>
     </parent>
 
     <name>Drools :: Quarkus Extension :: Integration Test with Rule Unit</name>

--- a/drools-drl-quarkus-extension/drools-drl-quarkus-util-deployment/pom.xml
+++ b/drools-drl-quarkus-extension/drools-drl-quarkus-util-deployment/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>org.drools</groupId>
         <artifactId>drools-drl-quarkus-extension</artifactId>
-        <version>8.37.0.Final</version>
+        <version>8.37.1-SNAPSHOT</version>
     </parent>
 
     <name>Drools :: Quarkus Extension :: Util :: Deployment</name>

--- a/drools-drl-quarkus-extension/drools-drl-quarkus/pom.xml
+++ b/drools-drl-quarkus-extension/drools-drl-quarkus/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>org.drools</groupId>
         <artifactId>drools-drl-quarkus-extension</artifactId>
-        <version>8.37.0.Final</version>
+        <version>8.37.1-SNAPSHOT</version>
     </parent>
 
     <name>Drools :: Quarkus Extension :: Runtime</name>

--- a/drools-drl-quarkus-extension/pom.xml
+++ b/drools-drl-quarkus-extension/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.kie</groupId>
     <artifactId>drools-build-parent</artifactId>
-    <version>8.37.0.Final</version>
+    <version>8.37.1-SNAPSHOT</version>
     <relativePath>../build-parent/pom.xml</relativePath>
   </parent>
 

--- a/drools-ecj/pom.xml
+++ b/drools-ecj/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>org.kie</groupId>
         <artifactId>drools-build-parent</artifactId>
-        <version>8.37.0.Final</version>
+        <version>8.37.1-SNAPSHOT</version>
         <relativePath>../build-parent/pom.xml</relativePath>
     </parent>
 

--- a/drools-engine-classic/pom.xml
+++ b/drools-engine-classic/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.kie</groupId>
     <artifactId>drools-build-parent</artifactId>
-    <version>8.37.0.Final</version>
+    <version>8.37.1-SNAPSHOT</version>
     <relativePath>../build-parent/pom.xml</relativePath>
   </parent>
 

--- a/drools-engine/pom.xml
+++ b/drools-engine/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.kie</groupId>
     <artifactId>drools-build-parent</artifactId>
-    <version>8.37.0.Final</version>
+    <version>8.37.1-SNAPSHOT</version>
     <relativePath>../build-parent/pom.xml</relativePath>
   </parent>
 

--- a/drools-examples-api/default-kiesession-from-file/pom.xml
+++ b/drools-examples-api/default-kiesession-from-file/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.drools</groupId>
     <artifactId>drools-examples-api</artifactId>
-    <version>8.37.0.Final</version>
+    <version>8.37.1-SNAPSHOT</version>
   </parent>
 
   <artifactId>default-kiesession-from-file</artifactId>

--- a/drools-examples-api/default-kiesession/pom.xml
+++ b/drools-examples-api/default-kiesession/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.drools</groupId>
     <artifactId>drools-examples-api</artifactId>
-    <version>8.37.0.Final</version>
+    <version>8.37.1-SNAPSHOT</version>
   </parent>
 
   <artifactId>default-kiesession</artifactId>

--- a/drools-examples-api/kie-module-from-multiple-files/pom.xml
+++ b/drools-examples-api/kie-module-from-multiple-files/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.drools</groupId>
     <artifactId>drools-examples-api</artifactId>
-    <version>8.37.0.Final</version>
+    <version>8.37.1-SNAPSHOT</version>
   </parent>
 
   <artifactId>kie-module-from-multiple-files</artifactId>

--- a/drools-examples-api/kiebase-inclusion/pom.xml
+++ b/drools-examples-api/kiebase-inclusion/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.drools</groupId>
     <artifactId>drools-examples-api</artifactId>
-    <version>8.37.0.Final</version>
+    <version>8.37.1-SNAPSHOT</version>
   </parent>
 
   <artifactId>kiebase-inclusion</artifactId>

--- a/drools-examples-api/kiecontainer-from-kierepo/pom.xml
+++ b/drools-examples-api/kiecontainer-from-kierepo/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.drools</groupId>
     <artifactId>drools-examples-api</artifactId>
-    <version>8.37.0.Final</version>
+    <version>8.37.1-SNAPSHOT</version>
   </parent>
 
   <artifactId>kiecontainer-from-kierepo</artifactId>

--- a/drools-examples-api/kiefilesystem-example/pom.xml
+++ b/drools-examples-api/kiefilesystem-example/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.drools</groupId>
     <artifactId>drools-examples-api</artifactId>
-    <version>8.37.0.Final</version>
+    <version>8.37.1-SNAPSHOT</version>
   </parent>
 
   <artifactId>kiefilesystem-example</artifactId>

--- a/drools-examples-api/kiemodulemodel-example/pom.xml
+++ b/drools-examples-api/kiemodulemodel-example/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.drools</groupId>
     <artifactId>drools-examples-api</artifactId>
-    <version>8.37.0.Final</version>
+    <version>8.37.1-SNAPSHOT</version>
   </parent>
 
   <artifactId>kiemodulemodel-example</artifactId>

--- a/drools-examples-api/multiple-kbases/pom.xml
+++ b/drools-examples-api/multiple-kbases/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.drools</groupId>
     <artifactId>drools-examples-api</artifactId>
-    <version>8.37.0.Final</version>
+    <version>8.37.1-SNAPSHOT</version>
   </parent>
 
   <artifactId>multiple-kbases</artifactId>

--- a/drools-examples-api/named-kiesession-from-file/pom.xml
+++ b/drools-examples-api/named-kiesession-from-file/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.drools</groupId>
     <artifactId>drools-examples-api</artifactId>
-    <version>8.37.0.Final</version>
+    <version>8.37.1-SNAPSHOT</version>
   </parent>
 
   <name>Drools :: API examples :: Named KieSession from File</name>

--- a/drools-examples-api/named-kiesession/pom.xml
+++ b/drools-examples-api/named-kiesession/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.drools</groupId>
     <artifactId>drools-examples-api</artifactId>
-    <version>8.37.0.Final</version>
+    <version>8.37.1-SNAPSHOT</version>
   </parent>
 
   <artifactId>named-kiesession</artifactId>

--- a/drools-examples-api/pom.xml
+++ b/drools-examples-api/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.kie</groupId>
     <artifactId>drools-build-parent</artifactId>
-    <version>8.37.0.Final</version>
+    <version>8.37.1-SNAPSHOT</version>
     <relativePath>../build-parent/pom.xml</relativePath>
   </parent>
 

--- a/drools-examples-api/reactive-kiesession/pom.xml
+++ b/drools-examples-api/reactive-kiesession/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.drools</groupId>
     <artifactId>drools-examples-api</artifactId>
-    <version>8.37.0.Final</version>
+    <version>8.37.1-SNAPSHOT</version>
   </parent>
 
   <artifactId>reactive-kiesession</artifactId>

--- a/drools-examples/pom.xml
+++ b/drools-examples/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.kie</groupId>
     <artifactId>drools-build-parent</artifactId>
-    <version>8.37.0.Final</version>
+    <version>8.37.1-SNAPSHOT</version>
     <relativePath>../build-parent/pom.xml</relativePath>
   </parent>
 

--- a/drools-fastutil/pom.xml
+++ b/drools-fastutil/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>org.kie</groupId>
         <artifactId>drools-build-parent</artifactId>
-        <version>8.37.0.Final</version>
+        <version>8.37.1-SNAPSHOT</version>
         <relativePath>../build-parent/pom.xml</relativePath>
     </parent>
 

--- a/drools-impact-analysis/drools-impact-analysis-graph/drools-impact-analysis-graph-common/pom.xml
+++ b/drools-impact-analysis/drools-impact-analysis-graph/drools-impact-analysis-graph-common/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <artifactId>drools-impact-analysis-graph</artifactId>
     <groupId>org.drools</groupId>
-    <version>8.37.0.Final</version>
+    <version>8.37.1-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/drools-impact-analysis/drools-impact-analysis-graph/drools-impact-analysis-graph-graphviz/pom.xml
+++ b/drools-impact-analysis/drools-impact-analysis-graph/drools-impact-analysis-graph-graphviz/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <artifactId>drools-impact-analysis-graph</artifactId>
     <groupId>org.drools</groupId>
-    <version>8.37.0.Final</version>
+    <version>8.37.1-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/drools-impact-analysis/drools-impact-analysis-graph/pom.xml
+++ b/drools-impact-analysis/drools-impact-analysis-graph/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <artifactId>drools-impact-analysis</artifactId>
     <groupId>org.drools</groupId>
-    <version>8.37.0.Final</version>
+    <version>8.37.1-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/drools-impact-analysis/drools-impact-analysis-itests/pom.xml
+++ b/drools-impact-analysis/drools-impact-analysis-itests/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <artifactId>drools-impact-analysis</artifactId>
     <groupId>org.drools</groupId>
-    <version>8.37.0.Final</version>
+    <version>8.37.1-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/drools-impact-analysis/drools-impact-analysis-model/pom.xml
+++ b/drools-impact-analysis/drools-impact-analysis-model/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <artifactId>drools-impact-analysis</artifactId>
     <groupId>org.drools</groupId>
-    <version>8.37.0.Final</version>
+    <version>8.37.1-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/drools-impact-analysis/drools-impact-analysis-parser/pom.xml
+++ b/drools-impact-analysis/drools-impact-analysis-parser/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <artifactId>drools-impact-analysis</artifactId>
     <groupId>org.drools</groupId>
-    <version>8.37.0.Final</version>
+    <version>8.37.1-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/drools-impact-analysis/pom.xml
+++ b/drools-impact-analysis/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.kie</groupId>
     <artifactId>drools-build-parent</artifactId>
-    <version>8.37.0.Final</version>
+    <version>8.37.1-SNAPSHOT</version>
     <relativePath>../build-parent/pom.xml</relativePath>
   </parent>
 

--- a/drools-io/pom.xml
+++ b/drools-io/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>org.kie</groupId>
         <artifactId>drools-build-parent</artifactId>
-        <version>8.37.0.Final</version>
+        <version>8.37.1-SNAPSHOT</version>
         <relativePath>../build-parent/pom.xml</relativePath>
     </parent>
 

--- a/drools-kiesession/pom.xml
+++ b/drools-kiesession/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.kie</groupId>
     <artifactId>drools-build-parent</artifactId>
-    <version>8.37.0.Final</version>
+    <version>8.37.1-SNAPSHOT</version>
     <relativePath>../build-parent/pom.xml</relativePath>
   </parent>
 

--- a/drools-legacy-test-util/pom.xml
+++ b/drools-legacy-test-util/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>org.kie</groupId>
         <artifactId>drools-build-parent</artifactId>
-        <version>8.37.0.Final</version>
+        <version>8.37.1-SNAPSHOT</version>
         <relativePath>../build-parent/pom.xml</relativePath>
     </parent>
 

--- a/drools-metric/pom.xml
+++ b/drools-metric/pom.xml
@@ -7,7 +7,7 @@
   <parent>
     <groupId>org.kie</groupId>
     <artifactId>drools-build-parent</artifactId>
-    <version>8.37.0.Final</version>
+    <version>8.37.1-SNAPSHOT</version>
     <relativePath>../build-parent/pom.xml</relativePath>
   </parent>
 

--- a/drools-model/drools-canonical-model/pom.xml
+++ b/drools-model/drools-canonical-model/pom.xml
@@ -7,7 +7,7 @@
   <parent>
     <groupId>org.drools</groupId>
     <artifactId>drools-model</artifactId>
-    <version>8.37.0.Final</version>
+    <version>8.37.1-SNAPSHOT</version>
   </parent>
 
   <name>Drools :: Canonical Model</name>

--- a/drools-model/drools-codegen-common/pom.xml
+++ b/drools-model/drools-codegen-common/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>org.drools</groupId>
         <artifactId>drools-model</artifactId>
-        <version>8.37.0.Final</version>
+        <version>8.37.1-SNAPSHOT</version>
     </parent>
 
     <groupId>org.drools</groupId>

--- a/drools-model/drools-model-codegen/pom.xml
+++ b/drools-model/drools-model-codegen/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>org.drools</groupId>
         <artifactId>drools-model</artifactId>
-        <version>8.37.0.Final</version>
+        <version>8.37.1-SNAPSHOT</version>
     </parent>
 
     <groupId>org.drools</groupId>

--- a/drools-model/drools-model-compiler/pom.xml
+++ b/drools-model/drools-model-compiler/pom.xml
@@ -7,7 +7,7 @@
   <parent>
     <groupId>org.drools</groupId>
     <artifactId>drools-model</artifactId>
-    <version>8.37.0.Final</version>
+    <version>8.37.1-SNAPSHOT</version>
   </parent>
 
   <name>Drools :: Model :: Compiler</name>

--- a/drools-model/drools-mvel-compiler/pom.xml
+++ b/drools-model/drools-mvel-compiler/pom.xml
@@ -7,7 +7,7 @@
   <parent>
     <groupId>org.drools</groupId>
     <artifactId>drools-model</artifactId>
-    <version>8.37.0.Final</version>
+    <version>8.37.1-SNAPSHOT</version>
   </parent>
 
   <name>Drools :: MVEL Compiler</name>

--- a/drools-model/drools-mvel-parser/pom.xml
+++ b/drools-model/drools-mvel-parser/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.drools</groupId>
     <artifactId>drools-model</artifactId>
-    <version>8.37.0.Final</version>
+    <version>8.37.1-SNAPSHOT</version>
   </parent>
 
   <name>Drools :: MVEL Parser</name>

--- a/drools-model/pom.xml
+++ b/drools-model/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.kie</groupId>
     <artifactId>drools-build-parent</artifactId>
-    <version>8.37.0.Final</version>
+    <version>8.37.1-SNAPSHOT</version>
     <relativePath>../build-parent/pom.xml</relativePath>
   </parent>
 

--- a/drools-mvel/pom.xml
+++ b/drools-mvel/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>org.kie</groupId>
         <artifactId>drools-build-parent</artifactId>
-        <version>8.37.0.Final</version>
+        <version>8.37.1-SNAPSHOT</version>
         <relativePath>../build-parent/pom.xml</relativePath>
     </parent>
 

--- a/drools-persistence/drools-persistence-api/pom.xml
+++ b/drools-persistence/drools-persistence-api/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.drools</groupId>
     <artifactId>drools-persistence</artifactId>
-    <version>8.37.0.Final</version>
+    <version>8.37.1-SNAPSHOT</version>
   </parent>
 
   <artifactId>drools-persistence-api</artifactId>

--- a/drools-persistence/drools-persistence-jpa/pom.xml
+++ b/drools-persistence/drools-persistence-jpa/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.drools</groupId>
     <artifactId>drools-persistence</artifactId>
-    <version>8.37.0.Final</version>
+    <version>8.37.1-SNAPSHOT</version>
   </parent>
 
   <artifactId>drools-persistence-jpa</artifactId>

--- a/drools-persistence/pom.xml
+++ b/drools-persistence/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.kie</groupId>
     <artifactId>drools-build-parent</artifactId>
-    <version>8.37.0.Final</version>
+    <version>8.37.1-SNAPSHOT</version>
     <relativePath>../build-parent/pom.xml</relativePath>
   </parent>
 

--- a/drools-reliability/pom.xml
+++ b/drools-reliability/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.kie</groupId>
     <artifactId>drools-build-parent</artifactId>
-    <version>8.37.0.Final</version>
+    <version>8.37.1-SNAPSHOT</version>
     <relativePath>../build-parent/pom.xml</relativePath>
   </parent>
   <modelVersion>4.0.0</modelVersion>

--- a/drools-retediagram/pom.xml
+++ b/drools-retediagram/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.kie</groupId>
     <artifactId>drools-build-parent</artifactId>
-    <version>8.37.0.Final</version>
+    <version>8.37.1-SNAPSHOT</version>
     <relativePath>../build-parent/pom.xml</relativePath>
   </parent>
 

--- a/drools-ruleunits/drools-ruleunits-api/pom.xml
+++ b/drools-ruleunits/drools-ruleunits-api/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>org.drools</groupId>
         <artifactId>drools-ruleunits</artifactId>
-        <version>8.37.0.Final</version>
+        <version>8.37.1-SNAPSHOT</version>
     </parent>
 
     <groupId>org.drools</groupId>

--- a/drools-ruleunits/drools-ruleunits-dsl/pom.xml
+++ b/drools-ruleunits/drools-ruleunits-dsl/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>org.drools</groupId>
         <artifactId>drools-ruleunits</artifactId>
-        <version>8.37.0.Final</version>
+        <version>8.37.1-SNAPSHOT</version>
     </parent>
 
     <groupId>org.drools</groupId>

--- a/drools-ruleunits/drools-ruleunits-engine/pom.xml
+++ b/drools-ruleunits/drools-ruleunits-engine/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.drools</groupId>
     <artifactId>drools-ruleunits</artifactId>
-    <version>8.37.0.Final</version>
+    <version>8.37.1-SNAPSHOT</version>
   </parent>
 
   <artifactId>drools-ruleunits-engine</artifactId>

--- a/drools-ruleunits/drools-ruleunits-impl/pom.xml
+++ b/drools-ruleunits/drools-ruleunits-impl/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>org.drools</groupId>
         <artifactId>drools-ruleunits</artifactId>
-        <version>8.37.0.Final</version>
+        <version>8.37.1-SNAPSHOT</version>
     </parent>
 
     <groupId>org.drools</groupId>

--- a/drools-ruleunits/pom.xml
+++ b/drools-ruleunits/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.kie</groupId>
     <artifactId>drools-build-parent</artifactId>
-    <version>8.37.0.Final</version>
+    <version>8.37.1-SNAPSHOT</version>
     <relativePath>../build-parent/pom.xml</relativePath>
   </parent>
 

--- a/drools-scenario-simulation/drools-scenario-simulation-api/pom.xml
+++ b/drools-scenario-simulation/drools-scenario-simulation-api/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <artifactId>drools-scenario-simulation</artifactId>
     <groupId>org.drools</groupId>
-    <version>8.37.0.Final</version>
+    <version>8.37.1-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/drools-scenario-simulation/drools-scenario-simulation-backend/pom.xml
+++ b/drools-scenario-simulation/drools-scenario-simulation-backend/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <artifactId>drools-scenario-simulation</artifactId>
     <groupId>org.drools</groupId>
-    <version>8.37.0.Final</version>
+    <version>8.37.1-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/drools-scenario-simulation/drools-scenario-simulation-integrationtest/pom.xml
+++ b/drools-scenario-simulation/drools-scenario-simulation-integrationtest/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <artifactId>drools-scenario-simulation</artifactId>
     <groupId>org.drools</groupId>
-    <version>8.37.0.Final</version>
+    <version>8.37.1-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/drools-scenario-simulation/pom.xml
+++ b/drools-scenario-simulation/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.kie</groupId>
     <artifactId>drools-build-parent</artifactId>
-    <version>8.37.0.Final</version>
+    <version>8.37.1-SNAPSHOT</version>
     <relativePath>../build-parent/pom.xml</relativePath>
   </parent>
 

--- a/drools-serialization-protobuf/pom.xml
+++ b/drools-serialization-protobuf/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>org.kie</groupId>
         <artifactId>drools-build-parent</artifactId>
-        <version>8.37.0.Final</version>
+        <version>8.37.1-SNAPSHOT</version>
         <relativePath>../build-parent/pom.xml</relativePath>
     </parent>
 

--- a/drools-templates/pom.xml
+++ b/drools-templates/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.kie</groupId>
     <artifactId>drools-build-parent</artifactId>
-    <version>8.37.0.Final</version>
+    <version>8.37.1-SNAPSHOT</version>
     <relativePath>../build-parent/pom.xml</relativePath>
   </parent>
 

--- a/drools-test-coverage/pom.xml
+++ b/drools-test-coverage/pom.xml
@@ -7,7 +7,7 @@
   <parent>
     <groupId>org.kie</groupId>
     <artifactId>drools-build-parent</artifactId>
-    <version>8.37.0.Final</version>
+    <version>8.37.1-SNAPSHOT</version>
     <relativePath>../build-parent/pom.xml</relativePath>
   </parent>
 

--- a/drools-test-coverage/standalone/kie-ci-with-domain/pom.xml
+++ b/drools-test-coverage/standalone/kie-ci-with-domain/pom.xml
@@ -8,7 +8,7 @@
   <parent>
     <groupId>org.drools.testcoverage</groupId>
     <artifactId>drools-standalone-parent</artifactId>
-    <version>8.37.0.Final</version>
+    <version>8.37.1-SNAPSHOT</version>
   </parent>
 
   <artifactId>drools-kie-ci-with-domain-parent</artifactId>

--- a/drools-test-coverage/standalone/kie-ci-with-domain/test-domain/pom.xml
+++ b/drools-test-coverage/standalone/kie-ci-with-domain/test-domain/pom.xml
@@ -8,7 +8,7 @@
   <parent>
     <groupId>org.drools.testcoverage</groupId>
     <artifactId>drools-kie-ci-with-domain-parent</artifactId>
-    <version>8.37.0.Final</version>
+    <version>8.37.1-SNAPSHOT</version>
   </parent>
 
   <artifactId>drools-kie-ci-with-domain-test-domain</artifactId>

--- a/drools-test-coverage/standalone/kie-ci-with-domain/test-kjar/pom.xml
+++ b/drools-test-coverage/standalone/kie-ci-with-domain/test-kjar/pom.xml
@@ -8,7 +8,7 @@
   <parent>
     <groupId>org.drools.testcoverage</groupId>
     <artifactId>drools-kie-ci-with-domain-parent</artifactId>
-    <version>8.37.0.Final</version>
+    <version>8.37.1-SNAPSHOT</version>
   </parent>
 
   <artifactId>drools-kie-ci-with-domain-test-kjar</artifactId>

--- a/drools-test-coverage/standalone/kie-ci-with-domain/tests/pom.xml
+++ b/drools-test-coverage/standalone/kie-ci-with-domain/tests/pom.xml
@@ -8,7 +8,7 @@
   <parent>
     <groupId>org.drools.testcoverage</groupId>
     <artifactId>drools-kie-ci-with-domain-parent</artifactId>
-    <version>8.37.0.Final</version>
+    <version>8.37.1-SNAPSHOT</version>
   </parent>
 
   <artifactId>drools-kie-ci-with-domain-tests</artifactId>

--- a/drools-test-coverage/standalone/kie-ci-without-domain/pom.xml
+++ b/drools-test-coverage/standalone/kie-ci-without-domain/pom.xml
@@ -8,7 +8,7 @@
   <parent>
     <groupId>org.drools.testcoverage</groupId>
     <artifactId>drools-standalone-parent</artifactId>
-    <version>8.37.0.Final</version>
+    <version>8.37.1-SNAPSHOT</version>
   </parent>
 
   <artifactId>drools-kie-ci-without-domain-parent</artifactId>

--- a/drools-test-coverage/standalone/kie-ci-without-domain/test-domain/pom.xml
+++ b/drools-test-coverage/standalone/kie-ci-without-domain/test-domain/pom.xml
@@ -8,7 +8,7 @@
   <parent>
     <groupId>org.drools.testcoverage</groupId>
     <artifactId>drools-kie-ci-without-domain-parent</artifactId>
-    <version>8.37.0.Final</version>
+    <version>8.37.1-SNAPSHOT</version>
   </parent>
 
   <artifactId>drools-kie-ci-without-domain-test-domain</artifactId>

--- a/drools-test-coverage/standalone/kie-ci-without-domain/test-kjar/pom.xml
+++ b/drools-test-coverage/standalone/kie-ci-without-domain/test-kjar/pom.xml
@@ -8,7 +8,7 @@
   <parent>
     <groupId>org.drools.testcoverage</groupId>
     <artifactId>drools-kie-ci-without-domain-parent</artifactId>
-    <version>8.37.0.Final</version>
+    <version>8.37.1-SNAPSHOT</version>
   </parent>
 
   <artifactId>drools-kie-ci-without-domain-test-kjar</artifactId>

--- a/drools-test-coverage/standalone/kie-ci-without-domain/tests/pom.xml
+++ b/drools-test-coverage/standalone/kie-ci-without-domain/tests/pom.xml
@@ -8,7 +8,7 @@
   <parent>
     <groupId>org.drools.testcoverage</groupId>
     <artifactId>drools-kie-ci-without-domain-parent</artifactId>
-    <version>8.37.0.Final</version>
+    <version>8.37.1-SNAPSHOT</version>
   </parent>
 
   <artifactId>drools-kie-ci-without-domain-tests</artifactId>

--- a/drools-test-coverage/standalone/pom.xml
+++ b/drools-test-coverage/standalone/pom.xml
@@ -8,7 +8,7 @@
   <parent>
     <groupId>org.drools.testcoverage</groupId>
     <artifactId>drools-test-coverage-parent</artifactId>
-    <version>8.37.0.Final</version>
+    <version>8.37.1-SNAPSHOT</version>
   </parent>
 
   <artifactId>drools-standalone-parent</artifactId>

--- a/drools-test-coverage/test-compiler-integration/pom.xml
+++ b/drools-test-coverage/test-compiler-integration/pom.xml
@@ -21,7 +21,7 @@
   <parent>
     <artifactId>drools-test-coverage-parent</artifactId>
     <groupId>org.drools.testcoverage</groupId>
-    <version>8.37.0.Final</version>
+    <version>8.37.1-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/drools-test-coverage/test-integration-nomvel/pom.xml
+++ b/drools-test-coverage/test-integration-nomvel/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <artifactId>drools-test-coverage-parent</artifactId>
         <groupId>org.drools.testcoverage</groupId>
-        <version>8.37.0.Final</version>
+        <version>8.37.1-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/drools-test-coverage/test-integration-notms/pom.xml
+++ b/drools-test-coverage/test-integration-notms/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <artifactId>drools-test-coverage-parent</artifactId>
         <groupId>org.drools.testcoverage</groupId>
-        <version>8.37.0.Final</version>
+        <version>8.37.1-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/drools-test-coverage/test-integration-noxml/pom.xml
+++ b/drools-test-coverage/test-integration-noxml/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <artifactId>drools-test-coverage-parent</artifactId>
         <groupId>org.drools.testcoverage</groupId>
-        <version>8.37.0.Final</version>
+        <version>8.37.1-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/drools-test-coverage/test-integration-ruleunits/pom.xml
+++ b/drools-test-coverage/test-integration-ruleunits/pom.xml
@@ -14,7 +14,7 @@
   <parent>
     <artifactId>drools-test-coverage-parent</artifactId>
     <groupId>org.drools.testcoverage</groupId>
-    <version>8.37.0.Final</version>
+    <version>8.37.1-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/drools-test-coverage/test-integration-ruleunits/test-integration-ruleunits-jar/pom.xml
+++ b/drools-test-coverage/test-integration-ruleunits/test-integration-ruleunits-jar/pom.xml
@@ -14,7 +14,7 @@
   <parent>
     <artifactId>test-integration-ruleunits</artifactId>
     <groupId>org.drools.testcoverage</groupId>
-    <version>8.37.0.Final</version>
+    <version>8.37.1-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/drools-test-coverage/test-integration-ruleunits/test-integration-ruleunits-tests/pom.xml
+++ b/drools-test-coverage/test-integration-ruleunits/test-integration-ruleunits-tests/pom.xml
@@ -14,7 +14,7 @@
   <parent>
     <artifactId>test-integration-ruleunits</artifactId>
     <groupId>org.drools.testcoverage</groupId>
-    <version>8.37.0.Final</version>
+    <version>8.37.1-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/drools-test-coverage/test-suite/pom.xml
+++ b/drools-test-coverage/test-suite/pom.xml
@@ -8,7 +8,7 @@
   <parent>
     <groupId>org.drools.testcoverage</groupId>
     <artifactId>drools-test-coverage-parent</artifactId>
-    <version>8.37.0.Final</version>
+    <version>8.37.1-SNAPSHOT</version>
   </parent>
 
   <artifactId>drools-test-suite</artifactId>

--- a/drools-tms/pom.xml
+++ b/drools-tms/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.kie</groupId>
     <artifactId>drools-build-parent</artifactId>
-    <version>8.37.0.Final</version>
+    <version>8.37.1-SNAPSHOT</version>
     <relativePath>../build-parent/pom.xml</relativePath>
   </parent>
 

--- a/drools-traits/pom.xml
+++ b/drools-traits/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.kie</groupId>
     <artifactId>drools-build-parent</artifactId>
-    <version>8.37.0.Final</version>
+    <version>8.37.1-SNAPSHOT</version>
     <relativePath>../build-parent/pom.xml</relativePath>
   </parent>
 

--- a/drools-util/pom.xml
+++ b/drools-util/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>org.kie</groupId>
         <artifactId>drools-build-parent</artifactId>
-        <version>8.37.0.Final</version>
+        <version>8.37.1-SNAPSHOT</version>
         <relativePath>../build-parent/pom.xml</relativePath>
     </parent>
 

--- a/drools-verifier/drools-verifier-api/pom.xml
+++ b/drools-verifier/drools-verifier-api/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>org.drools</groupId>
         <artifactId>drools-verifier</artifactId>
-        <version>8.37.0.Final</version>
+        <version>8.37.1-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/drools-verifier/drools-verifier-core/pom.xml
+++ b/drools-verifier/drools-verifier-core/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>drools-verifier</artifactId>
         <groupId>org.drools</groupId>
-        <version>8.37.0.Final</version>
+        <version>8.37.1-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/drools-verifier/drools-verifier-drl/pom.xml
+++ b/drools-verifier/drools-verifier-drl/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.drools</groupId>
     <artifactId>drools-verifier</artifactId>
-    <version>8.37.0.Final</version>
+    <version>8.37.1-SNAPSHOT</version>
   </parent>
 
   <artifactId>drools-verifier-drl</artifactId>

--- a/drools-verifier/pom.xml
+++ b/drools-verifier/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.kie</groupId>
     <artifactId>drools-build-parent</artifactId>
-    <version>8.37.0.Final</version>
+    <version>8.37.1-SNAPSHOT</version>
     <relativePath>../build-parent/pom.xml</relativePath>
   </parent>
 

--- a/drools-wiring/drools-wiring-api/pom.xml
+++ b/drools-wiring/drools-wiring-api/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>org.drools</groupId>
         <artifactId>drools-wiring</artifactId>
-        <version>8.37.0.Final</version>
+        <version>8.37.1-SNAPSHOT</version>
     </parent>
 
     <groupId>org.drools</groupId>

--- a/drools-wiring/drools-wiring-dynamic/pom.xml
+++ b/drools-wiring/drools-wiring-dynamic/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.drools</groupId>
     <artifactId>drools-wiring</artifactId>
-    <version>8.37.0.Final</version>
+    <version>8.37.1-SNAPSHOT</version>
   </parent>
 
   <groupId>org.drools</groupId>

--- a/drools-wiring/drools-wiring-static/pom.xml
+++ b/drools-wiring/drools-wiring-static/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.drools</groupId>
     <artifactId>drools-wiring</artifactId>
-    <version>8.37.0.Final</version>
+    <version>8.37.1-SNAPSHOT</version>
   </parent>
 
   <groupId>org.drools</groupId>

--- a/drools-wiring/pom.xml
+++ b/drools-wiring/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.kie</groupId>
     <artifactId>drools-build-parent</artifactId>
-    <version>8.37.0.Final</version>
+    <version>8.37.1-SNAPSHOT</version>
     <relativePath>../build-parent/pom.xml</relativePath>
   </parent>
 

--- a/drools-xml-support/pom.xml
+++ b/drools-xml-support/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.kie</groupId>
     <artifactId>drools-build-parent</artifactId>
-    <version>8.37.0.Final</version>
+    <version>8.37.1-SNAPSHOT</version>
     <relativePath>../build-parent/pom.xml</relativePath>
   </parent>
 

--- a/efesto/efesto-common-utils/pom.xml
+++ b/efesto/efesto-common-utils/pom.xml
@@ -7,7 +7,7 @@
   <parent>
     <groupId>org.kie</groupId>
     <artifactId>efesto</artifactId>
-    <version>8.37.0.Final</version>
+    <version>8.37.1-SNAPSHOT</version>
   </parent>
 
   <artifactId>efesto-common-utils</artifactId>

--- a/efesto/efesto-core/efesto-common-api/pom.xml
+++ b/efesto/efesto-core/efesto-common-api/pom.xml
@@ -7,7 +7,7 @@
   <parent>
     <groupId>org.kie</groupId>
     <artifactId>efesto-core</artifactId>
-    <version>8.37.0.Final</version>
+    <version>8.37.1-SNAPSHOT</version>
   </parent>
 
   <artifactId>efesto-common-api</artifactId>

--- a/efesto/efesto-core/efesto-common-core/pom.xml
+++ b/efesto/efesto-core/efesto-common-core/pom.xml
@@ -7,7 +7,7 @@
   <parent>
     <groupId>org.kie</groupId>
     <artifactId>efesto-core</artifactId>
-    <version>8.37.0.Final</version>
+    <version>8.37.1-SNAPSHOT</version>
   </parent>
 
   <artifactId>efesto-common-core</artifactId>

--- a/efesto/efesto-core/efesto-compilation-manager/efesto-compilation-manager-api/pom.xml
+++ b/efesto/efesto-core/efesto-compilation-manager/efesto-compilation-manager-api/pom.xml
@@ -7,7 +7,7 @@
   <parent>
     <groupId>org.kie</groupId>
     <artifactId>efesto-compilation-manager</artifactId>
-    <version>8.37.0.Final</version>
+    <version>8.37.1-SNAPSHOT</version>
   </parent>
 
   <artifactId>efesto-compilation-manager-api</artifactId>

--- a/efesto/efesto-core/efesto-compilation-manager/efesto-compilation-manager-core/pom.xml
+++ b/efesto/efesto-core/efesto-compilation-manager/efesto-compilation-manager-core/pom.xml
@@ -19,7 +19,7 @@
   <parent>
     <groupId>org.kie</groupId>
     <artifactId>efesto-compilation-manager</artifactId>
-    <version>8.37.0.Final</version>
+    <version>8.37.1-SNAPSHOT</version>
   </parent>
 
   <artifactId>efesto-compilation-manager-core</artifactId>

--- a/efesto/efesto-core/efesto-compilation-manager/pom.xml
+++ b/efesto/efesto-core/efesto-compilation-manager/pom.xml
@@ -7,7 +7,7 @@
   <parent>
     <groupId>org.kie</groupId>
     <artifactId>efesto-core</artifactId>
-    <version>8.37.0.Final</version>
+    <version>8.37.1-SNAPSHOT</version>
   </parent>
   <packaging>pom</packaging>
 

--- a/efesto/efesto-core/efesto-runtime-manager/efesto-runtime-manager-api/pom.xml
+++ b/efesto/efesto-core/efesto-runtime-manager/efesto-runtime-manager-api/pom.xml
@@ -7,7 +7,7 @@
   <parent>
     <groupId>org.kie</groupId>
     <artifactId>efesto-runtime-manager</artifactId>
-    <version>8.37.0.Final</version>
+    <version>8.37.1-SNAPSHOT</version>
   </parent>
 
  <artifactId>efesto-runtime-manager-api</artifactId>

--- a/efesto/efesto-core/efesto-runtime-manager/efesto-runtime-manager-core/pom.xml
+++ b/efesto/efesto-core/efesto-runtime-manager/efesto-runtime-manager-core/pom.xml
@@ -7,7 +7,7 @@
   <parent>
     <groupId>org.kie</groupId>
     <artifactId>efesto-runtime-manager</artifactId>
-    <version>8.37.0.Final</version>
+    <version>8.37.1-SNAPSHOT</version>
   </parent>
 
   <artifactId>efesto-runtime-manager-core</artifactId>

--- a/efesto/efesto-core/efesto-runtime-manager/pom.xml
+++ b/efesto/efesto-core/efesto-runtime-manager/pom.xml
@@ -7,7 +7,7 @@
   <parent>
     <groupId>org.kie</groupId>
     <artifactId>efesto-core</artifactId>
-    <version>8.37.0.Final</version>
+    <version>8.37.1-SNAPSHOT</version>
   </parent>
   <packaging>pom</packaging>
 

--- a/efesto/efesto-core/pom.xml
+++ b/efesto/efesto-core/pom.xml
@@ -7,7 +7,7 @@
   <parent>
     <groupId>org.kie</groupId>
     <artifactId>efesto</artifactId>
-    <version>8.37.0.Final</version>
+    <version>8.37.1-SNAPSHOT</version>
   </parent>
   <packaging>pom</packaging>
 

--- a/efesto/efesto-dependencies/pom.xml
+++ b/efesto/efesto-dependencies/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <artifactId>efesto</artifactId>
     <groupId>org.kie</groupId>
-    <version>8.37.0.Final</version>
+    <version>8.37.1-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/efesto/pom.xml
+++ b/efesto/pom.xml
@@ -7,7 +7,7 @@
   <parent>
     <groupId>org.kie</groupId>
     <artifactId>drools-build-parent</artifactId>
-    <version>8.37.0.Final</version>
+    <version>8.37.1-SNAPSHOT</version>
     <relativePath>../build-parent/pom.xml</relativePath>
   </parent>
 

--- a/jpmml-migration-recipe/pom.xml
+++ b/jpmml-migration-recipe/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.kie</groupId>
     <artifactId>drools-build-parent</artifactId>
-    <version>8.37.0.Final</version>
+    <version>8.37.1-SNAPSHOT</version>
     <relativePath>../build-parent/pom.xml</relativePath>
   </parent>
 

--- a/kie-api/pom.xml
+++ b/kie-api/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.kie</groupId>
     <artifactId>drools-build-parent</artifactId>
-    <version>8.37.0.Final</version>
+    <version>8.37.1-SNAPSHOT</version>
     <relativePath>../build-parent/pom.xml</relativePath>
   </parent>
 

--- a/kie-archetypes/kie-drools-dmn-archetype/pom.xml
+++ b/kie-archetypes/kie-drools-dmn-archetype/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.kie</groupId>
     <artifactId>kie-archetypes</artifactId>
-    <version>8.37.0.Final</version>
+    <version>8.37.1-SNAPSHOT</version>
   </parent>
 
   <artifactId>kie-drools-dmn-archetype</artifactId>

--- a/kie-archetypes/kie-drools-exec-model-archetype/pom.xml
+++ b/kie-archetypes/kie-drools-exec-model-archetype/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.kie</groupId>
     <artifactId>kie-archetypes</artifactId>
-    <version>8.37.0.Final</version>
+    <version>8.37.1-SNAPSHOT</version>
   </parent>
 
   <artifactId>kie-drools-exec-model-archetype</artifactId>

--- a/kie-archetypes/kie-drools-exec-model-ruleunit-archetype/pom.xml
+++ b/kie-archetypes/kie-drools-exec-model-ruleunit-archetype/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.kie</groupId>
     <artifactId>kie-archetypes</artifactId>
-    <version>8.37.0.Final</version>
+    <version>8.37.1-SNAPSHOT</version>
   </parent>
 
   <artifactId>kie-drools-exec-model-ruleunit-archetype</artifactId>

--- a/kie-archetypes/pom.xml
+++ b/kie-archetypes/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.kie</groupId>
     <artifactId>drools-build-parent</artifactId>
-    <version>8.37.0.Final</version>
+    <version>8.37.1-SNAPSHOT</version>
     <relativePath>../build-parent/pom.xml</relativePath>
   </parent>
 

--- a/kie-ci/pom.xml
+++ b/kie-ci/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.kie</groupId>
     <artifactId>drools-build-parent</artifactId>
-    <version>8.37.0.Final</version>
+    <version>8.37.1-SNAPSHOT</version>
     <relativePath>../build-parent/pom.xml</relativePath>
   </parent>
 

--- a/kie-dmn/kie-dmn-api/pom.xml
+++ b/kie-dmn/kie-dmn-api/pom.xml
@@ -7,7 +7,7 @@
   <parent>
     <groupId>org.kie</groupId>
     <artifactId>kie-dmn</artifactId>
-    <version>8.37.0.Final</version>
+    <version>8.37.1-SNAPSHOT</version>
   </parent>
 
   <artifactId>kie-dmn-api</artifactId>

--- a/kie-dmn/kie-dmn-backend/pom.xml
+++ b/kie-dmn/kie-dmn-backend/pom.xml
@@ -7,7 +7,7 @@
   <parent>
     <groupId>org.kie</groupId>
     <artifactId>kie-dmn</artifactId>
-    <version>8.37.0.Final</version>
+    <version>8.37.1-SNAPSHOT</version>
   </parent>
 
   <artifactId>kie-dmn-backend</artifactId>

--- a/kie-dmn/kie-dmn-core-jsr223-jq/pom.xml
+++ b/kie-dmn/kie-dmn-core-jsr223-jq/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <groupId>org.kie</groupId>
         <artifactId>kie-dmn</artifactId>
-        <version>8.37.0.Final</version>
+        <version>8.37.1-SNAPSHOT</version>
     </parent>
     <artifactId>kie-dmn-core-jsr223-jq</artifactId>
     <name>KIE :: Decision Model Notation :: JSR-223 JQ ScriptEngine</name>

--- a/kie-dmn/kie-dmn-core-jsr223/pom.xml
+++ b/kie-dmn/kie-dmn-core-jsr223/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.kie</groupId>
     <artifactId>kie-dmn</artifactId>
-    <version>8.37.0.Final</version>
+    <version>8.37.1-SNAPSHOT</version>
   </parent>
   <artifactId>kie-dmn-core-jsr223</artifactId>
   <name>KIE :: Decision Model Notation :: Core JSR-223</name>

--- a/kie-dmn/kie-dmn-core/pom.xml
+++ b/kie-dmn/kie-dmn-core/pom.xml
@@ -7,7 +7,7 @@
   <parent>
     <artifactId>kie-dmn</artifactId>
     <groupId>org.kie</groupId>
-    <version>8.37.0.Final</version>
+    <version>8.37.1-SNAPSHOT</version>
   </parent>
 
   <artifactId>kie-dmn-core</artifactId>

--- a/kie-dmn/kie-dmn-feel/pom.xml
+++ b/kie-dmn/kie-dmn-feel/pom.xml
@@ -7,7 +7,7 @@
   <parent>
     <groupId>org.kie</groupId>
     <artifactId>kie-dmn</artifactId>
-    <version>8.37.0.Final</version>
+    <version>8.37.1-SNAPSHOT</version>
   </parent>
 
   <artifactId>kie-dmn-feel</artifactId>

--- a/kie-dmn/kie-dmn-legacy-tests/pom.xml
+++ b/kie-dmn/kie-dmn-legacy-tests/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.kie</groupId>
     <artifactId>kie-dmn</artifactId>
-    <version>8.37.0.Final</version>
+    <version>8.37.1-SNAPSHOT</version>
   </parent>
   <artifactId>kie-dmn-legacy-tests</artifactId>
   

--- a/kie-dmn/kie-dmn-model/pom.xml
+++ b/kie-dmn/kie-dmn-model/pom.xml
@@ -7,7 +7,7 @@
   <parent>
     <artifactId>kie-dmn</artifactId>
     <groupId>org.kie</groupId>
-    <version>8.37.0.Final</version>
+    <version>8.37.1-SNAPSHOT</version>
   </parent>
 
   <artifactId>kie-dmn-model</artifactId>

--- a/kie-dmn/kie-dmn-openapi/pom.xml
+++ b/kie-dmn/kie-dmn-openapi/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.kie</groupId>
     <artifactId>kie-dmn</artifactId>
-    <version>8.37.0.Final</version>
+    <version>8.37.1-SNAPSHOT</version>
   </parent>
   <artifactId>kie-dmn-openapi</artifactId>
   

--- a/kie-dmn/kie-dmn-pmml-tests-parent/kie-dmn-pmml-tests-trusty/pom.xml
+++ b/kie-dmn/kie-dmn-pmml-tests-parent/kie-dmn-pmml-tests-trusty/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <artifactId>kie-dmn-pmml-tests-parent</artifactId>
     <groupId>org.kie</groupId>
-    <version>8.37.0.Final</version>
+    <version>8.37.1-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/kie-dmn/kie-dmn-pmml-tests-parent/kie-dmn-pmml-tests/pom.xml
+++ b/kie-dmn/kie-dmn-pmml-tests-parent/kie-dmn-pmml-tests/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <artifactId>kie-dmn-pmml-tests-parent</artifactId>
     <groupId>org.kie</groupId>
-    <version>8.37.0.Final</version>
+    <version>8.37.1-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/kie-dmn/kie-dmn-pmml-tests-parent/pom.xml
+++ b/kie-dmn/kie-dmn-pmml-tests-parent/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <artifactId>kie-dmn</artifactId>
     <groupId>org.kie</groupId>
-    <version>8.37.0.Final</version>
+    <version>8.37.1-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
   <packaging>pom</packaging>

--- a/kie-dmn/kie-dmn-ruleset2dmn-parent/kie-dmn-ruleset2dmn-cli/pom.xml
+++ b/kie-dmn/kie-dmn-ruleset2dmn-parent/kie-dmn-ruleset2dmn-cli/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.kie</groupId>
     <artifactId>kie-dmn-ruleset2dmn-parent</artifactId>
-    <version>8.37.0.Final</version>
+    <version>8.37.1-SNAPSHOT</version>
   </parent>
   <artifactId>kie-dmn-ruleset2dmn-cli</artifactId>
   

--- a/kie-dmn/kie-dmn-ruleset2dmn-parent/kie-dmn-ruleset2dmn/pom.xml
+++ b/kie-dmn/kie-dmn-ruleset2dmn-parent/kie-dmn-ruleset2dmn/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.kie</groupId>
     <artifactId>kie-dmn-ruleset2dmn-parent</artifactId>
-    <version>8.37.0.Final</version>
+    <version>8.37.1-SNAPSHOT</version>
   </parent>
   <artifactId>kie-dmn-ruleset2dmn</artifactId>
 

--- a/kie-dmn/kie-dmn-ruleset2dmn-parent/pom.xml
+++ b/kie-dmn/kie-dmn-ruleset2dmn-parent/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.kie</groupId>
     <artifactId>kie-dmn</artifactId>
-    <version>8.37.0.Final</version>
+    <version>8.37.1-SNAPSHOT</version>
   </parent>
   <artifactId>kie-dmn-ruleset2dmn-parent</artifactId>
   <packaging>pom</packaging>

--- a/kie-dmn/kie-dmn-signavio/pom.xml
+++ b/kie-dmn/kie-dmn-signavio/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.kie</groupId>
     <artifactId>kie-dmn</artifactId>
-    <version>8.37.0.Final</version>
+    <version>8.37.1-SNAPSHOT</version>
   </parent>
   <artifactId>kie-dmn-signavio</artifactId>
   

--- a/kie-dmn/kie-dmn-tck/pom.xml
+++ b/kie-dmn/kie-dmn-tck/pom.xml
@@ -21,7 +21,7 @@
   <parent>
     <artifactId>kie-dmn</artifactId>
     <groupId>org.kie</groupId>
-    <version>8.37.0.Final</version>
+    <version>8.37.1-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
   <packaging>pom</packaging>

--- a/kie-dmn/kie-dmn-trisotech/pom.xml
+++ b/kie-dmn/kie-dmn-trisotech/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.kie</groupId>
     <artifactId>kie-dmn</artifactId>
-    <version>8.37.0.Final</version>
+    <version>8.37.1-SNAPSHOT</version>
   </parent>
   <artifactId>kie-dmn-trisotech</artifactId>
 

--- a/kie-dmn/kie-dmn-validation-bootstrap/pom.xml
+++ b/kie-dmn/kie-dmn-validation-bootstrap/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.kie</groupId>
     <artifactId>kie-dmn</artifactId>
-    <version>8.37.0.Final</version>
+    <version>8.37.1-SNAPSHOT</version>
   </parent>
   <artifactId>kie-dmn-validation-bootstrap</artifactId>
 

--- a/kie-dmn/kie-dmn-validation/pom.xml
+++ b/kie-dmn/kie-dmn-validation/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.kie</groupId>
     <artifactId>kie-dmn</artifactId>
-    <version>8.37.0.Final</version>
+    <version>8.37.1-SNAPSHOT</version>
   </parent>
   <artifactId>kie-dmn-validation</artifactId>
     <packaging>jar</packaging>

--- a/kie-dmn/kie-dmn-xls2dmn-cli/pom.xml
+++ b/kie-dmn/kie-dmn-xls2dmn-cli/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.kie</groupId>
     <artifactId>kie-dmn</artifactId>
-    <version>8.37.0.Final</version>
+    <version>8.37.1-SNAPSHOT</version>
   </parent>
   <artifactId>kie-dmn-xls2dmn-cli</artifactId>
   <packaging>jar</packaging>

--- a/kie-dmn/pom.xml
+++ b/kie-dmn/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.kie</groupId>
     <artifactId>drools-build-parent</artifactId>
-    <version>8.37.0.Final</version>
+    <version>8.37.1-SNAPSHOT</version>
     <relativePath>../build-parent/pom.xml</relativePath>
   </parent>
 

--- a/kie-drl/kie-drl-api/pom.xml
+++ b/kie-drl/kie-drl-api/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>kie-drl</artifactId>
         <groupId>org.kie</groupId>
-        <version>8.37.0.Final</version>
+        <version>8.37.1-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/kie-drl/kie-drl-compilation-common/pom.xml
+++ b/kie-drl/kie-drl-compilation-common/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>kie-drl</artifactId>
         <groupId>org.kie</groupId>
-        <version>8.37.0.Final</version>
+        <version>8.37.1-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/kie-drl/kie-drl-implementations/kie-drl-kiesession-local/kie-drl-kiesession-local-runtime/pom.xml
+++ b/kie-drl/kie-drl-implementations/kie-drl-kiesession-local/kie-drl-kiesession-local-runtime/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>kie-drl-kiesession-local</artifactId>
         <groupId>org.kie</groupId>
-        <version>8.37.0.Final</version>
+        <version>8.37.1-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/kie-drl/kie-drl-implementations/kie-drl-kiesession-local/pom.xml
+++ b/kie-drl/kie-drl-implementations/kie-drl-kiesession-local/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>kie-drl-implementations</artifactId>
         <groupId>org.kie</groupId>
-        <version>8.37.0.Final</version>
+        <version>8.37.1-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <packaging>pom</packaging>

--- a/kie-drl/kie-drl-implementations/kie-drl-map-input/kie-drl-map-input-runtime/pom.xml
+++ b/kie-drl/kie-drl-implementations/kie-drl-map-input/kie-drl-map-input-runtime/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <artifactId>kie-drl-map-input</artifactId>
         <groupId>org.kie</groupId>
-        <version>8.37.0.Final</version>
+        <version>8.37.1-SNAPSHOT</version>
     </parent>
 
     <artifactId>kie-drl-map-input-runtime</artifactId>

--- a/kie-drl/kie-drl-implementations/kie-drl-map-input/pom.xml
+++ b/kie-drl/kie-drl-implementations/kie-drl-map-input/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>kie-drl-implementations</artifactId>
         <groupId>org.kie</groupId>
-        <version>8.37.0.Final</version>
+        <version>8.37.1-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <packaging>pom</packaging>

--- a/kie-drl/kie-drl-implementations/pom.xml
+++ b/kie-drl/kie-drl-implementations/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <artifactId>kie-drl</artifactId>
         <groupId>org.kie</groupId>
-        <version>8.37.0.Final</version>
+        <version>8.37.1-SNAPSHOT</version>
     </parent>
 
     <name>KIE :: DRL :: Implementations</name>

--- a/kie-drl/kie-drl-runtime-common/pom.xml
+++ b/kie-drl/kie-drl-runtime-common/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>kie-drl</artifactId>
         <groupId>org.kie</groupId>
-        <version>8.37.0.Final</version>
+        <version>8.37.1-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/kie-drl/kie-drl-tests-without-index-file/pom.xml
+++ b/kie-drl/kie-drl-tests-without-index-file/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <artifactId>kie-drl</artifactId>
     <groupId>org.kie</groupId>
-    <version>8.37.0.Final</version>
+    <version>8.37.1-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/kie-drl/kie-drl-tests/pom.xml
+++ b/kie-drl/kie-drl-tests/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <artifactId>kie-drl</artifactId>
     <groupId>org.kie</groupId>
-    <version>8.37.0.Final</version>
+    <version>8.37.1-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/kie-drl/pom.xml
+++ b/kie-drl/pom.xml
@@ -7,7 +7,7 @@
   <parent>
     <groupId>org.kie</groupId>
     <artifactId>drools-build-parent</artifactId>
-    <version>8.37.0.Final</version>
+    <version>8.37.1-SNAPSHOT</version>
     <relativePath>../build-parent/pom.xml</relativePath>
   </parent>
 

--- a/kie-internal/pom.xml
+++ b/kie-internal/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.kie</groupId>
     <artifactId>drools-build-parent</artifactId>
-    <version>8.37.0.Final</version>
+    <version>8.37.1-SNAPSHOT</version>
     <relativePath>../build-parent/pom.xml</relativePath>
   </parent>
 

--- a/kie-maven-plugin/pom.xml
+++ b/kie-maven-plugin/pom.xml
@@ -7,7 +7,7 @@
   <parent>
     <groupId>org.kie</groupId>
     <artifactId>drools-build-parent</artifactId>
-    <version>8.37.0.Final</version>
+    <version>8.37.1-SNAPSHOT</version>
     <relativePath>../build-parent/pom.xml</relativePath>
   </parent>
 

--- a/kie-memory-compiler/pom.xml
+++ b/kie-memory-compiler/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.kie</groupId>
     <artifactId>drools-build-parent</artifactId>
-    <version>8.37.0.Final</version>
+    <version>8.37.1-SNAPSHOT</version>
     <relativePath>../build-parent/pom.xml</relativePath>
   </parent>
 

--- a/kie-pmml-trusty/kie-pmml-api/pom.xml
+++ b/kie-pmml-trusty/kie-pmml-api/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <artifactId>kie-pmml-trusty</artifactId>
     <groupId>org.kie</groupId>
-    <version>8.37.0.Final</version>
+    <version>8.37.1-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/kie-pmml-trusty/kie-pmml-commons/pom.xml
+++ b/kie-pmml-trusty/kie-pmml-commons/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.kie</groupId>
     <artifactId>kie-pmml-trusty</artifactId>
-    <version>8.37.0.Final</version>
+    <version>8.37.1-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/kie-pmml-trusty/kie-pmml-compiler/kie-pmml-compiler-api/pom.xml
+++ b/kie-pmml-trusty/kie-pmml-compiler/kie-pmml-compiler-api/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.kie</groupId>
     <artifactId>kie-pmml-compiler</artifactId>
-    <version>8.37.0.Final</version>
+    <version>8.37.1-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/kie-pmml-trusty/kie-pmml-compiler/kie-pmml-compiler-commons/pom.xml
+++ b/kie-pmml-trusty/kie-pmml-compiler/kie-pmml-compiler-commons/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.kie</groupId>
     <artifactId>kie-pmml-compiler</artifactId>
-    <version>8.37.0.Final</version>
+    <version>8.37.1-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/kie-pmml-trusty/kie-pmml-compiler/kie-pmml-compiler-core/pom.xml
+++ b/kie-pmml-trusty/kie-pmml-compiler/kie-pmml-compiler-core/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.kie</groupId>
     <artifactId>kie-pmml-compiler</artifactId>
-    <version>8.37.0.Final</version>
+    <version>8.37.1-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/kie-pmml-trusty/kie-pmml-compiler/pom.xml
+++ b/kie-pmml-trusty/kie-pmml-compiler/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.kie</groupId>
     <artifactId>kie-pmml-trusty</artifactId>
-    <version>8.37.0.Final</version>
+    <version>8.37.1-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/kie-pmml-trusty/kie-pmml-dependencies/pom.xml
+++ b/kie-pmml-trusty/kie-pmml-dependencies/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.kie</groupId>
     <artifactId>kie-pmml-trusty</artifactId>
-    <version>8.37.0.Final</version>
+    <version>8.37.1-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/kie-pmml-trusty/kie-pmml-evaluator/kie-pmml-evaluator-api/pom.xml
+++ b/kie-pmml-trusty/kie-pmml-evaluator/kie-pmml-evaluator-api/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.kie</groupId>
     <artifactId>kie-pmml-evaluator</artifactId>
-    <version>8.37.0.Final</version>
+    <version>8.37.1-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/kie-pmml-trusty/kie-pmml-evaluator/kie-pmml-evaluator-core/pom.xml
+++ b/kie-pmml-trusty/kie-pmml-evaluator/kie-pmml-evaluator-core/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.kie</groupId>
     <artifactId>kie-pmml-evaluator</artifactId>
-    <version>8.37.0.Final</version>
+    <version>8.37.1-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/kie-pmml-trusty/kie-pmml-evaluator/kie-pmml-evaluator-utils/pom.xml
+++ b/kie-pmml-trusty/kie-pmml-evaluator/kie-pmml-evaluator-utils/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <artifactId>kie-pmml-evaluator</artifactId>
     <groupId>org.kie</groupId>
-    <version>8.37.0.Final</version>
+    <version>8.37.1-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/kie-pmml-trusty/kie-pmml-evaluator/pom.xml
+++ b/kie-pmml-trusty/kie-pmml-evaluator/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.kie</groupId>
     <artifactId>kie-pmml-trusty</artifactId>
-    <version>8.37.0.Final</version>
+    <version>8.37.1-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
   <packaging>pom</packaging>

--- a/kie-pmml-trusty/kie-pmml-models/kie-pmml-models-clustering/kie-pmml-models-clustering-compiler/pom.xml
+++ b/kie-pmml-trusty/kie-pmml-models/kie-pmml-models-clustering/kie-pmml-models-clustering-compiler/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.kie</groupId>
     <artifactId>kie-pmml-models-clustering</artifactId>
-    <version>8.37.0.Final</version>
+    <version>8.37.1-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/kie-pmml-trusty/kie-pmml-models/kie-pmml-models-clustering/kie-pmml-models-clustering-evaluator/pom.xml
+++ b/kie-pmml-trusty/kie-pmml-models/kie-pmml-models-clustering/kie-pmml-models-clustering-evaluator/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.kie</groupId>
     <artifactId>kie-pmml-models-clustering</artifactId>
-    <version>8.37.0.Final</version>
+    <version>8.37.1-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/kie-pmml-trusty/kie-pmml-models/kie-pmml-models-clustering/kie-pmml-models-clustering-model/pom.xml
+++ b/kie-pmml-trusty/kie-pmml-models/kie-pmml-models-clustering/kie-pmml-models-clustering-model/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.kie</groupId>
     <artifactId>kie-pmml-models-clustering</artifactId>
-    <version>8.37.0.Final</version>
+    <version>8.37.1-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/kie-pmml-trusty/kie-pmml-models/kie-pmml-models-clustering/kie-pmml-models-clustering-tests/pom.xml
+++ b/kie-pmml-trusty/kie-pmml-models/kie-pmml-models-clustering/kie-pmml-models-clustering-tests/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.kie</groupId>
     <artifactId>kie-pmml-models-clustering</artifactId>
-    <version>8.37.0.Final</version>
+    <version>8.37.1-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/kie-pmml-trusty/kie-pmml-models/kie-pmml-models-clustering/pom.xml
+++ b/kie-pmml-trusty/kie-pmml-models/kie-pmml-models-clustering/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.kie</groupId>
     <artifactId>kie-pmml-models</artifactId>
-    <version>8.37.0.Final</version>
+    <version>8.37.1-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
   <packaging>pom</packaging>

--- a/kie-pmml-trusty/kie-pmml-models/kie-pmml-models-drools/kie-pmml-models-drools-common/pom.xml
+++ b/kie-pmml-trusty/kie-pmml-models/kie-pmml-models-drools/kie-pmml-models-drools-common/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.kie</groupId>
     <artifactId>kie-pmml-models-drools</artifactId>
-    <version>8.37.0.Final</version>
+    <version>8.37.1-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/kie-pmml-trusty/kie-pmml-models/kie-pmml-models-drools/kie-pmml-models-drools-scorecard/kie-pmml-models-drools-scorecard-compiler/pom.xml
+++ b/kie-pmml-trusty/kie-pmml-models/kie-pmml-models-drools/kie-pmml-models-drools-scorecard/kie-pmml-models-drools-scorecard-compiler/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.kie</groupId>
     <artifactId>kie-pmml-models-drools-scorecard</artifactId>
-    <version>8.37.0.Final</version>
+    <version>8.37.1-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/kie-pmml-trusty/kie-pmml-models/kie-pmml-models-drools/kie-pmml-models-drools-scorecard/kie-pmml-models-drools-scorecard-evaluator/pom.xml
+++ b/kie-pmml-trusty/kie-pmml-models/kie-pmml-models-drools/kie-pmml-models-drools-scorecard/kie-pmml-models-drools-scorecard-evaluator/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.kie</groupId>
     <artifactId>kie-pmml-models-drools-scorecard</artifactId>
-    <version>8.37.0.Final</version>
+    <version>8.37.1-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/kie-pmml-trusty/kie-pmml-models/kie-pmml-models-drools/kie-pmml-models-drools-scorecard/kie-pmml-models-drools-scorecard-model/pom.xml
+++ b/kie-pmml-trusty/kie-pmml-models/kie-pmml-models-drools/kie-pmml-models-drools-scorecard/kie-pmml-models-drools-scorecard-model/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.kie</groupId>
     <artifactId>kie-pmml-models-drools-scorecard</artifactId>
-    <version>8.37.0.Final</version>
+    <version>8.37.1-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/kie-pmml-trusty/kie-pmml-models/kie-pmml-models-drools/kie-pmml-models-drools-scorecard/kie-pmml-models-drools-scorecard-tests/pom.xml
+++ b/kie-pmml-trusty/kie-pmml-models/kie-pmml-models-drools/kie-pmml-models-drools-scorecard/kie-pmml-models-drools-scorecard-tests/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.kie</groupId>
     <artifactId>kie-pmml-models-drools-scorecard</artifactId>
-    <version>8.37.0.Final</version>
+    <version>8.37.1-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/kie-pmml-trusty/kie-pmml-models/kie-pmml-models-drools/kie-pmml-models-drools-scorecard/pom.xml
+++ b/kie-pmml-trusty/kie-pmml-models/kie-pmml-models-drools/kie-pmml-models-drools-scorecard/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.kie</groupId>
     <artifactId>kie-pmml-models-drools</artifactId>
-    <version>8.37.0.Final</version>
+    <version>8.37.1-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
   <packaging>pom</packaging>

--- a/kie-pmml-trusty/kie-pmml-models/kie-pmml-models-drools/kie-pmml-models-drools-tree/kie-pmml-models-drools-tree-compiler/pom.xml
+++ b/kie-pmml-trusty/kie-pmml-models/kie-pmml-models-drools/kie-pmml-models-drools-tree/kie-pmml-models-drools-tree-compiler/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.kie</groupId>
     <artifactId>kie-pmml-models-drools-tree</artifactId>
-    <version>8.37.0.Final</version>
+    <version>8.37.1-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/kie-pmml-trusty/kie-pmml-models/kie-pmml-models-drools/kie-pmml-models-drools-tree/kie-pmml-models-drools-tree-evaluator/pom.xml
+++ b/kie-pmml-trusty/kie-pmml-models/kie-pmml-models-drools/kie-pmml-models-drools-tree/kie-pmml-models-drools-tree-evaluator/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.kie</groupId>
     <artifactId>kie-pmml-models-drools-tree</artifactId>
-    <version>8.37.0.Final</version>
+    <version>8.37.1-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/kie-pmml-trusty/kie-pmml-models/kie-pmml-models-drools/kie-pmml-models-drools-tree/kie-pmml-models-drools-tree-model/pom.xml
+++ b/kie-pmml-trusty/kie-pmml-models/kie-pmml-models-drools/kie-pmml-models-drools-tree/kie-pmml-models-drools-tree-model/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.kie</groupId>
     <artifactId>kie-pmml-models-drools-tree</artifactId>
-    <version>8.37.0.Final</version>
+    <version>8.37.1-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/kie-pmml-trusty/kie-pmml-models/kie-pmml-models-drools/kie-pmml-models-drools-tree/kie-pmml-models-drools-tree-tests/pom.xml
+++ b/kie-pmml-trusty/kie-pmml-models/kie-pmml-models-drools/kie-pmml-models-drools-tree/kie-pmml-models-drools-tree-tests/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.kie</groupId>
     <artifactId>kie-pmml-models-drools-tree</artifactId>
-    <version>8.37.0.Final</version>
+    <version>8.37.1-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/kie-pmml-trusty/kie-pmml-models/kie-pmml-models-drools/kie-pmml-models-drools-tree/pom.xml
+++ b/kie-pmml-trusty/kie-pmml-models/kie-pmml-models-drools/kie-pmml-models-drools-tree/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.kie</groupId>
     <artifactId>kie-pmml-models-drools</artifactId>
-    <version>8.37.0.Final</version>
+    <version>8.37.1-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
   <packaging>pom</packaging>

--- a/kie-pmml-trusty/kie-pmml-models/kie-pmml-models-drools/pom.xml
+++ b/kie-pmml-trusty/kie-pmml-models/kie-pmml-models-drools/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.kie</groupId>
     <artifactId>kie-pmml-models</artifactId>
-    <version>8.37.0.Final</version>
+    <version>8.37.1-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/kie-pmml-trusty/kie-pmml-models/kie-pmml-models-mining/kie-pmml-models-mining-compiler/pom.xml
+++ b/kie-pmml-trusty/kie-pmml-models/kie-pmml-models-mining/kie-pmml-models-mining-compiler/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.kie</groupId>
     <artifactId>kie-pmml-models-mining</artifactId>
-    <version>8.37.0.Final</version>
+    <version>8.37.1-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/kie-pmml-trusty/kie-pmml-models/kie-pmml-models-mining/kie-pmml-models-mining-evaluator/pom.xml
+++ b/kie-pmml-trusty/kie-pmml-models/kie-pmml-models-mining/kie-pmml-models-mining-evaluator/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.kie</groupId>
     <artifactId>kie-pmml-models-mining</artifactId>
-    <version>8.37.0.Final</version>
+    <version>8.37.1-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/kie-pmml-trusty/kie-pmml-models/kie-pmml-models-mining/kie-pmml-models-mining-model/pom.xml
+++ b/kie-pmml-trusty/kie-pmml-models/kie-pmml-models-mining/kie-pmml-models-mining-model/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.kie</groupId>
     <artifactId>kie-pmml-models-mining</artifactId>
-    <version>8.37.0.Final</version>
+    <version>8.37.1-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/kie-pmml-trusty/kie-pmml-models/kie-pmml-models-mining/kie-pmml-models-mining-tests/pom.xml
+++ b/kie-pmml-trusty/kie-pmml-models/kie-pmml-models-mining/kie-pmml-models-mining-tests/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.kie</groupId>
     <artifactId>kie-pmml-models-mining</artifactId>
-    <version>8.37.0.Final</version>
+    <version>8.37.1-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/kie-pmml-trusty/kie-pmml-models/kie-pmml-models-mining/pom.xml
+++ b/kie-pmml-trusty/kie-pmml-models/kie-pmml-models-mining/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.kie</groupId>
     <artifactId>kie-pmml-models</artifactId>
-    <version>8.37.0.Final</version>
+    <version>8.37.1-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
   <packaging>pom</packaging>

--- a/kie-pmml-trusty/kie-pmml-models/kie-pmml-models-regression/kie-pmml-models-regression-compiler/pom.xml
+++ b/kie-pmml-trusty/kie-pmml-models/kie-pmml-models-regression/kie-pmml-models-regression-compiler/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.kie</groupId>
     <artifactId>kie-pmml-models-regression</artifactId>
-    <version>8.37.0.Final</version>
+    <version>8.37.1-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/kie-pmml-trusty/kie-pmml-models/kie-pmml-models-regression/kie-pmml-models-regression-evaluator/pom.xml
+++ b/kie-pmml-trusty/kie-pmml-models/kie-pmml-models-regression/kie-pmml-models-regression-evaluator/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.kie</groupId>
     <artifactId>kie-pmml-models-regression</artifactId>
-    <version>8.37.0.Final</version>
+    <version>8.37.1-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/kie-pmml-trusty/kie-pmml-models/kie-pmml-models-regression/kie-pmml-models-regression-model/pom.xml
+++ b/kie-pmml-trusty/kie-pmml-models/kie-pmml-models-regression/kie-pmml-models-regression-model/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.kie</groupId>
     <artifactId>kie-pmml-models-regression</artifactId>
-    <version>8.37.0.Final</version>
+    <version>8.37.1-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/kie-pmml-trusty/kie-pmml-models/kie-pmml-models-regression/kie-pmml-models-regression-tests/pom.xml
+++ b/kie-pmml-trusty/kie-pmml-models/kie-pmml-models-regression/kie-pmml-models-regression-tests/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.kie</groupId>
     <artifactId>kie-pmml-models-regression</artifactId>
-    <version>8.37.0.Final</version>
+    <version>8.37.1-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/kie-pmml-trusty/kie-pmml-models/kie-pmml-models-regression/pom.xml
+++ b/kie-pmml-trusty/kie-pmml-models/kie-pmml-models-regression/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.kie</groupId>
     <artifactId>kie-pmml-models</artifactId>
-    <version>8.37.0.Final</version>
+    <version>8.37.1-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
   <packaging>pom</packaging>

--- a/kie-pmml-trusty/kie-pmml-models/kie-pmml-models-scorecard/kie-pmml-models-scorecard-compiler/pom.xml
+++ b/kie-pmml-trusty/kie-pmml-models/kie-pmml-models-scorecard/kie-pmml-models-scorecard-compiler/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.kie</groupId>
     <artifactId>kie-pmml-models-scorecard</artifactId>
-    <version>8.37.0.Final</version>
+    <version>8.37.1-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/kie-pmml-trusty/kie-pmml-models/kie-pmml-models-scorecard/kie-pmml-models-scorecard-evaluator/pom.xml
+++ b/kie-pmml-trusty/kie-pmml-models/kie-pmml-models-scorecard/kie-pmml-models-scorecard-evaluator/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.kie</groupId>
     <artifactId>kie-pmml-models-scorecard</artifactId>
-    <version>8.37.0.Final</version>
+    <version>8.37.1-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/kie-pmml-trusty/kie-pmml-models/kie-pmml-models-scorecard/kie-pmml-models-scorecard-model/pom.xml
+++ b/kie-pmml-trusty/kie-pmml-models/kie-pmml-models-scorecard/kie-pmml-models-scorecard-model/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.kie</groupId>
     <artifactId>kie-pmml-models-scorecard</artifactId>
-    <version>8.37.0.Final</version>
+    <version>8.37.1-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/kie-pmml-trusty/kie-pmml-models/kie-pmml-models-scorecard/kie-pmml-models-scorecard-tests/pom.xml
+++ b/kie-pmml-trusty/kie-pmml-models/kie-pmml-models-scorecard/kie-pmml-models-scorecard-tests/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.kie</groupId>
     <artifactId>kie-pmml-models-scorecard</artifactId>
-    <version>8.37.0.Final</version>
+    <version>8.37.1-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/kie-pmml-trusty/kie-pmml-models/kie-pmml-models-scorecard/pom.xml
+++ b/kie-pmml-trusty/kie-pmml-models/kie-pmml-models-scorecard/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.kie</groupId>
     <artifactId>kie-pmml-models</artifactId>
-    <version>8.37.0.Final</version>
+    <version>8.37.1-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
   <packaging>pom</packaging>

--- a/kie-pmml-trusty/kie-pmml-models/kie-pmml-models-tests/pom.xml
+++ b/kie-pmml-trusty/kie-pmml-models/kie-pmml-models-tests/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <artifactId>kie-pmml-models</artifactId>
     <groupId>org.kie</groupId>
-    <version>8.37.0.Final</version>
+    <version>8.37.1-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/kie-pmml-trusty/kie-pmml-models/kie-pmml-models-tree/kie-pmml-models-tree-compiler/pom.xml
+++ b/kie-pmml-trusty/kie-pmml-models/kie-pmml-models-tree/kie-pmml-models-tree-compiler/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.kie</groupId>
     <artifactId>kie-pmml-models-tree</artifactId>
-    <version>8.37.0.Final</version>
+    <version>8.37.1-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/kie-pmml-trusty/kie-pmml-models/kie-pmml-models-tree/kie-pmml-models-tree-evaluator/pom.xml
+++ b/kie-pmml-trusty/kie-pmml-models/kie-pmml-models-tree/kie-pmml-models-tree-evaluator/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.kie</groupId>
     <artifactId>kie-pmml-models-tree</artifactId>
-    <version>8.37.0.Final</version>
+    <version>8.37.1-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/kie-pmml-trusty/kie-pmml-models/kie-pmml-models-tree/kie-pmml-models-tree-model/pom.xml
+++ b/kie-pmml-trusty/kie-pmml-models/kie-pmml-models-tree/kie-pmml-models-tree-model/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.kie</groupId>
     <artifactId>kie-pmml-models-tree</artifactId>
-    <version>8.37.0.Final</version>
+    <version>8.37.1-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/kie-pmml-trusty/kie-pmml-models/kie-pmml-models-tree/kie-pmml-models-tree-tests/pom.xml
+++ b/kie-pmml-trusty/kie-pmml-models/kie-pmml-models-tree/kie-pmml-models-tree-tests/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.kie</groupId>
     <artifactId>kie-pmml-models-tree</artifactId>
-    <version>8.37.0.Final</version>
+    <version>8.37.1-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/kie-pmml-trusty/kie-pmml-models/kie-pmml-models-tree/pom.xml
+++ b/kie-pmml-trusty/kie-pmml-models/kie-pmml-models-tree/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.kie</groupId>
     <artifactId>kie-pmml-models</artifactId>
-    <version>8.37.0.Final</version>
+    <version>8.37.1-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
   <packaging>pom</packaging>

--- a/kie-pmml-trusty/kie-pmml-models/pom.xml
+++ b/kie-pmml-trusty/kie-pmml-models/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.kie</groupId>
     <artifactId>kie-pmml-trusty</artifactId>
-    <version>8.37.0.Final</version>
+    <version>8.37.1-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/kie-pmml-trusty/pom.xml
+++ b/kie-pmml-trusty/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.kie</groupId>
     <artifactId>drools-build-parent</artifactId>
-    <version>8.37.0.Final</version>
+    <version>8.37.1-SNAPSHOT</version>
     <relativePath>../build-parent/pom.xml</relativePath>
   </parent>
 

--- a/kie-test-util/pom.xml
+++ b/kie-test-util/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.kie</groupId>
     <artifactId>drools-build-parent</artifactId>
-    <version>8.37.0.Final</version>
+    <version>8.37.1-SNAPSHOT</version>
     <relativePath>../build-parent/pom.xml</relativePath>
   </parent>
 

--- a/kie-util/kie-util-maven-integration/pom.xml
+++ b/kie-util/kie-util-maven-integration/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.kie</groupId>
     <artifactId>kie-util</artifactId>
-    <version>8.37.0.Final</version>
+    <version>8.37.1-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/kie-util/kie-util-maven-support/pom.xml
+++ b/kie-util/kie-util-maven-support/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.kie</groupId>
     <artifactId>kie-util</artifactId>
-    <version>8.37.0.Final</version>
+    <version>8.37.1-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/kie-util/kie-util-xml/pom.xml
+++ b/kie-util/kie-util-xml/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.kie</groupId>
     <artifactId>kie-util</artifactId>
-    <version>8.37.0.Final</version>
+    <version>8.37.1-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/kie-util/pom.xml
+++ b/kie-util/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.kie</groupId>
     <artifactId>drools-build-parent</artifactId>
-    <version>8.37.0.Final</version>
+    <version>8.37.1-SNAPSHOT</version>
     <relativePath>../build-parent/pom.xml</relativePath>
   </parent>
 

--- a/pom.xml
+++ b/pom.xml
@@ -17,7 +17,7 @@
   <groupId>org.kie</groupId>
   <artifactId>drools-parent</artifactId>
   <packaging>pom</packaging>
-  <version>8.37.0.Final</version>
+  <version>8.37.1-SNAPSHOT</version>
 
   <name>Drools :: Parent</name>
   <description>


### PR DESCRIPTION
Generated by build jenkins-KIE-drools-8.37.x-release-drools-promote-1: https://eng-jenkins-csb-business-automation.apps.ocp-c1.prod.psi.redhat.com/job/KIE/job/drools/job/8.37.x/job/release/job/drools-promote/1/.
Please do not merge, it should be merged automatically.