### PR TITLE
D7454 reliable node memories 2

### DIFF
--- a/drools-core/src/main/java/org/drools/core/common/AgendaGroupsManager.java
+++ b/drools-core/src/main/java/org/drools/core/common/AgendaGroupsManager.java
@@ -16,6 +16,10 @@
 
 package org.drools.core.common;
 
+import org.drools.core.impl.RuleBase;
+import org.drools.core.phreak.RuleAgendaItem;
+import org.drools.core.reteoo.RuntimeComponentFactory;
+
 import java.io.Externalizable;
 import java.io.IOException;
 import java.io.ObjectInput;
@@ -29,10 +33,6 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
-
-import org.drools.core.impl.RuleBase;
-import org.drools.core.phreak.RuleAgendaItem;
-import org.drools.core.reteoo.RuntimeComponentFactory;
 
 public interface AgendaGroupsManager extends Externalizable {
     void setReteEvaluator(ReteEvaluator reteEvaluator);
@@ -179,7 +179,7 @@ public interface AgendaGroupsManager extends Externalizable {
 
         @Override
         public RuleAgendaItem peekNextRule() {
-            return (RuleAgendaItem) this.mainAgendaGroup.peek();
+            return this.mainAgendaGroup.peek();
         }
 
         @Override
@@ -394,10 +394,9 @@ public interface AgendaGroupsManager extends Externalizable {
             // Set the focus to the agendaGroup if it doesn't already have the focus
             if ( this.focusStack.getLast() != agendaGroup ) {
                 this.focusStack.getLast().setActive( false );
-                InternalAgendaGroup internalGroup = agendaGroup;
-                this.focusStack.add( internalGroup );
-                internalGroup.setActive( true );
-                internalGroup.setActivatedForRecency( this.workingMemory.getFactHandleFactory().getRecency() );
+                this.focusStack.add(agendaGroup);
+                agendaGroup.setActive( true );
+                agendaGroup.setActivatedForRecency( this.workingMemory.getFactHandleFactory().getRecency() );
                 final EventSupport eventsupport = this.workingMemory;
                 eventsupport.getAgendaEventSupport().fireAgendaGroupPushed( agendaGroup, this.workingMemory );
                 return true;
@@ -418,7 +417,7 @@ public interface AgendaGroupsManager extends Externalizable {
 
         @Override
         public RuleAgendaItem peekNextRule() {
-            return (RuleAgendaItem) (this.focusStack.peekLast()).peek();
+            return this.focusStack.peekLast().peek();
         }
 
         @Override

--- a/drools-core/src/main/java/org/drools/core/concurrent/SequentialRuleEvaluator.java
+++ b/drools-core/src/main/java/org/drools/core/concurrent/SequentialRuleEvaluator.java
@@ -39,7 +39,7 @@ public class SequentialRuleEvaluator extends AbstractRuleEvaluator implements Ru
                                 int fireCount,
                                 int fireLimit,
                                 InternalAgendaGroup group ) {
-        RuleAgendaItem item = sequential ? (RuleAgendaItem) group.remove() : (RuleAgendaItem) group.peek();
+        RuleAgendaItem item = sequential ? group.remove() : group.peek();
         return item != null ? internalEvaluateAndFire( filter, fireCount, fireLimit, item ) : 0;
     }
 

--- a/drools-core/src/main/java/org/drools/core/reteoo/BetaMemory.java
+++ b/drools-core/src/main/java/org/drools/core/reteoo/BetaMemory.java
@@ -24,9 +24,11 @@ import org.drools.core.reteoo.RightInputAdapterNode.RiaPathMemory;
 import org.drools.core.rule.ContextEntry;
 import org.drools.core.util.AbstractBaseLinkedListNode;
 
+import java.io.Serializable;
+
 public class BetaMemory extends AbstractBaseLinkedListNode<Memory>
         implements
-        SegmentNodeMemory {
+        SegmentNodeMemory, Serializable {
 
     private static final long serialVersionUID = 510l;
     private TupleMemory                leftTupleMemory;

--- a/drools-core/src/main/java/org/drools/core/reteoo/LeftInputAdapterNode.java
+++ b/drools-core/src/main/java/org/drools/core/reteoo/LeftInputAdapterNode.java
@@ -511,7 +511,7 @@ public class LeftInputAdapterNode extends LeftTupleSource
         return new LiaNodeMemory();
     }
 
-    public static class LiaNodeMemory extends AbstractBaseLinkedListNode<Memory> implements SegmentNodeMemory {
+    public static class LiaNodeMemory extends AbstractBaseLinkedListNode<Memory> implements SegmentNodeMemory, Serializable {
         private int               counter;
 
         private SegmentMemory     segmentMemory;

--- a/drools-core/src/main/java/org/drools/core/reteoo/LeftInputAdapterNode.java
+++ b/drools-core/src/main/java/org/drools/core/reteoo/LeftInputAdapterNode.java
@@ -16,11 +16,6 @@
 
 package org.drools.core.reteoo;
 
-import java.util.Collections;
-import java.util.HashSet;
-import java.util.List;
-import java.util.Set;
-
 import org.drools.core.RuleBaseConfiguration;
 import org.drools.core.base.ClassObjectType;
 import org.drools.core.base.ObjectType;
@@ -45,6 +40,12 @@ import org.kie.api.definition.rule.Rule;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import java.io.Serializable;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+
 import static org.drools.core.phreak.TupleEvaluationUtil.createLeftTupleTupleSets;
 import static org.drools.core.phreak.TupleEvaluationUtil.findPathToFlush;
 import static org.drools.core.phreak.TupleEvaluationUtil.findPathsToFlushFromRia;
@@ -62,7 +63,7 @@ import static org.drools.core.reteoo.PropertySpecificUtil.isPropertyReactive;
 public class LeftInputAdapterNode extends LeftTupleSource
         implements
         ObjectSinkNode,
-        MemoryFactory<LeftInputAdapterNode.LiaNodeMemory> {
+        MemoryFactory<LeftInputAdapterNode.LiaNodeMemory>, Serializable {
 
     protected static final transient Logger log = LoggerFactory.getLogger(LeftInputAdapterNode.class);
 

--- a/drools-core/src/main/java/org/drools/core/reteoo/ObjectTypeNode.java
+++ b/drools-core/src/main/java/org/drools/core/reteoo/ObjectTypeNode.java
@@ -16,17 +16,10 @@
 
 package org.drools.core.reteoo;
 
-import java.io.Externalizable;
-import java.io.IOException;
-import java.io.ObjectInput;
-import java.io.ObjectOutput;
-import java.util.Collections;
-import java.util.Iterator;
-import java.util.List;
-
 import org.drools.core.InitialFact;
 import org.drools.core.RuleBaseConfiguration;
 import org.drools.core.base.ClassObjectType;
+import org.drools.core.base.ObjectType;
 import org.drools.core.base.ValueType;
 import org.drools.core.common.DefaultFactHandle;
 import org.drools.core.common.FactHandleClassStore;
@@ -34,19 +27,27 @@ import org.drools.core.common.InternalFactHandle;
 import org.drools.core.common.InternalWorkingMemory;
 import org.drools.core.common.Memory;
 import org.drools.core.common.MemoryFactory;
+import org.drools.core.common.PropagationContext;
 import org.drools.core.common.ReteEvaluator;
 import org.drools.core.common.RuleBasePartitionId;
 import org.drools.core.common.UpdateContext;
 import org.drools.core.impl.WorkingMemoryReteExpireAction;
 import org.drools.core.reteoo.builder.BuildContext;
 import org.drools.core.rule.EntryPointId;
-import org.drools.core.base.ObjectType;
-import org.drools.core.common.PropagationContext;
 import org.drools.core.time.Job;
 import org.drools.core.time.JobContext;
 import org.drools.core.time.JobHandle;
 import org.drools.core.util.bitmask.BitMask;
 import org.drools.core.util.bitmask.EmptyBitMask;
+
+import java.io.Externalizable;
+import java.io.IOException;
+import java.io.ObjectInput;
+import java.io.ObjectOutput;
+import java.io.Serializable;
+import java.util.Collections;
+import java.util.Iterator;
+import java.util.List;
 
 import static org.drools.core.rule.TypeDeclaration.NEVER_EXPIRES;
 
@@ -64,7 +65,7 @@ import static org.drools.core.rule.TypeDeclaration.NEVER_EXPIRES;
  *
  * @see Rete
  */
-public class ObjectTypeNode extends ObjectSource implements ObjectSink, MemoryFactory<ObjectTypeNode.ObjectTypeNodeMemory> {
+public class ObjectTypeNode extends ObjectSource implements ObjectSink, MemoryFactory<ObjectTypeNode.ObjectTypeNodeMemory>, Serializable {
     // ------------------------------------------------------------
     // Instance members
     // ------------------------------------------------------------

--- a/drools-core/src/main/java/org/drools/core/reteoo/ObjectTypeNode.java
+++ b/drools-core/src/main/java/org/drools/core/reteoo/ObjectTypeNode.java
@@ -655,7 +655,7 @@ public class ObjectTypeNode extends ObjectSource implements ObjectSink, MemoryFa
         }
     }
 
-    public static class InitialFactObjectTypeNodeMemory extends ObjectTypeNodeMemory {
+    public static class InitialFactObjectTypeNodeMemory extends ObjectTypeNodeMemory implements Serializable {
         private List<InternalFactHandle> list = Collections.emptyList();
 
         InitialFactObjectTypeNodeMemory(Class<?> classType) {

--- a/drools-kiesession/src/main/java/org/drools/kiesession/session/StatefulKnowledgeSessionImpl.java
+++ b/drools-kiesession/src/main/java/org/drools/kiesession/session/StatefulKnowledgeSessionImpl.java
@@ -16,27 +16,6 @@
 
 package org.drools.kiesession.session;
 
-import java.io.ByteArrayOutputStream;
-import java.io.Externalizable;
-import java.io.IOException;
-import java.io.ObjectInput;
-import java.io.ObjectOutput;
-import java.lang.reflect.Type;
-import java.util.ArrayList;
-import java.util.Collection;
-import java.util.Collections;
-import java.util.HashMap;
-import java.util.Iterator;
-import java.util.List;
-import java.util.Map;
-import java.util.concurrent.ConcurrentHashMap;
-import java.util.concurrent.atomic.AtomicBoolean;
-import java.util.concurrent.atomic.AtomicInteger;
-import java.util.concurrent.atomic.AtomicLong;
-import java.util.concurrent.locks.Lock;
-import java.util.concurrent.locks.ReentrantLock;
-import java.util.function.Consumer;
-
 import org.drools.core.FlowSessionConfiguration;
 import org.drools.core.QueryResultsImpl;
 import org.drools.core.RuleBaseConfiguration;
@@ -137,6 +116,27 @@ import org.kie.internal.marshalling.MarshallerFactory;
 import org.kie.internal.process.CorrelationAwareProcessRuntime;
 import org.kie.internal.process.CorrelationKey;
 import org.kie.internal.runtime.StatefulKnowledgeSession;
+
+import java.io.ByteArrayOutputStream;
+import java.io.Externalizable;
+import java.io.IOException;
+import java.io.ObjectInput;
+import java.io.ObjectOutput;
+import java.lang.reflect.Type;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicLong;
+import java.util.concurrent.locks.Lock;
+import java.util.concurrent.locks.ReentrantLock;
+import java.util.function.Consumer;
 
 import static java.util.stream.Collectors.toList;
 import static org.drools.core.base.ClassObjectType.InitialFact_ObjectType;
@@ -329,7 +329,7 @@ public class StatefulKnowledgeSessionImpl extends AbstractRuntime
 
         this.lastIdleTimestamp = new AtomicLong(-1);
 
-        this.nodeMemories = new ConcurrentNodeMemories(kBase);
+        this.nodeMemories = createNodeMemories(kBase);
         registerReceiveNodes(kBase.getReceiveNodes());
 
         RuleBaseConfiguration conf = kBase.getRuleBaseConfiguration();
@@ -347,6 +347,10 @@ public class StatefulKnowledgeSessionImpl extends AbstractRuntime
         if (initInitFactHandle) {
             this.initialFactHandle = initInitialFact(null);
         }
+    }
+
+    protected ConcurrentNodeMemories createNodeMemories(InternalKnowledgeBase kBase) {
+        return new ConcurrentNodeMemories(kBase);
     }
 
     public StatefulKnowledgeSessionImpl setStateless( boolean stateless ) {

--- a/drools-kiesession/src/main/java/org/drools/kiesession/session/StatefulKnowledgeSessionImpl.java
+++ b/drools-kiesession/src/main/java/org/drools/kiesession/session/StatefulKnowledgeSessionImpl.java
@@ -329,14 +329,17 @@ public class StatefulKnowledgeSessionImpl extends AbstractRuntime
 
         this.lastIdleTimestamp = new AtomicLong(-1);
 
-        this.nodeMemories = createNodeMemories(kBase);
-        registerReceiveNodes(kBase.getReceiveNodes());
+        //this.nodeMemories = createNodeMemories(kBase);
+        //registerReceiveNodes(kBase.getReceiveNodes());
 
         RuleBaseConfiguration conf = kBase.getRuleBaseConfiguration();
         this.pctxFactory = RuntimeComponentFactory.get().getPropagationContextFactory();
 
         this.agenda = agenda != null ? agenda : RuntimeComponentFactory.get().getAgendaFactory( config ).createAgenda(kBase);
         this.agenda.setWorkingMemory(this);
+
+        this.nodeMemories = createNodeMemories(kBase);
+        registerReceiveNodes(kBase.getReceiveNodes());
 
         this.entryPointsManager = (NamedEntryPointsManager) RuntimeComponentFactory.get().getEntryPointFactory().createEntryPointsManager(this);
 

--- a/drools-reliability/drools-reliability-core/src/main/java/org/drools/reliability/core/FullReliableObjectStore.java
+++ b/drools-reliability/drools-reliability-core/src/main/java/org/drools/reliability/core/FullReliableObjectStore.java
@@ -19,7 +19,7 @@ import org.drools.core.common.IdentityObjectStore;
 import org.drools.core.common.InternalFactHandle;
 import org.drools.core.common.Storage;
 
-public class FullReliableObjectStore extends IdentityObjectStore {
+public class FullReliableObjectStore extends IdentityObjectStore implements ReliableObjectStore {
 
     private final transient Storage<Long, StoredObject> storage;
 
@@ -45,13 +45,13 @@ public class FullReliableObjectStore extends IdentityObjectStore {
         super.removeHandle(handle);
     }
 
-    void putIntoPersistedCache(InternalFactHandle handle, boolean propagated) {
+    private void putIntoPersistedCache(InternalFactHandle handle, boolean propagated) {
         Object object = handle.getObject();
         StoredObject storedObject = new SerializableStoredObject(object, propagated);
         storage.put(getHandleForObject(object).getId(), storedObject);
     }
 
-    void removeFromPersistedCache(Object object) {
+    private void removeFromPersistedCache(Object object) {
         InternalFactHandle fh = getHandleForObject(object);
         if (fh != null) {
             storage.remove(fh.getId());
@@ -62,5 +62,10 @@ public class FullReliableObjectStore extends IdentityObjectStore {
         for (StoredObject entry : storage.values()) {
             super.addHandle(getHandleForObject(entry.getObject()),entry.getObject());
         }
+    }
+
+    @Override
+    public void safepoint() {
+        // no-op
     }
 }

--- a/drools-reliability/drools-reliability-core/src/main/java/org/drools/reliability/core/FullReliableObjectStore.java
+++ b/drools-reliability/drools-reliability-core/src/main/java/org/drools/reliability/core/FullReliableObjectStore.java
@@ -66,6 +66,8 @@ public class FullReliableObjectStore extends IdentityObjectStore implements Reli
 
     @Override
     public void safepoint() {
-        // no-op
+        if (storage.requiresFlush()) {
+            storage.flush();
+        }
     }
 }

--- a/drools-reliability/drools-reliability-core/src/main/java/org/drools/reliability/core/ReliableList.java
+++ b/drools-reliability/drools-reliability-core/src/main/java/org/drools/reliability/core/ReliableList.java
@@ -1,0 +1,7 @@
+package org.drools.reliability.core;
+
+import org.drools.core.phreak.PropagationList;
+
+public interface ReliableList extends PropagationList {
+    void safepoint();
+}

--- a/drools-reliability/drools-reliability-core/src/main/java/org/drools/reliability/core/ReliableNamedEntryPoint.java
+++ b/drools-reliability/drools-reliability-core/src/main/java/org/drools/reliability/core/ReliableNamedEntryPoint.java
@@ -38,6 +38,6 @@ public class ReliableNamedEntryPoint extends NamedEntryPoint {
     }
 
     public void safepoint() {
-        ((SimpleReliableObjectStore) getObjectStore()).safepoint();
+        ((ReliableObjectStore) getObjectStore()).safepoint();
     }
 }

--- a/drools-reliability/drools-reliability-core/src/main/java/org/drools/reliability/core/ReliableNodeMemories.java
+++ b/drools-reliability/drools-reliability-core/src/main/java/org/drools/reliability/core/ReliableNodeMemories.java
@@ -1,0 +1,39 @@
+package org.drools.reliability.core;
+
+import org.drools.core.common.ConcurrentNodeMemories;
+import org.drools.core.common.Memory;
+import org.drools.core.common.MemoryFactory;
+import org.drools.core.common.ReteEvaluator;
+import org.drools.core.impl.RuleBase;
+import org.drools.core.reteoo.SegmentMemory;
+
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Set;
+
+public class ReliableNodeMemories extends ConcurrentNodeMemories {
+
+    private final Map<Integer, Memory> changedMemories = new HashMap<>();
+    private final Set<SegmentMemory> changedSegments = new HashSet<>();
+
+    public ReliableNodeMemories(RuleBase ruleBase) {
+        super(ruleBase);
+    }
+
+    @Override
+    public Memory getNodeMemory(MemoryFactory node, ReteEvaluator reteEvaluator) {
+        Memory memory = super.getNodeMemory(node, reteEvaluator);
+        changedMemories.put(node.getMemoryId(), memory);
+        if (memory.getSegmentMemory() != null) {
+            changedSegments.add(memory.getSegmentMemory());
+        }
+        return memory;
+    }
+
+    public void safepoint() {
+        // TODO: persist memories
+        changedMemories.clear();
+        changedSegments.clear();
+    }
+}

--- a/drools-reliability/drools-reliability-core/src/main/java/org/drools/reliability/core/ReliableNodeMemories.java
+++ b/drools-reliability/drools-reliability-core/src/main/java/org/drools/reliability/core/ReliableNodeMemories.java
@@ -33,6 +33,9 @@ public class ReliableNodeMemories extends ConcurrentNodeMemories {
 
     public void safepoint() {
         // TODO: persist memories
+        //Storage<String, Object> componentsStorage = StorageManagerFactory.get().getStorageManager().getOrCreateStorageForSession(, "components");
+        //componentsStorage.put("memories", changedMemories);
+        //componentsStorage.put("segments", changedSegments);
         changedMemories.clear();
         changedSegments.clear();
     }

--- a/drools-reliability/drools-reliability-core/src/main/java/org/drools/reliability/core/ReliableNodeMemories.java
+++ b/drools-reliability/drools-reliability-core/src/main/java/org/drools/reliability/core/ReliableNodeMemories.java
@@ -7,6 +7,7 @@ import org.drools.core.common.ReteEvaluator;
 import org.drools.core.common.Storage;
 import org.drools.core.impl.RuleBase;
 import org.drools.core.reteoo.SegmentMemory;
+import org.kie.internal.runtime.StatefulKnowledgeSession;
 
 import java.util.HashMap;
 import java.util.Map;
@@ -14,7 +15,6 @@ import java.util.Map;
 public class ReliableNodeMemories extends ConcurrentNodeMemories {
 
     private final Map<Integer, Memory> changedMemories = new HashMap<>();
-    //private final Set<SegmentMemory> changedSegments = new HashSet<>();
     private final Map<Integer,SegmentMemory> changedSegments = new HashMap<>();
     private final Storage<Integer, Object> storage;
 
@@ -41,17 +41,15 @@ public class ReliableNodeMemories extends ConcurrentNodeMemories {
         for (Integer key : changedSegments.keySet()){
             storage.put(key, changedSegments.get(key));
         }
+
         changedMemories.clear();
         changedSegments.clear();
+
+        if (storage.requiresFlush()) {this.storage.flush();}
+
     }
 
-    public void reInit() {
-        for (Integer key : storage.keySet()){
-            if (storage.get(key) instanceof Memory){
-                changedMemories.put(key,(Memory) storage.get(key));
-            }else if (storage.get(key) instanceof SegmentMemory) {
-                changedSegments.put(key,(SegmentMemory) storage.get(key));
-            }
-        }
+    public void reInit(StatefulKnowledgeSession session) {
+        super.reInit(this.storage, session);
     }
 }

--- a/drools-reliability/drools-reliability-core/src/main/java/org/drools/reliability/core/ReliableObjectStore.java
+++ b/drools-reliability/drools-reliability-core/src/main/java/org/drools/reliability/core/ReliableObjectStore.java
@@ -1,0 +1,7 @@
+package org.drools.reliability.core;
+
+import org.drools.core.common.ObjectStore;
+
+public interface ReliableObjectStore extends ObjectStore {
+    void safepoint();
+}

--- a/drools-reliability/drools-reliability-core/src/main/java/org/drools/reliability/core/ReliablePropagationList.java
+++ b/drools-reliability/drools-reliability-core/src/main/java/org/drools/reliability/core/ReliablePropagationList.java
@@ -25,7 +25,7 @@ import java.io.IOException;
 import java.io.ObjectInput;
 import java.io.ObjectOutput;
 
-public class ReliablePropagationList extends SynchronizedPropagationList implements Externalizable {
+public class ReliablePropagationList extends SynchronizedPropagationList implements Externalizable, ReliableList {
 
     public static final String PROPAGATION_LIST = "PropagationList";
 
@@ -46,8 +46,8 @@ public class ReliablePropagationList extends SynchronizedPropagationList impleme
     @Override
     public synchronized PropagationEntry takeAll() {
         PropagationEntry p = super.takeAll();
-        Storage<String, Object> componentsStorage = StorageManagerFactory.get().getStorageManager().getOrCreateStorageForSession(this.reteEvaluator, "components");
-        componentsStorage.put(PROPAGATION_LIST, this);
+        //Storage<String, Object> componentsStorage = StorageManagerFactory.get().getStorageManager().getOrCreateStorageForSession(this.reteEvaluator, "components");
+        //componentsStorage.put(PROPAGATION_LIST, this);
         return p;
     }
 
@@ -66,5 +66,11 @@ public class ReliablePropagationList extends SynchronizedPropagationList impleme
         this.disposed = in.readBoolean();
         this.hasEntriesDeferringExpiration = in.readBoolean();
         this.firingUntilHalt = in.readBoolean();
+    }
+
+    @Override
+    public void safepoint() {
+        Storage<String, Object> componentsStorage = StorageManagerFactory.get().getStorageManager().getOrCreateStorageForSession(this.reteEvaluator, "components");
+        componentsStorage.put(PROPAGATION_LIST, this);
     }
 }

--- a/drools-reliability/drools-reliability-core/src/main/java/org/drools/reliability/core/ReliableSessionInitializer.java
+++ b/drools-reliability/drools-reliability-core/src/main/java/org/drools/reliability/core/ReliableSessionInitializer.java
@@ -28,6 +28,7 @@ import org.kie.api.event.rule.ObjectUpdatedEvent;
 import org.kie.api.event.rule.RuleRuntimeEventListener;
 import org.kie.api.runtime.conf.PersistedSessionOption;
 import org.kie.api.runtime.rule.EntryPoint;
+import org.kie.internal.runtime.StatefulKnowledgeSession;
 
 import java.util.HashMap;
 import java.util.List;
@@ -126,7 +127,7 @@ public class ReliableSessionInitializer {
                 store.reInit();
                 //
                 ReliableNodeMemories memories = (ReliableNodeMemories)((WorkingMemoryEntryPoint) ep).getReteEvaluator().getNodeMemories();
-                memories.reInit();
+                memories.reInit((StatefulKnowledgeSession) session);
             }
             //
 

--- a/drools-reliability/drools-reliability-core/src/main/java/org/drools/reliability/core/ReliableSessionInitializer.java
+++ b/drools-reliability/drools-reliability-core/src/main/java/org/drools/reliability/core/ReliableSessionInitializer.java
@@ -124,7 +124,12 @@ public class ReliableSessionInitializer {
             for (EntryPoint ep : session.getEntryPoints()) {
                 FullReliableObjectStore store = (FullReliableObjectStore) ((WorkingMemoryEntryPoint) ep).getObjectStore();
                 store.reInit();
+                //
+                ReliableNodeMemories memories = (ReliableNodeMemories)((WorkingMemoryEntryPoint) ep).getReteEvaluator().getNodeMemories();
+                memories.reInit();
             }
+            //
+
         }
 
         static class FullStoreRuntimeEventListener implements RuleRuntimeEventListener {

--- a/drools-reliability/drools-reliability-core/src/main/java/org/drools/reliability/core/ReliableStatefulKnowledgeSessionImpl.java
+++ b/drools-reliability/drools-reliability-core/src/main/java/org/drools/reliability/core/ReliableStatefulKnowledgeSessionImpl.java
@@ -18,6 +18,7 @@ package org.drools.reliability.core;
 import org.drools.core.SessionConfiguration;
 import org.drools.core.common.ConcurrentNodeMemories;
 import org.drools.core.common.InternalAgenda;
+import org.drools.core.common.Storage;
 import org.drools.core.rule.accessor.FactHandleFactory;
 import org.drools.kiesession.rulebase.InternalKnowledgeBase;
 import org.drools.kiesession.session.StatefulKnowledgeSessionImpl;
@@ -50,7 +51,8 @@ public class ReliableStatefulKnowledgeSessionImpl extends StatefulKnowledgeSessi
     @Override
     protected ConcurrentNodeMemories createNodeMemories(InternalKnowledgeBase kBase) {
         if (getSessionConfiguration().getPersistedSessionOption().getPersistenceStrategy() == PersistedSessionOption.PersistenceStrategy.FULL) {
-            return new ReliableNodeMemories(kBase);
+            Storage<Integer, Object> storage = StorageManagerFactory.get().getStorageManager().getOrCreateStorageForSession(this, "ep" + getEntryPointId());
+            return new ReliableNodeMemories(kBase,storage);
         }
         return super.createNodeMemories(kBase);
     }

--- a/drools-reliability/drools-reliability-core/src/main/java/org/drools/reliability/core/ReliableStatefulKnowledgeSessionImpl.java
+++ b/drools-reliability/drools-reliability-core/src/main/java/org/drools/reliability/core/ReliableStatefulKnowledgeSessionImpl.java
@@ -51,7 +51,7 @@ public class ReliableStatefulKnowledgeSessionImpl extends StatefulKnowledgeSessi
     @Override
     protected ConcurrentNodeMemories createNodeMemories(InternalKnowledgeBase kBase) {
         if (getSessionConfiguration().getPersistedSessionOption().getPersistenceStrategy() == PersistedSessionOption.PersistenceStrategy.FULL) {
-            Storage<Integer, Object> storage = StorageManagerFactory.get().getStorageManager().getOrCreateStorageForSession(this, "ep" + getEntryPointId());
+            Storage<Integer, Object> storage = StorageManagerFactory.get().getStorageManager().getOrCreateStorageForSession(this, "mem" + getEntryPointId());
             return new ReliableNodeMemories(kBase,storage);
         }
         return super.createNodeMemories(kBase);

--- a/drools-reliability/drools-reliability-core/src/main/java/org/drools/reliability/core/SimpleReliableObjectStore.java
+++ b/drools-reliability/drools-reliability-core/src/main/java/org/drools/reliability/core/SimpleReliableObjectStore.java
@@ -18,17 +18,14 @@ package org.drools.reliability.core;
 import org.drools.core.common.InternalFactHandle;
 import org.drools.core.common.InternalWorkingMemory;
 import org.drools.core.common.InternalWorkingMemoryEntryPoint;
-import org.drools.core.common.ObjectStore;
 
 import java.util.List;
 
-public interface SimpleReliableObjectStore extends ObjectStore {
+public interface SimpleReliableObjectStore extends ReliableObjectStore {
 
     List<StoredObject> reInit(InternalWorkingMemory session, InternalWorkingMemoryEntryPoint ep);
 
     void putIntoPersistedStorage(InternalFactHandle handle, boolean propagated);
 
     void removeFromPersistedStorage(Object object);
-
-    void safepoint();
 }

--- a/drools-reliability/drools-reliability-infinispan/src/test/java/org/drools/reliability/infinispan/ReliabilityTest.java
+++ b/drools-reliability/drools-reliability-infinispan/src/test/java/org/drools/reliability/infinispan/ReliabilityTest.java
@@ -55,7 +55,7 @@ class ReliabilityTest extends ReliabilityTestBasics {
     }
 
     @ParameterizedTest
-    @MethodSource("strategyProviderStoresOnlyWithExplicitSafepoints") // FULL fails with "ReliablePropagationList; no valid constructor"
+    @MethodSource("strategyProviderFullPlusStoresOnlyWithExplicitSafepoints")
     void insertFailoverInsertFire_shouldRecoverFromFailover(PersistedSessionOption.PersistenceStrategy persistenceStrategy, PersistedSessionOption.SafepointStrategy safepointStrategy) {
         createSession(BASIC_RULE, persistenceStrategy, safepointStrategy);
 
@@ -78,7 +78,7 @@ class ReliabilityTest extends ReliabilityTestBasics {
 
 
     @ParameterizedTest
-    @MethodSource("strategyProviderStoresOnlyWithExplicitSafepoints") // With Remote, FULL fails with "ReliablePropagationList; no valid constructor" even without failover
+    @MethodSource("strategyProviderFullPlusStoresOnlyWithExplicitSafepoints")
     void noFailover(PersistedSessionOption.PersistenceStrategy persistenceStrategy, PersistedSessionOption.SafepointStrategy safepointStrategy) {
 
         createSession(BASIC_RULE, persistenceStrategy, safepointStrategy);
@@ -101,7 +101,7 @@ class ReliabilityTest extends ReliabilityTestBasics {
 
 
     @ParameterizedTest
-    @MethodSource("strategyProviderStoresOnlyWithExplicitSafepoints") // FULL fails with "ReliablePropagationList; no valid constructor"
+    @MethodSource("strategyProviderFullPlusStoresOnlyWithExplicitSafepoints")
     void insertFireInsertFailoverInsertFire_shouldMatchFactInsertedBeforeFailover(PersistedSessionOption.PersistenceStrategy persistenceStrategy, PersistedSessionOption.SafepointStrategy safepointStrategy) {
 
         createSession(BASIC_RULE, persistenceStrategy, safepointStrategy);

--- a/drools-reliability/drools-reliability-infinispan/src/test/java/org/drools/reliability/infinispan/ReliabilityTest.java
+++ b/drools-reliability/drools-reliability-infinispan/src/test/java/org/drools/reliability/infinispan/ReliabilityTest.java
@@ -101,7 +101,7 @@ class ReliabilityTest extends ReliabilityTestBasics {
 
 
     @ParameterizedTest
-    @MethodSource("strategyProviderFullPlusStoresOnlyWithExplicitSafepoints")
+    @MethodSource("strategyProviderFullWithExplicitSafepoints")
     void insertFireInsertFailoverInsertFire_shouldMatchFactInsertedBeforeFailover(PersistedSessionOption.PersistenceStrategy persistenceStrategy, PersistedSessionOption.SafepointStrategy safepointStrategy) {
 
         createSession(BASIC_RULE, persistenceStrategy, safepointStrategy);

--- a/drools-reliability/drools-reliability-infinispan/src/test/java/org/drools/reliability/infinispan/ReliabilityTestBasics.java
+++ b/drools-reliability/drools-reliability-infinispan/src/test/java/org/drools/reliability/infinispan/ReliabilityTestBasics.java
@@ -84,6 +84,12 @@ public abstract class ReliabilityTestBasics {
         );
     }
 
+    static Stream<Arguments> strategyProviderFullWithExplicitSafepoints() {
+        return Stream.of(
+                arguments(PersistedSessionOption.PersistenceStrategy.FULL, PersistedSessionOption.SafepointStrategy.EXPLICIT)
+        );
+    }
+
     static Stream<Arguments> strategyProviderStoresOnlyWithAllSafepoints() {
         return Stream.of(
                 arguments(PersistedSessionOption.PersistenceStrategy.STORES_ONLY, PersistedSessionOption.SafepointStrategy.ALWAYS),

--- a/drools-reliability/drools-reliability-infinispan/src/test/java/org/drools/reliability/infinispan/ReliabilityTestBasics.java
+++ b/drools-reliability/drools-reliability-infinispan/src/test/java/org/drools/reliability/infinispan/ReliabilityTestBasics.java
@@ -76,6 +76,14 @@ public abstract class ReliabilityTestBasics {
         );
     }
 
+    static Stream<Arguments> strategyProviderFullPlusStoresOnlyWithExplicitSafepoints() {
+        return Stream.of(
+                arguments(PersistedSessionOption.PersistenceStrategy.FULL, PersistedSessionOption.SafepointStrategy.EXPLICIT),
+                arguments(PersistedSessionOption.PersistenceStrategy.STORES_ONLY, PersistedSessionOption.SafepointStrategy.ALWAYS),
+                arguments(PersistedSessionOption.PersistenceStrategy.STORES_ONLY, PersistedSessionOption.SafepointStrategy.EXPLICIT)
+        );
+    }
+
     static Stream<Arguments> strategyProviderStoresOnlyWithAllSafepoints() {
         return Stream.of(
                 arguments(PersistedSessionOption.PersistenceStrategy.STORES_ONLY, PersistedSessionOption.SafepointStrategy.ALWAYS),


### PR DESCRIPTION
https://issues.redhat.com/browse/DROOLS-7452

adding node memories to cache seems to work
but when restoring a session the cache (storage) is empty:

protected ConcurrentNodeMemories createNodeMemories(InternalKnowledgeBase kBase) {
..
Storage<Integer, Object> storage = StorageManagerFactory.get().getStorageManager().getOrCreateStorageForSession(this, "mem" + getEntryPointId());
            return new ReliableNodeMemories(kBase,storage);
...
}
