### PR TITLE
kie-issues_599: set projectKey for sonarcloud

### DIFF
--- a/.ci/jenkins/Jenkinsfile
+++ b/.ci/jenkins/Jenkinsfile
@@ -17,6 +17,7 @@ pipeline {
         BUILDCHAIN_CONFIG_FILE_PATH = '.ci/buildchain-config-pr-cdb.yaml'
 
         ENABLE_SONARCLOUD = 'false'
+        SONAR_PROJECT_KEY = 'apache_incubator-kie-drools'
         DROOLS_BUILD_MVN_OPTS = '-Prun-code-coverage'
     }
     stages {

--- a/.ci/jenkins/dsl/jobs.groovy
+++ b/.ci/jenkins/dsl/jobs.groovy
@@ -195,10 +195,18 @@ Closure setup3AMCronTriggerJobParamsGetter = { script ->
     return jobParams
 }
 
+Closure setupSonarProjectKeyEnv = { Closure paramsGetter ->
+    return { script ->
+        def jobParams = paramsGetter(script)
+        jobParams.env.put('SONAR_PROJECT_KEY', 'apache_incubator-kie-drools')
+        return jobParams
+    }
+}
+
 Closure nightlyJobParamsGetter = isMainStream() ? JobParamsUtils.DEFAULT_PARAMS_GETTER : setup3AMCronTriggerJobParamsGetter
 KogitoJobUtils.createNightlyBuildChainBuildAndDeployJobForCurrentRepo(this, '', true)
 setupSpecificBuildChainNightlyJob('native', nightlyJobParamsGetter)
-setupSpecificBuildChainNightlyJob('sonarcloud', nightlyJobParamsGetter)
+setupSpecificBuildChainNightlyJob('sonarcloud', setupSonarProjectKeyEnv(nightlyJobParamsGetter))
 setupQuarkusIntegrationJob('quarkus-main', nightlyJobParamsGetter)
 setupQuarkusIntegrationJob('quarkus-branch', nightlyJobParamsGetter)
 setupQuarkusIntegrationJob('quarkus-lts', nightlyJobParamsGetter)


### PR DESCRIPTION
apache/incubator-kie-issues#599

Explicitly setting sonar.projectKey in PR checks and buildchain nightly.

apache/incubator-kie-drools#5573
apache/incubator-kie-kogito-apps#1910
apache/incubator-kie-kogito-pipelines#1116
apache/incubator-kie-kogito-runtimes#3274
apache/incubator-kie-optaplanner#3011