### PR TITLE
kie-issues#742: upgrade jacoco maven plugin to 0.8.11

### DIFF
--- a/build-parent/pom.xml
+++ b/build-parent/pom.xml
@@ -180,7 +180,7 @@
     <!-- Jacoco plugin configurations -->
     <jacoco.haltOnFailure>false</jacoco.haltOnFailure>
     <jacoco.line.coveredratio.minimum>0.9</jacoco.line.coveredratio.minimum>
-    <version.jacoco.plugin>0.8.7</version.jacoco.plugin>
+    <version.jacoco.plugin>0.8.11</version.jacoco.plugin>
     <!-- TODO: remove this once all repositories comply to the defined checkstyle rules -->
     <checkstyle.failOnViolation>false</checkstyle.failOnViolation>
     <checkstyle.logViolationsToConsole>false</checkstyle.logViolationsToConsole>


### PR DESCRIPTION
Fixes:
* apache/incubator-kie-issues#742

Upgrading jacoco maven plugin version due to JDK 17 issues we've seen in CI after JDK upgrade.