### PR TITLE
[KIE-724] allow to write rules in yaml format making files with extension .drl.yaml to be a native drools resource type

### DIFF
--- a/drools-compiler/src/main/java/org/drools/compiler/builder/impl/ResourceHandlerManager.java
+++ b/drools-compiler/src/main/java/org/drools/compiler/builder/impl/ResourceHandlerManager.java
@@ -26,6 +26,7 @@ import org.drools.compiler.builder.impl.resources.DrlResourceHandler;
 import org.drools.compiler.builder.impl.resources.DslrResourceHandler;
 import org.drools.compiler.builder.impl.resources.ResourceHandler;
 import org.drools.compiler.builder.impl.resources.TemplateResourceHandler;
+import org.drools.compiler.builder.impl.resources.YamlResourceHandler;
 import org.drools.drl.parser.lang.dsl.DefaultExpander;
 import org.kie.api.builder.ReleaseId;
 import org.kie.api.io.ResourceType;
@@ -39,12 +40,14 @@ public class ResourceHandlerManager {
     public ResourceHandlerManager(KnowledgeBuilderConfigurationImpl configuration, ReleaseId releaseId, Supplier<DefaultExpander> dslExpander){
         this.mappers = asList(
                 new DrlResourceHandler(configuration),
+                new YamlResourceHandler(configuration),
                 new TemplateResourceHandler(configuration, releaseId, dslExpander),
                 new DslrResourceHandler(configuration, dslExpander) ,
                 new DecisionTableResourceHandler(configuration, releaseId));
 
         this.orderedResourceTypes = asList(
                 ResourceType.DRL,
+                ResourceType.YAML,
                 ResourceType.GDRL,
                 ResourceType.RDRL,
                 ResourceType.DESCR,
@@ -57,10 +60,6 @@ public class ResourceHandlerManager {
 
     public List<ResourceType> getOrderedResourceTypes(){
         return this.orderedResourceTypes;
-    }
-
-    public List<ResourceHandler> getMappers(){
-        return this.mappers;
     }
 
     public ResourceHandler handlerForType(ResourceType type) {

--- a/drools-compiler/src/main/java/org/drools/compiler/builder/impl/resources/YamlResourceHandler.java
+++ b/drools-compiler/src/main/java/org/drools/compiler/builder/impl/resources/YamlResourceHandler.java
@@ -1,0 +1,67 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.drools.compiler.builder.impl.resources;
+
+import java.io.IOException;
+import java.io.StringReader;
+
+import org.drools.compiler.builder.impl.KnowledgeBuilderConfigurationImpl;
+import org.drools.drl.ast.descr.PackageDescr;
+import org.drools.drl.extensions.YamlFactory;
+import org.drools.drl.parser.DrlParser;
+import org.drools.drl.parser.DroolsParserException;
+import org.drools.drl.parser.ParserError;
+import org.drools.io.DescrResource;
+import org.kie.api.io.Resource;
+import org.kie.api.io.ResourceConfiguration;
+import org.kie.api.io.ResourceType;
+import org.kie.internal.builder.conf.LanguageLevelOption;
+
+public class YamlResourceHandler extends ResourceHandler {
+    public YamlResourceHandler(KnowledgeBuilderConfigurationImpl configuration) {
+        super(configuration);
+    }
+
+    @Override
+    public boolean handles(ResourceType type) {
+        return type == ResourceType.YAML;
+    }
+
+    public PackageDescr process(Resource resource, ResourceConfiguration resourceConfig) throws DroolsParserException, IOException {
+        PackageDescr pkg;
+        boolean hasErrors = false;
+        if (resource instanceof DescrResource) {
+            pkg = (PackageDescr) ((DescrResource) resource).getDescr();
+        } else {
+            String drl = YamlFactory.loadFromResource(resource);
+            DrlParser parser = new DrlParser(this.configuration.getOption(LanguageLevelOption.KEY));
+            pkg = parser.parse(new StringReader(drl));
+            this.results.addAll(parser.getErrors());
+            if (pkg == null) {
+                this.results.add(new ParserError(resource, "Parser returned a null Package", 0, 0));
+            }
+            hasErrors = parser.hasErrors();
+        }
+        if (pkg != null) {
+            pkg.setResource(resource);
+        }
+        return hasErrors ? null : pkg;
+    }
+
+}

--- a/drools-drl/drools-drl-extensions/src/main/java/org/drools/drl/extensions/YamlFactory.java
+++ b/drools-drl/drools-drl-extensions/src/main/java/org/drools/drl/extensions/YamlFactory.java
@@ -1,0 +1,37 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.drools.drl.extensions;
+
+import org.kie.api.internal.utils.KieService;
+import org.kie.api.io.Resource;
+
+public class YamlFactory {
+
+    private static class YamlProviderHolder {
+        private static final YamlProvider provider = KieService.load(YamlProvider.class);
+    }
+
+    public static YamlProvider getYamlProvider() {
+        return YamlProviderHolder.provider;
+    }
+
+    public static String loadFromResource(Resource resource) {
+        return getYamlProvider().loadFromResource(resource);
+    }
+}

--- a/drools-drl/drools-drl-extensions/src/main/java/org/drools/drl/extensions/YamlProvider.java
+++ b/drools-drl/drools-drl-extensions/src/main/java/org/drools/drl/extensions/YamlProvider.java
@@ -1,0 +1,27 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.drools.drl.extensions;
+
+import org.kie.api.internal.utils.KieService;
+import org.kie.api.io.Resource;
+
+public interface YamlProvider extends KieService {
+
+    String loadFromResource(Resource resource);
+}

--- a/drools-drlonyaml-parent/drools-drlonyaml-cli/src/main/java/org/drools/drlonyaml/cli/Drl2Yaml.java
+++ b/drools-drlonyaml-parent/drools-drlonyaml-cli/src/main/java/org/drools/drlonyaml/cli/Drl2Yaml.java
@@ -18,9 +18,6 @@
  */
 package org.drools.drlonyaml.cli;
 
-import static org.drools.drlonyaml.cli.utils.Utils.conventionInputStream;
-import static org.drools.drlonyaml.cli.utils.Utils.conventionOutputConsumer;
-
 import java.io.File;
 import java.io.InputStream;
 import java.io.StringReader;
@@ -31,14 +28,13 @@ import org.drools.drl.ast.descr.PackageDescr;
 import org.drools.drl.parser.DrlParser;
 import org.drools.drlonyaml.model.DrlPackage;
 import org.drools.util.IoUtils;
-
-import com.fasterxml.jackson.databind.ObjectMapper;
-import com.fasterxml.jackson.dataformat.yaml.YAMLFactory;
-import com.fasterxml.jackson.dataformat.yaml.YAMLGenerator.Feature;
-
 import picocli.CommandLine.Command;
 import picocli.CommandLine.Option;
 import picocli.CommandLine.Parameters;
+
+import static org.drools.drlonyaml.cli.utils.Utils.conventionInputStream;
+import static org.drools.drlonyaml.cli.utils.Utils.conventionOutputConsumer;
+import static org.drools.drlonyaml.model.Utils.getYamlMapper;
 
 /**
  * Note: beyond different annotations, Parameters and Options are managed per subcommand,
@@ -55,14 +51,7 @@ public class Drl2Yaml implements Callable<Integer> {
     private InputStream inputStream;
     
     private static final DrlParser drlParser = new DrlParser();
-    private static final ObjectMapper mapper;
-    static {
-        YAMLFactory yamlFactory = YAMLFactory.builder()
-                .enable(Feature.MINIMIZE_QUOTES)
-                .build();
-        mapper = new ObjectMapper(yamlFactory);
-    }
-    
+
     @Override
     public Integer call() throws Exception {
         inputStream = conventionInputStream(inputFile);
@@ -76,7 +65,7 @@ public class Drl2Yaml implements Callable<Integer> {
         PackageDescr pkgDescr = drlParser.parse(new StringReader(drl));
         DrlPackage model = DrlPackage.from(pkgDescr);
         StringWriter writer = new StringWriter();
-        mapper.writeValue(writer, model);
+        getYamlMapper().writeValue(writer, model);
         final String yaml = writer.toString();
         writer.close();
         return yaml;

--- a/drools-drlonyaml-parent/drools-drlonyaml-cli/src/main/java/org/drools/drlonyaml/cli/Yaml2Drl.java
+++ b/drools-drlonyaml-parent/drools-drlonyaml-cli/src/main/java/org/drools/drlonyaml/cli/Yaml2Drl.java
@@ -18,9 +18,6 @@
  */
 package org.drools.drlonyaml.cli;
 
-import static org.drools.drlonyaml.cli.utils.Utils.conventionInputStream;
-import static org.drools.drlonyaml.cli.utils.Utils.conventionOutputConsumer;
-
 import java.io.File;
 import java.io.InputStream;
 import java.util.concurrent.Callable;
@@ -28,14 +25,13 @@ import java.util.concurrent.Callable;
 import org.drools.drlonyaml.model.DrlPackage;
 import org.drools.drlonyaml.todrl.YAMLtoDrlDumper;
 import org.drools.util.IoUtils;
-
-import com.fasterxml.jackson.databind.ObjectMapper;
-import com.fasterxml.jackson.dataformat.yaml.YAMLFactory;
-import com.fasterxml.jackson.dataformat.yaml.YAMLGenerator.Feature;
-
 import picocli.CommandLine.Command;
 import picocli.CommandLine.Option;
 import picocli.CommandLine.Parameters;
+
+import static org.drools.drlonyaml.cli.utils.Utils.conventionInputStream;
+import static org.drools.drlonyaml.cli.utils.Utils.conventionOutputConsumer;
+import static org.drools.drlonyaml.model.Utils.getYamlMapper;
 
 /**
  * Note: beyond different annotations, Parameters and Options are managed per subcommand,
@@ -51,14 +47,6 @@ public class Yaml2Drl implements Callable<Integer> {
     private File inputFile;
     private InputStream inputStream;
     
-    private static final ObjectMapper mapper;
-    static {
-        YAMLFactory yamlFactory = YAMLFactory.builder()
-                .enable(Feature.MINIMIZE_QUOTES)
-                .build();
-        mapper = new ObjectMapper(yamlFactory);
-    }
-    
     @Override
     public Integer call() throws Exception {
         inputStream = conventionInputStream(inputFile);
@@ -69,7 +57,7 @@ public class Yaml2Drl implements Callable<Integer> {
     }
     
     public static String yaml2drl(String yaml) throws Exception {
-        DrlPackage readValue = mapper.readValue(yaml, DrlPackage.class);
+        DrlPackage readValue = getYamlMapper().readValue(yaml, DrlPackage.class);
         final String drlText = YAMLtoDrlDumper.dumpDRL(readValue);
         return drlText;
     }

--- a/drools-drlonyaml-parent/drools-drlonyaml-integration-tests/pom.xml
+++ b/drools-drlonyaml-parent/drools-drlonyaml-integration-tests/pom.xml
@@ -21,21 +21,40 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
   <parent>
-    <groupId>org.kie</groupId>
-    <artifactId>drools-build-parent</artifactId>
+    <groupId>org.drools</groupId>
+    <artifactId>drools-drlonyaml-parent</artifactId>
     <version>8.45.0-SNAPSHOT</version>
-    <relativePath>../build-parent/pom.xml</relativePath>
   </parent>
-  <groupId>org.drools</groupId>
-  <artifactId>drools-drlonyaml-parent</artifactId>
-  <name>Drools :: DRL on YAML</name>
-  <packaging>pom</packaging>
-  <modules>
-    <module>drools-drlonyaml-schemagen</module>
-    <module>drools-drlonyaml-model</module>
-    <module>drools-drlonyaml-todrl</module>
-    <module>drools-drlonyaml-cli</module>
-    <module>drools-drlonyaml-cli-tests</module>
-    <module>drools-drlonyaml-integration-tests</module>
-  </modules>
+  <artifactId>drools-drlonyaml-integration-tests</artifactId>
+  <name>Drools :: DRL on YAML :: Integration Tests</name>
+
+  <properties>
+    <java.module.name>org.drools.drlonyaml.integration.tests</java.module.name>
+  </properties>
+
+  <dependencies>
+    <dependency>
+      <groupId>org.drools</groupId>
+      <artifactId>drools-drlonyaml-todrl</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.drools</groupId>
+      <artifactId>drools-engine</artifactId>
+    </dependency>
+    <dependency><!-- For unit test logging: configure in src/test/resources/logback-test.xml -->
+      <groupId>ch.qos.logback</groupId>
+      <artifactId>logback-classic</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>junit</groupId>
+      <artifactId>junit</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.assertj</groupId>
+      <artifactId>assertj-core</artifactId>
+      <scope>test</scope>
+    </dependency>
+  </dependencies>
 </project>

--- a/drools-drlonyaml-parent/drools-drlonyaml-integration-tests/src/test/java/org/drools/drlonyaml/integration/tests/Message.java
+++ b/drools-drlonyaml-parent/drools-drlonyaml-integration-tests/src/test/java/org/drools/drlonyaml/integration/tests/Message.java
@@ -1,3 +1,21 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
 package org.drools.drlonyaml.integration.tests;
 
 public class Message {

--- a/drools-drlonyaml-parent/drools-drlonyaml-integration-tests/src/test/java/org/drools/drlonyaml/integration/tests/Message.java
+++ b/drools-drlonyaml-parent/drools-drlonyaml-integration-tests/src/test/java/org/drools/drlonyaml/integration/tests/Message.java
@@ -1,0 +1,18 @@
+package org.drools.drlonyaml.integration.tests;
+
+public class Message {
+
+    private final String text;
+
+    public Message(String text) {
+        this.text = text;
+    }
+
+    public String getText() {
+        return text;
+    }
+
+    public int getSize() {
+        return text.length();
+    }
+}

--- a/drools-drlonyaml-parent/drools-drlonyaml-integration-tests/src/test/java/org/drools/drlonyaml/integration/tests/ProgrammaticProjectTest.java
+++ b/drools-drlonyaml-parent/drools-drlonyaml-integration-tests/src/test/java/org/drools/drlonyaml/integration/tests/ProgrammaticProjectTest.java
@@ -1,0 +1,115 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.drools.drlonyaml.integration.tests;
+
+import java.io.StringReader;
+import java.io.StringWriter;
+import java.util.ArrayList;
+import java.util.List;
+
+import org.drools.drl.ast.descr.PackageDescr;
+import org.drools.drl.parser.DrlParser;
+import org.drools.drlonyaml.model.DrlPackage;
+import org.drools.model.codegen.ExecutableModelProject;
+import org.junit.Test;
+import org.kie.api.runtime.KieSession;
+import org.kie.internal.utils.KieHelper;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.drools.drlonyaml.model.Utils.getYamlMapper;
+
+public class ProgrammaticProjectTest {
+
+    @Test
+    public void testDrl() {
+        KieSession ksession = new KieHelper()
+                .addContent(getDrlRule(), "org/drools/drlonyaml/integration/tests/rule.drl")
+                .build(ExecutableModelProject.class)
+                .newKieSession();
+
+        checkKieSession(ksession);
+    }
+
+    @Test
+    public void testYaml() {
+        KieSession ksession = new KieHelper()
+                .addContent(getYamlRule(), "org/drools/drlonyaml/integration/tests/rule.drl.yaml")
+                .build(ExecutableModelProject.class)
+                .newKieSession();
+
+        checkKieSession(ksession);
+    }
+
+    private static void checkKieSession(KieSession ksession) {
+        List<String> result = new ArrayList<>();
+        ksession.setGlobal("result", result);
+
+        ksession.insert(new Message("test"));
+        ksession.insert(new Message("Hello World"));
+        ksession.insert(10);
+        ksession.insert(11);
+
+        int count = ksession.fireAllRules();
+        assertThat(count).isEqualTo(1);
+        assertThat(result).hasSize(1);
+        assertThat(result.get(0)).isEqualTo("Hello World");
+    }
+
+    private String drl2yaml(String drl) {
+        try (StringWriter writer = new StringWriter()) {
+            PackageDescr pkgDescr = new DrlParser().parse(new StringReader(drl));
+            DrlPackage model = DrlPackage.from(pkgDescr);
+            getYamlMapper().writeValue(writer, model);
+            return writer.toString();
+        } catch (Exception e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    private String getDrlRule() {
+        return "package org.drools.drlonyaml.integration.tests\n" +
+                "\n" +
+                "global java.util.List result;\n" +
+                "\n" +
+                "rule R when\n" +
+                "    $i : Integer()\n" +
+                "    $m : Message( size == $i )\n" +
+                "then\n" +
+                "    result.add( $m.getText() );\n" +
+                "end";
+    }
+
+    private String getYamlRule() {
+        return "name: org.drools.drlonyaml.integration.tests\n" +
+                "globals:\n" +
+                "- type: java.util.List\n" +
+                "  id: result\n" +
+                "rules:\n" +
+                "- name: R\n" +
+                "  when:\n" +
+                "  - given: Integer\n" +
+                "    as: $i\n" +
+                "  - given: Message\n" +
+                "    as: $m\n" +
+                "    having:\n" +
+                "    - size == $i\n" +
+                "  then: |\n" +
+                "    result.add( $m.getText() );";
+    }
+}

--- a/drools-drlonyaml-parent/drools-drlonyaml-integration-tests/src/test/resources/logback.xml
+++ b/drools-drlonyaml-parent/drools-drlonyaml-integration-tests/src/test/resources/logback.xml
@@ -1,0 +1,38 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Licensed to the Apache Software Foundation (ASF) under one
+    or more contributor license agreements.  See the NOTICE file
+    distributed with this work for additional information
+    regarding copyright ownership.  The ASF licenses this file
+    to you under the Apache License, Version 2.0 (the
+    "License"); you may not use this file except in compliance
+    with the License.  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing,
+    software distributed under the License is distributed on an
+    "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+    KIND, either express or implied.  See the License for the
+    specific language governing permissions and limitations
+    under the License.
+
+-->
+
+<configuration>
+
+  <appender name="consoleAppender" class="ch.qos.logback.core.ConsoleAppender">
+    <encoder>
+      <pattern>%-5level %msg%n</pattern>
+    </encoder>
+  </appender>
+
+  <logger name="org.kie" level="warn"/>
+  <logger name="org.drools" level="warn"/>
+
+  <root level="info">
+    <appender-ref ref="consoleAppender" />
+  </root>
+
+</configuration>

--- a/drools-drlonyaml-parent/drools-drlonyaml-model/src/main/java/org/drools/drlonyaml/model/Utils.java
+++ b/drools-drlonyaml-parent/drools-drlonyaml-model/src/main/java/org/drools/drlonyaml/model/Utils.java
@@ -21,6 +21,9 @@ package org.drools.drlonyaml.model;
 import java.util.ArrayList;
 import java.util.List;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.dataformat.yaml.YAMLFactory;
+import com.fasterxml.jackson.dataformat.yaml.YAMLGenerator;
 import org.drools.drl.ast.descr.AndDescr;
 import org.drools.drl.ast.descr.BaseDescr;
 import org.drools.drl.ast.descr.ExistsDescr;
@@ -28,6 +31,15 @@ import org.drools.drl.ast.descr.NotDescr;
 import org.drools.drl.ast.descr.PatternDescr;
 
 public class Utils {
+    private static final ObjectMapper mapper;
+
+    static {
+        YAMLFactory yamlFactory = YAMLFactory.builder()
+                .enable(YAMLGenerator.Feature.MINIMIZE_QUOTES)
+                .build();
+        mapper = new ObjectMapper(yamlFactory);
+    }
+
     private Utils() {
         // only static methods.
     }
@@ -52,5 +64,9 @@ public class Utils {
             results.add(from((BaseDescr) item));
         }
         return results;
+    }
+
+    public static ObjectMapper getYamlMapper() {
+        return mapper;
     }
 }

--- a/drools-drlonyaml-parent/drools-drlonyaml-todrl/pom.xml
+++ b/drools-drlonyaml-parent/drools-drlonyaml-todrl/pom.xml
@@ -35,6 +35,10 @@
   <dependencies>
     <dependency>
       <groupId>org.drools</groupId>
+      <artifactId>drools-drl-extensions</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.drools</groupId>
       <artifactId>drools-drlonyaml-model</artifactId>
     </dependency>
     <dependency>

--- a/drools-drlonyaml-parent/drools-drlonyaml-todrl/src/main/java/org/drools/drlonyaml/todrl/YAMLtoDrlDumper.java
+++ b/drools-drlonyaml-parent/drools-drlonyaml-todrl/src/main/java/org/drools/drlonyaml/todrl/YAMLtoDrlDumper.java
@@ -27,6 +27,8 @@ import freemarker.template.Configuration;
 import freemarker.template.Template;
 import freemarker.template.TemplateExceptionHandler;
 
+import static org.drools.drlonyaml.model.Utils.getYamlMapper;
+
 public class YAMLtoDrlDumper {
     public static final Configuration CONFIGURATION = config();
     
@@ -49,5 +51,10 @@ public class YAMLtoDrlDumper {
         String result = out.toString();
         out.close();
         return result;
+    }
+
+    public static String yaml2drl(String yaml) throws Exception {
+        DrlPackage readValue = getYamlMapper().readValue(yaml, DrlPackage.class);
+        return YAMLtoDrlDumper.dumpDRL(readValue);
     }
 }

--- a/drools-drlonyaml-parent/drools-drlonyaml-todrl/src/main/java/org/drools/drlonyaml/todrl/YamlProviderImpl.java
+++ b/drools-drlonyaml-parent/drools-drlonyaml-todrl/src/main/java/org/drools/drlonyaml/todrl/YamlProviderImpl.java
@@ -1,0 +1,38 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.drools.drlonyaml.todrl;
+
+import org.drools.drl.extensions.YamlProvider;
+import org.drools.util.IoUtils;
+import org.kie.api.io.Resource;
+
+import static org.drools.drlonyaml.todrl.YAMLtoDrlDumper.yaml2drl;
+
+public class YamlProviderImpl implements YamlProvider {
+
+    @Override
+    public String loadFromResource(Resource resource) {
+        try {
+            String content = new String(IoUtils.readBytesFromInputStream(resource.getInputStream()));
+            return yaml2drl(content);
+        } catch (Exception e) {
+            throw new RuntimeException(e);
+        }
+    }
+}

--- a/drools-drlonyaml-parent/drools-drlonyaml-todrl/src/main/resources/META-INF/services/org.drools.drl.extensions.YamlProvider
+++ b/drools-drlonyaml-parent/drools-drlonyaml-todrl/src/main/resources/META-INF/services/org.drools.drl.extensions.YamlProvider
@@ -1,0 +1,1 @@
+org.drools.drlonyaml.todrl.YamlProviderImpl

--- a/kie-api/src/main/java/org/kie/api/io/ResourceType.java
+++ b/kie-api/src/main/java/org/kie/api/io/ResourceType.java
@@ -258,6 +258,11 @@ public class ResourceType implements Serializable {
                                                                       "src/main/resources",
                                                                       "no_op");
 
+    public static final ResourceType YAML = addResourceTypeToRegistry("YAML",
+                                                                      "YAML format DRL",
+                                                                      "src/main/resources",
+                                                                      "drl.yaml", "drl.yml");
+
     public static ResourceType determineResourceType(final String resourceName) {
         for ( Map.Entry<String, ResourceType> entry : CACHE.entrySet() ) {
             if (resourceName.endsWith(entry.getKey())) {


### PR DESCRIPTION
**JIRA**: https://github.com/apache/incubator-kie-issues/issues/724