### PR TITLE
[incubator-kie-issues#814] Fix NPE on BaseKnowledgeBuilderResultImpl.hashCode()

### DIFF
--- a/drools-beliefs/src/main/java/org/drools/beliefs/bayes/assembler/BayesNetworkAssemblerError.java
+++ b/drools-beliefs/src/main/java/org/drools/beliefs/bayes/assembler/BayesNetworkAssemblerError.java
@@ -22,18 +22,11 @@ import org.drools.drl.parser.DroolsError;
 import org.kie.api.io.Resource;
 
 public class BayesNetworkAssemblerError extends DroolsError {
-    private String    message;
+
 
     public BayesNetworkAssemblerError(Resource resource,
                                       final String message) {
-        super( resource );
-        this.message = message;
-    }
-
-
-    @Override
-    public String getMessage() {
-        return message;
+        super( resource, message );
     }
 
     @Override

--- a/drools-compiler/src/main/java/org/drools/compiler/builder/impl/errors/SrcError.java
+++ b/drools-compiler/src/main/java/org/drools/compiler/builder/impl/errors/SrcError.java
@@ -24,14 +24,12 @@ import org.kie.internal.jci.CompilationProblem;
 public class SrcError extends DroolsError {
 
     private Object object;
-    private String message;
     private int[]  errorLines = new int[0];
 
     public SrcError(Object object,
                     String message) {
-        super(null);
+        super(null, message);
         this.object = object;
-        this.message = message;
     }
 
     public Object getObject() {
@@ -42,13 +40,10 @@ public class SrcError extends DroolsError {
         return this.errorLines;
     }
 
-    public String getMessage() {
-        return this.message;
-    }
 
     public String toString() {
         final StringBuilder buf = new StringBuilder();
-        buf.append(this.message);
+        buf.append(getMessage());
         buf.append(" : ");
         buf.append("\n");
         if (this.object instanceof CompilationProblem[]) {

--- a/drools-compiler/src/main/java/org/drools/compiler/compiler/ActionError.java
+++ b/drools-compiler/src/main/java/org/drools/compiler/compiler/ActionError.java
@@ -24,15 +24,17 @@ import org.drools.drl.parser.DroolsError;
 public class ActionError extends DroolsError {
     private BaseDescr descr;
     private Object    object;
-    private String    message;
     private int[]     errorLines = new int[0];
+
+    private String originalMessage;
 
     public ActionError(final BaseDescr descr,
                      final Object object,
                      final String message) {
+        super(BuilderResultUtils.getProblemMessage( object, message, "\n" ));
         this.descr = descr;
         this.object = object;
-        this.message = message;
+        this.originalMessage = message;
     }
 
     @Override
@@ -60,13 +62,9 @@ public class ActionError extends DroolsError {
         return this.descr != null ? this.descr.getLine() : -1;
     }
 
-    public String getMessage() {
-        return BuilderResultUtils.getProblemMessage( this.object, this.message, "\n" );
-    }
-
     public String toString() {
         final StringBuilder builder = new StringBuilder()
-                .append( this.message )
+                .append( originalMessage )
                 .append( " : " )
                 .append( "\n" );
         return BuilderResultUtils.appendProblems( this.object, builder ).toString();

--- a/drools-compiler/src/main/java/org/drools/compiler/compiler/AnnotationDeclarationError.java
+++ b/drools-compiler/src/main/java/org/drools/compiler/compiler/AnnotationDeclarationError.java
@@ -23,13 +23,11 @@ import org.drools.drl.parser.DroolsError;
 
 public class AnnotationDeclarationError extends DroolsError {
 
-    private String errorMessage;
     private int[]  line;
     private String namespace;
 
     public AnnotationDeclarationError(AnnotationDescr annotationDescr, String errorMessage) {
-        super(annotationDescr.getResource());
-        this.errorMessage = errorMessage;
+        super(annotationDescr.getResource(), errorMessage);
         this.line = new int[0];
         this.namespace = annotationDescr.getNamespace();
     }
@@ -45,13 +43,8 @@ public class AnnotationDeclarationError extends DroolsError {
     }
 
     @Override
-    public String getMessage() {
-        return this.errorMessage;
-    }
-
-    @Override
     public String toString() {
-        return this.getMessage();
+        return getMessage();
     }
 
 }

--- a/drools-compiler/src/main/java/org/drools/compiler/compiler/ConfigurableSeverityResult.java
+++ b/drools-compiler/src/main/java/org/drools/compiler/compiler/ConfigurableSeverityResult.java
@@ -31,8 +31,8 @@ import org.kie.internal.builder.conf.KBuilderSeverityOption;
  */
 public abstract class ConfigurableSeverityResult extends BaseKnowledgeBuilderResultImpl {
     
-    public ConfigurableSeverityResult(Resource resource, KnowledgeBuilderConfiguration config) {
-        super(resource);
+    public ConfigurableSeverityResult(Resource resource, KnowledgeBuilderConfiguration config, String message) {
+        super(resource, message);
         severity = config.getOption(KBuilderSeverityOption.KEY, getOptionKey()).getSeverity();
     }
     

--- a/drools-compiler/src/main/java/org/drools/compiler/compiler/DeprecatedResourceTypeWarning.java
+++ b/drools-compiler/src/main/java/org/drools/compiler/compiler/DeprecatedResourceTypeWarning.java
@@ -29,13 +29,8 @@ public class DeprecatedResourceTypeWarning extends DroolsWarning {
     }
 
     public DeprecatedResourceTypeWarning(Resource resource, String deprecatedFormat) {
-        super(resource);
+        super(resource, deprecatedFormat + " format usage detected. This format is deprecated and will be removed in future");
         this.deprecatedFormat = deprecatedFormat;
-    }
-
-    @Override
-    public String getMessage() {
-        return deprecatedFormat + " format usage detected. This format is deprecated and will be removed in future";
     }
 
     @Override

--- a/drools-compiler/src/main/java/org/drools/compiler/compiler/DescrBuildError.java
+++ b/drools-compiler/src/main/java/org/drools/compiler/compiler/DescrBuildError.java
@@ -25,19 +25,20 @@ public class DescrBuildError extends DroolsError {
     private BaseDescr parentDescr;
     private BaseDescr descr;
     private Object    object;
-    private String    message;
     private int[]     errorLines = new int[1];
+
+    private String originalMessage;
 
     public DescrBuildError(final BaseDescr parentDescr,
                            final BaseDescr descr,
                            final Object object,
                            final String message) {
-        super( descr.getResource() != null ? descr.getResource() : ( parentDescr != null ? parentDescr.getResource() : null ) );
+        super( descr.getResource() != null ? descr.getResource() : ( parentDescr != null ? parentDescr.getResource() : null ), BuilderResultUtils.getProblemMessage( object, message, "\n" ) );
         this.parentDescr = parentDescr;
         this.descr = descr;
         this.object = object;
-        this.message = message;
         this.errorLines[0] = getLine();
+        this.originalMessage = message;
     }
 
     @Override
@@ -73,13 +74,10 @@ public class DescrBuildError extends DroolsError {
         return this.descr != null ? this.descr.getColumn() : -1;
     }
 
-    public String getMessage() {
-        return BuilderResultUtils.getProblemMessage( this.object, this.message, "\n" );
-    }
 
     public String toString() {
         final StringBuilder builder = new StringBuilder()
-                .append( this.message )
+                .append( this.originalMessage )
                 .append( " : " )
                 .append( this.parentDescr )
                 .append( "\n" );

--- a/drools-compiler/src/main/java/org/drools/compiler/compiler/DescrBuildWarning.java
+++ b/drools-compiler/src/main/java/org/drools/compiler/compiler/DescrBuildWarning.java
@@ -24,18 +24,19 @@ public class DescrBuildWarning extends DroolsWarning {
     private BaseDescr parentDescr;
     private BaseDescr descr;
     private Object    object;
-    private String    message;
+    private String    originalMessage;
     private int[]     errorLines = new int[1];
 
     public DescrBuildWarning( final BaseDescr parentDescr,
                               final BaseDescr descr,
                               final Object object,
                               final String message ) {
-        super( descr.getResource() != null ? descr.getResource() : ( parentDescr != null ? parentDescr.getResource() : null ) );
+        super( descr.getResource() != null ? descr.getResource() : ( parentDescr != null ? parentDescr.getResource() : null ),
+               BuilderResultUtils.getProblemMessage( object, message, "\n" ));
         this.parentDescr = parentDescr;
         this.descr = descr;
         this.object = object;
-        this.message = message;
+        this.originalMessage = message;
         this.errorLines[0] = getLine();
     }
 
@@ -67,13 +68,9 @@ public class DescrBuildWarning extends DroolsWarning {
         return this.descr != null ? this.descr.getColumn() : -1;
     }
 
-    public String getMessage() {
-        return BuilderResultUtils.getProblemMessage( this.object, this.message, "\n" );
-    }
-
     public String toString() {
         final StringBuilder builder = new StringBuilder()
-                .append( this.message )
+                .append( this.originalMessage )
                 .append( " : " )
                 .append( this.parentDescr )
                 .append( "\n" );

--- a/drools-compiler/src/main/java/org/drools/compiler/compiler/DroolsErrorWrapper.java
+++ b/drools-compiler/src/main/java/org/drools/compiler/compiler/DroolsErrorWrapper.java
@@ -31,16 +31,11 @@ public class DroolsErrorWrapper extends DroolsError {
     private String namespace = "";
     
     public DroolsErrorWrapper (KnowledgeBuilderResult problem) {
-        super(problem.getResource());
+        super(problem.getResource(), problem.getMessage());
         this.backingProblem = problem;
         if (problem instanceof DroolsError) {
             namespace = ((DroolsError)problem).getNamespace();
         }
-    }
-    
-    @Override
-    public String getMessage() {
-        return backingProblem.getMessage();
     }
 
     @Override

--- a/drools-compiler/src/main/java/org/drools/compiler/compiler/DroolsWarning.java
+++ b/drools-compiler/src/main/java/org/drools/compiler/compiler/DroolsWarning.java
@@ -24,8 +24,8 @@ import org.kie.internal.builder.ResultSeverity;
 
 public abstract class DroolsWarning extends BaseKnowledgeBuilderResultImpl {
 
-    public DroolsWarning(Resource resource) {
-        super(resource);
+    public DroolsWarning(Resource resource, String message) {
+        super(resource, message);
     }
 
     @Override

--- a/drools-compiler/src/main/java/org/drools/compiler/compiler/DroolsWarningWrapper.java
+++ b/drools-compiler/src/main/java/org/drools/compiler/compiler/DroolsWarningWrapper.java
@@ -25,13 +25,8 @@ public class DroolsWarningWrapper extends DroolsWarning {
     KnowledgeBuilderResult backingProblem;
 
     public DroolsWarningWrapper (KnowledgeBuilderResult problem) {
-        super(problem.getResource());
+        super(problem.getResource(), problem.getMessage());
         this.backingProblem = problem;
-    }
-
-    @Override
-    public String getMessage() {
-        return backingProblem.getMessage();
     }
 
     @Override

--- a/drools-compiler/src/main/java/org/drools/compiler/compiler/DuplicateFunction.java
+++ b/drools-compiler/src/main/java/org/drools/compiler/compiler/DuplicateFunction.java
@@ -24,31 +24,16 @@ import org.drools.drl.ast.descr.FunctionDescr;
 import org.kie.internal.builder.KnowledgeBuilderConfiguration;
 
 
-
-
 public class DuplicateFunction extends ConfigurableSeverityResult {
     public static final String KEY = "duplicateFunction";
-    
-    private String functionName;
-    private String functionNamespace;
+
     
     public DuplicateFunction(FunctionDescr func, KnowledgeBuilderConfiguration config) {
-        super(func.getResource(), config);
-        functionName = func.getName();
-        functionNamespace = func.getNamespace();
+        super(func.getResource(), config, getSpecificMessage(func));
     }
     
     public DuplicateFunction(Function func, KnowledgeBuilderConfiguration config) {
-        super(func.getResource(), config);
-        functionName = func.getName();
-        functionName = func.getNamespace();
-    }
-
-    @Override
-    public String getMessage() {
-        return functionName 
-        + " in namespace " + functionNamespace 
-        + " is about to be redefined";
+        super(func.getResource(), config, getSpecificMessage(func));
     }
 
     @Override
@@ -61,4 +46,15 @@ public class DuplicateFunction extends ConfigurableSeverityResult {
         return KEY;
     }
 
+    private static String getSpecificMessage(FunctionDescr func) {
+        return func.getName()
+                + " in namespace " + func.getNamespace()
+                + " is about to be redefined";
+    }
+
+    private static String getSpecificMessage(Function func) {
+        return func.getName()
+                + " in namespace " + func.getNamespace()
+                + " is about to be redefined";
+    }
 }

--- a/drools-compiler/src/main/java/org/drools/compiler/compiler/DuplicateRule.java
+++ b/drools-compiler/src/main/java/org/drools/compiler/compiler/DuplicateRule.java
@@ -33,17 +33,11 @@ public class DuplicateRule extends ConfigurableSeverityResult {
     private int[] line;
     
     public DuplicateRule(RuleDescr ruleDescr, PackageDescr pkg, KnowledgeBuilderConfiguration config) {
-        super(ruleDescr.getResource(), config);
+        super(ruleDescr.getResource(), config, getSpecificMessage(ruleDescr, pkg));
         rule = ruleDescr.getName();
         pkgDescr = pkg;
         line = new int[1];
         line[0] = ruleDescr.getLine();
-    }
-
-    @Override
-    public String getMessage() {
-        return "Rule name " + rule 
-        + " already exists in package  " + pkgDescr.getName();
     }
 
     @Override
@@ -54,6 +48,10 @@ public class DuplicateRule extends ConfigurableSeverityResult {
     @Override
     protected String getOptionKey() {
         return KEY;
+    }
+    private static String getSpecificMessage(RuleDescr ruleDescr, PackageDescr pkg) {
+        return "Rule name " + ruleDescr.getName()
+        + " already exists in package  " + pkg.getName();
     }
 
 }

--- a/drools-compiler/src/main/java/org/drools/compiler/compiler/FactTemplateError.java
+++ b/drools-compiler/src/main/java/org/drools/compiler/compiler/FactTemplateError.java
@@ -25,7 +25,6 @@ public class FactTemplateError extends DroolsError {
     private Package   pkg;
     private BaseDescr descr;
     private Object    object;
-    private String    message;
     private int[]     line;
     private String    namespace;
 
@@ -33,12 +32,11 @@ public class FactTemplateError extends DroolsError {
                              final BaseDescr descr,
                              final Object object,
                              final String message) {
-        super(descr.getResource());
+        super(descr.getResource(), BuilderResultUtils.getProblemMessage( object, message ));
         this.namespace = pkg.getName();
         this.pkg = pkg;
         this.descr = descr;
         this.object = object;
-        this.message = message;
         this.line = new int[] {this.descr.getLine()};
     }
 
@@ -71,8 +69,5 @@ public class FactTemplateError extends DroolsError {
         return this.line[0];
     }
 
-    public String getMessage() {
-        return BuilderResultUtils.getProblemMessage( this.object, this.message );
-    }
 
 }

--- a/drools-compiler/src/main/java/org/drools/compiler/compiler/FieldTemplateError.java
+++ b/drools-compiler/src/main/java/org/drools/compiler/compiler/FieldTemplateError.java
@@ -25,7 +25,6 @@ public class FieldTemplateError extends DroolsError {
     private Package   pkg;
     private BaseDescr descr;
     private Object    object;
-    private String    message;
     private int[]     line;
     private String    namespace;
 
@@ -33,12 +32,11 @@ public class FieldTemplateError extends DroolsError {
                               final BaseDescr descr,
                               final Object object,
                               final String message) {
-        super(descr.getResource());
+        super(descr.getResource(), BuilderResultUtils.getProblemMessage( object, message ));
         this.namespace = pkg.getName();
         this.pkg = pkg;
         this.descr = descr;
         this.object = object;
-        this.message = message;
         this.line = new int[] {this.descr.getLine()};
     }
 
@@ -69,10 +67,6 @@ public class FieldTemplateError extends DroolsError {
      */
     public int getLine() {
         return this.line[0];
-    }
-
-    public String getMessage() {
-        return BuilderResultUtils.getProblemMessage( this.object, this.message );
     }
 
 }

--- a/drools-compiler/src/main/java/org/drools/compiler/compiler/FunctionError.java
+++ b/drools-compiler/src/main/java/org/drools/compiler/compiler/FunctionError.java
@@ -25,16 +25,16 @@ import org.kie.internal.jci.CompilationProblem;
 public class FunctionError extends DroolsError {
     final private FunctionDescr functionDescr;
     final private Object        object;
-    final private String        message;
     private int[]               errorLines;
 
     public FunctionError(final FunctionDescr functionDescr,
                          final Object object,
                          final String message) {
-        super(functionDescr.getResource());
+        super(functionDescr.getResource(), "");
         this.functionDescr = functionDescr;
         this.object = object;
-        this.message = createMessage( message );
+        setErrorLines();
+        setMessage(createMessage(message));
     }
 
     @Override
@@ -54,21 +54,26 @@ public class FunctionError extends DroolsError {
         return errorLines;
     }
 
-    public String getMessage() {
-        return this.message;
-    }
-    
     public String toString() {
-        return this.message;
+        return getMessage();
+    }
+
+    private void setErrorLines() {
+        if( object instanceof CompilationProblem[] cp) {
+            this.errorLines = new int[cp.length];
+            for( int i = 0; i < cp.length ; i ++ ) {
+                this.errorLines[i] = cp[i].getStartLine() - this.functionDescr.getOffset() + this.getFunctionDescr().getLine() - 1;
+            }
+        } else {
+            this.errorLines = new int[1];
+            this.errorLines[0] = functionDescr.getLine();
+        }
     }
     
     private String createMessage( String message ) {
         StringBuilder detail = new StringBuilder();
-        if( object instanceof CompilationProblem[] ) {
-            CompilationProblem[] cp = (CompilationProblem[]) object;
-            this.errorLines = new int[cp.length];
+        if( object instanceof CompilationProblem[] cp) {
             for( int i = 0; i < cp.length ; i ++ ) {
-               this.errorLines[i] = cp[i].getStartLine() - this.functionDescr.getOffset() + this.getFunctionDescr().getLine() - 1;
                detail.append( this.functionDescr.getName() );
                detail.append( " (line:" );
                detail.append( this.errorLines[i] );
@@ -76,10 +81,7 @@ public class FunctionError extends DroolsError {
                detail.append( cp[i].getMessage() );
                detail.append( "\n" );
             }
-        } else if( object instanceof Exception) {
-            Exception ex = (Exception) object;
-            this.errorLines = new int[1];
-            this.errorLines[0] = functionDescr.getLine();
+        } else if( object instanceof Exception ex) {
             detail.append( " (line:" );
             detail.append( this.errorLines[0] );
             detail.append( "): " );
@@ -90,11 +92,8 @@ public class FunctionError extends DroolsError {
                 detail.append( ": " );
                 detail.append( ex.getMessage() );
             }
-        } else {
-            this.errorLines = new int[1];
-            this.errorLines[0] = functionDescr.getLine();
         }
-        return "[ function "+functionDescr.getName() + detail.toString()+" ]";
+        return "[ function "+ functionDescr.getName() + detail +" ]";
     }
 
 }

--- a/drools-compiler/src/main/java/org/drools/compiler/compiler/GlobalError.java
+++ b/drools-compiler/src/main/java/org/drools/compiler/compiler/GlobalError.java
@@ -23,12 +23,10 @@ import org.drools.drl.parser.DroolsError;
 
 public class GlobalError extends DroolsError {
     private final GlobalDescr globalDescr;
-    private String message;
 
     public GlobalError(final GlobalDescr globalDescr, final String message) {
-        super(globalDescr.getResource());
+        super(globalDescr.getResource(), message);
         this.globalDescr = globalDescr;
-        this.message = message;
     }
 
     @Override
@@ -44,12 +42,8 @@ public class GlobalError extends DroolsError {
         return new int[] { globalDescr.getLine() };
     }
 
-    public String getMessage() {
-        return message;
-    }
-    
     public String toString() {
-        return "GlobalError: " + getGlobal() + " : " + message;
+        return "GlobalError: " + getGlobal() + " : " + getMessage();
     }
 
 }

--- a/drools-compiler/src/main/java/org/drools/compiler/compiler/ImportError.java
+++ b/drools-compiler/src/main/java/org/drools/compiler/compiler/ImportError.java
@@ -26,7 +26,7 @@ public class ImportError extends DroolsError {
     private int[]  line;
 
     public ImportError(final ImportDescr importDescr, final int line) {
-        super(importDescr.getResource());
+        super(importDescr.getResource(), getSpecificMessage(importDescr));
         this.importDescr = importDescr;
         this.line = new int[] { line };
     }
@@ -43,13 +43,13 @@ public class ImportError extends DroolsError {
     public int[] getLines() {
         return this.line;
     }
-
-    public String getMessage() {
-        return "Error importing : '" + getGlobal() + "'";
-    }
     
     public String toString() {
         return getMessage();
+    }
+
+    private static String getSpecificMessage(ImportDescr importDescr) {
+        return "Error importing : '" + importDescr.getTarget() + "'";
     }
 
 }

--- a/drools-compiler/src/main/java/org/drools/compiler/compiler/MissingDependencyError.java
+++ b/drools-compiler/src/main/java/org/drools/compiler/compiler/MissingDependencyError.java
@@ -23,20 +23,12 @@ import org.drools.drl.parser.DroolsError;
 import org.kie.api.io.Resource;
 
 public class MissingDependencyError extends DroolsError {
-    private final String message;
-
     public MissingDependencyError(String message) {
-        this.message = message;
+        super(message);
     }
 
     public MissingDependencyError(Resource resource, MissingDependencyException ex) {
-        super(resource);
-        message = ex.getMessage();
-    }
-
-    @Override
-    public String getMessage() {
-        return message;
+        super(resource, ex.getMessage());
     }
 
     @Override

--- a/drools-compiler/src/main/java/org/drools/compiler/compiler/ProcessLoadError.java
+++ b/drools-compiler/src/main/java/org/drools/compiler/compiler/ProcessLoadError.java
@@ -19,6 +19,7 @@
 package org.drools.compiler.compiler;
 
 
+import org.drools.drl.ast.descr.ImportDescr;
 import org.drools.drl.parser.DroolsError;
 import org.kie.api.io.Resource;
 
@@ -27,21 +28,20 @@ import org.kie.api.io.Resource;
  */
 public class ProcessLoadError extends DroolsError {
 
-    private String message;
     private Exception exception;
     private static final int[] lines = new int[0];
 
     public ProcessLoadError(Resource resource, String message, Exception nested) {
-        super(resource);
-        this.message = message;
+        super(resource, getSpecificMessage(message, nested));
         this.exception = nested;
     }
     
     public int[] getLines() {
         return this.lines;
     }
-    
-    public String getMessage() {
+
+
+    private static String getSpecificMessage(String message, Exception exception) {
         if (exception != null) {
             return message + " : Exception " + exception.getClass() + " : "+ exception.getMessage();
         } else {

--- a/drools-compiler/src/main/java/org/drools/compiler/compiler/ResourceTypeDeclarationWarning.java
+++ b/drools-compiler/src/main/java/org/drools/compiler/compiler/ResourceTypeDeclarationWarning.java
@@ -27,7 +27,7 @@ public class ResourceTypeDeclarationWarning extends DroolsWarning {
     private ResourceType actualResourceType;
 
     public ResourceTypeDeclarationWarning( Resource resource, ResourceType declaredResourceType, ResourceType actualResourceType ) {
-        super( resource );
+        super( resource, getSpecificMessage(resource, declaredResourceType, actualResourceType) );
         this.declaredResourceType = declaredResourceType;
         this.actualResourceType = actualResourceType;
     }
@@ -38,6 +38,7 @@ public class ResourceTypeDeclarationWarning extends DroolsWarning {
 
     public void setDeclaredResourceType( ResourceType declaredResourceType ) {
         this.declaredResourceType = declaredResourceType;
+        setMessage(getSpecificMessage(getResource(), this.declaredResourceType, this.actualResourceType));
     }
 
     public ResourceType getActualResourceType() {
@@ -46,15 +47,13 @@ public class ResourceTypeDeclarationWarning extends DroolsWarning {
 
     public void setActualResourceType( ResourceType actualResourceType ) {
         this.actualResourceType = actualResourceType;
+        setMessage(getSpecificMessage(getResource(), declaredResourceType, this.actualResourceType));
     }
-
-    @Override
-    public String getMessage() {
-        return "Resource " + getResource().getSourcePath() + " was created with type " + actualResourceType + " but is being added as " + declaredResourceType;
-    }
-
     @Override
     public int[] getLines() {
         return new int[ 0 ];  //To change body of implemented methods use File | Settings | File Templates.
+    }
+    private static String getSpecificMessage(Resource resource, ResourceType declaredResourceType, ResourceType actualResourceType) {
+        return "Resource " + resource.getSourcePath() + " was created with type " + actualResourceType + " but is being added as " + declaredResourceType;
     }
 }

--- a/drools-compiler/src/main/java/org/drools/compiler/compiler/SerializableDroolsError.java
+++ b/drools-compiler/src/main/java/org/drools/compiler/compiler/SerializableDroolsError.java
@@ -27,15 +27,20 @@ import org.drools.drl.parser.BaseKnowledgeBuilderResultImpl;
 import org.drools.drl.parser.DroolsError;
 
 public class SerializableDroolsError extends DroolsError implements Externalizable {
-    private String message;
     private int[] errorLines;
     private String errorClassName;
     private String namespace;
 
-    public SerializableDroolsError() { }
+    private String originalMessage;
+
+    public SerializableDroolsError() {
+        super("");
+        this.originalMessage = getMessage();
+    }
     
     public SerializableDroolsError(BaseKnowledgeBuilderResultImpl error) {
-        this.message = error.getMessage();
+        super(error.getMessage());
+        this.originalMessage = getMessage();
         this.errorLines = error.getLines();
         this.errorClassName = error.getClass().getName();
         this.namespace = error instanceof DroolsError ? ((DroolsError)error).getNamespace() : "";
@@ -46,13 +51,6 @@ public class SerializableDroolsError extends DroolsError implements Externalizab
         return namespace;
     }
 
-    /**
-     * Classes that extend this must provide a printable message,
-     * which summarises the error.
-     */
-    public String getMessage() {
-        return this.message;
-    }
     
     /**
      * Returns the lines of the error in the source file
@@ -67,7 +65,7 @@ public class SerializableDroolsError extends DroolsError implements Externalizab
     }
 
     public void writeExternal(ObjectOutput out) throws IOException {
-        out.writeObject( this.message );
+        out.writeObject(this.originalMessage);
         out.writeObject( this.errorLines );
         out.writeObject( this.errorClassName );
         out.writeObject( this.namespace );
@@ -75,7 +73,7 @@ public class SerializableDroolsError extends DroolsError implements Externalizab
     
     public void readExternal(ObjectInput in) throws IOException,
                                             ClassNotFoundException {
-        this.message = ( String ) in.readObject();
+        this.originalMessage = ( String ) in.readObject();
         this.errorLines = ( int[] ) in.readObject();
         this.errorClassName = ( String ) in.readObject();
         this.namespace = ( String ) in.readObject();

--- a/drools-compiler/src/main/java/org/drools/compiler/compiler/TypeDeclarationError.java
+++ b/drools-compiler/src/main/java/org/drools/compiler/compiler/TypeDeclarationError.java
@@ -23,20 +23,17 @@ import org.drools.drl.ast.descr.BaseDescr;
 import org.drools.drl.parser.DroolsError;
 
 public class TypeDeclarationError extends DroolsError {
-    private String errorMessage;
     private int[]  line;
     private String namespace;
 
     public TypeDeclarationError(BaseDescr typeDescr, String errorMessage) {
-        super(typeDescr.getResource());
-        this.errorMessage = errorMessage;
+        super(typeDescr.getResource(), errorMessage);
         this.line = new int[] { typeDescr.getLine() };
         this.namespace = typeDescr.getNamespace();
     }
 
     public TypeDeclarationError(TypeDeclaration typeDeclaration, String errorMessage) {
-        super(typeDeclaration.getResource());
-        this.errorMessage = errorMessage;
+        super(typeDeclaration.getResource(), errorMessage);
         this.line = new int[0];
         this.namespace = typeDeclaration.getNamespace();
     }
@@ -50,12 +47,9 @@ public class TypeDeclarationError extends DroolsError {
         return this.line;
     }
 
-    public String getMessage() {
-        return this.errorMessage;
-    }
     
     public String toString() {
-        return this.getMessage();
+        return getMessage();
     }
 
 }

--- a/drools-compiler/src/main/java/org/drools/compiler/compiler/TypeDeclarationWarning.java
+++ b/drools-compiler/src/main/java/org/drools/compiler/compiler/TypeDeclarationWarning.java
@@ -22,21 +22,16 @@ import org.drools.drl.parser.BaseKnowledgeBuilderResultImpl;
 import org.kie.internal.builder.ResultSeverity;
 
 public class TypeDeclarationWarning extends BaseKnowledgeBuilderResultImpl {
-    private String message;
+
     private int[]  line;
 
     public TypeDeclarationWarning(final String message, final int line) {
-        super(null);
-        this.message = message;
+        super(null, message);
         this.line = new int[] { line };
     }
 
     public int[] getLines() {
         return this.line;
-    }
-
-    public String getMessage() {
-        return this.message;
     }
 
     public String toString() {

--- a/drools-compiler/src/main/java/org/drools/compiler/rule/builder/dialect/DialectError.java
+++ b/drools-compiler/src/main/java/org/drools/compiler/rule/builder/dialect/DialectError.java
@@ -22,24 +22,18 @@ import org.drools.drl.parser.DroolsError;
 import org.kie.api.io.Resource;
 
 public class DialectError extends DroolsError {
-    private String message;
     private static final int[] line = new int[0];
 
     public DialectError(final Resource resource, final String message) {
-        super(resource);
-        this.message = message;
+        super(resource, message);
     }
 
     public int[] getLines() {
         return line;
     }
-    
-    public String getMessage() {
-        return this.message;
-    }
 
     public String toString() {
-        return "[DialectError message='" + this.message + "']";
+        return "[DialectError message='" + getMessage() + "']";
     }
 
 }

--- a/drools-drl/drools-drl-parser/src/main/java/org/drools/drl/parser/BaseKnowledgeBuilderResultImpl.java
+++ b/drools-drl/drools-drl-parser/src/main/java/org/drools/drl/parser/BaseKnowledgeBuilderResultImpl.java
@@ -32,8 +32,10 @@ import java.util.Arrays;
 public abstract class BaseKnowledgeBuilderResultImpl implements KnowledgeBuilderResult {
 
     private Resource resource;
+    private String message;
 
-    protected BaseKnowledgeBuilderResultImpl(Resource resource) {
+    protected BaseKnowledgeBuilderResultImpl(Resource resource, String message) {
+        this.message = message != null ? message : "";
         this.resource = resource;
     }
 
@@ -55,7 +57,17 @@ public abstract class BaseKnowledgeBuilderResultImpl implements KnowledgeBuilder
      * Classes that extend this must provide a printable message,
      * which summarises the error.
      */
-    public abstract String getMessage();
+    public final String getMessage() {
+        return message;
+    }
+
+    /**
+     * Needed when the message depends on status of mutable classes
+     * @param message
+     */
+    public final void setMessage(String message) {
+        this.message = message;
+    }
 
     /**
      * Returns the lines of the error in the source file
@@ -79,18 +91,18 @@ public abstract class BaseKnowledgeBuilderResultImpl implements KnowledgeBuilder
             return false;
         }
 
-        KnowledgeBuilderResult that = (KnowledgeBuilderResult) o;
+        BaseKnowledgeBuilderResultImpl that = (BaseKnowledgeBuilderResultImpl) o;
 
         if (resource != null ? !resource.equals(that.getResource()) : that.getResource() != null) {
             return false;
         }
 
-        return getMessage().equals(that.getMessage()) && Arrays.equals(getLines(), that.getLines());
+        return message.equals(that.message) && Arrays.equals(getLines(), that.getLines());
     }
 
     @Override
     public int hashCode() {
-        int hash = (29 * getMessage().hashCode()) + (31 * Arrays.hashCode(getLines()));
+        int hash = (29 * message.hashCode()) + (31 * Arrays.hashCode(getLines()));
         return resource != null ? hash + (37 * resource.hashCode()) : hash;
     }
 

--- a/drools-drl/drools-drl-parser/src/main/java/org/drools/drl/parser/DroolsError.java
+++ b/drools-drl/drools-drl-parser/src/main/java/org/drools/drl/parser/DroolsError.java
@@ -24,12 +24,12 @@ import org.kie.api.io.Resource;
 
 public abstract class DroolsError extends BaseKnowledgeBuilderResultImpl implements KnowledgeBuilderError {
 
-    public DroolsError() {
-        this(null);
+    public DroolsError(String message) {
+        this(null, message);
     }
 
-    public DroolsError(Resource resource) {
-        super(resource);
+    public DroolsError(Resource resource, String message) {
+        super(resource, message);
     }
 
     public ResultSeverity getSeverity() {

--- a/drools-drl/drools-drl-parser/src/main/java/org/drools/drl/parser/ParserError.java
+++ b/drools-drl/drools-drl-parser/src/main/java/org/drools/drl/parser/ParserError.java
@@ -23,7 +23,6 @@ import org.kie.api.io.Resource;
 public class ParserError extends DroolsError {
     private final int    row;
     private final int    col;
-    private final String message;
     private final String namespace;
 
     public ParserError(final String message,
@@ -44,15 +43,10 @@ public class ParserError extends DroolsError {
                        final int row,
                        final int col,
                        final String namespace) {
-        super(resource);
-        this.message = message;
+        super(resource, message);
         this.row = row;
         this.col = col;
         this.namespace = namespace;
-    }
-
-    public String getMessage() {
-        return this.message;
     }
 
     @Override
@@ -73,7 +67,7 @@ public class ParserError extends DroolsError {
     }
 
     public String toString() {
-        return "[" + this.row + "," + this.col + "]: " + this.message;
+        return "[" + this.row + "," + this.col + "]: " + getMessage();
     }
 
 }

--- a/drools-drl/drools-drl-parser/src/main/java/org/drools/drl/parser/lang/ExpanderException.java
+++ b/drools-drl/drools-drl-parser/src/main/java/org/drools/drl/parser/lang/ExpanderException.java
@@ -25,21 +25,16 @@ public class ExpanderException extends DroolsError {
 
     private static final long serialVersionUID = 510l;
 
-    private String            message;
     private int[]             line;
 
     public ExpanderException(final String message,
                              final int line) {
-        this.message = message;
+        super("[" + line + "] " + message);
         this.line = new int[] { line };
     }
     
     public int[] getLines() {
         return this.line;
-    }
-
-    public String getMessage() {
-        return "[" + this.line[0] + "] " + this.message;
     }
     
     public int getLine() {
@@ -47,7 +42,7 @@ public class ExpanderException extends DroolsError {
     }
     
     public String toString() {
-        return this.getMessage();
+        return getMessage();
     }
 
 }

--- a/drools-drl/drools-drl-parser/src/main/java/org/drools/drl/parser/lang/dsl/MappingError.java
+++ b/drools-drl/drools-drl-parser/src/main/java/org/drools/drl/parser/lang/dsl/MappingError.java
@@ -50,6 +50,7 @@ public class MappingError extends DroolsError {
                         final String token,
                         final String templateText,
                         final int line ) {
+        super(getSpecificMessage(errorCode, offset, token));
         this.errorCode = errorCode;
         this.template = template;
         this.token = token;
@@ -91,23 +92,19 @@ public class MappingError extends DroolsError {
         return this.templateText;
     }
 
-    /**
-     * @inheritDoc 
-     *
-     * @see org.kie.compiler.DroolsError#getMessage()
-     */
-    public String getMessage() {
-        switch ( this.errorCode ) {
+    private static String getSpecificMessage(int errorCode, int offset,
+                                             String token) {
+        switch ( errorCode ) {
             case ERROR_UNUSED_TOKEN :
-                return "Warning, the token " + this.token + " not used in the mapping.";
+                return "Warning, the token " + token + " not used in the mapping.";
             case ERROR_UNDECLARED_TOKEN :
-                return "Warning, the token " + this.token + " not found in the expression. (May not be a problem).";
+                return "Warning, the token " + token + " not found in the expression. (May not be a problem).";
             case ERROR_INVALID_TOKEN :
-                return "Invalid token declaration at offset " + this.offset + ": " + this.token;
+                return "Invalid token declaration at offset " + offset + ": " + token;
             case ERROR_UNMATCHED_BRACES :
-                return "Unexpected } found at offset " + this.offset;
+                return "Unexpected } found at offset " + offset;
             default :
-                return "Unkown error at offset: " + this.offset;
+                return "Unkown error at offset: " + offset;
         }
     }
 }

--- a/drools-model/drools-model-codegen/src/main/java/org/drools/model/codegen/execmodel/RuleUnitQueryWriter.java
+++ b/drools-model/drools-model-codegen/src/main/java/org/drools/model/codegen/execmodel/RuleUnitQueryWriter.java
@@ -196,12 +196,8 @@ public class RuleUnitQueryWriter {
         private final QueryModel query;
 
         public NoBindingQuery(QueryModel query) {
+            super("Query " + query.getName() + " has no bound variable. At least one binding is required to determine the value returned by this query");
             this.query = query;
-        }
-
-        @Override
-        public String getMessage() {
-            return "Query " + query.getName() + " has no bound variable. At least one binding is required to determine the value returned by this query";
         }
 
         @Override

--- a/drools-model/drools-model-codegen/src/main/java/org/drools/model/codegen/execmodel/errors/CompilationProblemErrorResult.java
+++ b/drools-model/drools-model-codegen/src/main/java/org/drools/model/codegen/execmodel/errors/CompilationProblemErrorResult.java
@@ -27,18 +27,13 @@ public class CompilationProblemErrorResult extends DroolsError {
     private CompilationProblem compilationProblem;
 
     public CompilationProblemErrorResult(CompilationProblem compilationProblem) {
-        super();
+        super(compilationProblem.getMessage());
         this.compilationProblem = compilationProblem;
     }
 
     @Override
     public ResultSeverity getSeverity() {
         return ResultSeverity.ERROR;
-    }
-
-    @Override
-    public String getMessage() {
-        return compilationProblem.getMessage();
     }
 
     @Override

--- a/drools-model/drools-model-codegen/src/main/java/org/drools/model/codegen/execmodel/errors/DuplicatedDeclarationError.java
+++ b/drools-model/drools-model-codegen/src/main/java/org/drools/model/codegen/execmodel/errors/DuplicatedDeclarationError.java
@@ -26,18 +26,13 @@ public class DuplicatedDeclarationError extends DroolsError {
     private String declaration;
 
     public DuplicatedDeclarationError( String declaration) {
-        super();
+        super("Duplicated declaration: " + declaration);
         this.declaration = declaration;
     }
 
     @Override
     public ResultSeverity getSeverity() {
         return ResultSeverity.ERROR;
-    }
-
-    @Override
-    public String getMessage() {
-        return "Duplicated declaration: " + declaration;
     }
 
     @Override

--- a/drools-model/drools-model-codegen/src/main/java/org/drools/model/codegen/execmodel/errors/GetterOverloadWarning.java
+++ b/drools-model/drools-model-codegen/src/main/java/org/drools/model/codegen/execmodel/errors/GetterOverloadWarning.java
@@ -30,6 +30,7 @@ public class GetterOverloadWarning extends DroolsError {
     private Class newType;
 
     public GetterOverloadWarning( Class klass, String oldName, Class oldType, String newName, Class newType ) {
+        super( " Getter overloading detected in class " + klass.getName() + " : " + oldName + " (" + oldType + ") vs " + newName + " (" + newType + ") ");
         this.klass = klass;
         this.oldName = oldName;
         this.oldType = oldType;
@@ -40,12 +41,6 @@ public class GetterOverloadWarning extends DroolsError {
     @Override
     public ResultSeverity getSeverity() {
         return ResultSeverity.WARNING;
-    }
-
-
-    @Override
-    public String getMessage() {
-        return " Getter overloading detected in class " + klass.getName() + " : " + oldName + " (" + oldType + ") vs " + newName + " (" + newType + ") ";
     }
 
 

--- a/drools-model/drools-model-codegen/src/main/java/org/drools/model/codegen/execmodel/errors/IncompatibleGetterOverloadError.java
+++ b/drools-model/drools-model-codegen/src/main/java/org/drools/model/codegen/execmodel/errors/IncompatibleGetterOverloadError.java
@@ -30,6 +30,7 @@ public class IncompatibleGetterOverloadError extends DroolsError {
     private Class newType;
 
     public IncompatibleGetterOverloadError( Class klass, String oldName, Class oldType, String newName, Class newType ) {
+        super(" Incompatible Getter overloading detected in class " + klass.getName() + " : " + oldName + " (" + oldType + ") vs " + newName + " (" + newType + ") ");
         this.klass = klass;
         this.oldName = oldName;
         this.oldType = oldType;
@@ -40,12 +41,6 @@ public class IncompatibleGetterOverloadError extends DroolsError {
     @Override
     public ResultSeverity getSeverity() {
         return ResultSeverity.ERROR;
-    }
-
-
-    @Override
-    public String getMessage() {
-        return " Imcompatible Getter overloading detected in class " + klass.getName() + " : " + oldName + " (" + oldType + ") vs " + newName + " (" + newType + ") ";
     }
 
 

--- a/drools-model/drools-model-codegen/src/main/java/org/drools/model/codegen/execmodel/errors/InvalidExpressionErrorResult.java
+++ b/drools-model/drools-model-codegen/src/main/java/org/drools/model/codegen/execmodel/errors/InvalidExpressionErrorResult.java
@@ -26,13 +26,10 @@ import org.kie.internal.builder.ResultSeverity;
 
 public class InvalidExpressionErrorResult extends DroolsError {
 
-    private String message;
-
     private int[] errorLines = new int[1];
 
     public InvalidExpressionErrorResult(String message) {
-        super();
-        this.message = message;
+        super(message);
         this.errorLines[0] = -1;
     }
 
@@ -46,10 +43,6 @@ public class InvalidExpressionErrorResult extends DroolsError {
         return ResultSeverity.ERROR;
     }
 
-    @Override
-    public String getMessage() {
-        return message;
-    }
 
     @Override
     public int[] getLines() {

--- a/drools-model/drools-model-codegen/src/main/java/org/drools/model/codegen/execmodel/errors/ParseExpressionErrorResult.java
+++ b/drools-model/drools-model-codegen/src/main/java/org/drools/model/codegen/execmodel/errors/ParseExpressionErrorResult.java
@@ -33,7 +33,7 @@ public class ParseExpressionErrorResult extends DroolsError {
     private int[] errorLines = new int[1];
 
     public ParseExpressionErrorResult(Expression expr) {
-        super();
+        super("Unable to Analyse Expression " + PrintUtil.printNode(expr) + ":");
         this.expr = expr;
         this.errorLines[0] = -1;
     }
@@ -46,11 +46,6 @@ public class ParseExpressionErrorResult extends DroolsError {
     @Override
     public ResultSeverity getSeverity() {
         return ResultSeverity.ERROR;
-    }
-
-    @Override
-    public String getMessage() {
-        return "Unable to Analyse Expression " + PrintUtil.printNode(expr) + ":";
     }
 
     @Override

--- a/drools-model/drools-model-codegen/src/main/java/org/drools/model/codegen/execmodel/errors/UnknownDeclarationError.java
+++ b/drools-model/drools-model-codegen/src/main/java/org/drools/model/codegen/execmodel/errors/UnknownDeclarationError.java
@@ -23,11 +23,9 @@ import org.kie.internal.builder.ResultSeverity;
 
 public class UnknownDeclarationError extends DroolsError {
 
-    private String declaration;
 
     public UnknownDeclarationError(String declaration) {
-        super();
-        this.declaration = declaration;
+        super("Unknown declaration: " + declaration);
     }
 
     @Override
@@ -35,10 +33,6 @@ public class UnknownDeclarationError extends DroolsError {
         return ResultSeverity.ERROR;
     }
 
-    @Override
-    public String getMessage() {
-        return "Unknown declaration: " + declaration;
-    }
 
     @Override
     public int[] getLines() {

--- a/drools-model/drools-model-codegen/src/main/java/org/drools/model/codegen/execmodel/errors/UnsupportedFeatureError.java
+++ b/drools-model/drools-model-codegen/src/main/java/org/drools/model/codegen/execmodel/errors/UnsupportedFeatureError.java
@@ -23,11 +23,9 @@ import org.kie.internal.builder.ResultSeverity;
 
 public class UnsupportedFeatureError extends DroolsError {
 
-    private String message;
 
     public UnsupportedFeatureError(String message) {
-        super();
-        this.message = message;
+        super(message);
     }
 
     @Override
@@ -35,10 +33,6 @@ public class UnsupportedFeatureError extends DroolsError {
         return ResultSeverity.ERROR;
     }
 
-    @Override
-    public String getMessage() {
-        return message;
-    }
 
     @Override
     public int[] getLines() {

--- a/drools-model/drools-model-codegen/src/main/java/org/drools/model/codegen/execmodel/errors/VariableUsedInBindingError.java
+++ b/drools-model/drools-model-codegen/src/main/java/org/drools/model/codegen/execmodel/errors/VariableUsedInBindingError.java
@@ -29,7 +29,9 @@ public class VariableUsedInBindingError extends DroolsError {
     private int[] errorLines = new int[1];
 
     public VariableUsedInBindingError(String usedDeclaration, String constraintExpressionString) {
-        super();
+        super(String.format("Variables can not be used inside bindings. Variable [%s] is being used in binding '%s'",
+                            usedDeclaration,
+                            constraintExpressionString));
         this.usedDeclaration = usedDeclaration;
         this.constraintExpressionString = constraintExpressionString;
         this.errorLines[0] = -1;
@@ -40,12 +42,6 @@ public class VariableUsedInBindingError extends DroolsError {
         return ResultSeverity.ERROR;
     }
 
-    @Override
-    public String getMessage() {
-        return String.format("Variables can not be used inside bindings. Variable [%s] is being used in binding '%s'",
-                             usedDeclaration,
-                             constraintExpressionString);
-    }
 
     @Override
     public int[] getLines() {

--- a/drools-model/drools-model-codegen/src/main/java/org/drools/model/codegen/execmodel/generator/visitor/accumulate/AccumulateVisitor.java
+++ b/drools-model/drools-model-codegen/src/main/java/org/drools/model/codegen/execmodel/generator/visitor/accumulate/AccumulateVisitor.java
@@ -217,8 +217,7 @@ public class AccumulateVisitor {
         } else if (accumulateFunctionParameter instanceof LiteralExpr) {
             literalExprParameter(basePattern, function, functionDSL, bindingId, accumulateFunctionParameter);
         } else {
-            context.addCompilationError(new InvalidExpressionErrorResult("Invalid expression " + accumulateFunctionParameterStr, Optional.of(context.getRuleDescr())));
-            throw new AccumulateParsingFailedException();
+            throw new AccumulateParsingFailedException("Invalid expression " + accumulateFunctionParameterStr);
         }
 
         return Optional.empty();
@@ -661,9 +660,6 @@ public class AccumulateVisitor {
     }
 
     private class AccumulateParsingFailedException extends RuntimeException {
-
-        AccumulateParsingFailedException() {
-        }
 
         AccumulateParsingFailedException(String message) {
             super(message);

--- a/drools-model/drools-model-codegen/src/test/java/org/drools/model/codegen/execmodel/GetterOverloadingTest.java
+++ b/drools-model/drools-model-codegen/src/test/java/org/drools/model/codegen/execmodel/GetterOverloadingTest.java
@@ -61,7 +61,7 @@ public class GetterOverloadingTest extends BaseModelTest {
 
         KieBuilder kieBuilder = createKieBuilder(str);
         List<org.kie.api.builder.Message> messages = kieBuilder.getResults().getMessages(Level.ERROR);
-        assertThat(messages.get(0).getText()).contains("Imcompatible Getter overloading detected");
+        assertThat(messages.get(0).getText()).contains("Incompatible Getter overloading detected");
     }
 
     public static class ClassA {

--- a/drools-model/drools-model-codegen/src/test/java/org/drools/model/codegen/execmodel/assembler/TestAssembler.java
+++ b/drools-model/drools-model-codegen/src/test/java/org/drools/model/codegen/execmodel/assembler/TestAssembler.java
@@ -56,16 +56,11 @@ public class TestAssembler implements KieAssemblerService {
 
     }
 
-    public static final KnowledgeBuilderResult AFTER_RULES = new DroolsError(null) {
+    public static final KnowledgeBuilderResult AFTER_RULES = new DroolsError( "AFTER_RULES") {
 
         @Override
         public ResultSeverity getSeverity() {
             return ResultSeverity.WARNING;
-        }
-
-        @Override
-        public String getMessage() {
-            return "AFTER_RULES";
         }
 
         @Override
@@ -75,16 +70,11 @@ public class TestAssembler implements KieAssemblerService {
 
     };
 
-    public static final KnowledgeBuilderResult BEFORE_RULES = new DroolsError(null) {
+    public static final KnowledgeBuilderResult BEFORE_RULES = new DroolsError("BEFORE_RULES") {
 
         @Override
         public ResultSeverity getSeverity() {
             return ResultSeverity.WARNING;
-        }
-
-        @Override
-        public String getMessage() {
-            return "BEFORE_RULES";
         }
 
         @Override

--- a/drools-mvel/src/main/java/org/drools/mvel/asm/ClassFieldInspectorImpl.java
+++ b/drools-mvel/src/main/java/org/drools/mvel/asm/ClassFieldInspectorImpl.java
@@ -574,7 +574,7 @@ public class ClassFieldInspectorImpl implements ClassFieldInspector {
 
 
         public String getMessage() {
-            return " Imcompatible Getter overloading detected in class " + klass.getName() + " : " + oldName + " (" + oldType + ") vs " + newName + " (" + newType + ") ";
+            return " Incompatible Getter overloading detected in class " + klass.getName() + " : " + oldName + " (" + oldType + ") vs " + newName + " (" + newType + ") ";
         }
 
 

--- a/drools-mvel/src/main/java/org/drools/mvel/java/JavaDialectError.java
+++ b/drools-mvel/src/main/java/org/drools/mvel/java/JavaDialectError.java
@@ -25,15 +25,12 @@ public class JavaDialectError extends DroolsError {
     private static final int[] line = new int[0];
 
     public JavaDialectError(final String message) {
+        super(message);
         this.message = message;
     }
 
     public int[] getLines() {
         return line;
-    }
-    
-    public String getMessage() {
-        return this.message;
     }
 
     public String toString() {

--- a/drools-util/src/main/java/org/drools/util/IncompatibleGetterOverloadException.java
+++ b/drools-util/src/main/java/org/drools/util/IncompatibleGetterOverloadException.java
@@ -28,7 +28,7 @@ public class IncompatibleGetterOverloadException extends RuntimeException {
     private Class<?> newType;
 
     public IncompatibleGetterOverloadException(Class<?> klass, String oldName, Class<?> oldType, String newName, Class<?> newType) {
-        super(" Imcompatible Getter overloading detected in class " + klass.getName() + " : " + oldName + " (" + oldType + ") vs " + newName + " (" + newType + ") ");
+        super(" Incompatible Getter overloading detected in class " + klass.getName() + " : " + oldName + " (" + oldType + ") vs " + newName + " (" + newType + ") ");
         this.klass = klass;
         this.oldName = oldName;
         this.oldType = oldType;

--- a/kie-dmn/kie-dmn-core/src/main/java/org/kie/dmn/core/impl/DMNKnowledgeBuilderError.java
+++ b/kie-dmn/kie-dmn-core/src/main/java/org/kie/dmn/core/impl/DMNKnowledgeBuilderError.java
@@ -28,16 +28,14 @@ import org.kie.internal.builder.ResultSeverity;
 public class DMNKnowledgeBuilderError extends DroolsError {
 
     private int[] lines = new int[0];
-    private String message;
     private String namespace;
     private ResultSeverity severity;
     private DMNMessage dmnMessage;
     
     public DMNKnowledgeBuilderError(ResultSeverity severity, Resource resource, String namespace, String message) {
-        super(resource);
+        super(resource, message);
         this.severity = severity;
         this.namespace = namespace;
-        this.message = message;
     }
     
     public DMNKnowledgeBuilderError(ResultSeverity severity, Resource resource, String message) {
@@ -79,11 +77,6 @@ public class DMNKnowledgeBuilderError extends DroolsError {
     }
 
     @Override
-    public String getMessage() {
-        return this.message;
-    }
-
-    @Override
     public int[] getLines() {
         return lines;
     }
@@ -101,7 +94,7 @@ public class DMNKnowledgeBuilderError extends DroolsError {
     public String toString() {
         StringBuilder sb = new StringBuilder();
         sb.append("DMNKnowledgeBuilderError [message=");
-        sb.append(message);
+        sb.append(getMessage());
         sb.append(", namespace=");
         sb.append(namespace);
         sb.append(", dmnMessage=");


### PR DESCRIPTION
Fixes https://github.com/apache/incubator-kie-issues/issues/814

Requires https://github.com/apache/incubator-kie-kogito-runtimes/pull/3346

This PR
1. refactor `AccumulateVisitor` to avoid instantiation of `InvalidExpressionErrorResult` with `null` message
2. refacotr `BaseKnowledgeBuilderResultImpl` (and children classes) to enforce population of `message`
 
**Ports** If a forward-port or a backport is needed, paste the forward port PR here

[link](https://www.example.com)

**JIRA**: _(please edit the JIRA link if it exists)_

[link](https://www.example.com)

**referenced Pull Requests**: _(please edit the URLs of referenced pullrequests if they exist)_

* paste the link(s) from GitHub here
* link 2
* link 3 etc.

<details>
<summary>
How to replicate CI configuration locally?
</summary>

Build Chain tool does "simple" maven build(s), the builds are just Maven commands, but because the repositories relates and depends on each other and any change in API or class method could affect several of those repositories there is a need to use [build-chain tool](https://github.com/kiegroup/github-action-build-chain) to handle cross repository builds and be sure that we always use latest version of the code for each repository.
 
[build-chain tool](https://github.com/kiegroup/github-action-build-chain) is a build tool which can be used on command line locally or in Github Actions workflow(s), in case you need to change multiple repositories and send multiple dependent pull requests related with a change you can easily reproduce the same build by executing it on Github hosted environment or locally in your development environment. See [local execution](https://github.com/kiegroup/github-action-build-chain#local-execution) details to get more information about it.
</details>

<details>
<summary>
How to retest this PR or trigger a specific build:
</summary>

- for <b>pull request checks</b>  
  Please add comment: <b>Jenkins retest this</b>

- for a <b>specific pull request check</b>  
  Please add comment: <b>Jenkins (re)run [drools|kogito-runtimes|kogito-apps|kogito-examples] tests</b>

- for a <b>full downstream build</b> 
  - for <b>jenkins</b> job: please add comment: <b>Jenkins run fdb</b>
  - for <b>github actions</b> job: add the label `run_fdb`

- <b>a compile downstream build</b> please  add comment: <b>Jenkins run cdb</b>

- <b>an upstream build</b> please add comment: <b>Jenkins run upstream</b>

- for <b>quarkus branch checks</b>  
  Run checks against Quarkus current used branch  
  Please add comment: <b>Jenkins run quarkus-branch</b>

- for a <b>quarkus branch specific check</b>  
  Run checks against Quarkus current used branch  
  Please add comment: <b>Jenkins (re)run [drools|kogito-runtimes|kogito-apps|kogito-examples] quarkus-branch</b>

- for <b>quarkus main checks</b>  
  Run checks against Quarkus main branch  
  Please add comment: <b>Jenkins run quarkus-main</b>

- for a <b>specific quarkus main check</b>  
  Run checks against Quarkus main branch  
  Please add comment: <b>Jenkins (re)run [drools|kogito-runtimes|kogito-apps|kogito-examples] quarkus-main</b>

- for <b>quarkus lts checks</b>  
  Run checks against Quarkus lts branch  
  Please add comment: <b>Jenkins run quarkus-lts</b>

- for a <b>specific quarkus lts check</b>  
  Run checks against Quarkus lts branch  
  Please add comment: <b>Jenkins (re)run [drools|kogito-runtimes|kogito-apps|kogito-examples] quarkus-lts</b>

- for <b>native checks</b>  
  Run native checks  
  Please add comment: <b>Jenkins run native</b>

- for a <b>specific native check</b>  
  Run native checks 
  Please add comment: <b>Jenkins (re)run [drools|kogito-runtimes|kogito-apps|kogito-examples] native</b>

 - for <b>native lts checks</b>  
  Run native checks against quarkus lts branch
  Please add comment: <b>Jenkins run native-lts</b>

- for a <b>specific native lts check</b>  
  Run native checks against quarkus lts branch
  Please add comment: <b>Jenkins (re)run [drools|kogito-runtimes|kogito-apps|kogito-examples] native-lts</b>
</details>

<details>
<summary>
How to backport a pull request to a different branch?
</summary>

In order to automatically create a **backporting pull request** please add one or more labels having the following format `backport-<branch-name>`, where `<branch-name>` is the name of the branch where the pull request must be backported to (e.g., `backport-7.67.x` to backport the original PR to the `7.67.x` branch).

> **NOTE**: **backporting** is an action aiming to move a change (usually a commit) from a branch (usually the main one) to another one, which is generally referring to a still maintained release branch. Keeping it simple: it is about to move a specific change or a set of them from one branch to another.

Once the original pull request is successfully merged, the automated action will create one backporting pull request per each label (with the previous format) that has been added.

If something goes wrong, the author will be notified and at this point a manual backporting is needed.

> **NOTE**: this automated backporting is triggered whenever a pull request on `main` branch is labeled or closed, but both conditions must be satisfied to get the new PR created.
</details>

<!-- TODO to uncomment if activating the quarkus-3 rewrite PR job -->
<!-- <details>
<summary>
Quarkus-3 PR check is failing ... what to do ?
</summary>
The Quarkus 3 check is applying patches from the `.ci/environments/quarkus-3/patches`.

The first patch, called `0001_before_sh.patch`, is generated from Openrewrite `.ci/environments/quarkus-3/quarkus3.yml` recipe. The patch is created to speed up the check. But it may be that some changes in the PR broke this patch.  
No panic, there is an easy way to regenerate it. You just need to comment on the PR:
```
jenkins rewrite quarkus-3
```
and it should, after some minutes (~20/30min) apply a commit on the PR with the patch regenerated.

Other patches were generated manually. If any of it fails, you will need to manually update it... and push your changes.
</details> -->