### PR TITLE
[DROOLS-7489] Use standard getOption and setOption in RuleSessionConfiguration

### DIFF
--- a/drools-core/src/main/java/org/drools/core/RuleSessionConfiguration.java
+++ b/drools-core/src/main/java/org/drools/core/RuleSessionConfiguration.java
@@ -34,7 +34,6 @@ import org.kie.api.runtime.conf.MultiValueKieSessionOption;
 import org.kie.api.runtime.conf.QueryListenerOption;
 import org.kie.api.runtime.conf.SingleValueKieSessionOption;
 import org.kie.api.runtime.conf.ThreadSafeOption;
-import org.kie.api.runtime.conf.TimedRuleExecutionFilter;
 import org.kie.api.runtime.conf.TimedRuleExecutionOption;
 import org.kie.internal.conf.CompositeConfiguration;
 import org.kie.internal.conf.InternalPropertiesConfiguration;
@@ -54,11 +53,12 @@ public class RuleSessionConfiguration extends BaseConfiguration<KieSessionOption
     private boolean                        accumulateNullPropagation;
 
     private ForceEagerActivationFilter     forceEagerActivationFilter;
-    private TimedRuleExecutionFilter       timedRuleExecutionFilter;
 
     private BeliefSystemType               beliefSystemType;
 
     private QueryListenerOption            queryListener;
+    
+    private TimedRuleExecutionOption timedRuleExecutionOption;
 
     public void writeExternal(ObjectOutput out) throws IOException {
         super.writeExternal(out);
@@ -92,7 +92,7 @@ public class RuleSessionConfiguration extends BaseConfiguration<KieSessionOption
 
         setForceEagerActivationFilter(ForceEagerActivationOption.resolve( getPropertyValue( ForceEagerActivationOption.PROPERTY_NAME, "false" ) ).getFilter());
 
-        setTimedRuleExecutionFilter(TimedRuleExecutionOption.resolve( getPropertyValue( TimedRuleExecutionOption.PROPERTY_NAME, "false" ) ).getFilter());
+        setTimedRuleExecutionFilter(TimedRuleExecutionOption.resolve( getPropertyValue( TimedRuleExecutionOption.PROPERTY_NAME, "false" ) ));
 
         setBeliefSystemType( BeliefSystemType.resolveBeliefSystemType( getPropertyValue( BeliefSystemTypeOption.PROPERTY_NAME, BeliefSystemType.SIMPLE.getId() ) ) );
 
@@ -135,13 +135,13 @@ public class RuleSessionConfiguration extends BaseConfiguration<KieSessionOption
         this.queryListener = queryListener;
     }
 
-    private void setTimedRuleExecutionFilter(TimedRuleExecutionFilter timedRuleExecutionFilter) {
+    private void setTimedRuleExecutionFilter(TimedRuleExecutionOption timedRuleExecutionOption) {
         checkCanChange(); // throws an exception if a change isn't possible;
-        this.timedRuleExecutionFilter = timedRuleExecutionFilter;
+        this.timedRuleExecutionOption = timedRuleExecutionOption;
     }
-
-    private TimedRuleExecutionFilter getTimedRuleExecutionFilter() {
-        return this.timedRuleExecutionFilter;
+    
+    private TimedRuleExecutionOption getTimedRuleExecutionOption() {
+        return this.timedRuleExecutionOption;
     }
 
     private void setForceEagerActivationFilter(ForceEagerActivationFilter forceEagerActivationFilter) {
@@ -182,7 +182,7 @@ public class RuleSessionConfiguration extends BaseConfiguration<KieSessionOption
                 break;
             }
             case TimedRuleExecutionOption.PROPERTY_NAME: {
-                setTimedRuleExecutionFilter(((TimedRuleExecutionOption) option).getFilter());
+                setTimedRuleExecutionFilter(((TimedRuleExecutionOption) option));
                 break;
             }
             case QueryListenerOption.PROPERTY_NAME: {
@@ -209,6 +209,9 @@ public class RuleSessionConfiguration extends BaseConfiguration<KieSessionOption
             }
             case AccumulateNullPropagationOption.PROPERTY_NAME: {
                 return (T) (isAccumulateNullPropagation() ? AccumulateNullPropagationOption.YES : AccumulateNullPropagationOption.NO);
+            }
+            case TimedRuleExecutionOption.PROPERTY_NAME: {
+                return (T) getTimedRuleExecutionOption();
             }
             case QueryListenerOption.PROPERTY_NAME: {
                 return (T) getQueryListenerOption();
@@ -250,7 +253,7 @@ public class RuleSessionConfiguration extends BaseConfiguration<KieSessionOption
                 break;
             }
             case TimedRuleExecutionOption.PROPERTY_NAME: {
-                setTimedRuleExecutionFilter(TimedRuleExecutionOption.resolve(StringUtils.isEmpty(value) ? "false" : value).getFilter());
+                setTimedRuleExecutionFilter(TimedRuleExecutionOption.resolve(StringUtils.isEmpty(value) ? "false" : value));
                 break;
             }
             case QueryListenerOption.PROPERTY_NAME: {

--- a/drools-core/src/main/java/org/drools/core/RuleSessionConfiguration.java
+++ b/drools-core/src/main/java/org/drools/core/RuleSessionConfiguration.java
@@ -99,49 +99,58 @@ public class RuleSessionConfiguration extends BaseConfiguration<KieSessionOption
         setQueryListenerOption( QueryListenerOption.determineQueryListenerClassOption( getPropertyValue( QueryListenerOption.PROPERTY_NAME, QueryListenerOption.STANDARD.getAsString() ) ) );
     }
 
-    public void setDirectFiring(boolean directFiring) {
+    private void setDirectFiring(boolean directFiring) {
         checkCanChange(); // throws an exception if a change isn't possible;
         this.directFiring = directFiring;
     }
 
-    public boolean isDirectFiring() {
+    private boolean isDirectFiring() {
         return this.directFiring;
     }
 
-    public void setThreadSafe(boolean threadSafe) {
+    private void setThreadSafe(boolean threadSafe) {
         checkCanChange(); // throws an exception if a change isn't possible;
         this.threadSafe = threadSafe;
     }
 
-    public boolean isThreadSafe() {
+    private boolean isThreadSafe() {
         return this.threadSafe;
     }
 
-    public void setAccumulateNullPropagation(boolean accumulateNullPropagation) {
+    private void setAccumulateNullPropagation(boolean accumulateNullPropagation) {
         checkCanChange(); // throws an exception if a change isn't possible;
         this.accumulateNullPropagation = accumulateNullPropagation;
     }
 
-    public boolean isAccumulateNullPropagation() {
+    private boolean isAccumulateNullPropagation() {
         return this.accumulateNullPropagation;
     }
 
-    public void setForceEagerActivationFilter(ForceEagerActivationFilter forceEagerActivationFilter) {
+    private QueryListenerOption getQueryListenerOption() {
+        return this.queryListener;
+    }
+
+    private void setQueryListenerOption( QueryListenerOption queryListener ) {
+        checkCanChange();
+        this.queryListener = queryListener;
+    }
+
+    private void setTimedRuleExecutionFilter(TimedRuleExecutionFilter timedRuleExecutionFilter) {
+        checkCanChange(); // throws an exception if a change isn't possible;
+        this.timedRuleExecutionFilter = timedRuleExecutionFilter;
+    }
+
+    private TimedRuleExecutionFilter getTimedRuleExecutionFilter() {
+        return this.timedRuleExecutionFilter;
+    }
+
+    private void setForceEagerActivationFilter(ForceEagerActivationFilter forceEagerActivationFilter) {
         checkCanChange(); // throws an exception if a change isn't possible;
         this.forceEagerActivationFilter = forceEagerActivationFilter;
     }
 
     public ForceEagerActivationFilter getForceEagerActivationFilter() {
         return this.forceEagerActivationFilter;
-    }
-
-    public void setTimedRuleExecutionFilter(TimedRuleExecutionFilter timedRuleExecutionFilter) {
-        checkCanChange(); // throws an exception if a change isn't possible;
-        this.timedRuleExecutionFilter = timedRuleExecutionFilter;
-    }
-
-    public TimedRuleExecutionFilter getTimedRuleExecutionFilter() {
-        return this.timedRuleExecutionFilter;
     }
 
     public BeliefSystemType getBeliefSystemType() {
@@ -151,15 +160,6 @@ public class RuleSessionConfiguration extends BaseConfiguration<KieSessionOption
     public void setBeliefSystemType(BeliefSystemType beliefSystemType) {
         checkCanChange(); // throws an exception if a change isn't possible;
         this.beliefSystemType = beliefSystemType;
-    }
-
-    public QueryListenerOption getQueryListenerOption() {
-        return this.queryListener;
-    }
-
-    public void setQueryListenerOption( QueryListenerOption queryListener ) {
-        checkCanChange();
-        this.queryListener = queryListener;
     }
 
 

--- a/drools-core/src/main/java/org/drools/core/RuleSessionConfiguration.java
+++ b/drools-core/src/main/java/org/drools/core/RuleSessionConfiguration.java
@@ -54,7 +54,7 @@ public class RuleSessionConfiguration extends BaseConfiguration<KieSessionOption
     
     private DirectFiringOption directFiringOption;
     
-    private QueryListenerOption queryListener;
+    private QueryListenerOption queryListenerOption;
     
     private ThreadSafeOption threadSafeOption;
     
@@ -62,12 +62,12 @@ public class RuleSessionConfiguration extends BaseConfiguration<KieSessionOption
 
     public void writeExternal(ObjectOutput out) throws IOException {
         super.writeExternal(out);
-        out.writeObject( queryListener );
+        out.writeObject( queryListenerOption );
     }
 
     public void readExternal(ObjectInput in) throws IOException, ClassNotFoundException {
         super.readExternal(in);
-        queryListener = (QueryListenerOption) in.readObject();
+        queryListenerOption = (QueryListenerOption) in.readObject();
     }
 
     public final boolean hasForceEagerActivationFilter() {
@@ -84,19 +84,19 @@ public class RuleSessionConfiguration extends BaseConfiguration<KieSessionOption
     }
 
     private void init() {
-    	setDirectFiringOption(DirectFiringOption.resolve(getPropertyValue(DirectFiringOption.PROPERTY_NAME, "false")));
-
-        setThreadSafeOption(ThreadSafeOption.resolve(getPropertyValue(ThreadSafeOption.PROPERTY_NAME, "true")));
-
         setAccumulateNullPropagation(AccumulateNullPropagationOption.resolve(getPropertyValue(AccumulateNullPropagationOption.PROPERTY_NAME, "false")));
+
+        setBeliefSystemType(BeliefSystemType.resolveBeliefSystemType( getPropertyValue( BeliefSystemTypeOption.PROPERTY_NAME, BeliefSystemType.SIMPLE.getId() ) ) );
+
+    	setDirectFiringOption(DirectFiringOption.resolve(getPropertyValue(DirectFiringOption.PROPERTY_NAME, "false")));
 
         setForceEagerActivationFilter(ForceEagerActivationOption.resolve( getPropertyValue( ForceEagerActivationOption.PROPERTY_NAME, "false" ) ).getFilter());
 
+        setQueryListenerOption(QueryListenerOption.determineQueryListenerClassOption( getPropertyValue( QueryListenerOption.PROPERTY_NAME, QueryListenerOption.STANDARD.getAsString() ) ) );
+
+        setThreadSafeOption(ThreadSafeOption.resolve(getPropertyValue(ThreadSafeOption.PROPERTY_NAME, "true")));
+
         setTimedRuleExecutionFilter(TimedRuleExecutionOption.resolve( getPropertyValue( TimedRuleExecutionOption.PROPERTY_NAME, "false" ) ));
-
-        setBeliefSystemType( BeliefSystemType.resolveBeliefSystemType( getPropertyValue( BeliefSystemTypeOption.PROPERTY_NAME, BeliefSystemType.SIMPLE.getId() ) ) );
-
-        setQueryListenerOption( QueryListenerOption.determineQueryListenerClassOption( getPropertyValue( QueryListenerOption.PROPERTY_NAME, QueryListenerOption.STANDARD.getAsString() ) ) );
     }
 
     private void setDirectFiringOption(DirectFiringOption directFiringOption) {
@@ -115,7 +115,7 @@ public class RuleSessionConfiguration extends BaseConfiguration<KieSessionOption
 
     private void setQueryListenerOption( QueryListenerOption queryListener ) {
         checkCanChange();
-        this.queryListener = queryListener;
+        this.queryListenerOption = queryListener;
     }
 
     private void setTimedRuleExecutionFilter(TimedRuleExecutionOption timedRuleExecutionOption) {
@@ -123,10 +123,6 @@ public class RuleSessionConfiguration extends BaseConfiguration<KieSessionOption
         this.timedRuleExecutionOption = timedRuleExecutionOption;
     }
     
-    private TimedRuleExecutionOption getTimedRuleExecutionOption() {
-        return this.timedRuleExecutionOption;
-    }
-
     private void setForceEagerActivationFilter(ForceEagerActivationFilter forceEagerActivationFilter) {
         checkCanChange(); // throws an exception if a change isn't possible;
         this.forceEagerActivationFilter = forceEagerActivationFilter;
@@ -148,32 +144,32 @@ public class RuleSessionConfiguration extends BaseConfiguration<KieSessionOption
 
     public final <T extends KieSessionOption> void setOption(T option) {
         switch (option.propertyName()) {
+	        case AccumulateNullPropagationOption.PROPERTY_NAME: {
+	            setAccumulateNullPropagation(((AccumulateNullPropagationOption) option));
+	            break;
+	        }
+            case BeliefSystemTypeOption.PROPERTY_NAME: {
+                setBeliefSystemType(((BeliefSystemType.resolveBeliefSystemType(((BeliefSystemTypeOption) option).getBeliefSystemType()))));
+                break;
+            }
             case DirectFiringOption.PROPERTY_NAME: {
                 setDirectFiringOption(((DirectFiringOption) option));
-                break;
-            }
-            case ThreadSafeOption.PROPERTY_NAME: {
-                setThreadSafeOption(((ThreadSafeOption) option));
-                break;
-            }
-            case AccumulateNullPropagationOption.PROPERTY_NAME: {
-                setAccumulateNullPropagation(((AccumulateNullPropagationOption) option));
                 break;
             }
             case ForceEagerActivationOption.PROPERTY_NAME: {
                 setForceEagerActivationFilter(((ForceEagerActivationOption) option).getFilter());
                 break;
             }
-            case TimedRuleExecutionOption.PROPERTY_NAME: {
-                setTimedRuleExecutionFilter(((TimedRuleExecutionOption) option));
-                break;
-            }
             case QueryListenerOption.PROPERTY_NAME: {
                 setQueryListenerOption((QueryListenerOption) option);
                 break;
             }
-            case BeliefSystemTypeOption.PROPERTY_NAME: {
-                setBeliefSystemType(((BeliefSystemType.resolveBeliefSystemType(((BeliefSystemTypeOption) option).getBeliefSystemType()))));
+            case ThreadSafeOption.PROPERTY_NAME: {
+                setThreadSafeOption(((ThreadSafeOption) option));
+                break;
+            }
+            case TimedRuleExecutionOption.PROPERTY_NAME: {
+                setTimedRuleExecutionFilter(((TimedRuleExecutionOption) option));
                 break;
             }
             default:
@@ -193,20 +189,20 @@ public class RuleSessionConfiguration extends BaseConfiguration<KieSessionOption
 	        case AccumulateNullPropagationOption.PROPERTY_NAME: {
 	            return (T) accumulateNullPropagation;
 	        }
+            case BeliefSystemTypeOption.PROPERTY_NAME: {
+                return (T) BeliefSystemTypeOption.get( this.getBeliefSystemType().getId() );
+            }
             case DirectFiringOption.PROPERTY_NAME: {
                 return (T) directFiringOption;
+            }
+            case QueryListenerOption.PROPERTY_NAME: {
+                return (T) queryListenerOption;
             }
             case ThreadSafeOption.PROPERTY_NAME: {
                 return (T) threadSafeOption;
             }
             case TimedRuleExecutionOption.PROPERTY_NAME: {
-                return (T) getTimedRuleExecutionOption();
-            }
-            case QueryListenerOption.PROPERTY_NAME: {
-                return (T) this.queryListener;
-            }
-            case BeliefSystemTypeOption.PROPERTY_NAME: {
-                return (T) BeliefSystemTypeOption.get( this.getBeliefSystemType().getId() );
+                return (T) timedRuleExecutionOption;
             }
             default:
                 return compConfig.getOption(option);
@@ -271,7 +267,7 @@ public class RuleSessionConfiguration extends BaseConfiguration<KieSessionOption
             } case AccumulateNullPropagationOption.PROPERTY_NAME: {
                 return Boolean.toString(accumulateNullPropagation.isAccumulateNullPropagation());
             } case QueryListenerOption.PROPERTY_NAME: {
-                return this.queryListener.getAsString();
+                return this.queryListenerOption.getAsString();
             } case BeliefSystemTypeOption.PROPERTY_NAME: {
                 return getBeliefSystemType().getId();
             }

--- a/drools-core/src/main/java/org/drools/core/RuleSessionConfiguration.java
+++ b/drools-core/src/main/java/org/drools/core/RuleSessionConfiguration.java
@@ -48,8 +48,6 @@ public class RuleSessionConfiguration extends BaseConfiguration<KieSessionOption
 
     private boolean                        directFiring;
 
-    private boolean                        threadSafe;
-
     private boolean                        accumulateNullPropagation;
 
     private ForceEagerActivationFilter     forceEagerActivationFilter;
@@ -57,6 +55,8 @@ public class RuleSessionConfiguration extends BaseConfiguration<KieSessionOption
     private BeliefSystemType               beliefSystemType;
 
     private QueryListenerOption            queryListener;
+    
+    private ThreadSafeOption threadSafeOption;
     
     private TimedRuleExecutionOption timedRuleExecutionOption;
 
@@ -86,7 +86,7 @@ public class RuleSessionConfiguration extends BaseConfiguration<KieSessionOption
     private void init() {
         setDirectFiring(Boolean.parseBoolean(getPropertyValue(DirectFiringOption.PROPERTY_NAME, "false")));
 
-        setThreadSafe(Boolean.parseBoolean(getPropertyValue(ThreadSafeOption.PROPERTY_NAME, "true")));
+        setThreadSafeOption(ThreadSafeOption.resolve(getPropertyValue(ThreadSafeOption.PROPERTY_NAME, "true")));
 
         setAccumulateNullPropagation(Boolean.parseBoolean(getPropertyValue(AccumulateNullPropagationOption.PROPERTY_NAME, "false")));
 
@@ -106,15 +106,6 @@ public class RuleSessionConfiguration extends BaseConfiguration<KieSessionOption
 
     private boolean isDirectFiring() {
         return this.directFiring;
-    }
-
-    private void setThreadSafe(boolean threadSafe) {
-        checkCanChange(); // throws an exception if a change isn't possible;
-        this.threadSafe = threadSafe;
-    }
-
-    private boolean isThreadSafe() {
-        return this.threadSafe;
     }
 
     private void setAccumulateNullPropagation(boolean accumulateNullPropagation) {
@@ -170,7 +161,7 @@ public class RuleSessionConfiguration extends BaseConfiguration<KieSessionOption
                 break;
             }
             case ThreadSafeOption.PROPERTY_NAME: {
-                setThreadSafe(((ThreadSafeOption) option).isThreadSafe());
+                setThreadSafeOption(((ThreadSafeOption) option));
                 break;
             }
             case AccumulateNullPropagationOption.PROPERTY_NAME: {
@@ -198,14 +189,20 @@ public class RuleSessionConfiguration extends BaseConfiguration<KieSessionOption
         }
     }
 
-    @SuppressWarnings("unchecked")
+    private void setThreadSafeOption(ThreadSafeOption threadSafeOption) {
+    	checkCanChange();
+		this.threadSafeOption = threadSafeOption;
+		
+	}
+
+	@SuppressWarnings("unchecked")
     public final <T extends SingleValueKieSessionOption> T getOption(OptionKey<T> option) {
         switch (option.name()) {
             case DirectFiringOption.PROPERTY_NAME: {
                 return (T) (isDirectFiring() ? DirectFiringOption.YES : DirectFiringOption.NO);
             }
             case ThreadSafeOption.PROPERTY_NAME: {
-                return (T) (isThreadSafe() ? ThreadSafeOption.YES : ThreadSafeOption.NO);
+                return (T) threadSafeOption;
             }
             case AccumulateNullPropagationOption.PROPERTY_NAME: {
                 return (T) (isAccumulateNullPropagation() ? AccumulateNullPropagationOption.YES : AccumulateNullPropagationOption.NO);
@@ -241,7 +238,7 @@ public class RuleSessionConfiguration extends BaseConfiguration<KieSessionOption
                 break;
             }
             case ThreadSafeOption.PROPERTY_NAME: {
-                setThreadSafe(StringUtils.isEmpty(value) || Boolean.parseBoolean(value));
+                setThreadSafeOption(ThreadSafeOption.resolve(value));
                 break;
             }
             case AccumulateNullPropagationOption.PROPERTY_NAME: {
@@ -278,7 +275,7 @@ public class RuleSessionConfiguration extends BaseConfiguration<KieSessionOption
             case DirectFiringOption.PROPERTY_NAME: {
                 return Boolean.toString(isDirectFiring());
             } case ThreadSafeOption.PROPERTY_NAME: {
-                return Boolean.toString(isThreadSafe());
+                return Boolean.toString(threadSafeOption.isThreadSafe());
             } case AccumulateNullPropagationOption.PROPERTY_NAME: {
                 return Boolean.toString(isAccumulateNullPropagation());
             } case QueryListenerOption.PROPERTY_NAME: {

--- a/drools-core/src/main/java/org/drools/core/common/AgendaGroupQueueImpl.java
+++ b/drools-core/src/main/java/org/drools/core/common/AgendaGroupQueueImpl.java
@@ -30,6 +30,7 @@ import org.drools.core.phreak.RuleAgendaItem;
 import org.drools.core.util.ArrayQueue;
 import org.drools.core.util.Queue;
 import org.drools.core.util.QueueFactory;
+import org.kie.api.runtime.conf.DirectFiringOption;
 
 /**
  * <code>AgendaGroup</code> implementation that uses a <code>PriorityQueue</code> to prioritise the evaluation of added
@@ -89,7 +90,7 @@ public class AgendaGroupQueueImpl
     public void setReteEvaluator(ReteEvaluator reteEvaluator) {
         this.reteEvaluator = reteEvaluator;
         // workingMemory can be null during deserialization
-        if (reteEvaluator != null && reteEvaluator.getRuleSessionConfiguration().isDirectFiring()) {
+        if ( reteEvaluator.getRuleSessionConfiguration().getOption(DirectFiringOption.KEY) == DirectFiringOption.YES) {
             this.priorityQueue = new ArrayQueue<>();
         } else {
             this.priorityQueue = QueueFactory.createQueue(RuleAgendaConflictResolver.INSTANCE);

--- a/drools-core/src/main/java/org/drools/core/common/AgendaGroupQueueImpl.java
+++ b/drools-core/src/main/java/org/drools/core/common/AgendaGroupQueueImpl.java
@@ -90,7 +90,7 @@ public class AgendaGroupQueueImpl
     public void setReteEvaluator(ReteEvaluator reteEvaluator) {
         this.reteEvaluator = reteEvaluator;
         // workingMemory can be null during deserialization
-        if ( reteEvaluator.getRuleSessionConfiguration().getOption(DirectFiringOption.KEY) == DirectFiringOption.YES) {
+        if ( reteEvaluator.getRuleSessionConfiguration().getOption(DirectFiringOption.KEY).isDirectFiring()) {
             this.priorityQueue = new ArrayQueue<>();
         } else {
             this.priorityQueue = QueueFactory.createQueue(RuleAgendaConflictResolver.INSTANCE);

--- a/drools-core/src/main/java/org/drools/core/common/InternalWorkingMemory.java
+++ b/drools-core/src/main/java/org/drools/core/common/InternalWorkingMemory.java
@@ -29,7 +29,6 @@ import org.drools.core.phreak.PropagationEntry;
 import org.drools.core.runtime.process.InternalProcessRuntime;
 import org.drools.core.rule.consequence.InternalMatch;
 import org.kie.api.runtime.Channel;
-import org.kie.api.runtime.conf.ThreadSafeOption;
 import org.kie.api.runtime.rule.EntryPoint;
 
 public interface InternalWorkingMemory
@@ -121,7 +120,4 @@ public interface InternalWorkingMemory
 
     void cancelActivation(InternalMatch internalMatch, boolean declarativeAgenda);
 
-    default boolean isThreadSafe() {
-        return getRuleSessionConfiguration().getOption(ThreadSafeOption.KEY).isThreadSafe();
-    }
 }

--- a/drools-core/src/main/java/org/drools/core/common/InternalWorkingMemory.java
+++ b/drools-core/src/main/java/org/drools/core/common/InternalWorkingMemory.java
@@ -122,6 +122,6 @@ public interface InternalWorkingMemory
     void cancelActivation(InternalMatch internalMatch, boolean declarativeAgenda);
 
     default boolean isThreadSafe() {
-        return getRuleSessionConfiguration().getOption(ThreadSafeOption.KEY) == ThreadSafeOption.YES;
+        return getRuleSessionConfiguration().getOption(ThreadSafeOption.KEY).isThreadSafe();
     }
 }

--- a/drools-core/src/main/java/org/drools/core/common/InternalWorkingMemory.java
+++ b/drools-core/src/main/java/org/drools/core/common/InternalWorkingMemory.java
@@ -29,6 +29,7 @@ import org.drools.core.phreak.PropagationEntry;
 import org.drools.core.runtime.process.InternalProcessRuntime;
 import org.drools.core.rule.consequence.InternalMatch;
 import org.kie.api.runtime.Channel;
+import org.kie.api.runtime.conf.ThreadSafeOption;
 import org.kie.api.runtime.rule.EntryPoint;
 
 public interface InternalWorkingMemory
@@ -121,6 +122,6 @@ public interface InternalWorkingMemory
     void cancelActivation(InternalMatch internalMatch, boolean declarativeAgenda);
 
     default boolean isThreadSafe() {
-        return getRuleSessionConfiguration().isThreadSafe();
+        return getRuleSessionConfiguration().getOption(ThreadSafeOption.KEY) == ThreadSafeOption.YES;
     }
 }

--- a/drools-core/src/main/java/org/drools/core/common/ReteEvaluator.java
+++ b/drools-core/src/main/java/org/drools/core/common/ReteEvaluator.java
@@ -94,9 +94,7 @@ public interface ReteEvaluator extends ValueResolver {
 
     long getNextPropagationIdCounter();
 
-    default boolean isThreadSafe() {
-        return true;
-    }
+    boolean isThreadSafe();
 
     default FactHandleClassStore getStoreForClass(Class<?> clazz) {
         return getDefaultEntryPoint().getObjectStore().getStoreForClass(clazz);
@@ -137,6 +135,8 @@ public interface ReteEvaluator extends ValueResolver {
     int fireAllRules(int max);
     int fireAllRules(AgendaFilter agendaFilter);
     int fireAllRules(AgendaFilter agendaFilter, int max);
+    
+
 
     default void setWorkingMemoryActionListener(Consumer<PropagationEntry> listener) {
         throw new UnsupportedOperationException();

--- a/drools-core/src/main/java/org/drools/core/phreak/PhreakAccumulateNode.java
+++ b/drools-core/src/main/java/org/drools/core/phreak/PhreakAccumulateNode.java
@@ -37,6 +37,7 @@ import org.drools.core.common.PropagationContext;
 import org.drools.core.reteoo.Tuple;
 import org.drools.core.util.AbstractHashTable;
 import org.drools.core.util.FastIterator;
+import org.kie.api.runtime.conf.AccumulateNullPropagationOption;
 import org.kie.api.runtime.rule.FactHandle;
 
 import static org.drools.core.phreak.RuleNetworkEvaluator.normalizeStagedTuples;
@@ -633,7 +634,7 @@ public class PhreakAccumulateNode {
 
         Object result = accumulate.getResult(memory.workingMemoryContext, accctx, leftTuple, reteEvaluator);
         propagateResult( accNode, sink, leftTuple, context, reteEvaluator, memory, trgLeftTuples, stagedLeftTuples,
-                         null, result, (AccumulateContextEntry) accctx, propagationContext, reteEvaluator.getRuleSessionConfiguration().isAccumulateNullPropagation());
+                         null, result, (AccumulateContextEntry) accctx, propagationContext, reteEvaluator.getRuleSessionConfiguration().getOption(AccumulateNullPropagationOption.KEY) == AccumulateNullPropagationOption.YES);
     }
 
     protected final void propagateResult(AccumulateNode accNode, LeftTupleSink sink, LeftTuple leftTuple, PropagationContext context,

--- a/drools-core/src/main/java/org/drools/core/phreak/PhreakAccumulateNode.java
+++ b/drools-core/src/main/java/org/drools/core/phreak/PhreakAccumulateNode.java
@@ -634,7 +634,7 @@ public class PhreakAccumulateNode {
 
         Object result = accumulate.getResult(memory.workingMemoryContext, accctx, leftTuple, reteEvaluator);
         propagateResult( accNode, sink, leftTuple, context, reteEvaluator, memory, trgLeftTuples, stagedLeftTuples,
-                         null, result, (AccumulateContextEntry) accctx, propagationContext, reteEvaluator.getRuleSessionConfiguration().getOption(AccumulateNullPropagationOption.KEY) == AccumulateNullPropagationOption.YES);
+                         null, result, (AccumulateContextEntry) accctx, propagationContext, reteEvaluator.getRuleSessionConfiguration().getOption(AccumulateNullPropagationOption.KEY).isAccumulateNullPropagation());
     }
 
     protected final void propagateResult(AccumulateNode accNode, LeftTupleSink sink, LeftTuple leftTuple, PropagationContext context,

--- a/drools-core/src/main/java/org/drools/core/phreak/PhreakRuleTerminalNode.java
+++ b/drools-core/src/main/java/org/drools/core/phreak/PhreakRuleTerminalNode.java
@@ -32,6 +32,7 @@ import org.drools.core.reteoo.Tuple;
 import org.drools.core.rule.consequence.InternalMatch;
 import org.kie.api.definition.rule.Rule;
 import org.kie.api.event.rule.MatchCancelledCause;
+import org.kie.api.runtime.conf.DirectFiringOption;
 
 /**
 * Created with IntelliJ IDEA.
@@ -93,7 +94,7 @@ public class PhreakRuleTerminalNode {
                                          ActivationsManager activationsManager, RuleAgendaItem ruleAgendaItem,
                                          LeftTuple leftTuple) {
         ReteEvaluator reteEvaluator = activationsManager.getReteEvaluator();
-        if ( reteEvaluator.getRuleSessionConfiguration().isDirectFiring() ) {
+        if ( reteEvaluator.getRuleSessionConfiguration().getOption(DirectFiringOption.KEY) == DirectFiringOption.YES) {
             executor.addLeftTuple(leftTuple);
             return;
         }
@@ -172,7 +173,7 @@ public class PhreakRuleTerminalNode {
         RuleTerminalNodeLeftTuple rtnLeftTuple = (RuleTerminalNodeLeftTuple) leftTuple;
         ReteEvaluator reteEvaluator = activationsManager.getReteEvaluator();
 
-        if ( reteEvaluator.getRuleSessionConfiguration().isDirectFiring() ) {
+        if ( reteEvaluator.getRuleSessionConfiguration().getOption(DirectFiringOption.KEY) == DirectFiringOption.YES) {
             if (!rtnLeftTuple.isQueued() ) {
                 executor.addLeftTuple( leftTuple );
                 reteEvaluator.getRuleEventSupport().onUpdateMatch( rtnLeftTuple );

--- a/drools-core/src/main/java/org/drools/core/phreak/PhreakRuleTerminalNode.java
+++ b/drools-core/src/main/java/org/drools/core/phreak/PhreakRuleTerminalNode.java
@@ -94,7 +94,7 @@ public class PhreakRuleTerminalNode {
                                          ActivationsManager activationsManager, RuleAgendaItem ruleAgendaItem,
                                          LeftTuple leftTuple) {
         ReteEvaluator reteEvaluator = activationsManager.getReteEvaluator();
-        if ( reteEvaluator.getRuleSessionConfiguration().getOption(DirectFiringOption.KEY) == DirectFiringOption.YES) {
+        if ( reteEvaluator.getRuleSessionConfiguration().getOption(DirectFiringOption.KEY).isDirectFiring()) {
             executor.addLeftTuple(leftTuple);
             return;
         }
@@ -173,7 +173,7 @@ public class PhreakRuleTerminalNode {
         RuleTerminalNodeLeftTuple rtnLeftTuple = (RuleTerminalNodeLeftTuple) leftTuple;
         ReteEvaluator reteEvaluator = activationsManager.getReteEvaluator();
 
-        if ( reteEvaluator.getRuleSessionConfiguration().getOption(DirectFiringOption.KEY) == DirectFiringOption.YES) {
+        if ( reteEvaluator.getRuleSessionConfiguration().getOption(DirectFiringOption.KEY).isDirectFiring()) {
             if (!rtnLeftTuple.isQueued() ) {
                 executor.addLeftTuple( leftTuple );
                 reteEvaluator.getRuleEventSupport().onUpdateMatch( rtnLeftTuple );

--- a/drools-core/src/main/java/org/drools/core/phreak/PhreakTimerNode.java
+++ b/drools-core/src/main/java/org/drools/core/phreak/PhreakTimerNode.java
@@ -46,6 +46,7 @@ import org.drools.core.util.index.TupleList;
 import org.kie.api.definition.rule.Rule;
 import org.kie.api.runtime.Calendars;
 import org.kie.api.runtime.conf.TimedRuleExecutionFilter;
+import org.kie.api.runtime.conf.TimedRuleExecutionOption;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -376,7 +377,7 @@ public class PhreakTimerNode {
 
         @Override
         public boolean requiresImmediateFlushing() {
-            return timerJobCtx.getReteEvaluator().getRuleSessionConfiguration().getTimedRuleExecutionFilter() != null;
+            return timerJobCtx.getReteEvaluator().getRuleSessionConfiguration().getOption(TimedRuleExecutionOption.KEY) != null;
         }
 
         @Override
@@ -404,7 +405,7 @@ public class PhreakTimerNode {
 
             timerJobCtx.getTimerNodeMemory().setNodeDirtyWithoutNotify();
 
-            TimedRuleExecutionFilter filter = reteEvaluator.getRuleSessionConfiguration().getTimedRuleExecutionFilter();
+            TimedRuleExecutionFilter filter = (TimedRuleExecutionFilter) reteEvaluator.getRuleSessionConfiguration().getOption(TimedRuleExecutionOption.KEY);
             needEvaluation &= filter != null;
 
             for (final PathMemory pmem : timerJobCtx.getPathMemories()) {

--- a/drools-core/src/main/java/org/drools/core/phreak/PhreakTimerNode.java
+++ b/drools-core/src/main/java/org/drools/core/phreak/PhreakTimerNode.java
@@ -377,7 +377,7 @@ public class PhreakTimerNode {
 
         @Override
         public boolean requiresImmediateFlushing() {
-            return timerJobCtx.getReteEvaluator().getRuleSessionConfiguration().getOption(TimedRuleExecutionOption.KEY) != null;
+            return timerJobCtx.getReteEvaluator().getRuleSessionConfiguration().getOption(TimedRuleExecutionOption.KEY).getFilter() != null;
         }
 
         @Override
@@ -405,7 +405,7 @@ public class PhreakTimerNode {
 
             timerJobCtx.getTimerNodeMemory().setNodeDirtyWithoutNotify();
 
-            TimedRuleExecutionFilter filter = (TimedRuleExecutionFilter) reteEvaluator.getRuleSessionConfiguration().getOption(TimedRuleExecutionOption.KEY);
+            TimedRuleExecutionFilter filter = reteEvaluator.getRuleSessionConfiguration().getOption(TimedRuleExecutionOption.KEY).getFilter();
             needEvaluation &= filter != null;
 
             for (final PathMemory pmem : timerJobCtx.getPathMemories()) {

--- a/drools-core/src/main/java/org/drools/core/phreak/RuleExecutor.java
+++ b/drools-core/src/main/java/org/drools/core/phreak/RuleExecutor.java
@@ -39,6 +39,7 @@ import org.drools.core.util.QueueFactory;
 import org.drools.core.util.index.TupleList;
 import org.kie.api.event.rule.BeforeMatchFiredEvent;
 import org.kie.api.event.rule.MatchCancelledCause;
+import org.kie.api.runtime.conf.DirectFiringOption;
 import org.kie.api.runtime.rule.AgendaFilter;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -88,7 +89,7 @@ public class RuleExecutor {
 
         reEvaluateNetwork( activationsManager );
 
-        if ( reteEvaluator.getRuleSessionConfiguration().isDirectFiring() ) {
+        if ( reteEvaluator.getRuleSessionConfiguration().getOption(DirectFiringOption.KEY) == DirectFiringOption.YES) {
             RuleTerminalNode rtn = (RuleTerminalNode) pmem.getPathEndNode();
             RuleImpl rule = rtn.getRule();
             int directFirings = tupleList.size();

--- a/drools-core/src/main/java/org/drools/core/phreak/RuleExecutor.java
+++ b/drools-core/src/main/java/org/drools/core/phreak/RuleExecutor.java
@@ -89,7 +89,7 @@ public class RuleExecutor {
 
         reEvaluateNetwork( activationsManager );
 
-        if ( reteEvaluator.getRuleSessionConfiguration().getOption(DirectFiringOption.KEY) == DirectFiringOption.YES) {
+        if ( reteEvaluator.getRuleSessionConfiguration().getOption(DirectFiringOption.KEY).isDirectFiring()) {
             RuleTerminalNode rtn = (RuleTerminalNode) pmem.getPathEndNode();
             RuleImpl rule = rtn.getRule();
             int directFirings = tupleList.size();

--- a/drools-kiesession/src/main/java/org/drools/kiesession/agenda/DefaultAgenda.java
+++ b/drools-kiesession/src/main/java/org/drools/kiesession/agenda/DefaultAgenda.java
@@ -210,7 +210,7 @@ public class DefaultAgenda implements Externalizable, InternalAgenda {
         this.workingMemory = workingMemory;
         this.agendaGroupsManager.setReteEvaluator( workingMemory );
 
-        if (!workingMemory.getRuleSessionConfiguration().getOption(ThreadSafeOption.KEY).isThreadSafe()) {
+        if (!workingMemory.isThreadSafe()) {
             executionStateMachine = new UnsafeExecutionStateMachine();
         }
 
@@ -219,7 +219,7 @@ public class DefaultAgenda implements Externalizable, InternalAgenda {
     }
 
     protected PropagationList createPropagationList() {
-        if (!workingMemory.getRuleSessionConfiguration().getOption(ThreadSafeOption.KEY).isThreadSafe()) {
+        if (!workingMemory.isThreadSafe()) {
             return new ThreadUnsafePropagationList( workingMemory );
         }
 

--- a/drools-kiesession/src/main/java/org/drools/kiesession/agenda/DefaultAgenda.java
+++ b/drools-kiesession/src/main/java/org/drools/kiesession/agenda/DefaultAgenda.java
@@ -210,7 +210,7 @@ public class DefaultAgenda implements Externalizable, InternalAgenda {
         this.workingMemory = workingMemory;
         this.agendaGroupsManager.setReteEvaluator( workingMemory );
 
-        if (workingMemory.getRuleSessionConfiguration().getOption(ThreadSafeOption.KEY) == ThreadSafeOption.NO) {
+        if (!workingMemory.getRuleSessionConfiguration().getOption(ThreadSafeOption.KEY).isThreadSafe()) {
             executionStateMachine = new UnsafeExecutionStateMachine();
         }
 
@@ -219,7 +219,7 @@ public class DefaultAgenda implements Externalizable, InternalAgenda {
     }
 
     protected PropagationList createPropagationList() {
-        if (workingMemory.getRuleSessionConfiguration().getOption(ThreadSafeOption.KEY) == ThreadSafeOption.NO) {
+        if (!workingMemory.getRuleSessionConfiguration().getOption(ThreadSafeOption.KEY).isThreadSafe()) {
             return new ThreadUnsafePropagationList( workingMemory );
         }
 

--- a/drools-kiesession/src/main/java/org/drools/kiesession/agenda/DefaultAgenda.java
+++ b/drools-kiesession/src/main/java/org/drools/kiesession/agenda/DefaultAgenda.java
@@ -71,6 +71,7 @@ import org.drools.util.StringUtils;
 import org.drools.wiring.api.ComponentsFactory;
 import org.kie.api.conf.EventProcessingOption;
 import org.kie.api.event.rule.MatchCancelledCause;
+import org.kie.api.runtime.conf.ThreadSafeOption;
 import org.kie.api.runtime.rule.AgendaFilter;
 import org.kie.api.runtime.rule.AgendaGroup;
 import org.slf4j.Logger;
@@ -209,7 +210,7 @@ public class DefaultAgenda implements Externalizable, InternalAgenda {
         this.workingMemory = workingMemory;
         this.agendaGroupsManager.setReteEvaluator( workingMemory );
 
-        if ( !workingMemory.getRuleSessionConfiguration().isThreadSafe() ) {
+        if (workingMemory.getRuleSessionConfiguration().getOption(ThreadSafeOption.KEY) == ThreadSafeOption.NO) {
             executionStateMachine = new UnsafeExecutionStateMachine();
         }
 
@@ -218,7 +219,7 @@ public class DefaultAgenda implements Externalizable, InternalAgenda {
     }
 
     protected PropagationList createPropagationList() {
-        if (!workingMemory.getRuleSessionConfiguration().isThreadSafe()) {
+        if (workingMemory.getRuleSessionConfiguration().getOption(ThreadSafeOption.KEY) == ThreadSafeOption.NO) {
             return new ThreadUnsafePropagationList( workingMemory );
         }
 

--- a/drools-kiesession/src/main/java/org/drools/kiesession/consequence/StatefulKnowledgeSessionForRHS.java
+++ b/drools-kiesession/src/main/java/org/drools/kiesession/consequence/StatefulKnowledgeSessionForRHS.java
@@ -735,4 +735,8 @@ public class StatefulKnowledgeSessionForRHS
     public ProcessInstance startProcessFromNodeIds(String processId, Map<String, Object> params, String... nodeIds) {
         return delegate.startProcessFromNodeIds(processId, params, nodeIds);
     }
+    
+    public boolean isThreadSafe() {
+    	return delegate.isThreadSafe();
+    }
 }

--- a/drools-kiesession/src/main/java/org/drools/kiesession/entrypoints/NamedEntryPoint.java
+++ b/drools-kiesession/src/main/java/org/drools/kiesession/entrypoints/NamedEntryPoint.java
@@ -108,7 +108,7 @@ public class NamedEntryPoint implements InternalWorkingMemoryEntryPoint, Propert
         this.entryPointNode = entryPointNode;
         this.reteEvaluator = reteEvaluator;
         this.ruleBase = this.reteEvaluator.getKnowledgeBase();
-        this.lock = reteEvaluator.getRuleSessionConfiguration().getOption(ThreadSafeOption.KEY) == ThreadSafeOption.YES ? new ReentrantLock() : null;
+        this.lock = reteEvaluator.getRuleSessionConfiguration().getOption(ThreadSafeOption.KEY).isThreadSafe() ? new ReentrantLock() : null;
         this.handleFactory = this.reteEvaluator.getFactHandleFactory();
 
         RuleBaseConfiguration conf = this.ruleBase.getRuleBaseConfiguration();

--- a/drools-kiesession/src/main/java/org/drools/kiesession/entrypoints/NamedEntryPoint.java
+++ b/drools-kiesession/src/main/java/org/drools/kiesession/entrypoints/NamedEntryPoint.java
@@ -48,7 +48,6 @@ import org.drools.core.rule.consequence.InternalMatch;
 import org.drools.core.util.bitmask.AllSetBitMask;
 import org.drools.core.util.bitmask.BitMask;
 import org.kie.api.conf.KieBaseMutabilityOption;
-import org.kie.api.runtime.conf.ThreadSafeOption;
 import org.kie.api.runtime.rule.FactHandle;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -108,7 +107,7 @@ public class NamedEntryPoint implements InternalWorkingMemoryEntryPoint, Propert
         this.entryPointNode = entryPointNode;
         this.reteEvaluator = reteEvaluator;
         this.ruleBase = this.reteEvaluator.getKnowledgeBase();
-        this.lock = reteEvaluator.getRuleSessionConfiguration().getOption(ThreadSafeOption.KEY).isThreadSafe() ? new ReentrantLock() : null;
+        this.lock = reteEvaluator.isThreadSafe() ? new ReentrantLock() : null;
         this.handleFactory = this.reteEvaluator.getFactHandleFactory();
 
         RuleBaseConfiguration conf = this.ruleBase.getRuleBaseConfiguration();

--- a/drools-kiesession/src/main/java/org/drools/kiesession/entrypoints/NamedEntryPoint.java
+++ b/drools-kiesession/src/main/java/org/drools/kiesession/entrypoints/NamedEntryPoint.java
@@ -48,6 +48,7 @@ import org.drools.core.rule.consequence.InternalMatch;
 import org.drools.core.util.bitmask.AllSetBitMask;
 import org.drools.core.util.bitmask.BitMask;
 import org.kie.api.conf.KieBaseMutabilityOption;
+import org.kie.api.runtime.conf.ThreadSafeOption;
 import org.kie.api.runtime.rule.FactHandle;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -107,7 +108,7 @@ public class NamedEntryPoint implements InternalWorkingMemoryEntryPoint, Propert
         this.entryPointNode = entryPointNode;
         this.reteEvaluator = reteEvaluator;
         this.ruleBase = this.reteEvaluator.getKnowledgeBase();
-        this.lock = reteEvaluator.getRuleSessionConfiguration().isThreadSafe() ? new ReentrantLock() : null;
+        this.lock = reteEvaluator.getRuleSessionConfiguration().getOption(ThreadSafeOption.KEY) == ThreadSafeOption.YES ? new ReentrantLock() : null;
         this.handleFactory = this.reteEvaluator.getFactHandleFactory();
 
         RuleBaseConfiguration conf = this.ruleBase.getRuleBaseConfiguration();

--- a/drools-kiesession/src/main/java/org/drools/kiesession/session/StatefulKnowledgeSessionImpl.java
+++ b/drools-kiesession/src/main/java/org/drools/kiesession/session/StatefulKnowledgeSessionImpl.java
@@ -1509,7 +1509,7 @@ public class StatefulKnowledgeSessionImpl extends AbstractRuntime
      */
     @Override
     public void startOperation(InternalOperationType operationType) {
-        if (getRuleSessionConfiguration().getOption(ThreadSafeOption.KEY) == ThreadSafeOption.YES && this.opCounter.getAndIncrement() == 0 ) {
+        if (getRuleSessionConfiguration().getOption(ThreadSafeOption.KEY).isThreadSafe() && this.opCounter.getAndIncrement() == 0 ) {
             // means the engine was idle, reset the timestamp
             this.lastIdleTimestamp.set(-1);
         }
@@ -1531,7 +1531,7 @@ public class StatefulKnowledgeSessionImpl extends AbstractRuntime
      */
     @Override
     public void endOperation(InternalOperationType operationType) {
-        if (getRuleSessionConfiguration().getOption(ThreadSafeOption.KEY) == ThreadSafeOption.YES && this.opCounter.decrementAndGet() == 0 ) {
+        if (getRuleSessionConfiguration().getOption(ThreadSafeOption.KEY).isThreadSafe() && this.opCounter.decrementAndGet() == 0 ) {
             // means the engine is idle, so, set the timestamp
             if (this.timerService != null) {
                 this.lastIdleTimestamp.set(this.timerService.getCurrentTime());

--- a/drools-kiesession/src/main/java/org/drools/kiesession/session/StatefulKnowledgeSessionImpl.java
+++ b/drools-kiesession/src/main/java/org/drools/kiesession/session/StatefulKnowledgeSessionImpl.java
@@ -324,6 +324,9 @@ public class StatefulKnowledgeSessionImpl extends AbstractRuntime
         this.propagationIdCounter = new AtomicLong(propagationContext);
         this.config = config;
         this.ruleSessionConfig = config.as(RuleSessionConfiguration.KEY);
+
+        isThreadSafe = ruleSessionConfig.getOption(ThreadSafeOption.KEY).isThreadSafe();
+
         this.environment = environment;
 
         this.propagationIdCounter = new AtomicLong( propagationContext);
@@ -352,7 +355,6 @@ public class StatefulKnowledgeSessionImpl extends AbstractRuntime
             this.initialFactHandle = initInitialFact(null);
         }
         
-        isThreadSafe = getRuleSessionConfiguration().getOption(ThreadSafeOption.KEY).isThreadSafe();
     }
 
     public StatefulKnowledgeSessionImpl setStateless( boolean stateless ) {
@@ -1517,7 +1519,7 @@ public class StatefulKnowledgeSessionImpl extends AbstractRuntime
      */
     @Override
     public void startOperation(InternalOperationType operationType) {
-        if (getRuleSessionConfiguration().getOption(ThreadSafeOption.KEY).isThreadSafe() && this.opCounter.getAndIncrement() == 0 ) {
+        if (isThreadSafe() && this.opCounter.getAndIncrement() == 0 ) {
             // means the engine was idle, reset the timestamp
             this.lastIdleTimestamp.set(-1);
         }
@@ -1539,7 +1541,7 @@ public class StatefulKnowledgeSessionImpl extends AbstractRuntime
      */
     @Override
     public void endOperation(InternalOperationType operationType) {
-        if (getRuleSessionConfiguration().getOption(ThreadSafeOption.KEY).isThreadSafe() && this.opCounter.decrementAndGet() == 0 ) {
+        if (isThreadSafe() && this.opCounter.decrementAndGet() == 0 ) {
             // means the engine is idle, so, set the timestamp
             if (this.timerService != null) {
                 this.lastIdleTimestamp.set(this.timerService.getCurrentTime());

--- a/drools-kiesession/src/main/java/org/drools/kiesession/session/StatefulKnowledgeSessionImpl.java
+++ b/drools-kiesession/src/main/java/org/drools/kiesession/session/StatefulKnowledgeSessionImpl.java
@@ -244,6 +244,8 @@ public class StatefulKnowledgeSessionImpl extends AbstractRuntime
 
     private Consumer<PropagationEntry> workingMemoryActionListener;
 
+	private boolean isThreadSafe;
+
     // ------------------------------------------------------------
     // Constructors
     // ------------------------------------------------------------
@@ -349,6 +351,8 @@ public class StatefulKnowledgeSessionImpl extends AbstractRuntime
         if (initInitFactHandle) {
             this.initialFactHandle = initInitialFact(null);
         }
+        
+        isThreadSafe = getRuleSessionConfiguration().getOption(ThreadSafeOption.KEY).isThreadSafe();
     }
 
     public StatefulKnowledgeSessionImpl setStateless( boolean stateless ) {
@@ -517,6 +521,10 @@ public class StatefulKnowledgeSessionImpl extends AbstractRuntime
 
     public void destroy() {
         dispose();
+    }
+    
+    public boolean isThreadSafe() {
+    	return isThreadSafe;
     }
 
     public void update(FactHandle factHandle) {
@@ -1755,4 +1763,6 @@ public class StatefulKnowledgeSessionImpl extends AbstractRuntime
     public ProcessInstance startProcessFromNodeIds(String processId, CorrelationKey key, Map<String, Object> params, String... nodeIds) {
         return getProcessRuntime().startProcessFromNodeIds(processId, key, params, nodeIds);
     }
+    
+    
 }

--- a/drools-kiesession/src/main/java/org/drools/kiesession/session/StatefulKnowledgeSessionImpl.java
+++ b/drools-kiesession/src/main/java/org/drools/kiesession/session/StatefulKnowledgeSessionImpl.java
@@ -124,6 +124,7 @@ import org.kie.api.runtime.KieSession;
 import org.kie.api.runtime.KieSessionConfiguration;
 import org.kie.api.runtime.RequestContext;
 import org.kie.api.runtime.conf.QueryListenerOption;
+import org.kie.api.runtime.conf.ThreadSafeOption;
 import org.kie.api.runtime.process.ProcessInstance;
 import org.kie.api.runtime.process.WorkItemHandler;
 import org.kie.api.runtime.process.WorkItemManager;
@@ -1508,7 +1509,7 @@ public class StatefulKnowledgeSessionImpl extends AbstractRuntime
      */
     @Override
     public void startOperation(InternalOperationType operationType) {
-        if (getRuleSessionConfiguration().isThreadSafe() && this.opCounter.getAndIncrement() == 0 ) {
+        if (getRuleSessionConfiguration().getOption(ThreadSafeOption.KEY) == ThreadSafeOption.YES && this.opCounter.getAndIncrement() == 0 ) {
             // means the engine was idle, reset the timestamp
             this.lastIdleTimestamp.set(-1);
         }
@@ -1530,7 +1531,7 @@ public class StatefulKnowledgeSessionImpl extends AbstractRuntime
      */
     @Override
     public void endOperation(InternalOperationType operationType) {
-        if (getRuleSessionConfiguration().isThreadSafe() && this.opCounter.decrementAndGet() == 0 ) {
+        if (getRuleSessionConfiguration().getOption(ThreadSafeOption.KEY) == ThreadSafeOption.YES && this.opCounter.decrementAndGet() == 0 ) {
             // means the engine is idle, so, set the timestamp
             if (this.timerService != null) {
                 this.lastIdleTimestamp.set(this.timerService.getCurrentTime());

--- a/drools-model/drools-model-codegen/src/main/java/org/drools/model/codegen/execmodel/generator/visitor/accumulate/AccumulateVisitor.java
+++ b/drools-model/drools-model-codegen/src/main/java/org/drools/model/codegen/execmodel/generator/visitor/accumulate/AccumulateVisitor.java
@@ -260,14 +260,25 @@ public class AccumulateVisitor {
         String rootNodeName = getRootNodeName(methodCallWithoutRootNode);
         Optional<DeclarationSpec> decl = context.getDeclarationById(rootNodeName);
 
-        Class<?> clazz = decl.map(DeclarationSpec::getDeclarationClass)
-                .orElseGet( () -> {
-                    try {
-                        return context.getTypeResolver().resolveType(rootNodeName);
-                    } catch (ClassNotFoundException e) {
-                        throw new RuntimeException( e );
-                    }
-                } );
+        Class<?> clazz = null;
+        if (decl.isPresent()) {
+        	clazz = decl.get().getDeclarationClass();
+        } else {
+            try {
+            	clazz= context.getTypeResolver().resolveType(rootNodeName);
+            } catch (ClassNotFoundException e) {
+                throw new RuntimeException( e );
+            }
+            
+        }
+//        		decl.map(DeclarationSpec::getDeclarationClass)
+//                .orElseGet( () -> {
+//                    try {
+//                        return context.getTypeResolver().resolveType(rootNodeName);
+//                    } catch (ClassNotFoundException e) {
+//                        throw new RuntimeException( e );
+//                    }
+//                } );
 
         final ExpressionTyperContext expressionTyperContext = new ExpressionTyperContext();
         final ExpressionTyper expressionTyper = new ExpressionTyper(context, clazz, bindingId, false, expressionTyperContext);

--- a/drools-model/drools-model-compiler/src/main/java/org/drools/modelcompiler/KiePackagesBuilder.java
+++ b/drools-model/drools-model-compiler/src/main/java/org/drools/modelcompiler/KiePackagesBuilder.java
@@ -148,6 +148,7 @@ import org.kie.api.definition.rule.All;
 import org.kie.api.definition.rule.Direct;
 import org.kie.api.definition.rule.Propagation;
 import org.kie.api.definition.type.Role;
+import org.kie.api.runtime.conf.ThreadSafeOption;
 import org.kie.internal.builder.KnowledgeBuilderConfiguration;
 import org.kie.internal.builder.conf.PropertySpecificOption;
 
@@ -391,6 +392,7 @@ public class KiePackagesBuilder {
         // This is changed, because we must use the Declarations provided by the RTN, otherwise tuple indexes are not set.
         Declaration[] requiredDeclarations = getRequiredDeclarationsIfPossible( ctx, consequence, name );
         boolean enabledTupleOptimization = requiredDeclarations != null && requiredDeclarations.length > 0;
+        
 
         if ( name.equals( RuleImpl.DEFAULT_CONSEQUENCE_NAME ) ) {
             if ("java".equals(consequence.getLanguage())) {

--- a/drools-model/drools-model-compiler/src/main/java/org/drools/modelcompiler/consequence/LambdaConsequence.java
+++ b/drools-model/drools-model-compiler/src/main/java/org/drools/modelcompiler/consequence/LambdaConsequence.java
@@ -30,6 +30,7 @@ import org.drools.core.common.ReteEvaluator;
 import org.drools.core.reteoo.RuleTerminalNode;
 import org.drools.core.rule.consequence.KnowledgeHelper;
 import org.drools.model.Variable;
+import org.kie.api.runtime.conf.ThreadSafeOption;
 import org.kie.api.runtime.rule.FactHandle;
 
 public class LambdaConsequence implements Consequence<KnowledgeHelper> {
@@ -124,7 +125,7 @@ public class LambdaConsequence implements Consequence<KnowledgeHelper> {
 
         Object[] facts;
         FactHandleLookup fhLookup = null;
-        if (reteEvaluator.getRuleSessionConfiguration().isThreadSafe()) {
+        if (reteEvaluator.getRuleSessionConfiguration().getOption(ThreadSafeOption.KEY) == ThreadSafeOption.YES) {
             if ( consequence.isUsingDrools() ) {
                 facts = new Object[consequence.getVariables().length + 1];
                 fhLookup = FactHandleLookup.create( factSuppliers.length );
@@ -216,7 +217,7 @@ public class LambdaConsequence implements Consequence<KnowledgeHelper> {
         this.globalSuppliers = globalSuppliers.isEmpty() ? null : globalSuppliers.toArray( new GlobalSupplier[globalSuppliers.size()] );
         this.factSuppliers = factSuppliers.toArray( new TupleFactSupplier[factSuppliers.size()] );
 
-        if (!reteEvaluator.getRuleSessionConfiguration().isThreadSafe()) {
+        if (reteEvaluator.getRuleSessionConfiguration().getOption(ThreadSafeOption.KEY) == ThreadSafeOption.NO) {
             this.facts = facts;
             this.fhLookup = fhLookup;
         }

--- a/drools-model/drools-model-compiler/src/main/java/org/drools/modelcompiler/consequence/LambdaConsequence.java
+++ b/drools-model/drools-model-compiler/src/main/java/org/drools/modelcompiler/consequence/LambdaConsequence.java
@@ -125,7 +125,7 @@ public class LambdaConsequence implements Consequence<KnowledgeHelper> {
 
         Object[] facts;
         FactHandleLookup fhLookup = null;
-        if (reteEvaluator.getRuleSessionConfiguration().getOption(ThreadSafeOption.KEY).isThreadSafe()) {
+        if (reteEvaluator.isThreadSafe()) {
             if ( consequence.isUsingDrools() ) {
                 facts = new Object[consequence.getVariables().length + 1];
                 fhLookup = FactHandleLookup.create( factSuppliers.length );
@@ -217,7 +217,7 @@ public class LambdaConsequence implements Consequence<KnowledgeHelper> {
         this.globalSuppliers = globalSuppliers.isEmpty() ? null : globalSuppliers.toArray( new GlobalSupplier[globalSuppliers.size()] );
         this.factSuppliers = factSuppliers.toArray( new TupleFactSupplier[factSuppliers.size()] );
 
-        if (!reteEvaluator.getRuleSessionConfiguration().getOption(ThreadSafeOption.KEY).isThreadSafe()) {
+        if (!reteEvaluator.isThreadSafe()) {
             this.facts = facts;
             this.fhLookup = fhLookup;
         }

--- a/drools-model/drools-model-compiler/src/main/java/org/drools/modelcompiler/consequence/LambdaConsequence.java
+++ b/drools-model/drools-model-compiler/src/main/java/org/drools/modelcompiler/consequence/LambdaConsequence.java
@@ -125,7 +125,7 @@ public class LambdaConsequence implements Consequence<KnowledgeHelper> {
 
         Object[] facts;
         FactHandleLookup fhLookup = null;
-        if (reteEvaluator.getRuleSessionConfiguration().getOption(ThreadSafeOption.KEY) == ThreadSafeOption.YES) {
+        if (reteEvaluator.getRuleSessionConfiguration().getOption(ThreadSafeOption.KEY).isThreadSafe()) {
             if ( consequence.isUsingDrools() ) {
                 facts = new Object[consequence.getVariables().length + 1];
                 fhLookup = FactHandleLookup.create( factSuppliers.length );
@@ -217,7 +217,7 @@ public class LambdaConsequence implements Consequence<KnowledgeHelper> {
         this.globalSuppliers = globalSuppliers.isEmpty() ? null : globalSuppliers.toArray( new GlobalSupplier[globalSuppliers.size()] );
         this.factSuppliers = factSuppliers.toArray( new TupleFactSupplier[factSuppliers.size()] );
 
-        if (reteEvaluator.getRuleSessionConfiguration().getOption(ThreadSafeOption.KEY) == ThreadSafeOption.NO) {
+        if (!reteEvaluator.getRuleSessionConfiguration().getOption(ThreadSafeOption.KEY).isThreadSafe()) {
             this.facts = facts;
             this.fhLookup = fhLookup;
         }

--- a/drools-ruleunits/drools-ruleunits-impl/src/main/java/org/drools/ruleunits/impl/sessions/RuleUnitExecutorImpl.java
+++ b/drools-ruleunits/drools-ruleunits-impl/src/main/java/org/drools/ruleunits/impl/sessions/RuleUnitExecutorImpl.java
@@ -300,6 +300,11 @@ public class RuleUnitExecutorImpl implements ReteEvaluator {
 
         this.timerService.shutdown();
     }
+    
+    @Override
+    public boolean isThreadSafe() {
+    	return true;
+    }
 
     @Override
     public QueryResults getQueryResults(String queryName, Object... arguments) {

--- a/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/compiler/integrationtests/AccumulateTest.java
+++ b/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/compiler/integrationtests/AccumulateTest.java
@@ -57,6 +57,7 @@ import org.kie.api.event.rule.AgendaEventListener;
 import org.kie.api.runtime.KieContainer;
 import org.kie.api.runtime.KieSession;
 import org.kie.api.runtime.KieSessionConfiguration;
+import org.kie.api.runtime.conf.AccumulateNullPropagationOption;
 import org.kie.api.runtime.rule.AccumulateFunction;
 import org.kie.api.runtime.rule.FactHandle;
 import org.kie.api.runtime.rule.Match;
@@ -3674,7 +3675,7 @@ public class AccumulateTest {
 
         kieSession.delete( fh );
         // changed by DROOLS-6064
-        if ((kieSession.getSessionConfiguration().as(RuleSessionConfiguration.KEY)).isAccumulateNullPropagation()) {
+        if (kieSession.getSessionConfiguration().as(RuleSessionConfiguration.KEY).getOption(AccumulateNullPropagationOption.KEY) == AccumulateNullPropagationOption.YES) {
             assertThat(kieSession.fireAllRules()).isEqualTo(1);
             assertThat(list.size()).isEqualTo(1);
             assertThat(list.get(0)).isNull();

--- a/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/compiler/integrationtests/AccumulateTest.java
+++ b/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/compiler/integrationtests/AccumulateTest.java
@@ -3675,7 +3675,7 @@ public class AccumulateTest {
 
         kieSession.delete( fh );
         // changed by DROOLS-6064
-        if (kieSession.getSessionConfiguration().as(RuleSessionConfiguration.KEY).getOption(AccumulateNullPropagationOption.KEY) == AccumulateNullPropagationOption.YES) {
+        if (kieSession.getSessionConfiguration().as(RuleSessionConfiguration.KEY).getOption(AccumulateNullPropagationOption.KEY).isAccumulateNullPropagation()) {
             assertThat(kieSession.fireAllRules()).isEqualTo(1);
             assertThat(list.size()).isEqualTo(1);
             assertThat(list.get(0)).isNull();

--- a/kie-api/src/main/java/org/kie/api/runtime/conf/AccumulateNullPropagationOption.java
+++ b/kie-api/src/main/java/org/kie/api/runtime/conf/AccumulateNullPropagationOption.java
@@ -61,4 +61,10 @@ public enum AccumulateNullPropagationOption implements SingleValueRuleRuntimeOpt
         return accumulateNullPropagation;
     }
 
+
+    
+    public static AccumulateNullPropagationOption resolve(String value) {
+        return Boolean.valueOf( value ) ? YES : NO;
+    }
+    
 }

--- a/kie-api/src/main/java/org/kie/api/runtime/conf/DirectFiringOption.java
+++ b/kie-api/src/main/java/org/kie/api/runtime/conf/DirectFiringOption.java
@@ -62,4 +62,8 @@ public enum DirectFiringOption implements SingleValueRuleRuntimeOption {
         return directFiring;
     }
 
+    public static DirectFiringOption resolve(String value) {
+        return Boolean.valueOf( value ) ? YES : NO;
+    }
+
 }

--- a/kie-api/src/main/java/org/kie/api/runtime/conf/ThreadSafeOption.java
+++ b/kie-api/src/main/java/org/kie/api/runtime/conf/ThreadSafeOption.java
@@ -61,5 +61,9 @@ public enum ThreadSafeOption implements SingleValueRuleRuntimeOption {
     public boolean isThreadSafe() {
         return threadSafe;
     }
+    
+    public static ThreadSafeOption resolve(String value) {
+        return Boolean.valueOf( value ) ? YES : NO;
+    }
 
 }


### PR DESCRIPTION
This PR is meant to replace custom methods for configuration options with standard getOption and setOption.

**JIRA**: _(please edit the JIRA link if it exists)_

[DROOLS-7489](https://issues.redhat.com/browse/DROOLS-7489)


<details>
<summary>
How to replicate CI configuration locally?
</summary>

Build Chain tool does "simple" maven build(s), the builds are just Maven commands, but because the repositories relates and depends on each other and any change in API or class method could affect several of those repositories there is a need to use [build-chain tool](https://github.com/kiegroup/github-action-build-chain) to handle cross repository builds and be sure that we always use latest version of the code for each repository.
 
[build-chain tool](https://github.com/kiegroup/github-action-build-chain) is a build tool which can be used on command line locally or in Github Actions workflow(s), in case you need to change multiple repositories and send multiple dependent pull requests related with a change you can easily reproduce the same build by executing it on Github hosted environment or locally in your development environment. See [local execution](https://github.com/kiegroup/github-action-build-chain#local-execution) details to get more information about it.
</details>

<details>
<summary>
How to retest this PR or trigger a specific build:
</summary>

- for <b>pull request checks</b>  
  Please add comment: <b>Jenkins retest this</b>

- for a <b>specific pull request check</b>  
  Please add comment: <b>Jenkins (re)run [drools|kogito-runtimes|kogito-apps|kogito-examples] tests</b>

- for a <b>full downstream build</b> 
  - for <b>jenkins</b> job: please add comment: <b>Jenkins run fdb</b>
  - for <b>github actions</b> job: add the label `run_fdb`

- <b>a compile downstream build</b> please  add comment: <b>Jenkins run cdb</b>

- <b>a full production downstream build</b> please add comment: <b>Jenkins execute product fdb</b>

- <b>an upstream build</b> please add comment: <b>Jenkins run upstream</b>

- for <b>quarkus branch checks</b>  
  Run checks against Quarkus current used branch  
  Please add comment: <b>Jenkins run quarkus-branch</b>

- for a <b>quarkus branch specific check</b>  
  Run checks against Quarkus current used branch  
  Please add comment: <b>Jenkins (re)run [drools|kogito-runtimes|kogito-apps|kogito-examples] quarkus-branch</b>

- for <b>quarkus main checks</b>  
  Run checks against Quarkus main branch  
  Please add comment: <b>Jenkins run quarkus-main</b>

- for a <b>specific quarkus main check</b>  
  Run checks against Quarkus main branch  
  Please add comment: <b>Jenkins (re)run [drools|kogito-runtimes|kogito-apps|kogito-examples] quarkus-main</b>

- for <b>quarkus lts checks</b>  
  Run checks against Quarkus lts branch  
  Please add comment: <b>Jenkins run quarkus-lts</b>

- for a <b>specific quarkus lts check</b>  
  Run checks against Quarkus lts branch  
  Please add comment: <b>Jenkins (re)run [drools|kogito-runtimes|kogito-apps|kogito-examples] quarkus-lts</b>

- for <b>native checks</b>  
  Run native checks  
  Please add comment: <b>Jenkins run native</b>

- for a <b>specific native check</b>  
  Run native checks 
  Please add comment: <b>Jenkins (re)run [drools|kogito-runtimes|kogito-apps|kogito-examples] native</b>

 - for <b>native lts checks</b>  
  Run native checks against quarkus lts branch
  Please add comment: <b>Jenkins run native-lts</b>

- for a <b>specific native lts check</b>  
  Run native checks against quarkus lts branch
  Please add comment: <b>Jenkins (re)run [drools|kogito-runtimes|kogito-apps|kogito-examples] native-lts</b>
</details>

<details>
<summary>
How to backport a pull request to a different branch?
</summary>

In order to automatically create a **backporting pull request** please add one or more labels having the following format `backport-<branch-name>`, where `<branch-name>` is the name of the branch where the pull request must be backported to (e.g., `backport-7.67.x` to backport the original PR to the `7.67.x` branch).

> **NOTE**: **backporting** is an action aiming to move a change (usually a commit) from a branch (usually the main one) to another one, which is generally referring to a still maintained release branch. Keeping it simple: it is about to move a specific change or a set of them from one branch to another.

Once the original pull request is successfully merged, the automated action will create one backporting pull request per each label (with the previous format) that has been added.

If something goes wrong, the author will be notified and at this point a manual backporting is needed.

> **NOTE**: this automated backporting is triggered whenever a pull request on `main` branch is labeled or closed, but both conditions must be satisfied to get the new PR created.
</details>

<!-- TODO to uncomment if activating the quarkus-3 rewrite PR job -->
<!-- <details>
<summary>
Quarkus-3 PR check is failing ... what to do ?
</summary>
The Quarkus 3 check is applying patches from the `.ci/environments/quarkus-3/patches`.

The first patch, called `0001_before_sh.patch`, is generated from Openrewrite `.ci/environments/quarkus-3/quarkus3.yml` recipe. The patch is created to speed up the check. But it may be that some changes in the PR broke this patch.  
No panic, there is an easy way to regenerate it. You just need to comment on the PR:
```
jenkins rewrite quarkus-3
```
and it should, after some minutes (~20/30min) apply a commit on the PR with the patch regenerated.

Other patches were generated manually. If any of it fails, you will need to manually update it... and push your changes.
</details> -->