### PR TITLE
[NO ISSUE] Shade kie-dmn-xls2dmn-cli runner separately.

### DIFF
--- a/kie-dmn/kie-dmn-xls2dmn-cli/pom.xml
+++ b/kie-dmn/kie-dmn-xls2dmn-cli/pom.xml
@@ -116,7 +116,6 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-shade-plugin</artifactId>
-        <version>3.2.4</version>
         <executions>
           <execution>
             <phase>package</phase>
@@ -124,6 +123,8 @@
               <goal>shade</goal>
             </goals>
             <configuration>
+              <shadedArtifactAttached>true</shadedArtifactAttached>
+              <shadedClassifierName>runner</shadedClassifierName>
               <filters> <!-- https://issues.redhat.com/browse/DROOLS-7524 https://stackoverflow.com/a/64063529/4206 -->
                 <filter>
                   <artifact>*:*</artifact>


### PR DESCRIPTION
The Maven deploy of the shaded kie-dmn-xls2dmn-cli artifact in the default configuration caused org.apache:xmlbeans maven-metadata.xml to be deployed separately for some reason. The only configuration fixing the problem is the one in the PR. This may need further investigation. Submitting this to fix the nightly builds deployment of snapshot artifacts. 