### PR TITLE
[new-parser] Allow package to be used as an identifier

### DIFF
--- a/drools-drl/drools-drl-parser-tests/src/test/java/org/drools/drl/parser/antlr4/MiscDRLParserTest.java
+++ b/drools-drl/drools-drl-parser-tests/src/test/java/org/drools/drl/parser/antlr4/MiscDRLParserTest.java
@@ -3978,4 +3978,24 @@ class MiscDRLParserTest {
         assertThat(query.getParameterTypes()).isEmpty();
         assertThat(query.getParameters()).isEmpty();
     }
+
+    @Test
+    public void packageInQualifiedName() throws Exception {
+        String pkgName = "org.drools.package";
+        String text = "package " + pkgName + "\n" +
+                "rule R\n" +
+                "when\n" +
+                "  $p : Person()\n" +
+                "then\n" +
+                "end\n";
+
+
+        PackageDescr pkg = parser.parse(text);
+        assertThat(parser.hasErrors()).as(parser.getErrorMessages().toString()).isFalse();
+
+        assertThat(pkg.getName()).isEqualTo(pkgName);
+        assertThat(pkg.getRules()).hasSize(1);
+
+        assertThat(pkg.getRules().get(0).getName()).isEqualTo("R");
+    }
 }

--- a/drools-drl/drools-drl-parser/src/main/antlr4/org/drools/drl/parser/antlr4/DRLParser.g4
+++ b/drools-drl/drools-drl-parser/src/main/antlr4/org/drools/drl/parser/antlr4/DRLParser.g4
@@ -198,6 +198,7 @@ drlIdentifier
     | RECORD
     | VAR
     | THIS
+    | PACKAGE
     ;
 
 drlKeywords


### PR DESCRIPTION
Fixes
- #5818 

### DRAFT
Let's discuss whether this is a good approach.

<details>
<summary>
How to replicate CI configuration locally?
</summary>

Build Chain tool does "simple" maven build(s), the builds are just Maven commands, but because the repositories relates and depends on each other and any change in API or class method could affect several of those repositories there is a need to use [build-chain tool](https://github.com/kiegroup/github-action-build-chain) to handle cross repository builds and be sure that we always use latest version of the code for each repository.
 
[build-chain tool](https://github.com/kiegroup/github-action-build-chain) is a build tool which can be used on command line locally or in Github Actions workflow(s), in case you need to change multiple repositories and send multiple dependent pull requests related with a change you can easily reproduce the same build by executing it on Github hosted environment or locally in your development environment. See [local execution](https://github.com/kiegroup/github-action-build-chain#local-execution) details to get more information about it.
</details>

<details>
<summary>
How to retest this PR or trigger a specific build:
</summary>

- for <b>pull request and downstream checks</b>  
  - Push a new commit to the PR. An empty commit would be enough.

- for a <b>full downstream build</b>
  - for <b>github actions</b> job: add the label `run_fdb`

- for <b>Jenkins PR check only</b>
  - If you are an ASF committer for KIE podling, login to Jenkins (https://ci-builds.apache.org/job/KIE/job/drools/), go to the specific PR job, and click on `Build Now` button.
</details>
