### PR TITLE
map a session to its persistedSessionId

### DIFF
--- a/drools-reliability/drools-reliability-infinispan/src/test/java/org/drools/reliability/infinispan/ReliabilityTest.java
+++ b/drools-reliability/drools-reliability-infinispan/src/test/java/org/drools/reliability/infinispan/ReliabilityTest.java
@@ -308,7 +308,7 @@ class ReliabilityTest extends ReliabilityTestBasics {
     }
 
     @ParameterizedTest
-    @MethodSource("strategyProviderStoresOnlyWithExplicitSafepoints") // FAILS in STORES_ONLY, EXPLICIT
+    @MethodSource("strategyProviderStoresOnlyWithExplicitSafepoints")
     void multipleKieSessions_BasicTest(PersistedSessionOption.PersistenceStrategy persistenceStrategy, PersistedSessionOption.SafepointStrategy safepointStrategy) {
         KieSession session1 = createSession(BASIC_RULE, persistenceStrategy, safepointStrategy);
         KieSession session2 = createSession(BASIC_RULE, persistenceStrategy, safepointStrategy);
@@ -338,4 +338,129 @@ class ReliabilityTest extends ReliabilityTestBasics {
         assertThat(fireAllRules(session2)).isEqualTo(1);
     }
 
+    @ParameterizedTest
+    @MethodSource("strategyProviderStoresOnlyWithExplicitSafepoints") // FULL fails with "ReliablePropagationList; no valid constructor"
+    void multipleKieSessions_insertFailoverInsertFire_shouldRecoverFromFailover(PersistedSessionOption.PersistenceStrategy persistenceStrategy, PersistedSessionOption.SafepointStrategy safepointStrategy) {
+        KieSession session1 = createSession(BASIC_RULE, persistenceStrategy, safepointStrategy);
+        KieSession session2 = createSession(BASIC_RULE, persistenceStrategy, safepointStrategy);
+
+        insert(session1,"M");
+        insertMatchingPerson(session1, "Mike", 37);
+        insert(session2,"N");
+        insertNonMatchingPerson(session2,"Helen",33);
+
+        failover();
+
+        session1 = restoreSession(session1.getIdentifier(), BASIC_RULE, persistenceStrategy, safepointStrategy);
+        session2 = restoreSession(session2.getIdentifier(), BASIC_RULE, persistenceStrategy, safepointStrategy);
+
+        insertNonMatchingPerson(session1,"Toshiya", 35);
+        insertMatchingPerson(session2,"Nicole", 40);
+
+        assertThat(fireAllRules(session1)).isEqualTo(1);
+        assertThat(fireAllRules(session2)).isEqualTo(1);
+
+        assertThat(getResults(session1)).containsExactlyInAnyOrder("Mike");
+        assertThat(getResults(session2)).containsExactlyInAnyOrder("Nicole");
+    }
+
+    @ParameterizedTest
+    @MethodSource("strategyProviderStoresOnlyWithExplicitSafepoints") // With Remote, FULL fails with "ReliablePropagationList; no valid constructor" even without failover
+    void multipleKieSessions_noFailover(PersistedSessionOption.PersistenceStrategy persistenceStrategy, PersistedSessionOption.SafepointStrategy safepointStrategy) {
+
+        KieSession session1 = createSession(BASIC_RULE, persistenceStrategy, safepointStrategy);
+        KieSession session2 = createSession(BASIC_RULE, persistenceStrategy, safepointStrategy);
+
+        insert(session1,"M");
+        insertMatchingPerson(session1,"Matching Person One", 37);
+        insert(session2, new Person("Mary",32));
+
+        if (safepointStrategy == PersistedSessionOption.SafepointStrategy.EXPLICIT) {
+            safepoint();
+        }
+
+        session1 = restoreSession(session1.getIdentifier(), BASIC_RULE, persistenceStrategy, safepointStrategy);
+        session2 = restoreSession(session2.getIdentifier(), BASIC_RULE, persistenceStrategy, safepointStrategy);
+
+        insertNonMatchingPerson(session1,"Toshiya", 41);
+        insertMatchingPerson(session1,"Matching Person Two", 40);
+        insert(session2, "H");
+        insert(session2,new Person("Helen",43));
+
+        fireAllRules(session1);
+        assertThat(getResults(session1)).containsExactlyInAnyOrder("Matching Person One", "Matching Person Two");
+
+        assertThat(fireAllRules(session2)).isEqualTo(1);
+    }
+
+    @ParameterizedTest
+    @MethodSource("strategyProviderStoresOnlyWithExplicitSafepoints") // FULL fails with "ReliablePropagationList; no valid constructor"
+    void multipleKieSessions_insertFireInsertFailoverInsertFire_shouldMatchFactInsertedBeforeFailover(PersistedSessionOption.PersistenceStrategy persistenceStrategy, PersistedSessionOption.SafepointStrategy safepointStrategy) {
+
+        KieSession session1 = createSession(BASIC_RULE, persistenceStrategy, safepointStrategy);
+        KieSession session2 = createSession(BASIC_RULE, persistenceStrategy, safepointStrategy);
+
+        insert(session1,"M");
+        insertMatchingPerson(session1,"Matching Person One", 37);
+        insert(session2, "N");
+        insertMatchingPerson(session2, "Nicole",34);
+
+        fireAllRules(session1);
+        fireAllRules(session2);
+
+        insertMatchingPerson(session1,"Matching Person Two", 40);
+        insertMatchingPerson(session2, "Nancy",23);
+
+        failover();
+
+        session1 = restoreSession(session1.getIdentifier(),BASIC_RULE, persistenceStrategy, safepointStrategy);
+        session2 = restoreSession(session2.getIdentifier(), BASIC_RULE, persistenceStrategy, safepointStrategy);
+
+        clearResults(session1);
+        clearResults(session2);
+
+        insertNonMatchingPerson(session1,"Nora", 35);
+        insertMatchingPerson(session1,"Matching Person Three", 41);
+        insertNonMatchingPerson(session2,"Mike", 35);
+        insertMatchingPerson(session2,"Noah", 41);
+
+        fireAllRules(session1);
+        fireAllRules(session2);
+
+        assertThat(getResults(session1)).containsExactlyInAnyOrder("Matching Person Two", "Matching Person Three");
+        assertThat(getResults(session2)).containsExactlyInAnyOrder("Nancy", "Noah");
+    }
+
+    @ParameterizedTest
+    @MethodSource("strategyProviderStoresOnlyWithExplicitSafepoints") // FULL fails with "ReliablePropagationList; no valid constructor"
+    void multipleKieSessions_updateBeforeFailover_shouldRecoverFromFailover(PersistedSessionOption.PersistenceStrategy persistenceStrategy, PersistedSessionOption.SafepointStrategy safepointStrategy) {
+        KieSession session1 = createSession(BASIC_RULE, persistenceStrategy, safepointStrategy);
+
+        insert(session1,"M");
+        Person p1 = new Person("Mario", 49);
+        FactHandle fh1 = insert(session1,p1);
+        Person p2 = new Person("Toshiya", 45);
+        FactHandle fh2 = insert(session1, p2);
+
+        assertThat(fireAllRules(session1)).isEqualTo(1);
+        assertThat(getResults(session1)).containsExactlyInAnyOrder("Mario");
+
+        p1.setName("SuperMario");
+        update(session1, fh1, p1);
+        p2.setName("MegaToshiya");
+        update(session1, fh2, p2);
+
+        failover();
+        session1 = restoreSession(session1.getIdentifier(), BASIC_RULE, persistenceStrategy, safepointStrategy);
+
+        assertThat(fireAllRules(session1)).isEqualTo(1);
+        assertThat(getResults(session1)).containsExactlyInAnyOrder("Mario", "MegaToshiya");
+
+        failover();
+        session1 = restoreSession(session1.getIdentifier(), BASIC_RULE, persistenceStrategy, safepointStrategy);
+        clearResults(session1);
+
+        assertThat(fireAllRules(session1)).isZero();
+        assertThat(getResults(session1)).isEmpty();
+    }
 }

--- a/drools-reliability/drools-reliability-infinispan/src/test/java/org/drools/reliability/infinispan/ReliabilityTestBasics.java
+++ b/drools-reliability/drools-reliability-infinispan/src/test/java/org/drools/reliability/infinispan/ReliabilityTestBasics.java
@@ -15,12 +15,6 @@
 
 package org.drools.reliability.infinispan;
 
-import java.util.ArrayList;
-import java.util.List;
-import java.util.Optional;
-import java.util.concurrent.TimeUnit;
-import java.util.stream.Stream;
-
 import org.drools.base.facttemplates.Event;
 import org.drools.core.ClassObjectFilter;
 import org.drools.model.Model;
@@ -52,14 +46,13 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.test.domain.Person;
 
-
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Optional;
+import java.util.concurrent.TimeUnit;
 import java.util.stream.Stream;
-
 
 import static org.drools.reliability.infinispan.InfinispanStorageManagerFactory.INFINISPAN_STORAGE_MARSHALLER;
 import static org.drools.reliability.infinispan.util.PrototypeUtils.createEvent;
@@ -262,7 +255,8 @@ public abstract class ReliabilityTestBasics {
     }
 
     protected KieSession restoreSession(Model ruleModel, PersistedSessionOption.PersistenceStrategy persistenceStrategy, PersistedSessionOption.SafepointStrategy safepointStrategy, Option... options) {
-        return getKieSession(ruleModel, PersistedSessionOption.fromSession(persistedSessionId).withPersistenceStrategy(persistenceStrategy).withSafepointStrategy(safepointStrategy), options);
+        Long sessionIdToRestoreFrom = (Long)this.persistedSessionIds.values().toArray()[0];
+        return getKieSession(ruleModel, PersistedSessionOption.fromSession(sessionIdToRestoreFrom).withPersistenceStrategy(persistenceStrategy).withSafepointStrategy(safepointStrategy), options);
     }
 
     protected void disposeSession() {


### PR DESCRIPTION
In multiple KieSession scenarios, a session is restored using its identifier, but this is not the same as the persisted session id. We therefore need a structure to map a sessionId with its persistedSessionId. I have therefore introduced persistedSessionIds HashMap in the ReliabilityTestsBasics class. With this solution we no longer need the property persistedSessionId.