### PR TITLE
DROOLS-7426 Quarkus 3: Setup rewrite in nightly

### DIFF
--- a/.ci/buildchain-config.yaml
+++ b/.ci/buildchain-config.yaml
@@ -15,10 +15,10 @@ default:
     before:
       current: |
         export INTEGRATION_BRANCH=${{ env.INTEGRATION_BRANCH_CURRENT }}
-        bash -c "if [ ! -z '${{ env.BUILD_ENVIRONMENT }}' ] && [ -f .ci/environments/update.sh ]; then .ci/environments/update.sh "${{ env.BUILD_ENVIRONMENT }}"; fi"
+        bash -c "if [ ! -z '${{ env.BUILD_ENVIRONMENT }}' ] && [ -f .ci/environments/update.sh ]; then .ci/environments/update.sh '${{ env.BUILD_ENVIRONMENT }}' '${{ env.BUILD_ENVIRONMENT_OPTIONS }}'; fi"
       upstream: |
         export INTEGRATION_BRANCH=${{ env.INTEGRATION_BRANCH_UPSTREAM }}
-        bash -c "if [ ! -z '${{ env.BUILD_ENVIRONMENT }}' ] && [ -f .ci/environments/update.sh ]; then .ci/environments/update.sh "${{ env.BUILD_ENVIRONMENT }}"; fi"
+        bash -c "if [ ! -z '${{ env.BUILD_ENVIRONMENT }}' ] && [ -f .ci/environments/update.sh ]; then .ci/environments/update.sh '${{ env.BUILD_ENVIRONMENT }}' '${{ env.BUILD_ENVIRONMENT_OPTIONS }}'; fi"
     current: |
       mvn clean install ${{ env.BUILD_MVN_OPTS }} ${{ env.BUILD_MVN_OPTS_CURRENT }}
     upstream: |

--- a/.ci/buildchain-config.yaml
+++ b/.ci/buildchain-config.yaml
@@ -15,10 +15,10 @@ default:
     before:
       current: |
         export INTEGRATION_BRANCH=${{ env.INTEGRATION_BRANCH_CURRENT }}
-        bash -c "if [ ! -z '${{ env.BUILD_ENVIRONMENT }}' ] && [ -f .ci/environments/update.sh ]; then .ci/environments/update.sh '${{ env.BUILD_ENVIRONMENT }}' '${{ env.BUILD_ENVIRONMENT_OPTIONS }}'; fi"
+        bash -c "if [ ! -z '${{ env.BUILD_ENVIRONMENT }}' ] && [ -f .ci/environments/update.sh ]; then .ci/environments/update.sh ${{ env.BUILD_ENVIRONMENT }} ${{ env.BUILD_ENVIRONMENT_OPTIONS }}; fi"
       upstream: |
         export INTEGRATION_BRANCH=${{ env.INTEGRATION_BRANCH_UPSTREAM }}
-        bash -c "if [ ! -z '${{ env.BUILD_ENVIRONMENT }}' ] && [ -f .ci/environments/update.sh ]; then .ci/environments/update.sh '${{ env.BUILD_ENVIRONMENT }}' '${{ env.BUILD_ENVIRONMENT_OPTIONS }}'; fi"
+        bash -c "if [ ! -z '${{ env.BUILD_ENVIRONMENT }}' ] && [ -f .ci/environments/update.sh ]; then .ci/environments/update.sh ${{ env.BUILD_ENVIRONMENT }} ${{ env.BUILD_ENVIRONMENT_OPTIONS }}; fi"
     current: |
       mvn clean install ${{ env.BUILD_MVN_OPTS }} ${{ env.BUILD_MVN_OPTS_CURRENT }}
     upstream: |

--- a/.ci/buildchain-config.yaml
+++ b/.ci/buildchain-config.yaml
@@ -15,10 +15,10 @@ default:
     before:
       current: |
         export INTEGRATION_BRANCH=${{ env.INTEGRATION_BRANCH_CURRENT }}
-        bash -c "if [ ! -z '${{ env.BUILD_ENVIRONMENT }}' ] && [ -f .ci/environments/update.sh ]; then .ci/environments/update.sh ${{ env.BUILD_ENVIRONMENT }} ${{ env.BUILD_ENVIRONMENT_OPTIONS }}; fi"
+        bash -c "if [ ! -z '${{ env.BUILD_ENVIRONMENT }}' ] && [ -f .ci/environments/update.sh ]; then .ci/environments/update.sh ${{ env.BUILD_ENVIRONMENT }} ${{ env.BUILD_ENVIRONMENT_OPTIONS_CURRENT }}; fi"
       upstream: |
         export INTEGRATION_BRANCH=${{ env.INTEGRATION_BRANCH_UPSTREAM }}
-        bash -c "if [ ! -z '${{ env.BUILD_ENVIRONMENT }}' ] && [ -f .ci/environments/update.sh ]; then .ci/environments/update.sh ${{ env.BUILD_ENVIRONMENT }} ${{ env.BUILD_ENVIRONMENT_OPTIONS }}; fi"
+        bash -c "if [ ! -z '${{ env.BUILD_ENVIRONMENT }}' ] && [ -f .ci/environments/update.sh ]; then .ci/environments/update.sh ${{ env.BUILD_ENVIRONMENT }} ${{ env.BUILD_ENVIRONMENT_OPTIONS_UPSTREAM }}; fi"
     current: |
       mvn clean install ${{ env.BUILD_MVN_OPTS }} ${{ env.BUILD_MVN_OPTS_CURRENT }}
     upstream: |

--- a/.ci/environments/quarkus-3/README.md
+++ b/.ci/environments/quarkus-3/README.md
@@ -56,7 +56,7 @@ There are 3 recipe files:
 - `project-recipe.yml` is the recipe file to update in case you need a new recipe
 - `quarkus3-base-recipe.yml` is the base recipe setup by Quarkus team in https://github.com/quarkusio/quarkus-updates. You should not modify it !
 - `quarkus3.yml` is the final recipe file and is a compute of the previous 2 files, plus some processing.  
-  See also comments in [Jbang script](jbang/CreateQuarkusDroolsMigrationRecipe.java) for more details on the generation.
+  See also comments in [Jbang script](jbang/CreateKieQuarkusProjectMigrationRecipe.java) for more details on the generation.
 
 ### How to reset the quarkus3.yaml recipe file ?
 
@@ -65,17 +65,17 @@ The `before.sh` script should handle the reset of the `quarkus3.yml` recipe file
 In case you want to do manually, just run:
 
 ```bash
-cd .ci/environments/quarkus-3 && curl -Ls https://sh.jbang.dev | bash -s - jbang/CreateQuarkusDroolsMigrationRecipe.java; cd -
+cd .ci/environments/quarkus-3 && curl -Ls https://sh.jbang.dev | bash -s - jbang/CreateKieQuarkusProjectMigrationRecipe.java; cd -
 ```
   
 ### How to update the Quarkus version ?
 
 If you are setting a new Quarkus version:
 
-1. Update `quarkus-devtools-common` version in `jbang/CreateQuarkusDroolsMigrationRecipe.java` file
-2. Update `QUARKUS_VERSION` in `jbang/CreateQuarkusDroolsMigrationRecipe.java` file
+1. Update `quarkus-devtools-common` version in `jbang/CreateKieQuarkusProjectMigrationRecipe.java` file
+2. Update `QUARKUS_VERSION` in `jbang/CreateKieQuarkusProjectMigrationRecipe.java` file
 3. Update `QUARKUS_UPDATES_BASE_URL` with the corresponding released version of https://github.com/quarkusio/quarkus-updates recipe file
 4. Run the jbang script to update the `quarkus3.yml` file
   ```bash
-  cd .ci/environments/quarkus-3 && curl -Ls https://sh.jbang.dev | bash -s - jbang/CreateQuarkusDroolsMigrationRecipe.java true; cd -
+  cd .ci/environments/quarkus-3 && curl -Ls https://sh.jbang.dev | bash -s - jbang/CreateKieQuarkusProjectMigrationRecipe.java true; cd -
   ```

--- a/.ci/environments/quarkus-3/after.sh
+++ b/.ci/environments/quarkus-3/after.sh
@@ -3,7 +3,9 @@ set -euo pipefail
 
 script_dir_path=$(cd `dirname "${BASH_SOURCE[0]}"`; pwd -P)
 mvn_cmd="mvn ${BUILD_MVN_OPTS:-} ${BUILD_MVN_OPTS_QUARKUS_UPDATE:-}"
-project_version='quarkus-3-SNAPSHOT'
+
+project_version=$(${mvn_cmd} -q -Dexpression=project.version -DforceStdout help:evaluate)
+new_version=$(echo ${project_version} | awk -F. -v OFS=. '{$1 += 1 ; print}')
 
 # Change version
-${mvn_cmd} -e -N -Dfull -DnewVersion=${project_version} -DallowSnapshots=true -DgenerateBackupPoms=false versions:set
+${mvn_cmd} -e -N -Dfull -DnewVersion=${new_version} -DallowSnapshots=true -DgenerateBackupPoms=false versions:set

--- a/.ci/environments/quarkus-3/after.sh
+++ b/.ci/environments/quarkus-3/after.sh
@@ -4,7 +4,9 @@ set -euo pipefail
 script_dir_path=$(cd `dirname "${BASH_SOURCE[0]}"`; pwd -P)
 mvn_cmd="mvn ${BUILD_MVN_OPTS:-} ${BUILD_MVN_OPTS_QUARKUS_UPDATE:-}"
 
-project_version=$(${mvn_cmd} -q -Dexpression=project.version -DforceStdout help:evaluate)
+# Retrieve current Maven project version
+project_version=$(mvn -q -Dexpression=project.version -DforceStdout help:evaluate)
+# New version is based on current project version and increment the Major => (M+1).m.y
 new_version=$(echo ${project_version} | awk -F. -v OFS=. '{$1 += 1 ; print}')
 
 # Change version

--- a/.ci/environments/quarkus-3/before.sh
+++ b/.ci/environments/quarkus-3/before.sh
@@ -34,8 +34,12 @@ project_version=$(${mvn_cmd} -q -Dexpression=project.version -DforceStdout help:
 
 # Regenerate quarkus3 recipe
 cd ${script_dir_path}
-curl -Ls https://sh.jbang.dev | bash -s - jbang/CreateQuarkusDroolsMigrationRecipe.java
+curl -Ls https://sh.jbang.dev | \
+    bash -s - jbang/CreateKieQuarkusProjectMigrationRecipe.java \
+        -v version.io.quarkus=${quarkus_version} 
 cd -
+
+exit 0
 
 # Launch Quarkus 3 Openrewrite
 ${mvn_cmd} org.openrewrite.maven:rewrite-maven-plugin:${rewrite_plugin_version}:run \

--- a/.ci/environments/quarkus-3/before.sh
+++ b/.ci/environments/quarkus-3/before.sh
@@ -6,7 +6,7 @@ mvn_cmd="mvn ${BUILD_MVN_OPTS:-} ${BUILD_MVN_OPTS_QUARKUS_UPDATE:-}"
 ci="${CI:-false}"
 
 rewrite_plugin_version=4.43.0
-quarkus_version=${QUARKUS_VERSION:-3.0.0.Final}
+quarkus_version=${QUARKUS_VERSION:-3.0.0.CR1}
 
 quarkus_recipe_file="${script_dir_path}/quarkus3.yml"
 patch_file="${script_dir_path}"/patches/0001_before_sh.patch
@@ -66,7 +66,6 @@ git reset
 if [ "$(git status --porcelain ${patch_file})" != '' ]; then
     if [ "$(git status --porcelain ${quarkus_recipe_file})" != '' ]; then
         git add "${quarkus_recipe_file}" # We suppose that if the recipe has changed, the patch file as well
-        git commit -m '[Quarkus 3 migration] Update Openrewrite recipe'
     fi
     git add "${patch_file}"
     git commit -m '[Quarkus 3] Updated rewrite data'

--- a/.ci/environments/quarkus-3/before.sh
+++ b/.ci/environments/quarkus-3/before.sh
@@ -6,7 +6,7 @@ mvn_cmd="mvn ${BUILD_MVN_OPTS:-} ${BUILD_MVN_OPTS_QUARKUS_UPDATE:-}"
 ci="${CI:-false}"
 
 rewrite_plugin_version=4.43.0
-quarkus_version=${QUARKUS_VERSION:-3.0.0.CR1}
+quarkus_version=${QUARKUS_VERSION:-3.0.0.Final}
 
 quarkus_recipe_file="${script_dir_path}/quarkus3.yml"
 patch_file="${script_dir_path}"/patches/0001_before_sh.patch

--- a/.ci/environments/quarkus-3/before.sh
+++ b/.ci/environments/quarkus-3/before.sh
@@ -8,12 +8,16 @@ ci="${CI:-false}"
 rewrite_plugin_version=4.43.0
 quarkus_version=${QUARKUS_VERSION:-3.0.0.Final}
 
-quarkus_file="${script_dir_path}/quarkus3.yml"
+quarkus_recipe_file="${script_dir_path}/quarkus3.yml"
 patch_file="${script_dir_path}"/patches/0001_before_sh.patch
+
+if [ "${ci}" = "true" ]; then
+    # In CI we need the main branch snapshot artifacts deployed locally
+    ${mvn_cmd} clean install -Dquickly
+fi
 
 rewrite=${1:-'none'}
 echo "rewrite "${rewrite}
-
 if [ "rewrite" != ${rewrite} ]; then
     echo "No rewrite to be done. Exited"
     exit 0
@@ -25,25 +29,16 @@ echo "Update project with Quarkus version ${quarkus_version}"
 
 set -x
 
-if [ "${ci}" = "true" ]; then
-    # In CI we need the main branch snapshot artifacts deployed locally
-    ${mvn_cmd} clean install -Dquickly
-fi
-
 project_version=$(${mvn_cmd} -q -Dexpression=project.version -DforceStdout help:evaluate)
 
 # Regenerate quarkus3 recipe
 cd ${script_dir_path}
 curl -Ls https://sh.jbang.dev | bash -s - jbang/CreateQuarkusDroolsMigrationRecipe.java
 cd -
-if [ "$(git status --porcelain ${quarkus_file})" != '' ]; then
-    git add "${quarkus_file}"
-    git commit -m '[Quarkus 3 migration] Update Openrewrite recipe'
-fi
 
 # Launch Quarkus 3 Openrewrite
 ${mvn_cmd} org.openrewrite.maven:rewrite-maven-plugin:${rewrite_plugin_version}:run \
-    -Drewrite.configLocation="${quarkus_file}" \
+    -Drewrite.configLocation="${quarkus_recipe_file}" \
     -DactiveRecipes=io.quarkus.openrewrite.Quarkus \
     -Drewrite.recipeArtifactCoordinates=org.kie:jpmml-migration-recipe:"${project_version}" \
     -Denforcer.skip \
@@ -62,13 +57,18 @@ ${mvn_cmd} \
 
 # Create the `patches/0001_before_sh.patch` file
 git add .
+git reset "${quarkus_recipe_file}" # Do not include recipe file
 git diff --cached > "${patch_file}"
 git reset
 
 # Commit the change on patch
 if [ "$(git status --porcelain ${patch_file})" != '' ]; then
+    if [ "$(git status --porcelain ${quarkus_recipe_file})" != '' ]; then
+        git add "${quarkus_recipe_file}" # We suppose that if the recipe has changed, the patch file as well
+        git commit -m '[Quarkus 3 migration] Update Openrewrite recipe'
+    fi
     git add "${patch_file}"
-    git commit -m '[Quarkus 3 migration] Updated Openrewrite patch'
+    git commit -m '[Quarkus 3] Updated rewrite data'
 fi
 
 # Reset all other changes as they will be applied next by the `patches/0001_before_sh.patch` file

--- a/.ci/environments/quarkus-3/before.sh
+++ b/.ci/environments/quarkus-3/before.sh
@@ -17,6 +17,7 @@ if [ "${ci}" = "true" ]; then
 fi
 
 rewrite=${1:-'none'}
+behavior=${2:-'none'}
 echo "rewrite "${rewrite}
 if [ "rewrite" != ${rewrite} ]; then
     echo "No rewrite to be done. Exited"
@@ -69,6 +70,13 @@ if [ "$(git status --porcelain ${patch_file})" != '' ]; then
     fi
     git add "${patch_file}"
     git commit -m '[Quarkus 3] Updated rewrite data'
+
+    if [ "${behavior}" = 'push_changes' ]; then
+        git_remote="${GIT_REMOTE:-origin}"
+        branch=$(git branch --show-current)
+        echo "Pushing changes to ${git_remote}/${branch}"
+        git push ${git_remote} ${branch}
+    fi
 fi
 
 # Reset all other changes as they will be applied next by the `patches/0001_before_sh.patch` file

--- a/.ci/environments/quarkus-3/before.sh
+++ b/.ci/environments/quarkus-3/before.sh
@@ -39,8 +39,6 @@ curl -Ls https://sh.jbang.dev | \
         -v version.io.quarkus=${quarkus_version} 
 cd -
 
-exit 0
-
 # Launch Quarkus 3 Openrewrite
 ${mvn_cmd} org.openrewrite.maven:rewrite-maven-plugin:${rewrite_plugin_version}:run \
     -Drewrite.configLocation="${quarkus_recipe_file}" \

--- a/.ci/environments/quarkus-3/patches/0001_before_sh.patch
+++ b/.ci/environments/quarkus-3/patches/0001_before_sh.patch
@@ -4113,7 +4113,7 @@ index 8f99b7d8c8..b4e5e7069f 100644
                                 min,
                                 max,
 diff --git a/kie-pmml-trusty/kie-pmml-compiler/kie-pmml-compiler-api/src/test/java/org/kie/pmml/compiler/api/mocks/TestModel.java b/kie-pmml-trusty/kie-pmml-compiler/kie-pmml-compiler-api/src/test/java/org/kie/pmml/compiler/api/mocks/TestModel.java
-index 29e0f7b7d0..ff3005526b 100644
+index 29e0f7b7d0..606759ffdc 100644
 --- a/kie-pmml-trusty/kie-pmml-compiler/kie-pmml-compiler-api/src/test/java/org/kie/pmml/compiler/api/mocks/TestModel.java
 +++ b/kie-pmml-trusty/kie-pmml-compiler/kie-pmml-compiler-api/src/test/java/org/kie/pmml/compiler/api/mocks/TestModel.java
 @@ -122,4 +122,14 @@ public class TestModel extends Model {
@@ -4126,7 +4126,7 @@ index 29e0f7b7d0..ff3005526b 100644
 +        return null;
 +    }
 +
-+    @ForkJoin
++    @Override
 +    public MiningSchema requireMiningSchema() {
 +        return null;
 +    }

--- a/.ci/environments/quarkus-3/patches/0001_before_sh.patch
+++ b/.ci/environments/quarkus-3/patches/0001_before_sh.patch
@@ -4113,7 +4113,7 @@ index 8f99b7d8c8..b4e5e7069f 100644
                                 min,
                                 max,
 diff --git a/kie-pmml-trusty/kie-pmml-compiler/kie-pmml-compiler-api/src/test/java/org/kie/pmml/compiler/api/mocks/TestModel.java b/kie-pmml-trusty/kie-pmml-compiler/kie-pmml-compiler-api/src/test/java/org/kie/pmml/compiler/api/mocks/TestModel.java
-index 29e0f7b7d0..606759ffdc 100644
+index 29e0f7b7d0..ff3005526b 100644
 --- a/kie-pmml-trusty/kie-pmml-compiler/kie-pmml-compiler-api/src/test/java/org/kie/pmml/compiler/api/mocks/TestModel.java
 +++ b/kie-pmml-trusty/kie-pmml-compiler/kie-pmml-compiler-api/src/test/java/org/kie/pmml/compiler/api/mocks/TestModel.java
 @@ -122,4 +122,14 @@ public class TestModel extends Model {
@@ -4126,7 +4126,7 @@ index 29e0f7b7d0..606759ffdc 100644
 +        return null;
 +    }
 +
-+    @Override
++    @ForkJoin
 +    public MiningSchema requireMiningSchema() {
 +        return null;
 +    }

--- a/.ci/environments/quarkus-3/patches/0001_before_sh.patch
+++ b/.ci/environments/quarkus-3/patches/0001_before_sh.patch
@@ -1,5 +1,5 @@
 diff --git a/build-parent/pom.xml b/build-parent/pom.xml
-index 649f596b3d..b0a0fdbde8 100644
+index 649f596b3d..534d8f953b 100644
 --- a/build-parent/pom.xml
 +++ b/build-parent/pom.xml
 @@ -55,9 +55,9 @@
@@ -11,7 +11,7 @@ index 649f596b3d..b0a0fdbde8 100644
 -    <version.io.smallrye.openapi.core>3.1.1</version.io.smallrye.openapi.core>
 +    <version.io.micrometer>1.10.5</version.io.micrometer>
 +    <version.io.quarkus>3.0.0.Final</version.io.quarkus>
-+    <version.io.smallrye.openapi.core>3.3.1</version.io.smallrye.openapi.core>
++    <version.io.smallrye.openapi.core>3.3.2</version.io.smallrye.openapi.core>
      <version.it.unimi.dsi.fastutil>8.5.11</version.it.unimi.dsi.fastutil>
      <version.junit>4.13.1</version.junit>
      <version.net.java.dev.glazedlists>1.8.0</version.net.java.dev.glazedlists>
@@ -32,7 +32,7 @@ index 649f596b3d..b0a0fdbde8 100644
      <!--This needs to be in sync with JUnit-->
      <version.org.hamcrest>1.3</version.org.hamcrest>
 -    <version.org.hibernate>5.6.12.Final</version.org.hibernate>
-+    <version.org.hibernate>6.2.0.CR4</version.org.hibernate>
++    <version.org.hibernate>6.2.0.Final</version.org.hibernate>
      <version.org.hsqldb>2.3.0</version.org.hsqldb>
      <version.org.javassist>3.26.0-GA</version.org.javassist>
 -    <version.org.jboss.narayana.tomcat>5.13.1.Final</version.org.jboss.narayana.tomcat>
@@ -56,7 +56,9 @@ index 649f596b3d..b0a0fdbde8 100644
      <version.jakarta.servlet.jsp.jstl-api>2.0.0</version.jakarta.servlet.jsp.jstl-api>
 -    <version.jakarta.transaction-api>1.3.3</version.jakarta.transaction-api>
 -    <version.jakarta.ws.rs-api>2.1.6</version.jakarta.ws.rs-api>
--    <version.jakarta.xml.ws-api>2.3.3</version.jakarta.xml.ws-api>
++    <version.jakarta.transaction-api>2.0.1</version.jakarta.transaction-api>
++    <version.jakarta.ws.rs-api>3.1.0</version.jakarta.ws.rs-api>
+     <version.jakarta.xml.ws-api>2.3.3</version.jakarta.xml.ws-api>
 -    <version.jakarta.persistence-api>2.2.3</version.jakarta.persistence-api>
 -    <version.jakarta.servlet-api>4.0.3</version.jakarta.servlet-api>
 -    <version.jakarta.xml.bind-api>2.3.3</version.jakarta.xml.bind-api>
@@ -64,9 +66,6 @@ index 649f596b3d..b0a0fdbde8 100644
 -    <version.jakarta.json>1.1.6</version.jakarta.json>
 -    <version.jakarta.json-api>1.1.6</version.jakarta.json-api>
 -    <version.org.jpmml.model>1.5.1</version.org.jpmml.model> <!-- jpmml-model BSD 3C license - ATTENTION 1.5.1 intentional, because 1.5.1 evaluators works with 1.5.1 -->
-+    <version.jakarta.transaction-api>2.0.1</version.jakarta.transaction-api>
-+    <version.jakarta.ws.rs-api>3.1.0</version.jakarta.ws.rs-api>
-+    <version.jakarta.xml.ws-api>4.0.0</version.jakarta.xml.ws-api>
 +    <version.jakarta.persistence-api>3.1.0</version.jakarta.persistence-api>
 +    <version.jakarta.servlet-api>6.0.0</version.jakarta.servlet-api>
 +    <version.jakarta.xml.bind-api>4.0.0</version.jakarta.xml.bind-api>

--- a/.ci/environments/quarkus-3/patches/0001_before_sh.patch
+++ b/.ci/environments/quarkus-3/patches/0001_before_sh.patch
@@ -1,5 +1,5 @@
 diff --git a/build-parent/pom.xml b/build-parent/pom.xml
-index 649f596b3d..534d8f953b 100644
+index 649f596b3d..a8935c1167 100644
 --- a/build-parent/pom.xml
 +++ b/build-parent/pom.xml
 @@ -55,9 +55,9 @@
@@ -56,9 +56,7 @@ index 649f596b3d..534d8f953b 100644
      <version.jakarta.servlet.jsp.jstl-api>2.0.0</version.jakarta.servlet.jsp.jstl-api>
 -    <version.jakarta.transaction-api>1.3.3</version.jakarta.transaction-api>
 -    <version.jakarta.ws.rs-api>2.1.6</version.jakarta.ws.rs-api>
-+    <version.jakarta.transaction-api>2.0.1</version.jakarta.transaction-api>
-+    <version.jakarta.ws.rs-api>3.1.0</version.jakarta.ws.rs-api>
-     <version.jakarta.xml.ws-api>2.3.3</version.jakarta.xml.ws-api>
+-    <version.jakarta.xml.ws-api>2.3.3</version.jakarta.xml.ws-api>
 -    <version.jakarta.persistence-api>2.2.3</version.jakarta.persistence-api>
 -    <version.jakarta.servlet-api>4.0.3</version.jakarta.servlet-api>
 -    <version.jakarta.xml.bind-api>2.3.3</version.jakarta.xml.bind-api>
@@ -66,6 +64,9 @@ index 649f596b3d..534d8f953b 100644
 -    <version.jakarta.json>1.1.6</version.jakarta.json>
 -    <version.jakarta.json-api>1.1.6</version.jakarta.json-api>
 -    <version.org.jpmml.model>1.5.1</version.org.jpmml.model> <!-- jpmml-model BSD 3C license - ATTENTION 1.5.1 intentional, because 1.5.1 evaluators works with 1.5.1 -->
++    <version.jakarta.transaction-api>2.0.1</version.jakarta.transaction-api>
++    <version.jakarta.ws.rs-api>3.1.0</version.jakarta.ws.rs-api>
++    <version.jakarta.xml.ws-api>4.0.0</version.jakarta.xml.ws-api>
 +    <version.jakarta.persistence-api>3.1.0</version.jakarta.persistence-api>
 +    <version.jakarta.servlet-api>6.0.0</version.jakarta.servlet-api>
 +    <version.jakarta.xml.bind-api>4.0.0</version.jakarta.xml.bind-api>
@@ -2752,7 +2753,7 @@ index 31038d2afa..775f3f19dc 100644
  import org.drools.core.impl.EnvironmentFactory;
  import org.kie.api.runtime.Environment;
 diff --git a/drools-reliability/drools-reliability-infinispan/pom.xml b/drools-reliability/drools-reliability-infinispan/pom.xml
-index 6aa2824192..58825724b7 100644
+index 6c7dc785a0..bb0d6822f8 100644
 --- a/drools-reliability/drools-reliability-infinispan/pom.xml
 +++ b/drools-reliability/drools-reliability-infinispan/pom.xml
 @@ -34,11 +34,11 @@

--- a/.ci/environments/quarkus-3/patches/0001_before_sh.patch
+++ b/.ci/environments/quarkus-3/patches/0001_before_sh.patch
@@ -1,5 +1,5 @@
 diff --git a/build-parent/pom.xml b/build-parent/pom.xml
-index 649f596b3d..a8935c1167 100644
+index 649f596b3d..b0a0fdbde8 100644
 --- a/build-parent/pom.xml
 +++ b/build-parent/pom.xml
 @@ -55,9 +55,9 @@
@@ -11,7 +11,7 @@ index 649f596b3d..a8935c1167 100644
 -    <version.io.smallrye.openapi.core>3.1.1</version.io.smallrye.openapi.core>
 +    <version.io.micrometer>1.10.5</version.io.micrometer>
 +    <version.io.quarkus>3.0.0.Final</version.io.quarkus>
-+    <version.io.smallrye.openapi.core>3.3.2</version.io.smallrye.openapi.core>
++    <version.io.smallrye.openapi.core>3.3.1</version.io.smallrye.openapi.core>
      <version.it.unimi.dsi.fastutil>8.5.11</version.it.unimi.dsi.fastutil>
      <version.junit>4.13.1</version.junit>
      <version.net.java.dev.glazedlists>1.8.0</version.net.java.dev.glazedlists>
@@ -32,7 +32,7 @@ index 649f596b3d..a8935c1167 100644
      <!--This needs to be in sync with JUnit-->
      <version.org.hamcrest>1.3</version.org.hamcrest>
 -    <version.org.hibernate>5.6.12.Final</version.org.hibernate>
-+    <version.org.hibernate>6.2.0.Final</version.org.hibernate>
++    <version.org.hibernate>6.2.0.CR4</version.org.hibernate>
      <version.org.hsqldb>2.3.0</version.org.hsqldb>
      <version.org.javassist>3.26.0-GA</version.org.javassist>
 -    <version.org.jboss.narayana.tomcat>5.13.1.Final</version.org.jboss.narayana.tomcat>

--- a/.ci/environments/quarkus-3/quarkus3.yml
+++ b/.ci/environments/quarkus-3/quarkus3.yml
@@ -3,8 +3,8 @@ description: Update Quarkus version and refactor imports and resources if needed
 type: specs.openrewrite.org/v1beta/recipe
 recipeList:
 - org.openrewrite.maven.ChangePropertyValue: {
-    newValue: 3.0.0.Final,
-    key: version.io.quarkus
+    key: version.io.quarkus,
+    newValue: 3.0.0.Final
   }
 - org.kie.drools.Quarkus3Migration
 - org.kie.ManagedDependencies
@@ -117,7 +117,9 @@ recipeList:
   }
 - org.kie.openrewrite.recipe.jpmml.JPMMLRecipe
 ---
-displayName: Update Managed Dependencies
+name: org.kie.ManagedDependencies
+description: Update all managed dependencies based on dependency updates from Quarkus.
+type: specs.openrewrite.org/v1beta/recipe
 recipeList:
 - org.openrewrite.maven.ChangeManagedDependencyGroupIdAndArtifactId: {
     oldGroupId: javax.activation,
@@ -502,9 +504,7 @@ recipeList:
     newGroupId: org.keycloak,
     newArtifactId: keycloak-admin-client-jakarta
   }
-type: specs.openrewrite.org/v1beta/recipe
-description: Update all managed dependencies based on dependency updates from Quarkus.
-name: org.kie.ManagedDependencies
+displayName: Update Managed Dependencies
 ---
 type: specs.openrewrite.org/v1beta/recipe
 name: io.quarkus.updates.core.quarkus30.UpgradeQuarkiverse

--- a/.ci/environments/quarkus-3/quarkus3.yml
+++ b/.ci/environments/quarkus-3/quarkus3.yml
@@ -117,6 +117,7 @@ recipeList:
   }
 - org.kie.openrewrite.recipe.jpmml.JPMMLRecipe
 ---
+displayName: Update Managed Dependencies
 name: org.kie.ManagedDependencies
 description: Update all managed dependencies based on dependency updates from Quarkus.
 type: specs.openrewrite.org/v1beta/recipe
@@ -504,7 +505,6 @@ recipeList:
     newGroupId: org.keycloak,
     newArtifactId: keycloak-admin-client-jakarta
   }
-displayName: Update Managed Dependencies
 ---
 type: specs.openrewrite.org/v1beta/recipe
 name: io.quarkus.updates.core.quarkus30.UpgradeQuarkiverse

--- a/.ci/environments/quarkus-3/quarkus3.yml
+++ b/.ci/environments/quarkus-3/quarkus3.yml
@@ -3,8 +3,8 @@ description: Update Quarkus version and refactor imports and resources if needed
 type: specs.openrewrite.org/v1beta/recipe
 recipeList:
 - org.openrewrite.maven.ChangePropertyValue: {
-    key: version.io.quarkus,
-    newValue: 3.0.0.Final
+    newValue: 3.0.0.Final,
+    key: version.io.quarkus
   }
 - org.kie.drools.Quarkus3Migration
 - org.kie.ManagedDependencies
@@ -117,9 +117,7 @@ recipeList:
   }
 - org.kie.openrewrite.recipe.jpmml.JPMMLRecipe
 ---
-displayName: Update Managed Dependencies
-name: org.kie.ManagedDependencies
-displayName: Update Managed Dependencies
+type: specs.openrewrite.org/v1beta/recipe
 recipeList:
 - org.openrewrite.maven.ChangeManagedDependencyGroupIdAndArtifactId: {
     oldGroupId: javax.activation,
@@ -504,6 +502,9 @@ recipeList:
     newGroupId: org.keycloak,
     newArtifactId: keycloak-admin-client-jakarta
   }
+displayName: Update Managed Dependencies
+name: org.kie.ManagedDependencies
+description: Update all managed dependencies based on dependency updates from Quarkus.
 ---
 type: specs.openrewrite.org/v1beta/recipe
 name: io.quarkus.updates.core.quarkus30.UpgradeQuarkiverse

--- a/.ci/environments/quarkus-3/quarkus3.yml
+++ b/.ci/environments/quarkus-3/quarkus3.yml
@@ -3,8 +3,8 @@ description: Update Quarkus version and refactor imports and resources if needed
 type: specs.openrewrite.org/v1beta/recipe
 recipeList:
 - org.openrewrite.maven.ChangePropertyValue: {
-    newValue: 3.0.0.Final,
-    key: version.io.quarkus
+    key: version.io.quarkus,
+    newValue: 3.0.0.Final
   }
 - org.kie.drools.Quarkus3Migration
 - org.kie.ManagedDependencies
@@ -117,6 +117,7 @@ recipeList:
   }
 - org.kie.openrewrite.recipe.jpmml.JPMMLRecipe
 ---
+displayName: Update Managed Dependencies
 name: org.kie.ManagedDependencies
 displayName: Update Managed Dependencies
 recipeList:
@@ -503,8 +504,6 @@ recipeList:
     newGroupId: org.keycloak,
     newArtifactId: keycloak-admin-client-jakarta
   }
-type: specs.openrewrite.org/v1beta/recipe
-description: Update all managed dependencies based on dependency updates from Quarkus.
 ---
 type: specs.openrewrite.org/v1beta/recipe
 name: io.quarkus.updates.core.quarkus30.UpgradeQuarkiverse

--- a/.ci/environments/quarkus-3/quarkus3.yml
+++ b/.ci/environments/quarkus-3/quarkus3.yml
@@ -117,7 +117,7 @@ recipeList:
   }
 - org.kie.openrewrite.recipe.jpmml.JPMMLRecipe
 ---
-type: specs.openrewrite.org/v1beta/recipe
+displayName: Update Managed Dependencies
 recipeList:
 - org.openrewrite.maven.ChangeManagedDependencyGroupIdAndArtifactId: {
     oldGroupId: javax.activation,
@@ -502,9 +502,9 @@ recipeList:
     newGroupId: org.keycloak,
     newArtifactId: keycloak-admin-client-jakarta
   }
-displayName: Update Managed Dependencies
-name: org.kie.ManagedDependencies
+type: specs.openrewrite.org/v1beta/recipe
 description: Update all managed dependencies based on dependency updates from Quarkus.
+name: org.kie.ManagedDependencies
 ---
 type: specs.openrewrite.org/v1beta/recipe
 name: io.quarkus.updates.core.quarkus30.UpgradeQuarkiverse

--- a/.ci/jenkins/dsl/jobs.groovy
+++ b/.ci/jenkins/dsl/jobs.groovy
@@ -174,8 +174,8 @@ setupQuarkusIntegrationJob('quarkus-lts')
 setupQuarkusIntegrationJob('native-lts')
 setupQuarkusIntegrationJob('quarkus-3') { script ->
     def jobParams = JobParamsUtils.DEFAULT_PARAMS_GETTER(script)
-    jobParams.env.put('BUILD_ENVIRONMENT_OPTIONS', 'rewrite push_changes')
-    jobParams.env.put('INTEGRATION_BRANCH_CURRENT', '9.x.x.x')
+    jobParams.env.put('BUILD_ENVIRONMENT_OPTIONS_CURRENT', 'rewrite push_changes')
+    jobParams.env.put('INTEGRATION_BRANCH_CURRENT', '9.x')
     JobParamsUtils.setupJobParamsDeployConfiguration(script, jobParams)
     return jobParams
 }

--- a/.ci/jenkins/dsl/jobs.groovy
+++ b/.ci/jenkins/dsl/jobs.groovy
@@ -172,7 +172,11 @@ setupQuarkusIntegrationJob('quarkus-main', addFullProfileJobParamsGetter)
 setupQuarkusIntegrationJob('quarkus-branch', addFullProfileJobParamsGetter)
 setupQuarkusIntegrationJob('quarkus-lts')
 setupQuarkusIntegrationJob('native-lts')
-setupQuarkusIntegrationJob('quarkus-3')
+setupQuarkusIntegrationJob('quarkus-3') { script ->
+    def jobParams = JobParamsUtils.DEFAULT_PARAMS_GETTER(script)
+    jobParams.env.put('BUILD_ENVIRONMENT_OPTIONS', 'rewrite')
+    return jobParams
+}
 
 // Release jobs
 setupDeployJob(JobType.RELEASE)

--- a/.ci/jenkins/dsl/jobs.groovy
+++ b/.ci/jenkins/dsl/jobs.groovy
@@ -174,7 +174,9 @@ setupQuarkusIntegrationJob('quarkus-lts')
 setupQuarkusIntegrationJob('native-lts')
 setupQuarkusIntegrationJob('quarkus-3') { script ->
     def jobParams = JobParamsUtils.DEFAULT_PARAMS_GETTER(script)
-    jobParams.env.put('BUILD_ENVIRONMENT_OPTIONS', 'rewrite')
+    jobParams.env.put('BUILD_ENVIRONMENT_OPTIONS', 'rewrite push_changes')
+    jobParams.env.put('INTEGRATION_BRANCH_CURRENT', '9.x.x.x')
+    JobParamsUtils.setupJobParamsDeployConfiguration(script, jobParams)
     return jobParams
 }
 


### PR DESCRIPTION
https://issues.redhat.com/browse/DROOLS-7426

Example of deployed Drools 9 snapshot artifact -> https://repository.jboss.org/org/kie/drools-build-parent/9.39.0-SNAPSHOT/drools-build-parent-9.39.0-20230504.125203-1.pom

Related:
- https://github.com/kiegroup/kogito-pipelines/pull/955
- https://github.com/kiegroup/drools/pull/5214
- https://github.com/kiegroup/kogito-runtimes/pull/2971

This Nightly does the following:
- Perfom the rewrite
- If changes in before.sh patch, push patch changes to current branch
- Update version to (M+1).m.y
- Setup integration branch (9.x ?) and push to it with all Q3 changes