### PR TITLE
[DROOLS-7518] NullPointerException in MemoryFileSystem when kbase.nam…

### DIFF
--- a/drools-compiler/src/main/java/org/drools/compiler/kproject/KieModuleException.java
+++ b/drools-compiler/src/main/java/org/drools/compiler/kproject/KieModuleException.java
@@ -1,0 +1,24 @@
+/*
+ * Copyright 2023 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.drools.compiler.kproject;
+
+public class KieModuleException extends RuntimeException {
+
+    public KieModuleException(String message) {
+        super(message);
+    }
+}

--- a/drools-compiler/src/main/java/org/drools/compiler/kproject/models/KieBaseModelImpl.java
+++ b/drools-compiler/src/main/java/org/drools/compiler/kproject/models/KieBaseModelImpl.java
@@ -30,6 +30,7 @@ import com.thoughtworks.xstream.converters.MarshallingContext;
 import com.thoughtworks.xstream.converters.UnmarshallingContext;
 import com.thoughtworks.xstream.io.HierarchicalStreamReader;
 import com.thoughtworks.xstream.io.HierarchicalStreamWriter;
+import org.drools.compiler.kproject.KieModuleException;
 import org.drools.core.util.AbstractXStreamConverter;
 import org.drools.core.util.StringUtils;
 import org.kie.api.builder.model.KieBaseModel;
@@ -432,6 +433,9 @@ public class KieBaseModelImpl
 
             String kbaseName = reader.getAttribute( "name" );
             kBase.name = kbaseName != null ? kbaseName : StringUtils.uuid();
+            if (kBase.name.isEmpty()) {
+                throw new KieModuleException("kbase name is empty in kmodule.xml");
+            }
 
             kBase.setDefault( "true".equals(reader.getAttribute( "default" )) );
 

--- a/drools-compiler/src/main/java/org/drools/compiler/kproject/models/KieSessionModelImpl.java
+++ b/drools-compiler/src/main/java/org/drools/compiler/kproject/models/KieSessionModelImpl.java
@@ -25,6 +25,7 @@ import com.thoughtworks.xstream.converters.MarshallingContext;
 import com.thoughtworks.xstream.converters.UnmarshallingContext;
 import com.thoughtworks.xstream.io.HierarchicalStreamReader;
 import com.thoughtworks.xstream.io.HierarchicalStreamWriter;
+import org.drools.compiler.kproject.KieModuleException;
 import org.drools.core.BeliefSystemType;
 import org.drools.core.util.AbstractXStreamConverter;
 import org.kie.api.builder.model.ChannelModel;
@@ -340,6 +341,9 @@ public class KieSessionModelImpl
         public Object unmarshal(HierarchicalStreamReader reader, final UnmarshallingContext context) {
             final KieSessionModelImpl kSession = new KieSessionModelImpl();
             kSession.name = reader.getAttribute("name");
+            if (kSession.name.isEmpty()) {
+                throw new KieModuleException("ksession name is empty in kmodule.xml");
+            }
             kSession.setDefault( "true".equals(reader.getAttribute( "default" )) );
             kSession.setDirectFiring( "true".equals(reader.getAttribute( "directFiring" )) );
             kSession.setThreadSafe( "true".equals(reader.getAttribute( "threadSafe" )) );

--- a/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/integrationtests/KmoduleXmlTest.java
+++ b/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/integrationtests/KmoduleXmlTest.java
@@ -1,0 +1,121 @@
+/*
+ * Copyright 2023 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+*/
+
+package org.drools.mvel.integrationtests;
+
+import java.util.Collection;
+import java.util.List;
+
+import org.drools.testcoverage.common.util.KieBaseTestConfiguration;
+import org.drools.testcoverage.common.util.KieUtil;
+import org.drools.testcoverage.common.util.TestParametersUtil;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+import org.kie.api.KieServices;
+import org.kie.api.builder.KieBuilder;
+import org.kie.api.builder.KieFileSystem;
+import org.kie.api.builder.Message;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@RunWith(Parameterized.class)
+public class KmoduleXmlTest {
+
+    enum Element {
+        KBASE,
+        KSESSION
+    }
+
+    private final KieBaseTestConfiguration kieBaseTestConfiguration;
+
+    public KmoduleXmlTest(final KieBaseTestConfiguration kieBaseTestConfiguration) {
+        this.kieBaseTestConfiguration = kieBaseTestConfiguration;
+    }
+
+    @Parameterized.Parameters(name = "KieBase type={0}")
+    public static Collection<Object[]> getParameters() {
+        return TestParametersUtil.getKieBaseCloudConfigurations(true);
+    }
+
+    @Test
+    public void kbaseEmptyName() throws Exception {
+        List<Message> errors = buildKmoduleWithEmptyValue("name", Element.KBASE);
+
+        assertThat(errors).isNotEmpty();
+        assertThat(errors.get(0).getText()).contains("kbase name is empty in kmodule.xml");
+    }
+
+    @Test
+    public void kbaseEmptyIncludes() throws Exception {
+        List<Message> errors = buildKmoduleWithEmptyValue("includes", Element.KBASE);
+
+        assertThat(errors).as("Empty includes is fine. It's ignored")
+                          .isEmpty();
+    }
+
+    @Test
+    public void kbaseEmptyPackages() throws Exception {
+        List<Message> errors = buildKmoduleWithEmptyValue("packages", Element.KBASE);
+
+        assertThat(errors).as("Empty packages is fine. It means the default package")
+                          .isEmpty();
+    }
+
+    @Test
+    public void ksessionEmptyName() throws Exception {
+        List<Message> errors = buildKmoduleWithEmptyValue("name", Element.KSESSION);
+
+        assertThat(errors).isNotEmpty();
+        assertThat(errors.get(0).getText()).contains("ksession name is empty in kmodule.xml");
+    }
+
+    private List<Message> buildKmoduleWithEmptyValue(String emptyAttribute, Element element) throws Exception {
+        String drl =
+                "package org.example\n" +
+                     "rule R1 when\n" +
+                     "then\n" +
+                     "end\n";
+
+        KieServices ks = KieServices.Factory.get();
+
+        KieFileSystem kfs = ks.newKieFileSystem();
+        kfs.write("src/main/resources/org/example/r1.drl", drl);
+        kfs.write("src/main/resources/META-INF/kmodule.xml", getKmoduleString(emptyAttribute, element));
+        final KieBuilder kieBuilder = KieUtil.getKieBuilderFromKieFileSystem(kieBaseTestConfiguration, kfs, false);
+
+        return kieBuilder.getResults().getMessages(Message.Level.ERROR);
+    }
+
+    private String getKmoduleString(String emptyAttribute, Element element) {
+        StringBuilder sb = new StringBuilder();
+        sb.append("<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n");
+        sb.append("<kmodule xmlns=\"http://www.drools.org/xsd/kmodule\" xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\">\n");
+        if (element == Element.KBASE) {
+            // if kbase name is omitted, UUID is given to its name
+            sb.append("<kbase " + emptyAttribute + "=\"\" default=\"true\">\n");
+            sb.append("  <ksession name=\"myKsession\" default=\"true\"/>\n");
+        } else if (element == Element.KSESSION) {
+            sb.append("<kbase name=\"myKbase\" default=\"true\">\n");
+            // if you test an attribute other than "name" in ksession, you need to add "name" attribute as it's required
+            sb.append("  <ksession " + emptyAttribute + "=\"\" default=\"true\"/>\n");
+        } else {
+            throw new IllegalArgumentException("Unsupported element : " + element);
+        }
+        sb.append("</kbase>\n");
+        sb.append("</kmodule>\n");
+        return sb.toString();
+    }
+}


### PR DESCRIPTION
…e is empty in kmodule.xml

**Ports** 
This is a PR for 7.x

for main -> https://github.com/kiegroup/drools/pull/5437
for 7.67.x -> https://github.com/kiegroup/drools/pull/5438
for 7.67.x-blue -> https://github.com/kiegroup/drools/pull/5439


**JIRA**: 
https://issues.redhat.com/browse/DROOLS-7518

<details>
<summary>
How to replicate CI configuration locally?
</summary>

Build Chain tool does "simple" maven build(s), the builds are just Maven commands, but because the repositories relates and depends on each other and any change in API or class method could affect several of those repositories there is a need to use [build-chain tool](https://github.com/kiegroup/github-action-build-chain) to handle cross repository builds and be sure that we always use latest version of the code for each repository.
 
[build-chain tool](https://github.com/kiegroup/github-action-build-chain) is a build tool which can be used on command line locally or in Github Actions workflow(s), in case you need to change multiple repositories and send multiple dependent pull requests related with a change you can easily reproduce the same build by executing it on Github hosted environment or locally in your development environment. See [local execution](https://github.com/kiegroup/github-action-build-chain#local-execution) details to get more information about it.
</details>

<details>
<summary>
How to retest this PR or trigger a specific build:
</summary>

- for <b>pull request checks</b>  
  Please add comment: <b>Jenkins retest this</b>

- for a <b>specific pull request check</b>  
  Please add comment: <b>Jenkins (re)run [drools|kogito-runtimes|kogito-apps|kogito-examples] tests</b>

- for a <b>full downstream build</b> 
  - for <b>jenkins</b> job: please add comment: <b>Jenkins run fdb</b>
  - for <b>github actions</b> job: add the label `run_fdb`

- <b>a compile downstream build</b> please  add comment: <b>Jenkins run cdb</b>

- <b>a full production downstream build</b> please add comment: <b>Jenkins execute product fdb</b>

- <b>an upstream build</b> please add comment: <b>Jenkins run upstream</b>

- for <b>quarkus branch checks</b>  
  Run checks against Quarkus current used branch  
  Please add comment: <b>Jenkins run quarkus-branch</b>

- for a <b>quarkus branch specific check</b>  
  Run checks against Quarkus current used branch  
  Please add comment: <b>Jenkins (re)run [drools|kogito-runtimes|kogito-apps|kogito-examples] quarkus-branch</b>

- for <b>quarkus main checks</b>  
  Run checks against Quarkus main branch  
  Please add comment: <b>Jenkins run quarkus-main</b>

- for a <b>specific quarkus main check</b>  
  Run checks against Quarkus main branch  
  Please add comment: <b>Jenkins (re)run [drools|kogito-runtimes|kogito-apps|kogito-examples] quarkus-main</b>

- for <b>quarkus lts checks</b>  
  Run checks against Quarkus lts branch  
  Please add comment: <b>Jenkins run quarkus-lts</b>

- for a <b>specific quarkus lts check</b>  
  Run checks against Quarkus lts branch  
  Please add comment: <b>Jenkins (re)run [drools|kogito-runtimes|kogito-apps|kogito-examples] quarkus-lts</b>

- for <b>native checks</b>  
  Run native checks  
  Please add comment: <b>Jenkins run native</b>

- for a <b>specific native check</b>  
  Run native checks 
  Please add comment: <b>Jenkins (re)run [drools|kogito-runtimes|kogito-apps|kogito-examples] native</b>

 - for <b>native lts checks</b>  
  Run native checks against quarkus lts branch
  Please add comment: <b>Jenkins run native-lts</b>

- for a <b>specific native lts check</b>  
  Run native checks against quarkus lts branch
  Please add comment: <b>Jenkins (re)run [drools|kogito-runtimes|kogito-apps|kogito-examples] native-lts</b>
</details>

<details>
<summary>
How to backport a pull request to a different branch?
</summary>

In order to automatically create a **backporting pull request** please add one or more labels having the following format `backport-<branch-name>`, where `<branch-name>` is the name of the branch where the pull request must be backported to (e.g., `backport-7.67.x` to backport the original PR to the `7.67.x` branch).

> **NOTE**: **backporting** is an action aiming to move a change (usually a commit) from a branch (usually the main one) to another one, which is generally referring to a still maintained release branch. Keeping it simple: it is about to move a specific change or a set of them from one branch to another.

Once the original pull request is successfully merged, the automated action will create one backporting pull request per each label (with the previous format) that has been added.

If something goes wrong, the author will be notified and at this point a manual backporting is needed.

> **NOTE**: this automated backporting is triggered whenever a pull request on `main` branch is labeled or closed, but both conditions must be satisfied to get the new PR created.
</details>

<!-- TODO to uncomment if activating the quarkus-3 rewrite PR job -->
<!-- <details>
<summary>
Quarkus-3 PR check is failing ... what to do ?
</summary>
The Quarkus 3 check is applying patches from the `.ci/environments/quarkus-3/patches`.

The first patch, called `0001_before_sh.patch`, is generated from Openrewrite `.ci/environments/quarkus-3/quarkus3.yml` recipe. The patch is created to speed up the check. But it may be that some changes in the PR broke this patch.  
No panic, there is an easy way to regenerate it. You just need to comment on the PR:
```
jenkins rewrite quarkus-3
```
and it should, after some minutes (~20/30min) apply a commit on the PR with the patch regenerated.

Other patches were generated manually. If any of it fails, you will need to manually update it... and push your changes.
</details> -->