### PR TITLE
DROOLS-7469 DMN memoize escaping for better runtime perf

### DIFF
--- a/kie-dmn/kie-dmn-feel/src/main/java/org/kie/dmn/feel/lang/ast/StringNode.java
+++ b/kie-dmn/kie-dmn-feel/src/main/java/org/kie/dmn/feel/lang/ast/StringNode.java
@@ -22,11 +22,12 @@ import org.kie.dmn.feel.lang.Type;
 import org.kie.dmn.feel.lang.types.BuiltInType;
 import org.kie.dmn.feel.util.EvalHelper;
 
-public class StringNode
-        extends BaseNode {
+public class StringNode extends BaseNode {
+    private final String value;
 
     public StringNode(ParserRuleContext ctx) {
         super( ctx );
+        this.value = EvalHelper.unescapeString(getText());
     }
 
     @Override
@@ -35,7 +36,7 @@ public class StringNode
     }
 
     public String getValue() {
-        return EvalHelper.unescapeString(getText());
+        return value;
     }
 
     @Override


### PR DESCRIPTION
Memoize escaping in string literal for better runtime performance.

On a few **_selected benchmarks I get a 13-21% runtime improvement_**, confirming this works good for Compile-Interpreted mode, which is likely the majority of the users:

Tabular version of a performance report validating this approach:

![Screenshot 2023-06-09 at 16 59 01](https://github.com/kiegroup/drools/assets/1699252/e0a78559-1cf9-4d6e-b0d2-bd27bf6e9baa)

Textual version of the report:

```
## BASELINE
FEELStringComparisonBenchmark.evaluateCompiledButInterpretedExpression   "foo" < "bar"  avgt  100   0.136 ± 0.002  us/op
FEELStringComparisonBenchmark.evaluateCompiledButInterpretedExpression  "foo" >= "bar"  avgt  100   0.267 ± 0.006  us/op
FEELStringComparisonBenchmark.evaluateCompiledButInterpretedExpression  "foo" != "bar"  avgt  100   0.227 ± 0.004  us/op
FEELStringComparisonBenchmark.evaluateCompiledButInterpretedExpression   "foo" = "foo"  avgt  100   0.227 ± 0.002  us/op
FEELStringComparisonBenchmark.evaluateCompiledJavaExpressionBenchmark    "foo" < "bar"  avgt  100   0.111 ± 0.006  us/op
FEELStringComparisonBenchmark.evaluateCompiledJavaExpressionBenchmark   "foo" >= "bar"  avgt  100   0.237 ± 0.004  us/op
FEELStringComparisonBenchmark.evaluateCompiledJavaExpressionBenchmark   "foo" != "bar"  avgt  100   0.188 ± 0.003  us/op
FEELStringComparisonBenchmark.evaluateCompiledJavaExpressionBenchmark    "foo" = "foo"  avgt  100   0.191 ± 0.004  us/op
FEELStringComparisonBenchmark.evaluateExpressionBenchmark                "foo" < "bar"  avgt  100  11.370 ± 0.172  us/op
FEELStringComparisonBenchmark.evaluateExpressionBenchmark               "foo" >= "bar"  avgt  100  11.611 ± 0.323  us/op
FEELStringComparisonBenchmark.evaluateExpressionBenchmark               "foo" != "bar"  avgt  100  11.635 ± 0.174  us/op
FEELStringComparisonBenchmark.evaluateExpressionBenchmark                "foo" = "foo"  avgt  100  11.807 ± 0.260  us/op

## MODIFIED
FEELStringComparisonBenchmark.evaluateCompiledButInterpretedExpression   "foo" < "bar"  avgt  100   0.107 ± 0.002  us/op
FEELStringComparisonBenchmark.evaluateCompiledButInterpretedExpression  "foo" >= "bar"  avgt  100   0.229 ± 0.003  us/op
FEELStringComparisonBenchmark.evaluateCompiledButInterpretedExpression  "foo" != "bar"  avgt  100   0.191 ± 0.003  us/op
FEELStringComparisonBenchmark.evaluateCompiledButInterpretedExpression   "foo" = "foo"  avgt  100   0.198 ± 0.003  us/op
FEELStringComparisonBenchmark.evaluateCompiledJavaExpressionBenchmark    "foo" < "bar"  avgt  100   0.105 ± 0.009  us/op
FEELStringComparisonBenchmark.evaluateCompiledJavaExpressionBenchmark   "foo" >= "bar"  avgt  100   0.222 ± 0.008  us/op
FEELStringComparisonBenchmark.evaluateCompiledJavaExpressionBenchmark   "foo" != "bar"  avgt  100   0.189 ± 0.003  us/op
FEELStringComparisonBenchmark.evaluateCompiledJavaExpressionBenchmark    "foo" = "foo"  avgt  100   0.187 ± 0.004  us/op
FEELStringComparisonBenchmark.evaluateExpressionBenchmark                "foo" < "bar"  avgt  100  11.032 ± 0.200  us/op
FEELStringComparisonBenchmark.evaluateExpressionBenchmark               "foo" >= "bar"  avgt  100  10.985 ± 0.109  us/op
FEELStringComparisonBenchmark.evaluateExpressionBenchmark               "foo" != "bar"  avgt  100  10.879 ± 0.104  us/op
FEELStringComparisonBenchmark.evaluateExpressionBenchmark                "foo" = "foo"  avgt  100  10.958 ± 0.194  us/op

## BASELINE
DMNEvaluateContextBenchmark.evaluateContext                            1000    ss  250  134.989 ± 14.884  ms/op

## MODIFIED
DMNEvaluateContextBenchmark.evaluateContext                            1000    ss  250  106.649 ± 0.415  ms/op
```

Please notice it is _expected_ that only Compile-Interpreted mode is benefitting the most from this change, given this change would put-forward, anticipate, bring-forward an operation at FEEL-compile-time, so to be netted-out for runtime.

As mentioned, the Compile-Interpreted is still the default so this would benefit the majority of the user base.

For example, a Decision Table with many FEEL:String enumerations, this would also benefit.

**Bonus content (because it's Friday 🥳 )**: https://thedailywtf.com/articles/The-Speedup-Loop

**JIRA**:  https://issues.redhat.com/browse/DROOLS-7469

**referenced Pull Requests**: none

<details>
<summary>
How to replicate CI configuration locally?
</summary>

Build Chain tool does "simple" maven build(s), the builds are just Maven commands, but because the repositories relates and depends on each other and any change in API or class method could affect several of those repositories there is a need to use [build-chain tool](https://github.com/kiegroup/github-action-build-chain) to handle cross repository builds and be sure that we always use latest version of the code for each repository.
 
[build-chain tool](https://github.com/kiegroup/github-action-build-chain) is a build tool which can be used on command line locally or in Github Actions workflow(s), in case you need to change multiple repositories and send multiple dependent pull requests related with a change you can easily reproduce the same build by executing it on Github hosted environment or locally in your development environment. See [local execution](https://github.com/kiegroup/github-action-build-chain#local-execution) details to get more information about it.
</details>

<details>
<summary>
How to retest this PR or trigger a specific build:
</summary>

- for <b>pull request checks</b>  
  Please add comment: <b>Jenkins retest this</b>

- for a <b>specific pull request check</b>  
  Please add comment: <b>Jenkins (re)run [drools|kogito-runtimes|kogito-apps|kogito-examples] tests</b>

- for a <b>full downstream build</b> 
  - for <b>jenkins</b> job: please add comment: <b>Jenkins run fdb</b>
  - for <b>github actions</b> job: add the label `run_fdb`

- <b>a compile downstream build</b> please  add comment: <b>Jenkins run cdb</b>

- <b>a full production downstream build</b> please add comment: <b>Jenkins execute product fdb</b>

- <b>an upstream build</b> please add comment: <b>Jenkins run upstream</b>

- for <b>quarkus branch checks</b>  
  Run checks against Quarkus current used branch  
  Please add comment: <b>Jenkins run quarkus-branch</b>

- for a <b>quarkus branch specific check</b>  
  Run checks against Quarkus current used branch  
  Please add comment: <b>Jenkins (re)run [drools|kogito-runtimes|kogito-apps|kogito-examples] quarkus-branch</b>

- for <b>quarkus main checks</b>  
  Run checks against Quarkus main branch  
  Please add comment: <b>Jenkins run quarkus-main</b>

- for a <b>specific quarkus main check</b>  
  Run checks against Quarkus main branch  
  Please add comment: <b>Jenkins (re)run [drools|kogito-runtimes|kogito-apps|kogito-examples] quarkus-main</b>

- for <b>quarkus lts checks</b>  
  Run checks against Quarkus lts branch  
  Please add comment: <b>Jenkins run quarkus-lts</b>

- for a <b>specific quarkus lts check</b>  
  Run checks against Quarkus lts branch  
  Please add comment: <b>Jenkins (re)run [drools|kogito-runtimes|kogito-apps|kogito-examples] quarkus-lts</b>

- for <b>native checks</b>  
  Run native checks  
  Please add comment: <b>Jenkins run native</b>

- for a <b>specific native check</b>  
  Run native checks 
  Please add comment: <b>Jenkins (re)run [drools|kogito-runtimes|kogito-apps|kogito-examples] native</b>

 - for <b>native lts checks</b>  
  Run native checks against quarkus lts branch
  Please add comment: <b>Jenkins run native-lts</b>

- for a <b>specific native lts check</b>  
  Run native checks against quarkus lts branch
  Please add comment: <b>Jenkins (re)run [drools|kogito-runtimes|kogito-apps|kogito-examples] native-lts</b>
</details>

<details>
<summary>
How to backport a pull request to a different branch?
</summary>

In order to automatically create a **backporting pull request** please add one or more labels having the following format `backport-<branch-name>`, where `<branch-name>` is the name of the branch where the pull request must be backported to (e.g., `backport-7.67.x` to backport the original PR to the `7.67.x` branch).

> **NOTE**: **backporting** is an action aiming to move a change (usually a commit) from a branch (usually the main one) to another one, which is generally referring to a still maintained release branch. Keeping it simple: it is about to move a specific change or a set of them from one branch to another.

Once the original pull request is successfully merged, the automated action will create one backporting pull request per each label (with the previous format) that has been added.

If something goes wrong, the author will be notified and at this point a manual backporting is needed.

> **NOTE**: this automated backporting is triggered whenever a pull request on `main` branch is labeled or closed, but both conditions must be satisfied to get the new PR created.
</details>

<!-- TODO to uncomment if activating the quarkus-3 rewrite PR job -->
<!-- <details>
<summary>
Quarkus-3 PR check is failing ... what to do ?
</summary>
The Quarkus 3 check is applying patches from the `.ci/environments/quarkus-3/patches`.

The first patch, called `0001_before_sh.patch`, is generated from Openrewrite `.ci/environments/quarkus-3/quarkus3.yml` recipe. The patch is created to speed up the check. But it may be that some changes in the PR broke this patch.  
No panic, there is an easy way to regenerate it. You just need to comment on the PR:
```
jenkins rewrite quarkus-3
```
and it should, after some minutes (~20/30min) apply a commit on the PR with the patch regenerated.

Other patches were generated manually. If any of it fails, you will need to manually update it... and push your changes.
</details> -->