### PR TITLE
[incubator-kie-issues#717] mvn package throws an exception in Kogito project in Microsoft Windows machines with `quarkus.package.type=uber-jar`

### DIFF
--- a/drools-model/drools-codegen-common/src/main/java/org/drools/codegen/common/GeneratedFile.java
+++ b/drools-model/drools-codegen-common/src/main/java/org/drools/codegen/common/GeneratedFile.java
@@ -62,12 +62,12 @@ public class GeneratedFile {
                 LOGGER.warn("STATIC_HTTP_RESOURCE is automatically placed under " + META_INF_RESOURCES + ". You don't need to specify the directory : {}", path);
             } else {
                 path = META_INF_RESOURCES_PATH.resolve(path);
-                pathAsString = path.toString().replace('\\', '/');
+                pathAsString = path.toString();
             }
         }
 
         this.path = path;
-        this.pathAsString = pathAsString;
+        this.pathAsString = pathAsString.replace('\\', '/');
         this.contents = contents;
     }
 

--- a/drools-model/drools-codegen-common/src/main/java/org/drools/codegen/common/GeneratedFile.java
+++ b/drools-model/drools-codegen-common/src/main/java/org/drools/codegen/common/GeneratedFile.java
@@ -62,7 +62,7 @@ public class GeneratedFile {
                 LOGGER.warn("STATIC_HTTP_RESOURCE is automatically placed under " + META_INF_RESOURCES + ". You don't need to specify the directory : {}", path);
             } else {
                 path = META_INF_RESOURCES_PATH.resolve(path);
-                pathAsString = path.toString();
+                pathAsString = path.toString().replace('\\', '/');
             }
         }
 
@@ -71,8 +71,18 @@ public class GeneratedFile {
         this.contents = contents;
     }
 
+    /**
+     * It returns the relativePath in OS-Dependant format
+     */
     public String relativePath() {
         return pathAsString;
+    }
+
+    /**
+     * It returns the relativePath in POSIX format
+     */
+    public String relativePathPOSIX() {
+        return pathAsString.replace('\\', '/');
     }
 
     public Path path() {

--- a/drools-model/drools-codegen-common/src/main/java/org/drools/codegen/common/GeneratedFile.java
+++ b/drools-model/drools-codegen-common/src/main/java/org/drools/codegen/common/GeneratedFile.java
@@ -71,18 +71,8 @@ public class GeneratedFile {
         this.contents = contents;
     }
 
-    /**
-     * It returns the relativePath in OS-Dependant format
-     */
     public String relativePath() {
         return pathAsString;
-    }
-
-    /**
-     * It returns the relativePath in POSIX format
-     */
-    public String relativePathPOSIX() {
-        return pathAsString.replace('\\', '/');
     }
 
     public Path path() {


### PR DESCRIPTION
Closes: https://github.com/apache/incubator-kie-issues/issues/717

@gitgabrio @mariofusco @baldimir 

**Findings** 
- When generating the JAR, Quarkus always manages the Paths in POSIX format, disregarding the runtime OS ( [here](https://github.com/quarkusio/quarkus/blob/main/core/deployment/src/main/java/io/quarkus/deployment/pkg/steps/JarResultBuildStep.java#L1177) and [here](https://github.com/quarkusio/quarkus/blob/main/core/deployment/src/main/java/io/quarkus/deployment/pkg/steps/JarResultBuildStep.java#L1198) )
- The issue's root cause is inside [this `else` block of code](https://github.com/apache/incubator-kie-drools/blob/main/drools-model/drools-codegen-common/src/main/java/org/drools/codegen/common/GeneratedFile.java#L64). When the build is launched in a Windows-based machine, the resulting `pathAsString` is in Windows format. This conflicts with the previous point and generates the  reported exception in `JarResultBuildStep.java`(please check the logs in the ticket)
- After a debug session, It seems to me that all the `pathAsString` passed to this constructor (https://github.com/apache/incubator-kie-drools/blob/d506c1a3b977fe5f4f20bb3db826837505e02c9e/drools-model/drools-codegen-common/src/main/java/org/drools/codegen/common/GeneratedFile.java#L57) are **ALWAYS** in POSIX format, disregarding the running OS (as shown in the below screenshot). Thus, the `path` holds the real Path (OS-Dependant format) and the `pathAsString` always holds the POSIX representation. That could explain why we need two parameters to manage the path. In addition, most of the `pathAsString` I observed are generated [in this point](https://github.com/apache/incubator-kie-drools/blob/main/drools-model/drools-model-codegen/src/main/java/org/drools/model/codegen/project/template/TemplatedGenerator.java#L74), always in POSIX format.

<img width="1129" alt="Screenshot 2024-02-19 at 15 51 49" src="https://github.com/apache/incubator-kie-drools/assets/16005046/4cae2096-758e-4023-814e-1e75959052b9">

- Another point where the issue may occur, is the [second constructor of `GeneratedFile` class](https://github.com/apache/incubator-kie-drools/blob/main/drools-model/drools-codegen-common/src/main/java/org/drools/codegen/common/GeneratedFile.java#L46), where `path.toString()` is called. That may potentially lead to the same issue.

For the above reasons, the fix I provided just to apply the POSIX format usage when setting the `pathAsString` field.

If one of my assumptions or if the fix is not correct, please feel free to comment or suggest any change.