### PR TITLE
[incubator-kie-issues#875] DMN - Do not create an exception when property is not defined.

### DIFF
--- a/kie-dmn/kie-dmn-feel/src/main/java/org/kie/dmn/feel/util/EvalHelper.java
+++ b/kie-dmn/kie-dmn-feel/src/main/java/org/kie/dmn/feel/util/EvalHelper.java
@@ -281,6 +281,11 @@ public class EvalHelper {
 
     public static class PropertyValueResult implements FEELPropertyAccessible.AbstractPropertyValueResult {
 
+        // This exception is used to signal an undefined property for notDefined(). This method may be many times when
+        // evaluating a decision, so a single instance is being cached to avoid the cost of creating the stack trace
+        // each time.
+        private static final Exception undefinedPropertyException = new UnsupportedOperationException("Property was not defined.");
+
         private final boolean defined;
         private final Either<Exception, Object> valueResult;
 
@@ -290,7 +295,7 @@ public class EvalHelper {
         }
 
         public static PropertyValueResult notDefined() {
-            return new PropertyValueResult(false, Either.ofRight(null));
+            return new PropertyValueResult(false, Either.ofLeft(undefinedPropertyException));
         }
 
         public static PropertyValueResult of(Either<Exception, Object> valueResult) {

--- a/kie-dmn/kie-dmn-feel/src/main/java/org/kie/dmn/feel/util/EvalHelper.java
+++ b/kie-dmn/kie-dmn-feel/src/main/java/org/kie/dmn/feel/util/EvalHelper.java
@@ -290,7 +290,7 @@ public class EvalHelper {
         }
 
         public static PropertyValueResult notDefined() {
-            return new PropertyValueResult(false, Either.ofLeft(new UnsupportedOperationException("Property was not defined.")));
+            return new PropertyValueResult(false, Either.ofRight(null));
         }
 
         public static PropertyValueResult of(Either<Exception, Object> valueResult) {


### PR DESCRIPTION
This PR addresses this issue https://github.com/apache/incubator-kie-issues/issues/875 by removing the creation of an exception when a property is not defined. 

This change is only observable by calling the `getValueResult`, but none of the uses of that method are affected by this change. There are only 4 uses of this method in the code base, and each case is either:

* guarded by a call to `isDefined` so that `getValueResult` is not called
* or transforms not defined results to `null` anyways.