### PR TITLE
[new-parser] Fix minor issues in the new parser

### DIFF
--- a/drools-compiler/src/main/java/org/drools/compiler/lang/DescrDumper.java
+++ b/drools-compiler/src/main/java/org/drools/compiler/lang/DescrDumper.java
@@ -138,7 +138,7 @@ public class DescrDumper extends ReflectiveVisitor implements ExpressionRewriter
     }
 
     private void processConstraint(StringBuilder sbuilder, ExprConstraintDescr base, boolean isInsideRelCons, DumperContext context) {
-        DrlExprParser expr = DrlExprParserFactory.getDrlExrParser(context.getRuleContext().getConfiguration().getOption(LanguageLevelOption.KEY));
+        DrlExprParser expr = DrlExprParserFactory.getDrlExprParser(context.getRuleContext().getConfiguration().getOption(LanguageLevelOption.KEY));
         ConstraintConnectiveDescr result = expr.parse( base.getExpression() );
         if ( result.getDescrs().size() == 1 ) {
             dump( sbuilder,

--- a/drools-compiler/src/main/java/org/drools/compiler/rule/builder/PatternBuilder.java
+++ b/drools-compiler/src/main/java/org/drools/compiler/rule/builder/PatternBuilder.java
@@ -1803,7 +1803,7 @@ public class PatternBuilder implements RuleConditionBuilder<PatternDescr> {
                                                         final PatternDescr patternDescr,
                                                         final BaseDescr original,
                                                         final String expression) {
-        DrlExprParser parser = DrlExprParserFactory.getDrlExrParser(context.getConfiguration().getOption(LanguageLevelOption.KEY));
+        DrlExprParser parser = DrlExprParserFactory.getDrlExprParser(context.getConfiguration().getOption(LanguageLevelOption.KEY));
         ConstraintConnectiveDescr result = parser.parse(normalizeEval(expression));
         result.setResource(patternDescr.getResource());
         result.copyLocation(original);

--- a/drools-compiler/src/main/java/org/drools/compiler/rule/builder/QueryElementBuilder.java
+++ b/drools-compiler/src/main/java/org/drools/compiler/rule/builder/QueryElementBuilder.java
@@ -69,7 +69,7 @@ public class QueryElementBuilder
                                        BaseDescr descr ) {
         throw new UnsupportedOperationException();
     }
-    
+
     public RuleConditionElement build( RuleBuildContext context,
                                        BaseDescr descr,
                                        Pattern prefixPattern ) {
@@ -265,7 +265,7 @@ public class QueryElementBuilder
             } else {
                 // it must be a literal/expression
                 // it's an expression and thus an input
-                DrlExprParser parser = DrlExprParserFactory.getDrlExrParser(context.getConfiguration().getOption(LanguageLevelOption.KEY));
+                DrlExprParser parser = DrlExprParserFactory.getDrlExprParser(context.getConfiguration().getOption(LanguageLevelOption.KEY));
                 ConstraintConnectiveDescr bresult = parser.parse( bind.getExpression() );
                 if ( parser.hasErrors() ) {
                     for ( DroolsParserException error : parser.getErrors() ) {
@@ -396,7 +396,7 @@ public class QueryElementBuilder
     private ConstraintConnectiveDescr parseExpression( final RuleBuildContext context,
                                                        final PatternDescr patternDescr,
                                                        final String expression ) {
-        DrlExprParser parser = DrlExprParserFactory.getDrlExrParser( context.getConfiguration().getOption(LanguageLevelOption.KEY));
+        DrlExprParser parser = DrlExprParserFactory.getDrlExprParser( context.getConfiguration().getOption(LanguageLevelOption.KEY));
         ConstraintConnectiveDescr result = parser.parse( expression );
         if ( result == null || parser.hasErrors() ) {
             for ( DroolsParserException error : parser.getErrors() ) {

--- a/drools-drl/drools-drl-parser-tests/src/test/java/org/drools/drl/parser/antlr4/MiscDRLParserTest.java
+++ b/drools-drl/drools-drl-parser-tests/src/test/java/org/drools/drl/parser/antlr4/MiscDRLParserTest.java
@@ -3115,7 +3115,7 @@ class MiscDRLParserTest {
 
     @Test
     public void parse_FromFollowedByQuery() throws Exception {
-        // the 'from' expression requires a ";" to disambiguate the "?" 
+        // the 'from' expression requires a ";" to disambiguate the "?"
         // prefix for queries from the ternary operator "? :"
         final String text = "rule X when Cheese() from $cheesery ?person( \"Mark\", 42; ) then end";
         RuleDescr rule = parseAndGetFirstRuleDescr(
@@ -3135,7 +3135,7 @@ class MiscDRLParserTest {
 
     @Test
     public void parse_FromWithTernaryFollowedByQuery() throws Exception {
-        // the 'from' expression requires a ";" to disambiguate the "?" 
+        // the 'from' expression requires a ";" to disambiguate the "?"
         // prefix for queries from the ternary operator "? :"
         final String text = "rule X when Cheese() from (isFull ? $cheesery : $market) ?person( \"Mark\", 42; ) then end";
         RuleDescr rule = parseAndGetFirstRuleDescr(
@@ -3521,6 +3521,7 @@ class MiscDRLParserTest {
         return ruleDescr.getConsequence().toString();
     }
 
+    @Test
     void ruleDescrProperties() {
         final String text = "package org.drools\n" +
                 "rule R1\n" +

--- a/drools-drl/drools-drl-parser/src/main/java/org/drools/drl/parser/DrlExprParserFactory.java
+++ b/drools-drl/drools-drl-parser/src/main/java/org/drools/drl/parser/DrlExprParserFactory.java
@@ -5,7 +5,7 @@ import org.kie.internal.builder.conf.LanguageLevelOption;
 
 public class DrlExprParserFactory {
 
-    public static DrlExprParser getDrlExrParser(LanguageLevelOption languageLevel) {
+    public static DrlExprParser getDrlExprParser(LanguageLevelOption languageLevel) {
         switch (languageLevel) {
             case DRL5:
             case DRL6:

--- a/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/compiler/lang/DRLExprParserTest.java
+++ b/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/compiler/lang/DRLExprParserTest.java
@@ -43,7 +43,7 @@ public class DRLExprParserTest {
     @Before
     public void setUp() throws Exception {
         new EvaluatorRegistry();
-        this.parser = DrlExprParserFactory.getDrlExrParser(LanguageLevelOption.DRL6);
+        this.parser = DrlExprParserFactory.getDrlExprParser(LanguageLevelOption.DRL6);
     }
 
     @After
@@ -182,7 +182,7 @@ public class DRLExprParserTest {
 
         AtomicExprDescr right = (AtomicExprDescr) rel.getRight();
         assertThat(right.getExpression()).isEqualTo("value");
-        
+
         rel = (RelationalExprDescr) result.getDescrs().get( 1 );
         assertThat(rel.getOperator()).isEqualTo("<");
 

--- a/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/compiler/lang/DescrDumperTest.java
+++ b/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/compiler/lang/DescrDumperTest.java
@@ -359,7 +359,7 @@ public class DescrDumperTest {
     }
 
     public ConstraintConnectiveDescr parse( final String constraint ) {
-        DrlExprParser parser = DrlExprParserFactory.getDrlExrParser(LanguageLevelOption.DRL6);
+        DrlExprParser parser = DrlExprParserFactory.getDrlExprParser(LanguageLevelOption.DRL6);
         ConstraintConnectiveDescr result = parser.parse( constraint );
         assertThat(parser.hasErrors()).as(parser.getErrors().toString()).isFalse();
 

--- a/drools-verifier/drools-verifier-drl/src/main/java/org/drools/verifier/visitor/ExprConstraintDescrVisitor.java
+++ b/drools-verifier/drools-verifier-drl/src/main/java/org/drools/verifier/visitor/ExprConstraintDescrVisitor.java
@@ -58,7 +58,7 @@ public class ExprConstraintDescrVisitor {
 
     public void visit(ExprConstraintDescr descr) {
 
-        DrlExprParser drlExprParser = DrlExprParserFactory.getDrlExrParser(LanguageLevelOption.DRL5);
+        DrlExprParser drlExprParser = DrlExprParserFactory.getDrlExprParser(LanguageLevelOption.DRL5);
         ConstraintConnectiveDescr constraintConnectiveDescr = drlExprParser.parse(descr.getExpression());
 
         visit(constraintConnectiveDescr.getDescrs());


### PR DESCRIPTION
- Missing `@Test` annotation that was accidentally removed during conflict resolution.
- Typo in a method name.