### PR TITLE
[DROOLS-7412] configure embedded cache to ignore returned values

### DIFF
--- a/drools-reliability/drools-reliability-infinispan/src/main/java/org/drools/reliability/infinispan/EmbeddedCacheManager.java
+++ b/drools-reliability/drools-reliability-infinispan/src/main/java/org/drools/reliability/infinispan/EmbeddedCacheManager.java
@@ -80,6 +80,9 @@ public class EmbeddedCacheManager implements InfinispanCacheManager {
                .indexLocation(CACHE_DIR + "/index");
         builder.clustering()
                .cacheMode(CacheMode.LOCAL);
+
+        builder.unsafe().unreliableReturnValues(true);
+
         cacheConfiguration = builder.build();
     }
 


### PR DESCRIPTION
**JIRA**: https://issues.redhat.com/browse/DROOLS-7412

As suggested [here](https://infinispan.org/docs/dev/titles/tuning/tuning.html#hints_for_program_developers) I'm flagging the embedded cache to avoid obeying to the `Map` contract (it's called unsafe for this reason, but there isn't anything of unsafe actually) not requiring a meaningful return value when calling `put` or `remove`, which is something that we actually don't need.

I created a [new benchmark](https://github.com/kiegroup/kie-benchmarks/pull/232) and with this flag the performances of the embedded cache went from 

```
Benchmark                    (factsNr)  (joinsNr)    (mode)  (rulesNr)  Mode   Cnt   Score   Error  Units
InsertAndFireBenchmark.test        100          1  EMBEDDED        192    ss  1000  17.116 ± 0.402  ms/op
```

to

```
Benchmark                    (factsNr)  (joinsNr)    (mode)  (rulesNr)  Mode   Cnt   Score   Error  Units
InsertAndFireBenchmark.test        100          1  EMBEDDED        192    ss  1000  15.350 ± 0.362  ms/op
```

So far I haven't find a way to configure the cache using the remote server in a similar way and I haven't understood why. I also gave a try to the other suggestion saying `Use simple cache for local caches` but I found that it cannot be enabled if you're using a persistent store.

More in general I will keep investigating performances and accumulate my findings in the jira.