### PR TITLE
Fix javadoc, sources and distribution generation.

### DIFF
--- a/build-parent/pom.xml
+++ b/build-parent/pom.xml
@@ -1963,23 +1963,6 @@
             <includes>**/*Constants.properties,**/*Constants_en.properties</includes>
           </configuration>
         </plugin>
-        <plugin>
-          <groupId>org.apache.maven.plugins</groupId>
-          <artifactId>maven-javadoc-plugin</artifactId>
-          <configuration>
-            <links>
-              <link>http://docs.oracle.com/javase/8/docs/api</link>
-            </links>
-            <source>${maven.compiler.source}</source>
-            <minmemory>128m</minmemory>
-            <maxmemory>512m</maxmemory>
-            <author>false</author>
-            <breakiterator>true</breakiterator>
-            <quiet>true</quiet>
-            <doclint>none</doclint>
-            <legacyMode>true</legacyMode>
-          </configuration>
-        </plugin>
 
         <!-- This plugin's configuration is used to store Eclipse m2e settings only.
              It has no influence on the Maven build itself. -->
@@ -2063,6 +2046,7 @@
             <archive>
               <index>true</index>
             </archive>
+            <quiet>true</quiet>
             <doclint>none</doclint>
             <legacyMode>true</legacyMode>
           </configuration>

--- a/build-parent/pom.xml
+++ b/build-parent/pom.xml
@@ -35,7 +35,6 @@
 
 
   <properties>
-    <javadoc.additional.params>-Xdoclint:none</javadoc.additional.params>
     <maven.compiler.release>11</maven.compiler.release>
     <maven.compiler.source>${maven.compiler.release}</maven.compiler.source>
     <maven.compiler.target>${maven.compiler.release}</maven.compiler.target>
@@ -232,7 +231,7 @@
     <!-- These are added as part of the migration from JBoss to Apache parent pom.xml. They may be extracted to a KIE parent bom. -->
     <version.maven-checkstyle>3.3.0</version.maven-checkstyle>
     <version.build.helper.maven.plugin>3.4.0</version.build.helper.maven.plugin>
-    
+    <version.maven-javadoc-plugin.override>3.6.0</version.maven-javadoc-plugin.override>
   </properties>
 
   <dependencyManagement>
@@ -1759,7 +1758,7 @@
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-source-plugin</artifactId>
-          <version>${version.source.plugin}</version>
+          <version>${version.maven-source-plugin}</version>
           <executions>
             <execution>
               <id>attach-sources</id>
@@ -1977,7 +1976,8 @@
             <author>false</author>
             <breakiterator>true</breakiterator>
             <quiet>true</quiet>
-            <additionalparam>${javadoc.additional.params}</additionalparam>
+            <doclint>none</doclint>
+            <legacyMode>true</legacyMode>
           </configuration>
         </plugin>
 
@@ -2056,14 +2056,15 @@
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-javadoc-plugin</artifactId>
-          <version>${version.maven-javadoc-plugin}</version>
+          <version>${version.maven-javadoc-plugin.override}</version>
           <configuration>
             <header><![CDATA[<b>${project.name} ${project.version}</b>]]></header>
             <footer><![CDATA[<b>${project.name} ${project.version}</b>]]></footer>
             <archive>
               <index>true</index>
             </archive>
-            <additionalOptions>${javadoc.additional.params}</additionalOptions>
+            <doclint>none</doclint>
+            <legacyMode>true</legacyMode>
           </configuration>
         </plugin>
       </plugins>
@@ -2094,6 +2095,18 @@
                 <source>target/generated-sources/annotations/</source>
               </sources>
             </configuration>
+          </execution>
+        </executions>
+      </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-source-plugin</artifactId>
+        <executions>
+          <execution>
+            <id>attach-sources</id>
+            <goals>
+              <goal>jar-no-fork</goal>
+            </goals>
           </execution>
         </executions>
       </plugin>

--- a/drools-alphanetwork-compiler/pom.xml
+++ b/drools-alphanetwork-compiler/pom.xml
@@ -36,7 +36,7 @@
   <name>Drools :: Alpha Network Compiler</name>
 
   <properties>
-    <java.module.name>org.drools.core.alphanetworkcompiler</java.module.name>
+    <java.module.name>org.drools.core.alphanetwork.compiler</java.module.name>
   </properties>
 
   <dependencies>
@@ -112,21 +112,6 @@
         <directory>src/main/filtered-resources</directory>
       </resource>
     </resources>
-
-    <plugins>
-      <plugin>
-        <groupId>org.apache.maven.plugins</groupId>
-        <artifactId>maven-javadoc-plugin</artifactId>
-        <configuration>
-          <!-- Hack/workaround for https://bugs.openjdk.java.net/browse/JDK-8061305. The Javadoc generation fails for
-               this class, so needs to be excluded. It seems the issue is fixed only in JDK 9+. -->
-          <sourceFileExcludes>
-            <sourceFileExclude>**/MetaProperty.java</sourceFileExclude>
-          </sourceFileExcludes>
-        </configuration>
-      </plugin>
-
-    </plugins>
   </build>
 
 </project>

--- a/drools-alphanetwork-compiler/pom.xml
+++ b/drools-alphanetwork-compiler/pom.xml
@@ -36,7 +36,7 @@
   <name>Drools :: Alpha Network Compiler</name>
 
   <properties>
-    <java.module.name>org.drools.core.alphanetwork.compiler</java.module.name>
+    <java.module.name>org.drools.ancompiler</java.module.name>
   </properties>
 
   <dependencies>

--- a/drools-distribution/src/main/assembly/assembly-drools.xml
+++ b/drools-distribution/src/main/assembly/assembly-drools.xml
@@ -14,7 +14,7 @@
   <fileSets>
     <fileSet><!-- Note: going outside the module dir is bad, but it is not fetching generated files -->
       <includes>
-        <include>../LICENSE-ASL-2.0.txt</include>
+        <include>../LICENSE-Apache-2.0.txt</include>
       </includes>
       <outputDirectory/>
     </fileSet>
@@ -89,7 +89,7 @@
         <include>ch.qos.logback:logback-classic</include>
       </includes>
       <excludes>
-        <exclude>*:sources</exclude>
+        <exclude>*:*:jar:sources</exclude>
       </excludes>
       <outputDirectory>examples/binaries</outputDirectory>
       <useTransitiveDependencies>true</useTransitiveDependencies>

--- a/drools-impact-analysis/drools-impact-analysis-graph/drools-impact-analysis-graph-common/pom.xml
+++ b/drools-impact-analysis/drools-impact-analysis-graph/drools-impact-analysis-graph-common/pom.xml
@@ -34,7 +34,7 @@
   <name>Drools :: Impact Analysis Graph :: Common</name>
 
   <properties>
-    <java.module.name>org.drools.impact.analysis.graph</java.module.name>
+    <java.module.name>org.drools.impact.analysis.graph.common</java.module.name>
   </properties>
 
   <dependencies>

--- a/drools-ruleunits/drools-ruleunits-dsl/pom.xml
+++ b/drools-ruleunits/drools-ruleunits-dsl/pom.xml
@@ -39,7 +39,7 @@
     </description>
 
     <properties>
-        <java.module.name>org.drools.ruleunits.impl</java.module.name>
+        <java.module.name>org.drools.ruleunits.dsl</java.module.name>
     </properties>
 
     <dependencies>

--- a/drools-traits/pom.xml
+++ b/drools-traits/pom.xml
@@ -36,7 +36,7 @@
   <name>Drools :: Traits</name>
 
   <properties>
-    <java.module.name>org.drools.core.traits</java.module.name>
+    <java.module.name>org.drools.traits</java.module.name>
     <surefire.forkCount>2</surefire.forkCount>
 
     <!-- These are properties used in the database profiles. Some of them must be initialized
@@ -230,21 +230,5 @@
         <filtering>true</filtering>
       </testResource>
     </testResources>
-
-
-    <plugins>
-      <plugin>
-        <groupId>org.apache.maven.plugins</groupId>
-        <artifactId>maven-javadoc-plugin</artifactId>
-        <configuration>
-          <!-- Hack/workaround for https://bugs.openjdk.java.net/browse/JDK-8061305. The Javadoc generation fails for
-               this class, so needs to be excluded. It seems the issue is fixed only in JDK 9+. -->
-          <sourceFileExcludes>
-            <sourceFileExclude>**/MetaProperty.java</sourceFileExclude>
-          </sourceFileExcludes>
-        </configuration>
-      </plugin>
-
-    </plugins>
   </build>
 </project>


### PR DESCRIPTION
Some problems showed up in fullProfile builds (nightlies) after migration to Apache parent pom. 
- Fixes javadoc generation.
- Fixes sources jars generation. 
- Fixes Drools distribution zip generation. 