### PR TITLE
Drools 7383 full reliable strategy - basic tests

### DIFF
--- a/drools-core/src/main/java/org/drools/core/phreak/PropagationEntry.java
+++ b/drools-core/src/main/java/org/drools/core/phreak/PropagationEntry.java
@@ -300,7 +300,6 @@ public interface PropagationEntry {
             out.writeObject(next);
             out.writeObject(handle);
             out.writeObject(context);
-            //out.writeObject(objectTypeConf);
         }
 
         @Override
@@ -308,7 +307,6 @@ public interface PropagationEntry {
             this.next = (PropagationEntry) in.readObject();
             this.handle = (InternalFactHandle) in.readObject();
             this.context = (PropagationContext) in.readObject();
-            //this.objectTypeConf = (ObjectTypeConf) in.readObject();
         }
     }
 

--- a/drools-core/src/main/java/org/drools/core/phreak/PropagationEntry.java
+++ b/drools-core/src/main/java/org/drools/core/phreak/PropagationEntry.java
@@ -300,7 +300,6 @@ public interface PropagationEntry {
             out.writeObject(next);
             out.writeObject(handle);
             out.writeObject(context);
-            out.writeObject(objectTypeConf);
         }
 
         @Override
@@ -308,7 +307,6 @@ public interface PropagationEntry {
             this.next = (PropagationEntry) in.readObject();
             this.handle = (InternalFactHandle) in.readObject();
             this.context = (PropagationContext) in.readObject();
-            this.objectTypeConf = (ObjectTypeConf) in.readObject();
         }
     }
 

--- a/drools-core/src/main/java/org/drools/core/phreak/PropagationEntry.java
+++ b/drools-core/src/main/java/org/drools/core/phreak/PropagationEntry.java
@@ -15,9 +15,6 @@
 
 package org.drools.core.phreak;
 
-import java.io.Serializable;
-import java.util.concurrent.CountDownLatch;
-
 import org.drools.core.base.DroolsQuery;
 import org.drools.core.common.EventFactHandle;
 import org.drools.core.common.InternalFactHandle;
@@ -40,6 +37,12 @@ import org.drools.core.reteoo.TerminalNode;
 import org.drools.core.time.JobContext;
 import org.drools.core.time.JobHandle;
 import org.drools.core.time.impl.PointInTimeTrigger;
+
+import java.io.Externalizable;
+import java.io.IOException;
+import java.io.ObjectInput;
+import java.io.ObjectOutput;
+import java.util.concurrent.CountDownLatch;
 
 import static org.drools.core.reteoo.EntryPointNode.removeRightTuplesMatchingOTN;
 import static org.drools.core.rule.TypeDeclaration.NEVER_EXPIRES;
@@ -66,7 +69,7 @@ public interface PropagationEntry {
     boolean defersExpiration();
 
     abstract class AbstractPropagationEntry implements PropagationEntry {
-        private PropagationEntry next;
+        protected PropagationEntry next;
 
         public void setNext(PropagationEntry next) {
             this.next = next;
@@ -196,12 +199,14 @@ public interface PropagationEntry {
         }
     }
 
-    class Insert extends AbstractPropagationEntry implements Serializable {
+    class Insert extends AbstractPropagationEntry implements Externalizable {
         private static final ObjectTypeNode.ExpireJob job = new ObjectTypeNode.ExpireJob();
 
-        private final InternalFactHandle handle;
-        private final PropagationContext context;
-        private final ObjectTypeConf objectTypeConf;
+        private InternalFactHandle handle;
+        private PropagationContext context;
+        private ObjectTypeConf objectTypeConf;
+
+        public Insert() { }
 
         public Insert( InternalFactHandle handle, PropagationContext context, ReteEvaluator reteEvaluator, ObjectTypeConf objectTypeConf) {
             this.handle = handle;
@@ -284,6 +289,22 @@ public interface PropagationEntry {
 
         public InternalFactHandle getHandle() {
             return handle;
+        }
+
+        @Override
+        public void writeExternal(ObjectOutput out) throws IOException {
+            out.writeObject(next);
+            out.writeObject(handle);
+            out.writeObject(context);
+            out.writeObject(objectTypeConf);
+        }
+
+        @Override
+        public void readExternal(ObjectInput in) throws IOException, ClassNotFoundException {
+            this.next = (PropagationEntry) in.readObject();
+            this.handle = (InternalFactHandle) in.readObject();
+            this.context = (PropagationContext) in.readObject();
+            this.objectTypeConf = (ObjectTypeConf) in.readObject();
         }
     }
 

--- a/drools-core/src/main/java/org/drools/core/phreak/PropagationEntry.java
+++ b/drools-core/src/main/java/org/drools/core/phreak/PropagationEntry.java
@@ -226,6 +226,10 @@ public interface PropagationEntry {
         }
 
         private static void propagate( InternalFactHandle handle, PropagationContext context, ReteEvaluator reteEvaluator, ObjectTypeConf objectTypeConf ) {
+            if (objectTypeConf == null) {
+                // it can be null after deserialization
+                objectTypeConf = handle.getEntryPoint(reteEvaluator).getObjectTypeConfigurationRegistry().getOrCreateObjectTypeConf(handle.getEntryPointId(), handle.getObject());
+            }
             for ( ObjectTypeNode otn : objectTypeConf.getObjectTypeNodes() ) {
                 otn.propagateAssert( handle, context, reteEvaluator );
             }

--- a/drools-core/src/main/java/org/drools/core/phreak/SynchronizedPropagationList.java
+++ b/drools-core/src/main/java/org/drools/core/phreak/SynchronizedPropagationList.java
@@ -15,29 +15,33 @@
 
 package org.drools.core.phreak;
 
-import java.util.Iterator;
-
 import org.drools.core.common.ReteEvaluator;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+
+import java.util.Iterator;
 
 public class SynchronizedPropagationList implements PropagationList {
 
     protected static final Logger log = LoggerFactory.getLogger( SynchronizedPropagationList.class );
 
-    protected final ReteEvaluator reteEvaluator;
+    protected ReteEvaluator reteEvaluator;
 
     protected volatile PropagationEntry head;
     protected volatile PropagationEntry tail;
 
-    private volatile boolean disposed = false;
+    protected volatile boolean disposed = false;
 
-    private volatile boolean hasEntriesDeferringExpiration = false;
+    protected volatile boolean hasEntriesDeferringExpiration = false;
 
-    private volatile boolean firingUntilHalt = false;
+    protected volatile boolean firingUntilHalt = false;
 
     public SynchronizedPropagationList(ReteEvaluator reteEvaluator) {
         this.reteEvaluator = reteEvaluator;
+    }
+
+    public SynchronizedPropagationList(){
+        //this.reteEvaluator=null;
     }
 
     @Override

--- a/drools-core/src/main/java/org/drools/core/phreak/SynchronizedPropagationList.java
+++ b/drools-core/src/main/java/org/drools/core/phreak/SynchronizedPropagationList.java
@@ -40,9 +40,7 @@ public class SynchronizedPropagationList implements PropagationList {
         this.reteEvaluator = reteEvaluator;
     }
 
-    public SynchronizedPropagationList(){
-        //this.reteEvaluator=null;
-    }
+    public SynchronizedPropagationList(){}
 
     @Override
     public void addEntry(final PropagationEntry entry) {

--- a/drools-reliability/drools-reliability-core/src/main/java/org/drools/reliability/core/FullReliableObjectStore.java
+++ b/drools-reliability/drools-reliability-core/src/main/java/org/drools/reliability/core/FullReliableObjectStore.java
@@ -72,7 +72,7 @@ public class FullReliableObjectStore extends IdentityObjectStore {
     void putIntoPersistedCache(InternalFactHandle handle, boolean propagated) {
         Object object = handle.getObject();
         boolean reInitPropagated = false; // temp
-        StoredObject storedObject = new StoredObject(object, propagated);
+        StoredObject storedObject = new StoredObject(object, propagated); //SerializableStoredObject
         storage.put(getHandleForObject(object).getId(), storedObject);
     }
 

--- a/drools-reliability/drools-reliability-core/src/main/java/org/drools/reliability/core/FullReliableObjectStore.java
+++ b/drools-reliability/drools-reliability-core/src/main/java/org/drools/reliability/core/FullReliableObjectStore.java
@@ -25,6 +25,11 @@ public class FullReliableObjectStore extends IdentityObjectStore {
 
     private final Storage<Long, StoredObject> storage;
 
+    public FullReliableObjectStore(){
+        super();
+        this.storage = null;
+    }
+
     public FullReliableObjectStore(Storage<Long, StoredObject> storage) {
         super();
         this.storage = storage;

--- a/drools-reliability/drools-reliability-core/src/main/java/org/drools/reliability/core/FullReliableObjectStore.java
+++ b/drools-reliability/drools-reliability-core/src/main/java/org/drools/reliability/core/FullReliableObjectStore.java
@@ -17,6 +17,8 @@ package org.drools.reliability.core;
 
 import org.drools.core.common.IdentityObjectStore;
 import org.drools.core.common.InternalFactHandle;
+import org.drools.core.common.InternalWorkingMemory;
+import org.drools.core.common.InternalWorkingMemoryEntryPoint;
 import org.drools.core.common.Storage;
 
 public class FullReliableObjectStore extends IdentityObjectStore {
@@ -50,6 +52,12 @@ public class FullReliableObjectStore extends IdentityObjectStore {
         InternalFactHandle fh = getHandleForObject(object);
         if (fh != null) {
             storage.remove(fh.getId());
+        }
+    }
+
+    public void reInit(InternalWorkingMemory session, InternalWorkingMemoryEntryPoint ep) {
+        for (StoredObject entry : storage.values()) {
+            super.addHandle(getHandleForObject(entry.getObject()),entry.getObject());
         }
     }
 }

--- a/drools-reliability/drools-reliability-core/src/main/java/org/drools/reliability/core/FullReliableObjectStore.java
+++ b/drools-reliability/drools-reliability-core/src/main/java/org/drools/reliability/core/FullReliableObjectStore.java
@@ -17,13 +17,7 @@ package org.drools.reliability.core;
 
 import org.drools.core.common.IdentityObjectStore;
 import org.drools.core.common.InternalFactHandle;
-import org.drools.core.common.InternalWorkingMemory;
-import org.drools.core.common.InternalWorkingMemoryEntryPoint;
 import org.drools.core.common.Storage;
-import org.drools.kiesession.agenda.DefaultAgenda;
-
-import java.util.ArrayList;
-import java.util.List;
 
 public class FullReliableObjectStore extends IdentityObjectStore {
 
@@ -46,33 +40,9 @@ public class FullReliableObjectStore extends IdentityObjectStore {
         super.removeHandle(handle);
     }
 
-
-    List<StoredObject> reInit(InternalWorkingMemory session, InternalWorkingMemoryEntryPoint ep) {
-        List<StoredObject> propagated = new ArrayList<>();
-        List<StoredObject> notPropagated = new ArrayList<>();
-        ReliablePropagationList reliablePropagationList = (ReliablePropagationList) ((DefaultAgenda) session.getAgenda()).getPropagationList();
-
-        for (StoredObject entry : storage.values()) {
-            if (!reliablePropagationList.entryInTheList(entry)) { // entry.isPropagated()
-                propagated.add(entry);
-            } else {
-                notPropagated.add(entry);
-            }
-        }
-        storage.clear();
-
-        // fact handles with a match have been already propagated in the original session, so they shouldn't fire
-        propagated.forEach(obj -> obj.repropagate(ep));
-        session.fireAllRules(match -> false);
-
-        // fact handles without any match have never been propagated in the original session, so they should fire
-        return notPropagated;
-    }
-
     void putIntoPersistedCache(InternalFactHandle handle, boolean propagated) {
         Object object = handle.getObject();
-        boolean reInitPropagated = false; // temp
-        StoredObject storedObject = new StoredObject(object, propagated); //SerializableStoredObject
+        StoredObject storedObject = new SerializableStoredObject(object, propagated);
         storage.put(getHandleForObject(object).getId(), storedObject);
     }
 

--- a/drools-reliability/drools-reliability-core/src/main/java/org/drools/reliability/core/FullReliableObjectStore.java
+++ b/drools-reliability/drools-reliability-core/src/main/java/org/drools/reliability/core/FullReliableObjectStore.java
@@ -15,13 +15,71 @@
 
 package org.drools.reliability.core;
 
+import org.drools.core.common.IdentityObjectStore;
 import org.drools.core.common.InternalFactHandle;
-import org.drools.core.common.MapObjectStore;
+import org.drools.core.common.InternalWorkingMemory;
+import org.drools.core.common.InternalWorkingMemoryEntryPoint;
 import org.drools.core.common.Storage;
+import org.drools.kiesession.agenda.DefaultAgenda;
 
-public class FullReliableObjectStore extends MapObjectStore {
+import java.util.ArrayList;
+import java.util.List;
 
-    public FullReliableObjectStore(Storage<Object, InternalFactHandle> fhStorage) {
-        super(fhStorage);
+public class FullReliableObjectStore extends IdentityObjectStore {
+
+    private final Storage<Long, StoredObject> storage;
+
+    public FullReliableObjectStore(Storage<Long, StoredObject> storage) {
+        super();
+        this.storage = storage;
+    }
+
+    @Override
+    public void addHandle(InternalFactHandle handle, Object object) {
+        super.addHandle(handle, object);
+        putIntoPersistedCache(handle, handle.hasMatches());
+    }
+
+    @Override
+    public void removeHandle(InternalFactHandle handle) {
+        removeFromPersistedCache(handle.getObject());
+        super.removeHandle(handle);
+    }
+
+
+    List<StoredObject> reInit(InternalWorkingMemory session, InternalWorkingMemoryEntryPoint ep) {
+        List<StoredObject> propagated = new ArrayList<>();
+        List<StoredObject> notPropagated = new ArrayList<>();
+        ReliablePropagationList reliablePropagationList = (ReliablePropagationList) ((DefaultAgenda) session.getAgenda()).getPropagationList();
+
+        for (StoredObject entry : storage.values()) {
+            if (!reliablePropagationList.entryInTheList(entry)) { // entry.isPropagated()
+                propagated.add(entry);
+            } else {
+                notPropagated.add(entry);
+            }
+        }
+        storage.clear();
+
+        // fact handles with a match have been already propagated in the original session, so they shouldn't fire
+        propagated.forEach(obj -> obj.repropagate(ep));
+        session.fireAllRules(match -> false);
+
+        // fact handles without any match have never been propagated in the original session, so they should fire
+        return notPropagated;
+    }
+
+    void putIntoPersistedCache(InternalFactHandle handle, boolean propagated) {
+        Object object = handle.getObject();
+        boolean reInitPropagated = false; // temp
+        StoredObject storedObject = new StoredObject(object, propagated);
+        storage.put(getHandleForObject(object).getId(), storedObject);
+    }
+
+    void removeFromPersistedCache(Object object) {
+        InternalFactHandle fh = getHandleForObject(object);
+        if (fh != null) {
+            storage.remove(fh.getId());
+        }
     }
 }

--- a/drools-reliability/drools-reliability-core/src/main/java/org/drools/reliability/core/ReliableAgenda.java
+++ b/drools-reliability/drools-reliability-core/src/main/java/org/drools/reliability/core/ReliableAgenda.java
@@ -46,7 +46,6 @@ public class ReliableAgenda extends DefaultAgenda {
             propagationList = new ReliablePropagationList(workingMemory);
             componentsStorage.put("PropagationList", propagationList);
         } else {
-            //propagationList = new ReliablePropagationList(workingMemory, propagationList);
             propagationList.setReteEvaluator(workingMemory);
         }
         return propagationList;

--- a/drools-reliability/drools-reliability-core/src/main/java/org/drools/reliability/core/ReliableAgenda.java
+++ b/drools-reliability/drools-reliability-core/src/main/java/org/drools/reliability/core/ReliableAgenda.java
@@ -46,7 +46,8 @@ public class ReliableAgenda extends DefaultAgenda {
             propagationList = new ReliablePropagationList(workingMemory);
             componentsStorage.put("PropagationList", propagationList);
         } else {
-            propagationList = new ReliablePropagationList(workingMemory, propagationList);
+            //propagationList = new ReliablePropagationList(workingMemory, propagationList);
+            propagationList.setReteEvaluator(workingMemory);
         }
         return propagationList;
     }

--- a/drools-reliability/drools-reliability-core/src/main/java/org/drools/reliability/core/ReliablePropagationList.java
+++ b/drools-reliability/drools-reliability-core/src/main/java/org/drools/reliability/core/ReliablePropagationList.java
@@ -15,20 +15,65 @@
 
 package org.drools.reliability.core;
 
+import org.drools.core.common.InternalFactHandle;
 import org.drools.core.common.ReteEvaluator;
+import org.drools.core.phreak.PropagationEntry;
 import org.drools.core.phreak.SynchronizedPropagationList;
 
-import java.io.Serializable;
+import java.io.Externalizable;
+import java.io.IOException;
+import java.io.ObjectInput;
+import java.io.ObjectOutput;
 
-public class ReliablePropagationList extends SynchronizedPropagationList implements Serializable {
+public class ReliablePropagationList extends SynchronizedPropagationList implements Externalizable {
 
     public ReliablePropagationList(ReteEvaluator reteEvaluator) {
         super(reteEvaluator);
     }
 
+    public ReliablePropagationList(){super();}
+
+    public void setReteEvaluator(ReteEvaluator reteEvaluator){this.reteEvaluator=reteEvaluator;}
+
     public ReliablePropagationList(ReteEvaluator reteEvaluator, ReliablePropagationList originalList) {
         super(reteEvaluator);
         this.head = originalList.head;
         this.tail = originalList.tail;
+    }
+
+    public boolean entryInTheList(Object entry){
+
+        boolean inTheList=false;
+
+        PropagationEntry current = this.head;
+
+        while (current!=null && !inTheList){
+            if (current instanceof  PropagationEntry.Insert){
+                InternalFactHandle fh = ((PropagationEntry.Insert) current).getHandle();
+                inTheList = fh.getObject().equals(entry);
+            }else if (entry instanceof PropagationEntry.Update){
+
+            }
+            current = current.getNext();
+        }
+
+        return inTheList;
+    }
+
+    @Override
+    public void writeExternal(ObjectOutput out) throws IOException {
+        out.writeObject(head);
+        out.writeObject(tail);
+        out.writeBoolean(disposed);
+        out.writeBoolean(hasEntriesDeferringExpiration);
+        out.writeBoolean(firingUntilHalt);
+   }
+    @Override
+    public void readExternal(ObjectInput in) throws IOException, ClassNotFoundException {
+        this.head = (PropagationEntry) in.readObject();
+        this.tail = (PropagationEntry) in.readObject();
+        this.disposed = in.readBoolean();
+        this.hasEntriesDeferringExpiration = in.readBoolean();
+        this.firingUntilHalt = in.readBoolean();
     }
 }

--- a/drools-reliability/drools-reliability-core/src/main/java/org/drools/reliability/core/ReliablePropagationList.java
+++ b/drools-reliability/drools-reliability-core/src/main/java/org/drools/reliability/core/ReliablePropagationList.java
@@ -15,8 +15,8 @@
 
 package org.drools.reliability.core;
 
-import org.drools.core.common.InternalFactHandle;
 import org.drools.core.common.ReteEvaluator;
+import org.drools.core.common.Storage;
 import org.drools.core.phreak.PropagationEntry;
 import org.drools.core.phreak.SynchronizedPropagationList;
 
@@ -41,23 +41,12 @@ public class ReliablePropagationList extends SynchronizedPropagationList impleme
         this.tail = originalList.tail;
     }
 
-    public boolean entryInTheList(Object entry){
-
-        boolean inTheList=false;
-
-        PropagationEntry current = this.head;
-
-        while (current!=null && !inTheList){
-            if (current instanceof  PropagationEntry.Insert){
-                InternalFactHandle fh = ((PropagationEntry.Insert) current).getHandle();
-                inTheList = fh.getObject().equals(entry);
-            }else if (entry instanceof PropagationEntry.Update){
-
-            }
-            current = current.getNext();
-        }
-
-        return inTheList;
+    @Override
+    public synchronized PropagationEntry takeAll() {
+        PropagationEntry p = super.takeAll();
+        Storage<String, Object> componentsStorage = StorageManagerFactory.get().getStorageManager().getOrCreateStorageForSession(this.reteEvaluator, "components");
+        componentsStorage.put("PropagationList", this);
+        return p;
     }
 
     @Override

--- a/drools-reliability/drools-reliability-core/src/main/java/org/drools/reliability/core/ReliableSessionInitializer.java
+++ b/drools-reliability/drools-reliability-core/src/main/java/org/drools/reliability/core/ReliableSessionInitializer.java
@@ -112,7 +112,6 @@ public class ReliableSessionInitializer {
                 // re-propagate objects from the storage to the new session
                 populateSessionFromStorage(session);
             }
-            //session.setWorkingMemoryActionListener(entry -> onWorkingMemoryAction(session, entry));
             session.getRuleRuntimeEventSupport().addEventListener(new FullReliableSessionInitializer.FullStoreRuntimeEventListener(session));
             return session;
         }
@@ -134,7 +133,6 @@ public class ReliableSessionInitializer {
             FullStoreRuntimeEventListener(InternalWorkingMemory session) {
                 this.componentsCache = StorageManagerFactory.get().getStorageManager().getOrCreateStorageForSession(session, "components");
                 this.propagationList = (ReliablePropagationList) ((ReliableAgenda) session.getAgenda()).getPropagationList();
-                //propagationList = (ReliablePropagationList) componentsCache.get("PropagationList");
             }
 
             public void objectInserted(ObjectInsertedEvent ev) {

--- a/drools-reliability/drools-reliability-core/src/main/java/org/drools/reliability/core/ReliableSessionInitializer.java
+++ b/drools-reliability/drools-reliability-core/src/main/java/org/drools/reliability/core/ReliableSessionInitializer.java
@@ -20,6 +20,7 @@ import org.drools.core.WorkingMemoryEntryPoint;
 import org.drools.core.common.InternalFactHandle;
 import org.drools.core.common.InternalWorkingMemory;
 import org.drools.core.common.InternalWorkingMemoryEntryPoint;
+import org.drools.core.common.Storage;
 import org.drools.core.phreak.PropagationEntry;
 import org.kie.api.event.rule.ObjectDeletedEvent;
 import org.kie.api.event.rule.ObjectInsertedEvent;
@@ -107,7 +108,32 @@ public class ReliableSessionInitializer {
 
         @Override
         public InternalWorkingMemory init(InternalWorkingMemory session, PersistedSessionOption persistedSessionOption) {
+
+            //session.setWorkingMemoryActionListener(entry -> onWorkingMemoryAction(session, entry));
+            session.getRuleRuntimeEventSupport().addEventListener(new FullReliableSessionInitializer.FullStoreRuntimeEventListener(session));
             return session;
+        }
+        static class FullStoreRuntimeEventListener implements RuleRuntimeEventListener {
+
+            private final Storage<Object, Object> componentsCache;
+            private final ReliablePropagationList propagationList;
+
+            FullStoreRuntimeEventListener(InternalWorkingMemory session) {
+                this.componentsCache = StorageManagerFactory.get().getStorageManager().getOrCreateStorageForSession(session, "components");
+                this.propagationList = (ReliablePropagationList) ((ReliableAgenda) session.getAgenda()).getPropagationList();
+            }
+
+            public void objectInserted(ObjectInsertedEvent ev) {
+                componentsCache.put("PropagationList", propagationList);
+            }
+
+            public void objectDeleted(ObjectDeletedEvent ev) {
+                componentsCache.put("PropagationList", propagationList);
+            }
+
+            public void objectUpdated(ObjectUpdatedEvent ev) {
+                componentsCache.put("PropagationList", propagationList);
+            }
         }
     }
 }

--- a/drools-reliability/drools-reliability-infinispan/pom.xml
+++ b/drools-reliability/drools-reliability-infinispan/pom.xml
@@ -52,7 +52,7 @@
 
     <dependency>
       <groupId>org.drools</groupId>
-      <artifactId>drools-mvel</artifactId>
+      <artifactId>drools-engine</artifactId>
       <scope>test</scope>
     </dependency>
 
@@ -119,6 +119,11 @@
     <dependency><!-- For unit test logging: configure in src/test/resources/logback-test.xml -->
       <groupId>ch.qos.logback</groupId>
       <artifactId>logback-classic</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.drools</groupId>
+      <artifactId>drools-model-codegen</artifactId>
       <scope>test</scope>
     </dependency>
   </dependencies>

--- a/drools-reliability/drools-reliability-infinispan/src/test/java/org/drools/reliability/infinispan/ReliabilityTest.java
+++ b/drools-reliability/drools-reliability-infinispan/src/test/java/org/drools/reliability/infinispan/ReliabilityTest.java
@@ -252,7 +252,58 @@ class ReliabilityTest extends ReliabilityTestBasics {
 
         restoreSession(BASIC_RULE, strategy);
 
+
         assertThat(session.fireAllRules()).isEqualTo(1);
     }
-    
+
+    @ParameterizedTest
+    @MethodSource("strategyProviderFull")
+    void insertFireFailover_shouldNotRepeatFiredMatch(PersistedSessionOption.PersistenceStrategy strategy){
+        createSession(BASIC_RULE, strategy);
+
+        insertString("M");
+        insertMatchingPerson("Maria", 30);
+
+        session.fireAllRules();
+
+        failover();
+
+        restoreSession(BASIC_RULE, strategy);
+
+        assertThat(session.fireAllRules()).isEqualTo(0);
+    }
+
+    @ParameterizedTest
+    @MethodSource("strategyProviderFull")
+    void insertUpdateFailover_shouldNotFiredMatch(PersistedSessionOption.PersistenceStrategy strategy){
+        createSession(BASIC_RULE, strategy);
+
+        insertString("M");
+        FactHandle fhMaria = insertMatchingPerson("Maria", 30);
+
+        updateWithNonMatchingPerson(fhMaria, new Person("Nicole", 32));
+
+        failover();
+
+        restoreSession(BASIC_RULE, strategy);
+
+        assertThat(session.fireAllRules()).isEqualTo(0);
+    }
+
+    @ParameterizedTest
+    @MethodSource("strategyProviderFull")
+    void insertNonMatching_Failover_UpdateWithMatching_ShouldFiredMatch(PersistedSessionOption.PersistenceStrategy strategy){
+        createSession(BASIC_RULE, strategy);
+
+        insertString("N");
+        FactHandle fhMaria = insertMatchingPerson("Maria", 30);
+
+        failover();
+
+        restoreSession(BASIC_RULE, strategy);
+
+        updateWithMatchingPerson(fhMaria, new Person("Nicole",32));
+
+        assertThat(session.fireAllRules()).isEqualTo(1);
+    }
 }

--- a/drools-reliability/drools-reliability-infinispan/src/test/java/org/drools/reliability/infinispan/ReliabilityTest.java
+++ b/drools-reliability/drools-reliability-infinispan/src/test/java/org/drools/reliability/infinispan/ReliabilityTest.java
@@ -242,7 +242,7 @@ class ReliabilityTest extends ReliabilityTestBasics {
 
     @ParameterizedTest
     @MethodSource("strategyProviderFull")
-    void insertFailover_propListShouldNotBeEmpty(PersistedSessionOption.Strategy strategy){
+    void insertFailover_propListShouldNotBeEmpty(PersistedSessionOption.PersistenceStrategy strategy){
         createSession(BASIC_RULE, strategy);
 
         insertString("M");

--- a/drools-reliability/drools-reliability-infinispan/src/test/java/org/drools/reliability/infinispan/ReliabilityTest.java
+++ b/drools-reliability/drools-reliability-infinispan/src/test/java/org/drools/reliability/infinispan/ReliabilityTest.java
@@ -251,14 +251,8 @@ class ReliabilityTest extends ReliabilityTestBasics {
         failover();
 
         restoreSession(BASIC_RULE, strategy);
+
         assertThat(session.fireAllRules()).isEqualTo(1);
-
-        //componentsCache = CacheManagerFactory.get().getCacheManager().getOrCreateCacheForSession(((InternalWorkingMemory) session).getReteEvaluator(), "components");
-        //reliablePropagationListPropList = (ReliablePropagationList) componentsCache.get("PropagationList");
-        //assertThat(reliablePropagationListPropList.isEmpty()).isFalse();
-
-        //restoreSession(BASIC_RULE, strategy);
-        //assertThat(session.fireAllRules()).isEqualTo(1);
-
     }
+    
 }

--- a/drools-reliability/drools-reliability-infinispan/src/test/java/org/drools/reliability/infinispan/ReliabilityTest.java
+++ b/drools-reliability/drools-reliability-infinispan/src/test/java/org/drools/reliability/infinispan/ReliabilityTest.java
@@ -240,4 +240,25 @@ class ReliabilityTest extends ReliabilityTestBasics {
         assertThat(session.fireAllRules()).isEqualTo(0);
     }
 
+    @ParameterizedTest
+    @MethodSource("strategyProviderFull")
+    void insertFailover_propListShouldNotBeEmpty(PersistedSessionOption.Strategy strategy){
+        createSession(BASIC_RULE, strategy);
+
+        insertString("M");
+        insertMatchingPerson("Maria", 30);
+
+        failover();
+
+        restoreSession(BASIC_RULE, strategy);
+        assertThat(session.fireAllRules()).isEqualTo(1);
+
+        //componentsCache = CacheManagerFactory.get().getCacheManager().getOrCreateCacheForSession(((InternalWorkingMemory) session).getReteEvaluator(), "components");
+        //reliablePropagationListPropList = (ReliablePropagationList) componentsCache.get("PropagationList");
+        //assertThat(reliablePropagationListPropList.isEmpty()).isFalse();
+
+        //restoreSession(BASIC_RULE, strategy);
+        //assertThat(session.fireAllRules()).isEqualTo(1);
+
+    }
 }

--- a/drools-reliability/drools-reliability-infinispan/src/test/java/org/drools/reliability/infinispan/ReliabilityTestBasics.java
+++ b/drools-reliability/drools-reliability-infinispan/src/test/java/org/drools/reliability/infinispan/ReliabilityTestBasics.java
@@ -86,8 +86,8 @@ public abstract class ReliabilityTestBasics {
     static boolean isProtoStream() {
         return "PROTOSTREAM".equalsIgnoreCase(getConfig(INFINISPAN_STORAGE_MARSHALLER));
     }
-    static Stream<PersistedSessionOption.Strategy> strategyProviderFull() {
-        return Stream.of(PersistedSessionOption.Strategy.FULL);
+    static Stream<PersistedSessionOption.PersistenceStrategy> strategyProviderFull() {
+        return Stream.of(PersistedSessionOption.PersistenceStrategy.FULL);
     }
 
     @BeforeEach

--- a/drools-reliability/drools-reliability-infinispan/src/test/java/org/drools/reliability/infinispan/ReliabilityTestBasics.java
+++ b/drools-reliability/drools-reliability-infinispan/src/test/java/org/drools/reliability/infinispan/ReliabilityTestBasics.java
@@ -191,7 +191,6 @@ public abstract class ReliabilityTestBasics {
 
     protected KieSession getKieSession(String drl, PersistedSessionOption persistedSessionOption, Option... options) {
         OptionsFilter optionsFilter = new OptionsFilter(options);
-        //KieBase kbase = new KieHelper().addContent(drl, ResourceType.DRL).build(optionsFilter.getKieBaseOptions());
         KieBase kbase = new KieHelper().addContent(drl, ResourceType.DRL).build(ExecutableModelProject.class, optionsFilter.getKieBaseOptions());
         KieSessionConfiguration conf = KieServices.get().newKieSessionConfiguration();
         if (persistedSessionOption != null) {

--- a/drools-reliability/drools-reliability-infinispan/src/test/java/org/drools/reliability/infinispan/ReliabilityTestBasics.java
+++ b/drools-reliability/drools-reliability-infinispan/src/test/java/org/drools/reliability/infinispan/ReliabilityTestBasics.java
@@ -16,6 +16,7 @@
 package org.drools.reliability.infinispan;
 
 import org.drools.core.ClassObjectFilter;
+import org.drools.model.codegen.ExecutableModelProject;
 import org.drools.reliability.core.ReliableKieSession;
 import org.drools.reliability.core.ReliableRuntimeComponentFactoryImpl;
 import org.drools.reliability.core.StorageManagerFactory;
@@ -190,7 +191,8 @@ public abstract class ReliabilityTestBasics {
 
     protected KieSession getKieSession(String drl, PersistedSessionOption persistedSessionOption, Option... options) {
         OptionsFilter optionsFilter = new OptionsFilter(options);
-        KieBase kbase = new KieHelper().addContent(drl, ResourceType.DRL).build(optionsFilter.getKieBaseOptions());
+        //KieBase kbase = new KieHelper().addContent(drl, ResourceType.DRL).build(optionsFilter.getKieBaseOptions());
+        KieBase kbase = new KieHelper().addContent(drl, ResourceType.DRL).build(ExecutableModelProject.class, optionsFilter.getKieBaseOptions());
         KieSessionConfiguration conf = KieServices.get().newKieSessionConfiguration();
         if (persistedSessionOption != null) {
             conf.setOption(persistedSessionOption);

--- a/drools-reliability/drools-reliability-infinispan/src/test/java/org/drools/reliability/infinispan/ReliabilityTestBasics.java
+++ b/drools-reliability/drools-reliability-infinispan/src/test/java/org/drools/reliability/infinispan/ReliabilityTestBasics.java
@@ -86,6 +86,9 @@ public abstract class ReliabilityTestBasics {
     static boolean isProtoStream() {
         return "PROTOSTREAM".equalsIgnoreCase(getConfig(INFINISPAN_STORAGE_MARSHALLER));
     }
+    static Stream<PersistedSessionOption.Strategy> strategyProviderFull() {
+        return Stream.of(PersistedSessionOption.Strategy.FULL);
+    }
 
     @BeforeEach
     public void setUp() {


### PR DESCRIPTION
The branch includes changes suggested in patches 
https://github.com/mariofusco/drools/commit/8f78bff36da1059ad3e533ed830c58b561e9a373.patch, and, 
https://gist.github.com/mariofusco/d274a8541913d70bee8ee6c8efe3b46e

and other changes to  support drools-reliability FULL strategy. 

It also includes basic methods for testing FULL strategy: 
- insertFailover_propListShouldNotBeEmpty
- insertFireFailover_shouldNotRepeatFiredMatch
- insertUpdateFailover_shouldNotFiredMatch
- insertNonMatching_Failover_UpdateWithMatching_ShouldFiredMatch
