### PR TITLE
[DROOLS-7371] Restoring KieActivator 

### DIFF
--- a/kie-api/src/main/java/org/kie/api/project/KieActivator.java
+++ b/kie-api/src/main/java/org/kie/api/project/KieActivator.java
@@ -1,0 +1,32 @@
+/*
+ * Copyright 2023 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.kie.api.project;
+
+import java.lang.annotation.Retention;
+import java.lang.annotation.Target;
+
+import static java.lang.annotation.ElementType.TYPE;
+import static java.lang.annotation.RetentionPolicy.RUNTIME;
+
+/**
+ * It defines the annotation required to enable the Java LSP Extension functionality in kie-tools
+ */
+@Target({TYPE})
+@Retention(RUNTIME)
+public @interface KieActivator {
+
+}


### PR DESCRIPTION
Restoring the KieActivator annotation, requested for [Import Java Class functionality](https://blog.kie.org/2022/05/dmn-types-from-java-classes.html) in kie-tools and removed in this PR https://github.com/kiegroup/drools/pull/5120
`Qualifier` annotation has been removed