### PR TITLE
DROOLS-7455 add global support to DRL-YAML projections

### DIFF
--- a/drools-drlonyaml-parent/drools-drlonyaml-model/src/main/java/org/drools/drlonyaml/model/DrlPackage.java
+++ b/drools-drlonyaml-parent/drools-drlonyaml-model/src/main/java/org/drools/drlonyaml/model/DrlPackage.java
@@ -21,6 +21,7 @@ import java.util.ArrayList;
 import java.util.List;
 
 import org.drools.drl.ast.descr.FunctionDescr;
+import org.drools.drl.ast.descr.GlobalDescr;
 import org.drools.drl.ast.descr.ImportDescr;
 import org.drools.drl.ast.descr.PackageDescr;
 import org.drools.drl.ast.descr.RuleDescr;
@@ -29,12 +30,14 @@ import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonInclude.Include;
 import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 
-@JsonPropertyOrder({"name", "imports", "rules", "functions"})
+@JsonPropertyOrder({"name", "imports", "globals", "rules", "functions"})
 public class DrlPackage {
     @JsonInclude(Include.NON_EMPTY)
     private String name = ""; // default empty, consistent with DRL parser.
     @JsonInclude(Include.NON_EMPTY)
     private List<Import> imports = new ArrayList<>();
+    @JsonInclude(Include.NON_EMPTY)
+    private List<Global> globals = new ArrayList<>();
     private List<Rule> rules = new ArrayList<>();
     @JsonInclude(Include.NON_EMPTY)
     private List<Function> functions = new ArrayList<>();
@@ -44,6 +47,9 @@ public class DrlPackage {
         result.name = o.getName();
         for (ImportDescr i : o.getImports()) {
             result.imports.add(Import.from(i));
+        }
+        for (GlobalDescr g : o.getGlobals()) {
+            result.globals.add(Global.from(g));
         }
         for (RuleDescr r : o.getRules()) {
             result.rules.add(Rule.from(r));
@@ -60,6 +66,10 @@ public class DrlPackage {
 
     public List<Import> getImports() {
         return imports;
+    }
+    
+    public List<Global> getGlobals() {
+        return globals;
     }
 
     public List<Rule> getRules() {

--- a/drools-drlonyaml-parent/drools-drlonyaml-model/src/main/java/org/drools/drlonyaml/model/Global.java
+++ b/drools-drlonyaml-parent/drools-drlonyaml-model/src/main/java/org/drools/drlonyaml/model/Global.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright 2023 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ *
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.drools.drlonyaml.model;
+
+import org.drools.drl.ast.descr.GlobalDescr;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonPropertyOrder;
+
+@JsonPropertyOrder({"type", "id"})
+public class Global {
+    @JsonProperty(required = true)
+    private String type;
+    @JsonProperty(required = true)
+    private String id;
+
+    public static Global from(GlobalDescr r) {
+        Global result = new Global();
+        result.type = r.getType();
+        result.id = r.getIdentifier();
+        return result;
+    }
+
+    public String getType() {
+        return type;
+    }
+
+    public String getId() {
+        return id;
+    }
+}

--- a/drools-drlonyaml-parent/drools-drlonyaml-model/src/main/resources/drlonyaml-schema.json
+++ b/drools-drlonyaml-parent/drools-drlonyaml-model/src/main/resources/drlonyaml-schema.json
@@ -61,6 +61,18 @@
         }
       }
     },
+    "Global" : {
+      "type" : "object",
+      "properties" : {
+        "type" : {
+          "type" : "string"
+        },
+        "id" : {
+          "type" : "string"
+        }
+      },
+      "required" : [ "type", "id" ]
+    },
     "Import" : {
       "type" : "string"
     },
@@ -155,6 +167,12 @@
       "type" : "array",
       "items" : {
         "$ref" : "#/definitions/Import"
+      }
+    },
+    "globals" : {
+      "type" : "array",
+      "items" : {
+        "$ref" : "#/definitions/Global"
       }
     },
     "rules" : {

--- a/drools-drlonyaml-parent/drools-drlonyaml-todrl/src/main/resources/drl.ftl
+++ b/drools-drlonyaml-parent/drools-drlonyaml-todrl/src/main/resources/drl.ftl
@@ -10,6 +10,14 @@ import ${import.target};
 </#list>
 <#--
 
+## DRL globals
+
+-->
+<#list globals as global>
+global ${global.type} ${global.id};
+</#list>
+<#--
+
 ## DRL rules
 
 -->

--- a/drools-drlonyaml-parent/drools-drlonyaml-todrl/src/test/java/org/drools/drlonyaml/todrl/YAMLtoDRLTest.java
+++ b/drools-drlonyaml-parent/drools-drlonyaml-todrl/src/test/java/org/drools/drlonyaml/todrl/YAMLtoDRLTest.java
@@ -97,4 +97,9 @@ public class YAMLtoDRLTest {
     public void smokeTestFromYAML10() {
         assertDumpingYAMLtoDRLisValid("/smoketests/yaml10.yml");
     }
+    
+    @Test
+    public void smokeTestFromYAML11() {
+        assertDumpingYAMLtoDRLisValid("/smoketests/yaml11.yml");
+    }
 }

--- a/drools-drlonyaml-parent/drools-drlonyaml-todrl/src/test/resources/smoketests/yaml11.yml
+++ b/drools-drlonyaml-parent/drools-drlonyaml-todrl/src/test/resources/smoketests/yaml11.yml
@@ -1,0 +1,44 @@
+# only syntactically valid yaml.
+name: rules.rhoc
+imports:
+- java.util.Map
+- org.drools.ruleops.model.Advice
+- io.fabric8.kubernetes.api.model.ConfigMap
+- io.fabric8.kubernetes.api.model.Pod
+globals:
+- type: String
+  id: arg0
+rules:
+- name: Find configMap in connector namespace to enable logs
+  when:
+  - given: Pod
+    as: $pod
+    having:
+    - "metadata.labels[\"cos.bf2.org/connector.id\"] == arg0"
+    - "$deploymentId : metadata.labels[\"cos.bf2.org/deployment.id\"]"
+    - "$namespace: metadata.namespace"
+  - given: ConfigMap
+    as: $configMap
+    having:
+    - metadata.name ==  "mctr-" + $deploymentId + "-configmap"
+    - metadata.namespace == $namespace
+  then: |
+    if(!$configMap.getData().containsKey("override.properties")) {
+            String description = """
+                    Run the following command:
+
+                        kubectl edit configmap %s -n %s
+
+                    Upgrade then the data field:
+
+                        override.properties: |-
+                            quarkus.log.level=DEBUG
+                            quarkus.log.min-level=DEBUG
+                            quarkus.log.category."org.apache".level = DEBUG
+                            quarkus.log.category."org.apache".min-level = DEBUG
+
+                    """
+                    .formatted($configMap.getMetadata().getName(), $namespace);
+
+            insert(new Advice("To enable logging on connector: %s".formatted(arg0), description));
+      }


### PR DESCRIPTION
**JIRA**: https://issues.redhat.com/browse/DROOLS-7455

**referenced Pull Requests**: none

<details>
<summary>
How to replicate CI configuration locally?
</summary>

Build Chain tool does "simple" maven build(s), the builds are just Maven commands, but because the repositories relates and depends on each other and any change in API or class method could affect several of those repositories there is a need to use [build-chain tool](https://github.com/kiegroup/github-action-build-chain) to handle cross repository builds and be sure that we always use latest version of the code for each repository.
 
[build-chain tool](https://github.com/kiegroup/github-action-build-chain) is a build tool which can be used on command line locally or in Github Actions workflow(s), in case you need to change multiple repositories and send multiple dependent pull requests related with a change you can easily reproduce the same build by executing it on Github hosted environment or locally in your development environment. See [local execution](https://github.com/kiegroup/github-action-build-chain#local-execution) details to get more information about it.
</details>

<details>
<summary>
How to retest this PR or trigger a specific build:
</summary>

- for <b>pull request checks</b>  
  Please add comment: <b>Jenkins retest this</b>

- for a <b>specific pull request check</b>  
  Please add comment: <b>Jenkins (re)run [drools|kogito-runtimes|kogito-apps|kogito-examples] tests</b>

- for a <b>full downstream build</b> 
  - for <b>jenkins</b> job: please add comment: <b>Jenkins run fdb</b>
  - for <b>github actions</b> job: add the label `run_fdb`

- <b>a compile downstream build</b> please  add comment: <b>Jenkins run cdb</b>

- <b>a full production downstream build</b> please add comment: <b>Jenkins execute product fdb</b>

- <b>an upstream build</b> please add comment: <b>Jenkins run upstream</b>

- for <b>quarkus branch checks</b>  
  Run checks against Quarkus current used branch  
  Please add comment: <b>Jenkins run quarkus-branch</b>

- for a <b>quarkus branch specific check</b>  
  Run checks against Quarkus current used branch  
  Please add comment: <b>Jenkins (re)run [drools|kogito-runtimes|kogito-apps|kogito-examples] quarkus-branch</b>

- for <b>quarkus main checks</b>  
  Run checks against Quarkus main branch  
  Please add comment: <b>Jenkins run quarkus-main</b>

- for a <b>specific quarkus main check</b>  
  Run checks against Quarkus main branch  
  Please add comment: <b>Jenkins (re)run [drools|kogito-runtimes|kogito-apps|kogito-examples] quarkus-main</b>

- for <b>quarkus lts checks</b>  
  Run checks against Quarkus lts branch  
  Please add comment: <b>Jenkins run quarkus-lts</b>

- for a <b>specific quarkus lts check</b>  
  Run checks against Quarkus lts branch  
  Please add comment: <b>Jenkins (re)run [drools|kogito-runtimes|kogito-apps|kogito-examples] quarkus-lts</b>

- for <b>native checks</b>  
  Run native checks  
  Please add comment: <b>Jenkins run native</b>

- for a <b>specific native check</b>  
  Run native checks 
  Please add comment: <b>Jenkins (re)run [drools|kogito-runtimes|kogito-apps|kogito-examples] native</b>

 - for <b>native lts checks</b>  
  Run native checks against quarkus lts branch
  Please add comment: <b>Jenkins run native-lts</b>

- for a <b>specific native lts check</b>  
  Run native checks against quarkus lts branch
  Please add comment: <b>Jenkins (re)run [drools|kogito-runtimes|kogito-apps|kogito-examples] native-lts</b>
</details>

<details>
<summary>
How to backport a pull request to a different branch?
</summary>

In order to automatically create a **backporting pull request** please add one or more labels having the following format `backport-<branch-name>`, where `<branch-name>` is the name of the branch where the pull request must be backported to (e.g., `backport-7.67.x` to backport the original PR to the `7.67.x` branch).

> **NOTE**: **backporting** is an action aiming to move a change (usually a commit) from a branch (usually the main one) to another one, which is generally referring to a still maintained release branch. Keeping it simple: it is about to move a specific change or a set of them from one branch to another.

Once the original pull request is successfully merged, the automated action will create one backporting pull request per each label (with the previous format) that has been added.

If something goes wrong, the author will be notified and at this point a manual backporting is needed.

> **NOTE**: this automated backporting is triggered whenever a pull request on `main` branch is labeled or closed, but both conditions must be satisfied to get the new PR created.
</details>

<!-- TODO to uncomment if activating the quarkus-3 rewrite PR job -->
<!-- <details>
<summary>
Quarkus-3 PR check is failing ... what to do ?
</summary>
The Quarkus 3 check is applying patches from the `.ci/environments/quarkus-3/patches`.

The first patch, called `0001_before_sh.patch`, is generated from Openrewrite `.ci/environments/quarkus-3/quarkus3.yml` recipe. The patch is created to speed up the check. But it may be that some changes in the PR broke this patch.  
No panic, there is an easy way to regenerate it. You just need to comment on the PR:
```
jenkins rewrite quarkus-3
```
and it should, after some minutes (~20/30min) apply a commit on the PR with the patch regenerated.

Other patches were generated manually. If any of it fails, you will need to manually update it... and push your changes.
</details> -->