### PR TITLE
[kie-issues#653] Don't use System.out and logger debug mode in test output in traits

### DIFF
--- a/drools-compiler/src/test/resources/logback-test.xml
+++ b/drools-compiler/src/test/resources/logback-test.xml
@@ -30,10 +30,10 @@
   <logger name="org.kie" level="warn"/>
   <logger name="org.drools" level="warn"/>
   
-  <logger name="org.drools.core.management" level="debug"/>
+  <logger name="org.drools.core.management" level="info"/>
   <!--<logger name="org.drools.ancompiler" level="debug"/>-->
 
-  <logger name="org.drools.metric.util.MetricLogUtils" level="trace"/>
+  <logger name="org.drools.metric.util.MetricLogUtils" level="info"/>
 
   <root level="warn">
     <appender-ref ref="consoleAppender" />

--- a/drools-examples-api/kie-module-from-multiple-files/src/main/resources/logback.xml
+++ b/drools-examples-api/kie-module-from-multiple-files/src/main/resources/logback.xml
@@ -28,7 +28,7 @@
   </appender>
 
   <logger name="org.kie" level="warn"/>
-  <logger name="org.drools" level="debug"/>
+  <logger name="org.drools" level="info"/>
 
   <root level="warn">
     <appender-ref ref="consoleAppender"/>

--- a/drools-mvel/src/test/resources/logback-test.xml
+++ b/drools-mvel/src/test/resources/logback-test.xml
@@ -30,7 +30,7 @@
   <logger name="org.kie" level="warn"/>
   <logger name="org.drools" level="warn"/>
   
-  <logger name="org.drools.core.management" level="debug"/>
+  <logger name="org.drools.core.management" level="info"/>
   <!--<logger name="org.drools.ancompiler" level="debug"/>-->
 
   <root level="warn">

--- a/drools-ruleunits/drools-ruleunits-impl/src/test/resources/logback-test.xml
+++ b/drools-ruleunits/drools-ruleunits-impl/src/test/resources/logback-test.xml
@@ -31,7 +31,7 @@
   <logger name="org.drools.compiler.kie.builder.impl" level="ERROR" />
 <!--  <logger name="org.drools.ruleunits.impl" level="debug"/>-->
   <!--  <logger name="org.drools.model.codegen.execmodel.generator.expressiontyper" level="debug"/>-->
-    <logger name="org.drools.model.codegen.execmodel" level="debug"/>
+    <logger name="org.drools.model.codegen.execmodel" level="info"/>
 
   <logger name="org.drools" level="warn"/>
 

--- a/drools-traits/src/main/java/org/drools/traits/core/reteoo/TraitObjectTypeNode.java
+++ b/drools-traits/src/main/java/org/drools/traits/core/reteoo/TraitObjectTypeNode.java
@@ -68,10 +68,7 @@ public class TraitObjectTypeNode extends ObjectTypeNode {
 
             boolean allowed = ! vetoed || sameAndNotCoveredByDescendants((TraitProxyImpl) factHandle.getObject(), typeMask );
             if ( allowed ) {
-                //System.err.println(" INSERT PASS !! " + factHandle.getObject() + " " + ( (TraitProxy) factHandle.getObject() )._getTypeCode() + " >> " + vetoMask + " checks in " + typeMask );
                 proxy.assignOtn( this.typeMask );
-            } else {
-                //System.err.println(" INSERT BLOCK !! " + factHandle.getObject() + " " + ( (TraitProxy) factHandle.getObject() )._getTypeCode() + " >> " + vetoMask + " checks in " + typeMask );
             }
             return allowed;
         }
@@ -134,8 +131,6 @@ public class TraitObjectTypeNode extends ObjectTypeNode {
                                                 modifyPreviousTuples,
                                                 context.adaptModificationMaskForObjectType(objectType, reteEvaluator),
                                                 reteEvaluator);
-            } else {
-                //System.err.println( ((ClassObjectType) this.getObjectType()).getClassName() + " : MODIFY BLOCK !! " + ( (TraitProxy) factHandle.getObject() ).getTraitName() + " " + ( (TraitProxy) factHandle.getObject() )._getTypeCode() + " >> " + " checks in " + typeMask );
             }
         } else {
             this.sink.propagateModifyObject(factHandle,

--- a/drools-traits/src/main/java/org/drools/traits/core/util/AbstractBitwiseHierarchyImpl.java
+++ b/drools-traits/src/main/java/org/drools/traits/core/util/AbstractBitwiseHierarchyImpl.java
@@ -130,7 +130,6 @@ public abstract class AbstractBitwiseHierarchyImpl<H ,J extends LatticeElement<H
     public Collection<H> upperAncestors( BitSet key ) {
         List<H> vals = new LinkedList<>();
         int l = key.length();
-        //System.out.println( key );
 
         BitSet start = new BitSet( l );
         BitSet end = new BitSet( l );
@@ -150,13 +149,8 @@ public abstract class AbstractBitwiseHierarchyImpl<H ,J extends LatticeElement<H
             start.set( s, true );
             end.set( s, t, true );
 
-//            System.out.println( "X  >> " + s + " << " + t );
-//            System.out.println( "S  >> " + start );
-//            System.out.println( "E  >> " + end );
-//            System.out.println( "E+1>> " + nextKey( end ) );
             if ( t > 0 ) {
                 for ( J val : line.subMap( start, nextKey( end ) ).values() ) {
-//                    System.out.println( "\t " + val.getValue() );
                     vals.add( val.getValue() );
                 }
             }
@@ -230,11 +224,9 @@ public abstract class AbstractBitwiseHierarchyImpl<H ,J extends LatticeElement<H
                     J ex = border.get( k );
                     if ( ex != null ) {
                         if ( superset( candidate, ex.getBitMask() ) >= 0 ) {
-//                                System.out.println( "Skipping " + val + " due to " + ex );
                             minimal = false;
                             break;
                         } else if ( superset( ex.getBitMask(), candidate ) > 0 ) {
-//                                System.out.println( "Clearing " + ex + " due to " + val );
                             border.set( k, null );
                         }
 
@@ -276,8 +268,6 @@ public abstract class AbstractBitwiseHierarchyImpl<H ,J extends LatticeElement<H
     List<J> lcsBorderNodes( BitSet key, boolean includeEquals ) {
         List<J> border = new ArrayList<>();
         if ( key == null ) { return border; }
-//        System.out.println( key );
-
         int l = key.length();
         BitSet start = new BitSet( l + 1 );
         BitSet end = new BitSet( l + 1 );
@@ -308,13 +298,11 @@ public abstract class AbstractBitwiseHierarchyImpl<H ,J extends LatticeElement<H
 
                         if ( ex != null ) {
                             if ( superset( candidate, ex.getBitMask() ) > 0 ) {
-//                            System.out.println( "Clearing " + ex + " due to " + val );
                                 border.set( j, null );
                             }
                         }
                     }
                 }
-//                System.out.println( "\t\t " + border );
             }
 
             index = key.nextSetBit( t );

--- a/drools-traits/src/main/java/org/drools/traits/core/util/AbstractCodedHierarchyImpl.java
+++ b/drools-traits/src/main/java/org/drools/traits/core/util/AbstractCodedHierarchyImpl.java
@@ -58,9 +58,6 @@ public abstract class AbstractCodedHierarchyImpl<T> extends AbstractBitwiseHiera
                 }
             }
             add( node );
-//            System.out.println( " Added inst node " + node );
-//            System.out.println( " \t parents " + parents( key ) );
-//            System.out.println( " \t children " + children( key ) );
         }
     }
 

--- a/drools-traits/src/main/java/org/drools/traits/core/util/HierarchyEncoderImpl.java
+++ b/drools-traits/src/main/java/org/drools/traits/core/util/HierarchyEncoderImpl.java
@@ -109,7 +109,6 @@ public class HierarchyEncoderImpl<T> extends CodedHierarchyImpl<T> implements Hi
 
     protected void encode( HierNode<T> node ) {
         Collection<HierNode<T>> parents = node.getParents();
-        //System.out.println( "Trying to encode " + node );
         switch ( parents.size() ) {
             case 0 :
                 BitSet zero = new BitSet();
@@ -143,7 +142,6 @@ public class HierarchyEncoderImpl<T> extends CodedHierarchyImpl<T> implements Hi
                 break;
             default:
                 inheritMerged( node );
-                //System.out.println( " ----------------------------------------------------------------------------------------- " );
                 resolveConflicts( node );
                 break;
         }
@@ -155,21 +153,17 @@ public class HierarchyEncoderImpl<T> extends CodedHierarchyImpl<T> implements Hi
         Collection<HierNode<T>> nodes = new ArrayList<>( getNodes() );
         for ( HierNode<T> y : nodes ) {
             if ( incomparable( x, y ) ) {
-//                System.out.println( " \t\tIncomparability between " + x + " and " + y );
                 int sup = superset( y, x );
                 if ( sup == 0 ) {
-                    //System.out.println( " \t\tIncomparable, with same mask " + y );
                     // can't use update mask here, or the already existing node would be removed
                     x.setBitMask( increment( x.getBitMask(), freeBit( x ) ) );
                     propagate( y, freeBit( x, y ) );
                 }
                 if ( sup > 0 ) {
-//                    System.out.println( " \t\tIncomparable, but as parent " + y );
                     updateMask( x, increment( x.getBitMask(), freeBit( x ) ) );
                 }
                 int sub = superset( x, y );
                 if ( sub > 0 ) {
-//                    System.out.println( " \t\tIncomparable, but as child " + y );
                     modify( x, y );
                     conflicted = true;
                 }
@@ -184,12 +178,9 @@ public class HierarchyEncoderImpl<T> extends CodedHierarchyImpl<T> implements Hi
     }
 
     protected void modify( HierNode<T> x, HierNode<T> y ) {
-        //System.out.println( "Modifying on a inc between " + x + " and " + y );
 
         int i = freeBit( x, y );
-        //System.out.println( "I " + i );
 
-        //System.out.println( "Getting parents of " + y + " >> " + y.getParents() );
         Collection<HierNode<T>> py = y.getParents();
         BitSet t = new BitSet( y.getBitMask().length() );
         for ( HierNode<T> parent : py ) {
@@ -202,10 +193,6 @@ public class HierarchyEncoderImpl<T> extends CodedHierarchyImpl<T> implements Hi
         if ( inDex < 0 ) {
             propagate( y, i );
         } else {
-
-            //System.out.println( "D " + toBinaryString( d ) );
-
-
             Set<HierNode<T>> ancestors = ancestorNodes( x );
             Set<HierNode<T>> affectedAncestors = new HashSet<>();
 
@@ -214,16 +201,11 @@ public class HierarchyEncoderImpl<T> extends CodedHierarchyImpl<T> implements Hi
                     affectedAncestors.add( anc );
                 }
             }
-            //System.out.println( "Ancestors of " + x + " >> " + ancestors );
-            //System.out.println( "Affected " + x + " >> " + affectedAncestors );
-
             if ( affectedAncestors.size() == 0 ) {
                 return;
             }
 
             Set<HierNode<T>> gcs = gcs( affectedAncestors );
-            //System.out.println( "GCS of Affected " + gcs );
-
             Set<HierNode<T>> affectedDescendants = new HashSet<>();
             for ( HierNode<T> g : gcs ) {
                 affectedDescendants.addAll( descendantNodes( g ) );
@@ -251,8 +233,6 @@ public class HierarchyEncoderImpl<T> extends CodedHierarchyImpl<T> implements Hi
                 subMask = increment( subMask, i );
 
                 updateMask( sub, subMask );
-
-                //System.out.println( "\tModified Desc" + sub );
             }
 
             inDex = d.nextSetBit( inDex + 1 );
@@ -286,7 +266,6 @@ public class HierarchyEncoderImpl<T> extends CodedHierarchyImpl<T> implements Hi
         while ( iter.hasNext() ) {
             a.and( iter.next().getBitMask() );
         }
-        //System.out.println( "Root mask for ceil " + toBinaryString( a ) );
         for ( HierNode<T> node : getNodes() ) {
             if ( superset( node.getBitMask(), a ) >= 0 ) {
                 s.add( node );
@@ -298,7 +277,6 @@ public class HierarchyEncoderImpl<T> extends CodedHierarchyImpl<T> implements Hi
     }
 
     protected Set<HierNode<T>> ceil( Set<HierNode<T>> s ) {
-        //System.out.println( "Looking for the ceiling of " + s);
         if ( s.size() <= 1 ) { return s; }
         Set<HierNode<T>> ceil = new HashSet<>( s );
         for ( HierNode<T> x : s ) {
@@ -309,12 +287,10 @@ public class HierarchyEncoderImpl<T> extends CodedHierarchyImpl<T> implements Hi
                 }
             }
         }
-        //System.out.println("Found ceiling " + ceil);
         return ceil;
     }
 
     protected Set<HierNode<T>> floor( Set<HierNode<T>> s ) {
-        //System.out.println( "Looking for the floor of " + s);
         if ( s.size() <= 1 ) { return s; }
         Set<HierNode<T>> ceil = new HashSet<>( s );
         for ( HierNode<T> x : s ) {
@@ -325,7 +301,6 @@ public class HierarchyEncoderImpl<T> extends CodedHierarchyImpl<T> implements Hi
                 }
             }
         }
-        //System.out.println("Found ceiling " + ceil);
         return ceil;
     }
 
@@ -370,30 +345,25 @@ public class HierarchyEncoderImpl<T> extends CodedHierarchyImpl<T> implements Hi
     }
 
     protected int freeBit( HierNode<T> x, HierNode<T> z ) {
-        //System.out.println( "Looking for a free bit in node " + x );
         BitSet forbid = new BitSet( this.size() );
         forbid.or( x.getBitMask() );
         for ( HierNode<T> y : getNodes() ) {
 
             if ( superset( y, x ) > 0 ) {
-                //System.out.println( "\t\t Subtype " + y + " contributes " + toBinaryString( y.getBitMask() ) );
                 forbid.or( y.getBitMask() );
             }
 
             if ( z != null ) {
                 if ( superset( y, z ) > 0 ) {
-//                  System.out.println( "\t\t Subtype " + y + " contributes " + toBinaryString( y.getBitMask() ) );
                     forbid.or( y.getBitMask() );
                 }
             }
 
             if ( superset( x, y ) < 0 ) {
                 BitSet diff = singleBitDiff( x.getBitMask(), y.getBitMask() );
-                //System.out.println( "\t\t Incomparable " + y + " contributes " + toBinaryString( diff ) );
                 forbid.or(diff);
             }
         }
-        //System.out.println( "\t Forbidden mask " + toBinaryString( forbid ) );
         return firstZero( forbid );
     }
 

--- a/drools-traits/src/test/java/org/drools/traits/UseOfRuleFlowGroupPlusLockOnTest.java
+++ b/drools-traits/src/test/java/org/drools/traits/UseOfRuleFlowGroupPlusLockOnTest.java
@@ -26,10 +26,14 @@ import org.kie.api.event.rule.DebugAgendaEventListener;
 import org.kie.api.io.ResourceType;
 import org.kie.api.runtime.KieSession;
 import org.kie.internal.utils.KieHelper;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
 public class UseOfRuleFlowGroupPlusLockOnTest {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(UseOfRuleFlowGroupPlusLockOnTest.class);
 
     private static final String drl = "package com.sample\n"
             + "import " + Person.class.getCanonicalName() + " ;\n"
@@ -57,7 +61,9 @@ public class UseOfRuleFlowGroupPlusLockOnTest {
         KieHelper kieHelper = new KieHelper().addContent(drl, ResourceType.DRL);
         KieBase kbase = kieHelper.build();
         KieSession ksession = kbase.newKieSession();
-        ReteDumper.dumpRete(ksession);
+        if (LOGGER.isDebugEnabled()) {
+            ReteDumper.dumpRete(ksession);
+        }
         ksession.addEventListener( new DebugAgendaEventListener() );
         try {
             ksession.insert(new Person());
@@ -65,8 +71,6 @@ public class UseOfRuleFlowGroupPlusLockOnTest {
             ((DefaultAgenda) ksession.getAgenda()).activateRuleFlowGroup("group1");
             int rulesFired = ksession.fireAllRules();
             assertThat(rulesFired).isEqualTo(1);
-
-
         } finally {
             ksession.dispose();
         }

--- a/drools-traits/src/test/java/org/drools/traits/compiler/factmodel/traits/Imp2.java
+++ b/drools-traits/src/test/java/org/drools/traits/compiler/factmodel/traits/Imp2.java
@@ -22,6 +22,8 @@ import org.drools.base.factmodel.traits.Thing;
 import org.drools.base.factmodel.traits.TraitFieldTMS;
 import org.drools.traits.core.factmodel.TraitFieldTMSImpl;
 import org.drools.base.factmodel.traits.TraitableBean;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.util.BitSet;
 import java.util.Collection;
@@ -32,6 +34,8 @@ import java.util.Map;
 import java.util.Set;
 
 public class Imp2 implements TraitableBean<Imp2,Imp2> {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(Imp2.class);
 
     private String name;
     private String school;
@@ -137,8 +141,7 @@ public class Imp2 implements TraitableBean<Imp2,Imp2> {
 
     public void foo() {
         Object f = __$$dynamic_properties_map$$.get( "goo" );
-        System.out.println( f );
-
+        LOGGER.debug( f.toString() );
     }
 
     private TraitFieldTMS tms;

--- a/drools-traits/src/test/java/org/drools/traits/compiler/factmodel/traits/LegacyTraitTest.java
+++ b/drools-traits/src/test/java/org/drools/traits/compiler/factmodel/traits/LegacyTraitTest.java
@@ -43,6 +43,8 @@ import org.kie.internal.builder.KnowledgeBuilder;
 import org.kie.internal.builder.KnowledgeBuilderFactory;
 import org.kie.internal.io.ResourceFactory;
 import org.kie.internal.utils.KieHelper;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.fail;
@@ -50,6 +52,8 @@ import static org.drools.traits.compiler.factmodel.traits.TraitTestUtils.createS
 
 @RunWith(Parameterized.class)
 public class LegacyTraitTest extends CommonTraitTest {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(LegacyTraitTest.class);
 
     public VirtualPropertyMode mode;
 
@@ -290,7 +294,7 @@ public class LegacyTraitTest extends CommonTraitTest {
 
         int n = ks.fireAllRules();
 
-        System.out.println( list );
+        LOGGER.debug( list.toString() );
         assertThat(list).isEqualTo(Arrays.asList(1, 2, 3));
         assertThat(n).isEqualTo(3);
     }

--- a/drools-traits/src/test/java/org/drools/traits/compiler/factmodel/traits/LogicalTraitTest.java
+++ b/drools-traits/src/test/java/org/drools/traits/compiler/factmodel/traits/LogicalTraitTest.java
@@ -52,6 +52,8 @@ import org.kie.internal.builder.KnowledgeBuilderFactory;
 import org.kie.internal.builder.conf.PropertySpecificOption;
 import org.kie.internal.io.ResourceFactory;
 import org.kie.internal.utils.KieHelper;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.fail;
@@ -59,6 +61,7 @@ import static org.assertj.core.api.Assertions.fail;
 @RunWith(Parameterized.class)
 public class LogicalTraitTest extends CommonTraitTest {
 
+    private static final Logger LOGGER = LoggerFactory.getLogger(LogicalTraitTest.class);
 
     public VirtualPropertyMode mode;
 
@@ -97,18 +100,16 @@ public class LogicalTraitTest extends CommonTraitTest {
         ks.fireAllRules();
 
         for ( Object o : ks.getObjects() ) {
-            System.out.println( o );
+            LOGGER.debug( o.toString() );
         }
-
 
         try {
             ks = SerializationHelper.getSerialisedStatefulKnowledgeSession(ks, true );
         } catch ( Exception e ) {
-            e.printStackTrace();
-            fail( e.getMessage() );
+            fail( e.getMessage(), e );
         }
 
-        System.out.println( list );
+        LOGGER.debug( list.toString() );
         assertThat(list.contains(false)).isFalse();
         assertThat(list.size()).isEqualTo(8);
     }
@@ -169,15 +170,14 @@ public class LogicalTraitTest extends CommonTraitTest {
 
         ks.fireAllRules();
         for ( Object o : ks.getObjects() ) {
-            System.out.println( o );
+            LOGGER.debug( o.toString() );
         }
         assertThat(list).isEqualTo(List.of("ok"));
 
         try {
             ks = SerializationHelper.getSerialisedStatefulKnowledgeSession( ks, true );
         } catch ( Exception e ) {
-            e.printStackTrace();
-            fail( e.getMessage() );
+            fail( e.getMessage(), e );
         }
 
     }
@@ -218,7 +218,6 @@ public class LogicalTraitTest extends CommonTraitTest {
                      "when \n" +
                      "  $x : Y( fld isA T ) \n" +
                      "then \n" +
-                     "  System.err.println( $x.getFld() ); \n" +
                      "  list.add( \"ok1\" );" +
                      "end \n" +
                      "" +
@@ -226,7 +225,6 @@ public class LogicalTraitTest extends CommonTraitTest {
                      "when \n" +
                      "  $x : X( fld isA T ) \n" +
                      "then \n" +
-                     "  System.err.println( $x.getFld() ); \n" +
                      "  list.add( \"ok2\" );" +
                      "end \n" +
                      "" +
@@ -248,15 +246,14 @@ public class LogicalTraitTest extends CommonTraitTest {
 
         ks.fireAllRules();
         for ( Object o : ks.getObjects() ) {
-            System.out.println( o );
+            LOGGER.debug( o.toString() );
         }
         assertThat(list).isEqualTo(Arrays.asList("ok1", "ok2"));
 
         try {
             ks = SerializationHelper.getSerialisedStatefulKnowledgeSession( ks, true );
         } catch ( Exception e ) {
-            e.printStackTrace();
-            fail( e.getMessage() );
+            fail( e.getMessage(), e );
         }
 
     }
@@ -322,15 +319,14 @@ public class LogicalTraitTest extends CommonTraitTest {
 
         ks.fireAllRules();
         for ( Object o : ks.getObjects() ) {
-            System.out.println( o );
+            LOGGER.debug( o.toString() );
         }
         assertThat(list).isEqualTo(List.of("ok"));
 
         try {
             ks = SerializationHelper.getSerialisedStatefulKnowledgeSession( ks, true );
         } catch ( Exception e ) {
-            e.printStackTrace();
-            fail( e.getMessage() );
+            fail( e.getMessage(), e );
         }
 
     }
@@ -403,19 +399,18 @@ public class LogicalTraitTest extends CommonTraitTest {
         knowledgeSession.fireAllRules();
 
         for ( Object o : knowledgeSession.getObjects() ) {
-            System.out.println( o );
+            LOGGER.debug( o.toString());
         }
 
-        System.out.println( list );
-        System.out.println( list2 );
+        LOGGER.debug( list.toString() );
+        LOGGER.debug( list2.toString() );
         assertThat(list).isEqualTo(Arrays.asList("1", null, "xyz", "xyz", "7", "aaa"));
         assertThat(list2).isEqualTo(Arrays.asList(18, null, 37, 99, 37));
 
         try {
             knowledgeSession = SerializationHelper.getSerialisedStatefulKnowledgeSession( knowledgeSession, true );
         } catch ( Exception e ) {
-            e.printStackTrace();
-            fail( e.getMessage() );
+            fail( e.getMessage(), e );
         }
     }
 
@@ -486,19 +481,18 @@ public class LogicalTraitTest extends CommonTraitTest {
         knowledgeSession.fireAllRules();
 
         for ( Object o : knowledgeSession.getObjects() ) {
-            System.out.println( o );
+            LOGGER.debug( o.toString() );
         }
 
-        System.out.println( list );
-        System.out.println( list2 );
+        LOGGER.debug( list.toString() );
+        LOGGER.debug( list2.toString() );
         assertThat(list).isEqualTo(Arrays.asList(1.0, 0.0, 16.3, 16.3, 0.0, -0.72));
         assertThat(list2).isEqualTo(Arrays.asList(18, 0, 37, 99, 0));
 
         try {
             knowledgeSession = SerializationHelper.getSerialisedStatefulKnowledgeSession( knowledgeSession, true );
         } catch ( Exception e ) {
-            e.printStackTrace();
-            fail( e.getMessage() );
+            fail( e.getMessage(), e );
         }
 
         knowledgeSession.dispose();
@@ -643,14 +637,13 @@ public class LogicalTraitTest extends CommonTraitTest {
         knowledgeSession.fireAllRules();
 
         for ( Object o : knowledgeSession.getObjects() ) {
-            System.out.println( o );
+            LOGGER.debug( o.toString() );
         }
 
         try {
             knowledgeSession = SerializationHelper.getSerialisedStatefulKnowledgeSession( knowledgeSession, true );
         } catch ( Exception e ) {
-            e.printStackTrace();
-            fail( e.getMessage() );
+            fail( e.getMessage(), e );
         }
 
 
@@ -726,14 +719,13 @@ public class LogicalTraitTest extends CommonTraitTest {
                         fail( "Unexpected id " );
                 }
             }
-            System.out.println( o );
+            LOGGER.debug( o.toString() );
         }
 
         try {
             knowledgeSession = SerializationHelper.getSerialisedStatefulKnowledgeSession( knowledgeSession, true );
         } catch ( Exception e ) {
-            e.printStackTrace();
-            fail( e.getMessage() );
+            fail( e.getMessage(), e );
         }
 
 
@@ -800,8 +792,7 @@ public class LogicalTraitTest extends CommonTraitTest {
         try {
             ks = SerializationHelper.getSerialisedStatefulKnowledgeSession( ks, true );
         } catch ( Exception e ) {
-            e.printStackTrace();
-            fail( e.getMessage() );
+            fail( e.getMessage(), e );
         }
 
     }
@@ -844,7 +835,6 @@ public class LogicalTraitTest extends CommonTraitTest {
                      "rule Don \n" +
                      "when \n" +
                      "then \n" +
-                     "  System.out.println( \"Create K !\" ); \n" +
                      "  K k = new K(1); " +
                      "  don( k, T.class ); \n" +
                      "  modify ( k ) { \n" +
@@ -857,7 +847,6 @@ public class LogicalTraitTest extends CommonTraitTest {
                      "when \n" +
                      "  $x : K( fld isA S, fld not isA R ) \n" +
                      "then \n" +
-                     "  System.out.println( \"K detected\" + $x );" +
                      "  list.add( \"ok1\" );" +
                      "end \n" +
                      "" +
@@ -867,7 +856,6 @@ public class LogicalTraitTest extends CommonTraitTest {
                      "  String() \n" +
                      "  $x : K( fld isA S ) \n" +
                      "then \n" +
-                     "  System.out.println( \"Add U - R\" );" +
                      "  don( $x, U.class ); \n" +
                      "end \n" +
                      "" +
@@ -889,23 +877,18 @@ public class LogicalTraitTest extends CommonTraitTest {
         ks.setGlobal( "list", list );
 
         int n = ks.fireAllRules();
-        System.out.println( "Rules fired " + n );
+        LOGGER.debug( "Rules fired " + n );
 
-        System.out.println( "------------- ROUND TRIP -------------" );
+        LOGGER.debug( "------------- ROUND TRIP -------------" );
 
         try {
             ks = SerializationHelper.getSerialisedStatefulKnowledgeSession( ks, true );
         } catch ( Exception e ) {
-            e.printStackTrace();
-            fail( e.getMessage() );
+            fail( e.getMessage(), e );
         }
 
         ks.insert( "go" );
         ks.fireAllRules();
-
-//        for ( Object o : ks.getObjects() ) {
-//            System.out.println( o );
-//        }
 
         assertThat(list).isEqualTo(List.of("ok1"));
     }
@@ -1011,7 +994,7 @@ public class LogicalTraitTest extends CommonTraitTest {
         assertThat(list).isEqualTo(List.of("ok"));
 
         for ( Object o : ks.getObjects() ) {
-            System.out.println( o  + " >> " + ((InternalFactHandle)ks.getFactHandle( o )).getEqualityKey() );
+            LOGGER.debug( o  + " >> " + ((InternalFactHandle)ks.getFactHandle( o )).getEqualityKey() );
         }
 
         ks.retract( handle );
@@ -1033,8 +1016,7 @@ public class LogicalTraitTest extends CommonTraitTest {
         try {
             ks = SerializationHelper.getSerialisedStatefulKnowledgeSession( ks, true );
         } catch ( Exception e ) {
-            e.printStackTrace();
-            fail( e.getMessage() );
+            fail( e.getMessage(), e );
         }
 
         ks.setGlobal( "list", list );
@@ -1042,7 +1024,7 @@ public class LogicalTraitTest extends CommonTraitTest {
         ks.insert( "go2" );
         ks.fireAllRules();
 
-        System.out.println( list );
+        LOGGER.debug( list.toString() );
 
         assertThat(list).isEqualTo(Arrays.asList("ok", "ok2", "ok3"));
 
@@ -1103,11 +1085,6 @@ public class LogicalTraitTest extends CommonTraitTest {
                      "  String( this == \"go\" ) \n" +
                      "  $x : X( $f1 : fld, $f2 : fld2 ) \n" +
                      "then \n" +
-                "  System.out.println(\"inizio check\");" +
-                "  System.out.println(list);" +
-                "  System.out.println($f1);" +
-                "  System.out.println($f1.getId());" +
-                "  System.out.println(\"fine check\");" +
                      "  list.add( $f1.getId() );" +
                      "  list.add( $f2.getId() );" +
                      "end \n" +
@@ -1117,15 +1094,9 @@ public class LogicalTraitTest extends CommonTraitTest {
                      "  not String( this == \"go\" ) \n" +
                      "  $x : Y( $f1 : fld, $f2 : fld2 ) \n" +
                      "then \n" +
-                     "  System.out.println(\"inizio check2\");" +
-                     "  System.out.println(list);" +
-                     "  System.out.println($f1);" +
-                     "  System.out.println($f1.getId());" +
-                "  System.out.println(\"fine check2\");" +
-                "  list.add( $f1.getId() );" +
+                     "  list.add( $f1.getId() );" +
                      "  list.add( $f2.getId() );" +
-                     "end \n" +
-                     "";
+                     "end \n";
 
         KnowledgeBuilder kbuilderImpl = KnowledgeBuilderFactory.newKnowledgeBuilder();
         kbuilderImpl.add( ResourceFactory.newByteArrayResource( drl.getBytes() ), ResourceType.DRL );
@@ -1156,11 +1127,10 @@ public class LogicalTraitTest extends CommonTraitTest {
         try {
             ks = SerializationHelper.getSerialisedStatefulKnowledgeSession( ks, true );
         } catch ( Exception e ) {
-            e.printStackTrace();
-            fail( e.getMessage() );
+            fail( e.getMessage(), e );
         }
 
-        System.out.println( list );
+        LOGGER.debug( list.toString() );
         assertThat(list).isEqualTo(Arrays.asList(1, 2, 1, 2));
 
     }
@@ -1212,23 +1182,19 @@ public class LogicalTraitTest extends CommonTraitTest {
 
         ks.fireAllRules();
         for ( Object o : ks.getObjects() ) {
-            System.out.println( o );
+            LOGGER.debug( o.toString() );
         }
 
         try {
             ks = SerializationHelper.getSerialisedStatefulKnowledgeSession( ks, true );
         } catch ( Exception e ) {
-            e.printStackTrace();
-            fail( e.getMessage() );
+            fail( e.getMessage(), e );
         }
 
         for ( Object o : ks.getObjects() ) {
-            System.out.println( o );
+            LOGGER.debug( o.toString() );
         }
-
-
     }
-
 
     @Test
     public void testTraitMismatchTypes()
@@ -1387,7 +1353,7 @@ public class LogicalTraitTest extends CommonTraitTest {
         ksession.setGlobal("list",list);
         ksession.fireAllRules();
 
-        System.out.println( "list" + list );
+        LOGGER.debug( "list" + list );
 
         assertThat(list.size()).isEqualTo(1);
         assertThat(list.get(0).getClass().getName()).isEqualTo("org.drools.base.factmodel.traits.test.Bar");

--- a/drools-traits/src/test/java/org/drools/traits/compiler/factmodel/traits/SomethingImpl.java
+++ b/drools-traits/src/test/java/org/drools/traits/compiler/factmodel/traits/SomethingImpl.java
@@ -18,9 +18,12 @@
  */
 package org.drools.traits.compiler.factmodel.traits;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 public class SomethingImpl<K> implements IDoSomething<K> {
 
-
+    private static final Logger LOGGER = LoggerFactory.getLogger(SomethingImpl.class);
 
     private ISomethingWithBehaviour<K> arg;
 
@@ -44,6 +47,6 @@ public class SomethingImpl<K> implements IDoSomething<K> {
     }
 
     public void doAnotherTask() {
-        System.out.println("X");
+        LOGGER.debug("X");
     }
 }

--- a/drools-traits/src/test/java/org/drools/traits/compiler/factmodel/traits/StandaloneTest.java
+++ b/drools-traits/src/test/java/org/drools/traits/compiler/factmodel/traits/StandaloneTest.java
@@ -27,11 +27,15 @@ import org.drools.traits.core.util.StandaloneTraitFactory;
 import org.drools.wiring.api.classloader.ProjectClassLoader;
 import org.junit.Before;
 import org.junit.Test;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.drools.traits.compiler.factmodel.traits.TraitTestUtils.createStandaloneTraitFactory;
 
 public class StandaloneTest {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(StandaloneTest.class);
 
     private StandaloneTraitFactory factory;
 
@@ -62,8 +66,8 @@ public class StandaloneTest {
         CoreWrapper<Imp> core = factory.makeTraitable(imp, Imp.class );
         IStudent student = (IStudent) factory.don( core, IStudent.class );
 
-        System.out.println( student.getName() );
-        System.out.println( student.getSchool() );
+        LOGGER.debug( student.getName() );
+        LOGGER.debug( student.getSchool() );
         assertThat(student.getName()).isEqualTo("john doe");
         assertThat(student.getSchool()).isNull();
 
@@ -71,7 +75,7 @@ public class StandaloneTest {
 
         student.setName( "alan ford" );
 
-        System.out.println( p.getName() );
+        LOGGER.debug( p.getName() );
         assertThat(p.getName()).isEqualTo("alan ford");
     }
 
@@ -92,8 +96,8 @@ public class StandaloneTest {
         CoreWrapper<Imp> core = factory.makeTraitable( imp, Imp.class );
         IFoo foo = (IFoo) factory.don( core, IFoo.class );
 
-        System.out.println( foo.getName() );
-        System.out.println( foo instanceof Thing );
+        LOGGER.debug( foo.getName() );
+        LOGGER.debug( "Is foo instance of Thing? : " + (foo instanceof Thing) );
 
         assertThat(foo.getName()).isEqualTo("john doe");
         assertThat(foo instanceof Thing).isTrue();

--- a/drools-traits/src/test/java/org/drools/traits/compiler/factmodel/traits/StudentProxyImpl3.java
+++ b/drools-traits/src/test/java/org/drools/traits/compiler/factmodel/traits/StudentProxyImpl3.java
@@ -33,9 +33,12 @@ import org.drools.traits.core.factmodel.TripleFactory;
 import org.drools.traits.core.factmodel.TripleFactoryImpl;
 import org.drools.traits.core.factmodel.TripleStore;
 import org.kie.api.runtime.rule.Variable;
-
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 public class StudentProxyImpl3 extends TraitProxyImpl implements IStudent {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(StudentProxyImpl3.class);
 
     private static final String traitType = IStudent.class.getName();
 
@@ -54,7 +57,7 @@ public class StudentProxyImpl3 extends TraitProxyImpl implements IStudent {
 
     public StudentProxyImpl3(Imp2 obj, final TripleStore m, TripleFactory factory) {
 
-        System.out.println( "ABSCS" );
+        LOGGER.debug( "ABSCS" );
 
         this.object = obj;
 

--- a/drools-traits/src/test/java/org/drools/traits/compiler/factmodel/traits/StudentProxyWrapper2.java
+++ b/drools-traits/src/test/java/org/drools/traits/compiler/factmodel/traits/StudentProxyWrapper2.java
@@ -45,21 +45,11 @@ public class StudentProxyWrapper2 implements Map<String, Object>, MapWrapper {
             this.object = object;
             this.map = map;
 
-//            System.out.println( map );
-//            System.out.println( object );
             object._setDynamicProperties( map );
-
-//            map.put( "age", 0 );
-//            map.put( "xcsvf" , 0.0 );
-//            map.put( "name" , null );
-//            map.put( "csdfsd", 0L );
-//            map.put( "school" , null );
-
         }
 
         public int size() {
             return map.size()
-//                   + ( object.getName() != null ? 1 : 0 )
                    + ( object.getSchool() != null ? 1 : 0 )
                    +  1
                    + ( object.getName() != null ? 1 : 0 )

--- a/drools-traits/src/test/java/org/drools/traits/compiler/factmodel/traits/TraitMapCoreTest.java
+++ b/drools-traits/src/test/java/org/drools/traits/compiler/factmodel/traits/TraitMapCoreTest.java
@@ -31,10 +31,14 @@ import org.drools.base.factmodel.traits.Traitable;
 import org.drools.traits.core.factmodel.VirtualPropertyMode;
 import org.junit.Test;
 import org.kie.api.runtime.KieSession;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
 public class TraitMapCoreTest extends CommonTraitTest {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(TraitMapCoreTest.class);
 
     @Test(timeout=10000)
     public void testMapCoreManyTraits(  ) {
@@ -70,7 +74,6 @@ public class TraitMapCoreTest extends CommonTraitTest {
                         "then  \n" +
                         "   Object obj1 = don( $m, PersonMap.class );\n" +
                         "   Object obj2 = don( obj1, StudentMap.class );\n" +
-                        "   System.out.println( \"done: PersonMap\" );\n" +
                         "\n" +
                         "end\n" +
                         "\n";
@@ -89,7 +92,7 @@ public class TraitMapCoreTest extends CommonTraitTest {
         ks.fireAllRules();
 
         for ( Object o : ks.getObjects() ) {
-            System.err.println( o );
+            LOGGER.debug( o.toString() );
         }
 
         assertThat(map.get("GPA")).isEqualTo(3.0);
@@ -124,11 +127,9 @@ public class TraitMapCoreTest extends CommonTraitTest {
                         "when \n" +
                         "   $p : PersonMap( name == \"john\", age > 10 ) \n" +
                         "then \n" +
-                        "   System.out.println( $p ); \n" +
                         "   modify ( $p ) { \n" +
                         "       setHeight( 184.0 ); \n" +
                         "   }" +
-                        "   System.out.println( $p ); " +
                         "end \n";
 
         KieSession ksession = loadKnowledgeBaseFromString( source ).newKieSession();
@@ -181,7 +182,6 @@ public class TraitMapCoreTest extends CommonTraitTest {
                         "  $m : Map( this[ \"age\"] == 18, this[ \"ID\" ] != \"100\" )\n" +
                         "then  \n" +
                         "   don( $m, PersonMap.class );\n" +
-                        "   System.out.println( \"done: PersonMap\" );\n" +
                         "\n" +
                         "end\n" +
                         "\n" +
@@ -192,20 +192,14 @@ public class TraitMapCoreTest extends CommonTraitTest {
                         "   modify ( $p ) {  \n" +
                         "       setHeight( 184.0 );  \n" +
                         "   }\n" +
-                        "   System.out.println(\"Log: \" +  $p );\n" +
                         "end\n" +
-                        "" +
-                        "" +
                         "rule Don2\n" +
                         "salience -1\n" +
                         "when\n" +
                         "   $m : Map( this[ \"age\"] == 18, this[ \"ID\" ] != \"100\" ) " +
                         "then\n" +
                         "   don( $m, StudentMap.class );\n" +
-                        "   System.out.println( \"done2: StudentMap\" );\n" +
                         "end\n" +
-                        "" +
-                        "" +
                         "rule Log2\n" +
                         "salience -2\n" +
                         "no-loop\n" +
@@ -216,10 +210,7 @@ public class TraitMapCoreTest extends CommonTraitTest {
                         "       setGPA( 4.0 ),\n" +
                         "       setID( \"100\" );\n" +
                         "   }\n" +
-                        "   System.out.println(\"Log2: \" + $p );\n" +
                         "end\n" +
-                        "" +
-                        "" +
                         "\n" +
                         "rule Shed1\n" +
                         "salience -5// it seams that the order of shed must be the same as applying don\n" +
@@ -227,7 +218,6 @@ public class TraitMapCoreTest extends CommonTraitTest {
                         "    $m : PersonMap()\n" +
                         "then\n" +
                         "   shed( $m, PersonMap.class );\n" +
-                        "   System.out.println( \"shed: PersonMap\" );\n" +
                         "end\n" +
                         "\n" +
                         "rule Shed2\n" +
@@ -236,7 +226,6 @@ public class TraitMapCoreTest extends CommonTraitTest {
                         "    $m : StudentMap()\n" +
                         "then\n" +
                         "   shed( $m, StudentMap.class );\n" +
-                        "   System.out.println( \"shed: StudentMap\" );\n" +
                         "end\n" +
                         "" +
                         "rule Last  \n" +
@@ -244,12 +233,9 @@ public class TraitMapCoreTest extends CommonTraitTest {
                         "when  \n" +
                         "  $m : Map( this not isA StudentMap.class )\n" +
                         "then  \n" +
-                        "   System.out.println( \"Final\" );\n" +
                         "   $m.put( \"final\", true );" +
                         "\n" +
-                        "end\n" +
-                        "\n" +
-                        "\n";
+                        "end\n";
 
         KieSession ks = loadKnowledgeBaseFromString( source ).newKieSession();
         TraitFactoryImpl.setMode(VirtualPropertyMode.MAP, ks.getKieBase() );
@@ -266,7 +252,7 @@ public class TraitMapCoreTest extends CommonTraitTest {
 
 
         for ( Object o : ks.getObjects() ) {
-            System.err.println( o );
+            LOGGER.debug( o.toString() );
         }
 
         assertThat(map.get("ID")).isEqualTo("100");
@@ -314,10 +300,7 @@ public class TraitMapCoreTest extends CommonTraitTest {
                         "       setHeight( 184.0 ), \n" +
                         "       setEta( 42 );  \n" +
                         "   }\n" +
-                        "   System.out.println(\"Log: \" +  $p );\n" +
-                        "end\n" +
-                        "" +
-                        "\n";
+                        "end\n";
 
         KieSession ks = loadKnowledgeBaseFromString( source ).newKieSession();
         TraitFactoryImpl.setMode(VirtualPropertyMode.MAP, ks.getKieBase() );
@@ -334,7 +317,7 @@ public class TraitMapCoreTest extends CommonTraitTest {
 
 
         for ( Object o : ks.getObjects() ) {
-            System.err.println( o );
+            LOGGER.debug( o.toString() );
         }
 
         assertThat(map.get("years")).isEqualTo(42);
@@ -455,7 +438,6 @@ public class TraitMapCoreTest extends CommonTraitTest {
                 "    $map.put(\"worker\" , s);\n" +
                 "    $map.put(\"isEmpty\" , false);\n" +
                 "    update($map);\n" +
-                "    System.out.println(\"don: Person -> Student \");\n" +
                 "    list.add(\"student is donned\");\n" +
                 "end\n" +
                 "\n" +
@@ -466,7 +448,6 @@ public class TraitMapCoreTest extends CommonTraitTest {
                 "    $map : Map($stu : this[\"worker\"] isA Student.class)\n" +
                 "then\n" +
                 "    Object obj = don( $map , Worker.class );\n" +
-                "    System.out.println(\"don: Map -> Worker : \"+obj);\n" +
                 "    list.add(\"worker is donned\");\n" +
                 "end\n";
 
@@ -544,7 +525,6 @@ public class TraitMapCoreTest extends CommonTraitTest {
                 "    $map.put(\"worker\" , s);\n" +
                 "    $map.put(\"isEmpty\" , false);\n" +
                 "    update($map);\n" +
-                "    System.out.println(\"don: Person -> Student \");\n" +
                 "    list.add(\"student is donned\");\n" +
                 "end\n" +
                 "\n" +
@@ -555,7 +535,6 @@ public class TraitMapCoreTest extends CommonTraitTest {
                 "    $map : Map($stu : this[\"worker\"], $stu isA Student.class)\n" +
                 "then\n" +
                 "    Object obj = don( $map , Worker.class );\n" +
-                "    System.out.println(\"don: Map -> Worker : \"+obj);\n" +
                 "    list.add(\"worker is donned\");\n" +
                 "end\n";
 
@@ -640,7 +619,6 @@ public class TraitMapCoreTest extends CommonTraitTest {
                 "    $map.put(\"isEmpty\" , false);\n" +
                 "    $map.put(\"hasBenefits\",null);\n" +
                 "    update($map);\n" +
-                "    System.out.println(\"don: Person -> Student \");\n" +
                 "    list.add(\"student is donned\");\n" +
                 "end\n" +
                 "\n" +
@@ -652,7 +630,6 @@ public class TraitMapCoreTest extends CommonTraitTest {
                 "    Map($stu isA Student.class, this == $map)\n" +
                 "then\n" +
                 "    Object obj = don( $map , Worker.class );\n" +
-                "    System.out.println(\"don: Map -> Worker : \"+obj);\n" +
                 "    list.add(\"worker is donned\");\n" +
                 "end\n" +
                 "\n" +
@@ -663,7 +640,6 @@ public class TraitMapCoreTest extends CommonTraitTest {
                 "    $stu : Student()\n" +
                 "then\n" +
                 "    Object obj = don( $stu , StudentWorker.class );\n" +
-                "    System.out.println(\"don: Map -> StudentWorker : \"+obj);\n" +
                 "    list.add(\"studentworker is donned\");\n" +
                 "end\n" +
                 "\n" +
@@ -673,7 +649,6 @@ public class TraitMapCoreTest extends CommonTraitTest {
                 "when\n" +
                 "    StudentWorker(tuitionWaiver == true)\n" +
                 "then\n" +
-                "    System.out.println(\"tuitionWaiver == true\");\n" +
                 "    list.add(\"tuitionWaiver is true\");\n" +
                 "end\n" +
                 "\n";
@@ -741,7 +716,6 @@ public class TraitMapCoreTest extends CommonTraitTest {
                 "    $stu : Person(isStudent == true)\n" +
                 "then\n" +
                 "    Student s = don( $stu , Student.class );\n" +
-                "    System.out.println(\"don: Person -> Student \" + s);\n" +
                 "    list.add(\"student is donned\");\n" +
                 "end\n" +
                 "\n" +
@@ -838,7 +812,6 @@ public class TraitMapCoreTest extends CommonTraitTest {
                           // success
                      "    ChildTrait ct = don( $map , ChildTrait.class );\n" +
                      "" +
-                     "  System.out.println( $map ); \n" +
                      "    list.add( pt );\n" +
                      "    list.add( ct );\n" +
                      "end";
@@ -895,8 +868,6 @@ public class TraitMapCoreTest extends CommonTraitTest {
                      "    $c : ChildTrait($n : naam == \"kudak\", id == 1020 )\n" +
                      "    $p : Map( this[\"naam\"] == $n )\n" +
                      "then\n" +
-                     "    System.out.println($p);\n" +
-                     "    System.out.println($c);\n" +
                      "    list.add(\"correct2\");\n" +
                      "end";
 
@@ -1013,7 +984,6 @@ public class TraitMapCoreTest extends CommonTraitTest {
                      "then\n" +
                      " ChildTrait ct = don( $map , ChildTrait.class );\n" +
                      " list.add( ct );\n" +
-                     " System.out.println(ct);\n" +
                      "end\n" +
                      "\n" +
                      "";
@@ -1085,10 +1055,7 @@ public class TraitMapCoreTest extends CommonTraitTest {
                      "then\n" +
                      " ChildTrait ct = don( $map , ChildTrait.class );\n" +
                      " list.add( ct );\n" +
-                     " System.out.println(ct);\n" +
-                     "end\n" +
-                     "\n" +
-                     "";
+                     "end\n";
 
         KieSession ksession = loadKnowledgeBaseFromString(drl).newKieSession();
         TraitFactoryImpl.setMode(VirtualPropertyMode.MAP, ksession.getKieBase());
@@ -1157,10 +1124,7 @@ public class TraitMapCoreTest extends CommonTraitTest {
                      "then\n" +
                      " ChildTrait ct = don( $map , ChildTrait.class );\n" +
                      " list.add( ct );\n" +
-                     " System.out.println(ct);\n" +
-                     "end\n" +
-                     "\n" +
-                     "";
+                     "end\n";
 
         KieSession ksession = loadKnowledgeBaseFromString(drl).newKieSession();
         TraitFactoryImpl.setMode(VirtualPropertyMode.MAP, ksession.getKieBase());
@@ -1232,10 +1196,7 @@ public class TraitMapCoreTest extends CommonTraitTest {
                      "then\n" +
                      " ChildTrait ct = don( $map , ChildTrait.class );\n" +
                      " list.add( ct );\n" +
-                     " System.out.println(ct);\n" +
-                     "end\n" +
-                     "\n" +
-                     "";
+                     "end\n";
 
         KieSession ksession = loadKnowledgeBaseFromString(drl).newKieSession();
         TraitFactoryImpl.setMode(VirtualPropertyMode.MAP, ksession.getKieBase());

--- a/drools-traits/src/test/java/org/drools/traits/compiler/factmodel/traits/TraitTest.java
+++ b/drools-traits/src/test/java/org/drools/traits/compiler/factmodel/traits/TraitTest.java
@@ -84,6 +84,8 @@ import org.kie.internal.command.CommandFactory;
 import org.kie.internal.io.ResourceFactory;
 import org.kie.internal.utils.KieHelper;
 import org.mockito.ArgumentCaptor;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -109,6 +111,8 @@ import static org.mockito.Mockito.verify;
 
 @RunWith(Parameterized.class)
 public class TraitTest extends CommonTraitTest {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(TraitTest.class);
 
     private static long t0;
 
@@ -144,7 +148,6 @@ public class TraitTest extends CommonTraitTest {
         return new KieHelper().addContent( drl, ResourceType.DRL ).build(options);
     }
 
-
     @Test
     public void testRetract( ) {
         String drl = "package org.drools.compiler.trait.test; \n" +
@@ -169,13 +172,12 @@ public class TraitTest extends CommonTraitTest {
 
         assertThat(ks.fireAllRules()).isEqualTo(2);
 
-        for(Object o : ks.getObjects()) {
-            System.out.println(o);
+        for (Object o : ks.getObjects()) {
+            LOGGER.debug(o.toString());
         }
 
         assertThat(ks.getObjects().size()).isEqualTo(0);
     }
-
 
     @Test
     public void testTraitWrapGetAndSet() {
@@ -225,13 +227,10 @@ public class TraitTest extends CommonTraitTest {
                     "name")).isEqualTo("john");
 
         } catch (Exception e) {
-            e.printStackTrace();
-            fail( e.getMessage() );
+            fail( e.getMessage(), e );
         }
 
     }
-
-
 
     @Test
     public void testTraitShed() {
@@ -269,8 +268,6 @@ public class TraitTest extends CommonTraitTest {
 
     }
 
-
-
     @Test
     public void testTraitDon() {
         String source = "org/drools/compiler/factmodel/traits/testTraitDon.drl";
@@ -298,15 +295,10 @@ public class TraitTest extends CommonTraitTest {
             x = it.next();
         }
 
-        System.out.println( x.getClass() );
-        System.out.println( x.getClass().getSuperclass() );
-        System.out.println( Arrays.asList( x.getClass().getInterfaces() ));
+        LOGGER.debug(x.getClass().toString());
+        LOGGER.debug(x.getClass().getSuperclass().toString());
+        LOGGER.debug(Arrays.asList(x.getClass().getInterfaces()).toString());
     }
-
-
-
-
-
     @Test
     public void testMixin() {
         String source = "org/drools/compiler/factmodel/traits/testTraitMixin.drl";
@@ -338,7 +330,7 @@ public class TraitTest extends CommonTraitTest {
         ks.fireAllRules();
 
         if (!errors.isEmpty()) {
-            System.err.println( errors.toString() );
+            LOGGER.error(errors.toString());
         }
         assertThat(errors.isEmpty()).isTrue();
 
@@ -359,7 +351,7 @@ public class TraitTest extends CommonTraitTest {
         ks.fireAllRules();
 
         if (!errors.isEmpty()) {
-            System.err.println( errors );
+            LOGGER.error(errors.toString());
         }
         assertThat(errors.isEmpty()).isTrue();
 
@@ -428,15 +420,8 @@ public class TraitTest extends CommonTraitTest {
 
             assertThat(proxy4).isEqualTo(proxy2);
 
-        } catch (InstantiationException e) {
-            e.printStackTrace();
-            fail( e.getMessage() );
-        } catch (IllegalAccessException e) {
-            e.printStackTrace();
-            fail( e.getMessage() );
-        } catch ( LogicalTypeInconsistencyException e ) {
-            e.printStackTrace();
-            fail( e.getMessage() );
+        } catch (InstantiationException | IllegalAccessException | LogicalTypeInconsistencyException e) {
+            fail( e.getMessage(), e );
         }
     }
 
@@ -543,13 +528,10 @@ public class TraitTest extends CommonTraitTest {
             assertThat(proxy100.getFields().size()).isEqualTo(4);
 
         } catch ( Exception e ) {
-            e.printStackTrace();
-            fail( e.getMessage() );
+            fail( e.getMessage(), e );
         }
 
     }
-
-
 
     @Test
     public void testWrapperEmpty() {
@@ -624,13 +606,10 @@ public class TraitTest extends CommonTraitTest {
             assertThat(wrapper2.isEmpty()).isFalse();
 
         } catch (Exception e) {
-            e.printStackTrace();
-            fail( e.getMessage() );
+            fail( e.getMessage(), e );
         }
 
     }
-
-
 
     @Test
     public void testWrapperContainsKey() {
@@ -748,12 +727,10 @@ public class TraitTest extends CommonTraitTest {
             assertThat(wrapper100.containsKey("surname")).isFalse();
 
         } catch (Exception e) {
-            e.printStackTrace();
-            fail( e.getMessage() );
+            fail( e.getMessage(), e );
         }
 
     }
-
 
     @Test
     public void testInternalComponents1(  ) {
@@ -807,11 +784,10 @@ public class TraitTest extends CommonTraitTest {
 
 
             StudentProxyImpl2 sp2 = new StudentProxyImpl2(new Imp2(), null );
-            System.out.println( sp2.toString() );
+            LOGGER.debug(sp2.toString());
 
         } catch ( Exception e ) {
-            e.printStackTrace();
-            fail( e.getMessage() );
+            fail( e.getMessage(), e );
         }
     }
 
@@ -905,13 +881,10 @@ public class TraitTest extends CommonTraitTest {
             assertThat(proxy.getFields().containsValue(-96)).isFalse();
 
         } catch (Exception e) {
-            e.printStackTrace();
-            fail( e.getMessage() );
+            fail( e.getMessage(), e );
         }
 
     }
-
-
 
     @Test
     public void testWrapperClearAndRemove() {
@@ -1010,15 +983,10 @@ public class TraitTest extends CommonTraitTest {
             assertThat(proxy.getFields().containsKey("surname")).isFalse();
 
         } catch (Exception e) {
-            e.printStackTrace();
-            fail( e.getMessage() );
+            fail( e.getMessage(), e );
         }
 
     }
-
-
-
-
 
     @Test
     public void testIsAEvaluator( ) {
@@ -1086,8 +1054,7 @@ public class TraitTest extends CommonTraitTest {
                       info );
 
         ks.fireAllRules();
-
-        System.out.println( info );
+        LOGGER.debug(info.toString());
         assertThat(info.contains("ok")).isTrue();
     }
 
@@ -1109,7 +1076,7 @@ public class TraitTest extends CommonTraitTest {
 
         int num = 10;
 
-        System.out.println( info );
+        LOGGER.debug(info.toString());
         assertThat(info.size()).isEqualTo(num);
         for (int j = 0; j < num; j++) {
             assertThat(info.contains("" + j)).isTrue();
@@ -1212,13 +1179,7 @@ public class TraitTest extends CommonTraitTest {
 
         ks.fireAllRules();
 
-        System.err.println( " -------------- " + ks.getObjects().size() + " ---------------- " );
-        for (Object o : ks.getObjects()) {
-            System.err.println( "\t\t" + o );
-        }
-        System.err.println( " --------------  ---------------- " );
-        System.err.println( info );
-        System.err.println( " --------------  ---------------- " );
+        printDebugInfoSessionObjects(ks.getObjects(), info);
 
         assertThat(info.size()).isEqualTo(5);
         assertThat(info.contains("OK")).isTrue();
@@ -1229,8 +1190,15 @@ public class TraitTest extends CommonTraitTest {
 
     }
 
-
-
+    private void printDebugInfoSessionObjects(final Collection<? extends Object> facts, final List globalList) {
+        LOGGER.debug( " -------------- " + facts.size() + " ---------------- " );
+        for (Object o : facts) {
+            LOGGER.debug( "\t\t" + o );
+        }
+        LOGGER.debug( " --------------  ---------------- " );
+        LOGGER.debug( globalList.toString() );
+        LOGGER.debug( " --------------  ---------------- " );
+    }
 
     @Test
     public void testTraitCollections() {
@@ -1246,21 +1214,12 @@ public class TraitTest extends CommonTraitTest {
 
         ks.fireAllRules();
 
-        System.err.println( " -------------- " + ks.getObjects().size() + " ---------------- " );
-        for (Object o : ks.getObjects()) {
-            System.err.println( "\t\t" + o );
-        }
-        System.err.println( " --------------  ---------------- " );
-        System.err.println( info );
-        System.err.println( " --------------  ---------------- " );
+        printDebugInfoSessionObjects(ks.getObjects(), info);
 
         assertThat(info.size()).isEqualTo(1);
         assertThat(info.contains("OK")).isTrue();
 
     }
-
-
-
 
     @Test
     public void testTraitCore() {
@@ -1275,22 +1234,13 @@ public class TraitTest extends CommonTraitTest {
 
         ks.fireAllRules();
 
-        System.err.println( " -------------- " + ks.getObjects().size() + " ---------------- " );
-        for (Object o : ks.getObjects()) {
-            System.err.println( "\t\t" + o );
-        }
-        System.err.println( " --------------  ---------------- " );
-        System.err.println( info );
-        System.err.println( " --------------  ---------------- " );
+        printDebugInfoSessionObjects(ks.getObjects(), info);
 
         assertThat(info.contains("OK")).isTrue();
         assertThat(info.contains("OK2")).isTrue();
         assertThat(info.size()).isEqualTo(2);
 
     }
-
-
-
 
     @Test
     public void traitWithEquality() {
@@ -1309,8 +1259,6 @@ public class TraitTest extends CommonTraitTest {
         assertThat(info.contains("EQUAL")).isTrue();
 
     }
-
-
 
     @Test
     public void traitDeclared() {
@@ -1335,8 +1283,6 @@ public class TraitTest extends CommonTraitTest {
         assertThat(untrueTraits.contains(1)).isFalse();
     }
 
-
-
     @Test
     public void traitPojo() {
 
@@ -1359,9 +1305,6 @@ public class TraitTest extends CommonTraitTest {
         assertThat(untrueTraits.contains(2)).isTrue();
         assertThat(untrueTraits.contains(1)).isFalse();
     }
-
-
-
 
     @Test
     public void testIsAOperator() {
@@ -1390,8 +1333,6 @@ public class TraitTest extends CommonTraitTest {
 
     }
 
-
-
     @Test
     public void testManyTraits() {
         String source = "" +
@@ -1411,7 +1352,6 @@ public class TraitTest extends CommonTraitTest {
                         "when\n" +
                         "  $n : NiceMessage( $m : message )\n" +
                         "then\n" +
-                        "  System.out.println( $m );\n" +
                         "end" +
                         "\n" +
                         "    rule load\n" +
@@ -1452,7 +1392,6 @@ public class TraitTest extends CommonTraitTest {
 
     }
 
-
     @Test
     public void traitManyTimes() {
 
@@ -1464,7 +1403,7 @@ public class TraitTest extends CommonTraitTest {
         ksession.fireAllRules();
 
         for ( Object o : ksession.getObjects() ) {
-            System.err.println( o );
+            LOGGER.debug(o.toString());
         }
         Collection x = ksession.getObjects();
         assertThat(ksession.getObjects().size()).isEqualTo(2);
@@ -1475,11 +1414,7 @@ public class TraitTest extends CommonTraitTest {
         assertThat(list.contains(2)).isTrue();
         assertThat(list.contains(3)).isTrue();
         assertThat(list.contains(4)).isTrue();
-
-
     }
-
-
 
     // BZ #748752
     @Test
@@ -1511,7 +1446,6 @@ public class TraitTest extends CommonTraitTest {
                      "    student : Person( this isA Student )\n" +
                      "  then" +
                      "    list.add( 1 );\n" +
-                     "    System.out.println(\"Person is a student: \" + student);\n" +
                      "end\n" +
                      "\n" +
                      "rule \"print school\"\n" +
@@ -1519,7 +1453,6 @@ public class TraitTest extends CommonTraitTest {
                      "    Student( $school : school )\n" +
                      "  then\n" +
                      "    list.add( 2 );\n" +
-                     "    System.out.println(\"Student is attending \" + $school);\n" +
                      "end";
 
         KnowledgeBuilder kbuilder = KnowledgeBuilderFactory.newKnowledgeBuilder();
@@ -1543,20 +1476,15 @@ public class TraitTest extends CommonTraitTest {
         Person student = new Person("student", 18);
         commands.add( CommandFactory.newInsert( student ));
 
-        System.out.println("Starting execution...");
+        LOGGER.debug("Starting execution...");
         commands.add(CommandFactory.newFireAllRules());
         ksession.execute(CommandFactory.newBatchExecution(commands));
-
-        System.out.println("Finished...");
+        LOGGER.debug("Finished...");
 
         assertThat(list.size()).isEqualTo(2);
         assertThat(list.contains(1)).isTrue();
         assertThat(list.contains(2)).isTrue();
     }
-
-
-
-
 
     @Test(timeout=10000)
     public void testManyTraitsStateless() {
@@ -1577,7 +1505,6 @@ public class TraitTest extends CommonTraitTest {
                         "when\n" +
                         "  $n : NiceMessage( $m : message )\n" +
                         "then\n" +
-                        "  System.out.println( $m );\n" +
                         "end" +
                         "\n" +
                         "    rule load\n" +
@@ -1657,7 +1584,6 @@ public class TraitTest extends CommonTraitTest {
                      "    $student : Student( $school : school == \"UniBoh\",  $f : fields, fields[ \"workPlace\" ] == \"UniBoh\" )\n" +
                      "  then \n " +
                      "    $student.setRank( 99 ); \n" +
-                     "    System.out.println( $student ); \n" +
                      "    $f.put( \"school\", \"Skool\" ); \n" +
 
                      "    list.add( $school );\n" +
@@ -1861,10 +1787,7 @@ public class TraitTest extends CommonTraitTest {
                      "  Mask m = don( $b, Mask.class ); \n" +
                      "  modify (m) { setXyz( 10 ); } \n" +
                      "  list.add( m ); \n" +
-                     "  System.out.println( \"Don result : \" + m ); \n " +
-                     "end \n" +
-                     "\n" +
-                     "";
+                     "end \n";
 
         KnowledgeBuilder kbuilder = KnowledgeBuilderFactory.newKnowledgeBuilder();
         kbuilder.add( ResourceFactory.newByteArrayResource( str.getBytes() ),
@@ -1951,15 +1874,9 @@ public class TraitTest extends CommonTraitTest {
 
 
         } catch ( Exception e ) {
-            e.printStackTrace();
-            fail( e.getMessage() );
+            fail( e.getMessage(), e );
         }
     }
-
-
-
-
-
 
     @Test
     public void testTraitRedundancy() {
@@ -1975,7 +1892,6 @@ public class TraitTest extends CommonTraitTest {
                      "when \n" +
                      "   $s : IStudent() \n" +
                      "then \n" +
-                     "   System.out.println( \"Student in \" + $s ); \n" +
                      "end \n" +
                      "" +
                      "rule \"Don\" \n" +
@@ -1983,7 +1899,6 @@ public class TraitTest extends CommonTraitTest {
                      "when \n" +
                      "  $p : IPerson( age < 30 ) \n" +
                      "then \n" +
-                     "   System.out.println( \"Candidate student \" + $p ); \n" +
                      "   don( $p, IStudent.class );\n" +
                      "end \n" +
                      "" +
@@ -1992,7 +1907,6 @@ public class TraitTest extends CommonTraitTest {
                      "when \n" +
                      "  $p : IPerson( this isA IStudent ) \n" +
                      "then \n" +
-                     "   System.out.println( \"Known student \" + $p ); " +
                      "   modify ($p) { setAge( 37 ); } \n" +
                      "   shed( $p, IStudent.class );\n" +
                      "end \n";
@@ -2021,11 +1935,10 @@ public class TraitTest extends CommonTraitTest {
         assertThat(ksession.fireAllRules()).isEqualTo(3);
 
         for ( Object o : ksession.getObjects() ) {
-            System.err.println( o );
+            LOGGER.debug(o.toString());
         }
 
     }
-
 
     @Test
     public void traitSimpleTypes() {
@@ -2141,8 +2054,7 @@ public class TraitTest extends CommonTraitTest {
         kbase.addPackages( kbuilder.getKnowledgePackages() );
 
         TraitRegistryImpl tr = (TraitRegistryImpl) ((TraitRuntimeComponentFactory) RuntimeComponentFactory.get()).getTraitRegistry(kbase);
-        System.out.println( tr.getHierarchy() );
-
+        LOGGER.debug( tr.getHierarchy().toString() );
 
         Entity ent = new Entity( "x" );
         KieSession ksession = kbase.newKieSession();
@@ -2154,7 +2066,7 @@ public class TraitTest extends CommonTraitTest {
         ksession.insert( "y" );
         ksession.fireAllRules();
 
-        System.out.println( ent.getMostSpecificTraits() );
+        LOGGER.debug( ent.getMostSpecificTraits().toString() );
         assertThat(ent.getMostSpecificTraits().size()).isEqualTo(2);
 
     }
@@ -2244,15 +2156,9 @@ public class TraitTest extends CommonTraitTest {
                     "when  " +
                     "  $p : Person( name == \"john\" )  " +
                     "then  " +
-                    "  System.out.println( $p );  " +
-                    "" +
-                    "  System.out.println( \" ----------------------------------------------------------------------------------- Don student\" );  " +
                     "  don( $p, Student.class );  " +
-                    "  System.out.println( \" ----------------------------------------------------------------------------------- Don worker\" );  " +
                     "  don( $p, Worker.class );  " +
-                    "  System.out.println( \" ----------------------------------------------------------------------------------- Don studentworker\" );  " +
                     "  don( $p, StudentWorker.class );  " +
-                    "  System.out.println( \" ----------------------------------------------------------------------------------- Don assistant\" );  " +
                     "  don( $p, Assistant.class );  " +
                     "end  " +
                     "" +
@@ -2260,28 +2166,24 @@ public class TraitTest extends CommonTraitTest {
                     "when  " +
                     "  $t : Student() @Watch( name ) " +
                     "then  " +
-                    "  System.out.println( \"Student >> \" +  $t ); " +
                     "  list.add( $t.getName() );  " +
                     "end  " +
                     "rule \"Log W\"  " +
                     "when  " +
                     "  $t : Worker() @Watch( name ) " +
                     "then  " +
-                    "  System.out.println( \"Worker >> \" + $t );  " +
                     "  list.add( $t.getName() );  " +
                     "end  " +
                     "rule \"Log SW\"  " +
                     "when  " +
                     "  $t : StudentWorker() @Watch( name ) " +
                     "then  " +
-                    "  System.out.println( \"StudentWorker >> \" + $t );  " +
                     "  list.add( $t.getName() );  " +
                     "end  " +
                     "rule \"Log RA\"  " +
                     "when  " +
                     "  $t : Assistant() @Watch( name ) " +
                     "then  " +
-                    "  System.out.println( \"Assistant >> \" + $t );  " +
                     "  list.add( $t.getName() );  " +
                     "end  " +
                     "" +
@@ -2290,7 +2192,6 @@ public class TraitTest extends CommonTraitTest {
                     "when  " +
                     "  $p : Person( name == \"john\" ) " +
                     "then  " +
-                    "   System.out.println( \"-----------------------------\" ); " +
                     "   modify ( $p ) { setName( \"alan\" ); } " +
                     "end  " +
                     "";
@@ -2343,11 +2244,8 @@ public class TraitTest extends CommonTraitTest {
                     "when  " +
                     "  $p : Person( name == \"john\" )  " +
                     "then  " +
-                    "  System.out.println( \">>>>>>>>>>>>>>>>>>>>>>>>>>>>>> DON WORKER \" + $p  );  " +
                     "  don( $p, Worker.class );  " +
-                    "  System.out.println( \">>>>>>>>>>>>>>>>>>>>>>>>>>>>>> DON STUDWORKER-2 \" + $p );  " +
                     "  don( $p, StudentWorker2.class );  " +
-                    "  System.out.println( \">>>>>>>>>>>>>>>>>>>>>>>>>>>>>> DON ASSISTANT \" + $p );  " +
                     "  don( $p, Assistant.class );  " +
                     "end  " +
                     "" +
@@ -2355,32 +2253,27 @@ public class TraitTest extends CommonTraitTest {
                     "when  " +
                     "  $t : Student() @watch( name )  " +
                     "then  " +
-                    "  System.err.println( \"@@Student >> \" +  $t );  " +
                     "end  " +
                     "rule \"Log W\"  " +
                     "when  " +
                     "  $t : Worker() @watch( name )  " +
                     "then  " +
-                    "  System.err.println( \"@@Worker >> \" + $t );  " +
                     "end  " +
                     "rule \"Log SW\"  " +
                     "when  " +
                     "  $t : StudentWorker() @watch( name )  " +
                     "then  " +
-                    "  System.err.println( \"@@StudentWorker >> \" + $t );  " +
                     "end  " +
                     "rule \"Log RA\"  " +
                     "when  " +
                     "  $t : Assistant() @watch( name )  " +
                     "then  " +
-                    "  System.err.println( \"@@Assistant >> \" + $t );  " +
                     "end  " +
                     "rule \"Log Px\"  " +
                     "salience -1  " +
                     "when  " +
                     "  $p : Person() @watch( name )  " +
                     "then  " +
-                    "  System.err.println( \"Poor Core Person >> \" + $p );  " +
                     "end  " +
                     "" +
                     "rule \"Mod\"  " +
@@ -2389,10 +2282,8 @@ public class TraitTest extends CommonTraitTest {
                     "  String( this == \"go\" )  " +
                     "  $p : Student( name == \"john\" )  " +
                     "then  " +
-                    "  System.out.println( \" ------------------------------------------------------------------------------ \" + $p );  " +
                     "  modify ( $p ) { setName( \"alan\" ); } " +
-                    "end  " +
-                    "";
+                    "end  ";
 
         KnowledgeBuilder kbuilder = KnowledgeBuilderFactory.newKnowledgeBuilder();
         kbuilder.add( new ByteArrayResource( s1.getBytes() ), ResourceType.DRL );
@@ -2440,9 +2331,7 @@ public class TraitTest extends CommonTraitTest {
                     "when \n" +
                     "  $p : Person( name == \"john\" ) \n" +
                     "then \n" +
-                    "  System.out.println( \">>>>>>>>>>>>>>>>>>>>>>>>>>>>>> DON WORKER \" + $p  ); \n" +
                     "  don( $p, Worker.class ); \n" +
-                    "  System.out.println( \">>>>>>>>>>>>>>>>>>>>>>>>>>>>>> DON STUDWORKER \" + $p ); \n" +
                     "  don( $p, StudentWorker.class ); \n" +
                     "end \n" +
                     "" +
@@ -2450,16 +2339,14 @@ public class TraitTest extends CommonTraitTest {
                     "when \n" +
                     "  $t : Worker( this isA StudentWorker ) @watch( name ) \n" +
                     "then \n" +
-                    "  System.out.println( \"@@Worker >> \" + $t ); \n" +
                     "  list.add( true ); \n" +
                     "end \n" +
                     "rule \"Log SW\" \n" +
                     "when \n" +
                     "  $t : StudentWorker() @watch( name ) \n" +
                     "then \n" +
-                    "  System.out.println( \"@@StudentWorker >> \" + $t ); \n" +
-                    "end \n" +
-                    "";
+                    "end \n";
+
         KnowledgeBuilder kbuilder = KnowledgeBuilderFactory.newKnowledgeBuilder();
         kbuilder.add( new ByteArrayResource( s1.getBytes() ), ResourceType.DRL );
         if ( kbuilder.hasErrors() ) {
@@ -2534,22 +2421,22 @@ public class TraitTest extends CommonTraitTest {
                     "\n" +
                     "\n" +
                     "\n" +
-                    "rule \"Log A\" when $x : A( id == 1 ) then System.out.println( \"A >> \" +  $x ); list.add( 1 ); end \n" +
-                    "rule \"Log B\" when $x : B( id == 1 ) then System.out.println( \"B >> \" +  $x ); list.add( 2 ); end \n" +
-                    "rule \"Log C\" when $x : C( id == 1 ) then System.out.println( \"C >> \" +  $x ); list.add( 3 ); end \n" +
-                    "rule \"Log D\" when $x : D( id == 1 ) then System.out.println( \"D >> \" +  $x ); list.add( 4 ); end \n" +
-                    "rule \"Log E\" when $x : E( id == 1 ) then System.out.println( \"E >> \" +  $x ); list.add( 5 ); end \n" +
-                    "rule \"Log F\" when $x : F( id == 1 ) then System.out.println( \"F >> \" +  $x ); list.add( 6 ); end \n" +
-                    "rule \"Log G\" when $x : G( id == 1 ) then System.out.println( \"G >> \" +  $x ); list.add( 7 ); end \n" +
-                    "rule \"Log H\" when $x : H( id == 1 ) then System.out.println( \"H >> \" +  $x ); list.add( 8 ); end \n" +
-                    "rule \"Log I\" when $x : I( id == 1 ) then System.out.println( \"I >> \" +  $x ); list.add( 9 ); end \n" +
-                    "rule \"Log J\" when $x : J( id == 1 ) then System.out.println( \"J >> \" +  $x ); list.add( 10 ); end \n" +
-                    "rule \"Log K\" when $x : K( id == 1 ) then System.out.println( \"K >> \" +  $x ); list.add( 11 ); end \n" +
-                    "rule \"Log L\" when $x : L( id == 1 ) then System.out.println( \"L >> \" +  $x ); list.add( 12 ); end \n" +
-                    "rule \"Log M\" when $x : M( id == 1 ) then System.out.println( \"M >> \" +  $x ); list.add( 13 ); end \n" +
-                    "rule \"Log N\" when $x : N( id == 1 ) then System.out.println( \"N >> \" +  $x ); list.add( 14 ); end \n" +
+                    "rule \"Log A\" when $x : A( id == 1 ) then list.add( 1 ); end \n" +
+                    "rule \"Log B\" when $x : B( id == 1 ) then list.add( 2 ); end \n" +
+                    "rule \"Log C\" when $x : C( id == 1 ) then list.add( 3 ); end \n" +
+                    "rule \"Log D\" when $x : D( id == 1 ) then list.add( 4 ); end \n" +
+                    "rule \"Log E\" when $x : E( id == 1 ) then list.add( 5 ); end \n" +
+                    "rule \"Log F\" when $x : F( id == 1 ) then list.add( 6 ); end \n" +
+                    "rule \"Log G\" when $x : G( id == 1 ) then list.add( 7 ); end \n" +
+                    "rule \"Log H\" when $x : H( id == 1 ) then list.add( 8 ); end \n" +
+                    "rule \"Log I\" when $x : I( id == 1 ) then list.add( 9 ); end \n" +
+                    "rule \"Log J\" when $x : J( id == 1 ) then list.add( 10 ); end \n" +
+                    "rule \"Log K\" when $x : K( id == 1 ) then list.add( 11 ); end \n" +
+                    "rule \"Log L\" when $x : L( id == 1 ) then list.add( 12 ); end \n" +
+                    "rule \"Log M\" when $x : M( id == 1 ) then list.add( 13 ); end \n" +
+                    "rule \"Log N\" when $x : N( id == 1 ) then list.add( 14 ); end \n" +
                     "" +
-                    "rule \"Log Core\" when $x : Core( $id : id ) then System.out.println( \"Core >>>>>> \" +  $x ); end \n" +
+                    "rule \"Log Core\" when $x : Core( $id : id ) then end \n" +
                     "" +
                     "rule \"Mod\" \n" +
                     "salience -10 \n" +
@@ -2557,7 +2444,6 @@ public class TraitTest extends CommonTraitTest {
                     "  String( this == \"go\" ) \n" +
                     "  $x : Core( id == 0 ) \n" +
                     "then \n" +
-                    "  System.out.println( \" ------------------------------------------------------------------------------ \" ); \n" +
                     "  modify ( $x ) { setId( 1 ); }" +
                     "end \n" +
                     "";
@@ -2636,7 +2522,6 @@ public class TraitTest extends CommonTraitTest {
                     "when \n" +
                     "  $p : Person( name == \"john\" ) \n" +
                     "then \n" +
-                    "  System.out.println( $p ); \n" +
                     "  don( $p, StudentWorker.class ); \n" +
                     "  don( $p, Assistant.class ); \n" +
                     "end \n" +
@@ -2646,28 +2531,24 @@ public class TraitTest extends CommonTraitTest {
                     "  $t : Student( age == 44 ) \n" +
                     "then \n" +
                     "  list.add( 1 );\n " +
-                    "  System.out.println( \"Student >> \" +  $t ); \n" +
                     "end \n" +
                     "rule \"Log W\" \n" +
                     "when \n" +
                     "  $t : Worker( name == \"alan\" ) \n" +
                     "then \n" +
                     "  list.add( 2 );\n " +
-                    "  System.out.println( \"Worker >> \" + $t ); \n" +
                     "end \n" +
                     "rule \"Log SW\" \n" +
                     "when \n" +
                     "  $t : StudentWorker( age == 44 ) \n" +
                     "then \n" +
                     "  list.add( 3 );\n " +
-                    "  System.out.println( \"StudentWorker >> \" + $t ); \n" +
                     "end \n" +
                     "rule \"Log Pers\" \n" +
                     "when \n" +
                     "  $t : Person( age == 44 ) \n" +
                     "then \n" +
                     "  list.add( 4 );\n " +
-                    "  System.out.println( \"Person >> \" + $t ); \n" +
                     "end \n" +
                     "" +
                     "rule \"Mod\" \n" +
@@ -2676,10 +2557,8 @@ public class TraitTest extends CommonTraitTest {
                     "  String( this == \"go\" ) \n" +
                     "  $p : Student( name == \"john\" ) \n" +
                     "then \n" +
-                    "  System.out.println( \" ------------------------------------------------------------------------------ \" + $p ); \n" +
                     "  modify ( $p ) { setSchool( \"myschool\" ), setAge( 44 ), setName( \"alan\" ); } " +
-                    "end \n" +
-                    "";
+                    "end \n";
 
         KnowledgeBuilder kbuilder = KnowledgeBuilderFactory.newKnowledgeBuilder();
         kbuilder.add( new ByteArrayResource( s1.getBytes() ), ResourceType.DRL );
@@ -2867,7 +2746,6 @@ public class TraitTest extends CommonTraitTest {
                         "   $t : org.drools.base.factmodel.traits.Thing( $c : core, _isTop(), this not isA t.x.E.class, this isA t.x.D.class ) " +
                         "then\n" +
                         "   list.add( \"E\" ); \n" +
-                        "   System.out.println( \"E due to \" + $t); \n" +
                         "   don( $t, E.class ); \n" +
                         "end\n" +
                         "" +
@@ -2894,7 +2772,7 @@ public class TraitTest extends CommonTraitTest {
         ks.setGlobal( "list", list );
         ks.fireAllRules();
 
-        System.out.println( list );
+        LOGGER.debug( list.toString() );
         assertThat(list.size()).isEqualTo(2);
         assertThat(list.contains("E")).isTrue();
         assertThat(list.contains("X")).isTrue();
@@ -2903,7 +2781,7 @@ public class TraitTest extends CommonTraitTest {
         ks.fireAllRules();
 
         for ( Object o : ks.getObjects() ) {
-            System.out.println( o );
+            LOGGER.debug( o.toString() );
         }
         assertThat(ks.getObjects().size()).isEqualTo(3);
 
@@ -2955,7 +2833,6 @@ public class TraitTest extends CommonTraitTest {
                         "   list.add( $m ); \n" +
                         "   list.add( $i ); \n" +
                         "   list.add( $d ); \n" +
-                        "   System.out.println( $x ); \n" +
                         "end\n" +
                         ""
                 ;
@@ -3016,12 +2893,10 @@ public class TraitTest extends CommonTraitTest {
                         "rule Check when\n" +
                         "   $x : Bar( this not isA Foo ) \n" +
                         "then \n" +
-                        "   System.out.println( $x ); \n" +
                         "end\n" +
                         "rule Check2 when\n" +
                         "   $x : Bar2( this not isA Foo ) \n" +
                         "then \n" +
-                        "   System.out.println( $x ); \n" +
                         "end\n" +
                         "";
 
@@ -3121,22 +2996,11 @@ public class TraitTest extends CommonTraitTest {
                         "rule Init when\n" +
                         "then\n" +
                         "   Kore k = new Kore();\n" +
-                        "   System.out.println( \"-----------------------------------------------------------------------\" ); \n " +
                         "   don( k, B.class ); \n" +
-
-                        "   System.out.println( \"-----------------------------------------------------------------------\" ); \n " +
                         "   don( k, C.class ); \n" +
-
-                        "   System.out.println( \"-----------------------------------------------------------------------\" ); \n " +
                         "   don( k, D.class ); \n" +
-
-                        "   System.out.println( \"-----------------------------------------------------------------------\" ); \n " +
                         "   don( k, E.class ); \n" +
-
-                        "   System.out.println( \"-----------------------------------------------------------------------\" ); \n " +
                         "   don( k, A.class ); \n" +
-
-                        "   System.out.println( \"-----------------------------------------------------------------------\" ); \n " +
                         "   don( k, F.class ); \n" +
                         "end\n" +
                         "" +
@@ -3144,7 +3008,6 @@ public class TraitTest extends CommonTraitTest {
                         "   $x : A( ) \n" +
                         "then \n" +
                         "   list.add( $x ); \n" +
-                        "   System.out.println( \" A by \" + $x ); \n" +
                         "end\n" +
                         "";
 
@@ -3243,7 +3106,6 @@ public class TraitTest extends CommonTraitTest {
                         "when \n" +
                         "   $x : A(  ) \n" +
                         "then \n" +
-                        "   System.out.println( $x ); \n " +
                         "end\n" +
                         " \n" +
                         "query queryA1\n" +
@@ -3322,7 +3184,7 @@ public class TraitTest extends CommonTraitTest {
         ks.setGlobal( "list", list );
         ks.fireAllRules();
 
-        System.out.println( list );
+        LOGGER.debug( list.toString() );
         assertThat(list).isEqualTo(Arrays.asList('A', 'B', 'C', 'D', 'E', 'F', 'G', 'Z'));
 
 
@@ -3391,7 +3253,7 @@ public class TraitTest extends CommonTraitTest {
         ks.setGlobal( "list", list );
         ks.fireAllRules();
 
-        System.out.println( list );
+        LOGGER.debug( list.toString() );
         assertThat(list).isEqualTo(Arrays.asList('A', 'D', 'G', 'Z'));
 
 
@@ -3493,7 +3355,6 @@ public class TraitTest extends CommonTraitTest {
                         "when\n" +
                         "   $x : Kore() \n" +
                         "then \n" +
-                        "   System.out.println( \"Donning\" ); \n" +
                         "   don( $x, A.class ); \n" +
                         "end\n" +
                         "rule React \n" +
@@ -3501,7 +3362,6 @@ public class TraitTest extends CommonTraitTest {
                         "when\n" +
                         "   $x : Kore( this isA A.class ) \n" +
                         "then \n" +
-                        "   System.out.println( \"XXXXXXXXXXXXXXXXXXXXXX \" + $x ); \n" +
                         "   list.add( $x ); \n" +
                         "end\n" +
                         "";
@@ -3513,7 +3373,7 @@ public class TraitTest extends CommonTraitTest {
         ks.fireAllRules();
 
         for ( Object o : ks.getObjects() ) {
-            System.err.println( o );
+            LOGGER.debug( o.toString() );
         }
         assertThat(list.size()).isEqualTo(1);
     }
@@ -3595,9 +3455,9 @@ public class TraitTest extends CommonTraitTest {
         ksession.fireAllRules();
 
         for ( Object o : ksession.getObjects() ) {
-            System.err.println( o );
+            LOGGER.debug( o.toString() );
         }
-        System.err.println( "---------------------------------" );
+        LOGGER.debug( "---------------------------------" );
 
         assertThat(ksession.getObjects().size()).isEqualTo(4);
 
@@ -3605,9 +3465,9 @@ public class TraitTest extends CommonTraitTest {
         ksession.fireAllRules();
 
         for ( Object o : ksession.getObjects() ) {
-            System.err.println( o );
+            LOGGER.debug( o.toString() );
         }
-        System.err.println( "---------------------------------" );
+        LOGGER.debug( "---------------------------------" );
 
         assertThat(ksession.getObjects().size()).isEqualTo(3);
 
@@ -3615,9 +3475,9 @@ public class TraitTest extends CommonTraitTest {
         ksession.fireAllRules();
 
         for ( Object o : ksession.getObjects() ) {
-            System.err.println( o );
+            LOGGER.debug( o.toString() );
         }
-        System.err.println( "---------------------------------" );
+        LOGGER.debug( "---------------------------------" );
 
         assertThat(ksession.getObjects().size()).isEqualTo(1);
 
@@ -3625,9 +3485,9 @@ public class TraitTest extends CommonTraitTest {
         ksession.fireAllRules();
 
         for ( Object o : ksession.getObjects() ) {
-            System.err.println( o );
+            LOGGER.debug( o.toString());
         }
-        System.err.println( "---------------------------------" );
+        LOGGER.debug( "---------------------------------" );
 
         assertThat(ksession.getObjects().size()).isEqualTo(1);
 
@@ -3635,9 +3495,9 @@ public class TraitTest extends CommonTraitTest {
         ksession.fireAllRules();
 
         for ( Object o : ksession.getObjects() ) {
-            System.err.println( o );
+            LOGGER.debug( o.toString() );
         }
-        System.err.println( "---------------------------------" );
+        LOGGER.debug( "---------------------------------" );
 
         assertThat(ksession.getObjects().size()).isEqualTo(3);
 
@@ -3645,14 +3505,12 @@ public class TraitTest extends CommonTraitTest {
         ksession.fireAllRules();
 
         for ( Object o : ksession.getObjects() ) {
-            System.err.println( o );
+            LOGGER.debug( o.toString() );
         }
-        System.err.println( "---------------------------------" );
+        LOGGER.debug( "---------------------------------" );
 
         assertThat(ksession.getObjects().size()).isEqualTo(1);
     }
-
-
 
     @Test
     public void testShedThing() {
@@ -3718,7 +3576,7 @@ public class TraitTest extends CommonTraitTest {
         ksession.fireAllRules();
 
         for ( Object o : ksession.getObjects() ) {
-            System.out.println( o );
+            LOGGER.debug( o.toString() );
         }
 
         assertThat(ksession.getObjects().size()).isEqualTo(1);
@@ -3789,7 +3647,7 @@ public class TraitTest extends CommonTraitTest {
         ksession.fireAllRules();
 
         for ( Object o : ksession.getObjects() ) {
-            System.out.println( o );
+            LOGGER.debug( o.toString() );
         }
 
         assertThat(ksession.getObjects().size()).isEqualTo(0);
@@ -3847,7 +3705,7 @@ public class TraitTest extends CommonTraitTest {
 
         for ( Object o : ksession.getObjects() ) {
             // lose the string and the Student proxy
-            System.out.println( o );
+            LOGGER.debug( o.toString() );
         }
         assertThat(ksession.getObjects().size()).isEqualTo(3);
 
@@ -3911,7 +3769,7 @@ public class TraitTest extends CommonTraitTest {
         ksession.fireAllRules();
 
         for ( Object o : ksession.getObjects() ) {
-            System.out.println( o );
+            LOGGER.debug( o.toString() );
         }
 
         assertThat(ksession.getObjects().size()).isEqualTo(2);
@@ -3952,7 +3810,6 @@ public class TraitTest extends CommonTraitTest {
                         "when\n" +
                         "   $x : Kore() \n" +
                         "then \n" +
-                        "   System.out.println( \"Donning\" ); \n" +
                         "   don( $x, A.class ); \n" +
                         "end\n" +
                         "" +
@@ -3962,7 +3819,6 @@ public class TraitTest extends CommonTraitTest {
                         "when \n" +
                         "   $x : String() \n" +
                         "then \n" +
-                        "   System.out.println( \"deleteing\" ); \n" +
                         "   delete( $x ); \n" +
                         "end \n" +
                         "\n";
@@ -3978,7 +3834,7 @@ public class TraitTest extends CommonTraitTest {
         ks.fireAllRules();
 
         for ( Object o : ks.getObjects() ) {
-            System.out.println( o );
+            LOGGER.debug( o.toString() );
         }
 
         assertThat(ks.getObjects().size()).isEqualTo(0);
@@ -4007,7 +3863,6 @@ public class TraitTest extends CommonTraitTest {
                         "when\n" +
                         "  $p : Person( this not isA Student )\n" +
                         "then\n" +
-                        "  System.out.println( \"Don person\" ); \n" +
                         "  don( $p, Student.class );\n" +
                         "end\n" +
                         "\n" +
@@ -4016,7 +3871,6 @@ public class TraitTest extends CommonTraitTest {
                         "  $s : String( this == \"X\" )\n" +
                         "  $p : Person()\n" +
                         "then\n" +
-                        "  System.out.println( \"Change name\" ); \n" +
                         "  delete( $s ); \n" +
                         "  modify( $p ) { setName( $s ); }\n" +
                         "end\n" +
@@ -4025,7 +3879,6 @@ public class TraitTest extends CommonTraitTest {
                         "when\n" +
                         "  Student( name == \"X\" )\n" +
                         "then\n" +
-                        "  System.out.println( \"Update detected\" );\n" +
                         "  list.add( 0 );\n" +
                         "end";
 
@@ -4086,8 +3939,6 @@ public class TraitTest extends CommonTraitTest {
                         "when\n" +
                         "   $p : Person() \n" +
                         "then\n" +
-                        "  System.out.println( \"Don person\" ); \n"
-                        +
                         "  Student $s = (Student) don( $p, Student.class );\n" +
                         "  modify ( $s ) { setId( \"xyz\" ); } " +
                         "  " +
@@ -4099,7 +3950,6 @@ public class TraitTest extends CommonTraitTest {
                         "when\n" +
                         "  $s : Student( $sid : id == \"xyz\", $f2 : fld2, $f3 : fld3, $f4 : fld4, $f5 : fldZ )\n" +
                         "then\n" +
-                        "  System.out.println( \">>>>>>>>>> Student\" + $s ); \n" +
                         "  list.add( $sid ); \n" +
                         "  list.add( $f2 ); \n" +
                         "  list.add( $f3 ); \n" +
@@ -4111,7 +3961,6 @@ public class TraitTest extends CommonTraitTest {
                         "when\n" +
                         "  $w : Worker( $wid : id == 99, $f2 : fld2, $f3 : fld3, $f4 : fld4, $f5 : fldY )\n" +
                         "then\n" +
-                        "  System.out.println( \">>>>>>>>>> Worker\" + $w );\n" +
                         "  list.add( $wid ); \n" +
                         "  list.add( $f2 ); \n" +
                         "  list.add( $f3 ); \n" +
@@ -4275,11 +4124,11 @@ public class TraitTest extends CommonTraitTest {
 
         for ( int j = 'A'; j <= 'J'; j ++ ) {
             String x = "" + (char) j;
-            drl += "rule \"Log " + x + "\" when " + x + "() then System.out.println( \"@@ " + x + " detected \" ); list.add( \"" + x + "\" ); end \n";
+            drl += "rule \"Log " + x + "\" when " + x + "() then list.add( \"" + x + "\" ); end \n";
 
             drl += "rule \"Log II" + x + "\" salience -1 when " + x + "( ";
             drl += "this isA H";
-            drl += " ) then System.out.println( \"@@ as H >> " + x + " detected \" ); list.add( \"H" + x + "\" ); end \n";
+            drl += " ) then list.add( \"H" + x + "\" ); end \n";
         }
 
         KieSession ks = new KieHelper().addContent( drl, ResourceType.DRL ).build().newKieSession();
@@ -4299,7 +4148,7 @@ public class TraitTest extends CommonTraitTest {
 
         list.clear();
 
-        System.out.println( "---------------------------------------" );
+        LOGGER.debug( "---------------------------------------" );
 
         ks.insert( "go" );
         ks.fireAllRules();
@@ -4313,11 +4162,11 @@ public class TraitTest extends CommonTraitTest {
         assertThat(list.contains("HF")).isTrue();
         assertThat(list.contains("HG")).isTrue();
         assertThat(list.contains("HH")).isTrue();
-        System.out.println( list );
+        LOGGER.debug( list.toString() );
         assertThat(list.size()).isEqualTo(9);
         list.clear();
 
-        System.out.println( "---------------------------------------" );
+        LOGGER.debug( "---------------------------------------" );
 
         ks.insert( "go2" );
         ks.fireAllRules();
@@ -4338,8 +4187,6 @@ public class TraitTest extends CommonTraitTest {
 
     }
 
-
-
     @Test
     public void testParentBlockers() {
         String drl = "package org.drools.test;\n" +
@@ -4355,9 +4202,7 @@ public class TraitTest extends CommonTraitTest {
                      "" +
                      "rule Init when then X x = new X(); insert( x ); don( x, A.class); don( x, B.class); end \n"+
                      "rule Go when String( this == \"go\" ) $x : X() then don( $x, C.class); end \n" +
-                     "rule Go2 when String( this == \"go2\" ) $x : C() then System.out.println( 1000 ); end \n" +
-                     "";
-
+                     "rule Go2 when String( this == \"go2\" ) $x : C() then end \n";
 
         KieSession ks = getSessionFromString( drl );
         TraitFactoryImpl.setMode(mode, ks.getKieBase() );
@@ -4373,14 +4218,11 @@ public class TraitTest extends CommonTraitTest {
         ks.insert( "go2" );
         ks.fireAllRules();
 
-        System.out.println( "---------------------------------------" );
+        LOGGER.debug( "---------------------------------------" );
 
         ks.dispose();
 
     }
-
-
-
 
     @Test
     public void testTraitLogicalTMS() {
@@ -4417,10 +4259,10 @@ public class TraitTest extends CommonTraitTest {
         ks.delete( handle );
         ks.fireAllRules();
 
-        System.out.println( "---------------------------------------" );
+        LOGGER.debug( "---------------------------------------" );
 
         for ( Object o : ks.getObjects() ) {
-            System.out.println( o );
+            LOGGER.debug( o.toString() );
         }
 
         ks.insert( "go3" );
@@ -4536,7 +4378,7 @@ public class TraitTest extends CommonTraitTest {
         ksession.delete( handle );
         ksession.fireAllRules();
 
-        System.out.println( list );
+        LOGGER.debug( list.toString() );
         assertThat(list).isEqualTo(Arrays.asList("B", "C", "A"));
     }
 
@@ -4660,7 +4502,6 @@ public class TraitTest extends CommonTraitTest {
                      "  $t : TBean() \n" +
                      "then \n" +
                      "  list.add( 0 ); \n" +
-                     "  System.out.println( \"Call DON MANY \" ); " +
                      "  don( $t, Arrays.asList( C.class, D.class, E.class, F.class ), true ); \n" +
                      "end \n" +
                      "" +
@@ -4678,21 +4519,18 @@ public class TraitTest extends CommonTraitTest {
                      "  B( this isA C ) \n" +
                      "then \n" +
                      "  list.add( 1 ); \n" +
-                     "  System.err.println( \"C is HERE !! \" ); " +
                      "end \n" +
                      "rule D \n" +
                      "when\n" +
                      "  D( this isA A, this isA C ) \n" +
                      "then \n" +
                      "  list.add( 2 ); \n" +
-                     "  System.err.println( \"D is HERE TOO !! \" ); " +
                      "end \n"+
                      "rule E \n" +
                      "when\n" +
                      "  D( this isA A, this isA E ) \n" +
                      "then \n" +
                      "  list.add( 3 ); \n" +
-                     "  System.err.println( \"AND E JOINS THE COMPANY !! \" ); " +
                      "end \n";
 
         KieSession ksession = loadKnowledgeBaseFromString(drl).newKieSession();
@@ -4733,7 +4571,7 @@ public class TraitTest extends CommonTraitTest {
         cwm.reset();
 
         for ( Object o : ksession.getObjects() ) {
-            System.out.println( o );
+            LOGGER.debug( o.toString() );
         }
 
         ksession.insert( "undo" );
@@ -4780,10 +4618,7 @@ public class TraitTest extends CommonTraitTest {
                      "  A(this isA B) \n" +
                      "then \n" +
                      "  list.add( 0 ); \n" +
-                     "  System.out.println( \"Call DON MANY (A isA B) \" ); " +
-                     "end \n" +
-                     "" +
-                     "" ;
+                     "end \n";
 
         KieSession ksession = loadKnowledgeBaseFromString(drl).newKieSession();
         TraitFactoryImpl.setMode(mode, ksession.getKieBase() );
@@ -4923,10 +4758,8 @@ public class TraitTest extends CommonTraitTest {
                           "when \n" +
                           " $t : Thing() \n" +
                           "then \n" +
-                          " System.out.println( \"Thing detected \" + $t ); \n" +
                           " list.add( $t.getClass().getName() ); \n" +
-                          "end \n" +
-                          "";
+                          "end \n";
 
         KieBase kbase = getKieBaseFromString(s1);
         TraitFactoryImpl.setMode(mode, kbase );
@@ -5000,10 +4833,8 @@ public class TraitTest extends CommonTraitTest {
                           "when \n" +
                           " $t : Thing() \n" +
                           "then \n" +
-                          "  System.out.println( \"Thing detected \" + $t ); \n" +
                           "  list.add( $t.getClass().getName() ); \n" +
-                          "end \n" +
-                          "";
+                          "end \n";
 
         KieBase kbase = getKieBaseFromString(s1);
         TraitFactoryImpl.setMode(mode, kbase );
@@ -5027,7 +4858,7 @@ public class TraitTest extends CommonTraitTest {
         knowledgeSession.insert( "don2" );
         knowledgeSession.fireAllRules();
 
-        System.out.println( list );
+        LOGGER.debug( list.toString() );
         assertThat(list.size()).isEqualTo(2);
         assertThat(list).isEqualTo(Arrays.asList("test.Mask.test.Core_Proxy", "test.Mask2.test.Core_Proxy"));
 
@@ -5297,7 +5128,7 @@ public class TraitTest extends CommonTraitTest {
 
         KnowledgeBuilder kb2 = KnowledgeBuilderFactory.newKnowledgeBuilder();
         kb2.add( new ByteArrayResource( drl1.getBytes() ), ResourceType.DRL );
-        System.out.print( kb2.getErrors() );
+        LOGGER.debug( kb2.getErrors().toString() );
         assertThat(kb2.hasErrors()).isFalse();
 
         knowledgeBase.addPackages( kb2.getKnowledgePackages() );
@@ -5334,7 +5165,6 @@ public class TraitTest extends CommonTraitTest {
                           "	when\n" +
                           "     $e : TBean( ) " +
                           "	then " +
-                          "     System.out.println( 'Don' ); " +
                           "		don( $e, Mask.class );\n" +
                           "end\n" +
                           "" +
@@ -5342,10 +5172,9 @@ public class TraitTest extends CommonTraitTest {
                           "	when \n" +
                           "		$m : Mask() \n" +
                           "then \n" +
-                          "     System.out.println( $m ); \n" +
                           "end\n" +
                           "" +
-                          "rule Zero when not Object() then System.out.println( 'Clean' ); end ";
+                          "rule Zero when not Object() then end ";
 
         KieBase kbase = getKieBaseFromString(s1, EqualityBehaviorOption.IDENTITY);
 
@@ -5458,15 +5287,12 @@ public class TraitTest extends CommonTraitTest {
                 "    IPerson x = don( $core, IPerson.class, true );\n" +
                 "    IStudent s = don( $core, IStudent.class, true );\n" +
                 "    Person p = don( $core, Person.class, true );\n" +
-                "    System.err.println( \"            Done donning              \" );\n " +
                 "end\n" +
 
                 "rule R2 when\n" +
                 "    $p: IPerson( name == null )\n" +
                 "then\n" +
-                "    System.out.println(\"IPerson: \" + $p);\n" +
-                "end\n" +
-                "\n";
+                "end\n";
 
         KieBase kbase = getKieBaseFromString( drl );
         TraitFactoryImpl.setMode(mode, kbase );
@@ -5579,7 +5405,6 @@ public class TraitTest extends CommonTraitTest {
                      "    $core: Entity( ) " +
                      "then " +
                      "    A o = don( $core, A.class ); " +
-                     "    System.out.println( 'Found ! ' + o ); " +
                      "end " +
 
                      "rule Test when " +
@@ -5640,7 +5465,6 @@ public class TraitTest extends CommonTraitTest {
                      "rule Mood when " +
                      "  $x : B() " +
                      "then " +
-                     "  System.out.println( 'Found B' ); " +
                      "end " +
 
                      "rule Shed when " +
@@ -5667,7 +5491,7 @@ public class TraitTest extends CommonTraitTest {
         int n = ksession.fireAllRules();
         assertThat(n).isEqualTo(2);
 
-        System.err.print( "---------------------------------------------------------------\n\n\n " );
+        LOGGER.debug( "---------------------------------------------------------------\n\n\n " );
 
         int counter = 0;
         for ( Object o : ksession.getObjects() ) {
@@ -5683,7 +5507,7 @@ public class TraitTest extends CommonTraitTest {
                 }
             } else if ( o instanceof TraitableBean ) {
                 TraitableBean tb = (TraitableBean) o;
-                System.out.println( tb.getCurrentTypeCode() );
+                LOGGER.debug( tb.getCurrentTypeCode().toString() );
                 counter++;
             }
         }
@@ -5693,7 +5517,7 @@ public class TraitTest extends CommonTraitTest {
         ksession.insert( "go" );
         ksession.fireAllRules();
 
-        System.err.print( "---------------------------------------------------------------\n\n\n " );
+        LOGGER.debug( "---------------------------------------------------------------\n\n\n " );
 
         int counter2 = 0;
         for ( Object o : ksession.getObjects() ) {
@@ -5936,6 +5760,9 @@ public class TraitTest extends CommonTraitTest {
     }
 
     public static class ScholarImpl<K> implements Scholar<K> {
+
+        private static final Logger LOGGER = LoggerFactory.getLogger(ScholarImpl.class);
+
         private Thing<K> core;
 
         public ScholarImpl() { }
@@ -5945,7 +5772,7 @@ public class TraitTest extends CommonTraitTest {
         }
 
         public void learn( String subject ) {
-            System.out.println( "I " + core.getFields().get( "name" ) + ", now know everything about " + subject );
+            LOGGER.debug( "I " + core.getFields().get( "name" ) + ", now know everything about " + subject );
         }
     }
 
@@ -6031,7 +5858,7 @@ public class TraitTest extends CommonTraitTest {
 
         ks.fireAllRules();
 
-        System.out.println(list);
+        LOGGER.debug(list.toString());
         assertThat(list.get(0)).isEqualTo("Y");
         assertThat(list.get(1)).isEqualTo("Z");
         assertThat(list.get(2)).isEqualTo(first);
@@ -6118,7 +5945,6 @@ public class TraitTest extends CommonTraitTest {
                 " MyThing( $x_0 := core, this isA D.class, $p : this#RootThing.objProp ) " +
                 " exists MyThing( $x_1 := core , core memberOf $p, this isA F.class ) " +
                 "then " +
-                " System.out.println( \"Recognized \" + $x_0 + \" as an instance of E by rule \" + drools.getRule().getName() ); " +
                 " don( $x_0, E.class, true ); " +
                 "end " +
                 "" +
@@ -6128,7 +5954,6 @@ public class TraitTest extends CommonTraitTest {
                 " $y : F( $z : core memberOf $objs ) " +
                 "then " +
                 " retract( $s ); " +
-                " System.out.println( \"SUCCESS : E has been recognized, removing Y \" ); " +
                 " modify ( $x ) { getObjProp().remove( $z ); } " +
                 " modify ( $y ) {} " +
                 "end ";

--- a/drools-traits/src/test/java/org/drools/traits/compiler/integrationtests/TraitTypeGenerationTest.java
+++ b/drools-traits/src/test/java/org/drools/traits/compiler/integrationtests/TraitTypeGenerationTest.java
@@ -43,10 +43,14 @@ import org.kie.api.runtime.KieSession;
 import org.kie.internal.builder.KnowledgeBuilder;
 import org.kie.internal.builder.KnowledgeBuilderFactory;
 import org.kie.internal.utils.KieHelper;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
 public class TraitTypeGenerationTest extends CommonTraitTest {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(TraitTypeGenerationTest.class);
 
     @PropertyReactive
     @Traitable
@@ -292,7 +296,6 @@ public class TraitTypeGenerationTest extends CommonTraitTest {
                         "when " +
                         "   $g : Goal( $m : entity, $prop : property, $val : value ) " +
                         "then " +
-                        "   System.out.println( 'Satisfy ' + $g ); \n" +
                         "   modify ( $m ) { getFields().put( $prop, $val ); } \n" +
                         "end " +
 
@@ -303,7 +306,6 @@ public class TraitTypeGenerationTest extends CommonTraitTest {
                         "rule Main\n" +
                         "when \n" +
                         "then \n" +
-                        "   System.out.println( 'Don MONKEY ' ); " +
                         "   Entity e = new Entity(); \n" +
                         "   Monkey monkey = don( e, Monkey.class );" +
                         "end \n" +
@@ -313,7 +315,6 @@ public class TraitTypeGenerationTest extends CommonTraitTest {
                         "   $m : Monkey( $pos : position ) " +
                         "   ?check( $m, \"position\", 4 ; ) " +
                         "then " +
-                        "   System.out.println( 'Monkey madness' + $m ); " +
                         "   list.add( $m.getPosition() ); " +
                         "end " +
 
@@ -328,7 +329,7 @@ public class TraitTypeGenerationTest extends CommonTraitTest {
         session.fireAllRules();
 
         for ( Object o : session.getObjects() ) {
-            System.out.println( ">>> " + o );
+            LOGGER.debug( ">>> " + o );
         }
 
         assertThat(list).isEqualTo(List.of(4));
@@ -372,7 +373,7 @@ public class TraitTypeGenerationTest extends CommonTraitTest {
         KnowledgeBuilder kBuilder = KnowledgeBuilderFactory.newKnowledgeBuilder();
         kBuilder.add(new ByteArrayResource(drl.getBytes()), ResourceType.DRL);
         if (kBuilder.hasErrors()) {
-            System.err.println(kBuilder.getErrors());
+            LOGGER.error(kBuilder.getErrors().toString());
         }
         assertThat(kBuilder.hasErrors()).isFalse();
 
@@ -408,7 +409,7 @@ public class TraitTypeGenerationTest extends CommonTraitTest {
         KnowledgeBuilder kBuilder = KnowledgeBuilderFactory.newKnowledgeBuilder();
         kBuilder.add(new ByteArrayResource(drl.getBytes()), ResourceType.DRL);
         if (kBuilder.hasErrors()) {
-            System.err.println(kBuilder.getErrors());
+            LOGGER.error(kBuilder.getErrors().toString());
         }
         assertThat(kBuilder.hasErrors()).isFalse();
 
@@ -444,7 +445,7 @@ public class TraitTypeGenerationTest extends CommonTraitTest {
         KnowledgeBuilder kBuilder = KnowledgeBuilderFactory.newKnowledgeBuilder();
         kBuilder.add(new ByteArrayResource(drl.getBytes()), ResourceType.DRL);
         if (kBuilder.hasErrors()) {
-            System.err.println(kBuilder.getErrors());
+            LOGGER.error(kBuilder.getErrors().toString());
         }
         assertThat(kBuilder.hasErrors()).isFalse();
 
@@ -480,7 +481,7 @@ public class TraitTypeGenerationTest extends CommonTraitTest {
         KnowledgeBuilder kBuilder = KnowledgeBuilderFactory.newKnowledgeBuilder();
         kBuilder.add(new ByteArrayResource(drl.getBytes()), ResourceType.DRL);
         if (kBuilder.hasErrors()) {
-            System.err.println(kBuilder.getErrors());
+            LOGGER.error(kBuilder.getErrors().toString());
         }
         assertThat(kBuilder.hasErrors()).isFalse();
 
@@ -516,7 +517,7 @@ public class TraitTypeGenerationTest extends CommonTraitTest {
         KnowledgeBuilder kBuilder = KnowledgeBuilderFactory.newKnowledgeBuilder();
         kBuilder.add(new ByteArrayResource(drl.getBytes()), ResourceType.DRL);
         if (kBuilder.hasErrors()) {
-            System.err.println(kBuilder.getErrors());
+            LOGGER.error(kBuilder.getErrors().toString());
         }
         assertThat(kBuilder.hasErrors()).isFalse();
 
@@ -558,7 +559,7 @@ public class TraitTypeGenerationTest extends CommonTraitTest {
         KnowledgeBuilder kBuilder = KnowledgeBuilderFactory.newKnowledgeBuilder();
         kBuilder.add(new ByteArrayResource(drl.getBytes()), ResourceType.DRL);
         if (kBuilder.hasErrors()) {
-            System.err.println(kBuilder.getErrors());
+            LOGGER.error(kBuilder.getErrors().toString());
         }
         assertThat(kBuilder.hasErrors()).isFalse();
 
@@ -601,7 +602,7 @@ public class TraitTypeGenerationTest extends CommonTraitTest {
         KnowledgeBuilder kBuilder = KnowledgeBuilderFactory.newKnowledgeBuilder();
         kBuilder.add(new ByteArrayResource(drl.getBytes()), ResourceType.DRL);
         if (kBuilder.hasErrors()) {
-            System.err.println(kBuilder.getErrors());
+            LOGGER.error(kBuilder.getErrors().toString());
         }
         assertThat(kBuilder.hasErrors()).isFalse();
 

--- a/drools-traits/src/test/java/org/drools/traits/core/factmodel/InstancesHashcodedTest.java
+++ b/drools-traits/src/test/java/org/drools/traits/core/factmodel/InstancesHashcodedTest.java
@@ -101,14 +101,6 @@ public class InstancesHashcodedTest {
             Object o2 = klass.newInstance();
             cd.getField("cutDate").getFieldAccessor().setValue(o2, cut);
             cd.getField("dueDate").getFieldAccessor().setValue(o2, d2);
-
-//            System.out.println(o1);
-//            System.out.println(o1.hashCode());
-//            System.out.println(o2);
-//            System.out.println(o2.hashCode());
-//
-//            System.out.println(o1.equals(o2));
-
         } catch (Exception e) {
 //            e.printStackTrace();
         }

--- a/drools-traits/src/test/java/org/drools/traits/core/factmodel/JeneratorTest.java
+++ b/drools-traits/src/test/java/org/drools/traits/core/factmodel/JeneratorTest.java
@@ -23,6 +23,8 @@ import java.util.jar.JarEntry;
 import java.util.jar.JarInputStream;
 
 import org.junit.Test;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -32,6 +34,7 @@ import static org.assertj.core.api.Assertions.assertThat;
  */
 public class JeneratorTest {
 
+    private static final Logger LOGGER = LoggerFactory.getLogger(JeneratorTest.class);
 
     @Test
     public void testRoundTrip() throws Exception {
@@ -62,24 +65,20 @@ public class JeneratorTest {
         JarEntry je = jis.getNextJarEntry();
 
         assertThat(je).isNotNull();
-        System.err.println(je.getName());
+        LOGGER.debug(je.getName());
         assertThat(je.getName()).isEqualTo("factmodel.xml");
 
-
         je = jis.getNextJarEntry();
 
         assertThat(je).isNotNull();
-        System.err.println(je.getName());
+        LOGGER.debug(je.getName());
         assertThat(je.getName()).isEqualTo("whee/waa/Foobar.class");
 
-
         je = jis.getNextJarEntry();
 
         assertThat(je).isNotNull();
-        System.err.println(je.getName());
+        LOGGER.debug(je.getName());
         assertThat(je.getName()).isEqualTo("whee/waa/Baz.class");
-
-
 
         Fact[] facts = jen.loadMetaModel(new JarInputStream(new ByteArrayInputStream(data)));
         assertThat(facts.length).isEqualTo(2);

--- a/drools-traits/src/test/java/org/drools/traits/core/meta/org/MetadataTest.java
+++ b/drools-traits/src/test/java/org/drools/traits/core/meta/org/MetadataTest.java
@@ -41,12 +41,15 @@ import org.drools.traits.core.metadata.Lit;
 import org.drools.traits.core.metadata.MetadataContainer;
 import org.drools.traits.core.metadata.With;
 import org.junit.Test;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import static org.drools.traits.compiler.factmodel.traits.TraitTestUtils.createStandaloneTraitFactory;
 import static org.assertj.core.api.Assertions.assertThat;
 
 public class MetadataTest {
 
+    private static final Logger LOGGER = LoggerFactory.getLogger(MetadataTest.class);
 
     @Test
     public void testKlassAndSubKlassWithImpl() {
@@ -99,7 +102,7 @@ public class MetadataTest {
         assertThat((int) sk.subProp.get(ski)).isEqualTo(-99);
         assertThat(sk.prop.get(ski)).isEqualTo("bye");
 
-        System.out.println( ski.map);
+        LOGGER.debug( ski.map.toString());
         Map tgt = new HashMap();
         tgt.put( "prop", "bye" );
         tgt.put( "subProp", -99 );

--- a/drools-traits/src/test/java/org/drools/traits/core/util/HierarchyTest.java
+++ b/drools-traits/src/test/java/org/drools/traits/core/util/HierarchyTest.java
@@ -22,6 +22,8 @@ import org.drools.traits.core.factmodel.CodedHierarchy;
 import org.drools.traits.core.factmodel.HierarchyEncoder;
 import org.drools.traits.core.factmodel.IndexedTypeHierarchy;
 import org.junit.Test;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -35,7 +37,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 public class HierarchyTest {
 
-
+    private static final Logger LOGGER = LoggerFactory.getLogger(HierarchyTest.class);
 
     @Test
     public void testHierEncoderTrivial() {
@@ -46,7 +48,7 @@ public class HierarchyTest {
         encoder.encode("C", List.of("B"));
         encoder.encode( "D", Arrays.asList( "B", "C" ) );
 
-        System.out.println( encoder );
+        LOGGER.debug( encoder.toString() );
 
         assertThat(encoder.getCode("A")).isEqualTo(parseBitSet("0"));
         assertThat(encoder.getCode("B")).isEqualTo(parseBitSet("1"));
@@ -64,7 +66,7 @@ public class HierarchyTest {
         encoder.encode( "D", Collections.EMPTY_LIST );
         encoder.encode( "E", Collections.EMPTY_LIST );
 
-        System.out.println( encoder );
+        LOGGER.debug( encoder.toString() );
 
         assertThat(encoder.getCode("A")).isEqualTo(parseBitSet("1"));
         assertThat(encoder.getCode("B")).isEqualTo(parseBitSet("10"));
@@ -89,7 +91,7 @@ public class HierarchyTest {
         encoder.encode( "D", Arrays.asList( "B", "C" ) );
         encoder.encode( "E", Collections.EMPTY_LIST );
 
-        System.out.println( encoder );
+        LOGGER.debug( encoder.toString() );
 
         BitSet a = encoder.getCode( "A" );
         BitSet b = encoder.getCode( "B" );
@@ -142,7 +144,7 @@ public class HierarchyTest {
         encoder.encode("F", List.of("C"));
         encoder.encode("G", List.of("C"));
 
-        System.out.println( encoder );
+        LOGGER.debug( encoder.toString() );
 
         assertThat(encoder.getCode("A")).isEqualTo(parseBitSet("0"));
         assertThat(encoder.getCode("B")).isEqualTo(parseBitSet("1"));
@@ -172,7 +174,7 @@ public class HierarchyTest {
         encoder.encode( "B6", Arrays.asList( "B2", "B3" ) );
         encoder.encode( "B7", Arrays.asList( "B4", "B5", "B6" ) );
 
-        System.out.println( encoder );
+        LOGGER.debug( encoder.toString() );
 
         assertThat(encoder.getCode("R")).isEqualTo(parseBitSet("0"));
         assertThat(encoder.getCode("A1")).isEqualTo(parseBitSet("1"));
@@ -207,7 +209,7 @@ public class HierarchyTest {
         encoder.encode("A2", List.of("R"));
         encoder.encode("A3", List.of("R"));
 
-        System.out.println( encoder );
+        LOGGER.debug( encoder.toString() );
 
         assertThat(encoder.getCode("R")).isEqualTo(parseBitSet("0"));
         assertThat(encoder.getCode("B1")).isEqualTo(parseBitSet("1"));
@@ -244,7 +246,7 @@ public class HierarchyTest {
         encoder.encode( "B5", Arrays.asList( "B1", "B2", "B3" ) );
         encoder.encode( "B6", Arrays.asList( "B1", "B2", "B3" ) );
 
-        System.out.println( encoder );
+        LOGGER.debug( encoder.toString() );
 
         assertThat(encoder.getCode("R")).isEqualTo(parseBitSet("0"));
         assertThat(encoder.getCode("A1")).isEqualTo(parseBitSet("1"));
@@ -276,7 +278,7 @@ public class HierarchyTest {
         encoder.encode("A2", List.of("R"));
         encoder.encode("A3", List.of("R"));
 
-        System.out.println( encoder );
+        LOGGER.debug( encoder.toString() );
 
         assertThat(encoder.getCode("R")).isEqualTo(parseBitSet("0"));
         assertThat(encoder.getCode("B1")).isEqualTo(parseBitSet("1"));
@@ -302,7 +304,7 @@ public class HierarchyTest {
         encoder.encode( "C", Arrays.asList( "A", "B" ) );
         encoder.encode( "D", Arrays.asList( "A", "B" ) );
 
-        System.out.println( encoder );
+        LOGGER.debug( encoder.toString() );
 
         assertThat(encoder.getCode("T")).isEqualTo(parseBitSet("0"));
         assertThat(encoder.getCode("A")).isEqualTo(parseBitSet("1"));
@@ -329,7 +331,7 @@ public class HierarchyTest {
         encoder.encode("H", List.of("E"));
 
 
-        System.out.println( encoder );
+        LOGGER.debug( encoder.toString() );
 
         assertThat(encoder.getCode("A")).isEqualTo(parseBitSet("0"));
         assertThat(encoder.getCode("B")).isEqualTo(parseBitSet("1"));
@@ -342,7 +344,7 @@ public class HierarchyTest {
 
         encoder.encode( "I", Arrays.asList( "E", "F" ) );
 
-        System.out.println( encoder );
+        LOGGER.debug( encoder.toString() );
 
         assertThat(encoder.getCode("A")).isEqualTo(parseBitSet("0"));
         assertThat(encoder.getCode("B")).isEqualTo(parseBitSet("1"));
@@ -374,11 +376,11 @@ public class HierarchyTest {
         encoder.encode("K", List.of("J"));
 
 
-        System.out.println( encoder );
+        LOGGER.debug( encoder.toString() );
 
         encoder.encode( "I", Arrays.asList( "E", "F" ) );
 
-        System.out.println( encoder );
+        LOGGER.debug( encoder.toString() );
 
         checkHier( encoder, 'K' );
 
@@ -410,7 +412,7 @@ public class HierarchyTest {
         encoder.encode("A7", List.of("A4"));
 
 
-        System.out.println( encoder );
+        LOGGER.debug( encoder.toString() );
 
         assertThat(encoder.getCode("R")).isEqualTo(parseBitSet("0"));
         assertThat(encoder.getCode("B1")).isEqualTo(parseBitSet("1"));
@@ -454,7 +456,7 @@ public class HierarchyTest {
 
 
 
-        System.out.println( encoder );
+        LOGGER.debug( encoder.toString() );
 
         assertThat(encoder.getCode("R")).isEqualTo(parseBitSet("0"));
 
@@ -536,7 +538,7 @@ public class HierarchyTest {
         encoder.encode( "O", Arrays.asList( "H", "M" ) );
         checkHier( encoder, 'O' );
 
-        System.out.println( encoder );
+        LOGGER.debug( encoder.toString() );
 
         Collection<BitSet> codes = encoder.getSortedMap().values();
         Iterator<BitSet> iter = codes.iterator();
@@ -544,7 +546,7 @@ public class HierarchyTest {
         for ( int j = 0; j < codes.size() -1; j++ ) {
             BitSet ns = iter.next();
             Long next = toLong( ns );
-            System.out.println( next );
+            LOGGER.debug( next.toString() );
             assertThat(next > last).isTrue();
             last = next;
         }
@@ -664,11 +666,11 @@ public class HierarchyTest {
         encoder.encode( "F", Arrays.asList( "B", "C" ) );
 
 
-        System.out.println( encoder );
+        LOGGER.debug( encoder.toString() );
 
         encoder.encode( "Z", Arrays.asList( "A", "B", "D" ) );
 
-        System.out.println( encoder );
+        LOGGER.debug( encoder.toString() );
 
         assertThat(((HierarchyEncoderImpl) encoder).superset(encoder.getCode("Z"), encoder.getCode("F")) < 0).isTrue() ;
         assertThat(((HierarchyEncoderImpl) encoder).superset(encoder.getCode("F"), encoder.getCode("Z")) < 0).isTrue() ;
@@ -696,14 +698,14 @@ public class HierarchyTest {
         encoder.encode( "M", Arrays.asList( "R", "Q" ) );
         encoder.encode( "O", Arrays.asList( "M", "P" ) );
 
-        System.out.println( encoder );
+        LOGGER.debug( encoder.toString() );
 
         BitSet b;
         Collection x;
 
         b = parseBitSet( "1100111" );
         x = encoder.upperAncestors(b);
-        System.out.println( "ANC " + x );
+        LOGGER.debug( "ANC " + x );
 
         assertThat(x.contains("A")).isTrue();
         assertThat(x.contains("Z")).isTrue();
@@ -719,7 +721,7 @@ public class HierarchyTest {
 
         b = parseBitSet( "100000" );
         x = encoder.upperAncestors(b);
-        System.out.println( "ANC " + x );
+        LOGGER.debug( "ANC " + x );
 
         assertThat(x.size()).isEqualTo(2);
         assertThat(x.contains("Q")).isTrue();
@@ -727,7 +729,7 @@ public class HierarchyTest {
 
         b = parseBitSet( "1111" );
         x = encoder.upperAncestors(b);
-        System.out.println( "ANC " + x );
+        LOGGER.debug( "ANC " + x );
 
         assertThat(x.size()).isEqualTo(6);
         assertThat(x.contains("A")).isTrue();
@@ -739,7 +741,7 @@ public class HierarchyTest {
 
         b = parseBitSet( "111" );
         x = encoder.upperAncestors(b);
-        System.out.println( "ANC " + x );
+        LOGGER.debug( "ANC " + x );
 
         assertThat(x.size()).isEqualTo(4);
         assertThat(x.contains("A")).isTrue();
@@ -749,7 +751,7 @@ public class HierarchyTest {
 
         b = parseBitSet( "1" );
         x = encoder.upperAncestors(b);
-        System.out.println( "ANC " + x );
+        LOGGER.debug( "ANC " + x );
 
         assertThat(x.size()).isEqualTo(2);
         assertThat(x.contains("A")).isTrue();
@@ -757,7 +759,7 @@ public class HierarchyTest {
 
         b = parseBitSet( "10" );
         x = encoder.upperAncestors(b);
-        System.out.println( "ANC " + x );
+        LOGGER.debug( "ANC " + x );
 
         assertThat(x.size()).isEqualTo(2);
         assertThat(x.contains("Z")).isTrue();
@@ -765,7 +767,7 @@ public class HierarchyTest {
 
         b = parseBitSet( "0" );
         x = encoder.upperAncestors(b);
-        System.out.println( "ANC " + x );
+        LOGGER.debug( "ANC " + x );
 
         assertThat(x.size()).isEqualTo(1);
         assertThat(x.contains("Thing")).isTrue();
@@ -773,7 +775,7 @@ public class HierarchyTest {
 
         b = parseBitSet( "1011" );
         x = encoder.upperAncestors(b);
-        System.out.println( "ANC " + x );
+        LOGGER.debug( "ANC " + x );
 
         assertThat(x.size()).isEqualTo(4);
         assertThat(x.contains("Thing")).isTrue();
@@ -802,14 +804,14 @@ public class HierarchyTest {
         encoder.encode( "M", Arrays.asList( "R", "Q" ) );
         encoder.encode( "O", Arrays.asList( "M", "P" ) );
 
-        System.out.println( encoder );
+        LOGGER.debug( encoder.toString() );
 
         BitSet b;
         Collection x;
 
         b = parseBitSet( "111" );
         x = encoder.lowerDescendants(b);
-        System.out.println( "DESC " + x );
+        LOGGER.debug( "DESC " + x );
 
         assertThat(x.size()).isEqualTo(3);
         assertThat(x.contains("C")).isTrue();
@@ -819,7 +821,7 @@ public class HierarchyTest {
 
         b = parseBitSet( "10" );
         x = encoder.lowerDescendants(b);
-        System.out.println( "DESC " + x );
+        LOGGER.debug( "DESC " + x );
 
         assertThat(x.size()).isEqualTo(5);
         assertThat(x.contains("C")).isTrue();
@@ -831,7 +833,7 @@ public class HierarchyTest {
 
         b = parseBitSet( "100000" );
         x = encoder.lowerDescendants(b);
-        System.out.println( "DESC " + x );
+        LOGGER.debug( "DESC " + x );
 
         assertThat(x.size()).isEqualTo(4);
         assertThat(x.contains("Q")).isTrue();
@@ -844,14 +846,14 @@ public class HierarchyTest {
 
         b = parseBitSet( "100010" );
         x = encoder.lowerDescendants(b);
-        System.out.println( "DESC " + x );
+        LOGGER.debug( "DESC " + x );
 
         assertThat(x.size()).isEqualTo(1);
         assertThat(x.contains("T")).isTrue();
 
         b = parseBitSet( "1111" );
         x = encoder.lowerDescendants(b);
-        System.out.println( "DESC " + x );
+        LOGGER.debug( "DESC " + x );
 
         assertThat(x.size()).isEqualTo(1);
         assertThat(x.contains("N")).isTrue();
@@ -859,7 +861,7 @@ public class HierarchyTest {
 
         b = parseBitSet( "1" );
         x = encoder.lowerDescendants(b);
-        System.out.println( "DESC " + x );
+        LOGGER.debug( "DESC " + x );
 
         assertThat(x.size()).isEqualTo(5);
         assertThat(x.contains("A")).isTrue();
@@ -868,10 +870,10 @@ public class HierarchyTest {
         assertThat(x.contains("N")).isTrue();
         assertThat(x.contains("T")).isTrue();
 
-        System.out.println(" +*******************************+ ");
+        LOGGER.debug(" +*******************************+ ");
 
         x = encoder.lowerDescendants(new BitSet());
-        System.out.println( "DESC " + x );
+        LOGGER.debug( "DESC " + x );
 
         assertThat(x.size()).isEqualTo(13);
         assertThat(x.contains("Z")).isTrue();
@@ -898,30 +900,30 @@ public class HierarchyTest {
         encoder.encode( "M", Arrays.asList( "R", "Q" ) );
         encoder.encode( "O", Arrays.asList( "M", "P" ) );
 
-        System.out.println( encoder );
+        LOGGER.debug( encoder.toString() );
 
         Collection x;
 
         x = encoder.lowerBorder( encoder.metMembersCode(List.of("B")));
-        System.out.println( "GCS " + x );
+        LOGGER.debug( "GCS " + x );
         assertThat(x.size()).isEqualTo(1);
         assertThat(x.contains("B")).isTrue();
 
         x = encoder.immediateChildren( encoder.metMembersCode(List.of("B")));
-        System.out.println( "GCS " + x );
+        LOGGER.debug( "GCS " + x );
         assertThat(x.size()).isEqualTo(1);
         assertThat(x.contains("N")).isTrue();
 
 
 
         x = encoder.lowerBorder( encoder.metMembersCode( Arrays.asList( "Z", "Q" ) ) );
-        System.out.println( "GCS " + x );
+        LOGGER.debug( "GCS " + x );
 
         assertThat(x.size()).isEqualTo(1);
         assertThat(x.contains("T")).isTrue();
 
         x = encoder.immediateChildren( encoder.metMembersCode( Arrays.asList( "Z", "Q" ) ) );
-        System.out.println( "GCS " + x );
+        LOGGER.debug( "GCS " + x );
 
         assertThat(x.size()).isEqualTo(1);
         assertThat(x.contains("T")).isTrue();
@@ -930,14 +932,14 @@ public class HierarchyTest {
 
 
         x = encoder.lowerBorder( encoder.metMembersCode( Arrays.asList( "A", "Z" ) ) );
-        System.out.println( "GCS " + x );
+        LOGGER.debug( "GCS " + x );
 
         assertThat(x.size()).isEqualTo(2);
         assertThat(x.contains("B")).isTrue();
         assertThat(x.contains("C")).isTrue();
 
         x = encoder.immediateChildren( encoder.metMembersCode( Arrays.asList( "A", "Z" ) ) );
-        System.out.println( "GCS " + x );
+        LOGGER.debug( "GCS " + x );
 
         assertThat(x.size()).isEqualTo(2);
         assertThat(x.contains("B")).isTrue();
@@ -947,13 +949,13 @@ public class HierarchyTest {
 
 
         x = encoder.lowerBorder( encoder.metMembersCode(List.of("Thing")));
-        System.out.println( "GCS " + x );
+        LOGGER.debug( "GCS " + x );
 
         assertThat(x.size()).isEqualTo(1);
         assertThat(x.contains("Thing")).isTrue();
 
         x = encoder.immediateChildren( encoder.metMembersCode(List.of("Thing")));
-        System.out.println( "GCS " + x );
+        LOGGER.debug( "GCS " + x );
 
         assertThat(x.size()).isEqualTo(5);
         assertThat(x.contains("A")).isTrue();
@@ -984,17 +986,17 @@ public class HierarchyTest {
         encoder.encode( "M", Arrays.asList( "R", "Q" ) );
         encoder.encode( "O", Arrays.asList( "M", "P" ) );
 
-        System.out.println( encoder );
+        LOGGER.debug( encoder.toString() );
 
         Collection x;
 
         x = encoder.upperBorder( encoder.metMembersCode(List.of("B")));
-        System.out.println( "LCS " + x );
+        LOGGER.debug( "LCS " + x );
         assertThat(x.size()).isEqualTo(1);
         assertThat(x.contains("B")).isTrue();
 
         x = encoder.immediateParents( encoder.metMembersCode(List.of("B")));
-        System.out.println( "LCS " + x );
+        LOGGER.debug( "LCS " + x );
         assertThat(x.size()).isEqualTo(2);
         assertThat(x.contains("A")).isTrue();
         assertThat(x.contains("Z")).isTrue();
@@ -1002,13 +1004,13 @@ public class HierarchyTest {
 
 
         x = encoder.upperBorder( encoder.jointMembersCode( Arrays.asList( "Z", "Q" ) ) );
-        System.out.println( "LCS " + x );
+        LOGGER.debug( "LCS " + x );
 
         assertThat(x.size()).isEqualTo(1);
         assertThat(x.contains("Thing")).isTrue();
 
         x = encoder.immediateParents( encoder.jointMembersCode( Arrays.asList( "Z", "Q" ) ) );
-        System.out.println( "LCS " + x );
+        LOGGER.debug( "LCS " + x );
 
         assertThat(x.size()).isEqualTo(1);
         assertThat(x.contains("Thing")).isTrue();
@@ -1016,14 +1018,14 @@ public class HierarchyTest {
 
 
         x = encoder.upperBorder( encoder.jointMembersCode( Arrays.asList( "B", "C" ) ) );
-        System.out.println( "LCS " + x );
+        LOGGER.debug( "LCS " + x );
 
         assertThat(x.size()).isEqualTo(2);
         assertThat(x.contains("A")).isTrue();
         assertThat(x.contains("Z")).isTrue();
 
         x = encoder.immediateParents( encoder.jointMembersCode( Arrays.asList( "B", "C" ) ) );
-        System.out.println( "LCS " + x );
+        LOGGER.debug( "LCS " + x );
 
         assertThat(x.size()).isEqualTo(2);
         assertThat(x.contains("A")).isTrue();
@@ -1031,13 +1033,13 @@ public class HierarchyTest {
 
 
         x = encoder.upperBorder( encoder.jointMembersCode(List.of("T")));
-        System.out.println( "LCS " + x );
+        LOGGER.debug( "LCS " + x );
 
         assertThat(x.size()).isEqualTo(1);
         assertThat(x.contains("T")).isTrue();
 
         x = encoder.immediateParents( encoder.jointMembersCode(List.of("T")));
-        System.out.println( "LCS " + x );
+        LOGGER.debug( "LCS " + x );
 
         assertThat(x.size()).isEqualTo(2);
         assertThat(x.contains("C")).isTrue();
@@ -1071,7 +1073,7 @@ public class HierarchyTest {
         BitSet nk = encoder.encode( "N", Arrays.asList( "I", "L" ) );
         BitSet ok = encoder.encode( "O", Arrays.asList( "H", "M" ) );
 
-        System.out.println( encoder );
+        LOGGER.debug( encoder.toString() );
 
         CodedHierarchy<String> types = new IndexedTypeHierarchy<String>("A", new BitSet(), "ZZZZ", encoder.getBottom() );
 
@@ -1085,7 +1087,7 @@ public class HierarchyTest {
         types.addMember( "h", hk );
 
 
-        System.out.println( types );
+        LOGGER.debug( types.toString() );
 
         assertThat(types.children("A")).isEqualTo(Arrays.asList("c", "h"));
         assertThat(types.children("c")).isEqualTo(Arrays.asList("f", "n", "o"));
@@ -1111,7 +1113,7 @@ public class HierarchyTest {
         BitSet pk = encoder.encode("P", List.of("O"));
         types.addMember( "p", pk );
 
-        System.out.println( types );
+        LOGGER.debug( types.toString() );
 
         assertThat(types.parents("p")).isEqualTo(List.of("o"));
         assertThat(types.parents("ZZZZ")).isEqualTo(Arrays.asList("j", "k", "n", "p"));
@@ -1120,7 +1122,7 @@ public class HierarchyTest {
 
         types.removeMember( "o" );
 
-        System.out.println( types );
+        LOGGER.debug( types.toString() );
 
         assertThat(types.parents("p")).isEqualTo(Arrays.asList("c", "h"));
         assertThat(types.children("c")).isEqualTo(Arrays.asList("f", "n", "p"));
@@ -1174,7 +1176,7 @@ public class HierarchyTest {
 
         assertThat(encoder.getCode("L")).isNotNull();
 
-        System.out.println( encoder );
+        LOGGER.debug( encoder.toString() );
         assertThat(encoder.size()).isEqualTo(16);
     }
 
@@ -1206,7 +1208,7 @@ public class HierarchyTest {
 
 
 
-        System.out.println( encoder );
+        LOGGER.debug( encoder.toString() );
 
         checkHier( encoder, 'O' );
     }
@@ -1242,11 +1244,11 @@ public class HierarchyTest {
         encoder.encode("W", List.of("V"));
         encoder.encode("X", List.of("W"));
 
-        System.out.println( encoder );
+        LOGGER.debug( encoder.toString() );
 
         encoder.encode( "Y", Arrays.asList( "F", "W") );
 
-        System.out.println( encoder );
+        LOGGER.debug( encoder.toString() );
 
         checkHier( encoder, (char) ( 'A' + encoder.size() - 1 ) );
 

--- a/drools-traits/src/test/resources/logback-test.xml
+++ b/drools-traits/src/test/resources/logback-test.xml
@@ -30,9 +30,9 @@
   <logger name="org.kie" level="warn"/>
   <logger name="org.drools" level="warn"/>
   
-  <logger name="org.drools.core.management" level="debug"/>
-  <logger name="org.kie.api.internal.utils" level="debug"/>
-  <!--<logger name="org.drools.ancompiler" level="debug"/>-->
+  <logger name="org.drools.core.management" level="info"/>
+  <logger name="org.kie.api.internal.utils" level="info"/>
+  <!--<logger name="org.drools.ancompiler" level="info"/>-->
 
   <root level="warn">
     <appender-ref ref="consoleAppender" />

--- a/drools-traits/src/test/resources/org/drools/compiler/factmodel/traits/testDeclaredFactTrait.drl
+++ b/drools-traits/src/test/resources/org/drools/compiler/factmodel/traits/testDeclaredFactTrait.drl
@@ -69,5 +69,4 @@ rule "Log"
 when
     $o : Object()
 then
-    System.out.println(" Log " + $o );
 end

--- a/drools-traits/src/test/resources/org/drools/compiler/factmodel/traits/testPojoFactTrait.drl
+++ b/drools-traits/src/test/resources/org/drools/compiler/factmodel/traits/testPojoFactTrait.drl
@@ -69,5 +69,4 @@ rule "By thing"
         $d : PojoFact()
         exists Thing( core == $d )
     then
-        System.out.println(" !!QQE!");
 end

--- a/drools-traits/src/test/resources/org/drools/compiler/factmodel/traits/testTraitCollections.drl
+++ b/drools-traits/src/test/resources/org/drools/compiler/factmodel/traits/testTraitCollections.drl
@@ -91,8 +91,6 @@ then
         setNested( st ),
         setNest2( at );
     }
-
-    System.out.println( complex );
 end
 
 

--- a/drools-traits/src/test/resources/org/drools/compiler/factmodel/traits/testTraitDon.drl
+++ b/drools-traits/src/test/resources/org/drools/compiler/factmodel/traits/testTraitDon.drl
@@ -101,7 +101,6 @@ rule "Check"
 when
     $z: Student( $s : school == "skl", fields[ "name" ] == "xx", $a : age == 88 )
 then
-    System.out.println( "DON" );
     list.add( "DON" );
 end 
  
@@ -112,6 +111,5 @@ salience -100
 when
     not Student( )
 then
-    System.out.println( "SHED" );
     list.add( "SHED" );
 end;

--- a/drools-traits/src/test/resources/org/drools/compiler/factmodel/traits/testTraitDonMultiple.drl
+++ b/drools-traits/src/test/resources/org/drools/compiler/factmodel/traits/testTraitDonMultiple.drl
@@ -43,7 +43,6 @@ rule "React"
 when
     $x : SeniorStudent( $y : year ) @watch( year )
 then
-    System.out.println( " SeniorStudent Updated " );
     list.add( $y );
 end
 
@@ -54,7 +53,6 @@ no-loop
 when
     $s : Student( grad == false ) @watch( year )
 then
-    System.out.println( " Don SeniorStudent " );
     SeniorStudent sen = don( $s, SeniorStudent.class );
 end
 
@@ -64,6 +62,5 @@ salience -5
 when
     $s : Student( grad == false, $y : year < 4 )
 then
-    System.out.println( " One year passes " + $y );
 modify( $s ) { setYear( $y + 1 ); }
 end

--- a/drools-traits/src/test/resources/org/drools/compiler/factmodel/traits/testTraitIsA2.drl
+++ b/drools-traits/src/test/resources/org/drools/compiler/factmodel/traits/testTraitIsA2.drl
@@ -35,12 +35,10 @@ rule "print student"
     when
         student : Person( this isA Student )
     then
-        // System.out.println("Person is a student: " + student);
 end
 
 rule "print school"
     when
         Student( $school : school )
     then
-        // System.out.println("Student is attending " + $school);
 end

--- a/drools-traits/src/test/resources/org/drools/compiler/factmodel/traits/testTraitIsAWithBC.drl
+++ b/drools-traits/src/test/resources/org/drools/compiler/factmodel/traits/testTraitIsAWithBC.drl
@@ -90,6 +90,5 @@ when
 
     $q := Country( $name : name == "Italy" )
 then
-    System.out.println( "Checking " + $p + " in " + $q );
     list.add( $name );
 end

--- a/drools-traits/src/test/resources/org/drools/compiler/factmodel/traits/testTraitLegacyCore.drl
+++ b/drools-traits/src/test/resources/org/drools/compiler/factmodel/traits/testTraitLegacyCore.drl
@@ -60,16 +60,12 @@ when
     $core: Imp()
     not Person( age == 30 )
 then
-    System.out.println( " Rule trait is firing " );
-
     Person p = don( $core, Person.class );
 
     modify( p ) {
         setName( "john" ),
         setAge( 30 );
     }
-
-    System.out.println( " Done firing Rule trait " );
 end
 
 rule "Cloak"
@@ -77,7 +73,6 @@ no-loop
 when
     $p    : Person( $core : core, name == "john" )
 then
-    System.out.println( "John the Person is here >>> " + $p );
     list.add("OK");
 
     IRole role = don( $core, IRole.class );
@@ -85,8 +80,6 @@ then
     modify( role ) {
         setRoleName("myRole");
     }
-
-    System.out.println( "John the Role is here >>> " + role.getRoleName() );
 end
 
 
@@ -94,6 +87,5 @@ rule "Role"
 when
     $role : IRole( roleName == "myRole" )
 then
-    System.out.println( "John the Role is here >>> " + $role );
     list.add("OK2");
 end

--- a/drools-traits/src/test/resources/org/drools/compiler/factmodel/traits/testTraitLegacyTrait.drl
+++ b/drools-traits/src/test/resources/org/drools/compiler/factmodel/traits/testTraitLegacyTrait.drl
@@ -95,14 +95,6 @@ then
     modify( s ) { setSchool( "skol" ); }
     modify( w ) { setAge( 30 ); }
     modify( r ) { setRoleName( "john" ); }
-
-
-    System.out.println(s);
-    System.out.println(p);
-    System.out.println(w);
-    System.out.println(x);
-    System.out.println(r);
-
 end
 
 
@@ -110,7 +102,6 @@ rule "Cloak"
 when
     $p : Person( name == "john" )
 then
-    System.out.println( "John the Person is here" );
     list.add( "OK" );
 end
 
@@ -118,7 +109,6 @@ rule "Cloak 2"
 when
     $p : Worker( name == "john", age == 30 )
 then
-    System.out.println( "John the Worker is here" );
     list.add( "OK2" );
 end
 
@@ -126,7 +116,6 @@ rule "Cloak 3"
 when
     $p : IPerson( name == "john" )
 then
-    System.out.println( "John the IPerson is here" );
     list.add( "OK3" );
 end
 
@@ -134,7 +123,6 @@ rule "Cloak 4"
 when
     $p : IStudent( name == "john", school == "skol" )
 then
-    System.out.println( "John the IStudent is here" );
     list.add( "OK4" );
 end
 
@@ -143,6 +131,5 @@ rule "Cloak 5"
 when
     $p : IRole( roleName == "john" )
 then
-    System.out.println( "John the IRole is here" );
     list.add( "OK5" );
 end

--- a/drools-traits/src/test/resources/org/drools/compiler/factmodel/traits/testTraitOverride.drl
+++ b/drools-traits/src/test/resources/org/drools/compiler/factmodel/traits/testTraitOverride.drl
@@ -57,7 +57,6 @@ when
 then
     Person<Imp> s = drools.<Person,Imp>don( $core, Person.class, true );
     s.setCode( 456 );
-    System.out.println(s);
     update(s);
 end
 

--- a/drools-traits/src/test/resources/org/drools/compiler/factmodel/traits/testTraitShed.drl
+++ b/drools-traits/src/test/resources/org/drools/compiler/factmodel/traits/testTraitShed.drl
@@ -41,7 +41,6 @@ end
 rule "Init"
 when
 then
-    System.out.println( "Init" );
     Imp core = new Imp( );
     insert( core );
 end
@@ -52,7 +51,6 @@ no-loop
 when
     $core: Imp( this not isA Thing )
 then
-    System.out.println( "Don student" );
     Student s = don( $core, Student.class );
     list.add( "Student" );
 end
@@ -64,7 +62,6 @@ when
     $s : Student( this not isA Worker )
     String( this == "hire" )
 then
-    System.out.println( "Don worker" );
     don( $s, Worker.class );
     list.add( "Worker" );
 end
@@ -75,7 +72,6 @@ when
     $w : Worker( this isA Student )
     String( this == "check" )
 then
-    System.out.println( "Shed student" );
     shed( $w, Student.class );
 end
 
@@ -84,7 +80,6 @@ rule "Conflict resolved"
 when
     $w : Worker( this not isA Student )
 then
-    System.out.println( "Shed worker too" );
     list.add( "Conflict" );
     shed( $w, Worker.class );
 end
@@ -94,6 +89,5 @@ rule "Nothing Left"
 when
     $t : Thing( this not isA Student, this not isA Worker )
 then
-    System.out.println( "Bare Thing" );
     list.add( "Nothing" );
 end

--- a/drools-traits/src/test/resources/org/drools/compiler/factmodel/traits/testTraitWithEquality.drl
+++ b/drools-traits/src/test/resources/org/drools/compiler/factmodel/traits/testTraitWithEquality.drl
@@ -88,8 +88,6 @@ when
     $s: Student( name == "alan", fields[ "school" ] == "zkl" )
     $z: Student( name == "alan", fields[ "school" ] == "squola" )
 then
-    System.out.println( "Compare " + $s + " vs " + $z );
-
     $z.setDcode(3.47);
     if ( $s.equals( $z ) ) {
         list.add( "EQUAL" );

--- a/drools-traits/src/test/resources/org/drools/compiler/factmodel/traits/testTraitWrapping.drl
+++ b/drools-traits/src/test/resources/org/drools/compiler/factmodel/traits/testTraitWrapping.drl
@@ -75,7 +75,6 @@ then
     Trait t = (Trait) drools.don( $core, Trait.class, true );
  
     Byte b0 = t.getByteh();
-    System.out.println( ">>> " + b0);
     if ( b0 != 0 ) list.add( " hard byte default value != 0 " + b0 );
     t.setByteh( Byte.valueOf("1") );
     if ( $core.getByteh() != 1 ) list.add( " hard byte setter on trait failed, core reports " + $core.getByteh() );

--- a/jpmml-migration-recipe/src/test/resources/logback.xml
+++ b/jpmml-migration-recipe/src/test/resources/logback.xml
@@ -27,8 +27,8 @@
     </encoder>
   </appender>
 
-  <logger name="org.openrewrite" level="debug"/>
-  <logger name="org.kie.openrewrite.recipe.jpmml" level="debug"/>
+  <logger name="org.openrewrite" level="info"/>
+  <logger name="org.kie.openrewrite.recipe.jpmml" level="info"/>
 
   <root level="warn">
     <appender-ref ref="consoleAppender" />

--- a/kie-dmn/kie-dmn-core-jsr223-jq/src/test/resources/logback.xml
+++ b/kie-dmn/kie-dmn-core-jsr223-jq/src/test/resources/logback.xml
@@ -28,7 +28,7 @@
     </encoder>
   </appender>
 
-  <logger name="org.kie" level="debug"/>
+  <logger name="org.kie" level="info"/>
   <logger name="org.kie.dmn.core.compiler.execmodelbased" level="info"/> <!-- useful default when moving generic org.kie to <info -->
   <logger name="org.kie.dmn.feel.codegen" level="info"/> <!-- useful default when moving generic org.kie to <info -->
 

--- a/kie-dmn/kie-dmn-core-jsr223/src/test/resources/logback.xml
+++ b/kie-dmn/kie-dmn-core-jsr223/src/test/resources/logback.xml
@@ -28,7 +28,7 @@
     </encoder>
   </appender>
 
-  <logger name="org.kie" level="debug"/>
+  <logger name="org.kie" level="info"/>
   <logger name="org.kie.dmn.core.compiler.execmodelbased" level="info"/> <!-- useful default when moving generic org.kie to <info -->
   <logger name="org.kie.dmn.feel.codegen" level="info"/> <!-- useful default when moving generic org.kie to <info -->
 

--- a/kie-internal/src/test/resources/logback-test.xml
+++ b/kie-internal/src/test/resources/logback-test.xml
@@ -30,7 +30,7 @@
   </appender>
 
   <!-- set to debug to see test output -->
-  <logger name="org.kie.internal" level="debug"/>
+  <logger name="org.kie.internal" level="info"/>
 
   <root level="info">
     <appender-ref ref="consoleAppender" />

--- a/kie-test-util/src/test/resources/logback-test.xml
+++ b/kie-test-util/src/test/resources/logback-test.xml
@@ -28,7 +28,7 @@
   </appender>
 
   <logger name="org.kie" level="warn"/>
-  <logger name="org.drools" level="debug"/>
+  <logger name="org.drools" level="info"/>
 
   <root level="warn">
     <appender-ref ref="consoleAppender"/>


### PR DESCRIPTION
Fixes https://github.com/apache/incubator-kie-issues/issues/653

- Changes logger debug mode in tests in the whole repository
- Replaces or removes the use of System.out or System.err in drools-traits tests. When an occurence is replaced, it is replaced with logger.

@jstastny-cz this should fix the huge logs you reported from drools-traits in the CI logs. 