### PR TITLE
MVEL.analyse is not using DataConverter coercions

### DIFF
--- a/drools-mvel/src/main/java/org/drools/mvel/MVELConstraintBuilder.java
+++ b/drools-mvel/src/main/java/org/drools/mvel/MVELConstraintBuilder.java
@@ -476,7 +476,7 @@ public class MVELConstraintBuilder implements ConstraintBuilder {
 
     public static class StringCoercionCompatibilityEvaluator extends CompatibilityStrategy.DefaultCompatibilityEvaluator {
 
-        private static final CompatibilityStrategy.CompatibilityEvaluator INSTANCE = new StringCoercionCompatibilityEvaluator();
+        public static final CompatibilityStrategy.CompatibilityEvaluator INSTANCE = new StringCoercionCompatibilityEvaluator();
 
         private StringCoercionCompatibilityEvaluator() { }
 

--- a/drools-mvel/src/test/java/org/drools/mvel/MVELDateCoercionTest.java
+++ b/drools-mvel/src/test/java/org/drools/mvel/MVELDateCoercionTest.java
@@ -16,13 +16,23 @@ package org.drools.mvel;
 
 import java.text.SimpleDateFormat;
 import java.util.Date;
+import java.util.HashMap;
 import java.util.Locale;
+import java.util.Map;
+import java.util.Objects;
 
+import org.drools.mvel.MVELConstraintBuilder.StringCoercionCompatibilityEvaluator;
 import org.drools.util.DateUtils;
 import org.drools.mvel.expr.MVELDateCoercion;
 import org.junit.Test;
+import org.mvel2.DataConversion;
+import org.mvel2.MVEL;
+import org.mvel2.ParserContext;
+import org.mvel2.util.CompatibilityStrategy;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.within;
+import static org.mvel2.MVEL.executeExpression;
 
 public class MVELDateCoercionTest {
 
@@ -47,4 +57,66 @@ public class MVELDateCoercionTest {
         assertThat(co.convertFrom(dt)).isEqualTo(dt_);
     }
 
+    @Test
+    public void testCoercionDuringAnalyze() {
+        CompatibilityStrategy.setCompatibilityEvaluator(StringCoercionCompatibilityEvaluator.INSTANCE);
+
+        DataConversion.addConversionHandler(Date.class,
+                                            new MVELDateCoercion());
+
+        String expr = "f.departureTime >= \"01-Jan-1970\" && f.departureTime <= \"01-Jan-2018\"";
+
+        ParserContext ctx = new ParserContext();
+        ctx.setStrongTyping(true);
+        ctx.setStrictTypeEnforcement(true);
+        ctx.addInput("f", Flight.class);
+
+        Class cls = MVEL.analyze( expr,
+                                   ctx );
+
+        assertThat(cls).isNotNull();
+    }
+
+    public static class Flight {
+        private Date departureTime;
+
+        public Flight(Date departureTime) {
+            this.departureTime = departureTime;
+        }
+
+        public Date getDepartureTime() {
+            return departureTime;
+        }
+
+        public void setDepartureTime(Date departureTime) {
+            this.departureTime = departureTime;
+        }
+
+
+        @Override
+        public boolean equals(Object o) {
+            if (this == o) {
+                return true;
+            }
+            if (o == null || getClass() != o.getClass()) {
+                return false;
+            }
+
+            Flight flight = (Flight) o;
+
+            return Objects.equals(departureTime, flight.departureTime);
+        }
+
+        @Override
+        public int hashCode() {
+            return departureTime != null ? departureTime.hashCode() : 0;
+        }
+
+        @Override
+        public String toString() {
+            return "Flight{" +
+                   "departureTime=" + departureTime +
+                   '}';
+        }
+    }
 }


### PR DESCRIPTION
This test proves that coercion is broken during analysis. Interesting during drools it did not fail until I combined the && back together again and I then made a standalone reproducer. I don't know why Drools doesn't fail if there is no &&, I couldn't reproduce that part.