### PR TITLE
[DROOLS-7444] join constraints are ignored when BigDecimal equality i…

### DIFF
--- a/drools-core/src/main/java/org/drools/core/util/index/IndexFactory.java
+++ b/drools-core/src/main/java/org/drools/core/util/index/IndexFactory.java
@@ -12,7 +12,7 @@ import static org.drools.core.util.index.IndexUtil.isBigDecimalEqualityConstrain
 public interface IndexFactory {
 
     static BetaMemory createBetaMemory(RuleBaseConfiguration config, short nodeType, BetaNodeFieldConstraint... constraints) {
-        if (config.getCompositeKeyDepth() < 1 || containsBigDecimalEqualityConstraint(constraints)) {
+        if (config.getCompositeKeyDepth() < 1) {
             return new BetaMemory( config.isSequential() ? null : new TupleList(),
                     new TupleList(),
                     createContext(constraints),
@@ -26,17 +26,8 @@ public interface IndexFactory {
                 nodeType );
     }
 
-    private static boolean containsBigDecimalEqualityConstraint(BetaNodeFieldConstraint[] constraints) {
-        for (BetaNodeFieldConstraint constraint : constraints) {
-            if (constraint instanceof IndexableConstraint && isBigDecimalEqualityConstraint((IndexableConstraint) constraint)) {
-                return true;
-            }
-        }
-        return false;
-    }
-
-        private static TupleMemory createRightMemory(RuleBaseConfiguration config, IndexSpec indexSpec) {
-        if ( !config.isIndexRightBetaMemory() || !indexSpec.getConstraintType().isIndexable() ) {
+    private static TupleMemory createRightMemory(RuleBaseConfiguration config, IndexSpec indexSpec) {
+        if ( !config.isIndexRightBetaMemory() || !indexSpec.getConstraintType().isIndexable() || indexSpec.getIndexes().length == 0 ) {
             return new TupleList();
         }
 
@@ -55,7 +46,7 @@ public interface IndexFactory {
         if (config.isSequential()) {
             return null;
         }
-        if ( !config.isIndexLeftBetaMemory() || !indexSpec.getConstraintType().isIndexable() ) {
+        if ( !config.isIndexLeftBetaMemory() || !indexSpec.getConstraintType().isIndexable() || indexSpec.getIndexes().length == 0 ) {
             return new TupleList();
         }
 

--- a/drools-core/src/main/java/org/drools/core/util/index/IndexSpec.java
+++ b/drools-core/src/main/java/org/drools/core/util/index/IndexSpec.java
@@ -9,6 +9,8 @@ import org.drools.core.rule.constraint.BetaNodeFieldConstraint;
 import org.drools.core.util.AbstractHashTable;
 import org.kie.internal.conf.IndexPrecedenceOption;
 
+import static org.drools.core.util.index.IndexUtil.isEqualIndexable;
+
 public class IndexSpec {
     private IndexUtil.ConstraintType constraintType = IndexUtil.ConstraintType.UNKNOWN;
     private AbstractHashTable.FieldIndex[] indexes;
@@ -38,11 +40,13 @@ public class IndexSpec {
 
         if (constraintType == IndexUtil.ConstraintType.EQUAL) {
             List<AbstractHashTable.FieldIndex> indexList = new ArrayList<>();
-            indexList.add(((IndexableConstraint)constraints[firstIndexableConstraint]).getFieldIndex());
+            if (isEqualIndexable(constraints[firstIndexableConstraint])) {
+                indexList.add(((IndexableConstraint) constraints[firstIndexableConstraint]).getFieldIndex());
+            }
 
             // look for other EQUAL constraint to eventually add them to the index
             for (int i = firstIndexableConstraint+1; i < constraints.length && indexList.size() < keyDepth; i++) {
-                if ( IndexUtil.ConstraintType.getType(constraints[i]) == IndexUtil.ConstraintType.EQUAL && ! ((IndexableConstraint) constraints[i]).isUnification() ) {
+                if ( isEqualIndexable(constraints[i]) && ! ((IndexableConstraint) constraints[i]).isUnification() ) {
                     indexList.add(((IndexableConstraint)constraints[i]).getFieldIndex());
                 }
             }

--- a/drools-core/src/main/java/org/drools/core/util/index/IndexUtil.java
+++ b/drools-core/src/main/java/org/drools/core/util/index/IndexUtil.java
@@ -190,8 +190,8 @@ public class IndexUtil {
         indexable[0] = true;
     }
 
-    private static boolean isEqualIndexable(BetaNodeFieldConstraint constraint) {
-        return constraint instanceof IndexableConstraint && ((IndexableConstraint)constraint).getConstraintType() == ConstraintType.EQUAL;
+    static boolean isEqualIndexable(BetaNodeFieldConstraint constraint) {
+        return constraint instanceof IndexableConstraint && ((IndexableConstraint)constraint).getConstraintType() == ConstraintType.EQUAL && !isBigDecimalEqualityConstraint((IndexableConstraint)constraint);
     }
 
     private static void swap(BetaNodeFieldConstraint[] constraints, int p1, int p2) {

--- a/drools-core/src/test/java/org/drools/core/util/index/IndexUtilTest.java
+++ b/drools-core/src/test/java/org/drools/core/util/index/IndexUtilTest.java
@@ -1,0 +1,363 @@
+/*
+ * Copyright 2023 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.drools.core.util.index;
+
+import java.io.IOException;
+import java.io.ObjectInput;
+import java.io.ObjectOutput;
+import java.lang.reflect.Method;
+
+import org.drools.core.RuleBaseConfiguration;
+import org.drools.core.base.ValueType;
+import org.drools.core.common.InternalFactHandle;
+import org.drools.core.common.ReteEvaluator;
+import org.drools.core.reteoo.BetaMemory;
+import org.drools.core.reteoo.NodeTypeEnums;
+import org.drools.core.reteoo.Tuple;
+import org.drools.core.rule.ContextEntry;
+import org.drools.core.rule.Declaration;
+import org.drools.core.rule.IndexableConstraint;
+import org.drools.core.rule.accessor.FieldValue;
+import org.drools.core.rule.accessor.ReadAccessor;
+import org.drools.core.rule.accessor.TupleValueExtractor;
+import org.drools.core.rule.constraint.BetaNodeFieldConstraint;
+import org.drools.core.rule.constraint.Constraint;
+import org.drools.core.util.AbstractHashTable.DoubleCompositeIndex;
+import org.drools.core.util.AbstractHashTable.FieldIndex;
+import org.drools.core.util.AbstractHashTable.Index;
+import org.junit.Test;
+import org.kie.api.KieBaseConfiguration;
+import org.kie.internal.conf.CompositeConfiguration;
+import org.kie.internal.conf.IndexPrecedenceOption;
+import org.kie.internal.utils.ChainedProperties;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class IndexUtilTest {
+
+    @Test
+    public void isEqualIndexable() {
+        FakeBetaNodeFieldConstraint intEqualsConstraint = new FakeBetaNodeFieldConstraint(IndexUtil.ConstraintType.EQUAL, new FakeReadAccessor(ValueType.PINTEGER_TYPE));
+        assertThat(IndexUtil.isEqualIndexable(intEqualsConstraint)).isTrue();
+
+        FakeBetaNodeFieldConstraint intLessThanConstraint = new FakeBetaNodeFieldConstraint(IndexUtil.ConstraintType.LESS_THAN, new FakeReadAccessor(ValueType.PINTEGER_TYPE));
+        assertThat(IndexUtil.isEqualIndexable(intLessThanConstraint)).isFalse();
+
+        FakeBetaNodeFieldConstraint bigDecimalEqualsConstraint = new FakeBetaNodeFieldConstraint(IndexUtil.ConstraintType.EQUAL, new FakeReadAccessor(ValueType.BIG_DECIMAL_TYPE));
+        assertThat(IndexUtil.isEqualIndexable(bigDecimalEqualsConstraint)).as("BigDecimal equality cannot be indexed because of scale").isFalse();
+    }
+
+    @Test
+    public void createBetaMemoryWithIntEquals_shouldBeTupleIndexHashTable() {
+        RuleBaseConfiguration config = getRuleBaseConfiguration();
+        FakeBetaNodeFieldConstraint intEqualsConstraint = new FakeBetaNodeFieldConstraint(IndexUtil.ConstraintType.EQUAL, new FakeReadAccessor(ValueType.PINTEGER_TYPE));
+        BetaMemory betaMemory = IndexFactory.createBetaMemory(config, NodeTypeEnums.JoinNode, intEqualsConstraint);
+        assertThat(betaMemory.getLeftTupleMemory()).isInstanceOf(TupleIndexHashTable.class);
+        assertThat(betaMemory.getRightTupleMemory()).isInstanceOf(TupleIndexHashTable.class);
+    }
+
+    private RuleBaseConfiguration getRuleBaseConfiguration() {
+        return new RuleBaseConfiguration(new CompositeConfiguration<>(ChainedProperties.getChainedProperties(null), null));
+    }
+
+    @Test
+    public void createBetaMemoryWithBigDecimalEquals_shouldNotBeTupleIndexHashTable() {
+        RuleBaseConfiguration config = getRuleBaseConfiguration();
+        FakeBetaNodeFieldConstraint bigDecimalEqualsConstraint = new FakeBetaNodeFieldConstraint(IndexUtil.ConstraintType.EQUAL, new FakeReadAccessor(ValueType.BIG_DECIMAL_TYPE));
+        BetaMemory betaMemory = IndexFactory.createBetaMemory(config, NodeTypeEnums.JoinNode, bigDecimalEqualsConstraint);
+        assertThat(betaMemory.getLeftTupleMemory()).isInstanceOf(TupleList.class);
+        assertThat(betaMemory.getRightTupleMemory()).isInstanceOf(TupleList.class);
+    }
+
+    @Test
+    public void createBetaMemoryWithBigDecimalEqualsAndOtherIndexableConstraints_shouldBeTupleIndexHashTableButBigDecimalIsNotIndexed() {
+        RuleBaseConfiguration config = getRuleBaseConfiguration();
+        FakeBetaNodeFieldConstraint intEqualsConstraint = new FakeBetaNodeFieldConstraint(IndexUtil.ConstraintType.EQUAL, new FakeReadAccessor(ValueType.PINTEGER_TYPE));
+        FakeBetaNodeFieldConstraint bigDecimalEqualsConstraint = new FakeBetaNodeFieldConstraint(IndexUtil.ConstraintType.EQUAL, new FakeReadAccessor(ValueType.BIG_DECIMAL_TYPE));
+        FakeBetaNodeFieldConstraint stringEqualsConstraint = new FakeBetaNodeFieldConstraint(IndexUtil.ConstraintType.EQUAL, new FakeReadAccessor(ValueType.STRING_TYPE));
+        BetaMemory betaMemory = IndexFactory.createBetaMemory(config, NodeTypeEnums.JoinNode, intEqualsConstraint, bigDecimalEqualsConstraint, stringEqualsConstraint);
+
+        // BigDecimal is not included in Indexes
+        assertThat(betaMemory.getLeftTupleMemory()).isInstanceOf(TupleIndexHashTable.class);
+        Index leftIndex = ((TupleIndexHashTable) betaMemory.getLeftTupleMemory()).getIndex();
+        assertThat(leftIndex).isInstanceOf(DoubleCompositeIndex.class);
+        FieldIndex leftFieldIndex0 = leftIndex.getFieldIndex(0);
+        assertThat(leftFieldIndex0.getLeftExtractor().getValueType()).isEqualTo(ValueType.PINTEGER_TYPE);
+        FieldIndex leftFieldIndex1 = leftIndex.getFieldIndex(1);
+        assertThat(leftFieldIndex1.getLeftExtractor().getValueType()).isEqualTo(ValueType.STRING_TYPE);
+
+        assertThat(betaMemory.getRightTupleMemory()).isInstanceOf(TupleIndexHashTable.class);
+        Index rightIndex = ((TupleIndexHashTable) betaMemory.getRightTupleMemory()).getIndex();
+        assertThat(rightIndex).isInstanceOf(DoubleCompositeIndex.class);
+        FieldIndex rightFieldIndex0 = rightIndex.getFieldIndex(0);
+        assertThat(rightFieldIndex0.getRightExtractor().getValueType()).isEqualTo(ValueType.PINTEGER_TYPE);
+        FieldIndex rightFieldIndex1 = rightIndex.getFieldIndex(1);
+        assertThat(rightFieldIndex1.getRightExtractor().getValueType()).isEqualTo(ValueType.STRING_TYPE);
+    }
+
+    @Test
+    public void isIndexableForNodeWithIntAndString() {
+        RuleBaseConfiguration config = getRuleBaseConfiguration();
+        FakeBetaNodeFieldConstraint intEqualsConstraint = new FakeBetaNodeFieldConstraint(IndexUtil.ConstraintType.EQUAL, new FakeReadAccessor(ValueType.PINTEGER_TYPE));
+        FakeBetaNodeFieldConstraint stringEqualsConstraint = new FakeBetaNodeFieldConstraint(IndexUtil.ConstraintType.EQUAL, new FakeReadAccessor(ValueType.STRING_TYPE));
+        BetaNodeFieldConstraint[] constraints = new FakeBetaNodeFieldConstraint[]{intEqualsConstraint, stringEqualsConstraint};
+        boolean[] indexed = IndexUtil.isIndexableForNode(IndexPrecedenceOption.EQUALITY_PRIORITY, NodeTypeEnums.JoinNode, config.getCompositeKeyDepth(), constraints, config);
+        assertThat(indexed).containsExactly(true, true);
+    }
+
+    @Test
+    public void isIndexableForNodeWithIntAndBigDecimalAndString() {
+        RuleBaseConfiguration config = getRuleBaseConfiguration();
+        FakeBetaNodeFieldConstraint intEqualsConstraint = new FakeBetaNodeFieldConstraint(IndexUtil.ConstraintType.EQUAL, new FakeReadAccessor(ValueType.PINTEGER_TYPE));
+        FakeBetaNodeFieldConstraint bigDecimalEqualsConstraint = new FakeBetaNodeFieldConstraint(IndexUtil.ConstraintType.EQUAL, new FakeReadAccessor(ValueType.BIG_DECIMAL_TYPE));
+        FakeBetaNodeFieldConstraint stringEqualsConstraint = new FakeBetaNodeFieldConstraint(IndexUtil.ConstraintType.EQUAL, new FakeReadAccessor(ValueType.STRING_TYPE));
+        BetaNodeFieldConstraint[] constraints = new FakeBetaNodeFieldConstraint[]{intEqualsConstraint, bigDecimalEqualsConstraint, stringEqualsConstraint};
+        boolean[] indexed = IndexUtil.isIndexableForNode(IndexPrecedenceOption.EQUALITY_PRIORITY, NodeTypeEnums.JoinNode, config.getCompositeKeyDepth(), constraints, config);
+        assertThat(indexed).as("BigDecimal is sorted to the last").containsExactly(true, true, false);
+    }
+
+    @Test
+    public void isIndexableForNodeWithBigDecimal() {
+        RuleBaseConfiguration config = getRuleBaseConfiguration();
+        FakeBetaNodeFieldConstraint bigDecimalEqualsConstraint = new FakeBetaNodeFieldConstraint(IndexUtil.ConstraintType.EQUAL, new FakeReadAccessor(ValueType.BIG_DECIMAL_TYPE));
+        BetaNodeFieldConstraint[] constraints = new FakeBetaNodeFieldConstraint[]{bigDecimalEqualsConstraint};
+        boolean[] indexed = IndexUtil.isIndexableForNode(IndexPrecedenceOption.EQUALITY_PRIORITY, NodeTypeEnums.JoinNode, config.getCompositeKeyDepth(), constraints, config);
+        assertThat(indexed).as("BigDecimal is not indexed").containsExactly(false);
+    }
+
+    static class FakeBetaNodeFieldConstraint implements BetaNodeFieldConstraint,
+                                                        IndexableConstraint {
+
+        private IndexUtil.ConstraintType constraintType;
+        private ReadAccessor fieldExtractor;
+
+        public FakeBetaNodeFieldConstraint() {}
+
+        public FakeBetaNodeFieldConstraint(IndexUtil.ConstraintType constraintType, ReadAccessor fieldExtractor) {
+            this.constraintType = constraintType;
+            this.fieldExtractor = fieldExtractor;
+        }
+
+        @Override
+        public boolean isUnification() {
+            return false;
+        }
+
+        @Override
+        public boolean isIndexable(short nodeType, KieBaseConfiguration config) {
+            return false;
+        }
+
+        @Override
+        public IndexUtil.ConstraintType getConstraintType() {
+            return constraintType;
+        }
+
+        @Override
+        public FieldValue getField() {
+            return null;
+        }
+
+        @Override
+        public FieldIndex getFieldIndex() {
+            return new FieldIndex(fieldExtractor, new Declaration("$p1", fieldExtractor, null));
+        }
+
+        @Override
+        public ReadAccessor getFieldExtractor() {
+            return fieldExtractor;
+        }
+
+        @Override
+        public TupleValueExtractor getIndexExtractor() {
+            return null;
+        }
+
+        @Override
+        public boolean isAllowedCachedLeft(ContextEntry context, InternalFactHandle handle) {
+            return false;
+        }
+
+        @Override
+        public boolean isAllowedCachedRight(Tuple tuple, ContextEntry context) {
+            return false;
+        }
+
+        @Override
+        public ContextEntry createContextEntry() {
+            return null;
+        }
+
+        @Override
+        public BetaNodeFieldConstraint cloneIfInUse() {
+            return null;
+        }
+
+        @Override
+        public Declaration[] getRequiredDeclarations() {
+            return new Declaration[0];
+        }
+
+        @Override
+        public void replaceDeclaration(Declaration oldDecl, Declaration newDecl) {
+
+        }
+
+        @Override
+        public Constraint clone() {
+            return null;
+        }
+
+        @Override
+        public ConstraintType getType() {
+            return null;
+        }
+
+        @Override
+        public boolean isTemporal() {
+            return false;
+        }
+
+        @Override
+        public void writeExternal(ObjectOutput out) throws IOException {
+
+        }
+
+        @Override
+        public void readExternal(ObjectInput in) throws IOException, ClassNotFoundException {
+
+        }
+    }
+
+    static class FakeReadAccessor implements ReadAccessor {
+
+        private final ValueType valueType;
+
+        private FakeReadAccessor(ValueType valueType) {
+            this.valueType = valueType;
+        }
+
+        @Override
+        public Object getValue(Object object) {
+            return null;
+        }
+
+        @Override
+        public boolean isNullValue(Object object) {
+            return false;
+        }
+
+        @Override
+        public ValueType getValueType() {
+            return valueType;
+        }
+
+        @Override
+        public Class<?> getExtractToClass() {
+            return null;
+        }
+
+        @Override
+        public String getExtractToClassName() {
+            return null;
+        }
+
+        @Override
+        public Method getNativeReadMethod() {
+            return null;
+        }
+
+        @Override
+        public String getNativeReadMethodName() {
+            return null;
+        }
+
+        @Override
+        public int getHashCode(Object object) {
+            return 0;
+        }
+
+        @Override
+        public int getIndex() {
+            return 0;
+        }
+
+        @Override
+        public Object getValue(ReteEvaluator reteEvaluator, Object object) {
+            return null;
+        }
+
+        @Override
+        public char getCharValue(ReteEvaluator reteEvaluator, Object object) {
+            return 0;
+        }
+
+        @Override
+        public int getIntValue(ReteEvaluator reteEvaluator, Object object) {
+            return 0;
+        }
+
+        @Override
+        public byte getByteValue(ReteEvaluator reteEvaluator, Object object) {
+            return 0;
+        }
+
+        @Override
+        public short getShortValue(ReteEvaluator reteEvaluator, Object object) {
+            return 0;
+        }
+
+        @Override
+        public long getLongValue(ReteEvaluator reteEvaluator, Object object) {
+            return 0;
+        }
+
+        @Override
+        public float getFloatValue(ReteEvaluator reteEvaluator, Object object) {
+            return 0;
+        }
+
+        @Override
+        public double getDoubleValue(ReteEvaluator reteEvaluator, Object object) {
+            return 0;
+        }
+
+        @Override
+        public boolean getBooleanValue(ReteEvaluator reteEvaluator, Object object) {
+            return false;
+        }
+
+        @Override
+        public boolean isNullValue(ReteEvaluator reteEvaluator, Object object) {
+            return false;
+        }
+
+        @Override
+        public int getHashCode(ReteEvaluator reteEvaluator, Object object) {
+            return 0;
+        }
+
+        @Override
+        public boolean isGlobal() {
+            return false;
+        }
+
+        @Override
+        public boolean isSelfReference() {
+            return false;
+        }
+    }
+}

--- a/drools-test-coverage/test-suite/src/test/java/org/drools/testcoverage/common/model/Person.java
+++ b/drools-test-coverage/test-suite/src/test/java/org/drools/testcoverage/common/model/Person.java
@@ -79,6 +79,13 @@ public class Person implements Serializable {
         this.salary = salary;
     }
 
+    public Person(final String name, final int age, final BigDecimal salary, String likes) {
+        this.name = name;
+        this.age = age;
+        this.salary = salary;
+        this.likes = likes;
+    }
+
     public int getId() {
         return id;
     }

--- a/drools-test-coverage/test-suite/src/test/java/org/drools/testcoverage/common/util/KieUtil.java
+++ b/drools-test-coverage/test-suite/src/test/java/org/drools/testcoverage/common/util/KieUtil.java
@@ -18,6 +18,7 @@ package org.drools.testcoverage.common.util;
 
 import java.io.StringReader;
 import java.util.ArrayList;
+import java.util.Collection;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -25,7 +26,11 @@ import java.util.UUID;
 
 import org.drools.compiler.kie.builder.impl.DrlProject;
 import org.drools.core.base.ClassObjectType;
+import org.drools.core.common.BaseNode;
+import org.drools.core.common.NetworkNode;
 import org.drools.core.impl.RuleBase;
+import org.drools.core.reteoo.EntryPointNode;
+import org.drools.core.reteoo.JoinNode;
 import org.drools.core.reteoo.ObjectTypeNode;
 import org.kie.api.KieBase;
 import org.kie.api.KieServices;
@@ -339,6 +344,32 @@ public final class KieUtil {
             }
         }
         return null;
+    }
+
+    // This method returns the first JoinNode found which meets the factClass
+    public static JoinNode getJoinNode(final KieBase kbase, final Class<?> factClass) {
+        Collection<EntryPointNode> entryPointNodes = ((RuleBase) kbase).getRete().getEntryPointNodes().values();
+        for (EntryPointNode entryPointNode : entryPointNodes) {
+            JoinNode joinNode = findNode(entryPointNode, JoinNode.class);
+            if (((ClassObjectType)joinNode.getObjectTypeNode().getObjectType()).getClassType().equals(factClass)) {
+                return joinNode;
+            }
+        }
+        return null;
+    }
+
+    private static <T> T findNode(BaseNode node, Class<T> nodeClass) {
+        if (node.getClass().equals(nodeClass)) {
+            return (T)node;
+        } else {
+            NetworkNode[] sinks = node.getSinks();
+            for (NetworkNode sink : sinks) {
+                if (sink instanceof BaseNode) {
+                    return findNode((BaseNode)sink, nodeClass);
+                }
+            }
+            return null;
+        }
     }
 
     private KieUtil() {


### PR DESCRIPTION
…… (#5233)

* [DROOLS-7444] join constraints are ignored when BigDecimal equality is involved in a Pattern

* - Add more tests

* - added more tests

* - improve assertion


**Ports** 
This is a forward-port PR of https://github.com/kiegroup/drools/pull/5233 for main

**JIRA**: 
https://issues.redhat.com/browse/DROOLS-7444

<details>
<summary>
How to replicate CI configuration locally?
</summary>

Build Chain tool does "simple" maven build(s), the builds are just Maven commands, but because the repositories relates and depends on each other and any change in API or class method could affect several of those repositories there is a need to use [build-chain tool](https://github.com/kiegroup/github-action-build-chain) to handle cross repository builds and be sure that we always use latest version of the code for each repository.
 
[build-chain tool](https://github.com/kiegroup/github-action-build-chain) is a build tool which can be used on command line locally or in Github Actions workflow(s), in case you need to change multiple repositories and send multiple dependent pull requests related with a change you can easily reproduce the same build by executing it on Github hosted environment or locally in your development environment. See [local execution](https://github.com/kiegroup/github-action-build-chain#local-execution) details to get more information about it.
</details>

<details>
<summary>
How to retest this PR or trigger a specific build:
</summary>

- for <b>pull request checks</b>  
  Please add comment: <b>Jenkins retest this</b>

- for a <b>specific pull request check</b>  
  Please add comment: <b>Jenkins (re)run [drools|kogito-runtimes|kogito-apps|kogito-examples] tests</b>

- for a <b>full downstream build</b> 
  - for <b>jenkins</b> job: please add comment: <b>Jenkins run fdb</b>
  - for <b>github actions</b> job: add the label `run_fdb`

- <b>a compile downstream build</b> please  add comment: <b>Jenkins run cdb</b>

- <b>a full production downstream build</b> please add comment: <b>Jenkins execute product fdb</b>

- <b>an upstream build</b> please add comment: <b>Jenkins run upstream</b>

- for <b>quarkus branch checks</b>  
  Run checks against Quarkus current used branch  
  Please add comment: <b>Jenkins run quarkus-branch</b>

- for a <b>quarkus branch specific check</b>  
  Run checks against Quarkus current used branch  
  Please add comment: <b>Jenkins (re)run [drools|kogito-runtimes|kogito-apps|kogito-examples] quarkus-branch</b>

- for <b>quarkus main checks</b>  
  Run checks against Quarkus main branch  
  Please add comment: <b>Jenkins run quarkus-main</b>

- for a <b>specific quarkus main check</b>  
  Run checks against Quarkus main branch  
  Please add comment: <b>Jenkins (re)run [drools|kogito-runtimes|kogito-apps|kogito-examples] quarkus-main</b>

- for <b>quarkus lts checks</b>  
  Run checks against Quarkus lts branch  
  Please add comment: <b>Jenkins run quarkus-lts</b>

- for a <b>specific quarkus lts check</b>  
  Run checks against Quarkus lts branch  
  Please add comment: <b>Jenkins (re)run [drools|kogito-runtimes|kogito-apps|kogito-examples] quarkus-lts</b>

- for <b>native checks</b>  
  Run native checks  
  Please add comment: <b>Jenkins run native</b>

- for a <b>specific native check</b>  
  Run native checks 
  Please add comment: <b>Jenkins (re)run [drools|kogito-runtimes|kogito-apps|kogito-examples] native</b>

 - for <b>native lts checks</b>  
  Run native checks against quarkus lts branch
  Please add comment: <b>Jenkins run native-lts</b>

- for a <b>specific native lts check</b>  
  Run native checks against quarkus lts branch
  Please add comment: <b>Jenkins (re)run [drools|kogito-runtimes|kogito-apps|kogito-examples] native-lts</b>
</details>

<details>
<summary>
How to backport a pull request to a different branch?
</summary>

In order to automatically create a **backporting pull request** please add one or more labels having the following format `backport-<branch-name>`, where `<branch-name>` is the name of the branch where the pull request must be backported to (e.g., `backport-7.67.x` to backport the original PR to the `7.67.x` branch).

> **NOTE**: **backporting** is an action aiming to move a change (usually a commit) from a branch (usually the main one) to another one, which is generally referring to a still maintained release branch. Keeping it simple: it is about to move a specific change or a set of them from one branch to another.

Once the original pull request is successfully merged, the automated action will create one backporting pull request per each label (with the previous format) that has been added.

If something goes wrong, the author will be notified and at this point a manual backporting is needed.

> **NOTE**: this automated backporting is triggered whenever a pull request on `main` branch is labeled or closed, but both conditions must be satisfied to get the new PR created.
</details>

<!-- TODO to uncomment if activating the quarkus-3 rewrite PR job -->
<!-- <details>
<summary>
Quarkus-3 PR check is failing ... what to do ?
</summary>
The Quarkus 3 check is applying patches from the `.ci/environments/quarkus-3/patches`.

The first patch, called `0001_before_sh.patch`, is generated from Openrewrite `.ci/environments/quarkus-3/quarkus3.yml` recipe. The patch is created to speed up the check. But it may be that some changes in the PR broke this patch.  
No panic, there is an easy way to regenerate it. You just need to comment on the PR:
```
jenkins rewrite quarkus-3
```
and it should, after some minutes (~20/30min) apply a commit on the PR with the patch regenerated.

Other patches were generated manually. If any of it fails, you will need to manually update it... and push your changes.
</details> -->