### PR TITLE
[new-parser] Add error listener to DrlExprParser

### DIFF
--- a/drools-compiler/src/main/java/org/drools/compiler/rule/builder/PatternBuilder.java
+++ b/drools-compiler/src/main/java/org/drools/compiler/rule/builder/PatternBuilder.java
@@ -1805,8 +1805,6 @@ public class PatternBuilder implements RuleConditionBuilder<PatternDescr> {
                                                         final String expression) {
         DrlExprParser parser = DrlExprParserFactory.getDrlExprParser(context.getConfiguration().getOption(LanguageLevelOption.KEY));
         ConstraintConnectiveDescr result = parser.parse(normalizeEval(expression));
-        result.setResource(patternDescr.getResource());
-        result.copyLocation(original);
         if (parser.hasErrors()) {
             for (DroolsParserException error : parser.getErrors()) {
                 registerDescrBuildError(context, patternDescr,
@@ -1814,6 +1812,8 @@ public class PatternBuilder implements RuleConditionBuilder<PatternDescr> {
             }
             return null;
         }
+        result.setResource(patternDescr.getResource());
+        result.copyLocation(original);
         return result;
     }
 

--- a/drools-drl/drools-drl-ast/src/main/java/org/drools/drl/ast/descr/OperatorDescr.java
+++ b/drools-drl/drools-drl-ast/src/main/java/org/drools/drl/ast/descr/OperatorDescr.java
@@ -55,7 +55,7 @@ public class OperatorDescr extends BaseDescr {
     }
 
     public void setOperator( String operator ) {
-        this.operator = operator.trim();
+        this.operator = operator != null ? operator.trim() : null;
     }
 
     public boolean isNegated() {

--- a/drools-drl/drools-drl-parser-tests/src/test/java/org/drools/drl/parser/antlr4/DRLExprParserTest.java
+++ b/drools-drl/drools-drl-parser-tests/src/test/java/org/drools/drl/parser/antlr4/DRLExprParserTest.java
@@ -26,6 +26,7 @@ import org.drools.drl.ast.descr.ConnectiveType;
 import org.drools.drl.ast.descr.ConstraintConnectiveDescr;
 import org.drools.drl.ast.descr.RelationalExprDescr;
 import org.drools.drl.parser.DrlExprParser;
+import org.drools.drl.parser.DroolsParserException;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -324,5 +325,51 @@ public class DRLExprParserTest {
 
         assertThat(left.getExpression()).isEqualTo("a");
         assertThat(right.getExpression()).isEqualTo("A");
+    }
+
+    @Test
+    public void testMismatchedInput() {
+        String source = "+";
+        parser.parse(source);
+        assertThat(parser.hasErrors()).isTrue();
+        assertThat(parser.getErrors()).hasSize(1);
+        DroolsParserException exception = parser.getErrors().get(0);
+        assertThat(exception.getErrorCode()).isEqualTo("ERR 102");
+        assertThat(exception.getLineNumber()).isEqualTo(1);
+        assertThat(exception.getColumn()).isEqualTo(1);
+        assertThat(exception.getOffset()).isEqualTo(1);
+        assertThat(exception.getMessage())
+                .startsWithIgnoringCase("[ERR 102] Line 1:1 mismatched input '<EOF>' expecting ")
+                .contains("TIME_INTERVAL", "DRL_STRING_LITERAL", "?/", "boolean", "byte", "char", "double", "float", "int", "long", "new", "short", "super", "DECIMAL_LITERAL", "HEX_LITERAL", "FLOAT_LITERAL", "BOOL_LITERAL", "STRING_LITERAL", "null", "(", "[", ".", "<", "!", "~", "++", "--", "+", "-", "*", "/", "IDENTIFIER");
+    }
+
+    @Test
+    public void testExtraneousInput() {
+        String source = "a +; b";
+        parser.parse(source);
+        assertThat(parser.hasErrors()).isTrue();
+        assertThat(parser.getErrors()).hasSize(1);
+        DroolsParserException exception = parser.getErrors().get(0);
+        assertThat(exception.getErrorCode()).isEqualTo("ERR 109");
+        assertThat(exception.getLineNumber()).isEqualTo(1);
+        assertThat(exception.getColumn()).isEqualTo(3);
+        assertThat(exception.getOffset()).isEqualTo(3);
+        assertThat(exception.getMessage())
+                .startsWithIgnoringCase("[ERR 109] Line 1:3 extraneous input ';' expecting ")
+                .contains("TIME_INTERVAL", "DRL_STRING_LITERAL", "?/", "boolean", "byte", "char", "double", "float", "int", "long", "new", "short", "super", "DECIMAL_LITERAL", "HEX_LITERAL", "FLOAT_LITERAL", "BOOL_LITERAL", "STRING_LITERAL", "null", "(", "[", ".", "<", "!", "~", "++", "--", "+", "-", "*", "/", "IDENTIFIER");
+    }
+    @Test
+    public void testNoViableAlt() {
+        String source = "a~a";
+        parser.parse(source);
+        assertThat(parser.hasErrors()).isTrue();
+        assertThat(parser.getErrors()).hasSize(1);
+        DroolsParserException exception = parser.getErrors().get(0);
+        assertThat(exception.getErrorCode()).isEqualTo("ERR 101");
+        assertThat(exception.getLineNumber()).isEqualTo(1);
+        assertThat(exception.getColumn()).isEqualTo(2);
+        assertThat(exception.getOffset()).isEqualTo(2);
+        assertThat(exception.getMessage())
+                .isEqualToIgnoringCase("[ERR 101] Line 1:2 no viable alternative at input 'a'");
     }
 }

--- a/drools-drl/drools-drl-parser/src/main/java/org/drools/drl/parser/antlr4/ParserHelper.java
+++ b/drools-drl/drools-drl-parser/src/main/java/org/drools/drl/parser/antlr4/ParserHelper.java
@@ -120,11 +120,9 @@ public class ParserHelper {
     private final LanguageLevelOption                 languageLevel;
 
     public ParserHelper(TokenStream input,
-                        RecognizerSharedState state,
                         LanguageLevelOption languageLevel) {
         this.errorMessageFactory = new DroolsParserExceptionFactory( paraphrases, languageLevel );
         this.input = input;
-        this.state = state;
         this.languageLevel = languageLevel;
     }
 
@@ -360,15 +358,8 @@ public class ParserHelper {
                              DroolsSoftKeywords.DIRECT );
     }
 
-    public void reportError( RecognitionException ex ) {
-        // if we've already reported an error and have not matched a token
-        // yet successfully, don't report any errors.
-        if ( state.errorRecovery ) {
-            return;
-        }
-        state.errorRecovery = true;
-
-        errors.add( errorMessageFactory.createDroolsException( ex ) );
+    public void reportError(Object offendingSymbol, int line, int charPositionInLine, String message, RecognitionException ex ) {
+        errors.add( errorMessageFactory.createDroolsException( offendingSymbol, line, charPositionInLine, message, ex ) );
     }
 
     public void reportError( Exception e ) {


### PR DESCRIPTION
Add an error listener to the expression parser that collects errors and stores them in the helper.

This slightly increases the number of failing tests but fewer of them are actually visible because the build fails earlier and the module with the most failing tests `drools-model-codegen` is now skipped. The build will return to a "normal" state (before this PR) once we fix #5702, which I'm already working on.

<details>
<summary>
How to replicate CI configuration locally?
</summary>

Build Chain tool does "simple" maven build(s), the builds are just Maven commands, but because the repositories relates and depends on each other and any change in API or class method could affect several of those repositories there is a need to use [build-chain tool](https://github.com/kiegroup/github-action-build-chain) to handle cross repository builds and be sure that we always use latest version of the code for each repository.
 
[build-chain tool](https://github.com/kiegroup/github-action-build-chain) is a build tool which can be used on command line locally or in Github Actions workflow(s), in case you need to change multiple repositories and send multiple dependent pull requests related with a change you can easily reproduce the same build by executing it on Github hosted environment or locally in your development environment. See [local execution](https://github.com/kiegroup/github-action-build-chain#local-execution) details to get more information about it.
</details>

<details>
<summary>
How to retest this PR or trigger a specific build:
</summary>

- for <b>pull request and downstream checks</b>  
  - Push a new commit to the PR. An empty commit would be enough.

- for a <b>full downstream build</b>
  - for <b>github actions</b> job: add the label `run_fdb`

- for <b>Jenkins PR check only</b>
  - If you are an ASF committer for KIE podling, login to Jenkins (https://ci-builds.apache.org/job/KIE/job/drools/), go to the specific PR job, and click on `Build Now` button.
</details>
