### PR TITLE
[DROOLS-7534] implement collect on custom Collection classes in executable model

### DIFF
--- a/drools-model/drools-model-codegen/src/main/java/org/drools/model/codegen/execmodel/generator/visitor/FromCollectVisitor.java
+++ b/drools-model/drools-model-codegen/src/main/java/org/drools/model/codegen/execmodel/generator/visitor/FromCollectVisitor.java
@@ -24,28 +24,46 @@ import org.drools.drl.ast.descr.PatternDescr;
 
 public class FromCollectVisitor {
 
+    public static final String GENERIC_COLLECT = "genericCollect";
+
     private final ModelGeneratorVisitor parentVisitor;
 
     public FromCollectVisitor(ModelGeneratorVisitor parentVisitor) {
         this.parentVisitor = parentVisitor;
     }
 
-    public void trasformFromCollectToCollectList(PatternDescr pattern, CollectDescr collectDescr) {
+    public void transformFromCollectToCollectList(PatternDescr pattern, CollectDescr collectDescr) {
         // The inner pattern of the "from collect" needs to be processed to have the binding
         final PatternDescr collectDescrInputPattern = collectDescr.getInputPattern();
         if (!parentVisitor.initPattern( collectDescrInputPattern )) {
             return;
         }
 
+        String collectTarget = pattern.getObjectType();
+
         final AccumulateDescr accumulateDescr = new AccumulateDescr();
         accumulateDescr.setInputPattern(collectDescrInputPattern);
-        accumulateDescr.addFunction("collectList", null, false, new String[]{collectDescrInputPattern.getIdentifier()});
+        accumulateDescr.addFunction(getCollectFunction(collectTarget), null, false, new String[]{collectDescrInputPattern.getIdentifier()});
 
-        final PatternDescr transformedPatternDescr = new PatternDescr(pattern.getObjectType(), pattern.getIdentifier());
+        final PatternDescr transformedPatternDescr = new PatternDescr(collectTarget, pattern.getIdentifier());
         for (BaseDescr o : pattern.getConstraint().getDescrs()) {
             transformedPatternDescr.addConstraint(o);
         }
         transformedPatternDescr.setSource(accumulateDescr);
         transformedPatternDescr.accept(parentVisitor);
+    }
+
+    private static String getCollectFunction(String collectTarget) {
+        switch (collectTarget) {
+            case "Collection":
+            case "java.util.Collection":
+            case "List":
+            case "java.util.List":
+                return "collectList";
+            case "Set":
+            case "java.util.Set":
+                return "collectSet";
+            default: return GENERIC_COLLECT;
+        }
     }
 }

--- a/drools-model/drools-model-codegen/src/main/java/org/drools/model/codegen/execmodel/generator/visitor/ModelGeneratorVisitor.java
+++ b/drools-model/drools-model-codegen/src/main/java/org/drools/model/codegen/execmodel/generator/visitor/ModelGeneratorVisitor.java
@@ -113,7 +113,7 @@ public class ModelGeneratorVisitor implements DescrVisitor {
     public void visit(PatternDescr descr) {
         final PatternSourceDescr patternSource = descr.getSource();
         if (patternSource instanceof CollectDescr) {
-            new FromCollectVisitor(this).trasformFromCollectToCollectList(descr, (CollectDescr) patternSource);
+            new FromCollectVisitor(this).transformFromCollectToCollectList(descr, (CollectDescr) patternSource);
         } else if (patternSource instanceof GroupByDescr) {
             new GroupByVisitor(this, context, packageModel).visit((GroupByDescr) patternSource, descr);
             new PatternVisitor(context, packageModel).visit(descr).buildPattern();

--- a/drools-model/drools-model-codegen/src/main/java/org/drools/model/codegen/execmodel/generator/visitor/accumulate/AccumulateVisitor.java
+++ b/drools-model/drools-model-codegen/src/main/java/org/drools/model/codegen/execmodel/generator/visitor/accumulate/AccumulateVisitor.java
@@ -17,15 +17,6 @@
 
 package org.drools.model.codegen.execmodel.generator.visitor.accumulate;
 
-import java.util.ArrayList;
-import java.util.Collection;
-import java.util.Collections;
-import java.util.HashSet;
-import java.util.List;
-import java.util.Objects;
-import java.util.Optional;
-import java.util.Set;
-
 import com.github.javaparser.ast.Node;
 import com.github.javaparser.ast.NodeList;
 import com.github.javaparser.ast.body.Parameter;
@@ -36,17 +27,20 @@ import com.github.javaparser.ast.expr.LiteralExpr;
 import com.github.javaparser.ast.expr.MethodCallExpr;
 import com.github.javaparser.ast.expr.MethodReferenceExpr;
 import com.github.javaparser.ast.expr.NameExpr;
+import com.github.javaparser.ast.expr.ObjectCreationExpr;
+import com.github.javaparser.ast.expr.StringLiteralExpr;
 import com.github.javaparser.ast.stmt.BlockStmt;
 import com.github.javaparser.ast.stmt.ExpressionStmt;
-import org.drools.drl.ast.descr.AccumulateDescr;
-import org.drools.drl.ast.descr.AndDescr;
-import org.drools.drl.ast.descr.BaseDescr;
-import org.drools.drl.ast.descr.PatternDescr;
+import com.github.javaparser.ast.type.ClassOrInterfaceType;
+import org.drools.base.rule.Pattern;
 import org.drools.compiler.rule.builder.util.AccumulateUtil;
 import org.drools.core.base.accumulators.CollectAccumulator;
 import org.drools.core.base.accumulators.CollectListAccumulateFunction;
 import org.drools.core.base.accumulators.CollectSetAccumulateFunction;
-import org.drools.base.rule.Pattern;
+import org.drools.drl.ast.descr.AccumulateDescr;
+import org.drools.drl.ast.descr.AndDescr;
+import org.drools.drl.ast.descr.BaseDescr;
+import org.drools.drl.ast.descr.PatternDescr;
 import org.drools.model.codegen.execmodel.PackageModel;
 import org.drools.model.codegen.execmodel.errors.InvalidExpressionErrorResult;
 import org.drools.model.codegen.execmodel.generator.DeclarationSpec;
@@ -65,23 +59,33 @@ import org.drools.model.codegen.execmodel.generator.expressiontyper.ExpressionTy
 import org.drools.model.codegen.execmodel.generator.expressiontyper.ExpressionTyperContext;
 import org.drools.model.codegen.execmodel.generator.visitor.ModelGeneratorVisitor;
 import org.drools.model.codegen.execmodel.util.LambdaUtil;
+import org.drools.modelcompiler.constraints.GenericCollectAccumulator;
 import org.drools.mvel.parser.ast.expr.DrlNameExpr;
 import org.kie.api.runtime.rule.AccumulateFunction;
 import org.kie.internal.builder.conf.AccumulateFunctionOption;
 
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.Set;
+
 import static java.util.Optional.ofNullable;
 import static java.util.stream.Collectors.toList;
-
 import static org.drools.model.codegen.execmodel.generator.DrlxParseUtil.getLiteralExpressionType;
 import static org.drools.model.codegen.execmodel.generator.DrlxParseUtil.validateDuplicateBindings;
 import static org.drools.model.codegen.execmodel.generator.DslMethodNames.ACCUMULATE_CALL;
 import static org.drools.model.codegen.execmodel.generator.DslMethodNames.ACC_FUNCTION_CALL;
 import static org.drools.model.codegen.execmodel.generator.DslMethodNames.AND_CALL;
-import static org.drools.model.codegen.execmodel.generator.DslMethodNames.BIND_CALL;
 import static org.drools.model.codegen.execmodel.generator.DslMethodNames.BIND_AS_CALL;
-import static org.drools.model.codegen.execmodel.generator.DslMethodNames.VALUE_OF_CALL;
+import static org.drools.model.codegen.execmodel.generator.DslMethodNames.BIND_CALL;
 import static org.drools.model.codegen.execmodel.generator.DslMethodNames.REACT_ON_CALL;
+import static org.drools.model.codegen.execmodel.generator.DslMethodNames.VALUE_OF_CALL;
 import static org.drools.model.codegen.execmodel.generator.DslMethodNames.createDslTopLevelMethod;
+import static org.drools.model.codegen.execmodel.generator.visitor.FromCollectVisitor.GENERIC_COLLECT;
 import static org.drools.model.codegen.execmodel.util.lambdareplace.ReplaceTypeInLambda.replaceTypeInExprLambdaAndIndex;
 import static org.drools.mvel.parser.printer.PrintUtil.printNode;
 
@@ -228,7 +232,7 @@ public class AccumulateVisitor {
         functionDSL.addArgument(createAccSupplierExpr(accumulateFunction));
         functionDSL.addArgument(createDslTopLevelMethod(VALUE_OF_CALL, NodeList.nodeList(accumulateFunctionParameter)));
 
-        addBindingAsDeclaration(context, bindingId, accumulateFunction);
+        addBindingAsDeclaration(context, bindingId, accumulateFunction.getResultType());
     }
 
     private void nameExprParameter(PatternDescr basePattern, AccumulateDescr.AccumulateFunctionCallDescr function, MethodCallExpr functionDSL, String bindingId, Expression accumulateFunctionParameter) {
@@ -244,13 +248,22 @@ public class AccumulateVisitor {
             }
         }
 
-        AccumulateFunction accumulateFunction = getAccumulateFunction(function, declaration.get().getDeclarationClass());
+        DeclarationSpec decSpec = declaration.get();
+        String accumulateFunctionName = AccumulateUtil.getFunctionName(() -> decSpec.getDeclarationClass(), function.getFunction());
+        if (GENERIC_COLLECT.equals(accumulateFunctionName)) {
+            String collectorType = basePattern.getObjectType();
+            MethodReferenceExpr collectorSupplierExpr = new MethodReferenceExpr(new NameExpr(collectorType), new NodeList<>(), "new");
+            ObjectCreationExpr accumulatorConstructor = new ObjectCreationExpr(null, new ClassOrInterfaceType(null, GenericCollectAccumulator.class.getCanonicalName()), NodeList.nodeList(collectorSupplierExpr));
+            functionDSL.addArgument(new LambdaExpr(new NodeList<>(), accumulatorConstructor));
+            functionDSL.addArgument(context.getVarExpr(nameExpr));
+            return;
+        }
 
+        AccumulateFunction accumulateFunction = getAccumulateFunction(accumulateFunctionName, function);
         validateAccFunctionTypeAgainstPatternType(context, basePattern, accumulateFunction);
         functionDSL.addArgument(createAccSupplierExpr(accumulateFunction));
         functionDSL.addArgument(context.getVarExpr(nameExpr));
-
-        addBindingAsDeclaration(context, bindingId, accumulateFunction);
+        addBindingAsDeclaration(context, bindingId, accumulateFunction.getResultType());
     }
 
     private Optional<NewBinding> methodCallExprParameter(PatternDescr basePattern, BaseDescr input, AccumulateDescr.AccumulateFunctionCallDescr function, MethodCallExpr functionDSL, String bindingId, Expression accumulateFunctionParameter) {
@@ -470,9 +483,8 @@ public class AccumulateVisitor {
         context.addCompilationError(new InvalidExpressionErrorResult(String.format("Unknown accumulate function: '%s' on rule '%s'.", function.getFunction(), context.getRuleDescr().getName()), Optional.of(context.getRuleDescr())));
     }
 
-    private void addBindingAsDeclaration(RuleContext context, String bindingId, AccumulateFunction accumulateFunction) {
+    private void addBindingAsDeclaration(RuleContext context, String bindingId, Class accumulateFunctionResultType) {
         if (bindingId != null) {
-            Class accumulateFunctionResultType = accumulateFunction.getResultType();
             context.addDeclarationReplacing(new DeclarationSpec(bindingId, accumulateFunctionResultType));
             if (context.getExpressions().size() > 1) {
                 // replace the type of the lambda with the one resulting from the accumulate operation only in the pattern immediately before it
@@ -483,6 +495,10 @@ public class AccumulateVisitor {
 
     private AccumulateFunction getAccumulateFunction(AccumulateDescr.AccumulateFunctionCallDescr function, Class<?> methodCallExprType) {
         final String accumulateFunctionName = AccumulateUtil.getFunctionName(() -> methodCallExprType, function.getFunction());
+        return getAccumulateFunction(accumulateFunctionName, function);
+    }
+
+    private AccumulateFunction getAccumulateFunction(String accumulateFunctionName, AccumulateDescr.AccumulateFunctionCallDescr function) {
         final Optional<AccumulateFunction> bundledAccumulateFunction = ofNullable(packageModel.getConfiguration().getOption(AccumulateFunctionOption.KEY, accumulateFunctionName).getFunction());
         final Optional<AccumulateFunction> importedAccumulateFunction = ofNullable(packageModel.getAccumulateFunctions().get(accumulateFunctionName));
 

--- a/drools-model/drools-model-codegen/src/test/java/org/drools/model/codegen/execmodel/FromTest.java
+++ b/drools-model/drools-model-codegen/src/test/java/org/drools/model/codegen/execmodel/FromTest.java
@@ -16,20 +16,6 @@
 
 package org.drools.model.codegen.execmodel;
 
-import java.util.AbstractMap;
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.Collection;
-import java.util.Collections;
-import java.util.HashMap;
-import java.util.HashSet;
-import java.util.List;
-import java.util.Map;
-import java.util.Objects;
-import java.util.Optional;
-import java.util.Set;
-import java.util.concurrent.atomic.AtomicInteger;
-
 import org.drools.model.codegen.execmodel.FunctionsTest.Pojo;
 import org.drools.model.codegen.execmodel.domain.Address;
 import org.drools.model.codegen.execmodel.domain.Adult;
@@ -47,6 +33,20 @@ import org.kie.api.builder.model.KieModuleModel;
 import org.kie.api.runtime.KieSession;
 import org.kie.api.runtime.rule.FactHandle;
 import org.kie.internal.builder.conf.PropertySpecificOption;
+
+import java.util.AbstractMap;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.Set;
+import java.util.concurrent.atomic.AtomicInteger;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -710,6 +710,47 @@ public class FromTest extends BaseModelTest {
         ksession.insert(p3);
 
         assertThat(ksession.fireAllRules()).isEqualTo(1);
+    }
+
+    @Test
+    public void testFromCollectCustomSet() {
+        // DROOLS-7534
+        String str =
+                "package org.drools.compiler.test  \n" +
+                     "import " + Person.class.getCanonicalName() + "\n" +
+                     "import " + MyHashSet.class.getCanonicalName() + "\n" +
+                     "import " + FromTest.class.getCanonicalName() + "\n" +
+                     "rule R\n" +
+                     "when\n" +
+                     "    $set : MyHashSet (size == 2) from collect (Person (age >= 30))\n" +
+                     "then\n" +
+                     "    FromTest.printPersons($set);" +
+                     "end \n";
+
+        KieSession ksession = getKieSession(str);
+
+        Person p1 = new Person("John", 32);
+        Person p1a = new Person("John", 32);
+        Person p2 = new Person("Paul", 30);
+        Person p3 = new Person("George", 29);
+
+        ksession.insert(p1);
+        ksession.insert(p1a);
+        ksession.insert(p2);
+        ksession.insert(p3);
+
+        assertThat(ksession.fireAllRules()).isEqualTo(1);
+    }
+
+    public static void printPersons(MyHashSet<Person> persons) {
+        System.out.println("persons found: " + persons);
+    }
+
+    public static class MyHashSet<T> extends HashSet<T> {
+
+        public MyHashSet() {
+            super();
+        }
     }
 
     @Test

--- a/drools-model/drools-model-compiler/src/main/java/org/drools/modelcompiler/constraints/GenericCollectAccumulator.java
+++ b/drools-model/drools-model-compiler/src/main/java/org/drools/modelcompiler/constraints/GenericCollectAccumulator.java
@@ -1,0 +1,97 @@
+/*
+ * Copyright 2019 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ *
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.drools.modelcompiler.constraints;
+
+import org.drools.base.base.ValueResolver;
+import org.drools.base.reteoo.BaseTuple;
+import org.drools.base.rule.Declaration;
+import org.drools.base.rule.accessor.Accumulator;
+import org.kie.api.runtime.rule.FactHandle;
+
+import java.util.Collection;
+import java.util.function.Supplier;
+
+public class GenericCollectAccumulator implements Accumulator {
+
+    private final Supplier<? extends Collection> collectTargetSupplier;
+
+    public GenericCollectAccumulator(Supplier<? extends Collection> collectTargetSupplier) {
+        this.collectTargetSupplier = collectTargetSupplier;
+    }
+
+    @Override
+    public Object createContext() {
+        return null;
+    }
+
+
+    @Override
+    public Object init(Object workingMemoryContext,
+                       Object context,
+                       BaseTuple leftTuple,
+                       Declaration[] declarations,
+                       ValueResolver valueResolver) {
+        return collectTargetSupplier.get();
+    }
+
+    @Override
+    public Object accumulate(Object workingMemoryContext,
+                             Object context,
+                             BaseTuple leftTuple,
+                             FactHandle handle,
+                             Declaration[] declarations,
+                             Declaration[] innerDeclarations,
+                             ValueResolver valueResolver) {
+        Object value = handle.getObject();
+        ((Collection) context).add( value );
+        return value;
+    }
+
+    @Override
+    public boolean tryReverse(Object workingMemoryContext,
+                              Object context,
+                              BaseTuple leftTuple,
+                              FactHandle handle,
+                              Object value,
+                              Declaration[] declarations,
+                              Declaration[] innerDeclarations,
+                              ValueResolver valueResolver) {
+        ((Collection) context).remove( value );
+        return true;
+    }
+
+    @Override
+    public Object getResult(Object workingMemoryContext,
+                            Object context,
+                            BaseTuple leftTuple,
+                            Declaration[] declarations,
+                            ValueResolver valueResolver) {
+        return context;
+    }
+
+    @Override
+    public boolean supportsReverse() {
+        return true;
+    }
+
+    @Override
+    public Object createWorkingMemoryContext() {
+        // no working memory context needed
+        return null;
+    }
+}


### PR DESCRIPTION
**JIRA**: https://issues.redhat.com/browse/DROOLS-7534

This pull request implements a feature that was totally missing in the executable model. See https://docs.drools.org/8.42.0.Final/drools-docs/drools/language-reference/index.html#con-drl-legacy_drl-rules where, in the `collect` section, it says: "The result pattern of the collect element can be any concrete class that implements the java.util.Collection interface and provides a default no-arg public constructor."