### PR TITLE
[incubator-kie-issues#1003] Refactored AppPaths - enforced immutability

### DIFF
--- a/drools-model/drools-codegen-common/src/main/java/org/drools/codegen/common/AppPaths.java
+++ b/drools-model/drools-codegen-common/src/main/java/org/drools/codegen/common/AppPaths.java
@@ -61,8 +61,6 @@ public class AppPaths {
 
     private final Path firstProjectPath;
 
-    private final Path[] jarPaths;
-
     private final Path[] resourcePaths;
     private final File[] resourceFiles;
 
@@ -96,9 +94,8 @@ public class AppPaths {
         this.classesPaths.addAll(classesPaths);
         this.outputTarget = outputTarget;
         firstProjectPath = getFirstProjectPath(this.projectPaths, outputTarget, bt);
-        jarPaths = getJarPaths(isJar, this.classesPaths);
         resourcePaths = getResourcePaths(this.projectPaths, resourcesBasePath, bt);
-        paths = isJar ? jarPaths : resourcePaths;
+        paths = isJar ? getJarPaths(isJar, this.classesPaths) : resourcePaths;
         resourceFiles = getResourceFiles(resourcePaths);
         sourcePaths = getSourcePaths(this.projectPaths);
     }
@@ -109,14 +106,6 @@ public class AppPaths {
 
     public Path getFirstProjectPath() {
         return firstProjectPath;
-    }
-
-    public Path[] getJarPaths() {
-        if (!isJar) {
-            throw new IllegalStateException("Not a jar");
-        } else {
-            return jarPaths;
-        }
     }
 
     public File[] getResourceFiles() {
@@ -155,7 +144,11 @@ public class AppPaths {
     }
 
     static Path[] getJarPaths(boolean isInnerJar, Collection<Path> innerClassesPaths) {
-        return isInnerJar ? innerClassesPaths.toArray(new Path[0]) : null;
+        if (!isInnerJar) {
+            throw new IllegalStateException("Not a jar");
+        } else {
+            return innerClassesPaths.toArray(new Path[0]);
+        }
     }
 
     static Path[] getResourcePaths(Set<Path> innerProjectPaths, String resourcesBasePath, BuildTool innerBt) {

--- a/drools-model/drools-codegen-common/src/test/java/org/drools/codegen/common/AppPathsTest.java
+++ b/drools-model/drools-codegen-common/src/test/java/org/drools/codegen/common/AppPathsTest.java
@@ -9,16 +9,21 @@ import org.junit.jupiter.api.parallel.ExecutionMode;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
 
+import static org.drools.codegen.common.AppPaths.GENERATED_RESOURCES_DIR;
+import static org.drools.codegen.common.AppPaths.MAIN_DIR;
+import static org.drools.codegen.common.AppPaths.RESOURCES_DIR;
+import static org.drools.codegen.common.AppPaths.SRC_DIR;
 import static org.drools.codegen.common.AppPaths.TARGET_DIR;
+import static org.drools.codegen.common.AppPaths.TEST_DIR;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 @Execution(ExecutionMode.SAME_THREAD)
-public class AppPathsTest {
+class AppPathsTest {
 
     @ParameterizedTest
     @ValueSource(booleans = {true, false})
-    public void fromProjectDir(boolean withGradle) {
+    void fromProjectDir(boolean withGradle) {
         String projectDirPath = "projectDir";
         String outputTargetPath = "outputTarget";
         Path projectDir = Path.of(projectDirPath);
@@ -40,7 +45,7 @@ public class AppPathsTest {
 
     @ParameterizedTest
     @ValueSource(booleans = {true, false})
-    public void fromTestDir(boolean withGradle) {
+    void fromTestDir(boolean withGradle) {
         String projectDirPath = "projectDir";
         String outputTargetPath = String.format("%s/%s", projectDirPath, TARGET_DIR).replace("/", File.separator);
         Path projectDir = Path.of(projectDirPath);
@@ -80,15 +85,15 @@ public class AppPathsTest {
         int expected = isGradle ? 1 : 2;
         assertEquals(expected, retrieved.length, "AppPathsTest.getResourceFilesTest");
         String expectedPath;
-        String sourceDir =  isTestDir ? "test" : "main";
+        String sourceDir =  isTestDir ? TEST_DIR : MAIN_DIR;
         if (isGradle) {
             expectedPath = projectDirPath;
         } else {
-            expectedPath = String.format("%s/src/%s/resources", projectDirPath, sourceDir).replace("/", File.separator);
+            expectedPath = String.format("%s/%s/%s/%s", projectDirPath, SRC_DIR, sourceDir, RESOURCES_DIR).replace("/", File.separator);
         }
         assertEquals(new File(expectedPath), retrieved[0], "AppPathsTest.getResourceFilesTest");
         if (!isGradle) {
-            expectedPath = String.format("%s/target/generated-resources", projectDirPath).replace("/", File.separator);
+            expectedPath = String.format("%s/%s/%s", projectDirPath, TARGET_DIR, GENERATED_RESOURCES_DIR).replace("/", File.separator);
             assertEquals(new File(expectedPath), retrieved[1], "AppPathsTest.getResourceFilesTest");
         }
     }


### PR DESCRIPTION
Fixes https://github.com/apache/incubator-kie-issues/issues/1003

This PR
1. instantiate immutable objects to be returned by the publicly available getters
2. uses static method to instantiate the above
3. avoid reinstantiation of same objects at each getter invocation
4. enforce immutability of class itself
5. define one single object (`resourcePaths`) regardless of generated-resources/ bt status

<details>
<summary>
How to replicate CI configuration locally?
</summary>

Build Chain tool does "simple" maven build(s), the builds are just Maven commands, but because the repositories relates and depends on each other and any change in API or class method could affect several of those repositories there is a need to use [build-chain tool](https://github.com/kiegroup/github-action-build-chain) to handle cross repository builds and be sure that we always use latest version of the code for each repository.
 
[build-chain tool](https://github.com/kiegroup/github-action-build-chain) is a build tool which can be used on command line locally or in Github Actions workflow(s), in case you need to change multiple repositories and send multiple dependent pull requests related with a change you can easily reproduce the same build by executing it on Github hosted environment or locally in your development environment. See [local execution](https://github.com/kiegroup/github-action-build-chain#local-execution) details to get more information about it.
</details>

<details>
<summary>
How to retest this PR or trigger a specific build:
</summary>

- for <b>pull request and downstream checks</b>  
  - Push a new commit to the PR. An empty commit would be enough.

- for a <b>full downstream build</b>
  - for <b>github actions</b> job: add the label `run_fdb`

- for <b>Jenkins PR check only</b>
  - If you are an ASF committer for KIE podling, login to Jenkins (https://ci-builds.apache.org/job/KIE/job/drools/), go to the specific PR job, and click on `Build Now` button.
</details>
