### PR TITLE
[kie-issues#913] Upgrade to Quarkus 3.2.10.Final LTS version. 

### DIFF
--- a/build-parent/pom.xml
+++ b/build-parent/pom.xml
@@ -74,7 +74,7 @@
     <version.guru.nidi>0.18.0</version.guru.nidi>
     <version.info.picocli>4.7.4</version.info.picocli>
     <version.io.micrometer>1.11.1</version.io.micrometer>
-    <version.io.quarkus>3.2.9.Final</version.io.quarkus>
+    <version.io.quarkus>3.2.10.Final</version.io.quarkus>
     <version.io.smallrye.openapi.core>3.4.0</version.io.smallrye.openapi.core>
     <version.it.unimi.dsi.fastutil>8.5.11</version.it.unimi.dsi.fastutil>
     <version.junit>4.13.1</version.junit>
@@ -98,7 +98,7 @@
     <version.org.glassfish.jaxb>4.0.4</version.org.glassfish.jaxb>
     <!--This needs to be in sync with JUnit-->
     <version.org.hamcrest>1.3</version.org.hamcrest>
-    <version.org.hibernate>6.2.13.Final</version.org.hibernate>
+    <version.org.hibernate>6.2.18.Final</version.org.hibernate>
     <version.org.hsqldb>2.3.0</version.org.hsqldb>
     <version.org.infinispan>14.0.13.Final</version.org.infinispan>
     <version.org.javassist>3.26.0-GA</version.org.javassist>
@@ -121,7 +121,7 @@
     <version.jakarta.servlet-api>6.0.0</version.jakarta.servlet-api>
     <version.jakarta.xml.bind-api>4.0.0</version.jakarta.xml.bind-api>
     <version.jakarta.json.bind-api>3.0.0</version.jakarta.json.bind-api>
-    <version.jakarta.json>1.1.2</version.jakarta.json>
+    <version.jakarta.json>1.1.6</version.jakarta.json>
     <version.jakarta.json-api>2.1.2</version.jakarta.json-api>
     <version.org.jpmml.model>1.6.4</version.org.jpmml.model> <!-- jpmml-model BSD 3C license - ATTENTION 1.5.1 intentional, because 1.5.1 evaluators works with 1.5.1 -->
     <version.org.junit>5.9.3</version.org.junit>
@@ -202,7 +202,7 @@
     <version.org.postgresql>42.6.0</version.org.postgresql>
 
     <version.ch.obermuhlner>2.0.1</version.ch.obermuhlner>
-    <version.io.smallrye.jandex>3.1.2</version.io.smallrye.jandex>
+    <version.io.smallrye.jandex>3.1.6</version.io.smallrye.jandex>
     <version.org.eclipse.yasson>3.0.3</version.org.eclipse.yasson>
 
     <version.com.github.javaparser>3.25.3</version.com.github.javaparser>

--- a/build-parent/pom.xml
+++ b/build-parent/pom.xml
@@ -121,7 +121,7 @@
     <version.jakarta.servlet-api>6.0.0</version.jakarta.servlet-api>
     <version.jakarta.xml.bind-api>4.0.0</version.jakarta.xml.bind-api>
     <version.jakarta.json.bind-api>3.0.0</version.jakarta.json.bind-api>
-    <version.jakarta.json>1.1.6</version.jakarta.json>
+    <version.jakarta.json>1.1.5</version.jakarta.json>
     <version.jakarta.json-api>2.1.2</version.jakarta.json-api>
     <version.org.jpmml.model>1.6.4</version.org.jpmml.model> <!-- jpmml-model BSD 3C license - ATTENTION 1.5.1 intentional, because 1.5.1 evaluators works with 1.5.1 -->
     <version.org.junit>5.9.3</version.org.junit>


### PR DESCRIPTION
Tracker: https://github.com/apache/incubator-kie-issues/issues/913

Aligns with Quarkus 3.2.10.Final and the dependency upgrades in the new release. 