### PR TITLE
[KIE-635] implement a cache for loaded services

### DIFF
--- a/drools-compiler/src/main/java/org/drools/compiler/builder/impl/CompositeKnowledgeBuilderImpl.java
+++ b/drools-compiler/src/main/java/org/drools/compiler/builder/impl/CompositeKnowledgeBuilderImpl.java
@@ -40,6 +40,8 @@ import java.util.stream.Collectors;
 
 public class CompositeKnowledgeBuilderImpl implements CompositeKnowledgeBuilder {
 
+    private static final KieAssemblers ASSEMBLERS = KieService.load(KieAssemblers.class);
+
     private final KnowledgeBuilderImpl kBuilder;
 
     private final Map<ResourceType, List<ResourceDescr>> resourcesByType = new HashMap<>();
@@ -176,13 +178,12 @@ public class CompositeKnowledgeBuilderImpl implements CompositeKnowledgeBuilder 
     }
 
     private void buildAssemblerResourcesBeforeRules() {
-        KieAssemblers assemblers = KieService.load(KieAssemblers.class);
         try {
             for (Map.Entry<ResourceType, List<ResourceDescr>> resourceTypeListEntry : resourcesByType.entrySet()) {
                 ResourceType type = resourceTypeListEntry.getKey();
                 List<ResourceDescr> descrs = resourceTypeListEntry.getValue();
                 for (ResourceDescr descr : descrs) {
-                    assemblers.addResourceBeforeRules(this.kBuilder, descr.resource, type, descr.configuration);
+                    ASSEMBLERS.addResourceBeforeRules(this.kBuilder, descr.resource, type, descr.configuration);
                 }
             }
         } catch (RuntimeException e) {
@@ -197,11 +198,10 @@ public class CompositeKnowledgeBuilderImpl implements CompositeKnowledgeBuilder 
     }
 
     private void buildAssemblerResourcesAfterRules() {
-        KieAssemblers assemblers = KieService.load(KieAssemblers.class);
         try {
             for (Map.Entry<ResourceType, List<ResourceDescr>> entry : resourcesByType.entrySet()) {
                 List<ResourceWithConfiguration> rds = entry.getValue().stream().map(CompositeKnowledgeBuilderImpl::descrToResourceWithConfiguration).collect(Collectors.toList());
-                assemblers.addResourcesAfterRules(kBuilder, rds, entry.getKey());
+                ASSEMBLERS.addResourcesAfterRules(kBuilder, rds, entry.getKey());
             }
         } catch (RuntimeException e) {
             throw e;

--- a/drools-compiler/src/main/java/org/drools/compiler/builder/impl/KnowledgeBuilderImpl.java
+++ b/drools-compiler/src/main/java/org/drools/compiler/builder/impl/KnowledgeBuilderImpl.java
@@ -18,24 +18,12 @@
  */
 package org.drools.compiler.builder.impl;
 
-import static java.util.Arrays.asList;
-
-import java.io.File;
-import java.io.IOException;
-import java.io.Reader;
-import java.lang.reflect.Type;
-import java.util.ArrayDeque;
-import java.util.ArrayList;
-import java.util.Collection;
-import java.util.Collections;
-import java.util.Deque;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
-import java.util.Optional;
-import java.util.concurrent.ForkJoinPool;
-import java.util.function.Supplier;
-
+import org.drools.base.base.ObjectType;
+import org.drools.base.definitions.InternalKnowledgePackage;
+import org.drools.base.definitions.rule.impl.RuleImpl;
+import org.drools.base.rule.Function;
+import org.drools.base.rule.ImportDeclaration;
+import org.drools.base.rule.TypeDeclaration;
 import org.drools.compiler.builder.InternalKnowledgeBuilder;
 import org.drools.compiler.builder.PackageRegistryManager;
 import org.drools.compiler.builder.impl.processors.CompilationPhase;
@@ -56,14 +44,8 @@ import org.drools.compiler.compiler.ProcessBuilderFactory;
 import org.drools.compiler.compiler.ResourceTypeDeclarationWarning;
 import org.drools.compiler.kie.builder.impl.BuildContext;
 import org.drools.compiler.lang.descr.CompositePackageDescr;
-import org.drools.base.base.ObjectType;
-import org.drools.base.definitions.InternalKnowledgePackage;
-import org.drools.base.definitions.rule.impl.RuleImpl;
 import org.drools.core.impl.InternalRuleBase;
 import org.drools.core.impl.RuleBaseFactory;
-import org.drools.base.rule.Function;
-import org.drools.base.rule.ImportDeclaration;
-import org.drools.base.rule.TypeDeclaration;
 import org.drools.drl.ast.descr.AttributeDescr;
 import org.drools.drl.ast.descr.ImportDescr;
 import org.drools.drl.ast.descr.PackageDescr;
@@ -81,6 +63,7 @@ import org.drools.kiesession.rulebase.KnowledgeBaseFactory;
 import org.drools.wiring.api.ComponentsFactory;
 import org.kie.api.KieBase;
 import org.kie.api.KieBaseConfiguration;
+import org.kie.api.KieServices;
 import org.kie.api.builder.ReleaseId;
 import org.kie.api.definition.KiePackage;
 import org.kie.api.definition.process.Process;
@@ -91,7 +74,6 @@ import org.kie.api.io.Resource;
 import org.kie.api.io.ResourceConfiguration;
 import org.kie.api.io.ResourceType;
 import org.kie.api.io.ResourceWithConfiguration;
-import org.kie.api.KieServices;
 import org.kie.internal.builder.CompositeKnowledgeBuilder;
 import org.kie.internal.builder.KnowledgeBuilderConfiguration;
 import org.kie.internal.builder.KnowledgeBuilderError;
@@ -107,8 +89,28 @@ import org.kie.internal.builder.conf.ParallelRulesBuildThresholdOption;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import java.io.File;
+import java.io.IOException;
+import java.io.Reader;
+import java.lang.reflect.Type;
+import java.util.ArrayDeque;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.Deque;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.concurrent.ForkJoinPool;
+import java.util.function.Supplier;
+
+import static java.util.Arrays.asList;
+
 public class KnowledgeBuilderImpl implements InternalKnowledgeBuilder, TypeDeclarationContext, BuildResultCollector, GlobalVariableContext {
     protected static final transient Logger logger = LoggerFactory.getLogger(KnowledgeBuilderImpl.class);
+
+    private static final KieAssemblers ASSEMBLERS = KieService.load(KieAssemblers.class);
 
     private final PackageRegistryManagerImpl pkgRegistryManager;
 
@@ -393,22 +395,13 @@ public class KnowledgeBuilderImpl implements InternalKnowledgeBuilder, TypeDecla
     }
 
     @Deprecated
-    void addPackageForExternalType(Resource resource,
-                                   ResourceType type,
-                                   ResourceConfiguration configuration) throws Exception {
-        KieAssemblers assemblers = KieService.load(KieAssemblers.class);
-
-        assemblers.addResourceAfterRules(this,
-                               resource,
-                               type,
-                               configuration);
+    void addPackageForExternalType(Resource resource, ResourceType type, ResourceConfiguration configuration) throws Exception {
+        ASSEMBLERS.addResourceAfterRules(this, resource, type, configuration);
     }
 
     @Deprecated
     void addPackageForExternalType(ResourceType type, List<ResourceWithConfiguration> resources) throws Exception {
-        KieAssemblers assemblers = KieService.load(KieAssemblers.class);
-
-        assemblers.addResourcesAfterRules(this, resources, type);
+        ASSEMBLERS.addResourcesAfterRules(this, resources, type);
     }
 
     void addPackageFromXSD(Resource resource, ResourceConfiguration configuration) throws IOException {

--- a/drools-compiler/src/main/java/org/drools/compiler/kie/builder/impl/KieServicesImpl.java
+++ b/drools-compiler/src/main/java/org/drools/compiler/kie/builder/impl/KieServicesImpl.java
@@ -18,13 +18,6 @@
  */
 package org.drools.compiler.kie.builder.impl;
 
-import java.io.File;
-import java.lang.ref.WeakReference;
-import java.util.Properties;
-import java.util.UUID;
-import java.util.concurrent.ConcurrentHashMap;
-import java.util.concurrent.ConcurrentMap;
-
 import org.drools.compiler.kie.builder.impl.event.KieServicesEventListerner;
 import org.drools.compiler.kproject.models.KieModuleModelImpl;
 import org.drools.core.BaseConfigurationFactories;
@@ -32,8 +25,8 @@ import org.drools.core.CompositeSessionConfiguration;
 import org.drools.core.SessionConfigurationFactories;
 import org.drools.core.concurrent.ExecutorProviderImpl;
 import org.drools.core.impl.EnvironmentFactory;
-import org.drools.kiesession.audit.KnowledgeRuntimeLoggerProviderImpl;
 import org.drools.io.ResourceFactoryServiceImpl;
+import org.drools.kiesession.audit.KnowledgeRuntimeLoggerProviderImpl;
 import org.drools.wiring.api.classloader.ProjectClassLoader;
 import org.kie.api.KieBaseConfiguration;
 import org.kie.api.builder.KieBuilder;
@@ -57,10 +50,18 @@ import org.kie.internal.conf.CompositeBaseConfiguration;
 import org.kie.internal.utils.ChainedProperties;
 import org.kie.util.maven.support.ReleaseIdImpl;
 
+import java.io.File;
+import java.lang.ref.WeakReference;
+import java.util.Properties;
+import java.util.UUID;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentMap;
+
 import static org.drools.compiler.compiler.io.memory.MemoryFileSystem.readFromJar;
 import static org.drools.util.ClassUtils.findParentClassLoader;
 
 public class KieServicesImpl implements InternalKieServices {
+
     private volatile KieContainer classpathKContainer;
     private volatile String classpathKContainerId;
     
@@ -137,8 +138,7 @@ public class KieServicesImpl implements InternalKieServices {
     @Override
     public KieContainer newKieClasspathContainer(String containerId, ClassLoader classLoader, ReleaseId releaseId) {
     	if (containerId == null) {
-            KieContainerImpl newContainer = new KieContainerImpl(UUID.randomUUID().toString(), new ClasspathKieProject(classLoader, listener, releaseId), null);
-    	    return newContainer;
+            return new KieContainerImpl(UUID.randomUUID().toString(), new ClasspathKieProject(classLoader, listener, releaseId), null);
     	}
     	if ( kContainers.get(containerId) == null ) {
             KieContainerImpl newContainer = new KieContainerImpl(containerId, new ClasspathKieProject(classLoader, listener, releaseId), null, releaseId);
@@ -204,9 +204,9 @@ public class KieServicesImpl implements InternalKieServices {
         }
 
     	if (containerId == null) {
-    	    KieContainerImpl newContainer = new KieContainerImpl( UUID.randomUUID().toString(), kProject, getRepository(), releaseId );
-    		return newContainer;
+            return new KieContainerImpl( UUID.randomUUID().toString(), kProject, getRepository(), releaseId );
     	}
+
     	if ( kContainers.get(containerId) == null ) {
             KieContainerImpl newContainer = new KieContainerImpl( containerId, kProject, getRepository(), releaseId );
             KieContainer check = kContainers.putIfAbsent(containerId, newContainer);
@@ -254,11 +254,14 @@ public class KieServicesImpl implements InternalKieServices {
     }
 
     public KieCommands getCommands() {
-        return KieService.load( KieCommands.class );
+        return KieCommandsHolder.KIE_COMMANDS;
+    }
+
+    private static class KieCommandsHolder {
+        private static final KieCommands KIE_COMMANDS = KieService.load( KieCommands.class );
     }
 
     public KieMarshallers getMarshallers() {
-        // instantiating directly, but we might want to use the service registry instead
         KieMarshallers kieMarshallers = KieService.load( KieMarshallers.class );
         if (kieMarshallers == null) {
             throw new RuntimeException("Marshaller not available, please add the module org.drools:drools-serialization-protobuf to your classpath.");
@@ -333,8 +336,7 @@ public class KieServicesImpl implements InternalKieServices {
     }
 
     private ClassLoader getClassLoader(ClassLoader classLoader) {
-        ClassLoader projClassLoader = classLoader instanceof ProjectClassLoader ? classLoader : ProjectClassLoader.getClassLoader(classLoader, getClass());
-        return projClassLoader;
+        return classLoader instanceof ProjectClassLoader ? classLoader : ProjectClassLoader.getClassLoader(classLoader, getClass());
     }
 
     public Environment newEnvironment() {

--- a/drools-core/src/main/java/org/drools/core/impl/KnowledgeBaseImpl.java
+++ b/drools-core/src/main/java/org/drools/core/impl/KnowledgeBaseImpl.java
@@ -105,6 +105,8 @@ public class KnowledgeBaseImpl implements InternalRuleBase {
 
     protected static final Logger logger = LoggerFactory.getLogger(KnowledgeBaseImpl.class);
 
+    private static final KieWeavers WEAVERS = KieService.load( KieWeavers.class );
+
     private Set<EntryPointNode> addedEntryNodeCache;
     private Set<EntryPointNode> removedEntryNodeCache;
 
@@ -445,9 +447,8 @@ public class KnowledgeBaseImpl implements InternalRuleBase {
             }
 
             if ( ! newPkg.getResourceTypePackages().isEmpty() ) {
-                KieWeavers weavers = KieService.load( KieWeavers.class );
                 for ( ResourceTypePackage rtkKpg : newPkg.getResourceTypePackages().values() ) {
-                    weavers.weave( newPkg, rtkKpg );
+                    WEAVERS.weave( newPkg, rtkKpg );
                 }
             }
 
@@ -817,12 +818,11 @@ public class KnowledgeBaseImpl implements InternalRuleBase {
         }
 
         if ( ! newPkg.getResourceTypePackages().isEmpty() ) {
-            KieWeavers weavers = KieService.load(KieWeavers.class);
-            if (weavers == null) {
+            if (WEAVERS == null) {
                 throw new IllegalStateException("Unable to find KieWeavers implementation");
             }
             for ( ResourceTypePackage rtkKpg : newPkg.getResourceTypePackages().values() ) {
-                weavers.merge( pkg, rtkKpg );
+                WEAVERS.merge( pkg, rtkKpg );
             }
         }
     }

--- a/drools-kiesession/src/main/java/org/drools/kiesession/session/StatelessKnowledgeSessionImpl.java
+++ b/drools-kiesession/src/main/java/org/drools/kiesession/session/StatelessKnowledgeSessionImpl.java
@@ -18,17 +18,6 @@
  */
 package org.drools.kiesession.session;
 
-import java.util.ArrayList;
-import java.util.Collection;
-import java.util.Collections;
-import java.util.EventListener;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
-import java.util.concurrent.CopyOnWriteArrayList;
-import java.util.concurrent.atomic.AtomicBoolean;
-import java.util.concurrent.atomic.AtomicLong;
-
 import org.drools.core.SessionConfiguration;
 import org.drools.core.base.MapGlobalResolver;
 import org.drools.core.common.InternalFactHandle;
@@ -57,6 +46,17 @@ import org.kie.api.runtime.StatelessKieSession;
 import org.kie.api.runtime.rule.FactHandle;
 import org.kie.internal.command.RegistryContext;
 import org.kie.internal.runtime.StatefulKnowledgeSession;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.EventListener;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.CopyOnWriteArrayList;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicLong;
 
 public class StatelessKnowledgeSessionImpl extends AbstractRuntime implements StatelessKieSession {
 
@@ -217,8 +217,7 @@ public class StatelessKnowledgeSessionImpl extends AbstractRuntime implements St
     }
     
     @Override
-    public void registerChannel(String name,
-                                Channel channel) {
+    public void registerChannel(String name, Channel channel) {
         this.channels.put(name, channel);
     }
     

--- a/drools-ruleunits/drools-ruleunits-dsl/src/main/java/org/drools/ruleunits/dsl/RuleUnitProviderForDSL.java
+++ b/drools-ruleunits/drools-ruleunits-dsl/src/main/java/org/drools/ruleunits/dsl/RuleUnitProviderForDSL.java
@@ -18,8 +18,6 @@
  */
 package org.drools.ruleunits.dsl;
 
-import java.util.Map;
-
 import org.drools.core.common.ReteEvaluator;
 import org.drools.core.impl.InternalRuleBase;
 import org.drools.core.reteoo.ReteDumper;
@@ -36,6 +34,8 @@ import org.drools.ruleunits.impl.RuleUnitProviderImpl;
 import org.drools.ruleunits.impl.factory.AbstractRuleUnit;
 import org.drools.ruleunits.impl.sessions.RuleUnitExecutorImpl;
 import org.kie.api.runtime.rule.EntryPoint;
+
+import java.util.Map;
 
 public class RuleUnitProviderForDSL extends RuleUnitProviderImpl {
 

--- a/kie-api/src/main/java/org/kie/api/internal/utils/KieService.java
+++ b/kie-api/src/main/java/org/kie/api/internal/utils/KieService.java
@@ -18,11 +18,9 @@
  */
 package org.kie.api.internal.utils;
 
-import java.util.ServiceLoader;
-
 public interface KieService extends Comparable<KieService> {
 
-    public static final String UNDEFINED = "undefined";
+    String UNDEFINED = "undefined";
 
     default int servicePriority() {
         return 0;
@@ -42,32 +40,10 @@ public interface KieService extends Comparable<KieService> {
     }
 
     static <T extends KieService> T load(Class<T> serviceClass) {
-        ServiceLoader<T> loader = ServiceLoader.load(serviceClass, serviceClass.getClassLoader());
-        T service = null;
-        for (T impl : loader) {
-            if (service == null || impl.compareTo(service) > 0) {
-                service = impl;
-            }
-        }
-        return service;
+        return KieServiceLoader.INSTANCE.lookup(serviceClass);
     }
 
     static <T extends KieService> T loadWithTag(Class<T> serviceClass, String tag) {
-        if (tag == null || tag.equals(UNDEFINED)) {
-            return load(serviceClass); // fall back to priority based loading
-        }
-
-        ServiceLoader<T> loader = ServiceLoader.load(serviceClass, serviceClass.getClassLoader());
-        T service = null;
-        for (T impl : loader) {
-            if (tag.equals(impl.serviceTag())) { // accept only services with the specified tag
-                if (service == null) {
-                    service = impl;
-                } else {
-                    throw new IllegalStateException("Found 2 services with the same tag \"" + tag + "\": " + service.getClass().getCanonicalName() + " and " + impl.getClass().getCanonicalName());
-                }
-            }
-        }
-        return service;
+        return KieServiceLoader.INSTANCE.lookup(serviceClass, tag);
     }
 }

--- a/kie-api/src/main/java/org/kie/api/internal/utils/KieServiceLoader.java
+++ b/kie-api/src/main/java/org/kie/api/internal/utils/KieServiceLoader.java
@@ -1,0 +1,61 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.kie.api.internal.utils;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.ServiceLoader;
+
+import static org.kie.api.internal.utils.KieService.UNDEFINED;
+
+public class KieServiceLoader {
+
+    static final KieServiceLoader INSTANCE = new KieServiceLoader();
+
+    private final Map<String, KieService> serviceCache = new HashMap<>();
+
+    private KieServiceLoader() {}
+
+    <T extends KieService> T lookup(Class<T> serviceClass) {
+        return lookup(serviceClass, UNDEFINED);
+    }
+
+    <T extends KieService> T lookup(Class<T> serviceClass, String tag) {
+        String serviceKey = serviceClass.getName() + ":" + tag;
+        if (serviceCache.containsKey(serviceKey)) {
+            return (T) serviceCache.get(serviceKey);
+        }
+        T loadedService = load(serviceClass, tag);
+        serviceCache.put(serviceKey, load(serviceClass, tag));
+        return loadedService;
+    }
+
+    <T extends KieService> T load(Class<T> serviceClass, String tag) {
+        ServiceLoader<T> loader = ServiceLoader.load(serviceClass, serviceClass.getClassLoader());
+        T service = null;
+        for (T impl : loader) {
+            if ( tag.equals(impl.serviceTag()) ) { // accept only services with the specified tag
+                if (service == null || impl.compareTo(service) > 0) {
+                    service = impl;
+                }
+            }
+        }
+        return service;
+    }
+}


### PR DESCRIPTION
Fix for https://github.com/apache/incubator-kie-issues/issues/635

Using [this benchmark](https://github.com/apache/incubator-kie-benchmarks/pull/269) I measure the performances of a simple stateless session execution before

```
Benchmark                              (factsNr)  (rulesNr)  Mode    Cnt   Score   Error  Units
ExecuteStatelessSessionBenchmark.test          1          1    ss  50000  61.736 ± 0.458  us/op

```
and after this fix

```
Benchmark                              (factsNr)  (rulesNr)  Mode    Cnt   Score   Error  Units
ExecuteStatelessSessionBenchmark.test          1          1    ss  50000  12.847 ± 0.480  us/op

```