### PR TITLE
PR multibranchPipelineJob

### DIFF
--- a/.ci/jenkins/dsl/jobs.groovy
+++ b/.ci/jenkins/dsl/jobs.groovy
@@ -182,8 +182,7 @@ Map getMultijobPRConfig(JenkinsFolder jobFolder) {
 }
 
 // PR checks
-// TODO create PR job with branch source plugin
-// KogitoJobUtils.createAllEnvironmentsPerRepoPRJobs(this) { jobFolder -> getMultijobPRConfig(jobFolder) }
+Utils.isMainBranch(this) && KogitoJobTemplate.createPullRequestMultibranchPipelineJob(this, "${jenkins_path}/Jenkinsfile")
 
 // Init branch
 createSetupBranchJob()


### PR DESCRIPTION
Enabling a simplified PR check, which repeatedly (each 5 minutes) polls for new PRs coming from both the origin itself and forks.

Full ensemble:
https://github.com/kiegroup/kogito-runtimes/pull/3224
https://github.com/kiegroup/kogito-apps/pull/1879
https://github.com/kiegroup/kogito-examples/pull/1808
https://github.com/kiegroup/drools/pull/5523
https://github.com/kiegroup/kogito-images/pull/1700
https://github.com/kiegroup/optaplanner-quickstarts/pull/602
https://github.com/apache/incubator-kie-optaplanner/pull/2975