### PR TITLE
[main] DSL: Remove branch 8.45.x

### DIFF
--- a/.ci/jenkins/config/main.yaml
+++ b/.ci/jenkins/config/main.yaml
@@ -14,9 +14,6 @@ git:
   branches:
   - name: main
     main_branch: true
-  - name: 8.45.x
-    seed:
-      branch: seed-drools-8.45.x
 seed:
   config_file:
     git:


### PR DESCRIPTION
Dropping 8.45.x from configuration, can be put back later on if needed.