### PR TITLE
[DO-NOT-MERGE] [DROOLS-7570] Hang in JpaPersistentStatefulSessionTest

### DIFF
--- a/drools-persistence/drools-persistence-jpa/src/test/java/org/drools/persistence/TransactionManagerFactoryTest.java
+++ b/drools-persistence/drools-persistence-jpa/src/test/java/org/drools/persistence/TransactionManagerFactoryTest.java
@@ -24,11 +24,13 @@ import org.drools.persistence.api.TransactionManagerFactory;
 import org.drools.persistence.jta.JtaTransactionManager;
 import org.drools.persistence.jta.JtaTransactionManagerFactory;
 import org.junit.After;
+import org.junit.Ignore;
 import org.junit.Test;
 import org.kie.api.runtime.Environment;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+@Ignore("DROOLS-7570 : Temporarily disabled because of test hang")
 public class TransactionManagerFactoryTest {
 
     TransactionManagerFactory transactionManagerFactory =

--- a/drools-persistence/drools-persistence-jpa/src/test/java/org/drools/persistence/command/MoreBatchExecutionPersistenceTest.java
+++ b/drools-persistence/drools-persistence-jpa/src/test/java/org/drools/persistence/command/MoreBatchExecutionPersistenceTest.java
@@ -26,6 +26,7 @@ import org.drools.core.impl.RuleBaseFactory;
 import org.drools.mvel.compiler.command.MoreBatchExecutionTest;
 import org.drools.persistence.util.DroolsPersistenceUtil;
 import org.junit.After;
+import org.junit.Ignore;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
 import org.junit.runners.Parameterized.Parameters;
@@ -42,6 +43,7 @@ import static org.drools.persistence.util.DroolsPersistenceUtil.PESSIMISTIC_LOCK
 import static org.drools.persistence.util.DroolsPersistenceUtil.cleanUp;
 import static org.drools.persistence.util.DroolsPersistenceUtil.createEnvironment;
 
+@Ignore("DROOLS-7570 : Temporarily disabled because of test hang")
 @RunWith(Parameterized.class)
 public class MoreBatchExecutionPersistenceTest extends MoreBatchExecutionTest {
 

--- a/drools-persistence/drools-persistence-jpa/src/test/java/org/drools/persistence/command/SimpleBatchExecutionPersistenceTest.java
+++ b/drools-persistence/drools-persistence-jpa/src/test/java/org/drools/persistence/command/SimpleBatchExecutionPersistenceTest.java
@@ -26,6 +26,7 @@ import org.drools.core.impl.RuleBaseFactory;
 import org.drools.mvel.compiler.command.SimpleBatchExecutionTest;
 import org.drools.persistence.util.DroolsPersistenceUtil;
 import org.junit.After;
+import org.junit.Ignore;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
 import org.junit.runners.Parameterized.Parameters;
@@ -36,6 +37,7 @@ import org.kie.api.runtime.KieSessionConfiguration;
 import org.kie.internal.persistence.jpa.JPAKnowledgeService;
 import org.kie.internal.runtime.StatefulKnowledgeSession;
 
+@Ignore("DROOLS-7570 : Temporarily disabled because of test hang")
 @RunWith(Parameterized.class)
 public class SimpleBatchExecutionPersistenceTest extends SimpleBatchExecutionTest {
 

--- a/drools-persistence/drools-persistence-jpa/src/test/java/org/drools/persistence/jta/JtaTransactionManagerFactoryTest.java
+++ b/drools-persistence/drools-persistence-jpa/src/test/java/org/drools/persistence/jta/JtaTransactionManagerFactoryTest.java
@@ -31,10 +31,12 @@ import org.drools.core.impl.EnvironmentFactory;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import org.junit.BeforeClass;
+import org.junit.Ignore;
 import org.junit.Test;
 import org.kie.api.runtime.Environment;
 import org.kie.api.runtime.EnvironmentName;
 
+@Ignore("DROOLS-7570 : Temporarily disabled because of test hang")
 public class JtaTransactionManagerFactoryTest {
 
     @BeforeClass

--- a/drools-persistence/drools-persistence-jpa/src/test/java/org/drools/persistence/jta/JtaTransactionManagerTest.java
+++ b/drools-persistence/drools-persistence-jpa/src/test/java/org/drools/persistence/jta/JtaTransactionManagerTest.java
@@ -38,6 +38,7 @@ import org.drools.persistence.util.DroolsPersistenceUtil;
 import org.hibernate.TransientObjectException;
 import org.junit.After;
 import org.junit.Before;
+import org.junit.Ignore;
 import org.junit.Test;
 import org.kie.api.KieBase;
 import org.kie.api.KieServices;
@@ -58,6 +59,7 @@ import static org.drools.persistence.util.DroolsPersistenceUtil.DROOLS_PERSISTEN
 import static org.drools.persistence.util.DroolsPersistenceUtil.createEnvironment;
 import static org.drools.persistence.util.DroolsPersistenceUtil.setupWithPoolingDataSource;
 
+@Ignore("DROOLS-7570 : Temporarily disabled because of test hang")
 public class JtaTransactionManagerTest {
 
     private Logger logger = LoggerFactory.getLogger(getClass());

--- a/drools-persistence/drools-persistence-jpa/src/test/java/org/drools/persistence/kie/persistence/session/JpaPersistentStatefulSessionTest.java
+++ b/drools-persistence/drools-persistence-jpa/src/test/java/org/drools/persistence/kie/persistence/session/JpaPersistentStatefulSessionTest.java
@@ -41,6 +41,7 @@ import org.drools.persistence.PersistableRunner;
 import org.drools.persistence.util.DroolsPersistenceUtil;
 import org.junit.After;
 import org.junit.Before;
+import org.junit.Ignore;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
@@ -72,6 +73,7 @@ import static org.drools.persistence.util.DroolsPersistenceUtil.OPTIMISTIC_LOCKI
 import static org.drools.persistence.util.DroolsPersistenceUtil.PESSIMISTIC_LOCKING;
 import static org.drools.persistence.util.DroolsPersistenceUtil.createEnvironment;
 
+@Ignore("DROOLS-7570 : Temporarily disabled because of test hang")
 @RunWith(Parameterized.class)
 public class JpaPersistentStatefulSessionTest {
 

--- a/drools-persistence/drools-persistence-jpa/src/test/java/org/drools/persistence/kie/persistence/session/PersistentSessionForallTest.java
+++ b/drools-persistence/drools-persistence-jpa/src/test/java/org/drools/persistence/kie/persistence/session/PersistentSessionForallTest.java
@@ -28,6 +28,7 @@ import org.drools.mvel.compiler.Person;
 import org.drools.persistence.util.DroolsPersistenceUtil;
 import org.junit.After;
 import org.junit.Before;
+import org.junit.Ignore;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
@@ -48,6 +49,7 @@ import static org.drools.persistence.util.DroolsPersistenceUtil.OPTIMISTIC_LOCKI
 import static org.drools.persistence.util.DroolsPersistenceUtil.PESSIMISTIC_LOCKING;
 import static org.drools.persistence.util.DroolsPersistenceUtil.createEnvironment;
 
+@Ignore("DROOLS-7570 : Temporarily disabled because of test hang")
 @RunWith(Parameterized.class)
 public class PersistentSessionForallTest {
 

--- a/drools-persistence/drools-persistence-jpa/src/test/java/org/drools/persistence/map/impl/JpaBasedPersistenceTest.java
+++ b/drools-persistence/drools-persistence-jpa/src/test/java/org/drools/persistence/map/impl/JpaBasedPersistenceTest.java
@@ -23,6 +23,7 @@ import org.drools.persistence.jta.JtaTransactionManager;
 import org.drools.persistence.util.DroolsPersistenceUtil;
 import org.junit.After;
 import org.junit.Before;
+import org.junit.Ignore;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
 import org.junit.runners.Parameterized.Parameters;
@@ -47,6 +48,7 @@ import static org.drools.persistence.util.DroolsPersistenceUtil.useTransactions;
 import static org.kie.api.runtime.EnvironmentName.ENTITY_MANAGER_FACTORY;
 import static org.kie.api.runtime.EnvironmentName.USE_PESSIMISTIC_LOCKING;
 
+@Ignore("DROOLS-7570 : Temporarily disabled because of test hang")
 @RunWith(Parameterized.class)
 public class JpaBasedPersistenceTest extends MapPersistenceTest {
 

--- a/drools-persistence/drools-persistence-jpa/src/test/java/org/drools/persistence/map/impl/MapBasedPersistenceTest.java
+++ b/drools-persistence/drools-persistence-jpa/src/test/java/org/drools/persistence/map/impl/MapBasedPersistenceTest.java
@@ -27,6 +27,7 @@ import org.drools.persistence.map.EnvironmentBuilder;
 import org.drools.persistence.map.KnowledgeSessionStorage;
 import org.drools.persistence.map.KnowledgeSessionStorageEnvironmentBuilder;
 import org.junit.Before;
+import org.junit.Ignore;
 import org.kie.api.KieBase;
 import org.kie.api.KieServices;
 import org.kie.internal.persistence.jpa.JPAKnowledgeService;
@@ -34,6 +35,7 @@ import org.kie.api.runtime.Environment;
 import org.kie.api.runtime.EnvironmentName;
 import org.kie.api.runtime.KieSession;
 
+@Ignore("DROOLS-7570 : Temporarily disabled because of test hang")
 public class MapBasedPersistenceTest extends MapPersistenceTest{
     
     private SimpleKnowledgeSessionStorage storage;

--- a/drools-persistence/drools-persistence-jpa/src/test/java/org/drools/persistence/map/impl/MapPersistenceTest.java
+++ b/drools-persistence/drools-persistence-jpa/src/test/java/org/drools/persistence/map/impl/MapPersistenceTest.java
@@ -22,6 +22,7 @@ import org.drools.kiesession.rulebase.InternalKnowledgeBase;
 import org.drools.io.ByteArrayResource;
 import org.drools.kiesession.rulebase.KnowledgeBaseFactory;
 import org.drools.persistence.jpa.marshaller.JPAPlaceholderResolverStrategy;
+import org.junit.Ignore;
 import org.junit.Test;
 import org.kie.api.KieBase;
 import org.kie.api.io.ResourceType;
@@ -37,6 +38,7 @@ import org.slf4j.LoggerFactory;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.fail;
 
+@Ignore("DROOLS-7570 : Temporarily disabled because of test hang")
 public abstract class MapPersistenceTest {
 
     private static Logger logger = LoggerFactory.getLogger(JPAPlaceholderResolverStrategy.class);

--- a/drools-persistence/drools-persistence-jpa/src/test/java/org/drools/persistence/monitoring/MonitoringWithJPAKnowledgeServiceTest.java
+++ b/drools-persistence/drools-persistence-jpa/src/test/java/org/drools/persistence/monitoring/MonitoringWithJPAKnowledgeServiceTest.java
@@ -23,6 +23,7 @@ import org.drools.core.management.DroolsManagementAgent;
 import org.drools.persistence.util.DroolsPersistenceUtil;
 import org.junit.After;
 import org.junit.Before;
+import org.junit.Ignore;
 import org.junit.Test;
 import org.kie.api.KieBase;
 import org.kie.api.KieServices;
@@ -48,6 +49,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.drools.persistence.util.DroolsPersistenceUtil.DROOLS_PERSISTENCE_UNIT_NAME;
 import static org.drools.persistence.util.DroolsPersistenceUtil.createEnvironment;
 
+@Ignore("DROOLS-7570 : Temporarily disabled because of test hang")
 public class MonitoringWithJPAKnowledgeServiceTest {
     private static Logger LOG = LoggerFactory.getLogger(MonitoringWithJPAKnowledgeServiceTest.class);
     

--- a/drools-persistence/drools-persistence-jpa/src/test/java/org/drools/persistence/session/AgendaRuleFlowGroupsTest.java
+++ b/drools-persistence/drools-persistence-jpa/src/test/java/org/drools/persistence/session/AgendaRuleFlowGroupsTest.java
@@ -33,6 +33,7 @@ import org.drools.persistence.util.DroolsPersistenceUtil;
 import org.drools.io.ClassPathResource;
 import org.junit.After;
 import org.junit.Before;
+import org.junit.Ignore;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
@@ -56,6 +57,7 @@ import static org.assertj.core.api.Assertions.fail;
 import static org.drools.persistence.util.DroolsPersistenceUtil.DROOLS_PERSISTENCE_UNIT_NAME;
 import static org.drools.persistence.util.DroolsPersistenceUtil.createEnvironment;
 
+@Ignore("DROOLS-7570 : Temporarily disabled because of test hang")
 @RunWith(Parameterized.class)
 public class AgendaRuleFlowGroupsTest {
     

--- a/drools-persistence/drools-persistence-jpa/src/test/java/org/drools/persistence/session/JpaOptLockPersistentStatefulSessionTest.java
+++ b/drools-persistence/drools-persistence-jpa/src/test/java/org/drools/persistence/session/JpaOptLockPersistentStatefulSessionTest.java
@@ -33,6 +33,7 @@ import org.drools.persistence.jpa.OptimisticLockRetryInterceptor;
 import org.drools.persistence.util.DroolsPersistenceUtil;
 import org.junit.After;
 import org.junit.Before;
+import org.junit.Ignore;
 import org.junit.Test;
 import org.kie.api.event.rule.DefaultRuleRuntimeEventListener;
 import org.kie.api.event.rule.ObjectInsertedEvent;
@@ -51,6 +52,7 @@ import static org.assertj.core.api.Assertions.fail;
 import static org.drools.persistence.util.DroolsPersistenceUtil.DROOLS_PERSISTENCE_UNIT_NAME;
 import static org.drools.persistence.util.DroolsPersistenceUtil.createEnvironment;
 
+@Ignore("DROOLS-7570 : Temporarily disabled because of test hang")
 public class JpaOptLockPersistentStatefulSessionTest {
 
     private static Logger logger = LoggerFactory.getLogger(JpaOptLockPersistentStatefulSessionTest.class);

--- a/drools-persistence/drools-persistence-jpa/src/test/java/org/drools/persistence/session/JpaPersistentStatefulSessionTest.java
+++ b/drools-persistence/drools-persistence-jpa/src/test/java/org/drools/persistence/session/JpaPersistentStatefulSessionTest.java
@@ -44,6 +44,7 @@ import org.drools.persistence.PersistableRunner;
 import org.drools.persistence.util.DroolsPersistenceUtil;
 import org.junit.After;
 import org.junit.Before;
+import org.junit.Ignore;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
@@ -69,6 +70,7 @@ import static org.drools.persistence.util.DroolsPersistenceUtil.OPTIMISTIC_LOCKI
 import static org.drools.persistence.util.DroolsPersistenceUtil.PESSIMISTIC_LOCKING;
 import static org.drools.persistence.util.DroolsPersistenceUtil.createEnvironment;
 
+@Ignore("DROOLS-7570 : Temporarily disabled because of test hang")
 @RunWith(Parameterized.class)
 public class JpaPersistentStatefulSessionTest {
 

--- a/drools-persistence/drools-persistence-jpa/src/test/java/org/drools/persistence/session/ReloadSessionTest.java
+++ b/drools-persistence/drools-persistence-jpa/src/test/java/org/drools/persistence/session/ReloadSessionTest.java
@@ -59,6 +59,7 @@ import static org.drools.persistence.util.DroolsPersistenceUtil.OPTIMISTIC_LOCKI
 import static org.drools.persistence.util.DroolsPersistenceUtil.PESSIMISTIC_LOCKING;
 import static org.kie.api.runtime.EnvironmentName.ENTITY_MANAGER_FACTORY;
 
+@Ignore("DROOLS-7570 : Temporarily disabled because of test hang")
 @RunWith(Parameterized.class)
 public class ReloadSessionTest {
 

--- a/drools-persistence/drools-persistence-jpa/src/test/java/org/drools/persistence/session/RuleFlowGroupRollbackTest.java
+++ b/drools-persistence/drools-persistence-jpa/src/test/java/org/drools/persistence/session/RuleFlowGroupRollbackTest.java
@@ -32,6 +32,7 @@ import org.drools.kiesession.rulebase.KnowledgeBaseFactory;
 import org.drools.persistence.util.DroolsPersistenceUtil;
 import org.junit.After;
 import org.junit.Before;
+import org.junit.Ignore;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
@@ -56,6 +57,7 @@ import static org.drools.persistence.util.DroolsPersistenceUtil.OPTIMISTIC_LOCKI
 import static org.drools.persistence.util.DroolsPersistenceUtil.PESSIMISTIC_LOCKING;
 import static org.drools.persistence.util.DroolsPersistenceUtil.createEnvironment;
 
+@Ignore("DROOLS-7570 : Temporarily disabled because of test hang")
 @RunWith(Parameterized.class)
 public class RuleFlowGroupRollbackTest {
 

--- a/drools-persistence/drools-persistence-jpa/src/test/java/org/drools/persistence/timer/integrationtests/TimerAndCalendarTest.java
+++ b/drools-persistence/drools-persistence-jpa/src/test/java/org/drools/persistence/timer/integrationtests/TimerAndCalendarTest.java
@@ -67,6 +67,7 @@ import static org.drools.persistence.util.DroolsPersistenceUtil.cleanUp;
 import static org.drools.persistence.util.DroolsPersistenceUtil.createEnvironment;
 import static org.drools.persistence.util.DroolsPersistenceUtil.setupWithPoolingDataSource;
 
+@Ignore("DROOLS-7570 : Temporarily disabled because of test hang")
 @RunWith(Parameterized.class)
 public class TimerAndCalendarTest {
     


### PR DESCRIPTION
- Temporarily disabled because of test hang
- disabled all test cases in drools-persistence-jpa

Just confirm if this PR affects CI.

**JIRA**: 
https://issues.redhat.com/browse/DROOLS-7570