### PR TITLE
[incubator-kie-issues#968] Support ConditionalExpr in Drools executable model

### DIFF
--- a/drools-model/drools-model-codegen/src/main/java/org/drools/model/codegen/execmodel/generator/expressiontyper/ExpressionTyper.java
+++ b/drools-model/drools-model-codegen/src/main/java/org/drools/model/codegen/execmodel/generator/expressiontyper/ExpressionTyper.java
@@ -44,6 +44,7 @@ import com.github.javaparser.ast.expr.BinaryExpr.Operator;
 import com.github.javaparser.ast.expr.CastExpr;
 import com.github.javaparser.ast.expr.CharLiteralExpr;
 import com.github.javaparser.ast.expr.ClassExpr;
+import com.github.javaparser.ast.expr.ConditionalExpr;
 import com.github.javaparser.ast.expr.DoubleLiteralExpr;
 import com.github.javaparser.ast.expr.EnclosedExpr;
 import com.github.javaparser.ast.expr.Expression;
@@ -378,6 +379,10 @@ public class ExpressionTyper {
                 }
             }
             return of(new TypedExpression(drlxExpr, type));
+        }
+
+        if (drlxExpr instanceof ConditionalExpr) {
+            return of(new TypedExpression(drlxExpr, Boolean.class));
         }
 
         if (drlxExpr.isAssignExpr()) {

--- a/drools-model/drools-model-codegen/src/test/java/org/drools/model/codegen/execmodel/ConditionalExprTest.java
+++ b/drools-model/drools-model-codegen/src/test/java/org/drools/model/codegen/execmodel/ConditionalExprTest.java
@@ -1,0 +1,87 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.drools.model.codegen.execmodel;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.drools.model.codegen.execmodel.domain.Person;
+import org.junit.Before;
+import org.junit.Test;
+import org.kie.api.runtime.KieSession;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class ConditionalExprTest extends BaseModelTest {
+
+    private static final String RULE_STRING = "package constraintexpression\n" +
+            "\n" +
+            "import " + Person.class.getCanonicalName() + "\n" +
+            "import java.util.List; \n" +
+            "global List<Boolean> booleanListGlobal; \n" +
+            "rule \"r1\"\n" +
+            "when \n" +
+            "    $p : Person($booleanVariable: (name != null ? true : false))\n" +
+            "then \n" +
+            "    System.out.println($booleanVariable); \n" +
+            "    System.out.println($p); \n" +
+            "    booleanListGlobal.add($booleanVariable); \n " +
+            "end \n";
+
+    private KieSession ksession;
+    private List<Boolean> booleanListGlobal;
+
+    public ConditionalExprTest(RUN_TYPE testRunType) {
+        super(testRunType);
+    }
+
+    @Before
+    public void setup() {
+        ksession = getKieSession(RULE_STRING);
+        booleanListGlobal = new ArrayList<>();
+        ksession.setGlobal("booleanListGlobal", booleanListGlobal);
+    }
+
+    @Test
+    public void testConditionalExpressionWithNamedPerson() {
+        try {
+            Person person = new Person("someName");
+            ksession.insert(person);
+            int rulesFired = ksession.fireAllRules();
+            assertThat(rulesFired).isEqualTo(1);
+            assertThat(booleanListGlobal).isNotEmpty().containsExactly(Boolean.TRUE);
+        } finally {
+            ksession.dispose();
+        }
+    }
+
+    @Test
+    public void testConditionalExpressionWithUnnamedPerson() {
+        try {
+            Person person = new Person();
+            ksession.insert(person);
+            int rulesFired = ksession.fireAllRules();
+            assertThat(rulesFired).isEqualTo(1);
+            assertThat(booleanListGlobal).isNotEmpty().containsExactly(Boolean.FALSE);
+        } finally {
+            ksession.dispose();
+        }
+    }
+
+}


### PR DESCRIPTION
Fixes https://github.com/apache/incubator-kie-issues/issues/968


Note: this is the `when` condition used as example
` $p : Person($booleanVariable: (name != null ? true : false))`

In both kind of executions (legacy vs executablemodel) the condition that populate the `$booleanVariable` is ignored for the evaluation of the rule, it is used only for the population of the variable itself


<details>
<summary>
How to replicate CI configuration locally?
</summary>

Build Chain tool does "simple" maven build(s), the builds are just Maven commands, but because the repositories relates and depends on each other and any change in API or class method could affect several of those repositories there is a need to use [build-chain tool](https://github.com/kiegroup/github-action-build-chain) to handle cross repository builds and be sure that we always use latest version of the code for each repository.
 
[build-chain tool](https://github.com/kiegroup/github-action-build-chain) is a build tool which can be used on command line locally or in Github Actions workflow(s), in case you need to change multiple repositories and send multiple dependent pull requests related with a change you can easily reproduce the same build by executing it on Github hosted environment or locally in your development environment. See [local execution](https://github.com/kiegroup/github-action-build-chain#local-execution) details to get more information about it.
</details>

<details>
<summary>
How to retest this PR or trigger a specific build:
</summary>

- for <b>pull request and downstream checks</b>  
  - Push a new commit to the PR. An empty commit would be enough.

- for a <b>full downstream build</b>
  - for <b>github actions</b> job: add the label `run_fdb`

- for <b>Jenkins PR check only</b>
  - If you are an ASF committer for KIE podling, login to Jenkins (https://ci-builds.apache.org/job/KIE/job/drools/), go to the specific PR job, and click on `Build Now` button.
</details>
