### PR TITLE
Make microprofile optional in drools-util

### DIFF
--- a/drools-util/pom.xml
+++ b/drools-util/pom.xml
@@ -24,6 +24,7 @@
         <dependency>
             <groupId>org.eclipse.microprofile.config</groupId>
             <artifactId>microprofile-config-api</artifactId>
+            <optional>true</optional>
         </dependency>
         <dependency>
             <groupId>junit</groupId>

--- a/drools-util/src/main/java/org/drools/util/Config.java
+++ b/drools-util/src/main/java/org/drools/util/Config.java
@@ -46,7 +46,7 @@ public class Config {
         private static ConfigResolver createConfigResolver() {
             try {
                 return new MicroprofileConfigResolver(ConfigProvider.getConfig());
-            } catch (Exception e) {
+            } catch (Throwable e) {
                 return new SystemPropertyConfigResolver();
             }
         }


### PR DESCRIPTION
CI is still failing, moving to draft in order to closely investigate whats going on on kogito-runtimes modules when the the dedepency is remove. 
Will move to ready for review when fixed