### PR TITLE
kie-issues#600: set credentials for buildchain

### DIFF
--- a/.ci/jenkins/config/branch.yaml
+++ b/.ci/jenkins/config/branch.yaml
@@ -75,6 +75,7 @@ buildchain_config:
   git:
     repository: incubator-kie-drools
     file_path: .ci/buildchain-config.yaml
+    token_credentials_id: kie-ci3-token
 maven:
   settings_file_id: kie-release-settings
   nexus:


### PR DESCRIPTION
apache/incubator-kie-issues#600

Depends on apache/incubator-kie-kogito-pipelines#1103

Passing different git credentials id to buildchain commands.