### PR TITLE
[Fix apache/incubator-kie-issues#987] Add onError listener

### DIFF
--- a/kie-api/src/main/java/org/kie/api/event/process/ErrorEvent.java
+++ b/kie-api/src/main/java/org/kie/api/event/process/ErrorEvent.java
@@ -1,0 +1,33 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.kie.api.event.process;
+
+import org.kie.api.runtime.process.NodeInstance;
+
+/**
+ * An event when a error is thrown
+ */
+public interface ErrorEvent extends ProcessNodeEvent {
+    /**
+     * Error associated to the event
+     *
+     * @return exception
+     */
+    Exception getException();
+}

--- a/kie-api/src/main/java/org/kie/api/event/process/ProcessEventListener.java
+++ b/kie-api/src/main/java/org/kie/api/event/process/ProcessEventListener.java
@@ -116,4 +116,10 @@ public interface ProcessEventListener
      * @param event
      */
     default void onMessage(MessageEvent event) {}
+    
+    /**
+     * This listener method is invoked when an error is captured
+     * @param event
+     */
+    default void onError (ErrorEvent event) {}
 }


### PR DESCRIPTION
Addind onErrorEvent method to ProcessEventListener

**Issue**: 

* [link](https://github.com/apache/incubator-kie-issues/issues/987)

**referenced Pull Requests**: _(please edit the URLs of referenced pullrequests if they exist)_

https://github.com/apache/incubator-kie-kogito-runtimes/pull/3428
https://github.com/apache/incubator-kie-kogito-apps/pull/2011

<details>
<summary>
How to replicate CI configuration locally?
</summary>

Build Chain tool does "simple" maven build(s), the builds are just Maven commands, but because the repositories relates and depends on each other and any change in API or class method could affect several of those repositories there is a need to use [build-chain tool](https://github.com/kiegroup/github-action-build-chain) to handle cross repository builds and be sure that we always use latest version of the code for each repository.
 
[build-chain tool](https://github.com/kiegroup/github-action-build-chain) is a build tool which can be used on command line locally or in Github Actions workflow(s), in case you need to change multiple repositories and send multiple dependent pull requests related with a change you can easily reproduce the same build by executing it on Github hosted environment or locally in your development environment. See [local execution](https://github.com/kiegroup/github-action-build-chain#local-execution) details to get more information about it.
</details>

<details>
<summary>
How to retest this PR or trigger a specific build:
</summary>

- for <b>pull request and downstream checks</b>  
  - Push a new commit to the PR. An empty commit would be enough.

- for a <b>full downstream build</b>
  - for <b>github actions</b> job: add the label `run_fdb`

- for <b>Jenkins PR check only</b>
  - If you are an ASF committer for KIE podling, login to Jenkins (https://ci-builds.apache.org/job/KIE/job/drools/), go to the specific PR job, and click on `Build Now` button.
</details>
