### PR TITLE
[DROOLS-7526] avoid emitting a misleading warning on a contains mvel expression

### DIFF
--- a/drools-mvel/src/main/java/org/drools/mvel/MVELConstraint.java
+++ b/drools-mvel/src/main/java/org/drools/mvel/MVELConstraint.java
@@ -14,25 +14,6 @@
 
 package org.drools.mvel;
 
-import java.io.Externalizable;
-import java.io.IOException;
-import java.io.ObjectInput;
-import java.io.ObjectOutput;
-import java.lang.reflect.Method;
-import java.lang.reflect.Modifier;
-import java.util.ArrayList;
-import java.util.Collection;
-import java.util.HashMap;
-import java.util.HashSet;
-import java.util.LinkedHashSet;
-import java.util.List;
-import java.util.Map;
-import java.util.Objects;
-import java.util.Optional;
-import java.util.Set;
-import java.util.concurrent.Executor;
-import java.util.concurrent.atomic.AtomicInteger;
-
 import org.drools.base.RuleBase;
 import org.drools.base.RuleBuildContext;
 import org.drools.base.base.DroolsQuery;
@@ -81,6 +62,25 @@ import org.mvel2.compiler.CompiledExpression;
 import org.mvel2.compiler.ExecutableStatement;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+
+import java.io.Externalizable;
+import java.io.IOException;
+import java.io.ObjectInput;
+import java.io.ObjectOutput;
+import java.lang.reflect.Method;
+import java.lang.reflect.Modifier;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.Set;
+import java.util.concurrent.Executor;
+import java.util.concurrent.atomic.AtomicInteger;
 
 import static org.drools.base.reteoo.PropertySpecificUtil.allSetBitMask;
 import static org.drools.base.reteoo.PropertySpecificUtil.allSetButTraitBitMask;
@@ -477,6 +477,11 @@ public class MVELConstraint extends MutableTypeConstraint implements IndexableCo
                 } else {
                     // if it is not able to find the property name it could be a function invocation so property reactivity shouldn't filter anything
                     if (firstProp) {
+                        if (simpleExpression.indexOf(" contains ") > simpleExpression.indexOf(originalPropertyName)) {
+                            // A contains expression could be a rewritten memberOf so give a change also to the part of expression
+                            // after the 'contains' keyword to be analyzed before emitting a warning and consider the constraint as class reactive
+                            continue;
+                        }
                         if (isBoundVariableFromDifferentPattern(originalPropertyName, pattern)) {
                             logger.warn("{} is not relevant to this pattern, so it causes class reactivity." +
                                         " Consider placing this constraint in the original pattern if possible : {}",


### PR DESCRIPTION
**JIRA**: https://issues.redhat.com/browse/DROOLS-7526

I understand this is a sort of a hack, but I didn't find a better alternative. @tkobayas please advice if you can find another solution.