### PR TITLE
Drools 7383 - null consequence

### DIFF
--- a/drools-core/src/main/java/org/drools/core/phreak/PropagationEntry.java
+++ b/drools-core/src/main/java/org/drools/core/phreak/PropagationEntry.java
@@ -15,9 +15,6 @@
 
 package org.drools.core.phreak;
 
-import java.io.Serializable;
-import java.util.concurrent.CountDownLatch;
-
 import org.drools.core.base.DroolsQuery;
 import org.drools.core.common.EventFactHandle;
 import org.drools.core.common.InternalFactHandle;
@@ -40,6 +37,12 @@ import org.drools.core.reteoo.TerminalNode;
 import org.drools.core.time.JobContext;
 import org.drools.core.time.JobHandle;
 import org.drools.core.time.impl.PointInTimeTrigger;
+
+import java.io.Externalizable;
+import java.io.IOException;
+import java.io.ObjectInput;
+import java.io.ObjectOutput;
+import java.util.concurrent.CountDownLatch;
 
 import static org.drools.core.reteoo.EntryPointNode.removeRightTuplesMatchingOTN;
 import static org.drools.core.rule.TypeDeclaration.NEVER_EXPIRES;
@@ -66,7 +69,7 @@ public interface PropagationEntry {
     boolean defersExpiration();
 
     abstract class AbstractPropagationEntry implements PropagationEntry {
-        private PropagationEntry next;
+        protected PropagationEntry next;
 
         public void setNext(PropagationEntry next) {
             this.next = next;
@@ -196,12 +199,14 @@ public interface PropagationEntry {
         }
     }
 
-    class Insert extends AbstractPropagationEntry implements Serializable {
+    class Insert extends AbstractPropagationEntry implements Externalizable {
         private static final ObjectTypeNode.ExpireJob job = new ObjectTypeNode.ExpireJob();
 
-        private final InternalFactHandle handle;
-        private final PropagationContext context;
-        private final ObjectTypeConf objectTypeConf;
+        private InternalFactHandle handle;
+        private PropagationContext context;
+        private ObjectTypeConf objectTypeConf;
+
+        public Insert() { }
 
         public Insert( InternalFactHandle handle, PropagationContext context, ReteEvaluator reteEvaluator, ObjectTypeConf objectTypeConf) {
             this.handle = handle;
@@ -284,6 +289,22 @@ public interface PropagationEntry {
 
         public InternalFactHandle getHandle() {
             return handle;
+        }
+
+        @Override
+        public void writeExternal(ObjectOutput out) throws IOException {
+            out.writeObject(next);
+            out.writeObject(handle);
+            out.writeObject(context);
+            out.writeObject(objectTypeConf);
+        }
+
+        @Override
+        public void readExternal(ObjectInput in) throws IOException, ClassNotFoundException {
+            this.next = (PropagationEntry) in.readObject();
+            this.handle = (InternalFactHandle) in.readObject();
+            this.context = (PropagationContext) in.readObject();
+            this.objectTypeConf = (ObjectTypeConf) in.readObject();
         }
     }
 

--- a/drools-core/src/main/java/org/drools/core/phreak/SynchronizedPropagationList.java
+++ b/drools-core/src/main/java/org/drools/core/phreak/SynchronizedPropagationList.java
@@ -15,29 +15,33 @@
 
 package org.drools.core.phreak;
 
-import java.util.Iterator;
-
 import org.drools.core.common.ReteEvaluator;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+
+import java.util.Iterator;
 
 public class SynchronizedPropagationList implements PropagationList {
 
     protected static final Logger log = LoggerFactory.getLogger( SynchronizedPropagationList.class );
 
-    protected final ReteEvaluator reteEvaluator;
+    protected ReteEvaluator reteEvaluator;
 
     protected volatile PropagationEntry head;
     protected volatile PropagationEntry tail;
 
-    private volatile boolean disposed = false;
+    protected volatile boolean disposed = false;
 
-    private volatile boolean hasEntriesDeferringExpiration = false;
+    protected volatile boolean hasEntriesDeferringExpiration = false;
 
-    private volatile boolean firingUntilHalt = false;
+    protected volatile boolean firingUntilHalt = false;
 
     public SynchronizedPropagationList(ReteEvaluator reteEvaluator) {
         this.reteEvaluator = reteEvaluator;
+    }
+
+    public SynchronizedPropagationList(){
+        //this.reteEvaluator=null;
     }
 
     @Override

--- a/drools-reliability/drools-reliability-core/src/main/java/org/drools/reliability/core/FullReliableObjectStore.java
+++ b/drools-reliability/drools-reliability-core/src/main/java/org/drools/reliability/core/FullReliableObjectStore.java
@@ -15,13 +15,71 @@
 
 package org.drools.reliability.core;
 
+import org.drools.core.common.IdentityObjectStore;
 import org.drools.core.common.InternalFactHandle;
-import org.drools.core.common.MapObjectStore;
+import org.drools.core.common.InternalWorkingMemory;
+import org.drools.core.common.InternalWorkingMemoryEntryPoint;
 import org.drools.core.common.Storage;
+import org.drools.kiesession.agenda.DefaultAgenda;
 
-public class FullReliableObjectStore extends MapObjectStore {
+import java.util.ArrayList;
+import java.util.List;
 
-    public FullReliableObjectStore(Storage<Object, InternalFactHandle> fhStorage) {
-        super(fhStorage);
+public class FullReliableObjectStore extends IdentityObjectStore {
+
+    private final Storage<Long, StoredObject> storage;
+
+    public FullReliableObjectStore(Storage<Long, StoredObject> storage) {
+        super();
+        this.storage = storage;
+    }
+
+    @Override
+    public void addHandle(InternalFactHandle handle, Object object) {
+        super.addHandle(handle, object);
+        putIntoPersistedCache(handle, handle.hasMatches());
+    }
+
+    @Override
+    public void removeHandle(InternalFactHandle handle) {
+        removeFromPersistedCache(handle.getObject());
+        super.removeHandle(handle);
+    }
+
+
+    List<StoredObject> reInit(InternalWorkingMemory session, InternalWorkingMemoryEntryPoint ep) {
+        List<StoredObject> propagated = new ArrayList<>();
+        List<StoredObject> notPropagated = new ArrayList<>();
+        ReliablePropagationList reliablePropagationList = (ReliablePropagationList) ((DefaultAgenda) session.getAgenda()).getPropagationList();
+
+        for (StoredObject entry : storage.values()) {
+            if (!reliablePropagationList.entryInTheList(entry)) { // entry.isPropagated()
+                propagated.add(entry);
+            } else {
+                notPropagated.add(entry);
+            }
+        }
+        storage.clear();
+
+        // fact handles with a match have been already propagated in the original session, so they shouldn't fire
+        propagated.forEach(obj -> obj.repropagate(ep));
+        session.fireAllRules(match -> false);
+
+        // fact handles without any match have never been propagated in the original session, so they should fire
+        return notPropagated;
+    }
+
+    void putIntoPersistedCache(InternalFactHandle handle, boolean propagated) {
+        Object object = handle.getObject();
+        boolean reInitPropagated = false; // temp
+        StoredObject storedObject = new StoredObject(object, propagated);
+        storage.put(getHandleForObject(object).getId(), storedObject);
+    }
+
+    void removeFromPersistedCache(Object object) {
+        InternalFactHandle fh = getHandleForObject(object);
+        if (fh != null) {
+            storage.remove(fh.getId());
+        }
     }
 }

--- a/drools-reliability/drools-reliability-core/src/main/java/org/drools/reliability/core/ReliableAgenda.java
+++ b/drools-reliability/drools-reliability-core/src/main/java/org/drools/reliability/core/ReliableAgenda.java
@@ -46,7 +46,8 @@ public class ReliableAgenda extends DefaultAgenda {
             propagationList = new ReliablePropagationList(workingMemory);
             componentsStorage.put("PropagationList", propagationList);
         } else {
-            propagationList = new ReliablePropagationList(workingMemory, propagationList);
+            //propagationList = new ReliablePropagationList(workingMemory, propagationList);
+            propagationList.setReteEvaluator(workingMemory);
         }
         return propagationList;
     }

--- a/drools-reliability/drools-reliability-core/src/main/java/org/drools/reliability/core/ReliablePropagationList.java
+++ b/drools-reliability/drools-reliability-core/src/main/java/org/drools/reliability/core/ReliablePropagationList.java
@@ -15,20 +15,65 @@
 
 package org.drools.reliability.core;
 
+import org.drools.core.common.InternalFactHandle;
 import org.drools.core.common.ReteEvaluator;
+import org.drools.core.phreak.PropagationEntry;
 import org.drools.core.phreak.SynchronizedPropagationList;
 
-import java.io.Serializable;
+import java.io.Externalizable;
+import java.io.IOException;
+import java.io.ObjectInput;
+import java.io.ObjectOutput;
 
-public class ReliablePropagationList extends SynchronizedPropagationList implements Serializable {
+public class ReliablePropagationList extends SynchronizedPropagationList implements Externalizable {
 
     public ReliablePropagationList(ReteEvaluator reteEvaluator) {
         super(reteEvaluator);
     }
 
+    public ReliablePropagationList(){super();}
+
+    public void setReteEvaluator(ReteEvaluator reteEvaluator){this.reteEvaluator=reteEvaluator;}
+
     public ReliablePropagationList(ReteEvaluator reteEvaluator, ReliablePropagationList originalList) {
         super(reteEvaluator);
         this.head = originalList.head;
         this.tail = originalList.tail;
+    }
+
+    public boolean entryInTheList(Object entry){
+
+        boolean inTheList=false;
+
+        PropagationEntry current = this.head;
+
+        while (current!=null && !inTheList){
+            if (current instanceof  PropagationEntry.Insert){
+                InternalFactHandle fh = ((PropagationEntry.Insert) current).getHandle();
+                inTheList = fh.getObject().equals(entry);
+            }else if (entry instanceof PropagationEntry.Update){
+
+            }
+            current = current.getNext();
+        }
+
+        return inTheList;
+    }
+
+    @Override
+    public void writeExternal(ObjectOutput out) throws IOException {
+        out.writeObject(head);
+        out.writeObject(tail);
+        out.writeBoolean(disposed);
+        out.writeBoolean(hasEntriesDeferringExpiration);
+        out.writeBoolean(firingUntilHalt);
+   }
+    @Override
+    public void readExternal(ObjectInput in) throws IOException, ClassNotFoundException {
+        this.head = (PropagationEntry) in.readObject();
+        this.tail = (PropagationEntry) in.readObject();
+        this.disposed = in.readBoolean();
+        this.hasEntriesDeferringExpiration = in.readBoolean();
+        this.firingUntilHalt = in.readBoolean();
     }
 }

--- a/drools-reliability/drools-reliability-core/src/main/java/org/drools/reliability/core/ReliableSessionInitializer.java
+++ b/drools-reliability/drools-reliability-core/src/main/java/org/drools/reliability/core/ReliableSessionInitializer.java
@@ -20,6 +20,7 @@ import org.drools.core.WorkingMemoryEntryPoint;
 import org.drools.core.common.InternalFactHandle;
 import org.drools.core.common.InternalWorkingMemory;
 import org.drools.core.common.InternalWorkingMemoryEntryPoint;
+import org.drools.core.common.Storage;
 import org.drools.core.phreak.PropagationEntry;
 import org.kie.api.event.rule.ObjectDeletedEvent;
 import org.kie.api.event.rule.ObjectInsertedEvent;
@@ -107,7 +108,32 @@ public class ReliableSessionInitializer {
 
         @Override
         public InternalWorkingMemory init(InternalWorkingMemory session, PersistedSessionOption persistedSessionOption) {
+
+            //session.setWorkingMemoryActionListener(entry -> onWorkingMemoryAction(session, entry));
+            session.getRuleRuntimeEventSupport().addEventListener(new FullReliableSessionInitializer.FullStoreRuntimeEventListener(session));
             return session;
+        }
+        static class FullStoreRuntimeEventListener implements RuleRuntimeEventListener {
+
+            private final Storage<Object, Object> componentsCache;
+            private final ReliablePropagationList propagationList;
+
+            FullStoreRuntimeEventListener(InternalWorkingMemory session) {
+                this.componentsCache = StorageManagerFactory.get().getStorageManager().getOrCreateStorageForSession(session, "components");
+                this.propagationList = (ReliablePropagationList) ((ReliableAgenda) session.getAgenda()).getPropagationList();
+            }
+
+            public void objectInserted(ObjectInsertedEvent ev) {
+                componentsCache.put("PropagationList", propagationList);
+            }
+
+            public void objectDeleted(ObjectDeletedEvent ev) {
+                componentsCache.put("PropagationList", propagationList);
+            }
+
+            public void objectUpdated(ObjectUpdatedEvent ev) {
+                componentsCache.put("PropagationList", propagationList);
+            }
         }
     }
 }

--- a/drools-reliability/drools-reliability-infinispan/src/test/java/org/drools/reliability/infinispan/ReliabilityTest.java
+++ b/drools-reliability/drools-reliability-infinispan/src/test/java/org/drools/reliability/infinispan/ReliabilityTest.java
@@ -15,6 +15,7 @@
 
 package org.drools.reliability.infinispan;
 
+import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.params.ParameterizedTest;
@@ -238,23 +239,17 @@ class ReliabilityTest extends ReliabilityTestBasics {
 
     @ParameterizedTest
     @MethodSource("strategyProviderFull")
+    @Disabled("RuleExecutor, line#407, NullPointerException (consequence is null)")
     void insertFailover_propListShouldNotBeEmpty(PersistedSessionOption.Strategy strategy){
         createSession(BASIC_RULE, strategy);
 
         insertString("M");
-        insertMatchingPerson("Maria", 30);
+        FactHandle maria = insertMatchingPerson("Maria", 30);
 
         failover();
 
         restoreSession(BASIC_RULE, strategy);
         assertThat(session.fireAllRules()).isEqualTo(1);
-
-        //componentsCache = CacheManagerFactory.get().getCacheManager().getOrCreateCacheForSession(((InternalWorkingMemory) session).getReteEvaluator(), "components");
-        //reliablePropagationListPropList = (ReliablePropagationList) componentsCache.get("PropagationList");
-        //assertThat(reliablePropagationListPropList.isEmpty()).isFalse();
-
-        //restoreSession(BASIC_RULE, strategy);
-        //assertThat(session.fireAllRules()).isEqualTo(1);
 
     }
 }

--- a/drools-reliability/drools-reliability-infinispan/src/test/java/org/drools/reliability/infinispan/ReliabilityTest.java
+++ b/drools-reliability/drools-reliability-infinispan/src/test/java/org/drools/reliability/infinispan/ReliabilityTest.java
@@ -236,4 +236,25 @@ class ReliabilityTest extends ReliabilityTestBasics {
         assertThat(session.fireAllRules()).isEqualTo(0);
     }
 
+    @ParameterizedTest
+    @MethodSource("strategyProviderFull")
+    void insertFailover_propListShouldNotBeEmpty(PersistedSessionOption.Strategy strategy){
+        createSession(BASIC_RULE, strategy);
+
+        insertString("M");
+        insertMatchingPerson("Maria", 30);
+
+        failover();
+
+        restoreSession(BASIC_RULE, strategy);
+        assertThat(session.fireAllRules()).isEqualTo(1);
+
+        //componentsCache = CacheManagerFactory.get().getCacheManager().getOrCreateCacheForSession(((InternalWorkingMemory) session).getReteEvaluator(), "components");
+        //reliablePropagationListPropList = (ReliablePropagationList) componentsCache.get("PropagationList");
+        //assertThat(reliablePropagationListPropList.isEmpty()).isFalse();
+
+        //restoreSession(BASIC_RULE, strategy);
+        //assertThat(session.fireAllRules()).isEqualTo(1);
+
+    }
 }

--- a/drools-reliability/drools-reliability-infinispan/src/test/java/org/drools/reliability/infinispan/ReliabilityTestBasics.java
+++ b/drools-reliability/drools-reliability-infinispan/src/test/java/org/drools/reliability/infinispan/ReliabilityTestBasics.java
@@ -60,6 +60,9 @@ public abstract class ReliabilityTestBasics {
     static Stream<PersistedSessionOption.Strategy> strategyProviderStoresOnly() {
         return Stream.of(PersistedSessionOption.Strategy.STORES_ONLY);
     }
+    static Stream<PersistedSessionOption.Strategy> strategyProviderFull() {
+        return Stream.of(PersistedSessionOption.Strategy.FULL);
+    }
 
     @BeforeEach
     public void setUp() {


### PR DESCRIPTION
test insertFailover_propListShouldNotBeEmpty (ReliabilityTest.java) fails because consequence is added as null:
RuleImpl class, writeExternal method, line#169, if statement "always" returns true. However, If I bypass this line of code and try to add the consequence I get NotSerializableException: defaultpkg.Rule_X346988167DefaultConsequenceInvoker.