### PR TITLE
[8.40.x][incubator-kie-issues#717] mvn package throws an exception in Kogito project in Microsoft Windows machines with `quarkus.package.type=uber-jar`

### DIFF
--- a/drools-model/drools-codegen-common/src/main/java/org/drools/codegen/common/GeneratedFile.java
+++ b/drools-model/drools-codegen-common/src/main/java/org/drools/codegen/common/GeneratedFile.java
@@ -64,7 +64,7 @@ public class GeneratedFile {
         }
 
         this.path = path;
-        this.pathAsString = pathAsString;
+        this.pathAsString = pathAsString.replace('\\', '/');
         this.contents = contents;
     }
 


### PR DESCRIPTION
Backport of https://github.com/apache/incubator-kie-drools/pull/5694