### PR TITLE
kie-issues#593: use install goal for downstream projects

### DIFF
--- a/.ci/buildchain-config-pr-cdb.yaml
+++ b/.ci/buildchain-config-pr-cdb.yaml
@@ -36,7 +36,7 @@ build:
       upstream: |
         mvn clean install -Dquickly ${{ env.BUILD_MVN_OPTS }} ${{ env.BUILD_MVN_OPTS_UPSTREAM }} ${{ env.DROOLS_BUILD_MVN_OPTS_UPSTREAM }}
       downstream: |
-        mvn clean compile ${{ env.BUILD_MVN_OPTS }} ${{ env.BUILD_MVN_OPTS_DOWNSTREAM }} ${{ env.DROOLS_BUILD_MVN_OPTS_DOWNSTREAM }}
+        mvn clean install -Dquickly ${{ env.BUILD_MVN_OPTS }} ${{ env.BUILD_MVN_OPTS_DOWNSTREAM }} ${{ env.DROOLS_BUILD_MVN_OPTS_DOWNSTREAM }}
   
   - project: apache/incubator-kie-kogito-runtimes
     build-command:
@@ -46,7 +46,7 @@ build:
       upstream: |
         mvn clean install -Dquickly -Dfull ${{ env.BUILD_MVN_OPTS }} ${{ env.BUILD_MVN_OPTS_UPSTREAM }} ${{ env.KOGITO_RUNTIMES_BUILD_MVN_OPTS_UPSTREAM }}
       downstream: |
-        mvn clean compile -Dfull ${{ env.BUILD_MVN_OPTS }} ${{ env.BUILD_MVN_OPTS_DOWNSTREAM }} ${{ env.KOGITO_RUNTIMES_BUILD_MVN_OPTS_DOWNSTREAM }}
+        mvn clean install -Dquickly -Dfull ${{ env.BUILD_MVN_OPTS }} ${{ env.BUILD_MVN_OPTS_DOWNSTREAM }} ${{ env.KOGITO_RUNTIMES_BUILD_MVN_OPTS_DOWNSTREAM }}
 
   - project: apache/incubator-kie-kogito-apps
     build-command: 
@@ -56,7 +56,7 @@ build:
       upstream: |
         mvn clean install -Dquickly ${{ env.BUILD_MVN_OPTS }} ${{ env.BUILD_MVN_OPTS_UPSTREAM }} ${{ env.KOGITO_APPS_BUILD_MVN_OPTS_UPSTREAM }}
       downstream: |
-        mvn clean compile ${{ env.BUILD_MVN_OPTS }} ${{ env.BUILD_MVN_OPTS_DOWNSTREAM }} ${{ env.KOGITO_APPS_BUILD_MVN_OPTS_DOWNSTREAM }}
+        mvn clean install -Dquickly ${{ env.BUILD_MVN_OPTS }} ${{ env.BUILD_MVN_OPTS_DOWNSTREAM }} ${{ env.KOGITO_APPS_BUILD_MVN_OPTS_DOWNSTREAM }}
     archive-artifacts:
       path: |
         **/*.log
@@ -74,7 +74,7 @@ build:
       upstream: |
         mvn clean install -DskipTests -DskipITs ${{ env.BUILD_MVN_OPTS }} ${{ env.BUILD_MVN_OPTS_UPSTREAM }} ${{ env.KOGITO_EXAMPLES_BUILD_MVN_OPTS_UPSTREAM }}
       downstream: |
-        mvn clean compile ${{ env.BUILD_MVN_OPTS }} ${{ env.BUILD_MVN_OPTS_DOWNSTREAM }} ${{ env.KOGITO_EXAMPLES_BUILD_MVN_OPTS_DOWNSTREAM }}
+        mvn clean install -DskipTests -DskipITs ${{ env.BUILD_MVN_OPTS }} ${{ env.BUILD_MVN_OPTS_DOWNSTREAM }} ${{ env.KOGITO_EXAMPLES_BUILD_MVN_OPTS_DOWNSTREAM }}
 
   # - project: kiegroup/kie-jpmml-integration
   #   build-command:


### PR DESCRIPTION
apache/incubator-kie-issues#593
For the chain to successfully complete, the maven builds should invoke install goal instead of compile.
This is needed due to dependent projects down the chain that would miss the artifacts if they were not installed.