### PR TITLE
[new-parser] Populate AST descriptors with line numbers

### DIFF
--- a/drools-drl/drools-drl-parser-tests/src/test/java/org/drools/drl/parser/antlr4/MiscDRLParserTest.java
+++ b/drools-drl/drools-drl-parser-tests/src/test/java/org/drools/drl/parser/antlr4/MiscDRLParserTest.java
@@ -864,7 +864,6 @@ class MiscDRLParserTest {
 // Failing tests are annotated with @Disabled. We can fix issues one by one
 //-------------------------------------------------------------------------
 
-    @Disabled("Priority : Mid | implement Descr lineNumber")
     @Test
     public void parse_LineNumberInAST() throws Exception {
         // also see testSimpleExpander to see how this works with an expander
@@ -1687,7 +1686,6 @@ class MiscDRLParserTest {
         assertThat(fld.getExpression()).isEqualToIgnoringWhitespace("type == $likes");
     }
 
-    @Disabled("Priority : Mid | Implement Descr lineNumber")
     @Test
     public void parse_Functions() throws Exception {
         final PackageDescr pkg = parseAndGetPackageDescrFromFile(
@@ -1703,7 +1701,7 @@ class MiscDRLParserTest {
         assertThat(func.getReturnType()).isEqualTo("String");
         assertThat(func.getParameterNames().size()).isEqualTo(2);
         assertThat(func.getParameterTypes().size()).isEqualTo(2);
-        assertThat(func.getLine()).isEqualTo(19);
+        assertThat(func.getLine()).isEqualTo(21);
         assertThat(func.getColumn()).isEqualTo(0);
 
         assertThat(func.getParameterTypes().get(0)).isEqualTo("String");
@@ -2070,15 +2068,14 @@ class MiscDRLParserTest {
         assertThat(parser.hasErrors()).as(parser.getErrors().toString()).isFalse();
     }
 
-    @Disabled("Priority : Mid | implement Descr lineNumber")
     @Test
     public void parse_EndPosition() throws Exception {
         final PackageDescr pkg = parseAndGetPackageDescrFromFile(
                                                                "test_EndPosition.drl" );
         final RuleDescr rule = (RuleDescr) pkg.getRules().get( 0 );
         final PatternDescr col = (PatternDescr) rule.getLhs().getDescrs().get( 0 );
-        assertThat(col.getLine()).isEqualTo(21);
-        assertThat(col.getEndLine()).isEqualTo(23);
+        assertThat(col.getLine()).isEqualTo(23);
+        assertThat(col.getEndLine()).isEqualTo(25);
     }
 
     @Test


### PR DESCRIPTION
Fixes #5719.

Fixes several tests scattered around the `drools-model-codegen` module. I've enabled the affected disabled tests but I chose not to create new tests for these reasons:
1. Line numbers are a cross-cutting concern and I'd rather not pollute the existing parser tests in `MiscDRLParserTest` by adding line number assertions there.
2. I don't see much added value in creating new dedicated tests since we have a decent coverage in the codegen module.
3. #5798 will ensure every `BaseDescr` receives these properties so testing that will be much simpler.

### Before PR in `drools-model-codegen`
```
[ERROR] Tests run: 2433, Failures: 275, Errors: 0, Skipped: 9
```

### After PR in `drools-model-codegen`
```
[ERROR] Tests run: 2434, Failures: 252, Errors: 0, Skipped: 9
```

<details>
<summary>
How to replicate CI configuration locally?
</summary>

Build Chain tool does "simple" maven build(s), the builds are just Maven commands, but because the repositories relates and depends on each other and any change in API or class method could affect several of those repositories there is a need to use [build-chain tool](https://github.com/kiegroup/github-action-build-chain) to handle cross repository builds and be sure that we always use latest version of the code for each repository.
 
[build-chain tool](https://github.com/kiegroup/github-action-build-chain) is a build tool which can be used on command line locally or in Github Actions workflow(s), in case you need to change multiple repositories and send multiple dependent pull requests related with a change you can easily reproduce the same build by executing it on Github hosted environment or locally in your development environment. See [local execution](https://github.com/kiegroup/github-action-build-chain#local-execution) details to get more information about it.
</details>

<details>
<summary>
How to retest this PR or trigger a specific build:
</summary>

- for <b>pull request and downstream checks</b>  
  - Push a new commit to the PR. An empty commit would be enough.

- for a <b>full downstream build</b>
  - for <b>github actions</b> job: add the label `run_fdb`

- for <b>Jenkins PR check only</b>
  - If you are an ASF committer for KIE podling, login to Jenkins (https://ci-builds.apache.org/job/KIE/job/drools/), go to the specific PR job, and click on `Build Now` button.
</details>
