### PR TITLE
[new-parser] Fix the rest of the keywords

### DIFF
--- a/drools-drl/drools-drl-parser-tests/pom.xml
+++ b/drools-drl/drools-drl-parser-tests/pom.xml
@@ -56,6 +56,11 @@
             <scope>test</scope>
         </dependency>
         <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-params</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
             <groupId>ch.qos.logback</groupId>
             <artifactId>logback-classic</artifactId>
             <scope>test</scope>

--- a/drools-drl/drools-drl-parser/src/main/antlr4/org/drools/drl/parser/antlr4/DRL6Expressions.g4
+++ b/drools-drl/drools-drl-parser/src/main/antlr4/org/drools/drl/parser/antlr4/DRL6Expressions.g4
@@ -770,72 +770,72 @@ assignmentOperator
 //                      KEYWORDS
 // --------------------------------------------------------
 extends_key
-    :      {(helper.validateIdentifierKey(DroolsSoftKeywords.EXTENDS))}? id=IDENTIFIER { helper.emit($id, DroolsEditorType.KEYWORD); }
+    : id=EXTENDS { helper.emit($id, DroolsEditorType.KEYWORD); }
     ;
 
 super_key
-    :      {(helper.validateIdentifierKey(DroolsSoftKeywords.SUPER))}? id=SUPER { helper.emit($id, DroolsEditorType.KEYWORD); }
+    : id=SUPER { helper.emit($id, DroolsEditorType.KEYWORD); }
     ;
 
 instanceof_key
-    :      {(helper.validateIdentifierKey(DroolsSoftKeywords.INSTANCEOF))}? id=IDENTIFIER { helper.emit($id, DroolsEditorType.KEYWORD); }
+    : id=INSTANCEOF { helper.emit($id, DroolsEditorType.KEYWORD); }
     ;
 
 boolean_key
-    :      {(helper.validateIdentifierKey(DroolsSoftKeywords.BOOLEAN))}? id=IDENTIFIER { helper.emit($id, DroolsEditorType.KEYWORD); }
+    : id=BOOLEAN { helper.emit($id, DroolsEditorType.KEYWORD); }
     ;
 
 char_key
-    :      {(helper.validateIdentifierKey(DroolsSoftKeywords.CHAR))}? id=IDENTIFIER { helper.emit($id, DroolsEditorType.KEYWORD); }
+    : id=CHAR { helper.emit($id, DroolsEditorType.KEYWORD); }
     ;
 
 byte_key
-    :      {(helper.validateIdentifierKey(DroolsSoftKeywords.BYTE))}? id=IDENTIFIER { helper.emit($id, DroolsEditorType.KEYWORD); }
+    : id=BYTE { helper.emit($id, DroolsEditorType.KEYWORD); }
     ;
 
 short_key
-    :      {(helper.validateIdentifierKey(DroolsSoftKeywords.SHORT))}? id=IDENTIFIER { helper.emit($id, DroolsEditorType.KEYWORD); }
+    : id=SHORT { helper.emit($id, DroolsEditorType.KEYWORD); }
     ;
 
 int_key
-    :      {(helper.validateIdentifierKey(DroolsSoftKeywords.INT))}? id=IDENTIFIER { helper.emit($id, DroolsEditorType.KEYWORD); }
+    : id=INT { helper.emit($id, DroolsEditorType.KEYWORD); }
     ;
 
 float_key
-    :      {(helper.validateIdentifierKey(DroolsSoftKeywords.FLOAT))}? id=IDENTIFIER { helper.emit($id, DroolsEditorType.KEYWORD); }
+    : id=FLOAT { helper.emit($id, DroolsEditorType.KEYWORD); }
     ;
 
 long_key
-    :      {(helper.validateIdentifierKey(DroolsSoftKeywords.LONG))}? id=IDENTIFIER { helper.emit($id, DroolsEditorType.KEYWORD); }
+    : id=LONG { helper.emit($id, DroolsEditorType.KEYWORD); }
     ;
 
 double_key
-    :      {(helper.validateIdentifierKey(DroolsSoftKeywords.DOUBLE))}? id=IDENTIFIER { helper.emit($id, DroolsEditorType.KEYWORD); }
+    : id=DOUBLE { helper.emit($id, DroolsEditorType.KEYWORD); }
     ;
 
 void_key
-    :      {(helper.validateIdentifierKey(DroolsSoftKeywords.VOID))}? id=IDENTIFIER { helper.emit($id, DroolsEditorType.KEYWORD); }
+    : id=VOID { helper.emit($id, DroolsEditorType.KEYWORD); }
     ;
 
 this_key
-    :      {(helper.validateIdentifierKey(DroolsSoftKeywords.THIS))}? id=IDENTIFIER { helper.emit($id, DroolsEditorType.KEYWORD); }
+    : id=THIS { helper.emit($id, DroolsEditorType.KEYWORD); }
     ;
 
 class_key
-    :      {(helper.validateIdentifierKey(DroolsSoftKeywords.CLASS))}? id=IDENTIFIER  { helper.emit($id, DroolsEditorType.KEYWORD); }
+    : id=CLASS  { helper.emit($id, DroolsEditorType.KEYWORD); }
     ;
 
 new_key
-    :      {(helper.validateIdentifierKey(DroolsSoftKeywords.NEW))}? id=IDENTIFIER { helper.emit($id, DroolsEditorType.KEYWORD); }
+    : id=NEW { helper.emit($id, DroolsEditorType.KEYWORD); }
     ;
 
 not_key
-    :      {(helper.validateIdentifierKey(DroolsSoftKeywords.NOT))}? id=DRL_NOT { helper.emit($id, DroolsEditorType.KEYWORD); }
+    : id=DRL_NOT { helper.emit($id, DroolsEditorType.KEYWORD); }
     ;
 
 in_key
-  :      {(helper.validateIdentifierKey(DroolsSoftKeywords.IN))}? id=DRL_IN { helper.emit($id, DroolsEditorType.KEYWORD); }
-  ;
+    : id=DRL_IN { helper.emit($id, DroolsEditorType.KEYWORD); }
+    ;
 
 operator_key
   // TODO get rid of the DRL_MATCHES token or introduce DRL_CONTAINS etc. for consistency.


### PR DESCRIPTION
Follow up on #5748.

Fixes:
- #5704 (casting to all kinds of primitive types)
- #5721 (`new` keyword)

Now that we're using a specialized token to match each keyword, it's redundant to use `helper.validateIdentifierKey()` so I'm removing that.

<details>
<summary>
How to replicate CI configuration locally?
</summary>

Build Chain tool does "simple" maven build(s), the builds are just Maven commands, but because the repositories relates and depends on each other and any change in API or class method could affect several of those repositories there is a need to use [build-chain tool](https://github.com/kiegroup/github-action-build-chain) to handle cross repository builds and be sure that we always use latest version of the code for each repository.
 
[build-chain tool](https://github.com/kiegroup/github-action-build-chain) is a build tool which can be used on command line locally or in Github Actions workflow(s), in case you need to change multiple repositories and send multiple dependent pull requests related with a change you can easily reproduce the same build by executing it on Github hosted environment or locally in your development environment. See [local execution](https://github.com/kiegroup/github-action-build-chain#local-execution) details to get more information about it.
</details>

<details>
<summary>
How to retest this PR or trigger a specific build:
</summary>

- for <b>pull request and downstream checks</b>  
  - Push a new commit to the PR. An empty commit would be enough.

- for a <b>full downstream build</b>
  - for <b>github actions</b> job: add the label `run_fdb`

- for <b>Jenkins PR check only</b>
  - If you are an ASF committer for KIE podling, login to Jenkins (https://ci-builds.apache.org/job/KIE/job/drools/), go to the specific PR job, and click on `Build Now` button.
</details>
