### PR TITLE
kie-issues#710: freeze kogito-ci-build image tag

### DIFF
--- a/.ci/jenkins/config/branch.yaml
+++ b/.ci/jenkins/config/branch.yaml
@@ -97,7 +97,7 @@ jenkins:
   agent:
     docker:
       builder:
-        image: quay.io/kiegroup/kogito-ci-build:main-latest
+        image: quay.io/kiegroup/kogito-ci-build:19a0b303bc64f473a01f5fa5bacde822f10b4946 # last main-latest based on ubi
         args: -v /var/run/docker.sock:/var/run/docker.sock --network host --group-add docker --group-add input --group-add render
   default_tools:
     jdk: jdk_11_latest


### PR DESCRIPTION
apache/incubator-kie-issues#710

In preparation for switching the kogito-ci-build to ubuntu based, setting explicitly the tag of the most recent tag before the switch.
This will allow to separate change of image dockerfile and necessary change of docker arguments for the new image into 2 separate PRs without introducing a CI disruption.

apache/incubator-kie-kogito-pipelines#1124
apache/incubator-kie-drools#5588
apache/incubator-kie-optaplanner#3023