### PR TITLE
[kie-issues#839] Remove comments script - ignore nonexistant files

### DIFF
--- a/drools-util/pom.xml
+++ b/drools-util/pom.xml
@@ -42,6 +42,10 @@
 
     <dependencies>
         <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>slf4j-api</artifactId>
+        </dependency>
+        <dependency>
             <groupId>org.eclipse.microprofile.config</groupId>
             <artifactId>microprofile-config-api</artifactId>
             <optional>true</optional>

--- a/drools-util/src/main/java/org/drools/util/RemoveCommentsMain.java
+++ b/drools-util/src/main/java/org/drools/util/RemoveCommentsMain.java
@@ -2,6 +2,7 @@ package org.drools.util;
 
 import java.io.IOException;
 import java.nio.file.Files;
+import java.nio.file.NoSuchFileException;
 import java.nio.file.Path;
 import java.util.stream.Collectors;
 
@@ -12,7 +13,10 @@ public class RemoveCommentsMain {
             try {
                 Files.write(Path.of(fileName), removeComments(fileName).getBytes());
             } catch (IOException e) {
-                throw new RuntimeException(e);
+                // Ignore non-existant files.
+                if (!(e instanceof NoSuchFileException)) {
+                    throw new RuntimeException(e);
+                }
             }
         }
     }
@@ -21,7 +25,10 @@ public class RemoveCommentsMain {
         try (var lines = Files.lines(Path.of(fileName))) {
             return lines.filter(line -> !line.startsWith("#")).collect(Collectors.joining("\n"));
         } catch (IOException e) {
-            throw new RuntimeException(e);
+            // Ignore non-existant files.
+            if (!(e instanceof NoSuchFileException)) {
+                throw new RuntimeException(e);
+            }
         }
     }
 

--- a/drools-util/src/main/java/org/drools/util/RemoveCommentsMain.java
+++ b/drools-util/src/main/java/org/drools/util/RemoveCommentsMain.java
@@ -1,5 +1,8 @@
 package org.drools.util;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.NoSuchFileException;
@@ -8,31 +11,40 @@ import java.util.stream.Collectors;
 
 public class RemoveCommentsMain {
 
+    private static final Logger LOGGER = LoggerFactory.getLogger(RemoveCommentsMain.class);
+
     public static void main(String... args) {
-        for (String fileName : args) {
-            try {
-                final String result = removeComments(fileName);
-                if (result != null) {
-                    Files.write(Path.of(fileName), result.getBytes());
-                }
-            } catch (IOException e) {
-                // Ignore non-existant files.
-                if (!(e instanceof NoSuchFileException)) {
+        final String ignoreMissingFilesArgument = args[0];
+        final boolean ignoreMissingFiles = Boolean.parseBoolean(ignoreMissingFilesArgument);
+        for (int i = 0; i < args.length; i++) {
+            // If the ignoreMissingFiles argument is defined, skip it in this iteration.
+            if ((ignoreMissingFiles || "false".equalsIgnoreCase(ignoreMissingFilesArgument)) && i == 0) {
+                continue;
+            } else {
+                try {
+                    final String fileName = args[i];
+                    final String result = removeComments(fileName, ignoreMissingFiles);
+                    if (result != null) {
+                        Files.write(Path.of(fileName), result.getBytes());
+                    }
+                } catch (IOException e) {
                     throw new RuntimeException(e);
                 }
             }
         }
     }
 
-    static String removeComments(String fileName) {
+    static String removeComments(String fileName, final boolean ignoreMissingFiles) {
         try (var lines = Files.lines(Path.of(fileName))) {
             return lines.filter(line -> !line.startsWith("#")).collect(Collectors.joining("\n"));
         } catch (IOException e) {
             // Ignore non-existant files.
-            if (!(e instanceof NoSuchFileException)) {
+            if (ignoreMissingFiles && e instanceof NoSuchFileException) {
+                LOGGER.info("Ignoring file that doesn't exist: " + fileName);
+                return null;
+            } else {
                 throw new RuntimeException(e);
             }
-            return null;
         }
     }
 

--- a/drools-util/src/main/java/org/drools/util/RemoveCommentsMain.java
+++ b/drools-util/src/main/java/org/drools/util/RemoveCommentsMain.java
@@ -11,7 +11,10 @@ public class RemoveCommentsMain {
     public static void main(String... args) {
         for (String fileName : args) {
             try {
-                Files.write(Path.of(fileName), removeComments(fileName).getBytes());
+                final String result = removeComments(fileName);
+                if (result != null) {
+                    Files.write(Path.of(fileName), result.getBytes());
+                }
             } catch (IOException e) {
                 // Ignore non-existant files.
                 if (!(e instanceof NoSuchFileException)) {
@@ -29,6 +32,7 @@ public class RemoveCommentsMain {
             if (!(e instanceof NoSuchFileException)) {
                 throw new RuntimeException(e);
             }
+            return null;
         }
     }
 

--- a/drools-util/src/test/java/org/drools/util/RemoveCommentsTest.java
+++ b/drools-util/src/test/java/org/drools/util/RemoveCommentsTest.java
@@ -8,7 +8,7 @@ public class RemoveCommentsTest {
 
     @Test
     public void test() {
-        String result = RemoveCommentsMain.removeComments("src/test/resources/commented.properties");
+        String result = RemoveCommentsMain.removeComments("src/test/resources/commented.properties", false);
         String expected = "provides-capabilities=org.drools.drl\ndeployment-artifact=org.drools\\:drools-quarkus-deployment\\:999-SNAPSHOT";
         assertEquals(expected, result);
     }


### PR DESCRIPTION
This change makes the RemoveCommentsMain class to ignore non-existant files. This is a prerequisite for configuration in kogito-runtimes. 