### PR TITLE
kie-issues#593: switch to compile downstream in Jenkins

### DIFF
--- a/.ci/buildchain-config-pr-cdb.yaml
+++ b/.ci/buildchain-config-pr-cdb.yaml
@@ -1,0 +1,85 @@
+version: "2.1"
+
+dependencies: ./buildchain-project-dependencies.yaml
+
+pre: |
+  export BUILD_MVN_OPTS="${{ env.BUILD_MVN_OPTS }} -nsu -ntp -fae -e -Dhttp.keepAlive=false -Dmaven.wagon.http.pool=false -Dmaven.wagon.httpconnectionManager.ttlSeconds=120 -Dmaven.wagon.http.retryHandler.count=3"
+  echo "BUILD_MVN_OPTS=${{ env.BUILD_MVN_OPTS }}"
+  export BUILD_MVN_OPTS_CURRENT="${{ env.BUILD_MVN_OPTS_CURRENT }} dependency:tree"
+  echo "BUILD_MVN_OPTS_CURRENT=${{ env.BUILD_MVN_OPTS_CURRENT }}"
+  echo "QUARKUS_VERSION=${{ env.QUARKUS_VERSION }}"
+  echo "ENABLE_DEPLOY=${{ env.ENABLE_DEPLOY }}"
+
+default:
+  build-command:
+    before:
+      current: |
+        export INTEGRATION_BRANCH=${{ env.INTEGRATION_BRANCH_CURRENT }}
+        bash -c "if [ ! -z '${{ env.BUILD_ENVIRONMENT }}' ] && [ -f .ci/environments/update.sh ]; then .ci/environments/update.sh ${{ env.BUILD_ENVIRONMENT }} ${{ env.BUILD_ENVIRONMENT_OPTIONS_CURRENT }}; fi"
+      upstream: |
+        export INTEGRATION_BRANCH=${{ env.INTEGRATION_BRANCH_UPSTREAM }}
+        bash -c "if [ ! -z '${{ env.BUILD_ENVIRONMENT }}' ] && [ -f .ci/environments/update.sh ]; then .ci/environments/update.sh ${{ env.BUILD_ENVIRONMENT }} ${{ env.BUILD_ENVIRONMENT_OPTIONS_UPSTREAM }}; fi"
+    current: |
+      mvn clean install ${{ env.BUILD_MVN_OPTS }} ${{ env.BUILD_MVN_OPTS_CURRENT }}
+    upstream: |
+      mvn clean install -Dquickly ${{ env.BUILD_MVN_OPTS }} ${{ env.BUILD_MVN_OPTS_UPSTREAM }}
+    after:
+      current: |
+        docker system prune -f
+
+build:
+  - project: apache/incubator-kie-drools
+    build-command:
+      current: |
+        export MVN_CMD=`bash -c "if [ '${{ env.ENABLE_DEPLOY }}' = 'true' ]; then printf 'deploy ${{ env.DEPLOY_MVN_OPTS }} ${{ env.DROOLS_DEPLOY_MVN_OPTS }}'; else printf 'install'; fi"`
+        mvn clean ${{ env.MVN_CMD }} ${{ env.BUILD_MVN_OPTS }} ${{ env.BUILD_MVN_OPTS_CURRENT }} ${{ env.DROOLS_BUILD_MVN_OPTS }}
+      upstream: |
+        mvn clean install -Dquickly ${{ env.BUILD_MVN_OPTS }} ${{ env.BUILD_MVN_OPTS_UPSTREAM }} ${{ env.DROOLS_BUILD_MVN_OPTS_UPSTREAM }}
+      downstream: |
+        mvn clean compile ${{ env.BUILD_MVN_OPTS }} ${{ env.BUILD_MVN_OPTS_DOWNSTREAM }} ${{ env.DROOLS_BUILD_MVN_OPTS_DOWNSTREAM }}
+  
+  - project: apache/incubator-kie-kogito-runtimes
+    build-command:
+      current: |
+        export MVN_CMD=`bash -c "if [ '${{ env.ENABLE_DEPLOY }}' = 'true' ]; then printf 'deploy ${{ env.DEPLOY_MVN_OPTS }} ${{ env.KOGITO_RUNTIMES_DEPLOY_MVN_OPTS }}'; else printf 'install'; fi"`
+        mvn clean ${{ env.MVN_CMD }} -Dfull ${{ env.BUILD_MVN_OPTS }} ${{ env.BUILD_MVN_OPTS_CURRENT }} ${{ env.KOGITO_RUNTIMES_BUILD_MVN_OPTS }}
+      upstream: |
+        mvn clean install -Dquickly -Dfull ${{ env.BUILD_MVN_OPTS }} ${{ env.BUILD_MVN_OPTS_UPSTREAM }} ${{ env.KOGITO_RUNTIMES_BUILD_MVN_OPTS_UPSTREAM }}
+      downstream: |
+        mvn clean compile -Dfull ${{ env.BUILD_MVN_OPTS }} ${{ env.BUILD_MVN_OPTS_DOWNSTREAM }} ${{ env.KOGITO_RUNTIMES_BUILD_MVN_OPTS_DOWNSTREAM }}
+
+  - project: apache/incubator-kie-kogito-apps
+    build-command: 
+      current: |
+        export MVN_CMD=`bash -c "if [ '${{ env.ENABLE_DEPLOY }}' = 'true' ]; then printf 'deploy ${{ env.DEPLOY_MVN_OPTS }} ${{ env.KOGITO_APPS_DEPLOY_MVN_OPTS }}'; else printf 'install'; fi"`
+        mvn clean ${{ env.MVN_CMD }} ${{ env.BUILD_MVN_OPTS }} ${{ env.BUILD_MVN_OPTS_CURRENT }} ${{ env.KOGITO_APPS_BUILD_MVN_OPTS }}
+      upstream: |
+        mvn clean install -Dquickly ${{ env.BUILD_MVN_OPTS }} ${{ env.BUILD_MVN_OPTS_UPSTREAM }} ${{ env.KOGITO_APPS_BUILD_MVN_OPTS_UPSTREAM }}
+      downstream: |
+        mvn clean compile ${{ env.BUILD_MVN_OPTS }} ${{ env.BUILD_MVN_OPTS_DOWNSTREAM }} ${{ env.KOGITO_APPS_BUILD_MVN_OPTS_DOWNSTREAM }}
+    archive-artifacts:
+      path: |
+        **/*.log
+        **/cypress/screenshots/**
+        **/cypress/videos/**
+
+  - project: apache/incubator-kie-kogito-examples
+    build-command:
+      # First install the main pom
+      # Then build the required submodule pom
+      current: |
+        export MVN_CMD=`bash -c "if [ '${{ env.ENABLE_DEPLOY }}' = 'true' ]; then printf 'deploy ${{ env.DEPLOY_MVN_OPTS }} ${{ env.KOGITO_EXAMPLES_DEPLOY_MVN_OPTS }}'; else printf 'install'; fi"`
+        mvn -pl :kogito-examples clean ${{ env.MVN_CMD }} ${{ env.BUILD_MVN_OPTS }} ${{ env.BUILD_MVN_OPTS_CURRENT }} ${{ env.KOGITO_EXAMPLES_BUILD_MVN_OPTS }}
+        mvn -f ${{ env.KOGITO_EXAMPLES_SUBFOLDER_POM }}pom.xml clean ${{ env.MVN_CMD }} ${{ env.BUILD_MVN_OPTS }} ${{ env.BUILD_MVN_OPTS_CURRENT }} ${{ env.KOGITO_EXAMPLES_BUILD_MVN_OPTS }}
+      upstream: |
+        mvn clean install -DskipTests -DskipITs ${{ env.BUILD_MVN_OPTS }} ${{ env.BUILD_MVN_OPTS_UPSTREAM }} ${{ env.KOGITO_EXAMPLES_BUILD_MVN_OPTS_UPSTREAM }}
+      downstream: |
+        mvn clean compile ${{ env.BUILD_MVN_OPTS }} ${{ env.BUILD_MVN_OPTS_DOWNSTREAM }} ${{ env.KOGITO_EXAMPLES_BUILD_MVN_OPTS_DOWNSTREAM }}
+
+  # - project: kiegroup/kie-jpmml-integration
+  #   build-command:
+  #     current: |
+  #       export MVN_CMD=`bash -c "if [ '${{ env.ENABLE_DEPLOY }}' = 'true' ]; then printf 'deploy ${{ env.DEPLOY_MVN_OPTS }} ${{ env.KIE_JPMML_INTEGRATION_DEPLOY_MVN_OPTS }}'; else printf 'install'; fi"`
+  #       mvn clean ${{ env.MVN_CMD }} ${{ env.BUILD_MVN_OPTS }} ${{ env.BUILD_MVN_OPTS_CURRENT }} ${{ env.KIE_JPMML_INTEGRATION_BUILD_MVN_OPTS }}
+  #     upstream: |
+  #       mvn clean install -DskipTests ${{ env.BUILD_MVN_OPTS }} ${{ env.BUILD_MVN_OPTS_UPSTREAM }} ${{ env.KIE_JPMML_INTEGRATION_BUILD_MVN_OPTS_UPSTREAM }}

--- a/.ci/jenkins/Jenkinsfile
+++ b/.ci/jenkins/Jenkinsfile
@@ -14,7 +14,7 @@ pipeline {
     environment {
         BUILDCHAIN_PROJECT = 'apache/incubator-kie-drools'
         BUILDCHAIN_CONFIG_REPO = 'incubator-kie-drools'
-        BUILDCHAIN_CONFIG_FILE_PATH = '.ci/buildchain-config.yaml'
+        BUILDCHAIN_CONFIG_FILE_PATH = '.ci/buildchain-config-pr-cdb.yaml'
 
         ENABLE_SONARCLOUD = 'true'
         DROOLS_BUILD_MVN_OPTS = '-Prun-code-coverage'


### PR DESCRIPTION
apache/incubator-kie-issues#593

Adding an extra Compile Downstream build-chain configuration for PRs, which is a copy of existing + definition of downstream scripts.

Reason is not to break existing configuration of other pipelines that use the original build-chain configuration - needs to be reviewed when I have better grasp of all affected places, scoping to jenkins PR check for now.