### PR TITLE
[kie-issues#986] Coerce object to String in executable model codegen

### DIFF
--- a/drools-model/drools-model-codegen/src/main/java/org/drools/model/codegen/execmodel/generator/drlxparse/ArithmeticCoercedExpression.java
+++ b/drools-model/drools-model-codegen/src/main/java/org/drools/model/codegen/execmodel/generator/drlxparse/ArithmeticCoercedExpression.java
@@ -97,15 +97,7 @@ public class ArithmeticCoercedExpression {
         if (!arithmeticOperators.contains(operator)) {
             return false;
         }
-        final Class<?> leftClass = left.getRawClass();
-        final Class<?> rightClass = right.getRawClass();
-        if (leftClass == rightClass) {
-            return false;
-        }
-        if (isNumericClass(leftClass) && isNumericClass(rightClass)) {
-            return false;
-        }
-        return true;
+        return canCoerce(left.getRawClass(), right.getRawClass());
     }
 
     private boolean canCoerce(Class<?> leftClass, Class<?> rightClass) {

--- a/drools-model/drools-model-codegen/src/main/java/org/drools/model/codegen/execmodel/generator/drlxparse/ArithmeticCoercedExpression.java
+++ b/drools-model/drools-model-codegen/src/main/java/org/drools/model/codegen/execmodel/generator/drlxparse/ArithmeticCoercedExpression.java
@@ -46,6 +46,18 @@ public class ArithmeticCoercedExpression {
 
     private static final Set<Operator> arithmeticOperators = new HashSet<>(asList(PLUS, MINUS, MULTIPLY, DIVIDE, REMAINDER));
 
+    public static boolean requiresCoercion(final Operator operator, final TypedExpression left, final TypedExpression right) {
+        if (!arithmeticOperators.contains(operator)) {
+            return false;
+        }
+        return canCoerce(left.getRawClass(), right.getRawClass());
+    }
+
+    private static boolean canCoerce(Class<?> leftClass, Class<?> rightClass) {
+        return leftClass == String.class && isNumericClass(rightClass) ||
+                rightClass == String.class && isNumericClass(leftClass);
+    }
+
     public ArithmeticCoercedExpression(TypedExpression left, TypedExpression right, Operator operator) {
         this.left = left;
         this.right = right;
@@ -57,10 +69,6 @@ public class ArithmeticCoercedExpression {
      * BigDecimal arithmetic operation is handled by ExpressionTyper.convertArithmeticBinaryToMethodCall()
      */
     public ArithmeticCoercedExpressionResult coerce() {
-
-        if (!requiresCoercion()) {
-            return new ArithmeticCoercedExpressionResult(left, right); // do not coerce
-        }
 
         final Class<?> leftClass = left.getRawClass();
         final Class<?> rightClass = right.getRawClass();
@@ -91,18 +99,6 @@ public class ArithmeticCoercedExpression {
         }
 
         return new ArithmeticCoercedExpressionResult(coercedLeft, coercedRight);
-    }
-
-    private boolean requiresCoercion() {
-        if (!arithmeticOperators.contains(operator)) {
-            return false;
-        }
-        return canCoerce(left.getRawClass(), right.getRawClass());
-    }
-
-    private boolean canCoerce(Class<?> leftClass, Class<?> rightClass) {
-        return leftClass == String.class && isNumericClass(rightClass) ||
-               rightClass == String.class && isNumericClass(leftClass);
     }
 
     private TypedExpression coerceToDouble(TypedExpression typedExpression) {

--- a/drools-model/drools-model-codegen/src/main/java/org/drools/model/codegen/execmodel/generator/expressiontyper/ExpressionTyper.java
+++ b/drools-model/drools-model-codegen/src/main/java/org/drools/model/codegen/execmodel/generator/expressiontyper/ExpressionTyper.java
@@ -226,16 +226,18 @@ public class ExpressionTyper {
             TypedExpression right = optRight.get();
 
             // Coerce number and string if needed.
-            ArithmeticCoercedExpression.ArithmeticCoercedExpressionResult coerced;
-            try {
-                coerced = new ArithmeticCoercedExpression(left, right, operator).coerce();
-            } catch (ArithmeticCoercedExpression.ArithmeticCoercedExpressionException e) {
-                logger.error("Failed to coerce : {}", e.getInvalidExpressionErrorResult());
-                return empty();
-            }
+            if (ArithmeticCoercedExpression.requiresCoercion(operator, left, right)) {
+                ArithmeticCoercedExpression.ArithmeticCoercedExpressionResult coerced;
+                try {
+                    coerced = new ArithmeticCoercedExpression(left, right, operator).coerce();
+                } catch (ArithmeticCoercedExpression.ArithmeticCoercedExpressionException e) {
+                    logger.error("Failed to coerce : {}", e.getInvalidExpressionErrorResult());
+                    return empty();
+                }
 
-            left = coerced.getCoercedLeft();
-            right = coerced.getCoercedRight();
+                left = coerced.getCoercedLeft();
+                right = coerced.getCoercedRight();
+            }
 
             final BinaryExpr combo = new BinaryExpr(left.getExpression(), right.getExpression(), operator);
 

--- a/drools-model/drools-model-codegen/src/main/java/org/drools/model/codegen/execmodel/generator/expressiontyper/ExpressionTyper.java
+++ b/drools-model/drools-model-codegen/src/main/java/org/drools/model/codegen/execmodel/generator/expressiontyper/ExpressionTyper.java
@@ -225,19 +225,17 @@ public class ExpressionTyper {
             TypedExpression left = optLeft.get();
             TypedExpression right = optRight.get();
 
-            // Can be a binary expression of non-numeric types, like String + customType, etc.
-            if (ClassUtils.isNumericClass(left.getRawClass()) || ClassUtils.isNumericClass(right.getRawClass())) {
-                ArithmeticCoercedExpression.ArithmeticCoercedExpressionResult coerced;
-                try {
-                    coerced = new ArithmeticCoercedExpression(left, right, operator).coerce();
-                } catch (ArithmeticCoercedExpression.ArithmeticCoercedExpressionException e) {
-                    logger.error("Failed to coerce : {}", e.getInvalidExpressionErrorResult());
-                    return empty();
-                }
-
-                left = coerced.getCoercedLeft();
-                right = coerced.getCoercedRight();
+            // Coerce number and string if needed.
+            ArithmeticCoercedExpression.ArithmeticCoercedExpressionResult coerced;
+            try {
+                coerced = new ArithmeticCoercedExpression(left, right, operator).coerce();
+            } catch (ArithmeticCoercedExpression.ArithmeticCoercedExpressionException e) {
+                logger.error("Failed to coerce : {}", e.getInvalidExpressionErrorResult());
+                return empty();
             }
+
+            left = coerced.getCoercedLeft();
+            right = coerced.getCoercedRight();
 
             final BinaryExpr combo = new BinaryExpr(left.getExpression(), right.getExpression(), operator);
 

--- a/drools-model/drools-model-codegen/src/test/java/org/drools/model/codegen/execmodel/NumberAndStringArithmeticOperationCoercionTest.java
+++ b/drools-model/drools-model-codegen/src/test/java/org/drools/model/codegen/execmodel/NumberAndStringArithmeticOperationCoercionTest.java
@@ -26,9 +26,9 @@ import org.kie.api.runtime.KieSession;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-public class ArithmeticCoecionTest extends BaseModelTest {
+public class NumberAndStringArithmeticOperationCoercionTest extends BaseModelTest {
 
-    public ArithmeticCoecionTest(RUN_TYPE testRunType) {
+    public NumberAndStringArithmeticOperationCoercionTest(RUN_TYPE testRunType) {
         super(testRunType);
     }
 

--- a/drools-model/drools-model-codegen/src/test/java/org/drools/model/codegen/execmodel/TypeCoercionTest.java
+++ b/drools-model/drools-model-codegen/src/test/java/org/drools/model/codegen/execmodel/TypeCoercionTest.java
@@ -612,4 +612,30 @@ public class TypeCoercionTest extends BaseModelTest {
         assertThat(list.size()).isEqualTo(1);
         assertThat(list.get(0)).isEqualTo("Mario");
     }
+
+    @Test
+    public void testCoerceObjectToString() {
+        String str = "package constraintexpression\n" +
+                "\n" +
+                "import " + Person.class.getCanonicalName() + "\n" +
+                "import java.util.List; \n" +
+                "rule \"r1\"\n" +
+                "when \n" +
+                "    $p: Person() \n" +
+                "    String(this == \"someString\" + $p)\n" +
+                "then \n" +
+                "    System.out.println($p); \n" +
+                "end \n";
+
+        KieSession ksession = getKieSession(str);
+        try {
+            Person person = new Person("someName");
+            ksession.insert(person);
+            ksession.insert(new String("someStringsomeName"));
+            int rulesFired = ksession.fireAllRules();
+            assertThat(rulesFired).isEqualTo(1);
+        } finally {
+            ksession.dispose();
+        }
+    }
 }

--- a/drools-util/src/main/java/org/drools/util/Pair.java
+++ b/drools-util/src/main/java/org/drools/util/Pair.java
@@ -1,0 +1,28 @@
+package org.drools.util;
+
+public class Pair<K, V> {
+
+    private final K left;
+    private final V right;
+
+    public Pair(K k, V v) {
+        this.left = k;
+        this.right = v;
+    }
+
+    public K getLeft() {
+        return left;
+    }
+
+    public V getRight() {
+        return right;
+    }
+
+    public boolean hasLeft() {
+        return left != null;
+    }
+
+    public boolean hasRight() {
+        return right != null;
+    }
+}


### PR DESCRIPTION
Fixes https://github.com/apache/incubator-kie-issues/issues/986

For binary expression, only numeric arithmetic operations were considered during code generation. 