### PR TITLE
[kie-issues#941] Fix wrongly generated type for parentheses enclosed expression variable binding

### DIFF
--- a/drools-model/drools-model-codegen/src/main/java/org/drools/model/codegen/execmodel/generator/drlxparse/ConstraintParser.java
+++ b/drools-model/drools-model-codegen/src/main/java/org/drools/model/codegen/execmodel/generator/drlxparse/ConstraintParser.java
@@ -202,7 +202,12 @@ public class ConstraintParser {
     private void addDeclaration(DrlxExpression drlx, SingleDrlxParseSuccess singleResult, String bindId) {
         TypedDeclarationSpec decl = context.addDeclaration(bindId, getDeclarationType(drlx, singleResult));
         if (drlx.getExpr() instanceof NameExpr) {
-            decl.setBoundVariable( PrintUtil.printNode(drlx.getExpr()) );
+            decl.setBoundVariable(PrintUtil.printNode(drlx.getExpr()));
+        } else if (drlx.getExpr() instanceof EnclosedExpr) {
+            ExpressionTyperContext expressionTyperContext = new ExpressionTyperContext();
+            ExpressionTyper expressionTyper = new ExpressionTyper(context, singleResult.getPatternType(), bindId, false, expressionTyperContext);
+            TypedExpressionResult typedExpressionResult = expressionTyper.toTypedExpression(drlx.getExpr());
+            singleResult.setBoundExpr(typedExpressionResult.typedExpressionOrException());
         } else if (drlx.getExpr() instanceof BinaryExpr) {
             Expression leftMostExpression = getLeftMostExpression(drlx.getExpr().asBinaryExpr());
             decl.setBoundVariable(PrintUtil.printNode(leftMostExpression));
@@ -212,7 +217,7 @@ public class ConstraintParser {
                 ExpressionTyper expressionTyper = new ExpressionTyper(context, singleResult.getPatternType(), bindId, false, expressionTyperContext);
                 TypedExpressionResult leftTypedExpressionResult = expressionTyper.toTypedExpression(leftMostExpression);
                 Optional<TypedExpression> optLeft = leftTypedExpressionResult.getTypedExpression();
-                if (!optLeft.isPresent()) {
+                if (optLeft.isEmpty()) {
                     throw new IllegalStateException("Cannot create TypedExpression for " + drlx.getExpr().asBinaryExpr().getLeft());
                 }
                 singleResult.setBoundExpr(optLeft.get());

--- a/drools-model/drools-model-codegen/src/main/java/org/drools/model/codegen/execmodel/generator/drlxparse/ConstraintParser.java
+++ b/drools-model/drools-model-codegen/src/main/java/org/drools/model/codegen/execmodel/generator/drlxparse/ConstraintParser.java
@@ -203,7 +203,7 @@ public class ConstraintParser {
         TypedDeclarationSpec decl = context.addDeclaration(bindId, getDeclarationType(drlx, singleResult));
         if (drlx.getExpr() instanceof NameExpr) {
             decl.setBoundVariable(PrintUtil.printNode(drlx.getExpr()));
-        } else if (drlx.getExpr() instanceof EnclosedExpr) {
+        } else if (drlx.getExpr() instanceof EnclosedExpr && drlx.getBind() != null) {
             ExpressionTyperContext expressionTyperContext = new ExpressionTyperContext();
             ExpressionTyper expressionTyper = new ExpressionTyper(context, singleResult.getPatternType(), bindId, false, expressionTyperContext);
             TypedExpressionResult typedExpressionResult = expressionTyper.toTypedExpression(drlx.getExpr());

--- a/drools-model/drools-model-codegen/src/main/java/org/drools/model/codegen/execmodel/generator/expression/AbstractExpressionBuilder.java
+++ b/drools-model/drools-model-codegen/src/main/java/org/drools/model/codegen/execmodel/generator/expression/AbstractExpressionBuilder.java
@@ -115,7 +115,7 @@ public abstract class AbstractExpressionBuilder {
         } else {
             final TypedExpression boundExpr = drlxParseResult.getBoundExpr();
             // Can we unify it? Sometimes expression is in the left sometimes in expression
-            final Expression e = boundExpr != null ? findLeftmostExpression(boundExpr.getExpression()) : drlxParseResult.getExpr();
+            final Expression e = boundExpr != null ? boundExpr.getExpression() : findLeftmostExpression(drlxParseResult.getExpr());
             return buildConstraintExpression(drlxParseResult, drlxParseResult.getUsedDeclarationsOnLeft(), e);
         }
     }

--- a/drools-model/drools-model-codegen/src/main/java/org/drools/model/codegen/execmodel/generator/expression/AbstractExpressionBuilder.java
+++ b/drools-model/drools-model-codegen/src/main/java/org/drools/model/codegen/execmodel/generator/expression/AbstractExpressionBuilder.java
@@ -115,8 +115,17 @@ public abstract class AbstractExpressionBuilder {
         } else {
             final TypedExpression boundExpr = drlxParseResult.getBoundExpr();
             // Can we unify it? Sometimes expression is in the left sometimes in expression
-            final Expression e = boundExpr != null ? boundExpr.getExpression() : findLeftmostExpression(drlxParseResult.getExpr());
-            return buildConstraintExpression(drlxParseResult, drlxParseResult.getUsedDeclarationsOnLeft(), e);
+            final Expression expression;
+            if (boundExpr != null) {
+                if (boundExpr.getExpression() instanceof EnclosedExpr) {
+                    expression = boundExpr.getExpression();
+                } else {
+                    expression = findLeftmostExpression(boundExpr.getExpression());
+                }
+            } else {
+                expression = drlxParseResult.getExpr();
+            }
+            return buildConstraintExpression(drlxParseResult, drlxParseResult.getUsedDeclarationsOnLeft(), expression);
         }
     }
 

--- a/drools-model/drools-model-codegen/src/test/java/org/drools/model/codegen/execmodel/BindingTest.java
+++ b/drools-model/drools-model-codegen/src/test/java/org/drools/model/codegen/execmodel/BindingTest.java
@@ -23,7 +23,6 @@ import java.util.List;
 
 import org.drools.model.codegen.execmodel.domain.Person;
 import org.junit.Test;
-import org.kie.api.KieBase;
 import org.kie.api.runtime.KieSession;
 
 import static org.assertj.core.api.Assertions.assertThat;

--- a/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/integrationtests/Misc2Test.java
+++ b/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/integrationtests/Misc2Test.java
@@ -159,65 +159,6 @@ public class Misc2Test {
     private static final Logger logger = LoggerFactory.getLogger( Misc2Test.class );
 
     @Test
-    public void testConstraintExpression() {
-        String str = "package constraintexpression\n" +
-                "\n" +
-                "import " + Address.class.getCanonicalName() + "\n" +
-                "\n" +
-                "rule \"r1\"\n" +
-                " dialect \"java\" \n" +
-                "when \n" +
-                "    $a : Address($booleanVariable: (street != null))\n" +
-                "then \n" +
-                "    System.out.println($booleanVariable); \n" +
-                "    System.out.println($a); \n" +
-                "end \n";
-
-        KieBase kbase = KieBaseUtil.getKieBaseFromKieModuleFromDrl("test", kieBaseTestConfiguration, str);
-        KieSession ksession = kbase.newKieSession();
-        try {
-            Address address = new Address();
-            address.setStreet("streetName");
-            ksession.insert(address);
-            int rulesFired = ksession.fireAllRules();
-            assertThat(rulesFired).isEqualTo(1);
-        } finally {
-            ksession.dispose();
-        }
-    }
-
-//    @Test
-//    public void testConstraintExpressionBoundVariableUsedInOtherConstraint() {
-//        String str = "package constraintexpression\n" +
-//                "\n" +
-//                "import " + Address.class.getCanonicalName() + "\n" +
-//                "import " + Person.class.getCanonicalName() + "\n" +
-//                "\n" +
-//                "rule \"r1\"\n" +
-//                "when \n" +
-//                "    $a : Address($booleanVariable: (street == null))\n" +
-//                "    $p: Person(!$booleanVariable && name == \"someName\") \n" +
-//                "then \n" +
-//                "    System.out.println($booleanVariable); \n" +
-//                "    System.out.println($a); \n" +
-//                "end \n";
-//
-//        KieBase kbase = KieBaseUtil.getKieBaseFromKieModuleFromDrl("test", kieBaseTestConfiguration, str);
-//        KieSession ksession = kbase.newKieSession();
-//        try {
-//            Address address = new Address();
-//            address.setStreet("streetname");
-//            Person person = new Person("someName");
-//            ksession.insert(address);
-//            ksession.insert(person);
-//            int rulesFired = ksession.fireAllRules();
-//            assertThat(rulesFired).isEqualTo(0);
-//        } finally {
-//            ksession.dispose();
-//        }
-//    }
-
-    @Test
     public void testUpdateWithNonEffectiveActivations() throws Exception {
         // JBRULES-3604
         String str = "package inheritance\n" +

--- a/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/integrationtests/Misc2Test.java
+++ b/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/integrationtests/Misc2Test.java
@@ -153,7 +153,7 @@ public class Misc2Test {
     @Parameterized.Parameters(name = "KieBase type={0}")
     public static Collection<Object[]> getParameters() {
      // TODO: EM failed with some tests. File JIRAs
-        return TestParametersUtil.getKieBaseCloudConfigurations(true);
+        return TestParametersUtil.getKieBaseCloudConfigurations(false);
     }
 
     private static final Logger logger = LoggerFactory.getLogger( Misc2Test.class );

--- a/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/integrationtests/Misc2Test.java
+++ b/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/integrationtests/Misc2Test.java
@@ -153,7 +153,7 @@ public class Misc2Test {
     @Parameterized.Parameters(name = "KieBase type={0}")
     public static Collection<Object[]> getParameters() {
      // TODO: EM failed with some tests. File JIRAs
-        return TestParametersUtil.getKieBaseCloudConfigurations(false);
+        return TestParametersUtil.getKieBaseCloudConfigurations(true);
     }
 
     private static final Logger logger = LoggerFactory.getLogger( Misc2Test.class );

--- a/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/integrationtests/Misc2Test.java
+++ b/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/integrationtests/Misc2Test.java
@@ -153,7 +153,7 @@ public class Misc2Test {
     @Parameterized.Parameters(name = "KieBase type={0}")
     public static Collection<Object[]> getParameters() {
      // TODO: EM failed with some tests. File JIRAs
-        return TestParametersUtil.getKieBaseCloudConfigurations(true);
+        return TestParametersUtil.getKieBaseCloudConfigurations(false);
     }
 
     private static final Logger logger = LoggerFactory.getLogger( Misc2Test.class );
@@ -186,36 +186,36 @@ public class Misc2Test {
         }
     }
 
-    @Test
-    public void testConstraintExpressionBoundVariableUsedInOtherConstraint() {
-        String str = "package constraintexpression\n" +
-                "\n" +
-                "import " + Address.class.getCanonicalName() + "\n" +
-                "import " + Person.class.getCanonicalName() + "\n" +
-                "\n" +
-                "rule \"r1\"\n" +
-                "when \n" +
-                "    $a : Address($booleanVariable: (street != null))\n" +
-                "    $p: Person(!$booleanVariable && name == \"someName\") \n" +
-                "then \n" +
-                "    System.out.println($booleanVariable); \n" +
-                "    System.out.println($a); \n" +
-                "end \n";
-
-        KieBase kbase = KieBaseUtil.getKieBaseFromKieModuleFromDrl("test", kieBaseTestConfiguration, str);
-        KieSession ksession = kbase.newKieSession();
-        try {
-            Address address = new Address();
-            address.setStreet("streetname");
-            Person person = new Person("someName");
-            ksession.insert(address);
-            ksession.insert(person);
-            int rulesFired = ksession.fireAllRules();
-            assertThat(rulesFired).isEqualTo(1);
-        } finally {
-            ksession.dispose();
-        }
-    }
+//    @Test
+//    public void testConstraintExpressionBoundVariableUsedInOtherConstraint() {
+//        String str = "package constraintexpression\n" +
+//                "\n" +
+//                "import " + Address.class.getCanonicalName() + "\n" +
+//                "import " + Person.class.getCanonicalName() + "\n" +
+//                "\n" +
+//                "rule \"r1\"\n" +
+//                "when \n" +
+//                "    $a : Address($booleanVariable: (street == null))\n" +
+//                "    $p: Person(!$booleanVariable && name == \"someName\") \n" +
+//                "then \n" +
+//                "    System.out.println($booleanVariable); \n" +
+//                "    System.out.println($a); \n" +
+//                "end \n";
+//
+//        KieBase kbase = KieBaseUtil.getKieBaseFromKieModuleFromDrl("test", kieBaseTestConfiguration, str);
+//        KieSession ksession = kbase.newKieSession();
+//        try {
+//            Address address = new Address();
+//            address.setStreet("streetname");
+//            Person person = new Person("someName");
+//            ksession.insert(address);
+//            ksession.insert(person);
+//            int rulesFired = ksession.fireAllRules();
+//            assertThat(rulesFired).isEqualTo(0);
+//        } finally {
+//            ksession.dispose();
+//        }
+//    }
 
     @Test
     public void testUpdateWithNonEffectiveActivations() throws Exception {


### PR DESCRIPTION
Fixes https://github.com/apache/incubator-kie-issues/issues/941

When an expression was enclosed in parentheses and bound to a variable, the executable model generator wrongly generated the Java expression providing value to the binding. See the added test case for the use case. 