### PR TITLE
NO-ISSUE: Updating Maven to 3.9.6 in GH Actions

### DIFF
--- a/.ci/jenkins/config/branch.yaml
+++ b/.ci/jenkins/config/branch.yaml
@@ -84,5 +84,5 @@ jenkins:
         args: --privileged --group-add docker
   default_tools:
     jdk: jdk_17_latest
-    maven: maven_3.9.3
+    maven: maven_3.9.6
     sonar_jdk: jdk_17_latest

--- a/.github/workflows/pr-downstream-full.yml
+++ b/.github/workflows/pr-downstream-full.yml
@@ -24,7 +24,7 @@ jobs:
       matrix:
         os: [ubuntu-latest]
         java-version: [17]
-        maven-version: ['3.9.3']
+        maven-version: ['3.9.6']
       fail-fast: false
     runs-on: ${{ matrix.os }}
     name: Build Chain (${{ matrix.os }} / Java-${{ matrix.java-version }} / Maven-${{ matrix.maven-version }})

--- a/.github/workflows/pr-downstream.yml
+++ b/.github/workflows/pr-downstream.yml
@@ -23,7 +23,7 @@ jobs:
         job_name: [ kogito-runtimes, kogito-apps, kogito-quarkus-examples, kogito-springboot-examples, serverless-workflow-examples ]
         os: [ubuntu-latest]
         java-version: [17]
-        maven-version: ['3.9.3']
+        maven-version: ['3.9.6']
         include:
           - job_name: kogito-runtimes
             repository: incubator-kie-kogito-runtimes

--- a/.github/workflows/pr-drools-ansible.yml
+++ b/.github/workflows/pr-drools-ansible.yml
@@ -22,7 +22,7 @@ jobs:
       matrix:
         os: [ubuntu-latest]
         java-version: [17]
-        maven-version: ['3.9.3']
+        maven-version: ['3.9.6']
       fail-fast: false
     runs-on: ${{ matrix.os }}
     name: Ansible Integration / ${{ matrix.os }} / Java-${{ matrix.java-version }} / Maven-${{ matrix.maven-version }}

--- a/.github/workflows/pr-drools-docs.yml
+++ b/.github/workflows/pr-drools-docs.yml
@@ -16,7 +16,7 @@ jobs:
       matrix:
         os: [ubuntu-latest]
         java-version: [17]
-        maven-version: ['3.9.3']
+        maven-version: ['3.9.6']
       fail-fast: false
     runs-on: ${{ matrix.os }}
     name: ${{ matrix.os }} / Java-${{ matrix.java-version }} / Maven-${{ matrix.maven-version }}

--- a/.github/workflows/pr-drools.yml
+++ b/.github/workflows/pr-drools.yml
@@ -22,7 +22,7 @@ jobs:
       matrix:
         os: [ubuntu-latest, windows-latest]
         java-version: [17]
-        maven-version: ['3.9.3']
+        maven-version: ['3.9.6']
       fail-fast: false
     runs-on: ${{ matrix.os }}
     name: ${{ matrix.os }} / Java-${{ matrix.java-version }} / Maven-${{ matrix.maven-version }}

--- a/drools-quarkus-extension/drools-quarkus-quickstart-test/guide.adoc
+++ b/drools-quarkus-extension/drools-quarkus-quickstart-test/guide.adoc
@@ -18,7 +18,7 @@ To complete this guide, you need:
 * less than 15 minutes
 * an IDE
 * JDK 17+ installed with `JAVA_HOME` configured appropriately
-* Apache Maven 3.9.3+
+* Apache Maven 3.9.6+
 * Docker
 * link:{quarkus-guides-url}/building-native-image[GraalVM installed if you want to run in native mode]
 


### PR DESCRIPTION
Updating Maven 3.9.6 version in GH Actions Builds.

<details>
<summary>
How to replicate CI configuration locally?
</summary>

Build Chain tool does "simple" maven build(s), the builds are just Maven commands, but because the repositories relates and depends on each other and any change in API or class method could affect several of those repositories there is a need to use [build-chain tool](https://github.com/kiegroup/github-action-build-chain) to handle cross repository builds and be sure that we always use latest version of the code for each repository.
 
[build-chain tool](https://github.com/kiegroup/github-action-build-chain) is a build tool which can be used on command line locally or in Github Actions workflow(s), in case you need to change multiple repositories and send multiple dependent pull requests related with a change you can easily reproduce the same build by executing it on Github hosted environment or locally in your development environment. See [local execution](https://github.com/kiegroup/github-action-build-chain#local-execution) details to get more information about it.
</details>

<details>
<summary>
How to retest this PR or trigger a specific build:
</summary>

- for <b>pull request and downstream checks</b>  
  - Push a new commit to the PR. An empty commit would be enough.

- for a <b>full downstream build</b>
  - for <b>github actions</b> job: add the label `run_fdb`

- for <b>Jenkins PR check only</b>
  - If you are an ASF committer for KIE podling, login to Jenkins (https://ci-builds.apache.org/job/KIE/job/drools/), go to the specific PR job, and click on `Build Now` button.
</details>
