### PR TITLE
[KIE-1085] avoid wasteful creation of a custom operator per constraint at runtime when using the executable model

### DIFF
--- a/drools-model/drools-model-codegen/src/main/java/org/drools/model/codegen/execmodel/PackageModel.java
+++ b/drools-model/drools-model-codegen/src/main/java/org/drools/model/codegen/execmodel/PackageModel.java
@@ -87,6 +87,7 @@ import org.drools.model.codegen.execmodel.generator.QueryGenerator;
 import org.drools.model.codegen.execmodel.generator.QueryParameter;
 import org.drools.model.codegen.execmodel.generator.TypedExpression;
 import org.drools.model.codegen.execmodel.generator.WindowReferenceGenerator;
+import org.drools.model.codegen.execmodel.generator.operatorspec.CustomOperatorSpec;
 import org.drools.model.codegen.execmodel.util.lambdareplace.CreatedClass;
 import org.drools.model.functions.PredicateInformation;
 import org.drools.modelcompiler.util.StringUtil;
@@ -186,6 +187,8 @@ public class PackageModel {
     private final Collection<String> executableRulesClasses = new HashSet<>();
 
     private final boolean prototypesAllowed;
+
+    private final CustomOperatorSpec customOperatorSpec = new CustomOperatorSpec();
 
     private PackageModel( ReleaseId releaseId, String name, KnowledgeBuilderConfigurationImpl configuration, DialectCompiletimeRegistry dialectCompiletimeRegistry, DRLIdGenerator exprIdGenerator) {
         this(name, configuration, dialectCompiletimeRegistry, exprIdGenerator, getPkgUUID(configuration, releaseId, name));
@@ -291,6 +294,10 @@ public class PackageModel {
     
     public DRLIdGenerator getExprIdGenerator() {
         return exprIdGenerator;
+    }
+
+    public CustomOperatorSpec getCustomOperatorSpec() {
+        return customOperatorSpec;
     }
 
     public void addImports(Collection<String> imports) {
@@ -611,6 +618,8 @@ public class PackageModel {
         }
 
         rulesClass.addMember( generateListField("org.drools.model.Global", "globals", globals.isEmpty() && !hasRuleUnit) );
+
+        customOperatorSpec.getOperatorDeclarations().forEach( op -> rulesClass.addMember( parseBodyDeclaration( op ) ) );
 
         if ( !typeMetaDataExpressions.isEmpty() ) {
             BodyDeclaration<?> typeMetaDatasList = parseBodyDeclaration("java.util.List<org.drools.model.TypeMetaData> typeMetaDatas = new java.util.ArrayList<>();");

--- a/drools-model/drools-model-codegen/src/main/java/org/drools/model/codegen/execmodel/generator/expressiontyper/ExpressionTyper.java
+++ b/drools-model/drools-model-codegen/src/main/java/org/drools/model/codegen/execmodel/generator/expressiontyper/ExpressionTyper.java
@@ -66,14 +66,13 @@ import com.github.javaparser.ast.type.ReferenceType;
 import com.github.javaparser.ast.type.Type;
 import org.drools.model.codegen.execmodel.errors.InvalidExpressionErrorResult;
 import org.drools.model.codegen.execmodel.errors.ParseExpressionErrorResult;
-import org.drools.model.codegen.execmodel.generator.TypedDeclarationSpec;
 import org.drools.model.codegen.execmodel.generator.DrlxParseUtil;
 import org.drools.model.codegen.execmodel.generator.ModelGenerator;
 import org.drools.model.codegen.execmodel.generator.RuleContext;
+import org.drools.model.codegen.execmodel.generator.TypedDeclarationSpec;
 import org.drools.model.codegen.execmodel.generator.TypedExpression;
 import org.drools.model.codegen.execmodel.generator.UnificationTypedExpression;
 import org.drools.model.codegen.execmodel.generator.drlxparse.NumberAndStringArithmeticOperationCoercion;
-import org.drools.model.codegen.execmodel.generator.operatorspec.CustomOperatorSpec;
 import org.drools.model.codegen.execmodel.generator.operatorspec.NativeOperatorSpec;
 import org.drools.model.codegen.execmodel.generator.operatorspec.OperatorSpec;
 import org.drools.model.codegen.execmodel.generator.operatorspec.TemporalOperatorSpec;
@@ -126,8 +125,8 @@ import static org.drools.model.codegen.execmodel.generator.expressiontyper.Flatt
 import static org.drools.mvel.parser.MvelParser.parseType;
 import static org.drools.mvel.parser.printer.PrintUtil.printNode;
 import static org.drools.util.ClassUtils.extractGenericType;
-import static org.drools.util.ClassUtils.getter2property;
 import static org.drools.util.ClassUtils.getTypeArgument;
+import static org.drools.util.ClassUtils.getter2property;
 import static org.drools.util.ClassUtils.toRawClass;
 import static org.kie.internal.ruleunit.RuleUnitUtil.isDataSource;
 
@@ -482,7 +481,7 @@ public class ExpressionTyper {
         if ( org.drools.model.functions.Operator.Register.hasOperator( operator ) ) {
             return NativeOperatorSpec.INSTANCE;
         }
-        return CustomOperatorSpec.INSTANCE;
+        return ruleContext.getPackageModel().getCustomOperatorSpec();
     }
 
     private TypedExpressionResult toTypedExpressionFromMethodCallOrField(Expression drlxExpr) {

--- a/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/compiler/integrationtests/CustomOperatorTest.java
+++ b/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/compiler/integrationtests/CustomOperatorTest.java
@@ -70,6 +70,18 @@ public class CustomOperatorTest {
     }
 
     @Test
+    public void testNoOperatorInstancesCreatedAtRuntime() {
+        String constraints =
+                "    $alice : Person(name == \"Alice\")\n" +
+                "    $bob : Person(name == \"Bob\", addresses supersetOf $alice.addresses)\n" +
+                "    Person(name == \"Bob\", addresses supersetOf $alice.addresses)\n";
+
+        customOperatorUsingCollections(constraints);
+
+        assertThat(SupersetOfEvaluatorDefinition.INSTANCES_COUNTER).isEqualTo(0);
+    }
+
+    @Test
     public void testCustomOperatorUsingCollectionsInverted() {
         // DROOLS-6983
         String constraints =
@@ -90,6 +102,9 @@ public class CustomOperatorTest {
         System.setProperty(EvaluatorOption.PROPERTY_NAME + "supersetOf", SupersetOfEvaluatorDefinition.class.getName());
         try {
             final KieBase kbase = KieBaseUtil.getKieBaseFromKieModuleFromDrl("custom-operator-test", kieBaseTestConfiguration, drl);
+
+            SupersetOfEvaluatorDefinition.INSTANCES_COUNTER = 0;
+
             final KieSession ksession = kbase.newKieSession();
             try {
                 final Person alice = new Person("Alice", 30);
@@ -117,6 +132,12 @@ public class CustomOperatorTest {
         private static final String[] SUPPORTED_IDS = {SUPERSET_OF.getOperatorString()};
 
         private Evaluator[] evaluator;
+
+        static int INSTANCES_COUNTER = 0;
+
+        public SupersetOfEvaluatorDefinition() {
+            INSTANCES_COUNTER++;
+        }
 
         public String[] getEvaluatorIds() {
             return SupersetOfEvaluatorDefinition.SUPPORTED_IDS;


### PR DESCRIPTION
See https://github.com/apache/incubator-kie-issues/issues/1085

With this change the operator instance is stored in a static field of the package model 

```
public static final org.drools.model.functions.Operator.SingleValue<Object, Object> OPERATOR_supersetOf_INSTANCE = new org.drools.model.codegen.execmodel.generator.operatorspec.CustomOperatorWrapper(new org.drools.compiler.integrationtests.CustomOperatorTest.SupersetOfEvaluatorDefinition().getEvaluator(org.drools.base.base.ValueType.OBJECT_TYPE, "supersetOf", false, null), "supersetOf");
```

so that the same instance can be reused by all constraints

```
     @Override()
    public boolean test(org.drools.testcoverage.common.model.Person _this, org.drools.testcoverage.common.model.Person $alice) throws java.lang.Exception {
        return D.eval(defaultpkg.Rules68EE95F12A426D19D8745A5FE99E2A61.OPERATOR_supersetOf_INSTANCE, _this.getAddresses(), $alice.getAddresses());
    }
```