### PR TITLE
kie-issues#595: revert accidental change of credentials

### DIFF
--- a/.ci/jenkins/config/branch.yaml
+++ b/.ci/jenkins/config/branch.yaml
@@ -60,8 +60,8 @@ git:
     name: apache
     # Taken from https://ci-builds.apache.org/credentials/
     # Need to be verified
-    credentials_id: kie-ci
-    token_credentials_id: kie-ci3-token
+    credentials_id: 399061d0-5ab5-4142-a186-a52081fef742
+    token_credentials_id: ci-builds
   fork_author:
     name: kie-ci
     credentials_id: kie-ci


### PR DESCRIPTION
apache/incubator-kie-issues#595

Move back original credentials that are working fine for PR checks.

Earlier they were not working for nightlies to download buildchain config, but that should be handled differently.