### PR TITLE
[kie-issues #681] Removing use of InternalRuleBase from drools-compiler

### DIFF
--- a/drools-base/src/main/java/org/drools/base/RuleBase.java
+++ b/drools-base/src/main/java/org/drools/base/RuleBase.java
@@ -19,8 +19,17 @@
 package org.drools.base;
 
 
+import java.lang.reflect.Type;
+import java.util.Collection;
+import java.util.Map;
+import java.util.concurrent.Future;
+
+import org.drools.base.definitions.InternalKnowledgePackage;
+import org.drools.base.definitions.rule.impl.RuleImpl;
+import org.drools.base.rule.InvalidPatternException;
 import org.drools.base.rule.TypeDeclaration;
 import org.kie.api.KieBaseConfiguration;
+import org.kie.api.definition.KiePackage;
 
 public interface RuleBase {
     ClassLoader getRootClassLoader();
@@ -30,4 +39,22 @@ public interface RuleBase {
     TypeDeclaration getTypeDeclaration(Class<?> classType);
 
     KieBaseConfiguration getConfiguration();
+    
+    InternalKnowledgePackage[] getPackages();
+    InternalKnowledgePackage getPackage(String name);
+    Future<KiePackage> addPackage(KiePackage pkg ); 
+    void addPackages( Collection<? extends KiePackage> newPkgs );
+    Map<String, InternalKnowledgePackage> getPackagesMap();
+
+    void addRules( Collection<RuleImpl> rules ) throws InvalidPatternException;
+    void removeRules( Collection<RuleImpl> rules ) throws InvalidPatternException;
+
+    String getId();
+    
+    String getContainerId();
+    void setContainerId(String containerId);
+    
+    Map<String, Type> getGlobals();
+
+
 }

--- a/drools-compiler/src/main/java/org/drools/compiler/builder/impl/KnowledgeBuilderImpl.java
+++ b/drools-compiler/src/main/java/org/drools/compiler/builder/impl/KnowledgeBuilderImpl.java
@@ -34,6 +34,7 @@ import java.util.Optional;
 import java.util.concurrent.ForkJoinPool;
 import java.util.function.Supplier;
 
+import org.drools.base.RuleBase;
 import org.drools.base.base.ObjectType;
 import org.drools.base.definitions.InternalKnowledgePackage;
 import org.drools.base.definitions.rule.impl.RuleImpl;
@@ -60,7 +61,6 @@ import org.drools.compiler.compiler.ProcessBuilderFactory;
 import org.drools.compiler.compiler.ResourceTypeDeclarationWarning;
 import org.drools.compiler.kie.builder.impl.BuildContext;
 import org.drools.compiler.lang.descr.CompositePackageDescr;
-import org.drools.core.impl.InternalRuleBase;
 import org.drools.core.impl.RuleBaseFactory;
 import org.drools.drl.ast.descr.AttributeDescr;
 import org.drools.drl.ast.descr.ImportDescr;
@@ -941,7 +941,7 @@ public class KnowledgeBuilderImpl implements InternalKnowledgeBuilder, TypeDecla
             }
             throw new IllegalArgumentException("Could not parse knowledge. See the logs for details.");
         }
-        InternalRuleBase kbase = RuleBaseFactory.newRuleBase(conf);
+        RuleBase kbase = RuleBaseFactory.newRuleBase(conf);
         kbase.addPackages(asList(getPackages()));
         return KnowledgeBaseFactory.newKnowledgeBase(kbase);
     }

--- a/drools-compiler/src/main/java/org/drools/compiler/builder/impl/processors/ReteCompiler.java
+++ b/drools-compiler/src/main/java/org/drools/compiler/builder/impl/processors/ReteCompiler.java
@@ -21,20 +21,20 @@ package org.drools.compiler.builder.impl.processors;
 import java.util.ArrayList;
 import java.util.Collection;
 
-import org.drools.base.definitions.InternalKnowledgePackage;
-import org.drools.base.definitions.rule.impl.RuleImpl;
+import org.drools.base.RuleBase;
 import org.drools.compiler.builder.impl.AssetFilter;
 import org.drools.compiler.compiler.PackageRegistry;
-import org.drools.core.impl.InternalRuleBase;
+import org.drools.base.definitions.InternalKnowledgePackage;
+import org.drools.base.definitions.rule.impl.RuleImpl;
 import org.drools.drl.ast.descr.PackageDescr;
 import org.drools.drl.ast.descr.RuleDescr;
 import org.kie.internal.builder.ResourceChange;
 
 public class ReteCompiler extends AbstractPackageCompilationPhase {
     private final AssetFilter assetFilter;
-    private InternalRuleBase kBase;
+    private RuleBase kBase;
 
-    public ReteCompiler(PackageRegistry pkgRegistry, PackageDescr packageDescr, InternalRuleBase kBase, AssetFilter assetFilter) {
+    public ReteCompiler(PackageRegistry pkgRegistry, PackageDescr packageDescr, RuleBase kBase, AssetFilter assetFilter) {
         super(pkgRegistry, packageDescr);
         this.kBase = kBase;
         this.assetFilter = assetFilter;

--- a/drools-compiler/src/main/java/org/drools/compiler/kie/builder/impl/AbstractKieModule.java
+++ b/drools-compiler/src/main/java/org/drools/compiler/kie/builder/impl/AbstractKieModule.java
@@ -39,7 +39,8 @@ import org.drools.compiler.builder.conf.DecisionTableConfigurationImpl;
 import org.drools.compiler.builder.impl.KnowledgeBuilderConfigurationImpl;
 import org.drools.compiler.kproject.models.KieBaseModelImpl;
 import org.drools.core.RuleBaseConfiguration;
-import org.drools.core.impl.InternalRuleBase;
+import org.drools.base.definitions.InternalKnowledgePackage;
+import org.drools.base.definitions.impl.KnowledgePackageImpl;
 import org.drools.core.impl.RuleBaseFactory;
 import org.drools.io.ResourceConfigurationImpl;
 import org.drools.kiesession.rulebase.InternalKnowledgeBase;
@@ -69,6 +70,7 @@ import org.kie.util.maven.support.PomModel;
 import org.kie.util.maven.support.ReleaseIdImpl;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.drools.base.RuleBase;
 
 import static org.kie.internal.builder.KnowledgeBuilderFactory.newKnowledgeBuilderConfiguration;
 
@@ -220,7 +222,7 @@ public abstract class AbstractKieModule implements InternalKieModule, Serializab
             ((RuleBaseConfiguration)conf).setClassLoader(cl);
         }
 
-        InternalRuleBase kBase = RuleBaseFactory.newRuleBase(kBaseModel.getName(), conf);
+        RuleBase kBase = RuleBaseFactory.newRuleBase(kBaseModel.getName(), conf);
         kBase.addPackages( pkgs );
         return KnowledgeBaseFactory.newKnowledgeBase(kBase);
     }

--- a/drools-compiler/src/main/java/org/drools/compiler/kie/builder/impl/KieContainerImpl.java
+++ b/drools-compiler/src/main/java/org/drools/compiler/kie/builder/impl/KieContainerImpl.java
@@ -32,6 +32,7 @@ import java.util.concurrent.ConcurrentHashMap;
 
 import javax.management.ObjectName;
 
+import org.drools.base.RuleBase;
 import org.drools.compiler.builder.InternalKnowledgeBuilder;
 import org.drools.compiler.builder.impl.KnowledgeBuilderConfigurationImpl;
 import org.drools.compiler.kie.builder.MaterializedLambda;
@@ -41,7 +42,6 @@ import org.drools.compiler.kproject.models.KieSessionModelImpl;
 import org.drools.compiler.management.KieContainerMonitor;
 import org.drools.core.SessionConfiguration;
 import org.drools.core.impl.InternalKieContainer;
-import org.drools.core.impl.InternalRuleBase;
 import org.drools.core.management.DroolsManagementAgent;
 import org.drools.core.management.DroolsManagementAgent.CBSKey;
 import org.drools.core.reteoo.RuntimeComponentFactory;
@@ -735,10 +735,10 @@ public class KieContainerImpl
         Set<DroolsManagementAgent.CBSKey> cbskeys = new HashSet<>();
         if ( isMBeanOptionEnabled() ) {
             for (Entry<String, KieSession> kv : kSessions.entrySet()) {
-                cbskeys.add(new DroolsManagementAgent.CBSKey(containerId, ((InternalRuleBase) kv.getValue().getKieBase()).getId(), kv.getKey()));
+                cbskeys.add(new DroolsManagementAgent.CBSKey(containerId, ((RuleBase) kv.getValue().getKieBase()).getId(), kv.getKey()));
             }
             for (Entry<String, StatelessKieSession> kv : statelessKSessions.entrySet()) {
-                cbskeys.add(new DroolsManagementAgent.CBSKey(containerId, ((InternalRuleBase) kv.getValue().getKieBase()).getId(), kv.getKey()));
+                cbskeys.add(new DroolsManagementAgent.CBSKey(containerId, ((RuleBase) kv.getValue().getKieBase()).getId(), kv.getKey()));
             }
         }
 
@@ -753,7 +753,7 @@ public class KieContainerImpl
                 DroolsManagementAgent.getInstance().unregisterKnowledgeSessionBean(c);
             }
             for (KieBase kb : kBases.values()) {
-                DroolsManagementAgent.getInstance().unregisterKnowledgeBase((InternalRuleBase) kb);
+                DroolsManagementAgent.getInstance().unregisterKnowledgeBase((RuleBase) kb);
             }
             DroolsManagementAgent.getInstance().unregisterMBeansFromOwner(this);
         }

--- a/drools-core/src/main/java/org/drools/core/impl/InternalRuleBase.java
+++ b/drools-core/src/main/java/org/drools/core/impl/InternalRuleBase.java
@@ -22,9 +22,7 @@ import java.io.IOException;
 import java.lang.reflect.Type;
 import java.util.Collection;
 import java.util.List;
-import java.util.Map;
 import java.util.Set;
-import java.util.concurrent.Future;
 
 import org.drools.base.RuleBase;
 import org.drools.base.common.RuleBasePartitionId;
@@ -80,7 +78,6 @@ public interface InternalRuleBase extends RuleBase {
 
     Set<String> getEntryPointIds();
 
-    String getId();
 
     RuleBasePartitionId createNewPartitionId();
     boolean isPartitioned();
@@ -99,7 +96,6 @@ public interface InternalRuleBase extends RuleBase {
 
     FactHandleFactory newFactHandleFactory(long id, long counter) throws IOException;
 
-    Map<String, Type> getGlobals();
 
     int getNodeCount();
     int getMemoryCount();
@@ -120,11 +116,6 @@ public interface InternalRuleBase extends RuleBase {
 
     Class<?> registerAndLoadTypeDefinition( String className, byte[] def ) throws ClassNotFoundException;
 
-    InternalKnowledgePackage[] getPackages();
-    InternalKnowledgePackage getPackage(String name);
-    Future<KiePackage> addPackage(KiePackage pkg );
-    void addPackages( Collection<? extends KiePackage> newPkgs );
-    Map<String, InternalKnowledgePackage> getPackagesMap();
 
     ClassFieldAccessorCache getClassFieldAccessorCache();
 
@@ -140,9 +131,6 @@ public interface InternalRuleBase extends RuleBase {
     boolean hasSegmentPrototypes();
 
     void processAllTypesDeclaration( Collection<InternalKnowledgePackage> pkgs );
-
-    void addRules( Collection<RuleImpl> rules ) throws InvalidPatternException;
-    void removeRules( Collection<RuleImpl> rules ) throws InvalidPatternException;
 
     default void beforeIncrementalUpdate(KieBaseUpdate kieBaseUpdate) { }
     default void afterIncrementalUpdate(KieBaseUpdate kieBaseUpdate) { }
@@ -160,8 +148,6 @@ public interface InternalRuleBase extends RuleBase {
 
     ReleaseId getResolvedReleaseId();
     void setResolvedReleaseId(ReleaseId currentReleaseId);
-    String getContainerId();
-    void setContainerId(String containerId);
 
     RuleUnitDescriptionRegistry getRuleUnitDescriptionRegistry();
     boolean hasUnits();

--- a/drools-core/src/main/java/org/drools/core/management/DroolsManagementAgent.java
+++ b/drools-core/src/main/java/org/drools/core/management/DroolsManagementAgent.java
@@ -28,8 +28,8 @@ import javax.management.MBeanServer;
 import javax.management.ObjectName;
 import javax.management.StandardMBean;
 
+import org.drools.base.RuleBase;
 import org.drools.core.common.InternalWorkingMemory;
-import org.drools.core.impl.InternalRuleBase;
 import org.drools.core.reteoo.RuntimeComponentFactory;
 import org.kie.api.builder.model.KieSessionModel;
 import org.kie.api.event.KieRuntimeEventManager;
@@ -59,7 +59,7 @@ public interface DroolsManagementAgent extends KieManagementAgentMBean {
         return DroolsManagementAgentHolder.INSTANCE;
     }
 
-    static ObjectName createObjectNameFor(InternalRuleBase kbase) {
+    static ObjectName createObjectNameFor(RuleBase kbase) {
         return DroolsManagementAgent.createObjectName(
                     DroolsManagementAgent.createObjectNameBy(kbase.getContainerId())
                     + ",kbaseId=" + ObjectName.quote(kbase.getId())
@@ -101,9 +101,9 @@ public interface DroolsManagementAgent extends KieManagementAgentMBean {
 
     long getNextKnowledgeSessionId();
 
-    void registerKnowledgeBase(InternalRuleBase kbase);
+    void registerKnowledgeBase(RuleBase kbase);
     
-    void unregisterKnowledgeBase(InternalRuleBase kbase);
+    void unregisterKnowledgeBase(RuleBase kbase);
     
     void registerKnowledgeSessionUnderName(CBSKey cbsKey, KieRuntimeEventManager ksession);
 
@@ -240,7 +240,7 @@ public interface DroolsManagementAgent extends KieManagementAgentMBean {
         }
 
         @Override
-        public void registerKnowledgeBase(InternalRuleBase kbase) {
+        public void registerKnowledgeBase(RuleBase kbase) {
             KnowledgeBaseMonitoring mbean = new KnowledgeBaseMonitoring( kbase );
             registerMBean( kbase,
                     mbean,
@@ -248,7 +248,7 @@ public interface DroolsManagementAgent extends KieManagementAgentMBean {
         }
 
         @Override
-        public void unregisterKnowledgeBase(InternalRuleBase kbase) {
+        public void unregisterKnowledgeBase(RuleBase kbase) {
             unregisterMBeansFromOwner(kbase);
         }
 
@@ -417,12 +417,12 @@ public interface DroolsManagementAgent extends KieManagementAgentMBean {
         }
 
         @Override
-        public void registerKnowledgeBase(InternalRuleBase kbase) {
+        public void registerKnowledgeBase(RuleBase kbase) {
 
         }
 
         @Override
-        public void unregisterKnowledgeBase(InternalRuleBase kbase) {
+        public void unregisterKnowledgeBase(RuleBase kbase) {
 
         }
 

--- a/drools-core/src/main/java/org/drools/core/management/KnowledgeBaseMonitoring.java
+++ b/drools-core/src/main/java/org/drools/core/management/KnowledgeBaseMonitoring.java
@@ -52,6 +52,7 @@ import javax.management.openmbean.TabularData;
 import javax.management.openmbean.TabularDataSupport;
 import javax.management.openmbean.TabularType;
 
+import org.drools.base.RuleBase;
 import org.drools.core.impl.InternalRuleBase;
 import org.drools.core.reteoo.EntryPointNode;
 import org.drools.core.reteoo.ObjectTypeNode;
@@ -114,8 +115,8 @@ public class KnowledgeBaseMonitoring
     // ************************************************************************************************
 
     // Constructor
-    public KnowledgeBaseMonitoring(InternalRuleBase kbase) {
-        this.kbase = kbase;
+    public KnowledgeBaseMonitoring(RuleBase kbase) {
+        this.kbase = (InternalRuleBase) kbase;
         this.name = DroolsManagementAgent.createObjectNameFor(kbase);
 
         initOpenMBeanInfo();

--- a/drools-kiesession/src/main/java/org/drools/kiesession/rulebase/KnowledgeBaseFactory.java
+++ b/drools-kiesession/src/main/java/org/drools/kiesession/rulebase/KnowledgeBaseFactory.java
@@ -19,9 +19,9 @@
 package org.drools.kiesession.rulebase;
 
 import org.drools.core.impl.KnowledgeBaseImpl;
-import org.drools.core.impl.InternalRuleBase;
 import org.kie.api.KieBaseConfiguration;
 import org.kie.internal.conf.CompositeBaseConfiguration;
+import org.drools.base.RuleBase;
 
 public class KnowledgeBaseFactory {
 
@@ -37,7 +37,7 @@ public class KnowledgeBaseFactory {
         return newKnowledgeBase(new KnowledgeBaseImpl(kbaseId, (CompositeBaseConfiguration) conf));
     }
 
-    public static InternalKnowledgeBase newKnowledgeBase(InternalRuleBase delegate) {
+    public static InternalKnowledgeBase newKnowledgeBase(RuleBase delegate) {
         return new SessionsAwareKnowledgeBase(delegate);
     }
 }

--- a/drools-kiesession/src/main/java/org/drools/kiesession/rulebase/SessionsAwareKnowledgeBase.java
+++ b/drools-kiesession/src/main/java/org/drools/kiesession/rulebase/SessionsAwareKnowledgeBase.java
@@ -18,6 +18,7 @@
  */
 package org.drools.kiesession.rulebase;
 
+import org.drools.base.RuleBase;
 import org.drools.base.common.RuleBasePartitionId;
 import org.drools.base.definitions.InternalKnowledgePackage;
 import org.drools.base.definitions.rule.impl.RuleImpl;
@@ -32,7 +33,6 @@ import org.drools.core.common.InternalWorkingMemory;
 import org.drools.core.common.ReteEvaluator;
 import org.drools.core.impl.EnvironmentFactory;
 import org.drools.core.impl.InternalKieContainer;
-import org.drools.core.impl.InternalRuleBase;
 import org.drools.core.impl.KieBaseUpdate;
 import org.drools.core.impl.KnowledgeBaseImpl;
 import org.drools.core.impl.RuleBaseFactory;
@@ -108,7 +108,7 @@ public class SessionsAwareKnowledgeBase implements InternalKnowledgeBase {
         this(RuleBaseFactory.newRuleBase(kbaseConfiguration));
     }
 
-    public SessionsAwareKnowledgeBase(InternalRuleBase delegate) {
+    public SessionsAwareKnowledgeBase(RuleBase delegate) {
         this.delegate = (KnowledgeBaseImpl) delegate;
 
         if (this.delegate.getRuleBaseConfiguration().getSessionPoolSize() > 0) {


### PR DESCRIPTION
This is part of the ongoing effort to separate drools-compiler from drools-core.

Closes https://github.com/apache/incubator-kie-issues/issues/681

<details>
<summary>
How to replicate CI configuration locally?
</summary>

Build Chain tool does "simple" maven build(s), the builds are just Maven commands, but because the repositories relates and depends on each other and any change in API or class method could affect several of those repositories there is a need to use [build-chain tool](https://github.com/kiegroup/github-action-build-chain) to handle cross repository builds and be sure that we always use latest version of the code for each repository.
 
[build-chain tool](https://github.com/kiegroup/github-action-build-chain) is a build tool which can be used on command line locally or in Github Actions workflow(s), in case you need to change multiple repositories and send multiple dependent pull requests related with a change you can easily reproduce the same build by executing it on Github hosted environment or locally in your development environment. See [local execution](https://github.com/kiegroup/github-action-build-chain#local-execution) details to get more information about it.
</details>

<details>
<summary>
How to retest this PR or trigger a specific build:
</summary>

- for <b>pull request checks</b>  
  Please add comment: <b>Jenkins retest this</b>

- for a <b>specific pull request check</b>  
  Please add comment: <b>Jenkins (re)run [drools|kogito-runtimes|kogito-apps|kogito-examples] tests</b>

- for a <b>full downstream build</b> 
  - for <b>jenkins</b> job: please add comment: <b>Jenkins run fdb</b>
  - for <b>github actions</b> job: add the label `run_fdb`

- <b>a compile downstream build</b> please  add comment: <b>Jenkins run cdb</b>

- <b>an upstream build</b> please add comment: <b>Jenkins run upstream</b>

- for <b>quarkus branch checks</b>  
  Run checks against Quarkus current used branch  
  Please add comment: <b>Jenkins run quarkus-branch</b>

- for a <b>quarkus branch specific check</b>  
  Run checks against Quarkus current used branch  
  Please add comment: <b>Jenkins (re)run [drools|kogito-runtimes|kogito-apps|kogito-examples] quarkus-branch</b>

- for <b>quarkus main checks</b>  
  Run checks against Quarkus main branch  
  Please add comment: <b>Jenkins run quarkus-main</b>

- for a <b>specific quarkus main check</b>  
  Run checks against Quarkus main branch  
  Please add comment: <b>Jenkins (re)run [drools|kogito-runtimes|kogito-apps|kogito-examples] quarkus-main</b>

- for <b>quarkus lts checks</b>  
  Run checks against Quarkus lts branch  
  Please add comment: <b>Jenkins run quarkus-lts</b>

- for a <b>specific quarkus lts check</b>  
  Run checks against Quarkus lts branch  
  Please add comment: <b>Jenkins (re)run [drools|kogito-runtimes|kogito-apps|kogito-examples] quarkus-lts</b>

- for <b>native checks</b>  
  Run native checks  
  Please add comment: <b>Jenkins run native</b>

- for a <b>specific native check</b>  
  Run native checks 
  Please add comment: <b>Jenkins (re)run [drools|kogito-runtimes|kogito-apps|kogito-examples] native</b>

 - for <b>native lts checks</b>  
  Run native checks against quarkus lts branch
  Please add comment: <b>Jenkins run native-lts</b>

- for a <b>specific native lts check</b>  
  Run native checks against quarkus lts branch
  Please add comment: <b>Jenkins (re)run [drools|kogito-runtimes|kogito-apps|kogito-examples] native-lts</b>
</details>

<details>
<summary>
How to backport a pull request to a different branch?
</summary>

In order to automatically create a **backporting pull request** please add one or more labels having the following format `backport-<branch-name>`, where `<branch-name>` is the name of the branch where the pull request must be backported to (e.g., `backport-7.67.x` to backport the original PR to the `7.67.x` branch).

> **NOTE**: **backporting** is an action aiming to move a change (usually a commit) from a branch (usually the main one) to another one, which is generally referring to a still maintained release branch. Keeping it simple: it is about to move a specific change or a set of them from one branch to another.

Once the original pull request is successfully merged, the automated action will create one backporting pull request per each label (with the previous format) that has been added.

If something goes wrong, the author will be notified and at this point a manual backporting is needed.

> **NOTE**: this automated backporting is triggered whenever a pull request on `main` branch is labeled or closed, but both conditions must be satisfied to get the new PR created.
</details>

<!-- TODO to uncomment if activating the quarkus-3 rewrite PR job -->
<!-- <details>
<summary>
Quarkus-3 PR check is failing ... what to do ?
</summary>
The Quarkus 3 check is applying patches from the `.ci/environments/quarkus-3/patches`.

The first patch, called `0001_before_sh.patch`, is generated from Openrewrite `.ci/environments/quarkus-3/quarkus3.yml` recipe. The patch is created to speed up the check. But it may be that some changes in the PR broke this patch.  
No panic, there is an easy way to regenerate it. You just need to comment on the PR:
```
jenkins rewrite quarkus-3
```
and it should, after some minutes (~20/30min) apply a commit on the PR with the patch regenerated.

Other patches were generated manually. If any of it fails, you will need to manually update it... and push your changes.
</details> -->