### PR TITLE
[kie-issues#969]: Negated value in accumulate function ends with Invalid expression error

### DIFF
--- a/drools-model/drools-model-codegen/src/main/java/org/drools/model/codegen/execmodel/generator/visitor/accumulate/AccumulateVisitor.java
+++ b/drools-model/drools-model-codegen/src/main/java/org/drools/model/codegen/execmodel/generator/visitor/accumulate/AccumulateVisitor.java
@@ -209,7 +209,7 @@ public class AccumulateVisitor {
         final Expression accumulateFunctionParameter = DrlxParseUtil.parseExpression(accumulateFunctionParameterStr).getExpr();
 
         if (accumulateFunctionParameter instanceof BinaryExpr || accumulateFunctionParameter instanceof UnaryExpr) {
-            return binaryOrUnaryExprParameter(basePattern, function, functionDSL, bindingId, accumulateFunctionParameterStr);
+            return bindingParameter(basePattern, function, functionDSL, bindingId, accumulateFunctionParameterStr);
         }
 
         if (parameterNeedsConvertionToMethodCallExpr(accumulateFunctionParameter)) {
@@ -414,7 +414,7 @@ public class AccumulateVisitor {
         return accumulateFunctionParameter.isMethodCallExpr() || accumulateFunctionParameter.isArrayAccessExpr() || accumulateFunctionParameter.isFieldAccessExpr();
     }
 
-    private Optional<NewBinding> binaryOrUnaryExprParameter(PatternDescr basePattern, AccumulateDescr.AccumulateFunctionCallDescr function, MethodCallExpr functionDSL, String bindingId, String accumulateFunctionParameterStr) {
+    private Optional<NewBinding> bindingParameter(PatternDescr basePattern, AccumulateDescr.AccumulateFunctionCallDescr function, MethodCallExpr functionDSL, String bindingId, String accumulateFunctionParameterStr) {
         final DrlxParseResult parseResult = ConstraintParser.defaultConstraintParser(context, packageModel).drlxParse(Object.class, bindingId, accumulateFunctionParameterStr);
 
         return parseResult.acceptWithReturnValue(new ParseResultVisitor<>() {

--- a/drools-model/drools-model-codegen/src/main/java/org/drools/model/codegen/execmodel/generator/visitor/accumulate/AccumulateVisitor.java
+++ b/drools-model/drools-model-codegen/src/main/java/org/drools/model/codegen/execmodel/generator/visitor/accumulate/AccumulateVisitor.java
@@ -38,6 +38,7 @@ import com.github.javaparser.ast.expr.MethodCallExpr;
 import com.github.javaparser.ast.expr.MethodReferenceExpr;
 import com.github.javaparser.ast.expr.NameExpr;
 import com.github.javaparser.ast.expr.ObjectCreationExpr;
+import com.github.javaparser.ast.expr.UnaryExpr;
 import com.github.javaparser.ast.stmt.BlockStmt;
 import com.github.javaparser.ast.stmt.ExpressionStmt;
 import com.github.javaparser.ast.type.ClassOrInterfaceType;
@@ -184,8 +185,11 @@ public class AccumulateVisitor {
             if ( function.getParams().length == 0 ) {
                 final AccumulateFunction optAccumulateFunction = getAccumulateFunction( function, Object.class );
                 zeroParameterFunction( basePattern, functionDSL, bindingId, optAccumulateFunction );
-            } else {
+            } else if (function.getParams().length == 1) {
                 optNewBinding = parseFirstParameter( basePattern, input, function, functionDSL, bindingId );
+            } else {
+                throw new AccumulateParsingFailedException(
+                        "Function \"" + function.getFunction() + "\" must have one parameter only");
             }
 
             if ( bindingId != null ) {
@@ -204,8 +208,8 @@ public class AccumulateVisitor {
         final String accumulateFunctionParameterStr = function.getParams()[0];
         final Expression accumulateFunctionParameter = DrlxParseUtil.parseExpression(accumulateFunctionParameterStr).getExpr();
 
-        if (accumulateFunctionParameter instanceof BinaryExpr) {
-            return binaryExprParameter(basePattern, function, functionDSL, bindingId, accumulateFunctionParameterStr);
+        if (accumulateFunctionParameter instanceof BinaryExpr || accumulateFunctionParameter instanceof UnaryExpr) {
+            return binaryOrUnaryExprParameter(basePattern, function, functionDSL, bindingId, accumulateFunctionParameterStr);
         }
 
         if (parameterNeedsConvertionToMethodCallExpr(accumulateFunctionParameter)) {
@@ -217,7 +221,11 @@ public class AccumulateVisitor {
         } else if (accumulateFunctionParameter instanceof LiteralExpr) {
             literalExprParameter(basePattern, function, functionDSL, bindingId, accumulateFunctionParameter);
         } else {
-            throw new AccumulateParsingFailedException("Invalid expression " + accumulateFunctionParameterStr);
+            throw new AccumulateParsingFailedException(
+                    "The expression ù\"" + accumulateFunctionParameterStr +
+                    "\" in function \"" + function.getFunction() +
+                    "\" of type \"" + accumulateFunctionParameter.getClass().getSimpleName() +
+                    "\" is not managed in " + this.getClass().getSimpleName());
         }
 
         return Optional.empty();
@@ -406,10 +414,10 @@ public class AccumulateVisitor {
         return accumulateFunctionParameter.isMethodCallExpr() || accumulateFunctionParameter.isArrayAccessExpr() || accumulateFunctionParameter.isFieldAccessExpr();
     }
 
-    private Optional<NewBinding> binaryExprParameter(PatternDescr basePattern, AccumulateDescr.AccumulateFunctionCallDescr function, MethodCallExpr functionDSL, String bindingId, String accumulateFunctionParameterStr) {
+    private Optional<NewBinding> binaryOrUnaryExprParameter(PatternDescr basePattern, AccumulateDescr.AccumulateFunctionCallDescr function, MethodCallExpr functionDSL, String bindingId, String accumulateFunctionParameterStr) {
         final DrlxParseResult parseResult = ConstraintParser.defaultConstraintParser(context, packageModel).drlxParse(Object.class, bindingId, accumulateFunctionParameterStr);
 
-        Optional<NewBinding> optNewBinding = parseResult.acceptWithReturnValue(new ParseResultVisitor<Optional<NewBinding>>() {
+        return parseResult.acceptWithReturnValue(new ParseResultVisitor<>() {
             @Override
             public Optional<NewBinding> onSuccess(DrlxParseSuccess drlxParseResult) {
                 SingleDrlxParseSuccess singleResult = (SingleDrlxParseSuccess) drlxParseResult;
@@ -436,7 +444,6 @@ public class AccumulateVisitor {
                 return Optional.empty();
             }
         });
-        return optNewBinding;
     }
 
     private void zeroParameterFunction(PatternDescr basePattern, MethodCallExpr functionDSL, String bindingId, AccumulateFunction accumulateFunction) {

--- a/drools-model/drools-model-codegen/src/main/java/org/drools/model/codegen/execmodel/generator/visitor/accumulate/AccumulateVisitor.java
+++ b/drools-model/drools-model-codegen/src/main/java/org/drools/model/codegen/execmodel/generator/visitor/accumulate/AccumulateVisitor.java
@@ -189,7 +189,7 @@ public class AccumulateVisitor {
                 optNewBinding = parseFirstParameter( basePattern, input, function, functionDSL, bindingId );
             } else {
                 throw new AccumulateParsingFailedException(
-                        "Function \"" + function.getFunction() + "\" must have one parameter only");
+                        "Function \"" + function.getFunction() + "\" cannot have more than 1 parameter");
             }
 
             if ( bindingId != null ) {

--- a/drools-model/drools-model-codegen/src/main/java/org/drools/model/codegen/execmodel/generator/visitor/accumulate/AccumulateVisitor.java
+++ b/drools-model/drools-model-codegen/src/main/java/org/drools/model/codegen/execmodel/generator/visitor/accumulate/AccumulateVisitor.java
@@ -222,7 +222,7 @@ public class AccumulateVisitor {
             literalExprParameter(basePattern, function, functionDSL, bindingId, accumulateFunctionParameter);
         } else {
             throw new AccumulateParsingFailedException(
-                    "The expression ù\"" + accumulateFunctionParameterStr +
+                    "The expression \"" + accumulateFunctionParameterStr +
                     "\" in function \"" + function.getFunction() +
                     "\" of type \"" + accumulateFunctionParameter.getClass().getSimpleName() +
                     "\" is not managed in " + this.getClass().getSimpleName());

--- a/drools-model/drools-model-codegen/src/test/java/org/drools/model/codegen/execmodel/AccumulateTest.java
+++ b/drools-model/drools-model-codegen/src/test/java/org/drools/model/codegen/execmodel/AccumulateTest.java
@@ -4224,7 +4224,7 @@ public class AccumulateTest extends BaseModelTest {
         if (testRunType.isExecutableModel()) {
             System.out.println(results.getMessages(Message.Level.ERROR).get(0).getText());
             assertThat(results.getMessages(Message.Level.ERROR).get(0).getText().contains(
-                    "Function \"sum\" must have one parameter only")).isTrue();
+                    "Function \"sum\" cannot have more than 1 parameter")).isTrue();
         } else {
             // At this time, this error is thrown with executable model only.
             assertThat(results.getMessages(Message.Level.ERROR).isEmpty()).isTrue();

--- a/drools-model/drools-model-codegen/src/test/java/org/drools/model/codegen/execmodel/AccumulateTest.java
+++ b/drools-model/drools-model-codegen/src/test/java/org/drools/model/codegen/execmodel/AccumulateTest.java
@@ -60,6 +60,8 @@ import org.drools.model.codegen.execmodel.domain.StockTick;
 import org.drools.model.codegen.execmodel.domain.TargetPolicy;
 import org.drools.model.codegen.execmodel.oopathdtables.InternationalAddress;
 import org.junit.Test;
+import org.kie.api.builder.Message;
+import org.kie.api.builder.Results;
 import org.kie.api.definition.type.FactType;
 import org.kie.api.runtime.KieSession;
 import org.kie.api.runtime.rule.AccumulateFunction;
@@ -4203,5 +4205,81 @@ public class AccumulateTest extends BaseModelTest {
         results = getObjectsIntoList(ksession, Result.class);
         assertThat(results.size()).isEqualTo(2);
         assertThat(results).containsExactlyInAnyOrder(new Result(0), new Result(75));
+    }
+
+    @Test
+    public void testAccumulateSumMultipleParametersExpression() {
+        String str =
+                "import " + Person.class.getCanonicalName() + ";" +
+                "import " + Result.class.getCanonicalName() + ";" +
+                "rule X when\n" +
+                "  accumulate ( $i : Integer() and $p: Person ( name.length >= $i ); \n" +
+                "                $sum : sum($p.getAge(), $p.getName())  \n" +
+                "              )                          \n" +
+                "then\n" +
+                "  insert(new Result($sum));\n" +
+                "end";
+
+        Results results = createKieBuilder(str).getResults();
+        if (testRunType.isExecutableModel()) {
+            System.out.println(results.getMessages(Message.Level.ERROR).get(0).getText());
+            assertThat(results.getMessages(Message.Level.ERROR).get(0).getText().contains(
+                    "Function \"sum\" must have one parameter only")).isTrue();
+        } else {
+            // At this time, this error is thrown with executable model only.
+            assertThat(results.getMessages(Message.Level.ERROR).isEmpty()).isTrue();
+        }
+    }
+
+    @Test
+    public void testAccumulateSumUnaryExpression() {
+        String str =
+                "import " + Person.class.getCanonicalName() + ";" +
+                "import " + Result.class.getCanonicalName() + ";" +
+                "rule X when\n" +
+                "  accumulate ( $p: Person ( getName().startsWith(\"M\") ); \n" +
+                "                $sum : sum(-$p.getAge()) \n" +
+                "              )                          \n" +
+                "then\n" +
+                "  insert(new Result($sum));\n" +
+                "end";
+
+        KieSession kieSession = getKieSession( str );
+
+        kieSession.insert(new Person("Mark", 37));
+        kieSession.insert(new Person("Edson", 35));
+        kieSession.insert(new Person("Mario", 40));
+
+        kieSession.fireAllRules();
+
+        Collection<Result> results = getObjectsIntoList(kieSession, Result.class);
+        assertThat(results.size()).isEqualTo(1);
+        assertThat(results.iterator().next().getValue()).isEqualTo(-77);
+    }
+
+    @Test
+    public void testAccumulateSumBinaryExpWithNestedUnaryExpression() {
+        String str =
+                "import " + Person.class.getCanonicalName() + ";" +
+                "import " + Result.class.getCanonicalName() + ";" +
+                "rule X when\n" +
+                "  accumulate ( $p: Person ( getName().startsWith(\"M\") ); \n" +
+                "                $sum : sum(-$p.getAge() + $p.getAge()) \n" +
+                "              )                          \n" +
+                "then\n" +
+                "  insert(new Result($sum));\n" +
+                "end";
+
+        KieSession kieSession = getKieSession( str );
+
+        kieSession.insert(new Person("Mark", 37));
+        kieSession.insert(new Person("Edson", 35));
+        kieSession.insert(new Person("Mario", 40));
+
+        kieSession.fireAllRules();
+
+        Collection<Result> results = getObjectsIntoList(kieSession, Result.class);
+        assertThat(results.size()).isEqualTo(1);
+        assertThat(results.iterator().next().getValue()).isEqualTo(0);
     }
 }

--- a/drools-model/drools-model-codegen/src/test/java/org/drools/model/codegen/execmodel/AccumulateTest.java
+++ b/drools-model/drools-model-codegen/src/test/java/org/drools/model/codegen/execmodel/AccumulateTest.java
@@ -4222,7 +4222,6 @@ public class AccumulateTest extends BaseModelTest {
 
         Results results = createKieBuilder(str).getResults();
         if (testRunType.isExecutableModel()) {
-            System.out.println(results.getMessages(Message.Level.ERROR).get(0).getText());
             assertThat(results.getMessages(Message.Level.ERROR).get(0).getText().contains(
                     "Function \"sum\" cannot have more than 1 parameter")).isTrue();
         } else {

--- a/drools-model/drools-mvel-parser/src/test/java/org/drools/mvel/parser/DroolsMvelParserTest.java
+++ b/drools-model/drools-mvel-parser/src/test/java/org/drools/mvel/parser/DroolsMvelParserTest.java
@@ -183,6 +183,22 @@ public class DroolsMvelParserTest {
     }
 
     @Test
+    public void testConstantUnaryExpression() {
+        String expr = "-49";
+        Expression expression = parseExpression( parser, expr ).getExpr();
+        assertThat(printNode(expression)).isEqualTo(expr);
+        assertThat(expression.isUnaryExpr()).isTrue();
+    }
+
+    @Test
+    public void testVariableUnaryExpression() {
+        String expr = "-$a";
+        Expression expression = parseExpression( parser, expr ).getExpr();
+        assertThat(printNode(expression)).isEqualTo(expr);
+        assertThat(expression.isUnaryExpr()).isTrue();
+    }
+
+    @Test
     public void testDotFreeEnclosedWithNameExpr() {
         String expr = "(something after $a)";
         Expression expression = parseExpression( parser, expr ).getExpr();
@@ -402,10 +418,12 @@ public class DroolsMvelParserTest {
         BinaryExpr first = (BinaryExpr) comboExpr.getLeft();
         assertThat(toString(first.getLeft())).isEqualTo("value");
         assertThat(toString(first.getRight())).isEqualTo("-2");
+        assertThat(first.getRight().isUnaryExpr()).isTrue();
         assertThat(first.getOperator()).isEqualTo(Operator.GREATER);
 
         HalfBinaryExpr second = (HalfBinaryExpr) comboExpr.getRight();
         assertThat(toString(second.getRight())).isEqualTo("-1");
+        assertThat(second.getRight().isUnaryExpr()).isTrue();
         assertThat(second.getOperator()).isEqualTo(HalfBinaryExpr.Operator.LESS);
     }
 


### PR DESCRIPTION
Closes: https://github.com/apache/incubator-kie-issues/issues/969

```
accumulate ($p: Person (getName().startsWith("M")); 
                     $sum : sum(-$p.getAge()))
```
This case leads to an `Invalid expression -$p.getAge()` error.

That is because the UnaryExpression types are not managed in the `AccumulateVisitor` logic.
To fix the issue, I managed that case relying on the existing BinaryExpression logic management, which fits well for the `UnaryExpression` case according to my analysis. 
Please correct me if I'm wrong @lucamolteni @mariofusco.

In addition, we added a check to ensure that the accumulate function always has no more than one parameter (kudos to @gitgabrio ). I added that check for the executable Model case only


<details>
<summary>
How to replicate CI configuration locally?
</summary>

Build Chain tool does "simple" maven build(s), the builds are just Maven commands, but because the repositories relates and depends on each other and any change in API or class method could affect several of those repositories there is a need to use [build-chain tool](https://github.com/kiegroup/github-action-build-chain) to handle cross repository builds and be sure that we always use latest version of the code for each repository.
 
[build-chain tool](https://github.com/kiegroup/github-action-build-chain) is a build tool which can be used on command line locally or in Github Actions workflow(s), in case you need to change multiple repositories and send multiple dependent pull requests related with a change you can easily reproduce the same build by executing it on Github hosted environment or locally in your development environment. See [local execution](https://github.com/kiegroup/github-action-build-chain#local-execution) details to get more information about it.
</details>

<details>
<summary>
How to retest this PR or trigger a specific build:
</summary>

- for <b>pull request and downstream checks</b>  
  - Push a new commit to the PR. An empty commit would be enough.

- for a <b>full downstream build</b>
  - for <b>github actions</b> job: add the label `run_fdb`

- for <b>Jenkins PR check only</b>
  - If you are an ASF committer for KIE podling, login to Jenkins (https://ci-builds.apache.org/job/KIE/job/drools/), go to the specific PR job, and click on `Build Now` button.
</details>
