### PR TITLE
[new-parser] Complete support for built-in operators (after, before)

### DIFF
--- a/drools-drl/drools-drl-parser-tests/src/test/java/org/drools/drl/parser/antlr4/DRLExprParserTest.java
+++ b/drools-drl/drools-drl-parser-tests/src/test/java/org/drools/drl/parser/antlr4/DRLExprParserTest.java
@@ -388,7 +388,7 @@ public class DRLExprParserTest {
     }
     @Test
     public void testNoViableAlt() {
-        String source = "a~a";
+        String source = "x.int";
         parser.parse(source);
         assertThat(parser.hasErrors()).isTrue();
         assertThat(parser.getErrors()).hasSize(1);
@@ -398,6 +398,6 @@ public class DRLExprParserTest {
         assertThat(exception.getColumn()).isEqualTo(2);
         assertThat(exception.getOffset()).isEqualTo(2);
         assertThat(exception.getMessage())
-                .isEqualToIgnoringCase("[ERR 101] Line 1:2 no viable alternative at input 'a'");
+                .isEqualToIgnoringCase("[ERR 101] Line 1:2 no viable alternative at input '.int'");
     }
 }

--- a/drools-drl/drools-drl-parser-tests/src/test/java/org/drools/drl/parser/antlr4/MiscDRLParserTest.java
+++ b/drools-drl/drools-drl-parser-tests/src/test/java/org/drools/drl/parser/antlr4/MiscDRLParserTest.java
@@ -1980,7 +1980,6 @@ class MiscDRLParserTest {
         assertThat(parser.hasErrors()).as(parser.getErrors().toString()).isFalse();
     }
 
-    @Disabled("Priority : Low | Implement soundslike")
     @Test
     public void parse_SoundsLike() throws Exception {
         final PackageDescr pkg = parseAndGetPackageDescrFromFile(

--- a/drools-drl/drools-drl-parser/src/main/antlr4/org/drools/drl/parser/antlr4/DRL6Expressions.g4
+++ b/drools-drl/drools-drl-parser/src/main/antlr4/org/drools/drl/parser/antlr4/DRL6Expressions.g4
@@ -927,7 +927,6 @@ in_key
 operator_key
   // IDENTIFIER is required to accept custom operators. We need to keep this semantic predicate for custom operators
   :      {(helper.isPluggableEvaluator(false))}? id=IDENTIFIER { helper.emit($id, DroolsEditorType.KEYWORD); }
-  // At the moment, we list possible DRLLexer tokens here, but we may be able to improve this by isolating lexers.
   |      op=builtInOperator { helper.emit($op.token, DroolsEditorType.KEYWORD); }
   ;
 

--- a/drools-drl/drools-drl-parser/src/main/antlr4/org/drools/drl/parser/antlr4/DRL6Expressions.g4
+++ b/drools-drl/drools-drl-parser/src/main/antlr4/org/drools/drl/parser/antlr4/DRL6Expressions.g4
@@ -162,9 +162,32 @@ typeArgument
     |	QUESTION ((extends_key | super_key) type)?
     ;
 
+// matches any identifiers including acceptable java keywords (defined in JavaParser.g4) and drl keywords
+drlIdentifier returns [Token token]
+    : drlKeywords
+    | IDENTIFIER
+    | MODULE
+    | OPEN
+    | REQUIRES
+    | EXPORTS
+    | OPENS
+    | TO
+    | USES
+    | PROVIDES
+    | WITH
+    | TRANSITIVE
+    | YIELD
+    | SEALED
+    | PERMITS
+    | RECORD
+    | VAR
+    | THIS
+    ;
+
 // matches any drl keywords
 drlKeywords returns [Token token]
-    : DRL_UNIT
+    : builtInOperator
+    | DRL_UNIT
     | DRL_FUNCTION
     | DRL_GLOBAL
     | DRL_DECLARE
@@ -179,12 +202,6 @@ drlKeywords returns [Token token]
     | DRL_NOT
     | DRL_IN
     | DRL_FROM
-    | DRL_MATCHES
-    | DRL_MEMBEROF
-    | DRL_CONTAINS
-    | DRL_EXCLUDES
-    | DRL_SOUNDSLIKE
-    | DRL_STR
     | DRL_ACCUMULATE
     | DRL_ACC
     | DRL_INIT
@@ -211,26 +228,26 @@ drlKeywords returns [Token token]
     | DRL_DURATION
     ;
 
-// matches any identifiers including acceptable java keywords (defined in JavaParser.g4) and drl keywords
-drlIdentifier returns [Token token]
-    : drlKeywords
-    | IDENTIFIER
-    | MODULE
-    | OPEN
-    | REQUIRES
-    | EXPORTS
-    | OPENS
-    | TO
-    | USES
-    | PROVIDES
-    | WITH
-    | TRANSITIVE
-    | YIELD
-    | SEALED
-    | PERMITS
-    | RECORD
-    | VAR
-    | THIS
+builtInOperator returns[Token token]
+    : DRL_CONTAINS
+    | DRL_EXCLUDES
+    | DRL_MATCHES
+    | DRL_MEMBEROF
+    | DRL_SOUNDSLIKE
+    | DRL_AFTER
+    | DRL_BEFORE
+    | DRL_COINCIDES
+    | DRL_DURING
+    | DRL_FINISHED_BY
+    | DRL_FINISHES
+    | DRL_INCLUDES
+    | DRL_MEETS
+    | DRL_MET_BY
+    | DRL_OVERLAPPED_BY
+    | DRL_OVERLAPS
+    | DRL_STARTED_BY
+    | DRL_STARTS
+    | DRL_STR
     ;
 
 // --------------------------------------------------------
@@ -908,11 +925,13 @@ in_key
     ;
 
 operator_key
-  // At the moment, we list possible DRLLexer tokens here, but we may be able to improve this by isolating lexers. IDENTIFIER is required to accept custom operators
-  // We need to keep this semantic predicate for custom operators
-  :      {(helper.isPluggableEvaluator(false))}? id=(IDENTIFIER|DRL_MATCHES|DRL_MEMBEROF|DRL_CONTAINS|DRL_EXCLUDES|DRL_SOUNDSLIKE|DRL_STR) { helper.emit($id, DroolsEditorType.KEYWORD); }
+  // IDENTIFIER is required to accept custom operators. We need to keep this semantic predicate for custom operators
+  :      {(helper.isPluggableEvaluator(false))}? id=IDENTIFIER { helper.emit($id, DroolsEditorType.KEYWORD); }
+  // At the moment, we list possible DRLLexer tokens here, but we may be able to improve this by isolating lexers.
+  |      op=builtInOperator { helper.emit($op.token, DroolsEditorType.KEYWORD); }
   ;
 
 neg_operator_key
-  :      {(helper.isPluggableEvaluator(true))}? id=(IDENTIFIER|DRL_MATCHES|DRL_MEMBEROF|DRL_CONTAINS|DRL_EXCLUDES|DRL_SOUNDSLIKE|DRL_STR) { helper.emit($id, DroolsEditorType.KEYWORD); }
+  :      {(helper.isPluggableEvaluator(true))}? id=IDENTIFIER { helper.emit($id, DroolsEditorType.KEYWORD); }
+  |      op=builtInOperator { helper.emit($op.token, DroolsEditorType.KEYWORD); }
   ;

--- a/drools-drl/drools-drl-parser/src/main/antlr4/org/drools/drl/parser/antlr4/DRLParser.g4
+++ b/drools-drl/drools-drl-parser/src/main/antlr4/org/drools/drl/parser/antlr4/DRLParser.g4
@@ -142,7 +142,7 @@ inExpression : left=relationalExpression ( 'not'? 'in' LPAREN drlExpression (COM
 relationalExpression : left=drlExpression (right=orRestriction)* ;
 orRestriction : left=andRestriction (OR right=andRestriction)* ;
 andRestriction : left=singleRestriction (AND right=singleRestriction)* ;
-singleRestriction : op=relationalOperator drlExpression ;
+singleRestriction : op=relationalOperator squareArguments? drlExpression ;
 
 // OOPath
 xpathSeparator : DIV | QUESTION_DIV ;
@@ -161,13 +161,7 @@ relationalOperator
     | temporalOperator
     ;
 
-drlRelationalOperator
-    : DRL_NOT? DRL_MATCHES
-    | DRL_NOT? DRL_MEMBEROF
-    | DRL_NOT? DRL_CONTAINS
-    | DRL_NOT? DRL_EXCLUDES
-    | DRL_NOT? DRL_SOUNDSLIKE
-    | DRL_NOT? DRL_STR LBRACK IDENTIFIER RBRACK ;
+drlRelationalOperator : DRL_NOT? builtInOperator ;
 
 /* function := FUNCTION type? ID parameters(typed) chunk_{_} */
 functiondef : DRL_FUNCTION typeTypeOrVoid? IDENTIFIER formalParameters drlBlock ;
@@ -201,7 +195,8 @@ drlIdentifier
     ;
 
 drlKeywords
-    : DRL_UNIT
+    : builtInOperator
+    | DRL_UNIT
     | DRL_FUNCTION
     | DRL_GLOBAL
     | DRL_DECLARE
@@ -216,12 +211,6 @@ drlKeywords
     | DRL_NOT
     | DRL_IN
     | DRL_FROM
-    | DRL_MATCHES
-    | DRL_MEMBEROF
-    | DRL_CONTAINS
-    | DRL_EXCLUDES
-    | DRL_SOUNDSLIKE
-    | DRL_STR
     | DRL_ACCUMULATE
     | DRL_ACC
     | DRL_INIT
@@ -246,6 +235,28 @@ drlKeywords
     | DRL_CALENDARS
     | DRL_TIMER
     | DRL_DURATION
+    ;
+
+builtInOperator
+    : DRL_CONTAINS
+    | DRL_EXCLUDES
+    | DRL_MATCHES
+    | DRL_MEMBEROF
+    | DRL_SOUNDSLIKE
+    | DRL_AFTER
+    | DRL_BEFORE
+    | DRL_COINCIDES
+    | DRL_DURING
+    | DRL_FINISHED_BY
+    | DRL_FINISHES
+    | DRL_INCLUDES
+    | DRL_MEETS
+    | DRL_MET_BY
+    | DRL_OVERLAPPED_BY
+    | DRL_OVERLAPS
+    | DRL_STARTED_BY
+    | DRL_STARTS
+    | DRL_STR
     ;
 
 /* extending JavaParser expression */
@@ -341,6 +352,8 @@ drlLiteral
     | TEXT_BLOCK // Java17
     | TIME_INTERVAL
     ;
+
+squareArguments : LBRACK expressionList? RBRACK ;
 
 inlineListExpression
     :   LBRACK expressionList? RBRACK


### PR DESCRIPTION
Fixes #5735.

### Before PR in `drools-model-codegen`
```
[ERROR] Tests run: 2434, Failures: 200, Errors: 0, Skipped: 9
```

### After PR in `drools-model-codegen`
```
[ERROR] Tests run: 2434, Failures: 173, Errors: 0, Skipped: 9
```

### :warning: Note
This PR fixes the last failing tests in `drools-serialization-protobuf` (3) and thereby unlocks `kie-ci` (1) and `drools-traits` (292) with a large number of failing tests so the total number of failing tests jumps from 270 to 533. This is expected and the number will probably go rapidly down when we implement traits in the new parser.

<details>
<summary>
How to replicate CI configuration locally?
</summary>

Build Chain tool does "simple" maven build(s), the builds are just Maven commands, but because the repositories relates and depends on each other and any change in API or class method could affect several of those repositories there is a need to use [build-chain tool](https://github.com/kiegroup/github-action-build-chain) to handle cross repository builds and be sure that we always use latest version of the code for each repository.
 
[build-chain tool](https://github.com/kiegroup/github-action-build-chain) is a build tool which can be used on command line locally or in Github Actions workflow(s), in case you need to change multiple repositories and send multiple dependent pull requests related with a change you can easily reproduce the same build by executing it on Github hosted environment or locally in your development environment. See [local execution](https://github.com/kiegroup/github-action-build-chain#local-execution) details to get more information about it.
</details>

<details>
<summary>
How to retest this PR or trigger a specific build:
</summary>

- for <b>pull request and downstream checks</b>  
  - Push a new commit to the PR. An empty commit would be enough.

- for a <b>full downstream build</b>
  - for <b>github actions</b> job: add the label `run_fdb`

- for <b>Jenkins PR check only</b>
  - If you are an ASF committer for KIE podling, login to Jenkins (https://ci-builds.apache.org/job/KIE/job/drools/), go to the specific PR job, and click on `Build Now` button.
</details>
