### PR TITLE
[incubator-kie-drools#5742] [new-parser] Broken inline cast

### DIFF
--- a/drools-drl/drools-drl-parser-tests/src/test/java/org/drools/drl/parser/antlr4/MiscDRLParserTest.java
+++ b/drools-drl/drools-drl-parser-tests/src/test/java/org/drools/drl/parser/antlr4/MiscDRLParserTest.java
@@ -3876,12 +3876,12 @@ class MiscDRLParserTest {
         final String text = "package org.drools\n" +
                 "rule R1\n" +
                 "when\n" +
-                "  $a : ICA( someB#ICB.someC#ICC.onlyConcrete() == \"Hello\" )\n" +
+                "  $a : ICA( someB#ICB.onlyConcrete() == \"Hello\" )\n" +
                 "then\n" +
                 "end\n";
         PackageDescr packageDescr = parser.parse(text);
         ExprConstraintDescr constraintDescr = getFirstExprConstraintDescr(packageDescr);
-        assertThat(constraintDescr.toString()).isEqualToIgnoringWhitespace("someB#ICB.someC#ICC.onlyConcrete() == \"Hello\"");
+        assertThat(constraintDescr.toString()).isEqualToIgnoringWhitespace("someB#ICB.onlyConcrete() == \"Hello\"");
     }
 
     @Test

--- a/drools-drl/drools-drl-parser-tests/src/test/java/org/drools/drl/parser/antlr4/MiscDRLParserTest.java
+++ b/drools-drl/drools-drl-parser-tests/src/test/java/org/drools/drl/parser/antlr4/MiscDRLParserTest.java
@@ -3870,4 +3870,43 @@ class MiscDRLParserTest {
         assertThat(constraintDescr.toString())
                 .isEqualToIgnoringWhitespace("/wife[$age : age] && age > $age");
     }
+
+    @Test
+    void inlineCast() {
+        final String text = "package org.drools\n" +
+                "rule R1\n" +
+                "when\n" +
+                "  $a : ICA( someB#ICB.someC#ICC.onlyConcrete() == \"Hello\" )\n" +
+                "then\n" +
+                "end\n";
+        PackageDescr packageDescr = parser.parse(text);
+        ExprConstraintDescr constraintDescr = getFirstExprConstraintDescr(packageDescr);
+        assertThat(constraintDescr.toString()).isEqualToIgnoringWhitespace("someB#ICB.someC#ICC.onlyConcrete() == \"Hello\"");
+    }
+
+    @Test
+    void inlineCastMultiple() {
+        final String text = "package org.drools\n" +
+                "rule R1\n" +
+                "when\n" +
+                "  $a : ICA( someB#ICB.someC#ICC.onlyConcrete() == \"Hello\" )\n" +
+                "then\n" +
+                "end\n";
+        PackageDescr packageDescr = parser.parse(text);
+        ExprConstraintDescr constraintDescr = getFirstExprConstraintDescr(packageDescr);
+        assertThat(constraintDescr.toString()).isEqualToIgnoringWhitespace("someB#ICB.someC#ICC.onlyConcrete() == \"Hello\"");
+    }
+
+    @Test
+    void inlineCastThis() {
+        final String text = "package org.drools\n" +
+                "rule R1\n" +
+                "when\n" +
+                "  $o : Object( this#Person.name == \"Mark\" )\n" +
+                "then\n" +
+                "end\n";
+        PackageDescr packageDescr = parser.parse(text);
+        ExprConstraintDescr constraintDescr = getFirstExprConstraintDescr(packageDescr);
+        assertThat(constraintDescr.toString()).isEqualToIgnoringWhitespace("this#Person.name == \"Mark\"");
+    }
 }

--- a/drools-drl/drools-drl-parser/src/main/antlr4/org/drools/drl/parser/antlr4/DRL6Expressions.g4
+++ b/drools-drl/drools-drl-parser/src/main/antlr4/org/drools/drl/parser/antlr4/DRL6Expressions.g4
@@ -230,6 +230,7 @@ drlIdentifier returns [Token token]
     | PERMITS
     | RECORD
     | VAR
+    | THIS
     ;
 
 // --------------------------------------------------------
@@ -671,7 +672,6 @@ primary returns [BaseDescr result]
     :	expr=parExpression {  if( buildDescr  ) { $result = $expr.result; }  }
     |   nonWildcardTypeArguments (explicitGenericInvocationSuffix | this_key arguments)
     |   literal { if( buildDescr  ) { $result = new AtomicExprDescr( $literal.text, true ); }  }
-    |   this_key (DOT drlIdentifier)* identifierSuffix?
     |   super_key superSuffix
     |   new_key creator
     |   primitiveType (LBRACK RBRACK)* DOT class_key

--- a/drools-drl/drools-drl-parser/src/main/antlr4/org/drools/drl/parser/antlr4/DRLParser.g4
+++ b/drools-drl/drools-drl-parser/src/main/antlr4/org/drools/drl/parser/antlr4/DRLParser.g4
@@ -197,6 +197,7 @@ drlIdentifier
     | PERMITS
     | RECORD
     | VAR
+    | THIS
     ;
 
 drlKeywords
@@ -258,6 +259,7 @@ drlExpression
        | NEW nonWildcardTypeArguments? innerCreator
        | SUPER superSuffix
        | explicitGenericInvocation
+       | inlineCast
       )
     | drlExpression NULL_SAFE_DOT ( drlIdentifier | drlMethodCall )
     | drlExpression LBRACK drlExpression RBRACK
@@ -321,7 +323,10 @@ drlPrimary
     | nonWildcardTypeArguments (explicitGenericInvocationSuffix | THIS arguments)
     | inlineListExpression
     | inlineMapExpression
+    | inlineCast
     ;
+
+inlineCast : drlIdentifier HASH drlIdentifier ;
 
 /* extending JavaParser literal */
 drlLiteral


### PR DESCRIPTION
**Issue**: 

* https://github.com/apache/incubator-kie-drools/issues/5742

<details>
<summary>
How to replicate CI configuration locally?
</summary>

Build Chain tool does "simple" maven build(s), the builds are just Maven commands, but because the repositories relates and depends on each other and any change in API or class method could affect several of those repositories there is a need to use [build-chain tool](https://github.com/kiegroup/github-action-build-chain) to handle cross repository builds and be sure that we always use latest version of the code for each repository.
 
[build-chain tool](https://github.com/kiegroup/github-action-build-chain) is a build tool which can be used on command line locally or in Github Actions workflow(s), in case you need to change multiple repositories and send multiple dependent pull requests related with a change you can easily reproduce the same build by executing it on Github hosted environment or locally in your development environment. See [local execution](https://github.com/kiegroup/github-action-build-chain#local-execution) details to get more information about it.
</details>

<details>
<summary>
How to retest this PR or trigger a specific build:
</summary>

- for <b>pull request and downstream checks</b>  
  - Push a new commit to the PR. An empty commit would be enough.

- for a <b>full downstream build</b>
  - for <b>github actions</b> job: add the label `run_fdb`

- for <b>Jenkins PR check only</b>
  - If you are an ASF committer for KIE podling, login to Jenkins (https://ci-builds.apache.org/job/KIE/job/drools/), go to the specific PR job, and click on `Build Now` button.
</details>
