### PR TITLE
still use apache_migration branch in apache

### DIFF
--- a/.ci/jenkins/config/branch.yaml
+++ b/.ci/jenkins/config/branch.yaml
@@ -52,8 +52,6 @@ repositories:
 #   job_display_name: drools-website
 - name: incubator-kie-kie-benchmarks
   job_display_name: kie-benchmarks
-  author:
-    name: radtriste # TODO set back. Could not push to kiegroup
 ## TODO to check if should be enabled
 # - name: incubator-kie-kie-jpmml-integration
 #   job_display_name: kie-jpmml-integration

--- a/.ci/jenkins/config/main.yaml
+++ b/.ci/jenkins/config/main.yaml
@@ -15,7 +15,7 @@ ecosystem:
     - incubator-kie-kie-benchmarks.*
 git:
   branches:
-  - name: main
+  - name: apache_migration
     main_branch: true
 seed:
   config_file:
@@ -23,8 +23,8 @@ seed:
       repository: incubator-kie-drools
       author:
         name: apache
-        credentials_id: kie-ci4
-      branch: main
+        credentials_id: ASF_Cloudbees_Jenkins_ci-builds
+      branch: apache_migration
     path: .ci/jenkins/config/branch.yaml
   jenkinsfile: dsl/seed/jenkinsfiles/Jenkinsfile.seed.branch
 jenkins:


### PR DESCRIPTION
Keep using apache_migration as main branch as long as we're on apache_migration with these changes.