### PR TITLE
kie-issues#647: add writeJunitReport to invoker configuration

### DIFF
--- a/build-parent/pom.xml
+++ b/build-parent/pom.xml
@@ -1884,6 +1884,9 @@
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-invoker-plugin</artifactId>
           <version>3.2.1</version>
+          <configuration>
+            <writeJunitReport>true</writeJunitReport>
+          </configuration>
         </plugin>
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>


### PR DESCRIPTION
apache/incubator-kie-issues#647

Given that CI builds set `maven.test.failure.ignore` to true, any build failure would be silently ignored, unless invoker plugin writes the build fail as a junit report with failure outcome.

This is achieved by property writeJunitReport which is false by default and needs to be overriden.

To be validated by the test results of the PR check - they should contain test cases named as the invoked projects (I need guidance of the repository SMEs on which those should be).
EDIT: should be prefixed by `maven.invoker.it` AFAIK.