### PR TITLE
rework drools-reliability tests to make them work seamlessly with one or more sessions

### DIFF
--- a/drools-reliability/drools-reliability-infinispan/src/test/java/org/drools/reliability/infinispan/ReliabilityCepTest.java
+++ b/drools-reliability/drools-reliability-infinispan/src/test/java/org/drools/reliability/infinispan/ReliabilityCepTest.java
@@ -49,33 +49,33 @@ class ReliabilityCepTest extends ReliabilityTestBasics {
 
         createSession(CEP_RULE, persistenceStrategy, safepointStrategy, EventProcessingOption.STREAM, ClockTypeOption.PSEUDO);
 
-        SessionPseudoClock clock = session.getSessionClock();
+        SessionPseudoClock clock = getSessionClock();
 
-        session.insert( new StockTick( "DROO" ) );
+        insert( new StockTick( "DROO" ) );
         clock.advanceTime( 6, TimeUnit.SECONDS );
-        session.insert( new StockTick( "ACME" ) );
+        insert( new StockTick( "ACME" ) );
 
         //-- Assume JVM down here. Fail-over to other JVM or rebooted JVM
         //-- ksession and kbase are lost. CacheManager is recreated. Client knows only "id"
         failover();
         restoreSession(CEP_RULE, persistenceStrategy, safepointStrategy, EventProcessingOption.STREAM, ClockTypeOption.PSEUDO);
-        clock = session.getSessionClock();
+        clock = getSessionClock();
 
-        assertThat(session.fireAllRules()).isEqualTo(1);
+        assertThat(fireAllRules()).isEqualTo(1);
         assertThat(getResults()).containsExactlyInAnyOrder("fired");
         clearResults();
 
         clock.advanceTime( 1, TimeUnit.SECONDS );
-        session.insert( new StockTick( "ACME" ) );
+        insert( new StockTick( "ACME" ) );
 
-        assertThat(session.fireAllRules()).isEqualTo(1);
+        assertThat(fireAllRules()).isEqualTo(1);
         assertThat(getResults()).containsExactlyInAnyOrder("fired");
         clearResults();
 
         clock.advanceTime( 3, TimeUnit.SECONDS );
-        session.insert( new StockTick( "ACME" ) );
+        insert( new StockTick( "ACME" ) );
 
-        assertThat(session.fireAllRules()).isZero();
+        assertThat(fireAllRules()).isZero();
         assertThat(getResults()).isEmpty();
     }
 
@@ -84,20 +84,20 @@ class ReliabilityCepTest extends ReliabilityTestBasics {
     void insertAdvanceFailoverExpireFire_shouldExpireAfterFailover(PersistedSessionOption.PersistenceStrategy persistenceStrategy, PersistedSessionOption.SafepointStrategy safepointStrategy) {
 
         createSession(CEP_RULE, persistenceStrategy, safepointStrategy, EventProcessingOption.STREAM, ClockTypeOption.PSEUDO);
-        SessionPseudoClock clock = session.getSessionClock();
+        SessionPseudoClock clock = getSessionClock();
 
-        session.insert( new StockTick( "DROO" ) );
+        insert( new StockTick( "DROO" ) );
         clock.advanceTime( 6, TimeUnit.SECONDS );
-        session.insert( new StockTick( "ACME" ) );
+        insert( new StockTick( "ACME" ) );
 
         failover();
         restoreSession(CEP_RULE, persistenceStrategy, safepointStrategy, EventProcessingOption.STREAM, ClockTypeOption.PSEUDO);
-        clock = session.getSessionClock();
+        clock = getSessionClock();
 
         clock.advanceTime(58, TimeUnit.SECONDS);
-        assertThat(session.fireAllRules()).as("DROO is expired, but a match is available.")
+        assertThat(fireAllRules()).as("DROO is expired, but a match is available.")
                                           .isEqualTo(1);
-        assertThat(session.getFactHandles()).as("DROO should have expired because @Expires = 60s")
+        assertThat(getFactHandles()).as("DROO should have expired because @Expires = 60s")
                                             .hasSize(1);
     }
 }

--- a/drools-reliability/drools-reliability-infinispan/src/test/java/org/drools/reliability/infinispan/ReliabilityUpdateInDrlTest.java
+++ b/drools-reliability/drools-reliability-infinispan/src/test/java/org/drools/reliability/infinispan/ReliabilityUpdateInDrlTest.java
@@ -49,12 +49,12 @@ class ReliabilityUpdateInDrlTest extends ReliabilityTestBasics {
 
         createSession(RULE_UPDATE, strategy);
 
-        insertString("M");
+        insert("M");
         insertMatchingPerson("Mike",22);
         insertNonMatchingPerson("Eleven", 17);
-        insertInteger(17); // person with age=17 will change to 18 (17+1)
+        insert(17); // person with age=17 will change to 18 (17+1)
 
-        assertThat(session.fireAllRules()).isEqualTo(2); // person with name that starts with M and has age>17 will be added to the results list
+        assertThat(fireAllRules()).isEqualTo(2); // person with name that starts with M and has age>17 will be added to the results list
         assertThat(getResults()).containsExactlyInAnyOrder(22);
 
         failover();
@@ -62,9 +62,9 @@ class ReliabilityUpdateInDrlTest extends ReliabilityTestBasics {
         restoreSession(RULE_UPDATE, strategy);
         clearResults();
 
-        insertString("E"); // NonMatchingPerson will match rule X
+        insert("E"); // NonMatchingPerson will match rule X
 
-        assertThat(session.fireAllRules()).isEqualTo(1);
+        assertThat(fireAllRules()).isEqualTo(1);
         assertThat(getResults()).containsExactlyInAnyOrder(18);
 
         failover();
@@ -72,7 +72,7 @@ class ReliabilityUpdateInDrlTest extends ReliabilityTestBasics {
         restoreSession(RULE_UPDATE, strategy);
         clearResults();
 
-        assertThat(session.fireAllRules()).isZero();
+        assertThat(fireAllRules()).isZero();
         assertThat(getResults()).isEmpty();
     }
 

--- a/drools-reliability/drools-reliability-infinispan/src/test/java/org/drools/reliability/infinispan/smoke/BaseSmokeTest.java
+++ b/drools-reliability/drools-reliability-infinispan/src/test/java/org/drools/reliability/infinispan/smoke/BaseSmokeTest.java
@@ -43,7 +43,7 @@ public class BaseSmokeTest extends ReliabilityTestBasics {
     void insertFailoverInsertFire_shouldRecoverFromFailover(PersistedSessionOption.PersistenceStrategy persistenceStrategy, PersistedSessionOption.SafepointStrategy safepointStrategy) {
         createSession(BASIC_RULE, persistenceStrategy, safepointStrategy);
 
-		insertString("M");
+		insert("M");
 		insertMatchingPerson("Matching Person One", 37);
 
         //-- Assume JVM down here. Fail-over to other JVM or rebooted JVM
@@ -55,7 +55,7 @@ public class BaseSmokeTest extends ReliabilityTestBasics {
 		insertNonMatchingPerson("Toshiya", 35);
         insertMatchingPerson("Matching Person Two", 40);
 
-		session.fireAllRules();
+		fireAllRules();
 
 		assertThat(getResults()).containsExactlyInAnyOrder("Matching Person One", "Matching Person Two");
     }


### PR DESCRIPTION
I tried to avoid the need of different methods for the cases when you're using one or more sessions. If you're using only one you can use all the tests as before and the base class will assume to be working with the only session available. Conversely when you're using more than one session you need to always pass the session on which you want to perform a specific action. The only exception to this is in the failover method because we assume that all sessions are running on the same cloud node, so when there is a failure on that node all the sessions in execution on it are to be considered lost at the same time.