### PR TITLE
D7454b - NotSerializableException: WeakHashMap

### DIFF
--- a/drools-core/src/main/java/org/drools/core/base/ClassFieldAccessorCache.java
+++ b/drools-core/src/main/java/org/drools/core/base/ClassFieldAccessorCache.java
@@ -16,13 +16,6 @@
 
 package org.drools.core.base;
 
-import java.security.AccessController;
-import java.security.PrivilegedAction;
-import java.util.Map;
-import java.util.WeakHashMap;
-import java.util.concurrent.ConcurrentHashMap;
-import java.util.concurrent.ConcurrentMap;
-
 import org.drools.base.base.AccessorKey;
 import org.drools.base.base.ClassFieldInspector;
 import org.drools.base.base.ClassObjectType;
@@ -31,9 +24,17 @@ import org.drools.base.rule.accessor.WriteAccessor;
 import org.drools.wiring.api.ComponentsFactory;
 import org.drools.wiring.api.util.ByteArrayClassLoader;
 
+import java.io.Serializable;
+import java.security.AccessController;
+import java.security.PrivilegedAction;
+import java.util.Map;
+import java.util.WeakHashMap;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentMap;
+
 import static org.drools.util.ClassUtils.convertPrimitiveNameToType;
 
-public class ClassFieldAccessorCache {
+public class ClassFieldAccessorCache implements Serializable {
 
     private Map<ClassLoader, CacheEntry> cacheByClassLoader;
 
@@ -233,6 +234,5 @@ public class ClassFieldAccessorCache {
 
             return existing;
         }
-
     }
 }

--- a/drools-core/src/main/java/org/drools/core/common/AgendaGroupsManager.java
+++ b/drools-core/src/main/java/org/drools/core/common/AgendaGroupsManager.java
@@ -16,6 +16,9 @@
 
 package org.drools.core.common;
 
+import org.drools.core.phreak.RuleAgendaItem;
+import org.drools.core.reteoo.RuntimeComponentFactory;
+
 import java.io.Externalizable;
 import java.io.IOException;
 import java.io.ObjectInput;
@@ -31,8 +34,6 @@ import java.util.Map;
 import java.util.stream.Collectors;
 
 import org.drools.core.impl.InternalRuleBase;
-import org.drools.core.phreak.RuleAgendaItem;
-import org.drools.core.reteoo.RuntimeComponentFactory;
 
 public interface AgendaGroupsManager extends Externalizable {
     void setReteEvaluator(ReteEvaluator reteEvaluator);
@@ -179,7 +180,7 @@ public interface AgendaGroupsManager extends Externalizable {
 
         @Override
         public RuleAgendaItem peekNextRule() {
-            return (RuleAgendaItem) this.mainAgendaGroup.peek();
+            return this.mainAgendaGroup.peek();
         }
 
         @Override
@@ -394,10 +395,9 @@ public interface AgendaGroupsManager extends Externalizable {
             // Set the focus to the agendaGroup if it doesn't already have the focus
             if ( this.focusStack.getLast() != agendaGroup ) {
                 this.focusStack.getLast().setActive( false );
-                InternalAgendaGroup internalGroup = agendaGroup;
-                this.focusStack.add( internalGroup );
-                internalGroup.setActive( true );
-                internalGroup.setActivatedForRecency( this.workingMemory.getFactHandleFactory().getRecency() );
+                this.focusStack.add(agendaGroup);
+                agendaGroup.setActive( true );
+                agendaGroup.setActivatedForRecency( this.workingMemory.getFactHandleFactory().getRecency() );
                 final EventSupport eventsupport = this.workingMemory;
                 eventsupport.getAgendaEventSupport().fireAgendaGroupPushed( agendaGroup, this.workingMemory );
                 return true;
@@ -418,7 +418,7 @@ public interface AgendaGroupsManager extends Externalizable {
 
         @Override
         public RuleAgendaItem peekNextRule() {
-            return (RuleAgendaItem) (this.focusStack.peekLast()).peek();
+            return this.focusStack.peekLast().peek();
         }
 
         @Override

--- a/drools-core/src/main/java/org/drools/core/common/ConcurrentNodeMemories.java
+++ b/drools-core/src/main/java/org/drools/core/common/ConcurrentNodeMemories.java
@@ -16,16 +16,16 @@
 
 package org.drools.core.common;
 
+import org.drools.base.RuleBase;
+import org.drools.core.impl.InternalRuleBase;
+import org.drools.core.reteoo.SegmentMemory;
+import org.kie.internal.runtime.StatefulKnowledgeSession;
+
 import java.util.HashSet;
 import java.util.Set;
 import java.util.concurrent.atomic.AtomicReferenceArray;
 import java.util.concurrent.locks.Lock;
 import java.util.concurrent.locks.ReentrantLock;
-
-import org.drools.core.impl.InternalRuleBase;
-import org.drools.core.reteoo.SegmentMemory;
-import org.kie.internal.runtime.StatefulKnowledgeSession;
-
 /**
  * A concurrent implementation for the node memories interface
  */
@@ -151,6 +151,26 @@ public class ConcurrentNodeMemories implements NodeMemories {
 
     public int length() {
         return this.memories.length();
+    }
+
+    protected void reInit(Storage<Integer, Object> storage, StatefulKnowledgeSession session){
+
+        this.clear();
+        int i =0;
+        Set<SegmentMemory> smemSet = new HashSet<>();
+
+        for (Integer key : storage.keySet()){
+            if (storage.get(key) instanceof Memory){
+                this.memories.getAndSet(i,(Memory) storage.get(key));
+            }else if (storage.get(key) instanceof SegmentMemory) {
+                smemSet.add((SegmentMemory) storage.get(key));
+                //changedSegments.put(key,(SegmentMemory) storage.get(key));
+            }
+        }
+
+        InternalRuleBase kBase = (InternalRuleBase) session.getKieBase();
+        smemSet.forEach(smem -> resetSegmentMemory(session, kBase, smem));
+
     }
 
 }

--- a/drools-core/src/main/java/org/drools/core/concurrent/SequentialRuleEvaluator.java
+++ b/drools-core/src/main/java/org/drools/core/concurrent/SequentialRuleEvaluator.java
@@ -39,7 +39,7 @@ public class SequentialRuleEvaluator extends AbstractRuleEvaluator implements Ru
                                 int fireCount,
                                 int fireLimit,
                                 InternalAgendaGroup group ) {
-        RuleAgendaItem item = sequential ? (RuleAgendaItem) group.remove() : (RuleAgendaItem) group.peek();
+        RuleAgendaItem item = sequential ? group.remove() : group.peek();
         return item != null ? internalEvaluateAndFire( filter, fireCount, fireLimit, item ) : 0;
     }
 

--- a/drools-core/src/main/java/org/drools/core/impl/KnowledgeBaseImpl.java
+++ b/drools-core/src/main/java/org/drools/core/impl/KnowledgeBaseImpl.java
@@ -16,35 +16,25 @@
 
 package org.drools.core.impl;
 
-import java.lang.reflect.Type;
-import java.util.ArrayList;
-import java.util.Collection;
-import java.util.Collections;
-import java.util.Comparator;
-import java.util.HashMap;
-import java.util.HashSet;
-import java.util.List;
-import java.util.Map;
-import java.util.Objects;
-import java.util.Queue;
-import java.util.Set;
-import java.util.concurrent.CompletableFuture;
-import java.util.concurrent.ConcurrentHashMap;
-import java.util.concurrent.ConcurrentLinkedQueue;
-import java.util.concurrent.Future;
-import java.util.concurrent.locks.ReentrantReadWriteLock;
-
-import org.drools.core.KieBaseConfigurationImpl;
-import org.drools.core.RuleBaseConfiguration;
-import org.drools.core.SessionConfiguration;
-import org.drools.core.base.ClassFieldAccessorCache;
 import org.drools.base.base.ClassObjectType;
-import org.drools.core.common.InternalWorkingMemory;
-import org.drools.core.common.ReteEvaluator;
 import org.drools.base.common.RuleBasePartitionId;
 import org.drools.base.definitions.InternalKnowledgePackage;
 import org.drools.base.definitions.rule.impl.RuleImpl;
 import org.drools.base.factmodel.ClassDefinition;
+import org.drools.base.rule.DialectRuntimeRegistry;
+import org.drools.base.rule.EntryPointId;
+import org.drools.base.rule.Function;
+import org.drools.base.rule.ImportDeclaration;
+import org.drools.base.rule.InvalidPatternException;
+import org.drools.base.rule.TypeDeclaration;
+import org.drools.base.rule.WindowDeclaration;
+import org.drools.base.ruleunit.RuleUnitDescriptionRegistry;
+import org.drools.core.KieBaseConfigurationImpl;
+import org.drools.core.RuleBaseConfiguration;
+import org.drools.core.SessionConfiguration;
+import org.drools.core.base.ClassFieldAccessorCache;
+import org.drools.core.common.InternalWorkingMemory;
+import org.drools.core.common.ReteEvaluator;
 import org.drools.core.management.DroolsManagementAgent;
 import org.drools.core.phreak.BuildtimeSegmentUtilities;
 import org.drools.core.phreak.EagerPhreakBuilder.Add;
@@ -65,16 +55,8 @@ import org.drools.core.reteoo.SegmentMemory.SegmentPrototype;
 import org.drools.core.reteoo.TerminalNode;
 import org.drools.core.reteoo.builder.BuildContext;
 import org.drools.core.reteoo.builder.NodeFactory;
-import org.drools.base.rule.DialectRuntimeRegistry;
-import org.drools.base.rule.EntryPointId;
-import org.drools.base.rule.Function;
-import org.drools.base.rule.ImportDeclaration;
-import org.drools.base.rule.InvalidPatternException;
 import org.drools.core.rule.JavaDialectRuntimeData;
-import org.drools.base.rule.TypeDeclaration;
-import org.drools.base.rule.WindowDeclaration;
 import org.drools.core.rule.accessor.FactHandleFactory;
-import org.drools.base.ruleunit.RuleUnitDescriptionRegistry;
 import org.drools.wiring.api.classloader.ProjectClassLoader;
 import org.kie.api.KieBaseConfiguration;
 import org.kie.api.builder.ReleaseId;
@@ -94,11 +76,30 @@ import org.kie.internal.conf.CompositeBaseConfiguration;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import java.io.Serializable;
+import java.lang.reflect.Type;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.Comparator;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Queue;
+import java.util.Set;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentLinkedQueue;
+import java.util.concurrent.Future;
+import java.util.concurrent.locks.ReentrantReadWriteLock;
+
 import static org.drools.core.phreak.PhreakBuilder.isEagerSegmentCreation;
 import static org.drools.util.BitMaskUtil.isSet;
 import static org.drools.util.ClassUtils.convertClassToResourcePath;
 
-public class KnowledgeBaseImpl implements InternalRuleBase {
+public class KnowledgeBaseImpl implements InternalRuleBase, Serializable {
 
     protected static final transient Logger logger = LoggerFactory.getLogger(KnowledgeBaseImpl.class);
 

--- a/drools-core/src/main/java/org/drools/core/reteoo/BetaMemory.java
+++ b/drools-core/src/main/java/org/drools/core/reteoo/BetaMemory.java
@@ -24,9 +24,11 @@ import org.drools.core.reteoo.RightInputAdapterNode.RiaPathMemory;
 import org.drools.base.rule.ContextEntry;
 import org.drools.core.util.AbstractBaseLinkedListNode;
 
+import java.io.Serializable;
+
 public class BetaMemory extends AbstractBaseLinkedListNode<Memory>
         implements
-        SegmentNodeMemory {
+        SegmentNodeMemory, Serializable {
 
     private static final long serialVersionUID = 510l;
     private TupleMemory                leftTupleMemory;

--- a/drools-core/src/main/java/org/drools/core/reteoo/LeftInputAdapterNode.java
+++ b/drools-core/src/main/java/org/drools/core/reteoo/LeftInputAdapterNode.java
@@ -16,29 +16,23 @@
 
 package org.drools.core.reteoo;
 
-import java.util.Collections;
-import java.util.HashSet;
-import java.util.List;
-import java.util.Set;
-
-import org.drools.base.reteoo.BaseTerminalNode;
-import org.drools.base.reteoo.NodeTypeEnums;
-import org.drools.core.RuleBaseConfiguration;
 import org.drools.base.base.ClassObjectType;
 import org.drools.base.base.ObjectType;
+import org.drools.base.common.NetworkNode;
+import org.drools.base.common.RuleBasePartitionId;
+import org.drools.base.reteoo.BaseTerminalNode;
+import org.drools.base.reteoo.NodeTypeEnums;
+import org.drools.base.rule.Pattern;
+import org.drools.core.RuleBaseConfiguration;
 import org.drools.core.common.InternalFactHandle;
 import org.drools.core.common.Memory;
 import org.drools.core.common.MemoryFactory;
-import org.drools.base.common.NetworkNode;
 import org.drools.core.common.PropagationContext;
 import org.drools.core.common.ReteEvaluator;
-import org.drools.base.common.RuleBasePartitionId;
 import org.drools.core.common.TupleSets;
 import org.drools.core.common.UpdateContext;
 import org.drools.core.phreak.RuntimeSegmentUtilities;
-import org.drools.core.reteoo.ObjectTypeNode.Id;
 import org.drools.core.reteoo.builder.BuildContext;
-import org.drools.base.rule.Pattern;
 import org.drools.core.rule.consequence.InternalMatch;
 import org.drools.core.util.AbstractBaseLinkedListNode;
 import org.drools.core.util.bitmask.AllSetBitMask;
@@ -47,13 +41,19 @@ import org.kie.api.definition.rule.Rule;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import java.io.Serializable;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+
+import static org.drools.base.reteoo.PropertySpecificUtil.isPropertyReactive;
 import static org.drools.core.phreak.TupleEvaluationUtil.createLeftTupleTupleSets;
 import static org.drools.core.phreak.TupleEvaluationUtil.findPathToFlush;
 import static org.drools.core.phreak.TupleEvaluationUtil.findPathsToFlushFromRia;
 import static org.drools.core.phreak.TupleEvaluationUtil.flushLeftTupleIfNecessary;
 import static org.drools.core.phreak.TupleEvaluationUtil.forceFlushLeftTuple;
 import static org.drools.core.phreak.TupleEvaluationUtil.forceFlushPath;
-import static org.drools.base.reteoo.PropertySpecificUtil.isPropertyReactive;
 
 /**
  * All asserting Facts must propagated into the right <code>ObjectSink</code> side of a BetaNode, if this is the first Pattern
@@ -64,7 +64,7 @@ import static org.drools.base.reteoo.PropertySpecificUtil.isPropertyReactive;
 public class LeftInputAdapterNode extends LeftTupleSource
         implements
         ObjectSinkNode,
-        MemoryFactory<LeftInputAdapterNode.LiaNodeMemory> {
+        MemoryFactory<LeftInputAdapterNode.LiaNodeMemory>, Serializable {
 
     protected static final transient Logger log = LoggerFactory.getLogger(LeftInputAdapterNode.class);
 
@@ -410,7 +410,7 @@ public class LeftInputAdapterNode extends LeftTupleSource
         }
     }
 
-    protected LeftTuple processDeletesFromModify(ModifyPreviousTuples modifyPreviousTuples, PropagationContext context, ReteEvaluator reteEvaluator, Id otnId) {
+    protected LeftTuple processDeletesFromModify(ModifyPreviousTuples modifyPreviousTuples, PropagationContext context, ReteEvaluator reteEvaluator, ObjectTypeNode.Id otnId) {
         LeftTuple leftTuple = modifyPreviousTuples.peekLeftTuple(partitionId);
         while ( leftTuple != null && leftTuple.getInputOtnId().before( otnId ) ) {
             modifyPreviousTuples.removeLeftTuple(partitionId);

--- a/drools-core/src/main/java/org/drools/core/reteoo/LeftInputAdapterNode.java
+++ b/drools-core/src/main/java/org/drools/core/reteoo/LeftInputAdapterNode.java
@@ -512,7 +512,7 @@ public class LeftInputAdapterNode extends LeftTupleSource
         return new LiaNodeMemory();
     }
 
-    public static class LiaNodeMemory extends AbstractBaseLinkedListNode<Memory> implements SegmentNodeMemory {
+    public static class LiaNodeMemory extends AbstractBaseLinkedListNode<Memory> implements SegmentNodeMemory, Serializable {
         private int               counter;
 
         private SegmentMemory     segmentMemory;

--- a/drools-core/src/main/java/org/drools/core/reteoo/ObjectTypeNode.java
+++ b/drools-core/src/main/java/org/drools/core/reteoo/ObjectTypeNode.java
@@ -16,20 +16,15 @@
 
 package org.drools.core.reteoo;
 
-import java.io.Externalizable;
-import java.io.IOException;
-import java.io.ObjectInput;
-import java.io.ObjectOutput;
-import java.util.Collections;
-import java.util.Iterator;
-import java.util.List;
-
 import org.drools.base.InitialFact;
-import org.drools.base.reteoo.NodeTypeEnums;
-import org.drools.core.RuleBaseConfiguration;
 import org.drools.base.base.ClassObjectType;
 import org.drools.base.base.ObjectType;
 import org.drools.base.base.ValueType;
+import org.drools.base.common.RuleBasePartitionId;
+import org.drools.base.reteoo.NodeTypeEnums;
+import org.drools.base.rule.EntryPointId;
+import org.drools.base.time.JobHandle;
+import org.drools.core.RuleBaseConfiguration;
 import org.drools.core.common.DefaultFactHandle;
 import org.drools.core.common.FactHandleClassStore;
 import org.drools.core.common.InternalFactHandle;
@@ -38,22 +33,25 @@ import org.drools.core.common.Memory;
 import org.drools.core.common.MemoryFactory;
 import org.drools.core.common.PropagationContext;
 import org.drools.core.common.ReteEvaluator;
-import org.drools.base.common.RuleBasePartitionId;
 import org.drools.core.common.UpdateContext;
 import org.drools.core.impl.WorkingMemoryReteExpireAction;
 import org.drools.core.reteoo.builder.BuildContext;
-import org.drools.base.rule.EntryPointId;
-
 import org.drools.core.time.Job;
 import org.drools.core.time.JobContext;
-import org.drools.base.time.JobHandle;
 import org.drools.core.time.impl.DefaultJobHandle;
 import org.drools.core.util.bitmask.BitMask;
 import org.drools.core.util.bitmask.EmptyBitMask;
 
-import static org.drools.base.rule.TypeDeclaration.NEVER_EXPIRES;
-
+import java.io.Externalizable;
+import java.io.IOException;
+import java.io.ObjectInput;
+import java.io.ObjectOutput;
 import java.io.Serializable;
+import java.util.Collections;
+import java.util.Iterator;
+import java.util.List;
+
+import static org.drools.base.rule.TypeDeclaration.NEVER_EXPIRES;
 
 /**
  * <code>ObjectTypeNodes<code> are responsible for filtering and propagating the matching
@@ -591,9 +589,11 @@ public class ObjectTypeNode extends ObjectSource implements ObjectSink, MemoryFa
     }
 
 
-    public static class ObjectTypeNodeMemory<T> implements Memory {
+    public static class ObjectTypeNodeMemory<T> implements Memory, Serializable {
         private FactHandleClassStore store;
         private Class classType;
+
+        public ObjectTypeNodeMemory() { } // for serialization
 
         ObjectTypeNodeMemory(Class classType) {
             this.classType = classType;
@@ -659,6 +659,8 @@ public class ObjectTypeNode extends ObjectSource implements ObjectSink, MemoryFa
 
     public static class InitialFactObjectTypeNodeMemory extends ObjectTypeNodeMemory implements Serializable {
         private List<InternalFactHandle> list = Collections.emptyList();
+
+        public InitialFactObjectTypeNodeMemory() { } // for serialization
 
         InitialFactObjectTypeNodeMemory(Class classType) {
             super(classType);

--- a/drools-core/src/main/java/org/drools/core/reteoo/ObjectTypeNode.java
+++ b/drools-core/src/main/java/org/drools/core/reteoo/ObjectTypeNode.java
@@ -36,13 +36,14 @@ import org.drools.core.common.InternalFactHandle;
 import org.drools.core.common.InternalWorkingMemory;
 import org.drools.core.common.Memory;
 import org.drools.core.common.MemoryFactory;
+import org.drools.core.common.PropagationContext;
 import org.drools.core.common.ReteEvaluator;
 import org.drools.base.common.RuleBasePartitionId;
 import org.drools.core.common.UpdateContext;
 import org.drools.core.impl.WorkingMemoryReteExpireAction;
 import org.drools.core.reteoo.builder.BuildContext;
-import org.drools.core.common.PropagationContext;
 import org.drools.base.rule.EntryPointId;
+
 import org.drools.core.time.Job;
 import org.drools.core.time.JobContext;
 import org.drools.base.time.JobHandle;
@@ -51,6 +52,8 @@ import org.drools.core.util.bitmask.BitMask;
 import org.drools.core.util.bitmask.EmptyBitMask;
 
 import static org.drools.base.rule.TypeDeclaration.NEVER_EXPIRES;
+
+import java.io.Serializable;
 
 /**
  * <code>ObjectTypeNodes<code> are responsible for filtering and propagating the matching
@@ -66,8 +69,7 @@ import static org.drools.base.rule.TypeDeclaration.NEVER_EXPIRES;
  *
  * @see Rete
  */
-public class ObjectTypeNode extends ObjectSource implements ObjectSink, MemoryFactory<ObjectTypeNode.ObjectTypeNodeMemory> {
-
+public class ObjectTypeNode extends ObjectSource implements ObjectSink, MemoryFactory<ObjectTypeNode.ObjectTypeNodeMemory>, Serializable {
 
     private static final long serialVersionUID = 510l;
 

--- a/drools-core/src/main/java/org/drools/core/reteoo/ObjectTypeNode.java
+++ b/drools-core/src/main/java/org/drools/core/reteoo/ObjectTypeNode.java
@@ -657,7 +657,7 @@ public class ObjectTypeNode extends ObjectSource implements ObjectSink, MemoryFa
         }
     }
 
-    public static class InitialFactObjectTypeNodeMemory<T> extends ObjectTypeNodeMemory<T>  {
+    public static class InitialFactObjectTypeNodeMemory extends ObjectTypeNodeMemory implements Serializable {
         private List<InternalFactHandle> list = Collections.emptyList();
 
         InitialFactObjectTypeNodeMemory(Class classType) {

--- a/drools-kiesession/src/main/java/org/drools/kiesession/session/StatefulKnowledgeSessionImpl.java
+++ b/drools-kiesession/src/main/java/org/drools/kiesession/session/StatefulKnowledgeSessionImpl.java
@@ -330,14 +330,17 @@ public class StatefulKnowledgeSessionImpl extends AbstractRuntime
 
         this.lastIdleTimestamp = new AtomicLong(-1);
 
-        this.nodeMemories = createNodeMemories(kBase);
-        registerReceiveNodes(kBase.getReceiveNodes());
+        //this.nodeMemories = createNodeMemories(kBase);
+        //registerReceiveNodes(kBase.getReceiveNodes());
 
         RuleBaseConfiguration conf = kBase.getRuleBaseConfiguration();
         this.pctxFactory = RuntimeComponentFactory.get().getPropagationContextFactory();
 
         this.agenda = agenda != null ? agenda : RuntimeComponentFactory.get().getAgendaFactory( config ).createAgenda(kBase);
         this.agenda.setWorkingMemory(this);
+
+        this.nodeMemories = createNodeMemories(kBase);
+        registerReceiveNodes(kBase.getReceiveNodes());
 
         this.entryPointsManager = (NamedEntryPointsManager) RuntimeComponentFactory.get().getEntryPointFactory().createEntryPointsManager(this);
 

--- a/drools-kiesession/src/main/java/org/drools/kiesession/session/StatefulKnowledgeSessionImpl.java
+++ b/drools-kiesession/src/main/java/org/drools/kiesession/session/StatefulKnowledgeSessionImpl.java
@@ -16,27 +16,6 @@
 
 package org.drools.kiesession.session;
 
-import java.io.ByteArrayOutputStream;
-import java.io.Externalizable;
-import java.io.IOException;
-import java.io.ObjectInput;
-import java.io.ObjectOutput;
-import java.lang.reflect.Type;
-import java.util.ArrayList;
-import java.util.Collection;
-import java.util.Collections;
-import java.util.HashMap;
-import java.util.Iterator;
-import java.util.List;
-import java.util.Map;
-import java.util.concurrent.ConcurrentHashMap;
-import java.util.concurrent.atomic.AtomicBoolean;
-import java.util.concurrent.atomic.AtomicInteger;
-import java.util.concurrent.atomic.AtomicLong;
-import java.util.concurrent.locks.Lock;
-import java.util.concurrent.locks.ReentrantLock;
-import java.util.function.Consumer;
-
 import org.drools.core.FlowSessionConfiguration;
 import org.drools.core.QueryResultsImpl;
 import org.drools.core.RuleBaseConfiguration;
@@ -138,6 +117,27 @@ import org.kie.internal.marshalling.MarshallerFactory;
 import org.kie.internal.process.CorrelationAwareProcessRuntime;
 import org.kie.internal.process.CorrelationKey;
 import org.kie.internal.runtime.StatefulKnowledgeSession;
+
+import java.io.ByteArrayOutputStream;
+import java.io.Externalizable;
+import java.io.IOException;
+import java.io.ObjectInput;
+import java.io.ObjectOutput;
+import java.lang.reflect.Type;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicLong;
+import java.util.concurrent.locks.Lock;
+import java.util.concurrent.locks.ReentrantLock;
+import java.util.function.Consumer;
 
 import static java.util.stream.Collectors.toList;
 import static org.drools.base.base.ClassObjectType.InitialFact_ObjectType;
@@ -330,7 +330,7 @@ public class StatefulKnowledgeSessionImpl extends AbstractRuntime
 
         this.lastIdleTimestamp = new AtomicLong(-1);
 
-        this.nodeMemories = new ConcurrentNodeMemories(kBase);
+        this.nodeMemories = createNodeMemories(kBase);
         registerReceiveNodes(kBase.getReceiveNodes());
 
         RuleBaseConfiguration conf = kBase.getRuleBaseConfiguration();
@@ -348,6 +348,10 @@ public class StatefulKnowledgeSessionImpl extends AbstractRuntime
         if (initInitFactHandle) {
             this.initialFactHandle = initInitialFact(null);
         }
+    }
+
+    protected ConcurrentNodeMemories createNodeMemories(InternalKnowledgeBase kBase) {
+        return new ConcurrentNodeMemories(kBase);
     }
 
     public StatefulKnowledgeSessionImpl setStateless( boolean stateless ) {

--- a/drools-model/drools-canonical-model/src/main/java/org/drools/model/Consequence.java
+++ b/drools-model/drools-canonical-model/src/main/java/org/drools/model/Consequence.java
@@ -19,7 +19,9 @@ package org.drools.model;
 
 import org.drools.model.functions.BlockN;
 
-public interface Consequence extends RuleItem {
+import java.io.Serializable;
+
+public interface Consequence extends RuleItem, Serializable {
 
     Variable[] getVariables();
     Variable[] getDeclarations();

--- a/drools-model/drools-canonical-model/src/main/java/org/drools/model/DomainClassMetadata.java
+++ b/drools-model/drools-canonical-model/src/main/java/org/drools/model/DomainClassMetadata.java
@@ -17,7 +17,9 @@
 
 package org.drools.model;
 
-public interface DomainClassMetadata {
+import java.io.Serializable;
+
+public interface DomainClassMetadata extends Serializable {
     Class<?> getDomainClass();
     int getPropertiesSize();
     int getPropertyIndex(String name);

--- a/drools-model/drools-canonical-model/src/main/java/org/drools/model/consequences/ConsequenceImpl.java
+++ b/drools-model/drools-canonical-model/src/main/java/org/drools/model/consequences/ConsequenceImpl.java
@@ -17,16 +17,17 @@
 
 package org.drools.model.consequences;
 
-import java.util.Arrays;
-import java.util.stream.Stream;
-
 import org.drools.model.Consequence;
 import org.drools.model.Variable;
 import org.drools.model.functions.Block0;
 import org.drools.model.functions.BlockN;
 import org.drools.model.impl.ModelComponent;
 
-public class ConsequenceImpl implements Consequence, ModelComponent {
+import java.io.Serializable;
+import java.util.Arrays;
+import java.util.stream.Stream;
+
+public class ConsequenceImpl implements Consequence, ModelComponent, Serializable {
     private final Variable[] variables;
     private final Variable[] declarations;
     private final BlockN block;

--- a/drools-model/drools-canonical-model/src/main/java/org/drools/model/impl/DeclarationImpl.java
+++ b/drools-model/drools-canonical-model/src/main/java/org/drools/model/impl/DeclarationImpl.java
@@ -21,7 +21,9 @@ import org.drools.model.DeclarationSource;
 import org.drools.model.DomainClassMetadata;
 import org.drools.model.Window;
 
-public class DeclarationImpl<T> extends VariableImpl<T> implements Declaration<T> {
+import java.io.Serializable;
+
+public class DeclarationImpl<T> extends VariableImpl<T> implements Declaration<T>, Serializable {
     private DeclarationSource source;
     private Window window;
     private DomainClassMetadata metadata;

--- a/drools-model/drools-canonical-model/src/main/java/org/drools/model/impl/GlobalImpl.java
+++ b/drools-model/drools-canonical-model/src/main/java/org/drools/model/impl/GlobalImpl.java
@@ -18,7 +18,9 @@ package org.drools.model.impl;
 
 import org.drools.model.Global;
 
-public class GlobalImpl<T> extends VariableImpl<T> implements Global<T>, ModelComponent {
+import java.io.Serializable;
+
+public class GlobalImpl<T> extends VariableImpl<T> implements Global<T>, ModelComponent, Serializable {
     private final String pkg;
 
     public GlobalImpl(Class<T> type, String pkg) {

--- a/drools-model/drools-model-compiler/src/main/java/org/drools/modelcompiler/consequence/LambdaConsequence.java
+++ b/drools-model/drools-model-compiler/src/main/java/org/drools/modelcompiler/consequence/LambdaConsequence.java
@@ -16,24 +16,25 @@
 
 package org.drools.modelcompiler.consequence;
 
+import org.drools.base.base.ValueResolver;
+import org.drools.base.definitions.rule.impl.RuleImpl;
+import org.drools.base.reteoo.BaseTuple;
+import org.drools.base.rule.Declaration;
+import org.drools.base.rule.consequence.Consequence;
+import org.drools.core.common.DefaultEventHandle;
+import org.drools.core.common.ReteEvaluator;
+import org.drools.core.reteoo.RuleTerminalNode;
+import org.drools.core.reteoo.Tuple;
+import org.drools.core.rule.consequence.KnowledgeHelper;
+import org.drools.model.Variable;
+import org.kie.api.runtime.rule.FactHandle;
+
+import java.io.Serializable;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 
-import org.drools.base.base.ValueResolver;
-import org.drools.core.common.DefaultEventHandle;
-import org.drools.core.common.ReteEvaluator;
-import org.drools.base.definitions.rule.impl.RuleImpl;
-import org.drools.base.reteoo.BaseTuple;
-import org.drools.core.reteoo.RuleTerminalNode;
-import org.drools.base.rule.Declaration;
-import org.drools.base.rule.consequence.Consequence;
-import org.drools.core.rule.consequence.KnowledgeHelper;
-import org.drools.core.reteoo.Tuple;
-import org.drools.model.Variable;
-import org.kie.api.runtime.rule.FactHandle;
-
-public class LambdaConsequence implements Consequence<KnowledgeHelper> {
+public class LambdaConsequence implements Consequence<KnowledgeHelper>, Serializable {
 
     // Enable the optimization to extract from the activation tuple the arguments to be passed to this
     // consequence in linear time by traversing the tuple only once.
@@ -224,7 +225,7 @@ public class LambdaConsequence implements Consequence<KnowledgeHelper> {
         return facts;
     }
 
-    private static class GlobalSupplier implements Comparable<GlobalSupplier> {
+    private static class GlobalSupplier implements Comparable<GlobalSupplier>, Serializable {
         private final int supplierIndex;
         private final String globalName;
 
@@ -242,7 +243,7 @@ public class LambdaConsequence implements Consequence<KnowledgeHelper> {
         }
     }
 
-    private static class TupleFactSupplier implements Comparable<TupleFactSupplier> {
+    private static class TupleFactSupplier implements Comparable<TupleFactSupplier>, Serializable {
         private final int         supplierIndex;
         private final Declaration declaration;
         private final int         declarationTupleIndex;

--- a/drools-reliability/drools-reliability-core/src/main/java/org/drools/reliability/core/FullReliableObjectStore.java
+++ b/drools-reliability/drools-reliability-core/src/main/java/org/drools/reliability/core/FullReliableObjectStore.java
@@ -19,7 +19,7 @@ import org.drools.core.common.IdentityObjectStore;
 import org.drools.core.common.InternalFactHandle;
 import org.drools.core.common.Storage;
 
-public class FullReliableObjectStore extends IdentityObjectStore {
+public class FullReliableObjectStore extends IdentityObjectStore implements ReliableObjectStore {
 
     private final transient Storage<Long, StoredObject> storage;
 
@@ -45,13 +45,13 @@ public class FullReliableObjectStore extends IdentityObjectStore {
         super.removeHandle(handle);
     }
 
-    void putIntoPersistedCache(InternalFactHandle handle, boolean propagated) {
+    private void putIntoPersistedCache(InternalFactHandle handle, boolean propagated) {
         Object object = handle.getObject();
         StoredObject storedObject = new SerializableStoredObject(object, propagated);
         storage.put(getHandleForObject(object).getId(), storedObject);
     }
 
-    void removeFromPersistedCache(Object object) {
+    private void removeFromPersistedCache(Object object) {
         InternalFactHandle fh = getHandleForObject(object);
         if (fh != null) {
             storage.remove(fh.getId());
@@ -62,5 +62,10 @@ public class FullReliableObjectStore extends IdentityObjectStore {
         for (StoredObject entry : storage.values()) {
             super.addHandle(getHandleForObject(entry.getObject()),entry.getObject());
         }
+    }
+
+    @Override
+    public void safepoint() {
+        // no-op
     }
 }

--- a/drools-reliability/drools-reliability-core/src/main/java/org/drools/reliability/core/FullReliableObjectStore.java
+++ b/drools-reliability/drools-reliability-core/src/main/java/org/drools/reliability/core/FullReliableObjectStore.java
@@ -66,6 +66,8 @@ public class FullReliableObjectStore extends IdentityObjectStore implements Reli
 
     @Override
     public void safepoint() {
-        // no-op
+        if (storage.requiresFlush()) {
+            storage.flush();
+        }
     }
 }

--- a/drools-reliability/drools-reliability-core/src/main/java/org/drools/reliability/core/ReliableList.java
+++ b/drools-reliability/drools-reliability-core/src/main/java/org/drools/reliability/core/ReliableList.java
@@ -1,0 +1,7 @@
+package org.drools.reliability.core;
+
+import org.drools.core.phreak.PropagationList;
+
+public interface ReliableList extends PropagationList {
+    void safepoint();
+}

--- a/drools-reliability/drools-reliability-core/src/main/java/org/drools/reliability/core/ReliableNamedEntryPoint.java
+++ b/drools-reliability/drools-reliability-core/src/main/java/org/drools/reliability/core/ReliableNamedEntryPoint.java
@@ -38,6 +38,6 @@ public class ReliableNamedEntryPoint extends NamedEntryPoint {
     }
 
     public void safepoint() {
-        ((SimpleReliableObjectStore) getObjectStore()).safepoint();
+        ((ReliableObjectStore) getObjectStore()).safepoint();
     }
 }

--- a/drools-reliability/drools-reliability-core/src/main/java/org/drools/reliability/core/ReliableNodeMemories.java
+++ b/drools-reliability/drools-reliability-core/src/main/java/org/drools/reliability/core/ReliableNodeMemories.java
@@ -1,0 +1,39 @@
+package org.drools.reliability.core;
+
+import org.drools.core.common.ConcurrentNodeMemories;
+import org.drools.core.common.Memory;
+import org.drools.core.common.MemoryFactory;
+import org.drools.core.common.ReteEvaluator;
+import org.drools.core.impl.RuleBase;
+import org.drools.core.reteoo.SegmentMemory;
+
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Set;
+
+public class ReliableNodeMemories extends ConcurrentNodeMemories {
+
+    private final Map<Integer, Memory> changedMemories = new HashMap<>();
+    private final Set<SegmentMemory> changedSegments = new HashSet<>();
+
+    public ReliableNodeMemories(RuleBase ruleBase) {
+        super(ruleBase);
+    }
+
+    @Override
+    public Memory getNodeMemory(MemoryFactory node, ReteEvaluator reteEvaluator) {
+        Memory memory = super.getNodeMemory(node, reteEvaluator);
+        changedMemories.put(node.getMemoryId(), memory);
+        if (memory.getSegmentMemory() != null) {
+            changedSegments.add(memory.getSegmentMemory());
+        }
+        return memory;
+    }
+
+    public void safepoint() {
+        // TODO: persist memories
+        changedMemories.clear();
+        changedSegments.clear();
+    }
+}

--- a/drools-reliability/drools-reliability-core/src/main/java/org/drools/reliability/core/ReliableNodeMemories.java
+++ b/drools-reliability/drools-reliability-core/src/main/java/org/drools/reliability/core/ReliableNodeMemories.java
@@ -33,6 +33,9 @@ public class ReliableNodeMemories extends ConcurrentNodeMemories {
 
     public void safepoint() {
         // TODO: persist memories
+        //Storage<String, Object> componentsStorage = StorageManagerFactory.get().getStorageManager().getOrCreateStorageForSession(, "components");
+        //componentsStorage.put("memories", changedMemories);
+        //componentsStorage.put("segments", changedSegments);
         changedMemories.clear();
         changedSegments.clear();
     }

--- a/drools-reliability/drools-reliability-core/src/main/java/org/drools/reliability/core/ReliableNodeMemories.java
+++ b/drools-reliability/drools-reliability-core/src/main/java/org/drools/reliability/core/ReliableNodeMemories.java
@@ -7,6 +7,7 @@ import org.drools.core.common.ReteEvaluator;
 import org.drools.core.common.Storage;
 import org.drools.core.impl.RuleBase;
 import org.drools.core.reteoo.SegmentMemory;
+import org.kie.internal.runtime.StatefulKnowledgeSession;
 
 import java.util.HashMap;
 import java.util.Map;
@@ -14,7 +15,6 @@ import java.util.Map;
 public class ReliableNodeMemories extends ConcurrentNodeMemories {
 
     private final Map<Integer, Memory> changedMemories = new HashMap<>();
-    //private final Set<SegmentMemory> changedSegments = new HashSet<>();
     private final Map<Integer,SegmentMemory> changedSegments = new HashMap<>();
     private final Storage<Integer, Object> storage;
 
@@ -41,17 +41,15 @@ public class ReliableNodeMemories extends ConcurrentNodeMemories {
         for (Integer key : changedSegments.keySet()){
             storage.put(key, changedSegments.get(key));
         }
+
         changedMemories.clear();
         changedSegments.clear();
+
+        if (storage.requiresFlush()) {this.storage.flush();}
+
     }
 
-    public void reInit() {
-        for (Integer key : storage.keySet()){
-            if (storage.get(key) instanceof Memory){
-                changedMemories.put(key,(Memory) storage.get(key));
-            }else if (storage.get(key) instanceof SegmentMemory) {
-                changedSegments.put(key,(SegmentMemory) storage.get(key));
-            }
-        }
+    public void reInit(StatefulKnowledgeSession session) {
+        super.reInit(this.storage, session);
     }
 }

--- a/drools-reliability/drools-reliability-core/src/main/java/org/drools/reliability/core/ReliableNodeMemories.java
+++ b/drools-reliability/drools-reliability-core/src/main/java/org/drools/reliability/core/ReliableNodeMemories.java
@@ -5,7 +5,7 @@ import org.drools.core.common.Memory;
 import org.drools.core.common.MemoryFactory;
 import org.drools.core.common.ReteEvaluator;
 import org.drools.core.common.Storage;
-import org.drools.core.impl.RuleBase;
+import org.drools.core.impl.InternalRuleBase;
 import org.drools.core.reteoo.SegmentMemory;
 import org.kie.internal.runtime.StatefulKnowledgeSession;
 
@@ -18,7 +18,7 @@ public class ReliableNodeMemories extends ConcurrentNodeMemories {
     private final Map<Integer,SegmentMemory> changedSegments = new HashMap<>();
     private final Storage<Integer, Object> storage;
 
-    public ReliableNodeMemories(RuleBase ruleBase, Storage<Integer, Object> storage) {
+    public ReliableNodeMemories(InternalRuleBase ruleBase, Storage<Integer, Object> storage) {
         super(ruleBase);
         this.storage = storage;
     }

--- a/drools-reliability/drools-reliability-core/src/main/java/org/drools/reliability/core/ReliableObjectStore.java
+++ b/drools-reliability/drools-reliability-core/src/main/java/org/drools/reliability/core/ReliableObjectStore.java
@@ -1,0 +1,7 @@
+package org.drools.reliability.core;
+
+import org.drools.core.common.ObjectStore;
+
+public interface ReliableObjectStore extends ObjectStore {
+    void safepoint();
+}

--- a/drools-reliability/drools-reliability-core/src/main/java/org/drools/reliability/core/ReliablePropagationList.java
+++ b/drools-reliability/drools-reliability-core/src/main/java/org/drools/reliability/core/ReliablePropagationList.java
@@ -25,7 +25,7 @@ import java.io.IOException;
 import java.io.ObjectInput;
 import java.io.ObjectOutput;
 
-public class ReliablePropagationList extends SynchronizedPropagationList implements Externalizable {
+public class ReliablePropagationList extends SynchronizedPropagationList implements Externalizable, ReliableList {
 
     public static final String PROPAGATION_LIST = "PropagationList";
 
@@ -46,8 +46,8 @@ public class ReliablePropagationList extends SynchronizedPropagationList impleme
     @Override
     public synchronized PropagationEntry takeAll() {
         PropagationEntry p = super.takeAll();
-        Storage<String, Object> componentsStorage = StorageManagerFactory.get().getStorageManager().getOrCreateStorageForSession(this.reteEvaluator, "components");
-        componentsStorage.put(PROPAGATION_LIST, this);
+        //Storage<String, Object> componentsStorage = StorageManagerFactory.get().getStorageManager().getOrCreateStorageForSession(this.reteEvaluator, "components");
+        //componentsStorage.put(PROPAGATION_LIST, this);
         return p;
     }
 
@@ -66,5 +66,11 @@ public class ReliablePropagationList extends SynchronizedPropagationList impleme
         this.disposed = in.readBoolean();
         this.hasEntriesDeferringExpiration = in.readBoolean();
         this.firingUntilHalt = in.readBoolean();
+    }
+
+    @Override
+    public void safepoint() {
+        Storage<String, Object> componentsStorage = StorageManagerFactory.get().getStorageManager().getOrCreateStorageForSession(this.reteEvaluator, "components");
+        componentsStorage.put(PROPAGATION_LIST, this);
     }
 }

--- a/drools-reliability/drools-reliability-core/src/main/java/org/drools/reliability/core/ReliableSessionInitializer.java
+++ b/drools-reliability/drools-reliability-core/src/main/java/org/drools/reliability/core/ReliableSessionInitializer.java
@@ -28,6 +28,7 @@ import org.kie.api.event.rule.ObjectUpdatedEvent;
 import org.kie.api.event.rule.RuleRuntimeEventListener;
 import org.kie.api.runtime.conf.PersistedSessionOption;
 import org.kie.api.runtime.rule.EntryPoint;
+import org.kie.internal.runtime.StatefulKnowledgeSession;
 
 import java.util.HashMap;
 import java.util.List;
@@ -126,7 +127,7 @@ public class ReliableSessionInitializer {
                 store.reInit();
                 //
                 ReliableNodeMemories memories = (ReliableNodeMemories)((WorkingMemoryEntryPoint) ep).getReteEvaluator().getNodeMemories();
-                memories.reInit();
+                memories.reInit((StatefulKnowledgeSession) session);
             }
             //
 

--- a/drools-reliability/drools-reliability-core/src/main/java/org/drools/reliability/core/ReliableSessionInitializer.java
+++ b/drools-reliability/drools-reliability-core/src/main/java/org/drools/reliability/core/ReliableSessionInitializer.java
@@ -124,7 +124,12 @@ public class ReliableSessionInitializer {
             for (EntryPoint ep : session.getEntryPoints()) {
                 FullReliableObjectStore store = (FullReliableObjectStore) ((WorkingMemoryEntryPoint) ep).getObjectStore();
                 store.reInit();
+                //
+                ReliableNodeMemories memories = (ReliableNodeMemories)((WorkingMemoryEntryPoint) ep).getReteEvaluator().getNodeMemories();
+                memories.reInit();
             }
+            //
+
         }
 
         static class FullStoreRuntimeEventListener implements RuleRuntimeEventListener {

--- a/drools-reliability/drools-reliability-core/src/main/java/org/drools/reliability/core/ReliableStatefulKnowledgeSessionImpl.java
+++ b/drools-reliability/drools-reliability-core/src/main/java/org/drools/reliability/core/ReliableStatefulKnowledgeSessionImpl.java
@@ -18,6 +18,7 @@ package org.drools.reliability.core;
 import org.drools.core.SessionConfiguration;
 import org.drools.core.common.ConcurrentNodeMemories;
 import org.drools.core.common.InternalAgenda;
+import org.drools.core.common.Storage;
 import org.drools.core.rule.accessor.FactHandleFactory;
 import org.drools.kiesession.rulebase.InternalKnowledgeBase;
 import org.drools.kiesession.session.StatefulKnowledgeSessionImpl;
@@ -50,7 +51,8 @@ public class ReliableStatefulKnowledgeSessionImpl extends StatefulKnowledgeSessi
     @Override
     protected ConcurrentNodeMemories createNodeMemories(InternalKnowledgeBase kBase) {
         if (getSessionConfiguration().getPersistedSessionOption().getPersistenceStrategy() == PersistedSessionOption.PersistenceStrategy.FULL) {
-            return new ReliableNodeMemories(kBase);
+            Storage<Integer, Object> storage = StorageManagerFactory.get().getStorageManager().getOrCreateStorageForSession(this, "ep" + getEntryPointId());
+            return new ReliableNodeMemories(kBase,storage);
         }
         return super.createNodeMemories(kBase);
     }

--- a/drools-reliability/drools-reliability-core/src/main/java/org/drools/reliability/core/ReliableStatefulKnowledgeSessionImpl.java
+++ b/drools-reliability/drools-reliability-core/src/main/java/org/drools/reliability/core/ReliableStatefulKnowledgeSessionImpl.java
@@ -51,7 +51,7 @@ public class ReliableStatefulKnowledgeSessionImpl extends StatefulKnowledgeSessi
     @Override
     protected ConcurrentNodeMemories createNodeMemories(InternalKnowledgeBase kBase) {
         if (getSessionConfiguration().getPersistedSessionOption().getPersistenceStrategy() == PersistedSessionOption.PersistenceStrategy.FULL) {
-            Storage<Integer, Object> storage = StorageManagerFactory.get().getStorageManager().getOrCreateStorageForSession(this, "ep" + getEntryPointId());
+            Storage<Integer, Object> storage = StorageManagerFactory.get().getStorageManager().getOrCreateStorageForSession(this, "mem" + getEntryPointId());
             return new ReliableNodeMemories(kBase,storage);
         }
         return super.createNodeMemories(kBase);

--- a/drools-reliability/drools-reliability-core/src/main/java/org/drools/reliability/core/SimpleReliableObjectStore.java
+++ b/drools-reliability/drools-reliability-core/src/main/java/org/drools/reliability/core/SimpleReliableObjectStore.java
@@ -18,17 +18,14 @@ package org.drools.reliability.core;
 import org.drools.core.common.InternalFactHandle;
 import org.drools.core.common.InternalWorkingMemory;
 import org.drools.core.common.InternalWorkingMemoryEntryPoint;
-import org.drools.core.common.ObjectStore;
 
 import java.util.List;
 
-public interface SimpleReliableObjectStore extends ObjectStore {
+public interface SimpleReliableObjectStore extends ReliableObjectStore {
 
     List<StoredObject> reInit(InternalWorkingMemory session, InternalWorkingMemoryEntryPoint ep);
 
     void putIntoPersistedStorage(InternalFactHandle handle, boolean propagated);
 
     void removeFromPersistedStorage(Object object);
-
-    void safepoint();
 }

--- a/drools-reliability/drools-reliability-infinispan/src/test/java/org/drools/reliability/infinispan/ReliabilityTest.java
+++ b/drools-reliability/drools-reliability-infinispan/src/test/java/org/drools/reliability/infinispan/ReliabilityTest.java
@@ -55,7 +55,7 @@ class ReliabilityTest extends ReliabilityTestBasics {
     }
 
     @ParameterizedTest
-    @MethodSource("strategyProviderStoresOnlyWithExplicitSafepoints") // FULL fails with "ReliablePropagationList; no valid constructor"
+    @MethodSource("strategyProviderFullPlusStoresOnlyWithExplicitSafepoints")
     void insertFailoverInsertFire_shouldRecoverFromFailover(PersistedSessionOption.PersistenceStrategy persistenceStrategy, PersistedSessionOption.SafepointStrategy safepointStrategy) {
         createSession(BASIC_RULE, persistenceStrategy, safepointStrategy);
 
@@ -78,7 +78,7 @@ class ReliabilityTest extends ReliabilityTestBasics {
 
 
     @ParameterizedTest
-    @MethodSource("strategyProviderStoresOnlyWithExplicitSafepoints") // With Remote, FULL fails with "ReliablePropagationList; no valid constructor" even without failover
+    @MethodSource("strategyProviderFullPlusStoresOnlyWithExplicitSafepoints")
     void noFailover(PersistedSessionOption.PersistenceStrategy persistenceStrategy, PersistedSessionOption.SafepointStrategy safepointStrategy) {
 
         createSession(BASIC_RULE, persistenceStrategy, safepointStrategy);
@@ -101,7 +101,7 @@ class ReliabilityTest extends ReliabilityTestBasics {
 
 
     @ParameterizedTest
-    @MethodSource("strategyProviderStoresOnlyWithExplicitSafepoints") // FULL fails with "ReliablePropagationList; no valid constructor"
+    @MethodSource("strategyProviderFullPlusStoresOnlyWithExplicitSafepoints")
     void insertFireInsertFailoverInsertFire_shouldMatchFactInsertedBeforeFailover(PersistedSessionOption.PersistenceStrategy persistenceStrategy, PersistedSessionOption.SafepointStrategy safepointStrategy) {
 
         createSession(BASIC_RULE, persistenceStrategy, safepointStrategy);

--- a/drools-reliability/drools-reliability-infinispan/src/test/java/org/drools/reliability/infinispan/ReliabilityTest.java
+++ b/drools-reliability/drools-reliability-infinispan/src/test/java/org/drools/reliability/infinispan/ReliabilityTest.java
@@ -101,7 +101,7 @@ class ReliabilityTest extends ReliabilityTestBasics {
 
 
     @ParameterizedTest
-    @MethodSource("strategyProviderFullPlusStoresOnlyWithExplicitSafepoints")
+    @MethodSource("strategyProviderFullWithExplicitSafepoints")
     void insertFireInsertFailoverInsertFire_shouldMatchFactInsertedBeforeFailover(PersistedSessionOption.PersistenceStrategy persistenceStrategy, PersistedSessionOption.SafepointStrategy safepointStrategy) {
 
         createSession(BASIC_RULE, persistenceStrategy, safepointStrategy);

--- a/drools-reliability/drools-reliability-infinispan/src/test/java/org/drools/reliability/infinispan/ReliabilityTestBasics.java
+++ b/drools-reliability/drools-reliability-infinispan/src/test/java/org/drools/reliability/infinispan/ReliabilityTestBasics.java
@@ -84,6 +84,12 @@ public abstract class ReliabilityTestBasics {
         );
     }
 
+    static Stream<Arguments> strategyProviderFullWithExplicitSafepoints() {
+        return Stream.of(
+                arguments(PersistedSessionOption.PersistenceStrategy.FULL, PersistedSessionOption.SafepointStrategy.EXPLICIT)
+        );
+    }
+
     static Stream<Arguments> strategyProviderStoresOnlyWithAllSafepoints() {
         return Stream.of(
                 arguments(PersistedSessionOption.PersistenceStrategy.STORES_ONLY, PersistedSessionOption.SafepointStrategy.ALWAYS),

--- a/drools-reliability/drools-reliability-infinispan/src/test/java/org/drools/reliability/infinispan/ReliabilityTestBasics.java
+++ b/drools-reliability/drools-reliability-infinispan/src/test/java/org/drools/reliability/infinispan/ReliabilityTestBasics.java
@@ -76,6 +76,14 @@ public abstract class ReliabilityTestBasics {
         );
     }
 
+    static Stream<Arguments> strategyProviderFullPlusStoresOnlyWithExplicitSafepoints() {
+        return Stream.of(
+                arguments(PersistedSessionOption.PersistenceStrategy.FULL, PersistedSessionOption.SafepointStrategy.EXPLICIT),
+                arguments(PersistedSessionOption.PersistenceStrategy.STORES_ONLY, PersistedSessionOption.SafepointStrategy.ALWAYS),
+                arguments(PersistedSessionOption.PersistenceStrategy.STORES_ONLY, PersistedSessionOption.SafepointStrategy.EXPLICIT)
+        );
+    }
+
     static Stream<Arguments> strategyProviderStoresOnlyWithAllSafepoints() {
         return Stream.of(
                 arguments(PersistedSessionOption.PersistenceStrategy.STORES_ONLY, PersistedSessionOption.SafepointStrategy.ALWAYS),


### PR DESCRIPTION
Testing with ReliableTest.insertFireInsertFailoverInsertFire_shouldMatchFactInsertedBeforeFailover, 
Serializable implementation based on “java.io.NotSerializableException” thrown, 
until I reached a point were the exception points to a java.util.WeakHashMap object, related to ClassFieldAccessorCache.cacheByClassLoader
which is instantiated as new WeakHashMap<>(); (class ClassFieldAccessorCache.java, line#44)
