### PR TITLE
KOGITO-8994: drools version update in kie-benchmarks

### DIFF
--- a/.ci/jenkins/Jenkinsfile.setup-branch
+++ b/.ci/jenkins/Jenkinsfile.setup-branch
@@ -76,29 +76,13 @@ pipeline {
                 }
             }
         }
-
-        // Should be moved to a job in kie-benchmarks repository
-        // and called from main setup-branch job directly after drools update
         stage('Update Drools version in kie-benchmarks') {
             when {
                 expression { isMainBranch() }
             }
             steps {
                 script {
-                    String commitMsg = 'bumped up Drools version to next SNAPSHOT'
-                    String localBranch = "kie-benchmarks-drools-update-${env.BRANCH_HASH}"
-                    String targetBranch = 'main'
-                    String kieBenchmarksRepo = 'kie-benchmarks'
-                    dir(kieBenchmarksRepo) {
-                        checkoutRepo(kieBenchmarksRepo, targetBranch)
-                        githubscm.createBranch(localBranch)
-                        maven.mvnSetVersionProperty('version.org.drools', getDroolsVersion())
-                        // Add changed files, commit, open and merge PR
-                        String prLink = commitAndCreatePR(commitMsg, localBranch, targetBranch)
-                        sh "git checkout ${targetBranch}"
-                        mergeAndPush(prLink, targetBranch)
-                        githubscm.removeRemoteBranch('origin', localBranch, getGitAuthorCredsId())
-                    }
+                    build job: '../tools/kie-benchmarks-update-drools', parameters: [ string(name: 'NEW_VERSION', value: "${getDroolsVersion()}")]                    
                 }
             }
         }

--- a/.ci/jenkins/config/branch.yaml
+++ b/.ci/jenkins/config/branch.yaml
@@ -51,6 +51,7 @@ disable:
 repositories:
 - name: drools
 - name: drools-website
+- name: kie-benchmarks
 git:
   author:
     name: kiegroup

--- a/.ci/jenkins/config/main.yaml
+++ b/.ci/jenkins/config/main.yaml
@@ -4,6 +4,10 @@ ecosystem:
   - name: drools
     regexs:
     - drools.*
+  - name: kie-benchmarks
+    ignore_release: true
+    regexs:
+    - kie-benchmarks.*  
 git:
   branches:
   - name: main


### PR DESCRIPTION
**Thank you for submitting this pull request**

**NOTE!:** Double check the target branch for this PR.
The default is `main` so it will target Drools 8 / Kogito.
If this PR is not strictly related to drools and kogito project in `drools.git`, it should probably target `7.x`as a branch

**Ports** If a forward-port or a backport is needed, paste the forward port PR here

[link](https://www.example.com)

### JIRA
[KOGITO-8994](https://issues.redhat.com/browse/KOGITO-8994)

[kie-benchmarks](https://github.com/kiegroup/kie-benchmarks/pull/231)
[optaplanner](https://github.com/kiegroup/optaplanner/pull/2796)
[drools](https://github.com/kiegroup/drools/pull/5183)

* paste the link(s) from GitHub here
* link 2
* link 3 etc.

<details>
<summary>
How to replicate CI configuration locally?
</summary>

Build Chain tool does "simple" maven build(s), the builds are just Maven commands, but because the repositories relates and depends on each other and any change in API or class method could affect several of those repositories there is a need to use [build-chain tool](https://github.com/kiegroup/github-action-build-chain) to handle cross repository builds and be sure that we always use latest version of the code for each repository.
 
[build-chain tool](https://github.com/kiegroup/github-action-build-chain) is a build tool which can be used on command line locally or in Github Actions workflow(s), in case you need to change multiple repositories and send multiple dependent pull requests related with a change you can easily reproduce the same build by executing it on Github hosted environment or locally in your development environment. See [local execution](https://github.com/kiegroup/github-action-build-chain#local-execution) details to get more information about it.
</details>

<details>
<summary>
How to retest this PR or trigger a specific build:
</summary>

- for <b>pull request checks</b>  
  Please add comment: <b>Jenkins retest this</b>

- for a <b>specific pull request check</b>  
  Please add comment: <b>Jenkins (re)run [drools|kogito-runtimes|kogito-apps|kogito-examples] tests</b>

- for a <b>full downstream build</b> 
  - for <b>jenkins</b> job: please add comment: <b>Jenkins run fdb</b>
  - for <b>github actions</b> job: add the label `run_fdb`

- <b>a compile downstream build</b> please  add comment: <b>Jenkins run cdb</b>

- <b>a full production downstream build</b> please add comment: <b>Jenkins execute product fdb</b>

- <b>an upstream build</b> please add comment: <b>Jenkins run upstream</b>

- for <b>quarkus branch checks</b>  
  Run checks against Quarkus current used branch  
  Please add comment: <b>Jenkins run quarkus-branch</b>

- for a <b>quarkus branch specific check</b>  
  Run checks against Quarkus current used branch  
  Please add comment: <b>Jenkins (re)run [drools|kogito-runtimes|kogito-apps|kogito-examples] quarkus-branch</b>

- for <b>quarkus main checks</b>  
  Run checks against Quarkus main branch  
  Please add comment: <b>Jenkins run quarkus-main</b>

- for a <b>specific quarkus main check</b>  
  Run checks against Quarkus main branch  
  Please add comment: <b>Jenkins (re)run [drools|kogito-runtimes|kogito-apps|kogito-examples] quarkus-main</b>

- for <b>quarkus lts checks</b>  
  Run checks against Quarkus lts branch  
  Please add comment: <b>Jenkins run quarkus-lts</b>

- for a <b>specific quarkus lts check</b>  
  Run checks against Quarkus lts branch  
  Please add comment: <b>Jenkins (re)run [drools|kogito-runtimes|kogito-apps|kogito-examples] quarkus-lts</b>

- for <b>native checks</b>  
  Run native checks  
  Please add comment: <b>Jenkins run native</b>

- for a <b>specific native check</b>  
  Run native checks 
  Please add comment: <b>Jenkins (re)run [drools|kogito-runtimes|kogito-apps|kogito-examples] native</b>

 - for <b>native lts checks</b>  
  Run native checks against quarkus lts branch
  Please add comment: <b>Jenkins run native-lts</b>

- for a <b>specific native lts check</b>  
  Run native checks against quarkus lts branch
  Please add comment: <b>Jenkins (re)run [drools|kogito-runtimes|kogito-apps|kogito-examples] native-lts</b>
</details>

<details>
<summary>
How to backport a pull request to a different branch?
</summary>

In order to automatically create a **backporting pull request** please add one or more labels having the following format `backport-<branch-name>`, where `<branch-name>` is the name of the branch where the pull request must be backported to (e.g., `backport-7.67.x` to backport the original PR to the `7.67.x` branch).

> **NOTE**: **backporting** is an action aiming to move a change (usually a commit) from a branch (usually the main one) to another one, which is generally referring to a still maintained release branch. Keeping it simple: it is about to move a specific change or a set of them from one branch to another.

Once the original pull request is successfully merged, the automated action will create one backporting pull request per each label (with the previous format) that has been added.

If something goes wrong, the author will be notified and at this point a manual backporting is needed.

> **NOTE**: this automated backporting is triggered whenever a pull request on `main` branch is labeled or closed, but both conditions must be satisfied to get the new PR created.
</details>