### PR TITLE
DROOLS-7463 revising `drools.dialect.java.compiler.lnglevel` in the kie-maven-plugin

### DIFF
--- a/kie-maven-plugin/src/it/kie-maven-plugin-test-kjar-setup/kie-maven-plugin-test-kjar-parent/pom.xml
+++ b/kie-maven-plugin/src/it/kie-maven-plugin-test-kjar-setup/kie-maven-plugin-test-kjar-parent/pom.xml
@@ -13,12 +13,12 @@
   <properties>
     <org.kie.version>${project.version}</org.kie.version>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-    <maven.compiler.target>1.8</maven.compiler.target>
-    <maven.compiler.source>1.8</maven.compiler.source>
+    <maven.compiler.release>11</maven.compiler.release>
     <junit.version>4.13.1</junit.version>
     <assertj.version>3.14.0</assertj.version>
-    <surefire.plugin.version>2.18.1</surefire.plugin.version>
-    <failsafe.plugin.version>2.18.1</failsafe.plugin.version>
+    <compiler.plugin.version>3.11.0</compiler.plugin.version>
+    <surefire.plugin.version>3.1.0</surefire.plugin.version>
+    <failsafe.plugin.version>3.1.0</failsafe.plugin.version>
   </properties>
 
   <dependencies>
@@ -48,11 +48,6 @@
         <artifactId>kie-maven-plugin</artifactId>
         <version>@org.kie.version@</version>
         <extensions>true</extensions>
-        <configuration>
-          <properties>
-            <drools.dialect.java.compiler.lnglevel>1.8</drools.dialect.java.compiler.lnglevel>
-          </properties>
-        </configuration>
       </plugin>
       <plugin>
         <artifactId>maven-resources-plugin</artifactId>
@@ -78,6 +73,10 @@
             </configuration>
           </execution>
         </executions>
+      </plugin>
+      <plugin>
+        <artifactId>maven-compiler-plugin</artifactId>
+        <version>${compiler.plugin.version}</version>
       </plugin>
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>

--- a/kie-maven-plugin/src/main/java/org/kie/maven/plugin/helpers/ExecutorHelper.java
+++ b/kie-maven-plugin/src/main/java/org/kie/maven/plugin/helpers/ExecutorHelper.java
@@ -21,6 +21,7 @@ import java.util.stream.Collectors;
 
 import org.apache.maven.plugin.logging.Log;
 import org.drools.compiler.kie.builder.impl.InternalKieModule;
+import org.kie.memorycompiler.JavaConfiguration;
 
 public class ExecutorHelper {
 
@@ -32,6 +33,12 @@ public class ExecutorHelper {
         if (properties != null) {
             log.debug("Additional system properties: " + properties);
             for (Map.Entry<String, String> property : properties.entrySet()) {
+                if (property.getKey().equals(JavaConfiguration.JAVA_LANG_LEVEL_PROPERTY)) {
+                    log.warn("It seems you are setting `" + 
+                            JavaConfiguration.JAVA_LANG_LEVEL_PROPERTY + 
+                            "` while building a KJAR in a Maven-based build; " +
+                            " you should consider relying on properly setting `maven.compiler.release` instead.");
+                }
                 System.setProperty(property.getKey(), property.getValue());
             }
             log.debug("Configured system properties were successfully set.");

--- a/kie-maven-plugin/src/main/java/org/kie/maven/plugin/helpers/ExecutorHelper.java
+++ b/kie-maven-plugin/src/main/java/org/kie/maven/plugin/helpers/ExecutorHelper.java
@@ -36,8 +36,8 @@ public class ExecutorHelper {
                 if (property.getKey().equals(JavaConfiguration.JAVA_LANG_LEVEL_PROPERTY)) {
                     log.warn("It seems you are setting `" + 
                             JavaConfiguration.JAVA_LANG_LEVEL_PROPERTY + 
-                            "` while building a KJAR in a Maven-based build; " +
-                            " you should consider relying on properly setting `maven.compiler.release` instead.");
+                            "` while building a KJAR in a Maven-based build." +
+                            " It is recommended to properly set `maven.compiler.release` instead.");
                 }
                 System.setProperty(property.getKey(), property.getValue());
             }


### PR DESCRIPTION
this is better to MERGE ONLY AFTER https://github.com/kiegroup/drools/pull/5267 if only for complementary release notes.

as suggested in: https://github.com/kiegroup/drools/pull/5267#discussion_r1212760805

emit a warn:

```
[INFO] 
[INFO] --- kie-maven-plugin:8.40.0-SNAPSHOT:build (default-build) @ kie-maven-plugin-test-kjar-11-default ---
[INFO] GenerateModel
[DEBUG] Additional system properties: {drools.dialect.java.compiler.lnglevel=1.8}
[WARNING] It seems you are setting `drools.dialect.java.compiler.lnglevel` while building a KJAR in a Maven-based build;  you should consider relying on properly setting `maven.compiler.release` instead.
[DEBUG] Configured system properties were successfully set.
```

further updates the integration tests and related version in light of: https://docs.drools.org/8.39.0.Final/drools-docs/docs-website/drools/release-notes/index.html#_minimum_requirements_update for the maven plugins

**JIRA**: https://issues.redhat.com/browse/DROOLS-7463

**referenced Pull Requests**: none

<details>
<summary>
How to replicate CI configuration locally?
</summary>

Build Chain tool does "simple" maven build(s), the builds are just Maven commands, but because the repositories relates and depends on each other and any change in API or class method could affect several of those repositories there is a need to use [build-chain tool](https://github.com/kiegroup/github-action-build-chain) to handle cross repository builds and be sure that we always use latest version of the code for each repository.
 
[build-chain tool](https://github.com/kiegroup/github-action-build-chain) is a build tool which can be used on command line locally or in Github Actions workflow(s), in case you need to change multiple repositories and send multiple dependent pull requests related with a change you can easily reproduce the same build by executing it on Github hosted environment or locally in your development environment. See [local execution](https://github.com/kiegroup/github-action-build-chain#local-execution) details to get more information about it.
</details>

<details>
<summary>
How to retest this PR or trigger a specific build:
</summary>

- for <b>pull request checks</b>  
  Please add comment: <b>Jenkins retest this</b>

- for a <b>specific pull request check</b>  
  Please add comment: <b>Jenkins (re)run [drools|kogito-runtimes|kogito-apps|kogito-examples] tests</b>

- for a <b>full downstream build</b> 
  - for <b>jenkins</b> job: please add comment: <b>Jenkins run fdb</b>
  - for <b>github actions</b> job: add the label `run_fdb`

- <b>a compile downstream build</b> please  add comment: <b>Jenkins run cdb</b>

- <b>a full production downstream build</b> please add comment: <b>Jenkins execute product fdb</b>

- <b>an upstream build</b> please add comment: <b>Jenkins run upstream</b>

- for <b>quarkus branch checks</b>  
  Run checks against Quarkus current used branch  
  Please add comment: <b>Jenkins run quarkus-branch</b>

- for a <b>quarkus branch specific check</b>  
  Run checks against Quarkus current used branch  
  Please add comment: <b>Jenkins (re)run [drools|kogito-runtimes|kogito-apps|kogito-examples] quarkus-branch</b>

- for <b>quarkus main checks</b>  
  Run checks against Quarkus main branch  
  Please add comment: <b>Jenkins run quarkus-main</b>

- for a <b>specific quarkus main check</b>  
  Run checks against Quarkus main branch  
  Please add comment: <b>Jenkins (re)run [drools|kogito-runtimes|kogito-apps|kogito-examples] quarkus-main</b>

- for <b>quarkus lts checks</b>  
  Run checks against Quarkus lts branch  
  Please add comment: <b>Jenkins run quarkus-lts</b>

- for a <b>specific quarkus lts check</b>  
  Run checks against Quarkus lts branch  
  Please add comment: <b>Jenkins (re)run [drools|kogito-runtimes|kogito-apps|kogito-examples] quarkus-lts</b>

- for <b>native checks</b>  
  Run native checks  
  Please add comment: <b>Jenkins run native</b>

- for a <b>specific native check</b>  
  Run native checks 
  Please add comment: <b>Jenkins (re)run [drools|kogito-runtimes|kogito-apps|kogito-examples] native</b>

 - for <b>native lts checks</b>  
  Run native checks against quarkus lts branch
  Please add comment: <b>Jenkins run native-lts</b>

- for a <b>specific native lts check</b>  
  Run native checks against quarkus lts branch
  Please add comment: <b>Jenkins (re)run [drools|kogito-runtimes|kogito-apps|kogito-examples] native-lts</b>
</details>

<details>
<summary>
How to backport a pull request to a different branch?
</summary>

In order to automatically create a **backporting pull request** please add one or more labels having the following format `backport-<branch-name>`, where `<branch-name>` is the name of the branch where the pull request must be backported to (e.g., `backport-7.67.x` to backport the original PR to the `7.67.x` branch).

> **NOTE**: **backporting** is an action aiming to move a change (usually a commit) from a branch (usually the main one) to another one, which is generally referring to a still maintained release branch. Keeping it simple: it is about to move a specific change or a set of them from one branch to another.

Once the original pull request is successfully merged, the automated action will create one backporting pull request per each label (with the previous format) that has been added.

If something goes wrong, the author will be notified and at this point a manual backporting is needed.

> **NOTE**: this automated backporting is triggered whenever a pull request on `main` branch is labeled or closed, but both conditions must be satisfied to get the new PR created.
</details>

<!-- TODO to uncomment if activating the quarkus-3 rewrite PR job -->
<!-- <details>
<summary>
Quarkus-3 PR check is failing ... what to do ?
</summary>
The Quarkus 3 check is applying patches from the `.ci/environments/quarkus-3/patches`.

The first patch, called `0001_before_sh.patch`, is generated from Openrewrite `.ci/environments/quarkus-3/quarkus3.yml` recipe. The patch is created to speed up the check. But it may be that some changes in the PR broke this patch.  
No panic, there is an easy way to regenerate it. You just need to comment on the PR:
```
jenkins rewrite quarkus-3
```
and it should, after some minutes (~20/30min) apply a commit on the PR with the patch regenerated.

Other patches were generated manually. If any of it fails, you will need to manually update it... and push your changes.
</details> -->