### PR TITLE
[incubator-kie-drools#5711] Broken OOPath expressions

### DIFF
--- a/drools-drl/drools-drl-parser-tests/src/test/java/org/drools/drl/parser/antlr4/MiscDRLParserTest.java
+++ b/drools-drl/drools-drl-parser-tests/src/test/java/org/drools/drl/parser/antlr4/MiscDRLParserTest.java
@@ -3859,4 +3859,18 @@ class MiscDRLParserTest {
         assertThat(constraintDescr.toString())
                 .isEqualToIgnoringWhitespace("$toy: /wife/children/toys[ name.length == ../name.length ]");
     }
+
+    @Test
+    void ooPathMixedWithStandardConstraint() {
+        final String text = "package org.drools\n" +
+                "rule R when\n" +
+                "  Man( /wife[$age : age] && age > $age )\n" +
+                "then\n" +
+                "end\n";
+
+        PackageDescr packageDescr = parser.parse(text);
+        ExprConstraintDescr constraintDescr = getFirstExprConstraintDescr(packageDescr);
+        assertThat(constraintDescr.toString())
+                .isEqualToIgnoringWhitespace("/wife[$age : age] && age > $age");
+    }
 }

--- a/drools-drl/drools-drl-parser/src/main/antlr4/org/drools/drl/parser/antlr4/DRLParser.g4
+++ b/drools-drl/drools-drl-parser/src/main/antlr4/org/drools/drl/parser/antlr4/DRLParser.g4
@@ -127,7 +127,7 @@ lhsPattern : xpathPrimary (OVER patternFilter)? |
 lhsPattern : QUESTION? objectType=drlQualifiedName LPAREN positionalConstraints? constraints? RPAREN drlAnnotation* (DRL_OVER patternFilter)? (DRL_FROM patternSource)? ;
 positionalConstraints : constraint (COMMA constraint)* SEMI ;
 constraints : constraint (COMMA constraint)* ;
-constraint : ( nestedConstraint | conditionalOrExpression ) ;
+constraint : ( nestedConstraint | conditionalOrExpression | xpathPrimary) ;
 nestedConstraint : ( IDENTIFIER ( DOT | NULL_SAFE_DOT | HASH ) )* IDENTIFIER (DOT | NULL_SAFE_DOT ) LPAREN constraints RPAREN ;
 
 // TBD: constraint parsing could be delegated to DRL6ExpressionParser
@@ -143,6 +143,12 @@ relationalExpression : left=drlExpression (right=orRestriction)* ;
 orRestriction : left=andRestriction (OR right=andRestriction)* ;
 andRestriction : left=singleRestriction (AND right=singleRestriction)* ;
 singleRestriction : op=relationalOperator drlExpression ;
+
+// OOPath
+xpathSeparator : DIV | QUESTION_DIV ;
+xpathPrimary : label? xpathChunk+ ;
+xpathChunk : xpathSeparator drlIdentifier (DOT drlIdentifier)* (HASH drlIdentifier)? (LBRACK xpathExpressionList RBRACK)? ;
+xpathExpressionList : label? drlExpression (COMMA label? drlExpression)* ;
 
 relationalOperator
     : EQUAL
@@ -284,7 +290,13 @@ drlExpression
     | drlExpression COLONCOLON typeArguments? drlIdentifier
     | typeType COLONCOLON (typeArguments? drlIdentifier | NEW)
     | classType COLONCOLON typeArguments? NEW
+
+    // OOPath feature
+    | backReferenceExpression
     ;
+
+backReferenceExpression : (DOT DOT DIV)+  drlExpression ;
+
 
 /* extending JavaParser methodCall in order to accept drl keywords as method name */
 drlMethodCall

--- a/drools-drl/drools-drl-parser/src/main/antlr4/org/drools/drl/parser/antlr4/DRLParser.g4
+++ b/drools-drl/drools-drl-parser/src/main/antlr4/org/drools/drl/parser/antlr4/DRLParser.g4
@@ -127,7 +127,7 @@ lhsPattern : xpathPrimary (OVER patternFilter)? |
 lhsPattern : QUESTION? objectType=drlQualifiedName LPAREN positionalConstraints? constraints? RPAREN drlAnnotation* (DRL_OVER patternFilter)? (DRL_FROM patternSource)? ;
 positionalConstraints : constraint (COMMA constraint)* SEMI ;
 constraints : constraint (COMMA constraint)* ;
-constraint : ( nestedConstraint | conditionalOrExpression | xpathPrimary) ;
+constraint : ( nestedConstraint | conditionalOrExpression ) ;
 nestedConstraint : ( IDENTIFIER ( DOT | NULL_SAFE_DOT | HASH ) )* IDENTIFIER (DOT | NULL_SAFE_DOT ) LPAREN constraints RPAREN ;
 
 // TBD: constraint parsing could be delegated to DRL6ExpressionParser
@@ -291,7 +291,8 @@ drlExpression
     | typeType COLONCOLON (typeArguments? drlIdentifier | NEW)
     | classType COLONCOLON typeArguments? NEW
 
-    // OOPath feature
+    // OOPath
+    | xpathPrimary
     | backReferenceExpression
     ;
 


### PR DESCRIPTION
**Issue**: 
* https://github.com/apache/incubator-kie-drools/issues/5711

<details>
<summary>
How to replicate CI configuration locally?
</summary>

Build Chain tool does "simple" maven build(s), the builds are just Maven commands, but because the repositories relates and depends on each other and any change in API or class method could affect several of those repositories there is a need to use [build-chain tool](https://github.com/kiegroup/github-action-build-chain) to handle cross repository builds and be sure that we always use latest version of the code for each repository.
 
[build-chain tool](https://github.com/kiegroup/github-action-build-chain) is a build tool which can be used on command line locally or in Github Actions workflow(s), in case you need to change multiple repositories and send multiple dependent pull requests related with a change you can easily reproduce the same build by executing it on Github hosted environment or locally in your development environment. See [local execution](https://github.com/kiegroup/github-action-build-chain#local-execution) details to get more information about it.
</details>

<details>
<summary>
How to retest this PR or trigger a specific build:
</summary>

- for <b>pull request and downstream checks</b>  
  - Push a new commit to the PR. An empty commit would be enough.

- for a <b>full downstream build</b>
  - for <b>github actions</b> job: add the label `run_fdb`

- for <b>Jenkins PR check only</b>
  - If you are an ASF committer for KIE podling, login to Jenkins (https://ci-builds.apache.org/job/KIE/job/drools/), go to the specific PR job, and click on `Build Now` button.
</details>
