### PR TITLE
Drools 7383 lambda consequence

### DIFF
--- a/drools-core/src/main/java/org/drools/core/phreak/PropagationEntry.java
+++ b/drools-core/src/main/java/org/drools/core/phreak/PropagationEntry.java
@@ -15,9 +15,6 @@
 
 package org.drools.core.phreak;
 
-import java.io.Serializable;
-import java.util.concurrent.CountDownLatch;
-
 import org.drools.core.base.DroolsQuery;
 import org.drools.core.common.EventFactHandle;
 import org.drools.core.common.InternalFactHandle;
@@ -40,6 +37,12 @@ import org.drools.core.reteoo.TerminalNode;
 import org.drools.core.time.JobContext;
 import org.drools.core.time.JobHandle;
 import org.drools.core.time.impl.PointInTimeTrigger;
+
+import java.io.Externalizable;
+import java.io.IOException;
+import java.io.ObjectInput;
+import java.io.ObjectOutput;
+import java.util.concurrent.CountDownLatch;
 
 import static org.drools.core.reteoo.EntryPointNode.removeRightTuplesMatchingOTN;
 import static org.drools.core.rule.TypeDeclaration.NEVER_EXPIRES;
@@ -66,7 +69,7 @@ public interface PropagationEntry {
     boolean defersExpiration();
 
     abstract class AbstractPropagationEntry implements PropagationEntry {
-        private PropagationEntry next;
+        protected PropagationEntry next;
 
         public void setNext(PropagationEntry next) {
             this.next = next;
@@ -196,12 +199,14 @@ public interface PropagationEntry {
         }
     }
 
-    class Insert extends AbstractPropagationEntry implements Serializable {
+    class Insert extends AbstractPropagationEntry implements Externalizable {
         private static final ObjectTypeNode.ExpireJob job = new ObjectTypeNode.ExpireJob();
 
-        private final InternalFactHandle handle;
-        private final PropagationContext context;
-        private final ObjectTypeConf objectTypeConf;
+        private InternalFactHandle handle;
+        private PropagationContext context;
+        private ObjectTypeConf objectTypeConf;
+
+        public Insert() { }
 
         public Insert( InternalFactHandle handle, PropagationContext context, ReteEvaluator reteEvaluator, ObjectTypeConf objectTypeConf) {
             this.handle = handle;
@@ -284,6 +289,22 @@ public interface PropagationEntry {
 
         public InternalFactHandle getHandle() {
             return handle;
+        }
+
+        @Override
+        public void writeExternal(ObjectOutput out) throws IOException {
+            out.writeObject(next);
+            out.writeObject(handle);
+            out.writeObject(context);
+            out.writeObject(objectTypeConf);
+        }
+
+        @Override
+        public void readExternal(ObjectInput in) throws IOException, ClassNotFoundException {
+            this.next = (PropagationEntry) in.readObject();
+            this.handle = (InternalFactHandle) in.readObject();
+            this.context = (PropagationContext) in.readObject();
+            this.objectTypeConf = (ObjectTypeConf) in.readObject();
         }
     }
 

--- a/drools-core/src/main/java/org/drools/core/phreak/SynchronizedPropagationList.java
+++ b/drools-core/src/main/java/org/drools/core/phreak/SynchronizedPropagationList.java
@@ -15,29 +15,33 @@
 
 package org.drools.core.phreak;
 
-import java.util.Iterator;
-
 import org.drools.core.common.ReteEvaluator;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+
+import java.util.Iterator;
 
 public class SynchronizedPropagationList implements PropagationList {
 
     protected static final Logger log = LoggerFactory.getLogger( SynchronizedPropagationList.class );
 
-    protected final ReteEvaluator reteEvaluator;
+    protected ReteEvaluator reteEvaluator;
 
     protected volatile PropagationEntry head;
     protected volatile PropagationEntry tail;
 
-    private volatile boolean disposed = false;
+    protected volatile boolean disposed = false;
 
-    private volatile boolean hasEntriesDeferringExpiration = false;
+    protected volatile boolean hasEntriesDeferringExpiration = false;
 
-    private volatile boolean firingUntilHalt = false;
+    protected volatile boolean firingUntilHalt = false;
 
     public SynchronizedPropagationList(ReteEvaluator reteEvaluator) {
         this.reteEvaluator = reteEvaluator;
+    }
+
+    public SynchronizedPropagationList(){
+        //this.reteEvaluator=null;
     }
 
     @Override

--- a/drools-model/drools-model-compiler/src/main/java/org/drools/modelcompiler/consequence/LambdaConsequence.java
+++ b/drools-model/drools-model-compiler/src/main/java/org/drools/modelcompiler/consequence/LambdaConsequence.java
@@ -16,22 +16,26 @@
 
 package org.drools.modelcompiler.consequence;
 
-import java.util.ArrayList;
-import java.util.Collections;
-import java.util.List;
-
 import org.drools.core.common.EventFactHandle;
 import org.drools.core.common.InternalFactHandle;
 import org.drools.core.common.ReteEvaluator;
 import org.drools.core.definitions.rule.impl.RuleImpl;
 import org.drools.core.reteoo.RuleTerminalNode;
+import org.drools.core.reteoo.Tuple;
 import org.drools.core.rule.Declaration;
 import org.drools.core.rule.consequence.Consequence;
 import org.drools.core.rule.consequence.KnowledgeHelper;
-import org.drools.core.reteoo.Tuple;
 import org.drools.model.Variable;
 
-public class LambdaConsequence implements Consequence {
+import java.io.Externalizable;
+import java.io.IOException;
+import java.io.ObjectInput;
+import java.io.ObjectOutput;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
+public class LambdaConsequence implements Consequence, Externalizable {
 
     // Enable the optimization to extract from the activation tuple the arguments to be passed to this
     // consequence in linear time by traversing the tuple only once.
@@ -46,6 +50,11 @@ public class LambdaConsequence implements Consequence {
     private Object[]            facts;
 
     private FactHandleLookup    fhLookup;
+
+    public LambdaConsequence(){
+        this.consequence = null;
+        this.enabledTupleOptimization=false;
+    }
 
     public LambdaConsequence( org.drools.model.Consequence consequence, boolean enabledTupleOptimization) {
         this.consequence = consequence;
@@ -219,6 +228,22 @@ public class LambdaConsequence implements Consequence {
             this.fhLookup = fhLookup;
         }
         return facts;
+    }
+
+    @Override
+    public void writeExternal(ObjectOutput out) throws IOException {
+        out.writeObject(requiredDeclarations);
+        out.writeObject(factSuppliers);
+        out.writeObject(globalSuppliers);
+        out.writeObject(facts);
+    }
+
+    @Override
+    public void readExternal(ObjectInput in) throws IOException, ClassNotFoundException {
+        this.requiredDeclarations = (Declaration[] ) in.readObject();
+        this.factSuppliers = (TupleFactSupplier[]) in.readObject();
+        this.globalSuppliers = (GlobalSupplier[]) in.readObject();
+        this.facts = (Object[]) in.readObject();
     }
 
     private static class GlobalSupplier implements Comparable<GlobalSupplier> {

--- a/drools-model/drools-model-compiler/src/main/java/org/drools/modelcompiler/constraints/LambdaConstraint.java
+++ b/drools-model/drools-model-compiler/src/main/java/org/drools/modelcompiler/constraints/LambdaConstraint.java
@@ -17,23 +17,17 @@
 
 package org.drools.modelcompiler.constraints;
 
-import java.io.IOException;
-import java.io.ObjectInput;
-import java.io.ObjectOutput;
-import java.util.List;
-
-import org.drools.core.RuleBaseConfiguration;
+import org.drools.core.base.ObjectType;
 import org.drools.core.base.ValueType;
 import org.drools.core.base.field.ObjectFieldImpl;
 import org.drools.core.common.InternalFactHandle;
 import org.drools.core.common.ReteEvaluator;
 import org.drools.core.reteoo.PropertySpecificUtil;
+import org.drools.core.reteoo.Tuple;
 import org.drools.core.rule.ContextEntry;
 import org.drools.core.rule.Declaration;
 import org.drools.core.rule.accessor.FieldValue;
 import org.drools.core.rule.accessor.ReadAccessor;
-import org.drools.core.base.ObjectType;
-import org.drools.core.reteoo.Tuple;
 import org.drools.core.rule.accessor.TupleValueExtractor;
 import org.drools.core.time.Interval;
 import org.drools.core.util.AbstractHashTable.FieldIndex;
@@ -53,6 +47,11 @@ import org.drools.model.functions.Function4;
 import org.drools.model.functions.PredicateInformation;
 import org.kie.api.KieBaseConfiguration;
 
+import java.io.IOException;
+import java.io.ObjectInput;
+import java.io.ObjectOutput;
+import java.util.List;
+
 import static org.drools.core.base.ValueType.determineValueType;
 import static org.drools.core.reteoo.PropertySpecificUtil.getEmptyPropertyReactiveMask;
 import static org.drools.modelcompiler.util.EvaluationUtil.adaptBitMask;
@@ -65,6 +64,11 @@ public class LambdaConstraint extends AbstractConstraint {
     private FieldValue field;
     private ReadAccessor readAccessor;
     private AbstractIndexValueExtractor indexExtractor;
+
+    public LambdaConstraint(){
+        this.evaluator=null;
+        this.predicateInformation=null;
+    }
 
     public LambdaConstraint(ConstraintEvaluator evaluator,
                             PredicateInformation predicateInformation) {

--- a/drools-reliability/drools-reliability-core/src/main/java/org/drools/reliability/core/FullReliableObjectStore.java
+++ b/drools-reliability/drools-reliability-core/src/main/java/org/drools/reliability/core/FullReliableObjectStore.java
@@ -15,13 +15,71 @@
 
 package org.drools.reliability.core;
 
+import org.drools.core.common.IdentityObjectStore;
 import org.drools.core.common.InternalFactHandle;
-import org.drools.core.common.MapObjectStore;
+import org.drools.core.common.InternalWorkingMemory;
+import org.drools.core.common.InternalWorkingMemoryEntryPoint;
 import org.drools.core.common.Storage;
+import org.drools.kiesession.agenda.DefaultAgenda;
 
-public class FullReliableObjectStore extends MapObjectStore {
+import java.util.ArrayList;
+import java.util.List;
 
-    public FullReliableObjectStore(Storage<Object, InternalFactHandle> fhStorage) {
-        super(fhStorage);
+public class FullReliableObjectStore extends IdentityObjectStore {
+
+    private final Storage<Long, StoredObject> storage;
+
+    public FullReliableObjectStore(Storage<Long, StoredObject> storage) {
+        super();
+        this.storage = storage;
+    }
+
+    @Override
+    public void addHandle(InternalFactHandle handle, Object object) {
+        super.addHandle(handle, object);
+        putIntoPersistedCache(handle, handle.hasMatches());
+    }
+
+    @Override
+    public void removeHandle(InternalFactHandle handle) {
+        removeFromPersistedCache(handle.getObject());
+        super.removeHandle(handle);
+    }
+
+
+    List<StoredObject> reInit(InternalWorkingMemory session, InternalWorkingMemoryEntryPoint ep) {
+        List<StoredObject> propagated = new ArrayList<>();
+        List<StoredObject> notPropagated = new ArrayList<>();
+        ReliablePropagationList reliablePropagationList = (ReliablePropagationList) ((DefaultAgenda) session.getAgenda()).getPropagationList();
+
+        for (StoredObject entry : storage.values()) {
+            if (!reliablePropagationList.entryInTheList(entry)) { // entry.isPropagated()
+                propagated.add(entry);
+            } else {
+                notPropagated.add(entry);
+            }
+        }
+        storage.clear();
+
+        // fact handles with a match have been already propagated in the original session, so they shouldn't fire
+        propagated.forEach(obj -> obj.repropagate(ep));
+        session.fireAllRules(match -> false);
+
+        // fact handles without any match have never been propagated in the original session, so they should fire
+        return notPropagated;
+    }
+
+    void putIntoPersistedCache(InternalFactHandle handle, boolean propagated) {
+        Object object = handle.getObject();
+        boolean reInitPropagated = false; // temp
+        StoredObject storedObject = new StoredObject(object, propagated);
+        storage.put(getHandleForObject(object).getId(), storedObject);
+    }
+
+    void removeFromPersistedCache(Object object) {
+        InternalFactHandle fh = getHandleForObject(object);
+        if (fh != null) {
+            storage.remove(fh.getId());
+        }
     }
 }

--- a/drools-reliability/drools-reliability-core/src/main/java/org/drools/reliability/core/ReliableAgenda.java
+++ b/drools-reliability/drools-reliability-core/src/main/java/org/drools/reliability/core/ReliableAgenda.java
@@ -46,7 +46,8 @@ public class ReliableAgenda extends DefaultAgenda {
             propagationList = new ReliablePropagationList(workingMemory);
             componentsStorage.put("PropagationList", propagationList);
         } else {
-            propagationList = new ReliablePropagationList(workingMemory, propagationList);
+            //propagationList = new ReliablePropagationList(workingMemory, propagationList);
+            propagationList.setReteEvaluator(workingMemory);
         }
         return propagationList;
     }

--- a/drools-reliability/drools-reliability-core/src/main/java/org/drools/reliability/core/ReliablePropagationList.java
+++ b/drools-reliability/drools-reliability-core/src/main/java/org/drools/reliability/core/ReliablePropagationList.java
@@ -15,20 +15,65 @@
 
 package org.drools.reliability.core;
 
+import org.drools.core.common.InternalFactHandle;
 import org.drools.core.common.ReteEvaluator;
+import org.drools.core.phreak.PropagationEntry;
 import org.drools.core.phreak.SynchronizedPropagationList;
 
-import java.io.Serializable;
+import java.io.Externalizable;
+import java.io.IOException;
+import java.io.ObjectInput;
+import java.io.ObjectOutput;
 
-public class ReliablePropagationList extends SynchronizedPropagationList implements Serializable {
+public class ReliablePropagationList extends SynchronizedPropagationList implements Externalizable {
 
     public ReliablePropagationList(ReteEvaluator reteEvaluator) {
         super(reteEvaluator);
     }
 
+    public ReliablePropagationList(){super();}
+
+    public void setReteEvaluator(ReteEvaluator reteEvaluator){this.reteEvaluator=reteEvaluator;}
+
     public ReliablePropagationList(ReteEvaluator reteEvaluator, ReliablePropagationList originalList) {
         super(reteEvaluator);
         this.head = originalList.head;
         this.tail = originalList.tail;
+    }
+
+    public boolean entryInTheList(Object entry){
+
+        boolean inTheList=false;
+
+        PropagationEntry current = this.head;
+
+        while (current!=null && !inTheList){
+            if (current instanceof  PropagationEntry.Insert){
+                InternalFactHandle fh = ((PropagationEntry.Insert) current).getHandle();
+                inTheList = fh.getObject().equals(entry);
+            }else if (entry instanceof PropagationEntry.Update){
+
+            }
+            current = current.getNext();
+        }
+
+        return inTheList;
+    }
+
+    @Override
+    public void writeExternal(ObjectOutput out) throws IOException {
+        out.writeObject(head);
+        out.writeObject(tail);
+        out.writeBoolean(disposed);
+        out.writeBoolean(hasEntriesDeferringExpiration);
+        out.writeBoolean(firingUntilHalt);
+   }
+    @Override
+    public void readExternal(ObjectInput in) throws IOException, ClassNotFoundException {
+        this.head = (PropagationEntry) in.readObject();
+        this.tail = (PropagationEntry) in.readObject();
+        this.disposed = in.readBoolean();
+        this.hasEntriesDeferringExpiration = in.readBoolean();
+        this.firingUntilHalt = in.readBoolean();
     }
 }

--- a/drools-reliability/drools-reliability-core/src/main/java/org/drools/reliability/core/ReliableSessionInitializer.java
+++ b/drools-reliability/drools-reliability-core/src/main/java/org/drools/reliability/core/ReliableSessionInitializer.java
@@ -20,6 +20,7 @@ import org.drools.core.WorkingMemoryEntryPoint;
 import org.drools.core.common.InternalFactHandle;
 import org.drools.core.common.InternalWorkingMemory;
 import org.drools.core.common.InternalWorkingMemoryEntryPoint;
+import org.drools.core.common.Storage;
 import org.drools.core.phreak.PropagationEntry;
 import org.kie.api.event.rule.ObjectDeletedEvent;
 import org.kie.api.event.rule.ObjectInsertedEvent;
@@ -107,7 +108,32 @@ public class ReliableSessionInitializer {
 
         @Override
         public InternalWorkingMemory init(InternalWorkingMemory session, PersistedSessionOption persistedSessionOption) {
+
+            //session.setWorkingMemoryActionListener(entry -> onWorkingMemoryAction(session, entry));
+            session.getRuleRuntimeEventSupport().addEventListener(new FullReliableSessionInitializer.FullStoreRuntimeEventListener(session));
             return session;
+        }
+        static class FullStoreRuntimeEventListener implements RuleRuntimeEventListener {
+
+            private final Storage<Object, Object> componentsCache;
+            private final ReliablePropagationList propagationList;
+
+            FullStoreRuntimeEventListener(InternalWorkingMemory session) {
+                this.componentsCache = StorageManagerFactory.get().getStorageManager().getOrCreateStorageForSession(session, "components");
+                this.propagationList = (ReliablePropagationList) ((ReliableAgenda) session.getAgenda()).getPropagationList();
+            }
+
+            public void objectInserted(ObjectInsertedEvent ev) {
+                componentsCache.put("PropagationList", propagationList);
+            }
+
+            public void objectDeleted(ObjectDeletedEvent ev) {
+                componentsCache.put("PropagationList", propagationList);
+            }
+
+            public void objectUpdated(ObjectUpdatedEvent ev) {
+                componentsCache.put("PropagationList", propagationList);
+            }
         }
     }
 }

--- a/drools-reliability/drools-reliability-infinispan/pom.xml
+++ b/drools-reliability/drools-reliability-infinispan/pom.xml
@@ -47,7 +47,7 @@
 
     <dependency>
       <groupId>org.drools</groupId>
-      <artifactId>drools-mvel</artifactId>
+      <artifactId>drools-engine</artifactId>
       <scope>test</scope>
     </dependency>
 
@@ -114,6 +114,11 @@
     <dependency><!-- For unit test logging: configure in src/test/resources/logback-test.xml -->
       <groupId>ch.qos.logback</groupId>
       <artifactId>logback-classic</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.drools</groupId>
+      <artifactId>drools-model-codegen</artifactId>
       <scope>test</scope>
     </dependency>
   </dependencies>

--- a/drools-reliability/drools-reliability-infinispan/src/test/java/org/drools/reliability/infinispan/ReliabilityTest.java
+++ b/drools-reliability/drools-reliability-infinispan/src/test/java/org/drools/reliability/infinispan/ReliabilityTest.java
@@ -239,7 +239,7 @@ class ReliabilityTest extends ReliabilityTestBasics {
 
     @ParameterizedTest
     @MethodSource("strategyProviderFull")
-    @Disabled("RuleExecutor, line#407, NullPointerException (consequence is null)")
+    @Disabled("LambdaConstraint.evaluator is null, line#225")
     void insertFailover_propListShouldNotBeEmpty(PersistedSessionOption.Strategy strategy){
         createSession(BASIC_RULE, strategy);
 
@@ -250,6 +250,19 @@ class ReliabilityTest extends ReliabilityTestBasics {
 
         restoreSession(BASIC_RULE, strategy);
         assertThat(session.fireAllRules()).isEqualTo(1);
-
     }
+
+    @ParameterizedTest
+    @MethodSource("strategyProviderFull")
+    void insertFire_NoFailover(PersistedSessionOption.Strategy strategy){
+        createSession(BASIC_RULE, strategy);
+
+        insertString("M");
+        FactHandle maria = insertMatchingPerson("Maria", 30);
+
+        session.fireAllRules();
+        assertThat(getResults()).contains("Maria");
+    }
+
+
 }

--- a/drools-reliability/drools-reliability-infinispan/src/test/java/org/drools/reliability/infinispan/ReliabilityTest.java
+++ b/drools-reliability/drools-reliability-infinispan/src/test/java/org/drools/reliability/infinispan/ReliabilityTest.java
@@ -15,6 +15,7 @@
 
 package org.drools.reliability.infinispan;
 
+import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.params.ParameterizedTest;
@@ -238,23 +239,17 @@ class ReliabilityTest extends ReliabilityTestBasics {
 
     @ParameterizedTest
     @MethodSource("strategyProviderFull")
+    @Disabled("RuleExecutor, line#407, NullPointerException (consequence is null)")
     void insertFailover_propListShouldNotBeEmpty(PersistedSessionOption.Strategy strategy){
         createSession(BASIC_RULE, strategy);
 
         insertString("M");
-        insertMatchingPerson("Maria", 30);
+        FactHandle maria = insertMatchingPerson("Maria", 30);
 
         failover();
 
         restoreSession(BASIC_RULE, strategy);
         assertThat(session.fireAllRules()).isEqualTo(1);
-
-        //componentsCache = CacheManagerFactory.get().getCacheManager().getOrCreateCacheForSession(((InternalWorkingMemory) session).getReteEvaluator(), "components");
-        //reliablePropagationListPropList = (ReliablePropagationList) componentsCache.get("PropagationList");
-        //assertThat(reliablePropagationListPropList.isEmpty()).isFalse();
-
-        //restoreSession(BASIC_RULE, strategy);
-        //assertThat(session.fireAllRules()).isEqualTo(1);
 
     }
 }

--- a/drools-reliability/drools-reliability-infinispan/src/test/java/org/drools/reliability/infinispan/ReliabilityTest.java
+++ b/drools-reliability/drools-reliability-infinispan/src/test/java/org/drools/reliability/infinispan/ReliabilityTest.java
@@ -236,4 +236,25 @@ class ReliabilityTest extends ReliabilityTestBasics {
         assertThat(session.fireAllRules()).isEqualTo(0);
     }
 
+    @ParameterizedTest
+    @MethodSource("strategyProviderFull")
+    void insertFailover_propListShouldNotBeEmpty(PersistedSessionOption.Strategy strategy){
+        createSession(BASIC_RULE, strategy);
+
+        insertString("M");
+        insertMatchingPerson("Maria", 30);
+
+        failover();
+
+        restoreSession(BASIC_RULE, strategy);
+        assertThat(session.fireAllRules()).isEqualTo(1);
+
+        //componentsCache = CacheManagerFactory.get().getCacheManager().getOrCreateCacheForSession(((InternalWorkingMemory) session).getReteEvaluator(), "components");
+        //reliablePropagationListPropList = (ReliablePropagationList) componentsCache.get("PropagationList");
+        //assertThat(reliablePropagationListPropList.isEmpty()).isFalse();
+
+        //restoreSession(BASIC_RULE, strategy);
+        //assertThat(session.fireAllRules()).isEqualTo(1);
+
+    }
 }

--- a/drools-reliability/drools-reliability-infinispan/src/test/java/org/drools/reliability/infinispan/ReliabilityTestBasics.java
+++ b/drools-reliability/drools-reliability-infinispan/src/test/java/org/drools/reliability/infinispan/ReliabilityTestBasics.java
@@ -16,8 +16,9 @@
 package org.drools.reliability.infinispan;
 
 import org.drools.core.ClassObjectFilter;
-import org.drools.reliability.core.StorageManagerFactory;
+import org.drools.model.codegen.ExecutableModelProject;
 import org.drools.reliability.core.ReliableRuntimeComponentFactoryImpl;
+import org.drools.reliability.core.StorageManagerFactory;
 import org.drools.reliability.core.TestableStorageManager;
 import org.infinispan.client.hotrod.RemoteCacheManager;
 import org.infinispan.server.test.core.InfinispanContainer;
@@ -151,7 +152,8 @@ public abstract class ReliabilityTestBasics {
 
     protected KieSession getKieSession(String drl, PersistedSessionOption persistedSessionOption, Option... options) {
         OptionsFilter optionsFilter = new OptionsFilter(options);
-        KieBase kbase = new KieHelper().addContent(drl, ResourceType.DRL).build(optionsFilter.getKieBaseOptions());
+        //KieBase kbase = new KieHelper().addContent(drl, ResourceType.DRL).build(optionsFilter.getKieBaseOptions());
+        KieBase kbase = new KieHelper().addContent(drl, ResourceType.DRL).build(ExecutableModelProject.class, optionsFilter.getKieBaseOptions());
         KieSessionConfiguration conf = KieServices.get().newKieSessionConfiguration();
         if (persistedSessionOption != null) {
             conf.setOption(persistedSessionOption);

--- a/drools-reliability/drools-reliability-infinispan/src/test/java/org/drools/reliability/infinispan/ReliabilityTestBasics.java
+++ b/drools-reliability/drools-reliability-infinispan/src/test/java/org/drools/reliability/infinispan/ReliabilityTestBasics.java
@@ -60,6 +60,9 @@ public abstract class ReliabilityTestBasics {
     static Stream<PersistedSessionOption.Strategy> strategyProviderStoresOnly() {
         return Stream.of(PersistedSessionOption.Strategy.STORES_ONLY);
     }
+    static Stream<PersistedSessionOption.Strategy> strategyProviderFull() {
+        return Stream.of(PersistedSessionOption.Strategy.FULL);
+    }
 
     @BeforeEach
     public void setUp() {


### PR DESCRIPTION
This is an attempt to Serialize the LambdaConsequence class. 
It required a default constructor in addition to the writeExternal and readExternal methods. The default constructor had to initialize the two final properties defined in the class.

   public LambdaConsequence(){
        this.consequence = null;
        this.enabledTupleOptimization=false;
    }


Similarly, a default constructor was needed in the LambdaConstraint class:

public LambdaConstraint(){
        this.evaluator=null;
        this.predicateInformation=null;
    }

Testing (ReliabilityTest class):
insertFailover_propListShouldNotBeEmpty fails because LambdaConstraint.evaluator is null after failover.
