### PR TITLE
[new-parser] Support pluggable evaluators and class literal

### DIFF
--- a/drools-drl/drools-drl-parser-tests/src/test/java/org/drools/drl/parser/antlr4/MiscDRLParserTest.java
+++ b/drools-drl/drools-drl-parser-tests/src/test/java/org/drools/drl/parser/antlr4/MiscDRLParserTest.java
@@ -4001,6 +4001,22 @@ class MiscDRLParserTest {
     }
 
     @Test
+    public void pluggableEvaluator() throws Exception {
+        final String source = "package org.drools\n" +
+                "rule R\n" +
+                "when\n" +
+                "   $t : Thing( $c : core, this not isA t.x.E.class, this isA t.x.D.class )\n" +
+                "then\n" +
+                "   list.add( \"E\" ); \n" +
+                "   don( $t, E.class ); \n" +
+                "end\n";
+        PatternDescr pattern = (PatternDescr) parseAndGetFirstRuleDescr(source).getLhs().getDescrs().get(0);
+        assertThat(pattern.getConstraint().getDescrs())
+                .extracting(Object::toString)
+                .containsExactly("$c : core", "this not isA t.x.E.class", "this isA t.x.D.class");
+    }
+
+    @Test
     void namedConsequenceDo() {
         final String text =
                 "rule R when\n" +

--- a/drools-drl/drools-drl-parser/src/main/antlr4/org/drools/drl/parser/antlr4/DRL6Expressions.g4
+++ b/drools-drl/drools-drl-parser/src/main/antlr4/org/drools/drl/parser/antlr4/DRL6Expressions.g4
@@ -747,7 +747,7 @@ identifierSuffix
                           expression
                           RBRACK { helper.emit($RBRACK, DroolsEditorType.SYMBOL); } )+ // can also be matched by selector, but do here
     |   arguments
-//    |   DOT class_key
+    |   DOT class_key
 //    |   DOT explicitGenericInvocation
 //    |   DOT this_key
 //    |   DOT super_key arguments

--- a/drools-drl/drools-drl-parser/src/main/antlr4/org/drools/drl/parser/antlr4/DRLParser.g4
+++ b/drools-drl/drools-drl-parser/src/main/antlr4/org/drools/drl/parser/antlr4/DRLParser.g4
@@ -188,7 +188,8 @@ relationalOperator
     | temporalOperator
     ;
 
-drlRelationalOperator : DRL_NOT? builtInOperator ;
+// IDENTIFIER is required to accept custom operators.
+drlRelationalOperator : DRL_NOT? (IDENTIFIER | builtInOperator) ;
 
 /* function := FUNCTION type? ID parameters(typed) chunk_{_} */
 functiondef : DRL_FUNCTION typeTypeOrVoid? IDENTIFIER formalParameters drlBlock ;
@@ -350,18 +351,43 @@ temporalOperator : DRL_NOT? bop=(DRL_AFTER | DRL_BEFORE | DRL_COINCIDES | DRL_DU
 
 timeAmount : LBRACK (TIME_INTERVAL | DECIMAL_LITERAL | MUL | SUB MUL) (COMMA (TIME_INTERVAL | DECIMAL_LITERAL | MUL | SUB MUL))* RBRACK ;
 
+unaryExpressionNotPlusMinus : (left2=xpathPrimary | left1=drlPrimary) (selector)* ;
+
+selector
+    : DOT SUPER superSuffix
+    | DOT NEW (nonWildcardTypeArguments)? innerCreator
+    | (DOT | NULL_SAFE_DOT) drlIdentifier (drlArguments)?
+    | (DOT | NULL_SAFE_DOT) drlMethodCall
+    | LBRACK drlExpression RBRACK
+    ;
+
 /* extending JavaParser primary */
 drlPrimary
     : LPAREN drlExpression RPAREN
     | THIS
     | SUPER
+    | NEW drlCreator
     | drlLiteral
-    | drlIdentifier
+    | drlIdentifier(
+        ( d=DOT i2=drlIdentifier )
+        |
+        ( d=(DOT | NULL_SAFE_DOT) LPAREN drlExpression (COMMA drlExpression)* RPAREN )
+        |
+        ( h=HASH i2=drlIdentifier )
+        |
+        ( n=NULL_SAFE_DOT i2=drlIdentifier )
+        )* (identifierSuffix)?
     | typeTypeOrVoid DOT CLASS
     | nonWildcardTypeArguments (explicitGenericInvocationSuffix | THIS arguments)
     | inlineListExpression
     | inlineMapExpression
     | inlineCast
+    ;
+
+identifierSuffix
+    : (LBRACK RBRACK)+ DOT CLASS
+    | (LBRACK drlExpression RBRACK)+
+    | arguments
     ;
 
 inlineCast : drlIdentifier HASH drlIdentifier ;
@@ -423,7 +449,7 @@ patternSource : fromAccumulate
               | fromExpression
               ;
 
-fromExpression : conditionalOrExpression ;
+fromExpression : unaryExpressionNotPlusMinus ;
 
 
 /*

--- a/drools-drl/drools-drl-parser/src/main/antlr4/org/drools/drl/parser/antlr4/DRLParser.g4
+++ b/drools-drl/drools-drl-parser/src/main/antlr4/org/drools/drl/parser/antlr4/DRLParser.g4
@@ -368,20 +368,17 @@ drlPrimary
     | SUPER
     | NEW drlCreator
     | drlLiteral
-    | drlIdentifier(
-        ( d=DOT i2=drlIdentifier )
-        |
-        ( d=(DOT | NULL_SAFE_DOT) LPAREN drlExpression (COMMA drlExpression)* RPAREN )
-        |
-        ( h=HASH i2=drlIdentifier )
-        |
-        ( n=NULL_SAFE_DOT i2=drlIdentifier )
-        )* (identifierSuffix)?
+    | drlIdentifier drlIdentifierMiddle* identifierSuffix?
     | typeTypeOrVoid DOT CLASS
     | nonWildcardTypeArguments (explicitGenericInvocationSuffix | THIS arguments)
     | inlineListExpression
     | inlineMapExpression
     | inlineCast
+    ;
+
+drlIdentifierMiddle
+    : (DOT | NULL_SAFE_DOT | HASH) drlIdentifier
+    | (DOT | NULL_SAFE_DOT) LPAREN drlExpression (COMMA drlExpression)* RPAREN
     ;
 
 identifierSuffix


### PR DESCRIPTION
- Fixes #5822
- Fixes #5833

### Before PR in `drools-traits`
```
[ERROR] Tests run: 363, Failures: 79, Errors: 90, Skipped: 6
```

### After PR in `drools-traits`
```
[ERROR] Tests run: 363, Failures: 34, Errors: 54, Skipped: 6
```

Fixes 81 tests in `drools-traits` and `org.drools.model.codegen.execmodel.CompilerTest#testMethodCallWithClass`.

<details>
<summary>
How to replicate CI configuration locally?
</summary>

Build Chain tool does "simple" maven build(s), the builds are just Maven commands, but because the repositories relates and depends on each other and any change in API or class method could affect several of those repositories there is a need to use [build-chain tool](https://github.com/kiegroup/github-action-build-chain) to handle cross repository builds and be sure that we always use latest version of the code for each repository.
 
[build-chain tool](https://github.com/kiegroup/github-action-build-chain) is a build tool which can be used on command line locally or in Github Actions workflow(s), in case you need to change multiple repositories and send multiple dependent pull requests related with a change you can easily reproduce the same build by executing it on Github hosted environment or locally in your development environment. See [local execution](https://github.com/kiegroup/github-action-build-chain#local-execution) details to get more information about it.
</details>

<details>
<summary>
How to retest this PR or trigger a specific build:
</summary>

- for <b>pull request and downstream checks</b>  
  - Push a new commit to the PR. An empty commit would be enough.

- for a <b>full downstream build</b>
  - for <b>github actions</b> job: add the label `run_fdb`

- for <b>Jenkins PR check only</b>
  - If you are an ASF committer for KIE podling, login to Jenkins (https://ci-builds.apache.org/job/KIE/job/drools/), go to the specific PR job, and click on `Build Now` button.
</details>
