### PR TITLE
[incubator-kie-drools#5700] [new-parser] Can't use single-quoted Stri…

### DIFF
--- a/drools-drl/drools-drl-parser-tests/src/test/java/org/drools/drl/parser/antlr4/MiscDRLParserTest.java
+++ b/drools-drl/drools-drl-parser-tests/src/test/java/org/drools/drl/parser/antlr4/MiscDRLParserTest.java
@@ -3449,7 +3449,6 @@ class MiscDRLParserTest {
                 "    $s : String()\n" +
                 "then\n" +
                 "    delete($s);end\n"; // no space after semicolon
-
         PackageDescr packageDescr = parser.parse(text );
 
         RuleDescr ruleDescr = packageDescr.getRules().get(0);
@@ -3464,9 +3463,6 @@ class MiscDRLParserTest {
                 "    $p : Person()\n" +
                 "then\n" +
                 "    modify($p) { setAge(2) }end\n"; // no space after right brace
-
-        System.out.println(text);
-
         PackageDescr packageDescr = parser.parse(text );
 
         RuleDescr ruleDescr = packageDescr.getRules().get(0);
@@ -3481,12 +3477,47 @@ class MiscDRLParserTest {
                 "    $p : Person()\n" +
                 "then\n" +
                 "    retract($p)end\n"; // no space after right parenthesis
-
-        System.out.println(text);
-
-        PackageDescr packageDescr = parser.parse(text );
+        PackageDescr packageDescr = parser.parse(text);
 
         RuleDescr ruleDescr = packageDescr.getRules().get(0);
         assertThat(ruleDescr.getConsequence().toString()).isEqualToIgnoringWhitespace("retract($p)");
+    }
+
+    @Test
+    void singleQuoteInRhsWithSpace() {
+        String consequence = getResultConsequence("    System.out.println( 'singleQuoteInRhs' );\n");
+        assertThat(consequence)
+                .as("Single quote should be converted to double quote")
+                .isEqualToIgnoringWhitespace("System.out.println( \"singleQuoteInRhs\" );");
+    }
+
+    @Test
+    void singleQuoteInRhsWithoutSpace() {
+        String consequence = getResultConsequence("    System.out.println('singleQuoteInRhs');\n");
+        assertThat(consequence)
+                .as("Single quote should be converted to double quote")
+                .isEqualToIgnoringWhitespace("System.out.println( \"singleQuoteInRhs\" );");
+    }
+
+    @Test
+    void singleQuoteInDoubleQuoteInRhsWithoutSpace() {
+        String consequence = getResultConsequence("    System.out.println(\"There is '\" + $s + \"' in the workspace.\");\n");
+        assertThat(consequence)
+                .as("Single quote should not be converted to double quote in case of inside double quotes")
+                .isEqualToIgnoringWhitespace("System.out.println(\"There is '\" + $s + \"' in the workspace.\");");
+    }
+
+    private String getResultConsequence(String rhs) {
+        final String text = "package org.drools\n" +
+                "rule X\n" +
+                "when\n" +
+                "    $s : String()\n" +
+                "then\n" +
+                rhs +
+                "end\n";
+        PackageDescr packageDescr = parser.parse(text);
+
+        RuleDescr ruleDescr = packageDescr.getRules().get(0);
+        return ruleDescr.getConsequence().toString();
     }
 }

--- a/drools-drl/drools-drl-parser/src/main/antlr4/org/drools/drl/parser/antlr4/DRLLexer.g4
+++ b/drools-drl/drools-drl-parser/src/main/antlr4/org/drools/drl/parser/antlr4/DRLLexer.g4
@@ -158,9 +158,21 @@ DrlUnicodeEscape
 mode RHS;
 RHS_WS : [ \t\r\n\u000C]+ -> channel(HIDDEN);
 DRL_RHS_END : 'end' [ \t]* SEMI? [ \t]* ('\n' | '\r\n' | EOF) {setText("end");} -> popMode;
+
+RHS_STRING_LITERAL
+      // cannot reuse DRL_STRING_LITERAL because Actions are ignored in referenced rules
+    : ('"' ( DrlEscapeSequence | ~('\\'|'"') )* '"')
+    | ('\'' ( DrlEscapeSequence | ~('\\'|'\'') )* '\'') { setText( normalizeString( getText() ) ); }
+    ;
+
 RHS_CHUNK
-    : ~[ ;})\t\r\n\u000C]+ [;})]? // ; } ) could be a delimitter proceding 'end'
-    | SEMI
-    | RBRACE
+    : ~[ ()[\]{},;\t\r\n\u000C]+ // ;}) could be a delimitter proceding 'end'. ()[]{},; are delimiters to match RHS_STRING_LITERAL
+    | LPAREN
     | RPAREN
+    | LBRACK
+    | RBRACK
+    | LBRACE
+    | RBRACE
+    | COMMA
+    | SEMI
     ;

--- a/drools-drl/drools-drl-parser/src/main/antlr4/org/drools/drl/parser/antlr4/DRLParser.g4
+++ b/drools-drl/drools-drl-parser/src/main/antlr4/org/drools/drl/parser/antlr4/DRLParser.g4
@@ -428,7 +428,7 @@ lhsAccumulate : (DRL_ACCUMULATE|DRL_ACC) LPAREN lhsAndDef (COMMA|SEMI)
 
 rhs : DRL_THEN consequence ;
 
-consequence : RHS_CHUNK* ;
+consequence : ( RHS_STRING_LITERAL | RHS_CHUNK )* ;
 
 stringId : ( IDENTIFIER | DRL_STRING_LITERAL ) ;
 

--- a/drools-drl/drools-drl-parser/src/main/java/org/drools/drl/parser/antlr4/DRLVisitorImpl.java
+++ b/drools-drl/drools-drl-parser/src/main/java/org/drools/drl/parser/antlr4/DRLVisitorImpl.java
@@ -263,7 +263,7 @@ public class DRLVisitorImpl extends DRLParserBaseVisitor<Object> {
 
         if (ctx.rhs() != null) {
             ruleDescr.setConsequenceLocation(ctx.rhs().getStart().getLine(), ctx.rhs().getStart().getCharPositionInLine()); // location of "then"
-            ruleDescr.setConsequence(trimThen(getTextPreservingWhitespace(ctx.rhs()))); // RHS is just a text
+            ruleDescr.setConsequence(trimThen(getTokenTextPreservingWhitespace(ctx.rhs(), tokenStream))); // RHS is just a text
         }
 
         return ruleDescr;


### PR DESCRIPTION
…ngs in RHS

**Issue:**
- #5700

With this PR, `org.drools.model.codegen.execmodel.CompilerTest#testPrettyPrinterCrashing` is fixed.

`org.drools.model.codegen.execmodel.RuleAttributesTest#testCrossNoLoopWithNodeSharing` issue is also fixed, but another issue hit in the same test. It will be addressed in a separate issue -> https://github.com/apache/incubator-kie-drools/issues/5727