### PR TITLE
[9.x-dsl-config] Quarkus 3: Enable `kie-jpmml-integration` nightly

### DIFF
--- a/.ci/jenkins/config/branch.yaml
+++ b/.ci/jenkins/config/branch.yaml
@@ -68,6 +68,8 @@ disable:
 repositories:
 - name: drools
   branch: 9.x
+- name: kie-jpmml-integration
+  branch: 9.x
 productized_repositories:
 - name: drools
 git:


### PR DESCRIPTION
Related:
- https://github.com/kiegroup/kie-jpmml-integration/pull/88
- https://github.com/kiegroup/kogito-pipelines/pull/1055
- https://github.com/kiegroup/drools/pull/5488
- https://github.com/kiegroup/drools/pull/5490