### PR TITLE
D7507 structured data persistency

### DIFF
--- a/drools-reliability/drools-reliability-core/src/main/java/org/drools/reliability/core/SimpleSerializationReliableObjectStore.java
+++ b/drools-reliability/drools-reliability-core/src/main/java/org/drools/reliability/core/SimpleSerializationReliableObjectStore.java
@@ -15,10 +15,6 @@
 
 package org.drools.reliability.core;
 
-import java.util.ArrayList;
-import java.util.List;
-import java.util.concurrent.TimeUnit;
-
 import org.drools.core.ClockType;
 import org.drools.core.common.DefaultEventHandle;
 import org.drools.core.common.IdentityObjectStore;
@@ -26,6 +22,13 @@ import org.drools.core.common.InternalFactHandle;
 import org.drools.core.common.InternalWorkingMemory;
 import org.drools.core.common.InternalWorkingMemoryEntryPoint;
 import org.drools.core.common.Storage;
+
+import java.lang.reflect.Field;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.concurrent.TimeUnit;
+import java.util.stream.Collectors;
 
 public class SimpleSerializationReliableObjectStore extends IdentityObjectStore implements SimpleReliableObjectStore {
 
@@ -39,7 +42,17 @@ public class SimpleSerializationReliableObjectStore extends IdentityObjectStore 
 
     public SimpleSerializationReliableObjectStore(Storage<Long, StoredObject> storage) {
         super();
-        this.storage = storage;
+        this.storage = storage.size()>0 ? updateObjectReferences(storage) : storage;
+    }
+
+    private Storage<Long, StoredObject> updateObjectReferences(Storage<Long, StoredObject> storage){
+        Storage<Long, StoredObject> updateStorage = storage;
+
+        for (Long key: storage.keySet()){
+            updateStorage.put(key, ((SerializableStoredObject) storage.get(key)).updateReferencedObjects(storage));
+        }
+
+        return updateStorage;
     }
 
     @Override
@@ -110,7 +123,7 @@ public class SimpleSerializationReliableObjectStore extends IdentityObjectStore 
     public void putIntoPersistedStorage(InternalFactHandle handle, boolean propagated) {
         Object object = handle.getObject();
         StoredObject storedObject = factHandleToStoredObject(handle, reInitPropagated || propagated, object);
-        storage.put(getHandleForObject(object).getId(), storedObject);
+        storage.put(getHandleForObject(object).getId(), setReferencedObjects(storedObject));
     }
 
     private StoredObject factHandleToStoredObject(InternalFactHandle handle, boolean propagated, Object object) {
@@ -141,4 +154,53 @@ public class SimpleSerializationReliableObjectStore extends IdentityObjectStore 
             storage.flush();
         }
     }
+
+    private void updateReferencedObjects(StoredObject object){
+        List<Field> referencedObjects = getReferencedObjects(object.getObject());
+        if (referencedObjects.size()>0) {
+
+        }
+    }
+
+    private StoredObject setReferencedObjects(StoredObject object){
+        List<Field> referencedObjects = getReferencedObjects(object.getObject());
+        if (referencedObjects.size()>0) {
+            // for each referenced object in sObject
+            //  lookup in storage, find the object of reference, get its fact handle id
+            //      save this association in the StoredObject
+            referencedObjects.forEach(field -> {
+                field.setAccessible(true);
+                Object fieldObject = null;
+                try {
+                    fieldObject = field.get(object.getObject());
+                } catch (IllegalAccessException e) {
+                    e.printStackTrace();
+                }
+                Long objectKey = fromObjectToFactHandleId(fieldObject);
+                if (objectKey!=null){
+                    ((SerializableStoredObject) object).addReferencedObject(field.getName(), objectKey);}
+            });
+        }
+        return object;
+    }
+
+    private Long fromObjectToFactHandleId(Object object){
+        for (Long key : this.storage.keySet()){
+            if (( (SerializableStoredObject) storage.get(key)).getObject()==object){
+                return key;
+            }
+        }
+        return null;
+    }
+
+    private List<Field> getReferencedObjects(Object object){
+        Field[] fields = object.getClass().getDeclaredFields();
+
+        List<Field> nonPrimitiveFields = Arrays.stream(fields)
+                .filter(field -> !field.getType().isPrimitive())
+                .filter(field -> !field.getType().equals(String.class))
+                .collect(Collectors.toList());
+        return nonPrimitiveFields;
+    }
 }
+

--- a/drools-reliability/drools-reliability-tests/src/test/java/org/drools/reliability/test/ReliabilityFireAndAlarmTest.java
+++ b/drools-reliability/drools-reliability-tests/src/test/java/org/drools/reliability/test/ReliabilityFireAndAlarmTest.java
@@ -1,0 +1,86 @@
+package org.drools.reliability.test;
+
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
+import org.kie.api.runtime.conf.PersistedSessionOption;
+import org.kie.api.runtime.rule.FactHandle;
+import org.test.domain.fireandalarm.Alarm;
+import org.test.domain.fireandalarm.Fire;
+import org.test.domain.fireandalarm.Room;
+import org.test.domain.fireandalarm.Sprinkler;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class ReliabilityFireAndAlarmTest extends ReliabilityTestBasics{
+    private static final String FIRE_AND_ALARM =
+            "import " + Alarm.class.getCanonicalName() + ";" +
+                    "import " + Fire.class.getCanonicalName() + ";" +
+                    "import " + Sprinkler.class.getCanonicalName() + ";" +
+                    "import " + Room.class.getCanonicalName() + ";" +
+                    "global java.util.List results;" +
+                    "rule 'When there is a fire turn on the sprinkler' when\n" +
+                    "  Fire($room : room) \n" +
+                    "  $sprinkler: Sprinkler( room == $room, on == false ) \n" +
+                    "then\n" +
+                    "  modify($sprinkler) { setOn(true); } \n" +
+                    "  System.out.println(\"Turn on the sprinkler for room\" + $room.getName()); \n" +
+                    "end\n" +
+                    "rule 'Raise the alarm when we have one or more firs' when\n" +
+                    "  exists Fire() \n" +
+                    "then\n" +
+                    "  insert( new Alarm() );\n" +
+                    "  System.out.println(\"Raise the alarm\");\n" +
+                    "end\n"+
+                    "rule 'Cancel the alarm when all the fires have gone' when \n" +
+                    "   not Fire() \n" +
+                    "   $alarm : Alarm() \n" +
+                    "then\n" +
+                    "   delete ( $alarm ); \n" +
+                    "   System.out.println(\"Cancel the alarm\"); \n" +
+                    "end\n" +
+                    "rule 'Status output when things are ok' when\n" +
+                    "   not Alarm() \n" +
+                    "   not Sprinkler ( on == true ) \n" +
+                    "then \n" +
+                    "   System.out.println(\"Everything is ok\"); \n" +
+                    "end";
+
+    @ParameterizedTest
+    @MethodSource("strategyProviderStoresOnlyWithExplicitSafepoints")
+    void testNoFailover(PersistedSessionOption.PersistenceStrategy persistenceStrategy, PersistedSessionOption.SafepointStrategy safepointStrategy){
+        createSession(FIRE_AND_ALARM, persistenceStrategy, safepointStrategy);
+
+        // phase 1
+        Room room1 = new Room("Room 1");
+        insert(room1);
+        FactHandle fireFact1 = insert(new Fire(room1));
+        fireAllRules();
+
+        // phase 2
+        Sprinkler sprinkler1 = new Sprinkler(room1);
+        insert(sprinkler1);
+        fireAllRules();
+
+        assertThat(sprinkler1.isOn()).isTrue();
+
+        // phase 3
+        delete(fireFact1);
+        fireAllRules();
+    }
+
+    @ParameterizedTest
+    @MethodSource("strategyProviderStoresOnlyWithExplicitSafepoints")
+    void testInsertFailover_ShouldFireRules(PersistedSessionOption.PersistenceStrategy persistenceStrategy, PersistedSessionOption.SafepointStrategy safepointStrategy){
+        createSession(FIRE_AND_ALARM, persistenceStrategy, safepointStrategy);
+
+        Room room1 = new Room("Room 1");
+        insert(room1);
+        insert(new Fire(room1));
+        insert(new Sprinkler(room1));
+
+        failover();
+        restoreSession(FIRE_AND_ALARM, persistenceStrategy,safepointStrategy);
+
+        assertThat(fireAllRules()).isEqualTo(2);
+    }
+}

--- a/drools-reliability/drools-reliability-tests/src/test/java/org/test/domain/fireandalarm/Alarm.java
+++ b/drools-reliability/drools-reliability-tests/src/test/java/org/test/domain/fireandalarm/Alarm.java
@@ -1,0 +1,6 @@
+package org.test.domain.fireandalarm;
+
+import java.io.Serializable;
+
+public class Alarm implements Serializable {
+}

--- a/drools-reliability/drools-reliability-tests/src/test/java/org/test/domain/fireandalarm/Fire.java
+++ b/drools-reliability/drools-reliability-tests/src/test/java/org/test/domain/fireandalarm/Fire.java
@@ -1,0 +1,21 @@
+package org.test.domain.fireandalarm;
+
+import java.io.Serializable;
+
+public class Fire implements Serializable {
+    private Room room;
+
+    public Fire() { }
+
+    public Fire(Room room) {
+        this.room = room;
+    }
+
+    public Room getRoom() {
+        return room;
+    }
+
+    public void setRoom(Room room) {
+        this.room = room;
+    }
+}

--- a/drools-reliability/drools-reliability-tests/src/test/java/org/test/domain/fireandalarm/Room.java
+++ b/drools-reliability/drools-reliability-tests/src/test/java/org/test/domain/fireandalarm/Room.java
@@ -1,0 +1,26 @@
+package org.test.domain.fireandalarm;
+
+import java.io.Serializable;
+
+public class Room implements Serializable {
+    private String name;
+
+    public Room() { }
+
+    public Room(String name) {
+        this.name = name;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    @Override
+    public String toString() {
+        return name;
+    }
+}

--- a/drools-reliability/drools-reliability-tests/src/test/java/org/test/domain/fireandalarm/Sprinkler.java
+++ b/drools-reliability/drools-reliability-tests/src/test/java/org/test/domain/fireandalarm/Sprinkler.java
@@ -1,0 +1,35 @@
+package org.test.domain.fireandalarm;
+
+import java.io.Serializable;
+
+public class Sprinkler implements Serializable {
+    private Room room;
+    private boolean on = false;
+
+    public Sprinkler() { }
+
+    public Sprinkler(Room room) {
+        this.room = room;
+    }
+
+    public Room getRoom() {
+        return room;
+    }
+
+    public void setRoom(Room room) {
+        this.room = room;
+    }
+
+    public boolean isOn() {
+        return on;
+    }
+
+    public void setOn(boolean on) {
+        this.on = on;
+    }
+
+    @Override
+    public String toString() {
+        return "Sprinkler for " + room;
+    }
+}


### PR DESCRIPTION
**JIRA**: [DROOLS-7507](https://github.com/nprentza/drools/pull/new/d7507)

**Issue**:
Structured data, i.e. objects that reference other objects, when restored from the cache the reference is lost - all objects are re-instantiated with a different identifier.

**A candidate workaround**:
A candidate workaround is to maintain the references relation in the StoredObject so that we can restore it when reading a fact from the cache.

To explore this idea we can use a `Map<String, Long> referencedObjects` in the SerializableStoredObject class, for the relation between an object's field-name and the key (in cache) of the object it refers to. 

Then, when adding a fact in the cache (object store, `putIntoPersistedStorage`), we set the referencedObjects relations, by taking into account only the non-primitive fields and non strings. Of course this just an assumption for this experimentation. Another assumption is that a referenced object is already in the storage, that is, in a test scenario we first add a single fact to the memory (e.g. Room1) and then we add the object that refers to that fact (e.g. Fire(Room1)).

The references between the objects are restored during the initialization of the object store.