### PR TITLE
[kie-issues#656] Change Overpass font to more widely used Arial in ReteDiagram generator.

### DIFF
--- a/drools-retediagram/src/main/java/org/drools/retediagram/ReteDiagram.java
+++ b/drools-retediagram/src/main/java/org/drools/retediagram/ReteDiagram.java
@@ -164,9 +164,9 @@ public class ReteDiagram {
         File pngFile = new File(outputPath, pngFileName);
         try (PrintStream out = new PrintStream(new FileOutputStream(gvFile));) {
             out.println("digraph g {\n" +
-                    "graph [fontname = \"Overpass\" fontsize=11];\n" + 
-                    " node [fontname = \"Overpass\" fontsize=11];\n" + 
-                    " edge [fontname = \"Overpass\" fontsize=11];");
+                    "graph [fontname = \"Arial\" fontsize=11];\n" +
+                    " node [fontname = \"Arial\" fontsize=11];\n" +
+                    " edge [fontname = \"Arial\" fontsize=11];");
             HashMap<Class<? extends BaseNode>, Set<BaseNode>> levelMap = new HashMap<>();
             HashMap<Class<? extends BaseNode>, List<BaseNode>> nodeMap = new HashMap<>();
             List<Vertex<BaseNode,BaseNode>> vertexes = new ArrayList<>();


### PR DESCRIPTION
Fixes https://github.com/apache/incubator-kie-issues/issues/656