### PR TITLE
[DROOLS-7525] immediately delete a logical assertion

### DIFF
--- a/drools-core/src/main/java/org/drools/core/common/InternalWorkingMemoryEntryPoint.java
+++ b/drools-core/src/main/java/org/drools/core/common/InternalWorkingMemoryEntryPoint.java
@@ -70,12 +70,11 @@ public interface InternalWorkingMemoryEntryPoint extends WorkingMemoryEntryPoint
                               RuleImpl rule,
                               TerminalNode terminalNode);
 
-    PropagationContext delete(InternalFactHandle handle,
-                              Object object,
-                              ObjectTypeConf typeConf,
-                              RuleImpl rule,
-                              TerminalNode terminalNode,
-                              boolean immediate);
+    PropagationContext immediateDelete(InternalFactHandle handle,
+                                       Object object,
+                                       ObjectTypeConf typeConf,
+                                       RuleImpl rule,
+                                       TerminalNode terminalNode);
 
     void removeFromObjectStore(InternalFactHandle handle);
 }

--- a/drools-core/src/main/java/org/drools/core/common/InternalWorkingMemoryEntryPoint.java
+++ b/drools-core/src/main/java/org/drools/core/common/InternalWorkingMemoryEntryPoint.java
@@ -68,14 +68,14 @@ public interface InternalWorkingMemoryEntryPoint extends WorkingMemoryEntryPoint
                               Object object,
                               ObjectTypeConf typeConf,
                               RuleImpl rule,
-                              InternalMatch internalMatch);
+                              TerminalNode terminalNode);
 
     PropagationContext delete(InternalFactHandle handle,
                               Object object,
                               ObjectTypeConf typeConf,
                               RuleImpl rule,
-                              InternalMatch internalMatch,
-                              TerminalNode terminalNode);
+                              TerminalNode terminalNode,
+                              boolean immediate);
 
     void removeFromObjectStore(InternalFactHandle handle);
 }

--- a/drools-core/src/main/java/org/drools/core/phreak/PropagationEntry.java
+++ b/drools-core/src/main/java/org/drools/core/phreak/PropagationEntry.java
@@ -15,14 +15,13 @@
 
 package org.drools.core.phreak;
 
-import java.util.concurrent.CountDownLatch;
-
+import org.drools.base.facttemplates.Event;
+import org.drools.base.reteoo.NodeTypeEnums;
 import org.drools.core.base.DroolsQueryImpl;
 import org.drools.core.common.DefaultEventHandle;
 import org.drools.core.common.InternalFactHandle;
 import org.drools.core.common.PropagationContext;
 import org.drools.core.common.ReteEvaluator;
-import org.drools.base.facttemplates.Event;
 import org.drools.core.impl.WorkingMemoryReteExpireAction;
 import org.drools.core.reteoo.ClassObjectTypeConf;
 import org.drools.core.reteoo.CompositePartitionAwareObjectSinkAdapter;
@@ -30,7 +29,6 @@ import org.drools.core.reteoo.EntryPointNode;
 import org.drools.core.reteoo.LeftInputAdapterNode;
 import org.drools.core.reteoo.LeftTupleSource;
 import org.drools.core.reteoo.ModifyPreviousTuples;
-import org.drools.base.reteoo.NodeTypeEnums;
 import org.drools.core.reteoo.ObjectTypeConf;
 import org.drools.core.reteoo.ObjectTypeNode;
 import org.drools.core.reteoo.PathMemory;
@@ -44,9 +42,10 @@ import java.io.Externalizable;
 import java.io.IOException;
 import java.io.ObjectInput;
 import java.io.ObjectOutput;
+import java.util.concurrent.CountDownLatch;
 
-import static org.drools.core.reteoo.EntryPointNode.removeRightTuplesMatchingOTN;
 import static org.drools.base.rule.TypeDeclaration.NEVER_EXPIRES;
+import static org.drools.core.reteoo.EntryPointNode.removeRightTuplesMatchingOTN;
 
 public interface PropagationEntry {
 
@@ -421,6 +420,10 @@ public interface PropagationEntry {
         }
 
         public void internalExecute(ReteEvaluator reteEvaluator) {
+            execute(reteEvaluator, epn, handle, context, objectTypeConf);
+        }
+
+        public static void execute(ReteEvaluator reteEvaluator, EntryPointNode epn, InternalFactHandle handle, PropagationContext context, ObjectTypeConf objectTypeConf) {
             epn.propagateRetract(handle, context, objectTypeConf, reteEvaluator);
         }
 

--- a/drools-core/src/main/java/org/drools/core/reteoo/EntryPointNode.java
+++ b/drools-core/src/main/java/org/drools/core/reteoo/EntryPointNode.java
@@ -288,15 +288,17 @@ public class EntryPointNode extends ObjectSource implements ObjectSink {
      * @param reteEvaluator
      *            The working memory session.
      */
-    public void retractObject(final InternalFactHandle handle,
-                              final PropagationContext context,
-                              final ObjectTypeConf objectTypeConf,
-                              final ReteEvaluator reteEvaluator) {
+    public void retractObject(InternalFactHandle handle, PropagationContext context,
+                              ObjectTypeConf objectTypeConf, ReteEvaluator reteEvaluator, boolean immediate) {
         if ( log.isTraceEnabled() ) {
             log.trace( "Delete {}", handle.toString()  );
         }
 
-        reteEvaluator.addPropagation(new PropagationEntry.Delete(this, handle, context, objectTypeConf));
+        if (immediate) {
+            PropagationEntry.Delete.execute(reteEvaluator, this, handle, context, objectTypeConf);
+        } else {
+            reteEvaluator.addPropagation(new PropagationEntry.Delete(this, handle, context, objectTypeConf));
+        }
     }
 
     public void propagateRetract(InternalFactHandle handle, PropagationContext context, ObjectTypeConf objectTypeConf, ReteEvaluator reteEvaluator) {

--- a/drools-core/src/main/java/org/drools/core/reteoo/EntryPointNode.java
+++ b/drools-core/src/main/java/org/drools/core/reteoo/EntryPointNode.java
@@ -289,16 +289,21 @@ public class EntryPointNode extends ObjectSource implements ObjectSink {
      *            The working memory session.
      */
     public void retractObject(InternalFactHandle handle, PropagationContext context,
-                              ObjectTypeConf objectTypeConf, ReteEvaluator reteEvaluator, boolean immediate) {
+                              ObjectTypeConf objectTypeConf, ReteEvaluator reteEvaluator) {
         if ( log.isTraceEnabled() ) {
             log.trace( "Delete {}", handle.toString()  );
         }
 
-        if (immediate) {
-            PropagationEntry.Delete.execute(reteEvaluator, this, handle, context, objectTypeConf);
-        } else {
-            reteEvaluator.addPropagation(new PropagationEntry.Delete(this, handle, context, objectTypeConf));
+        reteEvaluator.addPropagation(new PropagationEntry.Delete(this, handle, context, objectTypeConf));
+    }
+
+    public void immediateDeleteObject(InternalFactHandle handle, PropagationContext context,
+                                      ObjectTypeConf objectTypeConf, ReteEvaluator reteEvaluator) {
+        if ( log.isTraceEnabled() ) {
+            log.trace( "Delete {}", handle.toString()  );
         }
+
+        PropagationEntry.Delete.execute(reteEvaluator, this, handle, context, objectTypeConf);
     }
 
     public void propagateRetract(InternalFactHandle handle, PropagationContext context, ObjectTypeConf objectTypeConf, ReteEvaluator reteEvaluator) {

--- a/drools-core/src/main/java/org/drools/core/reteoo/Rete.java
+++ b/drools-core/src/main/java/org/drools/core/reteoo/Rete.java
@@ -119,7 +119,7 @@ public class Rete extends ObjectSource implements ObjectSink {
         EntryPointNode node = this.entryPoints.get( entryPoint );
         ObjectTypeConf typeConf = reteEvaluator.getEntryPoint( entryPoint.getEntryPointId() )
                 .getObjectTypeConfigurationRegistry().getObjectTypeConf( handle.getObject() );
-        node.retractObject( handle, context, typeConf, reteEvaluator );
+        node.retractObject( handle, context, typeConf, reteEvaluator, false );
     }
     
     public void modifyObject(final InternalFactHandle factHandle,

--- a/drools-core/src/main/java/org/drools/core/reteoo/Rete.java
+++ b/drools-core/src/main/java/org/drools/core/reteoo/Rete.java
@@ -119,7 +119,7 @@ public class Rete extends ObjectSource implements ObjectSink {
         EntryPointNode node = this.entryPoints.get( entryPoint );
         ObjectTypeConf typeConf = reteEvaluator.getEntryPoint( entryPoint.getEntryPointId() )
                 .getObjectTypeConfigurationRegistry().getObjectTypeConf( handle.getObject() );
-        node.retractObject( handle, context, typeConf, reteEvaluator, false );
+        node.retractObject( handle, context, typeConf, reteEvaluator );
     }
     
     public void modifyObject(final InternalFactHandle factHandle,

--- a/drools-kiesession/src/main/java/org/drools/kiesession/entrypoints/NamedEntryPoint.java
+++ b/drools-kiesession/src/main/java/org/drools/kiesession/entrypoints/NamedEntryPoint.java
@@ -508,12 +508,20 @@ public class NamedEntryPoint implements InternalWorkingMemoryEntryPoint, Propert
     }
 
     @Override
-    public PropagationContext delete(InternalFactHandle handle, Object object, ObjectTypeConf typeConf, RuleImpl rule, TerminalNode terminalNode, boolean immediate) {
+    public PropagationContext immediateDelete(InternalFactHandle handle, Object object, ObjectTypeConf typeConf, RuleImpl rule, TerminalNode terminalNode) {
+        return delete(handle, object, typeConf, rule, terminalNode, true);
+    }
+
+    private PropagationContext delete(InternalFactHandle handle, Object object, ObjectTypeConf typeConf, RuleImpl rule, TerminalNode terminalNode, boolean immediate) {
         final PropagationContext propagationContext = pctxFactory.createPropagationContext( this.reteEvaluator.getNextPropagationIdCounter(), PropagationContext.Type.DELETION,
                 rule, terminalNode,
                 handle, this.entryPoint );
 
-        this.entryPointNode.retractObject( handle, propagationContext, typeConf, this.reteEvaluator, immediate );
+        if (immediate) {
+            this.entryPointNode.immediateDeleteObject( handle, propagationContext, typeConf, this.reteEvaluator );
+        } else {
+            this.entryPointNode.retractObject( handle, propagationContext, typeConf, this.reteEvaluator );
+        }
 
         afterRetract(handle, rule, terminalNode);
 

--- a/drools-kiesession/src/main/java/org/drools/kiesession/entrypoints/NamedEntryPoint.java
+++ b/drools-kiesession/src/main/java/org/drools/kiesession/entrypoints/NamedEntryPoint.java
@@ -479,7 +479,7 @@ public class NamedEntryPoint implements InternalWorkingMemoryEntryPoint, Propert
             removePropertyChangeListener( handle, true );
         }
 
-        PropagationContext propagationContext = delete( handle, object, typeConf, rule, null, terminalNode );
+        PropagationContext propagationContext = delete( handle, object, typeConf, rule, terminalNode );
 
         deleteFromTMS( handle, key, typeConf, propagationContext );
 
@@ -502,16 +502,18 @@ public class NamedEntryPoint implements InternalWorkingMemoryEntryPoint, Propert
         }
     }
 
-    public PropagationContext delete(InternalFactHandle handle, Object object, ObjectTypeConf typeConf, RuleImpl rule, InternalMatch internalMatch) {
-        return delete(handle, object, typeConf, rule, internalMatch, internalMatch == null ? null : internalMatch.getTuple().getTupleSink());
+    @Override
+    public PropagationContext delete(InternalFactHandle handle, Object object, ObjectTypeConf typeConf, RuleImpl rule, TerminalNode terminalNode) {
+        return delete(handle, object, typeConf, rule, terminalNode, false);
     }
 
-    public PropagationContext delete(InternalFactHandle handle, Object object, ObjectTypeConf typeConf, RuleImpl rule, InternalMatch internalMatch, TerminalNode terminalNode) {
+    @Override
+    public PropagationContext delete(InternalFactHandle handle, Object object, ObjectTypeConf typeConf, RuleImpl rule, TerminalNode terminalNode, boolean immediate) {
         final PropagationContext propagationContext = pctxFactory.createPropagationContext( this.reteEvaluator.getNextPropagationIdCounter(), PropagationContext.Type.DELETION,
                 rule, terminalNode,
                 handle, this.entryPoint );
 
-        this.entryPointNode.retractObject( handle, propagationContext, typeConf, this.reteEvaluator );
+        this.entryPointNode.retractObject( handle, propagationContext, typeConf, this.reteEvaluator, immediate );
 
         afterRetract(handle, rule, terminalNode);
 

--- a/drools-tms/src/main/java/org/drools/tms/beliefsystem/jtms/JTMSBeliefSystem.java
+++ b/drools-tms/src/main/java/org/drools/tms/beliefsystem/jtms/JTMSBeliefSystem.java
@@ -141,7 +141,7 @@ public class JTMSBeliefSystem<M extends JTMSMode<M>>
         if ( beliefSet.isEmpty() && fh.getEqualityKey().getStatus() == EqualityKey.JUSTIFIED ) {
             // the set is empty, so delete form the EP, so things are cleaned up.
             ep.delete(fh, fh.getObject(), getObjectTypeConf(beliefSet), context.getRuleOrigin(),
-                      null, internalMatch != null ? internalMatch.getTuple().getTupleSink() : null);
+                      internalMatch != null ? internalMatch.getTuple().getTupleSink() : null);
         } else  if ( !(processBeliefSet(rule, internalMatch, payload, context, jtmsBeliefSet, wasDecided, wasNegated, fh) && beliefSet.isEmpty())  ) {
             //  The state of the BS did not change, but maybe the prime did
             if ( fh.getObject() == payload ) {
@@ -207,7 +207,7 @@ public class JTMSBeliefSystem<M extends JTMSMode<M>>
 
             // was decided, now is not, so must be removed from the network. Leave in EP though, we only delete from that when the set is empty
             ep.delete(fh, fh.getObject(), getObjectTypeConf(jtmsBeliefSet), pctx.getRuleOrigin(),
-                      null, internalMatch != null ? internalMatch.getTuple().getTupleSink() : null);
+                      internalMatch != null ? internalMatch.getTuple().getTupleSink() : null);
             return true;
         } else if (wasNegated != jtmsBeliefSet.isNegated()) {
             // was decided, still is decided by the negation changed. This must be propagated through the engine

--- a/drools-tms/src/main/java/org/drools/tms/beliefsystem/simple/BeliefSystemLogicalCallback.java
+++ b/drools-tms/src/main/java/org/drools/tms/beliefsystem/simple/BeliefSystemLogicalCallback.java
@@ -94,7 +94,7 @@ public class BeliefSystemLogicalCallback extends PropagationEntry.AbstractPropag
                 nep.delete( this.handle, context.getRuleOrigin(), this.internalMatch.getTuple().getTupleSink());
             } else {
                 ObjectTypeConf typeConf = nep.getObjectTypeConfigurationRegistry().getOrCreateObjectTypeConf( nep.getEntryPoint(), handle.getObject() );
-                nep.getEntryPointNode().retractObject( handle, context, typeConf, reteEvaluator, true );
+                nep.getEntryPointNode().immediateDeleteObject( handle, context, typeConf, reteEvaluator );
             }
         }
     }

--- a/drools-tms/src/main/java/org/drools/tms/beliefsystem/simple/BeliefSystemLogicalCallback.java
+++ b/drools-tms/src/main/java/org/drools/tms/beliefsystem/simple/BeliefSystemLogicalCallback.java
@@ -15,19 +15,19 @@
 
 package org.drools.tms.beliefsystem.simple;
 
-import java.io.IOException;
-
-import org.drools.core.rule.consequence.InternalMatch;
-import org.drools.tms.TruthMaintenanceSystemEqualityKey;
-import org.drools.tms.beliefsystem.BeliefSet;
 import org.drools.core.common.InternalFactHandle;
-import org.drools.kiesession.entrypoints.NamedEntryPoint;
+import org.drools.core.common.PropagationContext;
 import org.drools.core.common.ReteEvaluator;
 import org.drools.core.common.WorkingMemoryAction;
 import org.drools.core.marshalling.MarshallerReaderContext;
 import org.drools.core.phreak.PropagationEntry;
 import org.drools.core.reteoo.ObjectTypeConf;
-import org.drools.core.common.PropagationContext;
+import org.drools.core.rule.consequence.InternalMatch;
+import org.drools.kiesession.entrypoints.NamedEntryPoint;
+import org.drools.tms.TruthMaintenanceSystemEqualityKey;
+import org.drools.tms.beliefsystem.BeliefSet;
+
+import java.io.IOException;
 
 import static org.drools.base.reteoo.PropertySpecificUtil.allSetButTraitBitMask;
 
@@ -94,7 +94,7 @@ public class BeliefSystemLogicalCallback extends PropagationEntry.AbstractPropag
                 nep.delete( this.handle, context.getRuleOrigin(), this.internalMatch.getTuple().getTupleSink());
             } else {
                 ObjectTypeConf typeConf = nep.getObjectTypeConfigurationRegistry().getOrCreateObjectTypeConf( nep.getEntryPoint(), handle.getObject() );
-                nep.getEntryPointNode().retractObject( handle, context, typeConf, reteEvaluator );
+                nep.getEntryPointNode().retractObject( handle, context, typeConf, reteEvaluator, true );
             }
         }
     }

--- a/drools-tms/src/main/java/org/drools/tms/beliefsystem/simple/SimpleBeliefSystem.java
+++ b/drools-tms/src/main/java/org/drools/tms/beliefsystem/simple/SimpleBeliefSystem.java
@@ -125,7 +125,7 @@ public class SimpleBeliefSystem
 
         if ( beliefSet.isEmpty() && bfh.getEqualityKey() != null && bfh.getEqualityKey().getStatus() == EqualityKey.JUSTIFIED ) {
             ep.delete(bfh, bfh.getObject(), getObjectTypeConf(beliefSet), context.getRuleOrigin(),
-                      null, internalMatch != null ? internalMatch.getTuple().getTupleSink() : null);
+                      internalMatch != null ? internalMatch.getTuple().getTupleSink() : null, true);
         } else if ( !beliefSet.isEmpty() && bfh.getObject() == payload && payload != bfh.getObject() ) {
             // prime has changed, to update new object
             // Equality might have changed on the object, so remove (which uses the handle id) and add back in
@@ -151,7 +151,7 @@ public class SimpleBeliefSystem
                       BeliefSet<SimpleMode> beliefSet) {
         InternalFactHandle bfh = beliefSet.getFactHandle();
         // Remove the FH from the network
-        ep.delete(bfh, bfh.getObject(), getObjectTypeConf(beliefSet), context.getRuleOrigin(), null);
+        ep.delete(bfh, bfh.getObject(), getObjectTypeConf(beliefSet), context.getRuleOrigin(), null, true);
 
         bfh.getEqualityKey().setStatus( EqualityKey.STATED ); // revert to stated
     }

--- a/drools-tms/src/main/java/org/drools/tms/beliefsystem/simple/SimpleBeliefSystem.java
+++ b/drools-tms/src/main/java/org/drools/tms/beliefsystem/simple/SimpleBeliefSystem.java
@@ -124,8 +124,8 @@ public class SimpleBeliefSystem
         InternalFactHandle bfh = beliefSet.getFactHandle();
 
         if ( beliefSet.isEmpty() && bfh.getEqualityKey() != null && bfh.getEqualityKey().getStatus() == EqualityKey.JUSTIFIED ) {
-            ep.delete(bfh, bfh.getObject(), getObjectTypeConf(beliefSet), context.getRuleOrigin(),
-                      internalMatch != null ? internalMatch.getTuple().getTupleSink() : null, true);
+            ep.immediateDelete(bfh, bfh.getObject(), getObjectTypeConf(beliefSet), context.getRuleOrigin(),
+                               internalMatch != null ? internalMatch.getTuple().getTupleSink() : null);
         } else if ( !beliefSet.isEmpty() && bfh.getObject() == payload && payload != bfh.getObject() ) {
             // prime has changed, to update new object
             // Equality might have changed on the object, so remove (which uses the handle id) and add back in
@@ -151,7 +151,7 @@ public class SimpleBeliefSystem
                       BeliefSet<SimpleMode> beliefSet) {
         InternalFactHandle bfh = beliefSet.getFactHandle();
         // Remove the FH from the network
-        ep.delete(bfh, bfh.getObject(), getObjectTypeConf(beliefSet), context.getRuleOrigin(), null, true);
+        ep.immediateDelete(bfh, bfh.getObject(), getObjectTypeConf(beliefSet), context.getRuleOrigin(), null);
 
         bfh.getEqualityKey().setStatus( EqualityKey.STATED ); // revert to stated
     }


### PR DESCRIPTION
**JIRA**: https://issues.redhat.com/browse/DROOLS-7525

The deletion of a logical inserted object should be always executed and made effective immediately instead of being enqueued on the propagation list. This is also safe because it can only happen during the deletion of another object (the logical justifier).