### PR TITLE
[new-parser] Primary rule should accept `this` keyword

### DIFF
--- a/drools-drl/drools-drl-parser-tests/src/test/java/org/drools/drl/parser/antlr4/DRLExprParserTest.java
+++ b/drools-drl/drools-drl-parser-tests/src/test/java/org/drools/drl/parser/antlr4/DRLExprParserTest.java
@@ -317,6 +317,7 @@ public class DRLExprParserTest {
             "(long) l",
             "(float) f",
             "(double) d",
+            "this",
             "<Type>this()",
             "Object[][].class.getName()",
             "new<Integer>ArrayList<Integer>()"

--- a/drools-drl/drools-drl-parser/src/main/antlr4/org/drools/drl/parser/antlr4/DRL6Expressions.g4
+++ b/drools-drl/drools-drl-parser/src/main/antlr4/org/drools/drl/parser/antlr4/DRL6Expressions.g4
@@ -671,7 +671,7 @@ primary returns [BaseDescr result]
     :	expr=parExpression {  if( buildDescr  ) { $result = $expr.result; }  }
     |   nonWildcardTypeArguments (explicitGenericInvocationSuffix | this_key arguments)
     |   literal { if( buildDescr  ) { $result = new AtomicExprDescr( $literal.text, true ); }  }
-    //|   this_key ({!helper.validateSpecialID(2)}? DOT IDENTIFIER)* ({helper.validateIdentifierSufix()}? identifierSuffix)?
+    |   this_key (DOT drlIdentifier)* identifierSuffix?
     |   super_key superSuffix
     |   new_key creator
     |   primitiveType (LBRACK RBRACK)* DOT class_key


### PR DESCRIPTION
Fixes #5702.

Allows `this` to appear as `primary`, for example in `String(this == "x")`.

<details>
<summary>
How to replicate CI configuration locally?
</summary>

Build Chain tool does "simple" maven build(s), the builds are just Maven commands, but because the repositories relates and depends on each other and any change in API or class method could affect several of those repositories there is a need to use [build-chain tool](https://github.com/kiegroup/github-action-build-chain) to handle cross repository builds and be sure that we always use latest version of the code for each repository.
 
[build-chain tool](https://github.com/kiegroup/github-action-build-chain) is a build tool which can be used on command line locally or in Github Actions workflow(s), in case you need to change multiple repositories and send multiple dependent pull requests related with a change you can easily reproduce the same build by executing it on Github hosted environment or locally in your development environment. See [local execution](https://github.com/kiegroup/github-action-build-chain#local-execution) details to get more information about it.
</details>

<details>
<summary>
How to retest this PR or trigger a specific build:
</summary>

- for <b>pull request and downstream checks</b>  
  - Push a new commit to the PR. An empty commit would be enough.

- for a <b>full downstream build</b>
  - for <b>github actions</b> job: add the label `run_fdb`

- for <b>Jenkins PR check only</b>
  - If you are an ASF committer for KIE podling, login to Jenkins (https://ci-builds.apache.org/job/KIE/job/drools/), go to the specific PR job, and click on `Build Now` button.
</details>
