### PR TITLE
[DROOLS-7485] StoresOnly Strategy - multiple kieSession from the same…

### DIFF
--- a/drools-reliability/drools-reliability-infinispan/src/test/java/org/drools/reliability/infinispan/ReliabilityTest.java
+++ b/drools-reliability/drools-reliability-infinispan/src/test/java/org/drools/reliability/infinispan/ReliabilityTest.java
@@ -282,10 +282,10 @@ class ReliabilityTest extends ReliabilityTestBasics {
     }
 
     @ParameterizedTest
-    @MethodSource("strategyProviderStoresOnlyWithExplicitSafepoints")
-    void multipleKieSessions_BasicTest(PersistedSessionOption.PersistenceStrategy persistenceStrategy, PersistedSessionOption.SafepointStrategy safepointStrategy) {
-        KieSession session1 = createSession(BASIC_RULE, persistenceStrategy, safepointStrategy);
-        KieSession session2 = createSession(BASIC_RULE, persistenceStrategy, safepointStrategy);
+    @MethodSource("strategyProviderStoresOnlyWithExplicitSafepointsAndKieBaseCache")
+    void multipleKieSessions_BasicTest(PersistedSessionOption.PersistenceStrategy persistenceStrategy, PersistedSessionOption.SafepointStrategy safepointStrategy, boolean useKieBaseCache) {
+        KieSession session1 = createSession(BASIC_RULE, persistenceStrategy, safepointStrategy, useKieBaseCache);
+        KieSession session2 = createSession(BASIC_RULE, persistenceStrategy, safepointStrategy, useKieBaseCache);
 
         insert(session1, "M");
         insert(session2, "N");
@@ -298,8 +298,8 @@ class ReliabilityTest extends ReliabilityTestBasics {
 
         failover();
 
-        session1 = restoreSession(session1.getIdentifier(), BASIC_RULE, persistenceStrategy, safepointStrategy);
-        session2 = restoreSession(session2.getIdentifier(), BASIC_RULE, persistenceStrategy, safepointStrategy);
+        session1 = restoreSession(session1.getIdentifier(), BASIC_RULE, persistenceStrategy, safepointStrategy, useKieBaseCache);
+        session2 = restoreSession(session2.getIdentifier(), BASIC_RULE, persistenceStrategy, safepointStrategy, useKieBaseCache);
 
         // clear results
         clearResults(session1);
@@ -313,10 +313,10 @@ class ReliabilityTest extends ReliabilityTestBasics {
     }
 
     @ParameterizedTest
-    @MethodSource("strategyProviderStoresOnlyWithExplicitSafepoints") // FULL fails with "ReliablePropagationList; no valid constructor"
-    void multipleKieSessions_insertFailoverInsertFire_shouldRecoverFromFailover(PersistedSessionOption.PersistenceStrategy persistenceStrategy, PersistedSessionOption.SafepointStrategy safepointStrategy) {
-        KieSession session1 = createSession(BASIC_RULE, persistenceStrategy, safepointStrategy);
-        KieSession session2 = createSession(BASIC_RULE, persistenceStrategy, safepointStrategy);
+    @MethodSource("strategyProviderStoresOnlyWithExplicitSafepointsAndKieBaseCache") // FULL fails with "ReliablePropagationList; no valid constructor"
+    void multipleKieSessions_insertFailoverInsertFire_shouldRecoverFromFailover(PersistedSessionOption.PersistenceStrategy persistenceStrategy, PersistedSessionOption.SafepointStrategy safepointStrategy, boolean useKieBaseCache) {
+        KieSession session1 = createSession(BASIC_RULE, persistenceStrategy, safepointStrategy, useKieBaseCache);
+        KieSession session2 = createSession(BASIC_RULE, persistenceStrategy, safepointStrategy, useKieBaseCache);
 
         insert(session1,"M");
         insertMatchingPerson(session1, "Mike", 37);
@@ -325,8 +325,8 @@ class ReliabilityTest extends ReliabilityTestBasics {
 
         failover();
 
-        session1 = restoreSession(session1.getIdentifier(), BASIC_RULE, persistenceStrategy, safepointStrategy);
-        session2 = restoreSession(session2.getIdentifier(), BASIC_RULE, persistenceStrategy, safepointStrategy);
+        session1 = restoreSession(session1.getIdentifier(), BASIC_RULE, persistenceStrategy, safepointStrategy, useKieBaseCache);
+        session2 = restoreSession(session2.getIdentifier(), BASIC_RULE, persistenceStrategy, safepointStrategy, useKieBaseCache);
 
         insertNonMatchingPerson(session1,"Toshiya", 35);
         insertMatchingPerson(session2,"Nicole", 40);
@@ -339,11 +339,11 @@ class ReliabilityTest extends ReliabilityTestBasics {
     }
 
     @ParameterizedTest
-    @MethodSource("strategyProviderStoresOnlyWithExplicitSafepoints") // With Remote, FULL fails with "ReliablePropagationList; no valid constructor" even without failover
-    void multipleKieSessions_noFailover(PersistedSessionOption.PersistenceStrategy persistenceStrategy, PersistedSessionOption.SafepointStrategy safepointStrategy) {
+    @MethodSource("strategyProviderStoresOnlyWithExplicitSafepointsAndKieBaseCache") // With Remote, FULL fails with "ReliablePropagationList; no valid constructor" even without failover
+    void multipleKieSessions_noFailover(PersistedSessionOption.PersistenceStrategy persistenceStrategy, PersistedSessionOption.SafepointStrategy safepointStrategy, boolean useKieBaseCache) {
 
-        KieSession session1 = createSession(BASIC_RULE, persistenceStrategy, safepointStrategy);
-        KieSession session2 = createSession(BASIC_RULE, persistenceStrategy, safepointStrategy);
+        KieSession session1 = createSession(BASIC_RULE, persistenceStrategy, safepointStrategy, useKieBaseCache);
+        KieSession session2 = createSession(BASIC_RULE, persistenceStrategy, safepointStrategy, useKieBaseCache);
 
         insert(session1,"M");
         insertMatchingPerson(session1,"Matching Person One", 37);
@@ -353,8 +353,8 @@ class ReliabilityTest extends ReliabilityTestBasics {
             safepoint();
         }
 
-        session1 = restoreSession(session1.getIdentifier(), BASIC_RULE, persistenceStrategy, safepointStrategy);
-        session2 = restoreSession(session2.getIdentifier(), BASIC_RULE, persistenceStrategy, safepointStrategy);
+        session1 = restoreSession(session1.getIdentifier(), BASIC_RULE, persistenceStrategy, safepointStrategy, useKieBaseCache);
+        session2 = restoreSession(session2.getIdentifier(), BASIC_RULE, persistenceStrategy, safepointStrategy, useKieBaseCache);
 
         insertNonMatchingPerson(session1,"Toshiya", 41);
         insertMatchingPerson(session1,"Matching Person Two", 40);
@@ -368,11 +368,11 @@ class ReliabilityTest extends ReliabilityTestBasics {
     }
 
     @ParameterizedTest
-    @MethodSource("strategyProviderStoresOnlyWithExplicitSafepoints") // FULL fails with "ReliablePropagationList; no valid constructor"
-    void multipleKieSessions_insertFireInsertFailoverInsertFire_shouldMatchFactInsertedBeforeFailover(PersistedSessionOption.PersistenceStrategy persistenceStrategy, PersistedSessionOption.SafepointStrategy safepointStrategy) {
+    @MethodSource("strategyProviderStoresOnlyWithExplicitSafepointsAndKieBaseCache") // FULL fails with "ReliablePropagationList; no valid constructor"
+    void multipleKieSessions_insertFireInsertFailoverInsertFire_shouldMatchFactInsertedBeforeFailover(PersistedSessionOption.PersistenceStrategy persistenceStrategy, PersistedSessionOption.SafepointStrategy safepointStrategy, boolean useKieBaseCache) {
 
-        KieSession session1 = createSession(BASIC_RULE, persistenceStrategy, safepointStrategy);
-        KieSession session2 = createSession(BASIC_RULE, persistenceStrategy, safepointStrategy);
+        KieSession session1 = createSession(BASIC_RULE, persistenceStrategy, safepointStrategy, useKieBaseCache);
+        KieSession session2 = createSession(BASIC_RULE, persistenceStrategy, safepointStrategy, useKieBaseCache);
 
         insert(session1,"M");
         insertMatchingPerson(session1,"Matching Person One", 37);
@@ -387,8 +387,8 @@ class ReliabilityTest extends ReliabilityTestBasics {
 
         failover();
 
-        session1 = restoreSession(session1.getIdentifier(),BASIC_RULE, persistenceStrategy, safepointStrategy);
-        session2 = restoreSession(session2.getIdentifier(), BASIC_RULE, persistenceStrategy, safepointStrategy);
+        session1 = restoreSession(session1.getIdentifier(),BASIC_RULE, persistenceStrategy, safepointStrategy, useKieBaseCache);
+        session2 = restoreSession(session2.getIdentifier(), BASIC_RULE, persistenceStrategy, safepointStrategy, useKieBaseCache);
 
         clearResults(session1);
         clearResults(session2);
@@ -406,10 +406,10 @@ class ReliabilityTest extends ReliabilityTestBasics {
     }
 
     @ParameterizedTest
-    @MethodSource("strategyProviderStoresOnlyWithExplicitSafepoints") // FULL fails with "ReliablePropagationList; no valid constructor"
-    void multipleKieSessions_updateBeforeFailover_shouldRecoverFromFailover(PersistedSessionOption.PersistenceStrategy persistenceStrategy, PersistedSessionOption.SafepointStrategy safepointStrategy) {
-        KieSession session1 = createSession(BASIC_RULE, persistenceStrategy, safepointStrategy);
-        KieSession session2 = createSession(BASIC_RULE, persistenceStrategy, safepointStrategy);
+    @MethodSource("strategyProviderStoresOnlyWithExplicitSafepointsAndKieBaseCache") // FULL fails with "ReliablePropagationList; no valid constructor"
+    void multipleKieSessions_updateBeforeFailover_shouldRecoverFromFailover(PersistedSessionOption.PersistenceStrategy persistenceStrategy, PersistedSessionOption.SafepointStrategy safepointStrategy, boolean useKieBaseCache) {
+        KieSession session1 = createSession(BASIC_RULE, persistenceStrategy, safepointStrategy, useKieBaseCache);
+        KieSession session2 = createSession(BASIC_RULE, persistenceStrategy, safepointStrategy, useKieBaseCache);
 
         insert(session1,"M");
         Person p1 = new Person("Mario", 49);
@@ -429,8 +429,8 @@ class ReliabilityTest extends ReliabilityTestBasics {
         update(session1, fh2, p2);
 
         failover();
-        session1 = restoreSession(session1.getIdentifier(), BASIC_RULE, persistenceStrategy, safepointStrategy);
-        session2 = restoreSession(session2.getIdentifier(), BASIC_RULE, persistenceStrategy, safepointStrategy);
+        session1 = restoreSession(session1.getIdentifier(), BASIC_RULE, persistenceStrategy, safepointStrategy, useKieBaseCache);
+        session2 = restoreSession(session2.getIdentifier(), BASIC_RULE, persistenceStrategy, safepointStrategy, useKieBaseCache);
 
         assertThat(fireAllRules(session1)).isEqualTo(1);
         assertThat(getResults(session1)).containsExactlyInAnyOrder("Mario", "MegaToshiya");
@@ -438,8 +438,8 @@ class ReliabilityTest extends ReliabilityTestBasics {
         assertThat(getResults(session2)).containsExactlyInAnyOrder("Toshiya");
 
         failover();
-        session1 = restoreSession(session1.getIdentifier(), BASIC_RULE, persistenceStrategy, safepointStrategy);
-        session2 = restoreSession(session2.getIdentifier(), BASIC_RULE, persistenceStrategy, safepointStrategy);
+        session1 = restoreSession(session1.getIdentifier(), BASIC_RULE, persistenceStrategy, safepointStrategy, useKieBaseCache);
+        session2 = restoreSession(session2.getIdentifier(), BASIC_RULE, persistenceStrategy, safepointStrategy, useKieBaseCache);
         clearResults(session1);
         clearResults(session2);
 
@@ -451,11 +451,11 @@ class ReliabilityTest extends ReliabilityTestBasics {
     }
 
     @ParameterizedTest
-    @MethodSource("strategyProviderStoresOnlyWithExplicitSafepoints") // FULL fails with "ReliablePropagationList; no valid constructor"
-    void multipleKieSessions_deleteBeforeFailover_shouldRecoverFromFailover(PersistedSessionOption.PersistenceStrategy persistenceStrategy, PersistedSessionOption.SafepointStrategy safepointStrategy) {
+    @MethodSource("strategyProviderStoresOnlyWithExplicitSafepointsAndKieBaseCache") // FULL fails with "ReliablePropagationList; no valid constructor"
+    void multipleKieSessions_deleteBeforeFailover_shouldRecoverFromFailover(PersistedSessionOption.PersistenceStrategy persistenceStrategy, PersistedSessionOption.SafepointStrategy safepointStrategy, boolean useKieBaseCache) {
 
-        KieSession session1 = createSession(BASIC_RULE, persistenceStrategy, safepointStrategy);
-        KieSession session2 = createSession(BASIC_RULE, persistenceStrategy, safepointStrategy);
+        KieSession session1 = createSession(BASIC_RULE, persistenceStrategy, safepointStrategy, useKieBaseCache);
+        KieSession session2 = createSession(BASIC_RULE, persistenceStrategy, safepointStrategy, useKieBaseCache);
 
         FactHandle fhStringM = insert(session1,"M");
         insertMatchingPerson(session1,"Matching Person One",37);
@@ -471,8 +471,8 @@ class ReliabilityTest extends ReliabilityTestBasics {
 
         failover();
 
-        session1 = restoreSession(session1.getIdentifier(), BASIC_RULE, persistenceStrategy, safepointStrategy);
-        session2 = restoreSession(session2.getIdentifier(), BASIC_RULE, persistenceStrategy, safepointStrategy);
+        session1 = restoreSession(session1.getIdentifier(), BASIC_RULE, persistenceStrategy, safepointStrategy, useKieBaseCache);
+        session2 = restoreSession(session2.getIdentifier(), BASIC_RULE, persistenceStrategy, safepointStrategy, useKieBaseCache);
         clearResults(session1);
         clearResults(session2);
 
@@ -487,8 +487,8 @@ class ReliabilityTest extends ReliabilityTestBasics {
         insert(session1,"T");
 
         failover();
-        session1 = restoreSession(session1.getIdentifier(), BASIC_RULE, persistenceStrategy, safepointStrategy);
-        session2 = restoreSession(session2.getIdentifier(), BASIC_RULE, persistenceStrategy, safepointStrategy);
+        session1 = restoreSession(session1.getIdentifier(), BASIC_RULE, persistenceStrategy, safepointStrategy, useKieBaseCache);
+        session2 = restoreSession(session2.getIdentifier(), BASIC_RULE, persistenceStrategy, safepointStrategy, useKieBaseCache);
 
         assertThat(fireAllRules(session1)).isEqualTo(1);
         assertThat(getResults(session1)).containsExactlyInAnyOrder("Toshiya");


### PR DESCRIPTION
… KieBase test

- Parameterize multiple ksession tests to use multiple kbases or one kbase

**JIRA**: 
https://issues.redhat.com/browse/DROOLS-7485

<details>
<summary>
How to replicate CI configuration locally?
</summary>

Build Chain tool does "simple" maven build(s), the builds are just Maven commands, but because the repositories relates and depends on each other and any change in API or class method could affect several of those repositories there is a need to use [build-chain tool](https://github.com/kiegroup/github-action-build-chain) to handle cross repository builds and be sure that we always use latest version of the code for each repository.
 
[build-chain tool](https://github.com/kiegroup/github-action-build-chain) is a build tool which can be used on command line locally or in Github Actions workflow(s), in case you need to change multiple repositories and send multiple dependent pull requests related with a change you can easily reproduce the same build by executing it on Github hosted environment or locally in your development environment. See [local execution](https://github.com/kiegroup/github-action-build-chain#local-execution) details to get more information about it.
</details>

<details>
<summary>
How to retest this PR or trigger a specific build:
</summary>

- for <b>pull request checks</b>  
  Please add comment: <b>Jenkins retest this</b>

- for a <b>specific pull request check</b>  
  Please add comment: <b>Jenkins (re)run [drools|kogito-runtimes|kogito-apps|kogito-examples] tests</b>

- for a <b>full downstream build</b> 
  - for <b>jenkins</b> job: please add comment: <b>Jenkins run fdb</b>
  - for <b>github actions</b> job: add the label `run_fdb`

- <b>a compile downstream build</b> please  add comment: <b>Jenkins run cdb</b>

- <b>a full production downstream build</b> please add comment: <b>Jenkins execute product fdb</b>

- <b>an upstream build</b> please add comment: <b>Jenkins run upstream</b>

- for <b>quarkus branch checks</b>  
  Run checks against Quarkus current used branch  
  Please add comment: <b>Jenkins run quarkus-branch</b>

- for a <b>quarkus branch specific check</b>  
  Run checks against Quarkus current used branch  
  Please add comment: <b>Jenkins (re)run [drools|kogito-runtimes|kogito-apps|kogito-examples] quarkus-branch</b>

- for <b>quarkus main checks</b>  
  Run checks against Quarkus main branch  
  Please add comment: <b>Jenkins run quarkus-main</b>

- for a <b>specific quarkus main check</b>  
  Run checks against Quarkus main branch  
  Please add comment: <b>Jenkins (re)run [drools|kogito-runtimes|kogito-apps|kogito-examples] quarkus-main</b>

- for <b>quarkus lts checks</b>  
  Run checks against Quarkus lts branch  
  Please add comment: <b>Jenkins run quarkus-lts</b>

- for a <b>specific quarkus lts check</b>  
  Run checks against Quarkus lts branch  
  Please add comment: <b>Jenkins (re)run [drools|kogito-runtimes|kogito-apps|kogito-examples] quarkus-lts</b>

- for <b>native checks</b>  
  Run native checks  
  Please add comment: <b>Jenkins run native</b>

- for a <b>specific native check</b>  
  Run native checks 
  Please add comment: <b>Jenkins (re)run [drools|kogito-runtimes|kogito-apps|kogito-examples] native</b>

 - for <b>native lts checks</b>  
  Run native checks against quarkus lts branch
  Please add comment: <b>Jenkins run native-lts</b>

- for a <b>specific native lts check</b>  
  Run native checks against quarkus lts branch
  Please add comment: <b>Jenkins (re)run [drools|kogito-runtimes|kogito-apps|kogito-examples] native-lts</b>
</details>

<details>
<summary>
How to backport a pull request to a different branch?
</summary>

In order to automatically create a **backporting pull request** please add one or more labels having the following format `backport-<branch-name>`, where `<branch-name>` is the name of the branch where the pull request must be backported to (e.g., `backport-7.67.x` to backport the original PR to the `7.67.x` branch).

> **NOTE**: **backporting** is an action aiming to move a change (usually a commit) from a branch (usually the main one) to another one, which is generally referring to a still maintained release branch. Keeping it simple: it is about to move a specific change or a set of them from one branch to another.

Once the original pull request is successfully merged, the automated action will create one backporting pull request per each label (with the previous format) that has been added.

If something goes wrong, the author will be notified and at this point a manual backporting is needed.

> **NOTE**: this automated backporting is triggered whenever a pull request on `main` branch is labeled or closed, but both conditions must be satisfied to get the new PR created.
</details>

<!-- TODO to uncomment if activating the quarkus-3 rewrite PR job -->
<!-- <details>
<summary>
Quarkus-3 PR check is failing ... what to do ?
</summary>
The Quarkus 3 check is applying patches from the `.ci/environments/quarkus-3/patches`.

The first patch, called `0001_before_sh.patch`, is generated from Openrewrite `.ci/environments/quarkus-3/quarkus3.yml` recipe. The patch is created to speed up the check. But it may be that some changes in the PR broke this patch.  
No panic, there is an easy way to regenerate it. You just need to comment on the PR:
```
jenkins rewrite quarkus-3
```
and it should, after some minutes (~20/30min) apply a commit on the PR with the patch regenerated.

Other patches were generated manually. If any of it fails, you will need to manually update it... and push your changes.
</details> -->