### PR TITLE
[drools-9.42.x] DSL triggers disabled

### DIFF
--- a/.ci/jenkins/config/branch.yaml
+++ b/.ci/jenkins/config/branch.yaml
@@ -55,7 +55,7 @@ environments:
     - coverage
 productized_branch: false
 disable:
-  triggers: false
+  triggers: true
 repositories:
 - name: drools
   branch: 9.42.x


### PR DESCRIPTION
Generated by https://eng-jenkins-csb-business-automation.apps.ocp-c1.prod.psi.redhat.com/job/KIE/job/drools-9.x/job/9.42.x/job/tools/job/toggle-dsl-triggers/1/