### PR TITLE
Add optional Regular Expression cache to MatchesOperator

### DIFF
--- a/drools-model/drools-canonical-model/src/main/java/org/drools/model/operators/MatchesOperator.java
+++ b/drools-model/drools-canonical-model/src/main/java/org/drools/model/operators/MatchesOperator.java
@@ -32,10 +32,10 @@ public enum MatchesOperator implements Operator.SingleValue<String, String> {
     INSTANCE;
 
     // not final due to unit tests
-    private int MAX_SIZE_CACHE = getMaxSizeCache();
+    private static int MAX_SIZE_CACHE = getMaxSizeCache();
 
     // store Pattern for regular expressions using the regular expression as the key up to MAX_SIZE_CACHE entries.
-    private final Map<String, Pattern> patternMap = Collections.synchronizedMap(new LinkedHashMap<>() {
+    private static final Map<String, Pattern> patternMap = Collections.synchronizedMap(new LinkedHashMap<>() {
         @Override
         protected boolean removeEldestEntry(Map.Entry<String, Pattern> eldest) {
             return size() > (MAX_SIZE_CACHE);

--- a/drools-model/drools-canonical-model/src/test/java/org/drools/model/operators/MatchesOperatorTest.java
+++ b/drools-model/drools-canonical-model/src/test/java/org/drools/model/operators/MatchesOperatorTest.java
@@ -1,0 +1,23 @@
+package org.drools.model.operators;
+
+import org.junit.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+
+public class MatchesOperatorTest {
+    @Test
+    public void testMatchesOperator() {
+        MatchesOperator instance = MatchesOperator.INSTANCE;
+        // Regular expression is second parameter
+        assertThat(instance.eval("a","a")).isTrue();
+        assertThat(instance.eval("a","b")).isFalse();
+        assertThat(instance.eval("a","a")).isTrue();
+        assertThat(instance.eval("b","b")).isTrue();
+
+        // s1 maybe null
+        assertThat(instance.eval(null,"anything")).isFalse();
+
+    }
+
+}

--- a/drools-model/drools-canonical-model/src/test/java/org/drools/model/operators/MatchesOperatorTest.java
+++ b/drools-model/drools-canonical-model/src/test/java/org/drools/model/operators/MatchesOperatorTest.java
@@ -1,23 +1,69 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
 package org.drools.model.operators;
 
+import org.junit.After;
 import org.junit.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
 
 public class MatchesOperatorTest {
+
+
     @Test
-    public void testMatchesOperator() {
+    public void testMatchesOperatorCache() {
         MatchesOperator instance = MatchesOperator.INSTANCE;
-        // Regular expression is second parameter
+        instance.forceCacheSize(100);
+
+        // input maybe null
+        assertThat(instance.eval(null,"anything")).isFalse();
+        assertThat(instance.mapSize()).isEqualTo(0); // not added to cache with null input
+        // cache enabled
+        assertThat(instance.eval("a","a")).isTrue();
+        assertThat(instance.mapSize()).isEqualTo(1);
+        assertThat(instance.eval("a","b")).isFalse();
+        assertThat(instance.mapSize()).isEqualTo(2);
+        assertThat(instance.eval("a","a")).isTrue();  // regular expression "a" in map.
+        assertThat(instance.eval("b","b")).isTrue();  // regular expression "b" in map.
+        assertThat(instance.eval("c","a")).isFalse(); // regular expression "a" in map.
+        assertThat(instance.eval("c","b")).isFalse(); // regular expression "b" in map.
+        assertThat(instance.mapSize()).isEqualTo(2);
+    }
+
+    @Test
+    public void testMatchesOperatorNoCache() {
+        MatchesOperator instance = MatchesOperator.INSTANCE;
+        instance.forceCacheSize(0);
+        // input maybe null
+        assertThat(instance.eval(null,"anything")).isFalse();
         assertThat(instance.eval("a","a")).isTrue();
         assertThat(instance.eval("a","b")).isFalse();
-        assertThat(instance.eval("a","a")).isTrue();
+        assertThat(instance.eval("b","a")).isFalse();
         assertThat(instance.eval("b","b")).isTrue();
+        assertThat(instance.mapSize()).isEqualTo(0);
+    }
 
-        // s1 maybe null
-        assertThat(instance.eval(null,"anything")).isFalse();
-
+    @After
+    public void resetCache() {
+        MatchesOperator instance = MatchesOperator.INSTANCE;
+        instance.reInitialize();
     }
 
 }


### PR DESCRIPTION
Improves performance of matches operator by optionally caching the Pattern instances compiled from the regular expression.

To use the cache add the following property before MatchesOperator is initialized.

System.setProperty("drools.matches.compiled.cache.count", "100");

I did not know how to create a test case that would run for both cases where the system property "drools.matches.compiled.cache.count" is 0 and is a positive number > 0.
