### PR TITLE
[new-parser] Fix super_key failed predicate

### DIFF
--- a/drools-drl/drools-drl-parser-tests/src/test/java/org/drools/drl/parser/antlr4/DRLExprParserTest.java
+++ b/drools-drl/drools-drl-parser-tests/src/test/java/org/drools/drl/parser/antlr4/DRLExprParserTest.java
@@ -268,4 +268,42 @@ public class DRLExprParserTest {
         assertThat(left.getExpression()).isEqualTo("a");
         assertThat(right.getExpression()).isEqualTo("b");
     }
+
+    @Test
+    public void selector_dot_super() {
+        String source = "SomeClass.super.getData() != null";
+        ConstraintConnectiveDescr result = parser.parse( source );
+        assertThat(parser.hasErrors()).as(parser.getErrors().toString()).isFalse();
+
+        assertThat(result.getConnective()).isEqualTo(ConnectiveType.AND);
+        assertThat(result.getDescrs().size()).isEqualTo(1);
+
+        RelationalExprDescr expr = (RelationalExprDescr) result.getDescrs().get( 0 );
+        assertThat(expr.getOperator()).isEqualTo("!=");
+
+        AtomicExprDescr left = (AtomicExprDescr) expr.getLeft();
+        AtomicExprDescr right = (AtomicExprDescr) expr.getRight();
+
+        assertThat(left.getExpression()).isEqualTo("SomeClass.super.getData()");
+        assertThat(right.getExpression()).isEqualTo("null");
+    }
+
+    @Test
+    public void selector_dot_identifier() {
+        String source = "getAddress().getCity().length() == 5";
+        ConstraintConnectiveDescr result = parser.parse( source );
+        assertThat(parser.hasErrors()).as(parser.getErrors().toString()).isFalse();
+
+        assertThat(result.getConnective()).isEqualTo(ConnectiveType.AND);
+        assertThat(result.getDescrs().size()).isEqualTo(1);
+
+        RelationalExprDescr expr = (RelationalExprDescr) result.getDescrs().get( 0 );
+        assertThat(expr.getOperator()).isEqualTo("==");
+
+        AtomicExprDescr left = (AtomicExprDescr) expr.getLeft();
+        AtomicExprDescr right = (AtomicExprDescr) expr.getRight();
+
+        assertThat(left.getExpression()).isEqualTo("getAddress().getCity().length()");
+        assertThat(right.getExpression()).isEqualTo("5");
+    }
 }

--- a/drools-drl/drools-drl-parser/src/main/antlr4/org/drools/drl/parser/antlr4/DRL6Expressions.g4
+++ b/drools-drl/drools-drl-parser/src/main/antlr4/org/drools/drl/parser/antlr4/DRL6Expressions.g4
@@ -774,7 +774,7 @@ extends_key
     ;
 
 super_key
-    :      {(helper.validateIdentifierKey(DroolsSoftKeywords.SUPER))}? id=IDENTIFIER { helper.emit($id, DroolsEditorType.KEYWORD); }
+    :      {(helper.validateIdentifierKey(DroolsSoftKeywords.SUPER))}? id=SUPER { helper.emit($id, DroolsEditorType.KEYWORD); }
     ;
 
 instanceof_key


### PR DESCRIPTION
## How it works on `main`

This is how the `selector` rule and its first alternative looks like in the old parser:

```
selector
    :   (DOT super_key)=>DOT { helper.emit($DOT, DroolsEditorType.SYMBOL); } super_key superSuffix
    |   ...
```

The whole first alternative is guarded by a syntactic predicate that is used to make the decision whether this alternative is viable. The syntactic predicate relies on the `super_key` rule, which looks like this:

```
super_key
    : {(helper.validateIdentifierKey(DroolsSoftKeywords.SUPER))}? id=IDENTIFIER { helper.emit($id, DroolsEditorType.KEYWORD); }
```

If the next token is not `super`, `validateIdentifierKey()` will evaluate to `false`, rendering the first alternative of the `selector` rule non-viable.

## What is the problem on the `dev-new-parser` branch?

Syntactic predicates were removed in ANTLR 4 so the `selector` rule became:

```
selector
    :   DOT { helper.emit($DOT, DroolsEditorType.SYMBOL); } super_key superSuffix
    |   ...
```

The semantic predicate `{(helper.validateIdentifierKey(DroolsSoftKeywords.SUPER))}?` now cannot be used to make the decision about the viability of the first alternative because it is now "invisible". See https://github.com/antlr/antlr4/blob/master/doc/predicates.md#finding-visible-predicates that explains how predicates can become invisible. The thing that makes the predicate invisible here is the action after DOT. And since the `super_key` rule matches the `IDENTIFIER` type of token, this alternative seems viable and the parser takes it even if the next token is not `super`.

When the decision has been made and the alternative is taken, the parser executes the action after `DOT` and the semantic predicate inside `super_key` is no longer invisible. It is now evaluated as well. But if the next token is not `super` it evaluates to false, which is an error condition because there is no other alternative inside `super_key`.

The fix is to replace the `IDENTIFIER` token type with `SUPER`.

Fixes https://github.com/apache/incubator-kie-drools/issues/5703.