### PR TITLE
use correct vfs path 'contents'

### DIFF
--- a/drools-compiler/src/main/java/org/drools/compiler/kie/builder/impl/ClasspathKieProject.java
+++ b/drools-compiler/src/main/java/org/drools/compiler/kie/builder/impl/ClasspathKieProject.java
@@ -508,7 +508,7 @@ public class ClasspathKieProject extends AbstractKieProject {
             jarName = jarName.substring(jarName.lastIndexOf('/')+1);
             String jarFolderPath = path.substring( 0, path.length() - ("contents/" + KieModuleModelImpl.KMODULE_JAR_PATH.asString()).length() );
             String jarPath = jarFolderPath + jarName;
-            path = new File(jarPath).exists() ? jarPath : jarFolderPath + "content";
+            path = new File(jarPath).exists() ? jarPath : jarFolderPath + "contents";
         }
         if (path.endsWith("/" + KieModuleModelImpl.KMODULE_FILE_NAME)) {
             return path.substring( 0, path.length() - ("/" + KieModuleModelImpl.KMODULE_JAR_PATH.asString()).length() );


### PR DESCRIPTION
Since Wildfly 31.0.0 we encountered the following problem:
```
ERROR [org.drools.compiler.kie.builder.impl.ClasspathKieProject] (EJB async-pool - 3) [Usr#] Unable to build index of kmodule.xml url=vfs:/.../wildfly-31.0.0.Final/standalone/deployments/.../META-INF/kmodule.xml
Unable to get all ZipFile entries: ...\wildfly-31.0.0.Final\standalone\tmp\vfs\deployment\deploymentedb670f3fadfd5b0\...\content



Caused by: java.lang.RuntimeException: Cannot find a default KieSession
	at deployment.BisonProcess.ear//org.drools.compiler.kie.builder.impl.KieContainerImpl.findKieSessionModel(KieContainerImpl.java:557)
	at deployment.BisonProcess.ear//org.drools.compiler.kie.builder.impl.KieContainerImpl.newKieSession(KieContainerImpl.java:600)
	at deployment.BisonProcess.ear//org.drools.compiler.kie.builder.impl.KieContainerImpl.newKieSession(KieContainerImpl.java:530)
	at deployment.BisonProcess.ear//org.drools.compiler.kie.builder.impl.KieContainerImpl.newKieSession(KieContainerImpl.java:513)
```

Seems that the problem comes from the typo in the fixed typed vfs lookup path.
After changing it to 'contents' it works well!