### PR TITLE
Improve AppPaths

### DIFF
--- a/drools-model/drools-codegen-common/src/main/java/org/drools/codegen/common/AppPaths.java
+++ b/drools-model/drools-codegen-common/src/main/java/org/drools/codegen/common/AppPaths.java
@@ -20,14 +20,12 @@ package org.drools.codegen.common;
 
 import java.io.File;
 import java.nio.file.Path;
-import java.nio.file.Paths;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.LinkedHashSet;
 import java.util.Set;
-import java.util.function.UnaryOperator;
 
 public class AppPaths {
 
@@ -77,7 +75,7 @@ public class AppPaths {
      * @return
      */
     public static AppPaths fromTestDir(Path projectDir) {
-        return new AppPaths(Collections.singleton(projectDir), Collections.emptyList(), false, BuildTool.findBuildTool(), TEST_DIR, Paths.get(projectDir.toString(), TARGET_DIR));
+        return new AppPaths(Collections.singleton(projectDir), Collections.emptyList(), false, BuildTool.findBuildTool(), TEST_DIR, Path.of(projectDir.toString(), TARGET_DIR));
     }
 
     /**
@@ -150,12 +148,10 @@ public class AppPaths {
     static Path[] getResourcePaths(Set<Path> innerProjectPaths, String resourcesBasePath, BuildTool innerBt) {
         Path[] toReturn;
         if (innerBt == BuildTool.GRADLE) {
-            toReturn = transformPaths(innerProjectPaths, p -> p.resolve(Paths.get("")));
+            toReturn = transformPaths(innerProjectPaths, Path.of(""));
         } else {
-            toReturn = transformPaths(innerProjectPaths, p -> p.resolve(Paths.get(SRC_DIR, resourcesBasePath,
-                                                                                  RESOURCES_DIR)));
-            Path[] generatedResourcesPaths = transformPaths(innerProjectPaths, p -> p.resolve(Paths.get(TARGET_DIR,
-                                                                                                        GENERATED_RESOURCES_DIR)));
+            toReturn = transformPaths(innerProjectPaths, Path.of(SRC_DIR, resourcesBasePath, RESOURCES_DIR));
+            Path[] generatedResourcesPaths = transformPaths(innerProjectPaths, Path.of(TARGET_DIR, GENERATED_RESOURCES_DIR));
             Path[] newToReturn = new Path[toReturn.length + generatedResourcesPaths.length];
             System.arraycopy(toReturn, 0, newToReturn, 0, toReturn.length);
             System.arraycopy(generatedResourcesPaths, 0, newToReturn, toReturn.length, generatedResourcesPaths.length);
@@ -169,11 +165,11 @@ public class AppPaths {
     }
 
     static Path[] getSourcePaths(Set<Path> innerProjectPaths) {
-        return transformPaths(innerProjectPaths, p -> p.resolve(SRC_DIR));
+        return transformPaths(innerProjectPaths, Path.of(SRC_DIR));
     }
 
-    static Path[] transformPaths(Collection<Path> paths, UnaryOperator<Path> f) {
-        return paths.stream().map(f).toArray(Path[]::new);
+    static Path[] transformPaths(Collection<Path> paths, Path pathToResolve) {
+        return paths.stream().map(p -> p.resolve(pathToResolve)).toArray(Path[]::new);
     }
 
 }

--- a/drools-model/drools-codegen-common/src/main/java/org/drools/codegen/common/AppPaths.java
+++ b/drools-model/drools-codegen-common/src/main/java/org/drools/codegen/common/AppPaths.java
@@ -95,7 +95,7 @@ public class AppPaths {
         this.outputTarget = outputTarget;
         firstProjectPath = getFirstProjectPath(this.projectPaths, outputTarget, bt);
         resourcePaths = getResourcePaths(this.projectPaths, resourcesBasePath, bt);
-        paths = isJar ? getJarPaths(isJar, this.classesPaths) : resourcePaths;
+        paths = isJar ? getJarPaths(this.classesPaths) : resourcePaths;
         resourceFiles = getResourceFiles(resourcePaths);
         sourcePaths = getSourcePaths(this.projectPaths);
     }
@@ -143,12 +143,8 @@ public class AppPaths {
                 : innerOutputTarget;
     }
 
-    static Path[] getJarPaths(boolean isInnerJar, Collection<Path> innerClassesPaths) {
-        if (!isInnerJar) {
-            throw new IllegalStateException("Not a jar");
-        } else {
-            return innerClassesPaths.toArray(new Path[0]);
-        }
+    static Path[] getJarPaths(Collection<Path> innerClassesPaths) {
+        return innerClassesPaths.toArray(new Path[0]);
     }
 
     static Path[] getResourcePaths(Set<Path> innerProjectPaths, String resourcesBasePath, BuildTool innerBt) {

--- a/drools-model/drools-codegen-common/src/main/java/org/drools/codegen/common/AppPaths.java
+++ b/drools-model/drools-codegen-common/src/main/java/org/drools/codegen/common/AppPaths.java
@@ -75,7 +75,7 @@ public class AppPaths {
      * @return
      */
     public static AppPaths fromTestDir(Path projectDir) {
-        return new AppPaths(Collections.singleton(projectDir), Collections.emptyList(), false, BuildTool.findBuildTool(), TEST_DIR, Path.of(projectDir.toString(), TARGET_DIR));
+        return new AppPaths(Collections.singleton(projectDir), Collections.emptyList(), false, BuildTool.findBuildTool(), TEST_DIR, projectDir.resolve(TARGET_DIR));
     }
 
     /**


### PR DESCRIPTION
Hi @gitgabrio, I came across https://github.com/apache/incubator-kie-drools/pull/5777 and noticed a few things that could be improved a little further (in my opinion). So I decided to take a stab at it while it's fresh. Let's see if you find this useful as well.

- The `isJar` flag was useless because it was `true` on every invocation of the method.
- I find it simpler to feed the transformation method with just a path than repeating the same lambda over and over.
- I noticed that `Paths.get()` is [deprecated](https://docs.oracle.com/en/java/javase/18/docs/api/java.base/java/nio/file/Paths.html) so I replaced it with `Path.of()`.


<details>
<summary>
How to replicate CI configuration locally?
</summary>

Build Chain tool does "simple" maven build(s), the builds are just Maven commands, but because the repositories relates and depends on each other and any change in API or class method could affect several of those repositories there is a need to use [build-chain tool](https://github.com/kiegroup/github-action-build-chain) to handle cross repository builds and be sure that we always use latest version of the code for each repository.
 
[build-chain tool](https://github.com/kiegroup/github-action-build-chain) is a build tool which can be used on command line locally or in Github Actions workflow(s), in case you need to change multiple repositories and send multiple dependent pull requests related with a change you can easily reproduce the same build by executing it on Github hosted environment or locally in your development environment. See [local execution](https://github.com/kiegroup/github-action-build-chain#local-execution) details to get more information about it.
</details>

<details>
<summary>
How to retest this PR or trigger a specific build:
</summary>

- for <b>pull request and downstream checks</b>  
  - Push a new commit to the PR. An empty commit would be enough.

- for a <b>full downstream build</b>
  - for <b>github actions</b> job: add the label `run_fdb`

- for <b>Jenkins PR check only</b>
  - If you are an ASF committer for KIE podling, login to Jenkins (https://ci-builds.apache.org/job/KIE/job/drools/), go to the specific PR job, and click on `Build Now` button.
</details>
