### PR TITLE
[Quarkus 3 migration] Updated Openrewrite patch

### DIFF
--- a/.ci/environments/quarkus-3/patches/0001_before_sh.patch
+++ b/.ci/environments/quarkus-3/patches/0001_before_sh.patch
@@ -1,5 +1,5 @@
 diff --git a/build-parent/pom.xml b/build-parent/pom.xml
-index f01825ce2c..d85e31cb62 100644
+index ba78a93374..acb0a5ff7e 100644
 --- a/build-parent/pom.xml
 +++ b/build-parent/pom.xml
 @@ -40,22 +40,22 @@
@@ -18,7 +18,7 @@ index f01825ce2c..d85e31cb62 100644
      <version.com.google.protobuf>3.22.0</version.com.google.protobuf>
 -    <version.com.h2database>2.2.220</version.com.h2database>
 +    <version.com.h2database>2.1.214</version.com.h2database>
-     <version.com.networknt.json-schema-validator>1.0.43</version.com.networknt.json-schema-validator>
+     <version.com.networknt.json-schema-validator>1.0.86</version.com.networknt.json-schema-validator>
      <version.com.sun.xml.bind>2.3.0</version.com.sun.xml.bind>
      <version.com.thoughtworks.xstream>1.4.20</version.com.thoughtworks.xstream>
      <version.guru.nidi>0.18.0</version.guru.nidi>

--- a/.ci/environments/quarkus-3/quarkus3.yml
+++ b/.ci/environments/quarkus-3/quarkus3.yml
@@ -3,8 +3,8 @@ description: Update Quarkus version and refactor imports and resources if needed
 type: specs.openrewrite.org/v1beta/recipe
 recipeList:
 - org.openrewrite.maven.ChangePropertyValue: {
-    key: version.io.quarkus,
-    newValue: 3.0.0.Final
+    newValue: 3.0.0.Final,
+    key: version.io.quarkus
   }
 - org.kie.drools.Quarkus3Migration
 - org.kie.ManagedDependencies
@@ -117,9 +117,6 @@ recipeList:
   }
 - org.kie.openrewrite.recipe.jpmml.JPMMLRecipe
 ---
-name: org.kie.ManagedDependencies
-description: Update all managed dependencies based on dependency updates from Quarkus.
-type: specs.openrewrite.org/v1beta/recipe
 recipeList:
 - org.openrewrite.maven.ChangeManagedDependencyGroupIdAndArtifactId: {
     oldGroupId: javax.activation,
@@ -505,6 +502,9 @@ recipeList:
     newArtifactId: keycloak-admin-client-jakarta
   }
 displayName: Update Managed Dependencies
+name: org.kie.ManagedDependencies
+description: Update all managed dependencies based on dependency updates from Quarkus.
+type: specs.openrewrite.org/v1beta/recipe
 ---
 type: specs.openrewrite.org/v1beta/recipe
 name: io.quarkus.updates.core.quarkus30.UpgradeQuarkiverse


### PR DESCRIPTION
Please review and merge.

Generated by build jenkins-KIE-drools-main-tools-drools.quarkus-3.rewrite-9: https://eng-jenkins-csb-business-automation.apps.ocp-c1.prod.psi.redhat.com/job/KIE/job/drools/job/main/job/tools/job/drools.quarkus-3.rewrite/9/.