### PR TITLE
[incubator-kie-drools-5712] Queries with arguments cannot be parsed

### DIFF
--- a/drools-drl/drools-drl-parser-tests/src/test/java/org/drools/drl/parser/antlr4/MiscDRLParserTest.java
+++ b/drools-drl/drools-drl-parser-tests/src/test/java/org/drools/drl/parser/antlr4/MiscDRLParserTest.java
@@ -3909,4 +3909,74 @@ class MiscDRLParserTest {
         ExprConstraintDescr constraintDescr = getFirstExprConstraintDescr(packageDescr);
         assertThat(constraintDescr.toString()).isEqualToIgnoringWhitespace("this#Person.name == \"Mark\"");
     }
+
+    @Test
+    public void queryArgumentWithoutType() throws Exception {
+        final String text = "package org.drools\n" +
+                "query olderThan( $age )\n" +
+                "    $p : Person(age > (Integer)$age)\n" +
+                "end ";
+        final QueryDescr query = parseAndGetFirstQueryDescr(text);
+
+        assertThat(query).isNotNull();
+        assertThat(query.getName()).isEqualTo("olderThan");
+        assertThat(query.getParameterTypes()).containsExactly("Object");
+        assertThat(query.getParameters()).containsExactly("$age");
+    }
+
+    @Test
+    public void queryMultipleArguments() throws Exception {
+        final String text = "package org.drools\n" +
+                "query olderThan( String $name, int $age )\n" +
+                "    $p : Person(age > $age)\n" +
+                "end ";
+        final QueryDescr query = parseAndGetFirstQueryDescr(text);
+
+        assertThat(query).isNotNull();
+        assertThat(query.getName()).isEqualTo("olderThan");
+        assertThat(query.getParameterTypes()).containsExactly("String", "int");
+        assertThat(query.getParameters()).containsExactly("$name", "$age");
+    }
+
+    @Test
+    public void queryArrayArgument() throws Exception {
+        final String text = "package org.drools\n" +
+                "query olderThan( int[] $ages )\n" +
+                "    $p : Person(age > $ages[0])\n" +
+                "end ";
+        final QueryDescr query = parseAndGetFirstQueryDescr(text);
+
+        assertThat(query).isNotNull();
+        assertThat(query.getName()).isEqualTo("olderThan");
+        assertThat(query.getParameterTypes()).containsExactly("int[]");
+        assertThat(query.getParameters()).containsExactly("$ages");
+    }
+
+    @Test
+    public void queryZeroArgument() throws Exception {
+        final String text = "package org.drools\n" +
+                "query olderThan()\n" +
+                "    $p : Person()\n" +
+                "end ";
+        final QueryDescr query = parseAndGetFirstQueryDescr(text);
+
+        assertThat(query).isNotNull();
+        assertThat(query.getName()).isEqualTo("olderThan");
+        assertThat(query.getParameterTypes()).isEmpty();
+        assertThat(query.getParameters()).isEmpty();
+    }
+
+    @Test
+    public void queryNoArgument() throws Exception {
+        final String text = "package org.drools\n" +
+                "query olderThan\n" +
+                "    $p : Person()\n" +
+                "end ";
+        final QueryDescr query = parseAndGetFirstQueryDescr(text);
+
+        assertThat(query).isNotNull();
+        assertThat(query.getName()).isEqualTo("olderThan");
+        assertThat(query.getParameterTypes()).isEmpty();
+        assertThat(query.getParameters()).isEmpty();
+    }
 }

--- a/drools-drl/drools-drl-parser/src/main/antlr4/org/drools/drl/parser/antlr4/DRLParser.g4
+++ b/drools-drl/drools-drl-parser/src/main/antlr4/org/drools/drl/parser/antlr4/DRLParser.g4
@@ -79,7 +79,13 @@ ruledef : DRL_RULE name=stringId (EXTENDS parentName=stringId)? drlAnnotation* a
 
 // query := QUERY stringId parameters? annotation* lhsExpression END
 
-querydef : DRL_QUERY name=stringId formalParameters? drlAnnotation* lhsExpression+ DRL_END SEMI?;
+querydef : DRL_QUERY name=stringId parameters? drlAnnotation* lhsExpression+ DRL_END SEMI?;
+
+// parameters := LEFT_PAREN ( parameter ( COMMA parameter )* )? RIGHT_PAREN
+parameters : LPAREN ( parameter ( COMMA parameter )* )? RPAREN ;
+
+// parameter := ({requiresType}?=>type)? ID (LEFT_SQUARE RIGHT_SQUARE)*
+parameter : type? drlIdentifier ; // type is optional. Removed (LEFT_SQUARE RIGHT_SQUARE)* as it doesn't make sense in the grammar
 
 lhs : DRL_WHEN lhsExpression* ;
 

--- a/drools-drl/drools-drl-parser/src/main/java/org/drools/drl/parser/antlr4/DRLVisitorImpl.java
+++ b/drools-drl/drools-drl-parser/src/main/java/org/drools/drl/parser/antlr4/DRLVisitorImpl.java
@@ -304,14 +304,13 @@ public class DRLVisitorImpl extends DRLParserBaseVisitor<Object> {
     public QueryDescr visitQuerydef(DRLParser.QuerydefContext ctx) {
         QueryDescr queryDescr = new QueryDescr(safeStripStringDelimiters(ctx.name.getText()));
 
-        DRLParser.FormalParametersContext formalParametersContext = ctx.formalParameters();
-        if (formalParametersContext != null) {
-            DRLParser.FormalParameterListContext formalParameterListContext = formalParametersContext.formalParameterList();
-            List<DRLParser.FormalParameterContext> formalParameterContexts = formalParameterListContext.formalParameter();
-            formalParameterContexts.forEach(formalParameterContext -> {
-                DRLParser.TypeTypeContext typeTypeContext = formalParameterContext.typeType();
-                DRLParser.VariableDeclaratorIdContext variableDeclaratorIdContext = formalParameterContext.variableDeclaratorId();
-                queryDescr.addParameter(typeTypeContext.getText(), variableDeclaratorIdContext.getText());
+        DRLParser.ParametersContext parametersContext = ctx.parameters();
+        if (parametersContext != null) {
+            List<DRLParser.ParameterContext> parameterContexts = parametersContext.parameter();
+            parameterContexts.forEach(parameterContext -> {
+                String type = parameterContext.type() != null ? parameterContext.type().getText() : "Object"; // default type is Object
+                String name = parameterContext.drlIdentifier().getText();
+                queryDescr.addParameter(type, name);
             });
         }
 


### PR DESCRIPTION
**Issue**: 

* https://github.com/apache/incubator-kie-drools/issues/5712

<details>
<summary>
How to replicate CI configuration locally?
</summary>

Build Chain tool does "simple" maven build(s), the builds are just Maven commands, but because the repositories relates and depends on each other and any change in API or class method could affect several of those repositories there is a need to use [build-chain tool](https://github.com/kiegroup/github-action-build-chain) to handle cross repository builds and be sure that we always use latest version of the code for each repository.
 
[build-chain tool](https://github.com/kiegroup/github-action-build-chain) is a build tool which can be used on command line locally or in Github Actions workflow(s), in case you need to change multiple repositories and send multiple dependent pull requests related with a change you can easily reproduce the same build by executing it on Github hosted environment or locally in your development environment. See [local execution](https://github.com/kiegroup/github-action-build-chain#local-execution) details to get more information about it.
</details>

<details>
<summary>
How to retest this PR or trigger a specific build:
</summary>

- for <b>pull request and downstream checks</b>  
  - Push a new commit to the PR. An empty commit would be enough.

- for a <b>full downstream build</b>
  - for <b>github actions</b> job: add the label `run_fdb`

- for <b>Jenkins PR check only</b>
  - If you are an ASF committer for KIE podling, login to Jenkins (https://ci-builds.apache.org/job/KIE/job/drools/), go to the specific PR job, and click on `Build Now` button.
</details>
