### PR TITLE
[DROOLS-7412] introduce safepoints for reliable session

### DIFF
--- a/drools-core/src/main/java/org/drools/core/common/MapStorage.java
+++ b/drools-core/src/main/java/org/drools/core/common/MapStorage.java
@@ -42,6 +42,11 @@ public class MapStorage<K, V> implements Storage<K, V> {
     }
 
     @Override
+    public void putAll(Map<? extends K, ? extends V> otherMap) {
+        map.putAll(otherMap);
+    }
+
+    @Override
     public boolean containsKey(K key) {
         return map.containsKey(key);
     }

--- a/drools-core/src/main/java/org/drools/core/common/Storage.java
+++ b/drools-core/src/main/java/org/drools/core/common/Storage.java
@@ -49,7 +49,13 @@ public interface Storage<K, V> {
 
     V getOrDefault(K key, V value);
 
-    default void flush() { }
+    default boolean requiresFlush() {
+        return false;
+    }
+
+    default void flush() {
+        throw new UnsupportedOperationException();
+    }
 
     static <K, V> Storage<K,V> fromMap(Map<K, V> input) {
         return new MapStorage<>(input);

--- a/drools-core/src/main/java/org/drools/core/common/Storage.java
+++ b/drools-core/src/main/java/org/drools/core/common/Storage.java
@@ -18,7 +18,6 @@ package org.drools.core.common;
 import java.util.Collection;
 import java.util.Map;
 import java.util.Set;
-import java.util.stream.Collectors;
 
 /**
  * This interface represents the minimal abstraction to store data. It might be merged into ObjectStore in the long run.
@@ -31,6 +30,8 @@ public interface Storage<K, V> {
     V get(K key);
 
     V put(K key, V value);
+
+    void putAll(Map<? extends K, ? extends V> otherMap);
 
     boolean containsKey(K key);
 
@@ -47,6 +48,8 @@ public interface Storage<K, V> {
     boolean isEmpty();
 
     V getOrDefault(K key, V value);
+
+    default void flush() { }
 
     static <K, V> Storage<K,V> fromMap(Map<K, V> input) {
         return new MapStorage<>(input);

--- a/drools-reliability/drools-reliability-core/src/main/java/org/drools/reliability/core/BatchingStorageDecorator.java
+++ b/drools-reliability/drools-reliability-core/src/main/java/org/drools/reliability/core/BatchingStorageDecorator.java
@@ -1,0 +1,116 @@
+/*
+ * Copyright 2023 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.drools.reliability.core;
+
+import org.drools.core.common.Storage;
+
+import java.util.*;
+
+public class BatchingStorageDecorator<K, V> implements Storage<K, V> {
+
+    private final Storage<K, V> storage;
+
+    private Map<K, V> batchingMap = new HashMap<>();
+
+    private Set<K> batchingRemoveSet = new HashSet<>();
+
+
+    public BatchingStorageDecorator(Storage<K, V> storage) {
+        this.storage = storage;
+    }
+
+    @Override
+    public V get(K key) {
+        if (batchingRemoveSet.contains(key)) {
+            return null;
+        }
+        return batchingMap.containsKey(key) ? batchingMap.get(key) : storage.get(key);
+    }
+
+    @Override
+    public V getOrDefault(K key, V value) {
+        if (batchingRemoveSet.contains(key)) {
+            return value;
+        }
+        return batchingMap.containsKey(key) ? batchingMap.get(key) : storage.getOrDefault(key, value);
+    }
+
+    @Override
+    public V put(K key, V value) {
+        batchingRemoveSet.remove(key);
+        return batchingMap.put(key, value);
+    }
+
+    @Override
+    public void putAll(Map<? extends K, ? extends V> otherMap) {
+        batchingRemoveSet.removeAll(otherMap.keySet());
+        batchingMap.putAll(otherMap);
+    }
+
+    @Override
+    public boolean containsKey(K key) {
+        return !batchingRemoveSet.contains(key) && ( batchingMap.containsKey(key) || storage.containsKey(key) );
+    }
+
+    @Override
+    public V remove(K key) {
+        batchingRemoveSet.add(key);
+        return batchingMap.remove(key);
+    }
+
+    @Override
+    public void clear() {
+        batchingRemoveSet.clear();
+        batchingMap.clear();
+        storage.clear();
+    }
+
+    @Override
+    public Collection<V> values() {
+        flush();
+        return storage.values();
+    }
+
+    @Override
+    public Set<K> keySet() {
+        if (batchingMap.isEmpty() && batchingRemoveSet.isEmpty()) {
+            return storage.keySet();
+        }
+        Set<K> keys = new HashSet<>();
+        keys.addAll(storage.keySet());
+        keys.addAll(batchingMap.keySet());
+        keys.removeAll(batchingRemoveSet);
+        return keys;
+    }
+
+    @Override
+    public int size() {
+        return storage.size() + batchingMap.size() - batchingRemoveSet.size();
+    }
+
+    @Override
+    public boolean isEmpty() {
+        return size() == 0;
+    }
+
+    @Override
+    public void flush() {
+        storage.putAll(batchingMap);
+        batchingMap.clear();
+        batchingRemoveSet.forEach(storage::remove);
+        batchingRemoveSet.clear();
+    }
+}

--- a/drools-reliability/drools-reliability-core/src/main/java/org/drools/reliability/core/BatchingStorageDecorator.java
+++ b/drools-reliability/drools-reliability-core/src/main/java/org/drools/reliability/core/BatchingStorageDecorator.java
@@ -23,9 +23,9 @@ public class BatchingStorageDecorator<K, V> implements Storage<K, V> {
 
     private final Storage<K, V> storage;
 
-    private Map<K, V> batchingMap = new HashMap<>();
+    private final Map<K, V> batchingMap = new HashMap<>();
 
-    private Set<K> batchingRemoveSet = new HashSet<>();
+    private final Set<K> batchingRemoveSet = new HashSet<>();
 
 
     public BatchingStorageDecorator(Storage<K, V> storage) {
@@ -104,6 +104,11 @@ public class BatchingStorageDecorator<K, V> implements Storage<K, V> {
     @Override
     public boolean isEmpty() {
         return size() == 0;
+    }
+
+    @Override
+    public boolean requiresFlush() {
+        return true;
     }
 
     @Override

--- a/drools-reliability/drools-reliability-core/src/main/java/org/drools/reliability/core/ReliableKieSession.java
+++ b/drools-reliability/drools-reliability-core/src/main/java/org/drools/reliability/core/ReliableKieSession.java
@@ -15,20 +15,8 @@
 
 package org.drools.reliability.core;
 
-import org.drools.core.common.InternalFactHandle;
-import org.drools.core.common.InternalWorkingMemory;
-import org.drools.core.common.InternalWorkingMemoryEntryPoint;
-import org.drools.core.common.ObjectStore;
+import org.kie.api.runtime.KieSession;
 
-import java.util.List;
-
-public interface SimpleReliableObjectStore extends ObjectStore {
-
-    List<StoredObject> reInit(InternalWorkingMemory session, InternalWorkingMemoryEntryPoint ep);
-
-    void putIntoPersistedStorage(InternalFactHandle handle, boolean propagated);
-
-    void removeFromPersistedStorage(Object object);
-
+public interface ReliableKieSession extends KieSession {
     void safepoint();
 }

--- a/drools-reliability/drools-reliability-core/src/main/java/org/drools/reliability/core/ReliableNamedEntryPoint.java
+++ b/drools-reliability/drools-reliability-core/src/main/java/org/drools/reliability/core/ReliableNamedEntryPoint.java
@@ -31,9 +31,13 @@ public class ReliableNamedEntryPoint extends NamedEntryPoint {
 
     @Override
     protected ObjectStore createObjectStore(EntryPointId entryPoint, RuleBaseConfiguration conf, ReteEvaluator reteEvaluator) {
-        boolean storesOnlyStrategy = reteEvaluator.getSessionConfiguration().getPersistedSessionOption().getStrategy() == PersistedSessionOption.Strategy.STORES_ONLY;
+        boolean storesOnlyStrategy = reteEvaluator.getSessionConfiguration().getPersistedSessionOption().getPersistenceStrategy() == PersistedSessionOption.PersistenceStrategy.STORES_ONLY;
         return storesOnlyStrategy ?
                 SimpleReliableObjectStoreFactory.get().createSimpleReliableObjectStore(StorageManagerFactory.get().getStorageManager().getOrCreateStorageForSession(reteEvaluator, "ep" + getEntryPointId())) :
                 new FullReliableObjectStore(StorageManagerFactory.get().getStorageManager().getOrCreateStorageForSession(reteEvaluator, "ep" + getEntryPointId()));
+    }
+
+    public void safepoint() {
+        ((SimpleReliableObjectStore) getObjectStore()).safepoint();
     }
 }

--- a/drools-reliability/drools-reliability-core/src/main/java/org/drools/reliability/core/ReliableRuntimeComponentFactoryImpl.java
+++ b/drools-reliability/drools-reliability-core/src/main/java/org/drools/reliability/core/ReliableRuntimeComponentFactoryImpl.java
@@ -84,7 +84,7 @@ public class ReliableRuntimeComponentFactoryImpl extends RuntimeComponentFactory
         if (!reteEvaluator.getSessionConfiguration().hasPersistedSessionOption()) {
             return super.createGlobalResolver(reteEvaluator, environment);
         }
-        return new ReliableGlobalResolver(StorageManagerFactory.get().getStorageManager().getOrCreateStorageForSession(reteEvaluator, "globals"));
+        return new ReliableGlobalResolver(StorageManagerFactory.get().getStorageManager().getOrCreateStorageForSession(reteEvaluator, PersistedSessionOption.SafepointStrategy.ALWAYS, "globals"));
     }
 
     @Override
@@ -92,7 +92,7 @@ public class ReliableRuntimeComponentFactoryImpl extends RuntimeComponentFactory
         if (!reteEvaluator.getSessionConfiguration().hasPersistedSessionOption()) {
             return super.createTimerService(reteEvaluator);
         }
-        return new ReliablePseudoClockScheduler(StorageManagerFactory.get().getStorageManager().getOrCreateStorageForSession(reteEvaluator, "timer"));
+        return new ReliablePseudoClockScheduler(StorageManagerFactory.get().getStorageManager().getOrCreateStorageForSession(reteEvaluator, PersistedSessionOption.SafepointStrategy.ALWAYS, "timer"));
     }
 
     private InternalWorkingMemory internalInitSession(InternalKnowledgeBase kbase, SessionConfiguration sessionConfig, InternalWorkingMemory session) {
@@ -104,7 +104,7 @@ public class ReliableRuntimeComponentFactoryImpl extends RuntimeComponentFactory
 
     @Override
     public AgendaFactory getAgendaFactory(SessionConfiguration sessionConfig) {
-        if (!sessionConfig.hasPersistedSessionOption() || sessionConfig.getPersistedSessionOption().getStrategy() == PersistedSessionOption.Strategy.STORES_ONLY) {
+        if (!sessionConfig.hasPersistedSessionOption() || sessionConfig.getPersistedSessionOption().getPersistenceStrategy() == PersistedSessionOption.PersistenceStrategy.STORES_ONLY) {
             return super.getAgendaFactory(sessionConfig);
         }
         return agendaFactory;

--- a/drools-reliability/drools-reliability-core/src/main/java/org/drools/reliability/core/ReliableSessionInitializer.java
+++ b/drools-reliability/drools-reliability-core/src/main/java/org/drools/reliability/core/ReliableSessionInitializer.java
@@ -34,13 +34,13 @@ import java.util.Map;
 
 public class ReliableSessionInitializer {
 
-    private static final Map<PersistedSessionOption.Strategy, SessionInitializer> initializersMap = Map.of(
-            PersistedSessionOption.Strategy.STORES_ONLY, new StoresOnlySessionInitializer(),
-            PersistedSessionOption.Strategy.FULL, new FullReliableSessionInitializer());
+    private static final Map<PersistedSessionOption.PersistenceStrategy, SessionInitializer> initializersMap = Map.of(
+            PersistedSessionOption.PersistenceStrategy.STORES_ONLY, new StoresOnlySessionInitializer(),
+            PersistedSessionOption.PersistenceStrategy.FULL, new FullReliableSessionInitializer());
 
     public static InternalWorkingMemory initReliableSession(SessionConfiguration sessionConfig, InternalWorkingMemory session) {
         PersistedSessionOption persistedSessionOption = sessionConfig.getPersistedSessionOption();
-        return initializersMap.get(persistedSessionOption.getStrategy()).init(session, persistedSessionOption);
+        return initializersMap.get(persistedSessionOption.getPersistenceStrategy()).init(session, persistedSessionOption);
     }
 
     interface SessionInitializer {

--- a/drools-reliability/drools-reliability-core/src/main/java/org/drools/reliability/core/ReliableStatefulKnowledgeSessionImpl.java
+++ b/drools-reliability/drools-reliability-core/src/main/java/org/drools/reliability/core/ReliableStatefulKnowledgeSessionImpl.java
@@ -21,8 +21,9 @@ import org.drools.core.rule.accessor.FactHandleFactory;
 import org.drools.kiesession.rulebase.InternalKnowledgeBase;
 import org.drools.kiesession.session.StatefulKnowledgeSessionImpl;
 import org.kie.api.runtime.Environment;
+import org.kie.api.runtime.conf.PersistedSessionOption;
 
-public class ReliableStatefulKnowledgeSessionImpl extends StatefulKnowledgeSessionImpl {
+public class ReliableStatefulKnowledgeSessionImpl extends StatefulKnowledgeSessionImpl implements ReliableKieSession {
 
     public ReliableStatefulKnowledgeSessionImpl() {
     }
@@ -65,6 +66,14 @@ public class ReliableStatefulKnowledgeSessionImpl extends StatefulKnowledgeSessi
         super.endOperation(operationType);
         if (operationType == InternalOperationType.FIRE) {
             ((ReliableGlobalResolver) getGlobalResolver()).updateStorage();
+            if (getSessionConfiguration().getPersistedSessionOption().getSafepointStrategy() == PersistedSessionOption.SafepointStrategy.ON_FIRING) {
+                safepoint();
+            }
         }
+    }
+
+    @Override
+    public void safepoint() {
+        getEntryPoints().stream().map(ReliableNamedEntryPoint.class::cast).forEach(ReliableNamedEntryPoint::safepoint);
     }
 }

--- a/drools-reliability/drools-reliability-core/src/main/java/org/drools/reliability/core/ReliableStatefulKnowledgeSessionImpl.java
+++ b/drools-reliability/drools-reliability-core/src/main/java/org/drools/reliability/core/ReliableStatefulKnowledgeSessionImpl.java
@@ -66,7 +66,7 @@ public class ReliableStatefulKnowledgeSessionImpl extends StatefulKnowledgeSessi
         super.endOperation(operationType);
         if (operationType == InternalOperationType.FIRE) {
             ((ReliableGlobalResolver) getGlobalResolver()).updateStorage();
-            if (getSessionConfiguration().getPersistedSessionOption().getSafepointStrategy() == PersistedSessionOption.SafepointStrategy.ON_FIRING) {
+            if (getSessionConfiguration().getPersistedSessionOption().getSafepointStrategy() == PersistedSessionOption.SafepointStrategy.AFTER_FIRE) {
                 safepoint();
             }
         }

--- a/drools-reliability/drools-reliability-core/src/main/java/org/drools/reliability/core/SimpleSerializationReliableObjectStore.java
+++ b/drools-reliability/drools-reliability-core/src/main/java/org/drools/reliability/core/SimpleSerializationReliableObjectStore.java
@@ -102,6 +102,8 @@ public class SimpleSerializationReliableObjectStore extends IdentityObjectStore 
 
     @Override
     public void safepoint() {
-        storage.flush();
+        if (storage.requiresFlush()) {
+            storage.flush();
+        }
     }
 }

--- a/drools-reliability/drools-reliability-core/src/main/java/org/drools/reliability/core/StorageManager.java
+++ b/drools-reliability/drools-reliability-core/src/main/java/org/drools/reliability/core/StorageManager.java
@@ -29,7 +29,15 @@ public interface StorageManager {
         return getOrCreateStorageForSession(reteEvaluator, reteEvaluator.getSessionConfiguration().getPersistedSessionOption().getSafepointStrategy(), storageName);
     }
 
-    <K, V> Storage<K, V> getOrCreateStorageForSession(ReteEvaluator reteEvaluator, PersistedSessionOption.SafepointStrategy safepointStrategy, String storageName);
+    default <K, V> Storage<K, V> getOrCreateStorageForSession(ReteEvaluator reteEvaluator, PersistedSessionOption.SafepointStrategy safepointStrategy, String storageName) {
+        Storage<K, V> storage = internalGetOrCreateStorageForSession(reteEvaluator, storageName);
+        if (safepointStrategy.useSafepoints()) {
+            storage = new BatchingStorageDecorator<>(storage);
+        }
+        return storage;
+    }
+
+    <K, V> Storage<K, V> internalGetOrCreateStorageForSession(ReteEvaluator reteEvaluator, String storageName);
 
     <K, V> Storage<K, V> getOrCreateSharedStorage(String storageName);
 

--- a/drools-reliability/drools-reliability-core/src/main/java/org/drools/reliability/core/StorageManager.java
+++ b/drools-reliability/drools-reliability-core/src/main/java/org/drools/reliability/core/StorageManager.java
@@ -25,7 +25,11 @@ public interface StorageManager {
 
     void initStorageManager();
 
-    <K, V> Storage<K, V> getOrCreateStorageForSession(ReteEvaluator reteEvaluator, String storageName);
+    default <K, V> Storage<K, V> getOrCreateStorageForSession(ReteEvaluator reteEvaluator, String storageName) {
+        return getOrCreateStorageForSession(reteEvaluator, reteEvaluator.getSessionConfiguration().getPersistedSessionOption().getSafepointStrategy(), storageName);
+    }
+
+    <K, V> Storage<K, V> getOrCreateStorageForSession(ReteEvaluator reteEvaluator, PersistedSessionOption.SafepointStrategy safepointStrategy, String storageName);
 
     <K, V> Storage<K, V> getOrCreateSharedStorage(String storageName);
 

--- a/drools-reliability/drools-reliability-infinispan/src/main/java/org/drools/reliability/infinispan/EmbeddedStorageManager.java
+++ b/drools-reliability/drools-reliability-infinispan/src/main/java/org/drools/reliability/infinispan/EmbeddedStorageManager.java
@@ -92,15 +92,15 @@ public class EmbeddedStorageManager implements InfinispanStorageManager {
     }
 
     @Override
-    public <k, V> Storage<k, V> getOrCreateStorageForSession(ReteEvaluator reteEvaluator, PersistedSessionOption.SafepointStrategy safepointStrategy, String cacheName) {
+    public <k, V> Storage<k, V> internalGetOrCreateStorageForSession(ReteEvaluator reteEvaluator, String cacheName) {
         Cache<k, V> cache = embeddedCacheManager.administration().getOrCreateCache(createStorageId(reteEvaluator, cacheName), cacheConfiguration);
-        return InfinispanStorage.fromCache(cache, safepointStrategy);
+        return InfinispanStorage.fromCache(cache);
     }
 
     @Override
     public <k, V> Storage<k, V> getOrCreateSharedStorage(String cacheName) {
         Cache<k, V> cache = embeddedCacheManager.administration().getOrCreateCache(SHARED_STORAGE_PREFIX + cacheName, cacheConfiguration);
-        return InfinispanStorage.fromCache(cache, PersistedSessionOption.SafepointStrategy.ALWAYS);
+        return InfinispanStorage.fromCache(cache);
     }
 
     @Override

--- a/drools-reliability/drools-reliability-infinispan/src/main/java/org/drools/reliability/infinispan/EmbeddedStorageManager.java
+++ b/drools-reliability/drools-reliability-infinispan/src/main/java/org/drools/reliability/infinispan/EmbeddedStorageManager.java
@@ -15,12 +15,10 @@
 
 package org.drools.reliability.infinispan;
 
-import java.nio.file.Paths;
-import java.util.Set;
-
 import org.drools.core.common.ReteEvaluator;
 import org.drools.core.common.Storage;
 import org.drools.util.FileUtils;
+import org.infinispan.Cache;
 import org.infinispan.client.hotrod.RemoteCacheManager;
 import org.infinispan.commons.marshall.JavaSerializationMarshaller;
 import org.infinispan.configuration.cache.CacheMode;
@@ -29,8 +27,12 @@ import org.infinispan.configuration.cache.ConfigurationBuilder;
 import org.infinispan.configuration.global.GlobalConfigurationBuilder;
 import org.infinispan.globalstate.ConfigurationStorage;
 import org.infinispan.manager.DefaultCacheManager;
+import org.kie.api.runtime.conf.PersistedSessionOption;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+
+import java.nio.file.Paths;
+import java.util.Set;
 
 import static org.drools.reliability.core.StorageManager.createStorageId;
 import static org.drools.reliability.infinispan.InfinispanStorageManagerFactory.DELIMITER;
@@ -90,13 +92,15 @@ public class EmbeddedStorageManager implements InfinispanStorageManager {
     }
 
     @Override
-    public <k, V> Storage<k, V> getOrCreateStorageForSession(ReteEvaluator reteEvaluator, String cacheName) {
-        return InfinispanStorage.fromCache(embeddedCacheManager.administration().getOrCreateCache(createStorageId(reteEvaluator, cacheName), cacheConfiguration));
+    public <k, V> Storage<k, V> getOrCreateStorageForSession(ReteEvaluator reteEvaluator, PersistedSessionOption.SafepointStrategy safepointStrategy, String cacheName) {
+        Cache<k, V> cache = embeddedCacheManager.administration().getOrCreateCache(createStorageId(reteEvaluator, cacheName), cacheConfiguration);
+        return InfinispanStorage.fromCache(cache, safepointStrategy);
     }
 
     @Override
     public <k, V> Storage<k, V> getOrCreateSharedStorage(String cacheName) {
-        return InfinispanStorage.fromCache(embeddedCacheManager.administration().getOrCreateCache(SHARED_STORAGE_PREFIX + cacheName, cacheConfiguration));
+        Cache<k, V> cache = embeddedCacheManager.administration().getOrCreateCache(SHARED_STORAGE_PREFIX + cacheName, cacheConfiguration);
+        return InfinispanStorage.fromCache(cache, PersistedSessionOption.SafepointStrategy.ALWAYS);
     }
 
     @Override

--- a/drools-reliability/drools-reliability-infinispan/src/main/java/org/drools/reliability/infinispan/InfinispanStorage.java
+++ b/drools-reliability/drools-reliability-infinispan/src/main/java/org/drools/reliability/infinispan/InfinispanStorage.java
@@ -16,9 +16,7 @@
 package org.drools.reliability.infinispan;
 
 import org.drools.core.common.Storage;
-import org.drools.reliability.core.BatchingStorageDecorator;
 import org.infinispan.commons.api.BasicCache;
-import org.kie.api.runtime.conf.PersistedSessionOption;
 
 import java.util.Collection;
 import java.util.Map;
@@ -28,12 +26,8 @@ public class InfinispanStorage<K, V> implements Storage<K, V> {
 
     private BasicCache<K, V> cache;
 
-    public static <K1, V1> Storage<K1, V1> fromCache(BasicCache<K1, V1> cache, PersistedSessionOption.SafepointStrategy safepointStrategy) {
-        Storage<K1, V1> storage = new InfinispanStorage<>(cache);
-        if (safepointStrategy.useSafepoints()) {
-            storage = new BatchingStorageDecorator<>(storage);
-        }
-        return storage;
+    public static <K1, V1> Storage<K1, V1> fromCache(BasicCache<K1, V1> cache) {
+        return new InfinispanStorage<>(cache);
     }
 
     private InfinispanStorage(BasicCache<K, V> cache) {

--- a/drools-reliability/drools-reliability-infinispan/src/main/java/org/drools/reliability/infinispan/RemoteStorageManager.java
+++ b/drools-reliability/drools-reliability-infinispan/src/main/java/org/drools/reliability/infinispan/RemoteStorageManager.java
@@ -17,12 +17,14 @@ package org.drools.reliability.infinispan;
 
 import org.drools.core.common.ReteEvaluator;
 import org.drools.core.common.Storage;
+import org.infinispan.client.hotrod.RemoteCache;
 import org.infinispan.client.hotrod.configuration.ConfigurationBuilder;
 import org.infinispan.commons.marshall.JavaSerializationMarshaller;
 import org.infinispan.commons.marshall.ProtoStreamMarshaller;
 import org.infinispan.manager.DefaultCacheManager;
 import org.infinispan.protostream.SerializationContext;
 import org.infinispan.protostream.SerializationContextInitializer;
+import org.kie.api.runtime.conf.PersistedSessionOption;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -97,13 +99,15 @@ public class RemoteStorageManager implements InfinispanStorageManager {
     }
 
     @Override
-    public <k, V> Storage<k, V> getOrCreateStorageForSession(ReteEvaluator reteEvaluator, String cacheName) {
-        return InfinispanStorage.fromCache(remoteCacheManager.administration().getOrCreateCache(createStorageId(reteEvaluator, cacheName), (String) null));
+    public <k, V> Storage<k, V> getOrCreateStorageForSession(ReteEvaluator reteEvaluator, PersistedSessionOption.SafepointStrategy safepointStrategy, String cacheName) {
+        RemoteCache<k, V> cache = remoteCacheManager.administration().getOrCreateCache(createStorageId(reteEvaluator, cacheName), (String) null);
+        return InfinispanStorage.fromCache(cache, safepointStrategy);
     }
 
     @Override
     public <k, V> Storage<k, V> getOrCreateSharedStorage(String cacheName) {
-        return InfinispanStorage.fromCache(remoteCacheManager.administration().getOrCreateCache(SHARED_STORAGE_PREFIX + cacheName, (String) null));
+        RemoteCache<k, V> cache = remoteCacheManager.administration().getOrCreateCache(SHARED_STORAGE_PREFIX + cacheName, (String) null);
+        return InfinispanStorage.fromCache(cache, PersistedSessionOption.SafepointStrategy.ALWAYS);
     }
 
     @Override

--- a/drools-reliability/drools-reliability-infinispan/src/main/java/org/drools/reliability/infinispan/RemoteStorageManager.java
+++ b/drools-reliability/drools-reliability-infinispan/src/main/java/org/drools/reliability/infinispan/RemoteStorageManager.java
@@ -99,15 +99,15 @@ public class RemoteStorageManager implements InfinispanStorageManager {
     }
 
     @Override
-    public <k, V> Storage<k, V> getOrCreateStorageForSession(ReteEvaluator reteEvaluator, PersistedSessionOption.SafepointStrategy safepointStrategy, String cacheName) {
+    public <k, V> Storage<k, V> internalGetOrCreateStorageForSession(ReteEvaluator reteEvaluator, String cacheName) {
         RemoteCache<k, V> cache = remoteCacheManager.administration().getOrCreateCache(createStorageId(reteEvaluator, cacheName), (String) null);
-        return InfinispanStorage.fromCache(cache, safepointStrategy);
+        return InfinispanStorage.fromCache(cache);
     }
 
     @Override
     public <k, V> Storage<k, V> getOrCreateSharedStorage(String cacheName) {
         RemoteCache<k, V> cache = remoteCacheManager.administration().getOrCreateCache(SHARED_STORAGE_PREFIX + cacheName, (String) null);
-        return InfinispanStorage.fromCache(cache, PersistedSessionOption.SafepointStrategy.ALWAYS);
+        return InfinispanStorage.fromCache(cache);
     }
 
     @Override

--- a/drools-reliability/drools-reliability-infinispan/src/main/java/org/drools/reliability/infinispan/proto/SimpleProtoStreamReliableObjectStore.java
+++ b/drools-reliability/drools-reliability-infinispan/src/main/java/org/drools/reliability/infinispan/proto/SimpleProtoStreamReliableObjectStore.java
@@ -15,8 +15,6 @@
 
 package org.drools.reliability.infinispan.proto;
 
-import org.drools.core.common.EventFactHandle;
-import org.drools.core.common.InternalFactHandle;
 import org.drools.core.common.Storage;
 import org.drools.reliability.core.SimpleSerializationReliableObjectStore;
 import org.drools.reliability.core.StoredObject;
@@ -28,11 +26,12 @@ public class SimpleProtoStreamReliableObjectStore extends SimpleSerializationRel
     }
 
     @Override
-    public void putIntoPersistedStorage(InternalFactHandle handle, boolean propagated) {
-        Object object = handle.getObject();
-        StoredObject storedObject = handle.isEvent() ?
-                new ProtoStreamStoredObject(object, reInitPropagated || propagated, ((EventFactHandle) handle).getStartTimestamp(), ((EventFactHandle) handle).getDuration()) :
-                new ProtoStreamStoredObject(object, reInitPropagated || propagated);
-        storage.put(getHandleForObject(object).getId(), storedObject);
+    protected StoredObject createStoredObject(boolean propagated, Object object) {
+        return new ProtoStreamStoredObject(object, propagated);
+    }
+
+    @Override
+    protected StoredObject createStoredObject(boolean propagated, Object object, long timestamp, long duration) {
+        return new ProtoStreamStoredObject(object, propagated, timestamp, duration);
     }
 }

--- a/drools-reliability/drools-reliability-infinispan/src/test/java/org/drools/reliability/infinispan/CachePersistenceTest.java
+++ b/drools-reliability/drools-reliability-infinispan/src/test/java/org/drools/reliability/infinispan/CachePersistenceTest.java
@@ -45,7 +45,7 @@ class CachePersistenceTest extends ReliabilityTestBasics {
     @DisabledOnOs(OS.WINDOWS) // temporarily disabled until DROOLS-7393 is fixed
     @ParameterizedTest
     @MethodSource("strategyProviderStoresOnly")
-    void removeAllSessionCaches_shouldRemoveAllSessionCachesEvenAfterFailover(PersistedSessionOption.Strategy strategy) {
+    void removeAllSessionCaches_shouldRemoveAllSessionCachesEvenAfterFailover(PersistedSessionOption.PersistenceStrategy strategy) {
         createSession(EMPTY_RULE, strategy); // savedSessionId = 0, sessionId = 0
         insertNonMatchingPerson("Toshiya", 10);
 
@@ -63,7 +63,7 @@ class CachePersistenceTest extends ReliabilityTestBasics {
 
     @ParameterizedTest
     @MethodSource("strategyProviderStoresOnly")
-    void ksessionDispose_shouldRemoveCache(PersistedSessionOption.Strategy strategy){
+    void ksessionDispose_shouldRemoveCache(PersistedSessionOption.PersistenceStrategy strategy){
 
         createSession(EMPTY_RULE, strategy); // sessionId = 0. This creates session_0_epDEFAULT and session_0_globals
 
@@ -76,7 +76,7 @@ class CachePersistenceTest extends ReliabilityTestBasics {
 
     @ParameterizedTest
     @MethodSource("strategyProviderStoresOnly")
-    void missingDispose_shouldNotReuseOrphanedCache(PersistedSessionOption.Strategy strategy) {
+    void missingDispose_shouldNotReuseOrphanedCache(PersistedSessionOption.PersistenceStrategy strategy) {
         createSession(EMPTY_RULE, strategy); // sessionId = 0
         insertNonMatchingPerson("Toshiya", 10);
 
@@ -98,7 +98,7 @@ class CachePersistenceTest extends ReliabilityTestBasics {
 
     @ParameterizedTest
     @MethodSource("strategyProviderStoresOnly")
-    void reliableSessionCounter_shouldNotHaveTheSameIdAsPreviousKsession(PersistedSessionOption.Strategy strategy) {
+    void reliableSessionCounter_shouldNotHaveTheSameIdAsPreviousKsession(PersistedSessionOption.PersistenceStrategy strategy) {
         createSession(EMPTY_RULE, strategy); // new session. sessionId = 0
         long firstSessionId = session.getIdentifier();
 

--- a/drools-reliability/drools-reliability-infinispan/src/test/java/org/drools/reliability/infinispan/ReliabilityCepTest.java
+++ b/drools-reliability/drools-reliability-infinispan/src/test/java/org/drools/reliability/infinispan/ReliabilityCepTest.java
@@ -44,7 +44,7 @@ class ReliabilityCepTest extends ReliabilityTestBasics {
             "end\n";
 
     @ParameterizedTest
-    @MethodSource("strategyProviderStoresOnlyWithSafepoints") // FULL fails with "ReliablePropagationList; no valid constructor"
+    @MethodSource("strategyProviderStoresOnlyWithExplicitSafepoints") // FULL fails with "ReliablePropagationList; no valid constructor"
     void insertAdvanceInsertFailoverFire_shouldRecoverFromFailover(PersistedSessionOption.PersistenceStrategy persistenceStrategy, PersistedSessionOption.SafepointStrategy safepointStrategy) {
 
         createSession(CEP_RULE, persistenceStrategy, safepointStrategy, EventProcessingOption.STREAM, ClockTypeOption.PSEUDO);

--- a/drools-reliability/drools-reliability-infinispan/src/test/java/org/drools/reliability/infinispan/ReliabilityTest.java
+++ b/drools-reliability/drools-reliability-infinispan/src/test/java/org/drools/reliability/infinispan/ReliabilityTest.java
@@ -55,7 +55,7 @@ class ReliabilityTest extends ReliabilityTestBasics {
     }
 
     @ParameterizedTest
-    @MethodSource("strategyProviderStoresOnlyWithSafepoints") // FULL fails with "ReliablePropagationList; no valid constructor"
+    @MethodSource("strategyProviderStoresOnlyWithExplicitSafepoints") // FULL fails with "ReliablePropagationList; no valid constructor"
     void insertFailoverInsertFire_shouldRecoverFromFailover(PersistedSessionOption.PersistenceStrategy persistenceStrategy, PersistedSessionOption.SafepointStrategy safepointStrategy) {
         createSession(BASIC_RULE, persistenceStrategy, safepointStrategy);
 
@@ -78,7 +78,7 @@ class ReliabilityTest extends ReliabilityTestBasics {
 
 
     @ParameterizedTest
-    @MethodSource("strategyProviderStoresOnlyWithSafepoints") // With Remote, FULL fails with "ReliablePropagationList; no valid constructor" even without failover
+    @MethodSource("strategyProviderStoresOnlyWithExplicitSafepoints") // With Remote, FULL fails with "ReliablePropagationList; no valid constructor" even without failover
     void noFailover(PersistedSessionOption.PersistenceStrategy persistenceStrategy, PersistedSessionOption.SafepointStrategy safepointStrategy) {
 
         createSession(BASIC_RULE, persistenceStrategy, safepointStrategy);
@@ -101,7 +101,7 @@ class ReliabilityTest extends ReliabilityTestBasics {
 
 
     @ParameterizedTest
-    @MethodSource("strategyProviderStoresOnlyWithSafepoints") // FULL fails with "ReliablePropagationList; no valid constructor"
+    @MethodSource("strategyProviderStoresOnlyWithExplicitSafepoints") // FULL fails with "ReliablePropagationList; no valid constructor"
     void insertFireInsertFailoverInsertFire_shouldMatchFactInsertedBeforeFailover(PersistedSessionOption.PersistenceStrategy persistenceStrategy, PersistedSessionOption.SafepointStrategy safepointStrategy) {
 
         createSession(BASIC_RULE, persistenceStrategy, safepointStrategy);
@@ -127,7 +127,7 @@ class ReliabilityTest extends ReliabilityTestBasics {
     }
 
     @ParameterizedTest
-    @MethodSource("strategyProviderStoresOnlyWithSafepoints") // FULL fails with "ReliablePropagationList; no valid constructor"
+    @MethodSource("strategyProviderStoresOnlyWithAllSafepoints") // FULL fails with "ReliablePropagationList; no valid constructor"
     void insertFireFailoverInsertFire_shouldNotRepeatFiredMatch(PersistedSessionOption.PersistenceStrategy persistenceStrategy, PersistedSessionOption.SafepointStrategy safepointStrategy) {
         createSession(BASIC_RULE, persistenceStrategy, safepointStrategy);
 
@@ -149,7 +149,7 @@ class ReliabilityTest extends ReliabilityTestBasics {
     }
 
     @ParameterizedTest
-    @MethodSource("strategyProviderStoresOnlyWithSafepoints") // FULL fails with "ReliablePropagationList; no valid constructor"
+    @MethodSource("strategyProviderStoresOnlyWithExplicitSafepoints") // FULL fails with "ReliablePropagationList; no valid constructor"
     void updateBeforeFailover_shouldRecoverFromFailover(PersistedSessionOption.PersistenceStrategy persistenceStrategy, PersistedSessionOption.SafepointStrategy safepointStrategy) {
 
         createSession(BASIC_RULE, persistenceStrategy, safepointStrategy);
@@ -183,7 +183,7 @@ class ReliabilityTest extends ReliabilityTestBasics {
     }
 
     @ParameterizedTest
-    @MethodSource("strategyProviderStoresOnlyWithSafepoints") // FULL fails with "ReliablePropagationList; no valid constructor"
+    @MethodSource("strategyProviderStoresOnlyWithExplicitSafepoints") // FULL fails with "ReliablePropagationList; no valid constructor"
     void deleteBeforeFailover_shouldRecoverFromFailover(PersistedSessionOption.PersistenceStrategy persistenceStrategy, PersistedSessionOption.SafepointStrategy safepointStrategy) {
 
         createSession(BASIC_RULE, persistenceStrategy, safepointStrategy);
@@ -216,7 +216,7 @@ class ReliabilityTest extends ReliabilityTestBasics {
     }
 
     @ParameterizedTest
-    @MethodSource("strategyProviderStoresOnlyWithSafepoints")
+    @MethodSource("strategyProviderStoresOnlyWithExplicitSafepoints")
     void updateByObjectBeforeFailover_shouldMatchUpdatedFact(PersistedSessionOption.PersistenceStrategy persistenceStrategy, PersistedSessionOption.SafepointStrategy safepointStrategy){
 
         createSession(BASIC_RULE, persistenceStrategy, safepointStrategy);

--- a/drools-reliability/drools-reliability-infinispan/src/test/java/org/drools/reliability/infinispan/ReliabilityTest.java
+++ b/drools-reliability/drools-reliability-infinispan/src/test/java/org/drools/reliability/infinispan/ReliabilityTest.java
@@ -15,6 +15,7 @@
 
 package org.drools.reliability.infinispan;
 
+import org.drools.reliability.core.ReliableKieSession;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.params.ParameterizedTest;
@@ -54,9 +55,9 @@ class ReliabilityTest extends ReliabilityTestBasics {
     }
 
     @ParameterizedTest
-    @MethodSource("strategyProviderStoresOnly") // FULL fails with "ReliablePropagationList; no valid constructor"
-    void insertFailoverInsertFire_shouldRecoverFromFailover(PersistedSessionOption.Strategy strategy) {
-        createSession(BASIC_RULE, strategy);
+    @MethodSource("strategyProviderStoresOnlyWithSafepoints") // FULL fails with "ReliablePropagationList; no valid constructor"
+    void insertFailoverInsertFire_shouldRecoverFromFailover(PersistedSessionOption.PersistenceStrategy persistenceStrategy, PersistedSessionOption.SafepointStrategy safepointStrategy) {
+        createSession(BASIC_RULE, persistenceStrategy, safepointStrategy);
 
 		insertString("M");
 		insertMatchingPerson("Matching Person One", 37);
@@ -65,7 +66,7 @@ class ReliabilityTest extends ReliabilityTestBasics {
         //-- ksession and kbase are lost. CacheManager is recreated. Client knows only "id"
         failover();
 
-        restoreSession(BASIC_RULE, strategy);
+        restoreSession(BASIC_RULE, persistenceStrategy, safepointStrategy);
 
 		insertNonMatchingPerson("Toshiya", 35);
         insertMatchingPerson("Matching Person Two", 40);
@@ -77,15 +78,18 @@ class ReliabilityTest extends ReliabilityTestBasics {
 
 
     @ParameterizedTest
-    @MethodSource("strategyProviderStoresOnly") // With Remote, FULL fails with "ReliablePropagationList; no valid constructor" even without failover
-    void noFailover(PersistedSessionOption.Strategy strategy) {
+    @MethodSource("strategyProviderStoresOnlyWithSafepoints") // With Remote, FULL fails with "ReliablePropagationList; no valid constructor" even without failover
+    void noFailover(PersistedSessionOption.PersistenceStrategy persistenceStrategy, PersistedSessionOption.SafepointStrategy safepointStrategy) {
 
-        createSession(BASIC_RULE, strategy);
+        createSession(BASIC_RULE, persistenceStrategy, safepointStrategy);
 
 		insertString("M");
 		insertMatchingPerson("Matching Person One", 37);
 
-        restoreSession(BASIC_RULE, strategy);
+        if (safepointStrategy == PersistedSessionOption.SafepointStrategy.EXPLICIT) {
+            ((ReliableKieSession) session).safepoint();
+        }
+        restoreSession(BASIC_RULE, persistenceStrategy, safepointStrategy);
 
 		insertNonMatchingPerson("Toshiya", 41);
 		insertMatchingPerson("Matching Person Two", 40);
@@ -97,10 +101,10 @@ class ReliabilityTest extends ReliabilityTestBasics {
 
 
     @ParameterizedTest
-    @MethodSource("strategyProviderStoresOnly") // FULL fails with "ReliablePropagationList; no valid constructor"
-    void insertFireInsertFailoverInsertFire_shouldMatchFactInsertedBeforeFailover(PersistedSessionOption.Strategy strategy) {
+    @MethodSource("strategyProviderStoresOnlyWithSafepoints") // FULL fails with "ReliablePropagationList; no valid constructor"
+    void insertFireInsertFailoverInsertFire_shouldMatchFactInsertedBeforeFailover(PersistedSessionOption.PersistenceStrategy persistenceStrategy, PersistedSessionOption.SafepointStrategy safepointStrategy) {
 
-        createSession(BASIC_RULE, strategy);
+        createSession(BASIC_RULE, persistenceStrategy, safepointStrategy);
 
 		insertString("M");
 		insertMatchingPerson("Matching Person One", 37);
@@ -111,7 +115,7 @@ class ReliabilityTest extends ReliabilityTestBasics {
 
         failover();
 
-        restoreSession(BASIC_RULE, strategy);
+        restoreSession(BASIC_RULE, persistenceStrategy, safepointStrategy);
         clearResults();
 
         insertNonMatchingPerson("Toshiya", 35);
@@ -123,9 +127,9 @@ class ReliabilityTest extends ReliabilityTestBasics {
     }
 
     @ParameterizedTest
-    @MethodSource("strategyProviderStoresOnly") // FULL fails with "ReliablePropagationList; no valid constructor"
-    void insertFireFailoverInsertFire_shouldNotRepeatFiredMatch(PersistedSessionOption.Strategy strategy) {
-        createSession(BASIC_RULE, strategy);
+    @MethodSource("strategyProviderStoresOnlyWithSafepoints") // FULL fails with "ReliablePropagationList; no valid constructor"
+    void insertFireFailoverInsertFire_shouldNotRepeatFiredMatch(PersistedSessionOption.PersistenceStrategy persistenceStrategy, PersistedSessionOption.SafepointStrategy safepointStrategy) {
+        createSession(BASIC_RULE, persistenceStrategy, safepointStrategy);
 
 		insertString("M");
 		insertMatchingPerson("Matching Person One", 37);
@@ -134,7 +138,7 @@ class ReliabilityTest extends ReliabilityTestBasics {
 
         failover();
 
-        restoreSession(BASIC_RULE, strategy);
+        restoreSession(BASIC_RULE, persistenceStrategy, safepointStrategy);
 
         insertNonMatchingPerson("Toshiya", 35);
 		insertMatchingPerson("Matching Person Two", 40);
@@ -145,10 +149,10 @@ class ReliabilityTest extends ReliabilityTestBasics {
     }
 
     @ParameterizedTest
-    @MethodSource("strategyProviderStoresOnly") // FULL fails with "ReliablePropagationList; no valid constructor"
-    void updateBeforeFailover_shouldRecoverFromFailover(PersistedSessionOption.Strategy strategy) {
+    @MethodSource("strategyProviderStoresOnlyWithSafepoints") // FULL fails with "ReliablePropagationList; no valid constructor"
+    void updateBeforeFailover_shouldRecoverFromFailover(PersistedSessionOption.PersistenceStrategy persistenceStrategy, PersistedSessionOption.SafepointStrategy safepointStrategy) {
 
-        createSession(BASIC_RULE, strategy);
+        createSession(BASIC_RULE, persistenceStrategy, safepointStrategy);
 
         insertString("M");
         Person p1 = new Person("Mario", 49);
@@ -165,13 +169,13 @@ class ReliabilityTest extends ReliabilityTestBasics {
         session.update(fh2, p2);
 
         failover();
-        restoreSession(BASIC_RULE, strategy);
+        restoreSession(BASIC_RULE, persistenceStrategy, safepointStrategy);
 
         assertThat(session.fireAllRules()).isEqualTo(1);
         assertThat(getResults()).containsExactlyInAnyOrder("Mario", "MegaToshiya");
 
         failover();
-        restoreSession(BASIC_RULE, strategy);
+        restoreSession(BASIC_RULE, persistenceStrategy, safepointStrategy);
         clearResults();
 
         assertThat(session.fireAllRules()).isEqualTo(0);
@@ -179,10 +183,10 @@ class ReliabilityTest extends ReliabilityTestBasics {
     }
 
     @ParameterizedTest
-    @MethodSource("strategyProviderStoresOnly") // FULL fails with "ReliablePropagationList; no valid constructor"
-    void deleteBeforeFailover_shouldRecoverFromFailover(PersistedSessionOption.Strategy strategy) {
+    @MethodSource("strategyProviderStoresOnlyWithSafepoints") // FULL fails with "ReliablePropagationList; no valid constructor"
+    void deleteBeforeFailover_shouldRecoverFromFailover(PersistedSessionOption.PersistenceStrategy persistenceStrategy, PersistedSessionOption.SafepointStrategy safepointStrategy) {
 
-        createSession(BASIC_RULE, strategy);
+        createSession(BASIC_RULE, persistenceStrategy, safepointStrategy);
 
         FactHandle fhString = insertString("M");
         insertMatchingPerson("Matching Person One",37);
@@ -194,7 +198,7 @@ class ReliabilityTest extends ReliabilityTestBasics {
         session.delete(fhString);
 
         failover();
-        restoreSession(BASIC_RULE, strategy);
+        restoreSession(BASIC_RULE, persistenceStrategy, safepointStrategy);
         clearResults();
 
         insertMatchingPerson("Matching Person Two",40);
@@ -205,17 +209,17 @@ class ReliabilityTest extends ReliabilityTestBasics {
         insertString("T");
 
         failover();
-        restoreSession(BASIC_RULE, strategy);
+        restoreSession(BASIC_RULE, persistenceStrategy, safepointStrategy);
 
         assertThat(session.fireAllRules()).isEqualTo(1);
         assertThat(getResults()).containsExactlyInAnyOrder("Toshiya");
     }
 
     @ParameterizedTest
-    @MethodSource("strategyProviderStoresOnly")
-    void updateByObjectBeforeFailover_shouldMatchUpdatedFact(PersistedSessionOption.Strategy strategy){
+    @MethodSource("strategyProviderStoresOnlyWithSafepoints")
+    void updateByObjectBeforeFailover_shouldMatchUpdatedFact(PersistedSessionOption.PersistenceStrategy persistenceStrategy, PersistedSessionOption.SafepointStrategy safepointStrategy){
 
-        createSession(BASIC_RULE, strategy);
+        createSession(BASIC_RULE, persistenceStrategy, safepointStrategy);
 
         insertString("M");
         insertMatchingPerson("Mark", 37);
@@ -227,7 +231,7 @@ class ReliabilityTest extends ReliabilityTestBasics {
 
         failover();
 
-        restoreSession(BASIC_RULE, strategy);
+        restoreSession(BASIC_RULE, persistenceStrategy, safepointStrategy);
 
         assertThat(session.fireAllRules()).isEqualTo(1);
 

--- a/drools-reliability/drools-reliability-infinispan/src/test/java/org/drools/reliability/infinispan/ReliabilityTestBasics.java
+++ b/drools-reliability/drools-reliability-infinispan/src/test/java/org/drools/reliability/infinispan/ReliabilityTestBasics.java
@@ -68,10 +68,18 @@ public abstract class ReliabilityTestBasics {
         return Stream.of(arguments(PersistedSessionOption.PersistenceStrategy.STORES_ONLY));
     }
 
-    static Stream<Arguments> strategyProviderStoresOnlyWithSafepoints() {
+    static Stream<Arguments> strategyProviderStoresOnlyWithExplicitSafepoints() {
         return Stream.of(
                 arguments(PersistedSessionOption.PersistenceStrategy.STORES_ONLY, PersistedSessionOption.SafepointStrategy.ALWAYS),
                 arguments(PersistedSessionOption.PersistenceStrategy.STORES_ONLY, PersistedSessionOption.SafepointStrategy.EXPLICIT)
+        );
+    }
+
+    static Stream<Arguments> strategyProviderStoresOnlyWithAllSafepoints() {
+        return Stream.of(
+                arguments(PersistedSessionOption.PersistenceStrategy.STORES_ONLY, PersistedSessionOption.SafepointStrategy.ALWAYS),
+                arguments(PersistedSessionOption.PersistenceStrategy.STORES_ONLY, PersistedSessionOption.SafepointStrategy.EXPLICIT),
+                arguments(PersistedSessionOption.PersistenceStrategy.STORES_ONLY, PersistedSessionOption.SafepointStrategy.AFTER_FIRE)
         );
     }
 

--- a/drools-reliability/drools-reliability-infinispan/src/test/java/org/drools/reliability/infinispan/ReliabilityTestUpdateInDrl.java
+++ b/drools-reliability/drools-reliability-infinispan/src/test/java/org/drools/reliability/infinispan/ReliabilityTestUpdateInDrl.java
@@ -45,7 +45,7 @@ public class ReliabilityTestUpdateInDrl extends ReliabilityTestBasics {
 
     @ParameterizedTest
     @MethodSource("strategyProviderStoresOnly")
-    void updateInRHS_insertFireFailoverFire_shouldMatchUpdatesFromFirstSession(PersistedSessionOption.Strategy strategy){
+    void updateInRHS_insertFireFailoverFire_shouldMatchUpdatesFromFirstSession(PersistedSessionOption.PersistenceStrategy strategy){
 
         createSession(RULE_UPDATE, strategy);
 

--- a/drools-reliability/drools-reliability-infinispan/src/test/java/org/drools/reliability/infinispan/example/RemoteCacheManagerExample.java
+++ b/drools-reliability/drools-reliability-infinispan/src/test/java/org/drools/reliability/infinispan/example/RemoteCacheManagerExample.java
@@ -54,7 +54,7 @@ public class RemoteCacheManagerExample {
                     "end";
 
     public static void main(String[] args) {
-        KieSession session = getKieSession(PersistedSessionOption.newSession(PersistedSessionOption.Strategy.STORES_ONLY));
+        KieSession session = getKieSession(PersistedSessionOption.newSession().withPersistenceStrategy(PersistedSessionOption.PersistenceStrategy.STORES_ONLY));
 
         long savedSessionId = session.getIdentifier();
         System.out.println("savedSessionId = " + savedSessionId);

--- a/drools-reliability/drools-reliability-infinispan/src/test/java/org/drools/reliability/infinispan/example/RemoteCacheManagerExampleAfterFailOver.java
+++ b/drools-reliability/drools-reliability-infinispan/src/test/java/org/drools/reliability/infinispan/example/RemoteCacheManagerExampleAfterFailOver.java
@@ -27,7 +27,7 @@ public class RemoteCacheManagerExampleAfterFailOver {
 
     public static void main(String[] args) {
         // Here we use the savedSessionId to retrieve the session. Explicitly 0 for now, but it could be different.
-        KieSession session = RemoteCacheManagerExample.getKieSession(PersistedSessionOption.fromSession(0, PersistedSessionOption.Strategy.STORES_ONLY));
+        KieSession session = RemoteCacheManagerExample.getKieSession(PersistedSessionOption.fromSession(0).withPersistenceStrategy(PersistedSessionOption.PersistenceStrategy.STORES_ONLY));
 
         try {
             System.out.println("fireAllRules");

--- a/kie-api/src/main/java/org/kie/api/runtime/conf/PersistedSessionOption.java
+++ b/kie-api/src/main/java/org/kie/api/runtime/conf/PersistedSessionOption.java
@@ -29,7 +29,7 @@ public class PersistedSessionOption implements SingleValueKieSessionOption {
     }
 
     public enum SafepointStrategy {
-        ALWAYS, ON_FIRING, EXPLICIT;
+        ALWAYS, AFTER_FIRE, EXPLICIT;
 
         public boolean useSafepoints() {
             return this != ALWAYS;

--- a/kie-api/src/main/java/org/kie/api/runtime/conf/PersistedSessionOption.java
+++ b/kie-api/src/main/java/org/kie/api/runtime/conf/PersistedSessionOption.java
@@ -24,8 +24,16 @@ import java.util.Objects;
  */
 public class PersistedSessionOption implements SingleValueKieSessionOption {
 
-    public enum Strategy {
+    public enum PersistenceStrategy {
         FULL, STORES_ONLY
+    }
+
+    public enum SafepointStrategy {
+        ALWAYS, ON_FIRING, EXPLICIT;
+
+        public boolean useSafepoints() {
+            return this != ALWAYS;
+        }
     }
 
     /**
@@ -35,39 +43,24 @@ public class PersistedSessionOption implements SingleValueKieSessionOption {
 
     private final long sessionId;
 
-    private final Strategy strategy;
+    private PersistenceStrategy persistenceStrategy = PersistenceStrategy.FULL;
+
+    private SafepointStrategy safepointStrategy = SafepointStrategy.ALWAYS;
 
     private PersistedSessionOption() {
         this(-1L);
     }
 
     private PersistedSessionOption(long sessionId) {
-        this(sessionId, Strategy.FULL);
-    }
-
-    private PersistedSessionOption(Strategy strategy) {
-        this(-1, strategy);
-    }
-
-    private PersistedSessionOption(long sessionId, Strategy strategy) {
         this.sessionId = sessionId;
-        this.strategy = strategy;
     }
 
     public static PersistedSessionOption newSession() {
         return new PersistedSessionOption();
     }
 
-    public static PersistedSessionOption newSession(Strategy strategy) {
-        return new PersistedSessionOption(strategy);
-    }
-
     public static PersistedSessionOption fromSession(long sessionId) {
         return new PersistedSessionOption(sessionId);
-    }
-
-    public static PersistedSessionOption fromSession(long sessionId, Strategy strategy) {
-        return new PersistedSessionOption(sessionId, strategy);
     }
 
     /**
@@ -81,8 +74,22 @@ public class PersistedSessionOption implements SingleValueKieSessionOption {
         return sessionId;
     }
 
-    public Strategy getStrategy() {
-        return strategy;
+    public PersistenceStrategy getPersistenceStrategy() {
+        return persistenceStrategy;
+    }
+
+    public PersistedSessionOption withPersistenceStrategy(PersistenceStrategy persistenceStrategy) {
+        this.persistenceStrategy = persistenceStrategy;
+        return this;
+    }
+
+    public SafepointStrategy getSafepointStrategy() {
+        return safepointStrategy;
+    }
+
+    public PersistedSessionOption withSafepointStrategy(SafepointStrategy safepointStrategy) {
+        this.safepointStrategy = safepointStrategy;
+        return this;
     }
 
     public boolean isNewSession() {


### PR DESCRIPTION
**JIRA**: https://issues.redhat.com/browse/DROOLS-7412

I introduced the possibility of optionally having explicit safepoints when using the reliable session. The state of a stateful session is guaranteed to be consistently persisted only at a safepoint. In other words on a failover everything that happened after the latest safepoint is lost. In fact relaxing the constraint of consistency after each and every invocation of the session allows to reduce the interaction with the cache, thus improving performances. 

At the moment there are 3 different safepoints strategies:

1. `ALWAYS` (default): this is the original implementation guaranteeing the session's reliability after each and every operation.
2. `ON_FIRING`: automatically performs a safepoint only immediately after a firing.
3. `EXPLICIT`: safepoints need to be executed explicitly and programmatically through the new `ReliableKieSession` interface. This should also allow to plug different persistency mechanism requiring to explicitly take snapshots of the session at specific points in time.

I modified one of our benchmarks to compare performances of strategies 1. and 2. obtaining the following results:

```
Benchmark                    (factsNr)  (joinsNr)       (mode)  (rulesNr)  (useSafepoints)  Mode   Cnt   Score   Error  Units
InsertAndFireBenchmark.test        100          1         NONE        192             true    ss  1000   4.955 ± 0.099  ms/op
InsertAndFireBenchmark.test        100          1         NONE        192            false    ss  1000   4.968 ± 0.101  ms/op
InsertAndFireBenchmark.test        100          1     EMBEDDED        192             true    ss  1000   7.467 ± 0.147  ms/op
InsertAndFireBenchmark.test        100          1     EMBEDDED        192            false    ss  1000  13.679 ± 0.221  ms/op
InsertAndFireBenchmark.test        100          1       REMOTE        192             true    ss  1000   6.934 ± 0.180  ms/op
InsertAndFireBenchmark.test        100          1       REMOTE        192            false    ss  1000  23.595 ± 0.428  ms/op
InsertAndFireBenchmark.test        100          1  REMOTEPROTO        192             true    ss  1000   7.721 ± 0.205  ms/op
InsertAndFireBenchmark.test        100          1  REMOTEPROTO        192            false    ss  1000  22.783 ± 0.379  ms/op
```