### PR TITLE
[incubator-kie-drools-5792] [new-parser] improve drools-drl-parser-tests

### DIFF
--- a/drools-drl/drools-drl-parser-tests/pom.xml
+++ b/drools-drl/drools-drl-parser-tests/pom.xml
@@ -83,4 +83,42 @@
         </dependency>
     </dependencies>
 
+    <profiles>
+        <profile>
+            <id>default</id>
+            <activation>
+                <activeByDefault>true</activeByDefault>
+            </activation>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-surefire-plugin</artifactId>
+                        <executions>
+                            <execution>
+                                <!-- override default-test for new parser -->
+                                <id>default-test</id>
+                                <configuration>
+                                    <systemPropertyVariables>
+                                        <drools.drl.antlr4.parser.enabled>true</drools.drl.antlr4.parser.enabled>
+                                    </systemPropertyVariables>
+                                </configuration>
+                            </execution>
+                            <execution>
+                                <id>old-parser-test</id>
+                                <configuration>
+                                    <systemPropertyVariables>
+                                        <drools.drl.antlr4.parser.enabled>false</drools.drl.antlr4.parser.enabled>
+                                    </systemPropertyVariables>
+                                </configuration>
+                                <goals>
+                                    <goal>test</goal>
+                                </goals>
+                            </execution>
+                        </executions>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+    </profiles>
 </project>

--- a/drools-drl/drools-drl-parser-tests/src/test/java/org/drools/drl/parser/antlr4/DRLExprParserTest.java
+++ b/drools-drl/drools-drl-parser-tests/src/test/java/org/drools/drl/parser/antlr4/DRLExprParserTest.java
@@ -30,6 +30,8 @@ import org.drools.drl.ast.descr.ConnectiveType;
 import org.drools.drl.ast.descr.ConstraintConnectiveDescr;
 import org.drools.drl.ast.descr.RelationalExprDescr;
 import org.drools.drl.parser.DrlExprParser;
+import org.drools.drl.parser.DrlExprParserFactory;
+import org.drools.drl.parser.DrlParser;
 import org.drools.drl.parser.DroolsParserException;
 import org.drools.drl.parser.impl.Operator;
 import org.junit.jupiter.api.AfterEach;
@@ -49,17 +51,17 @@ public class DRLExprParserTest {
     DrlExprParser parser;
 
     @BeforeEach
-    public void setUp() throws Exception {
-        this.parser = new Drl6ExprParserAntlr4(LanguageLevelOption.DRL6);
+    public void setUp() {
+        this.parser = DrlExprParserFactory.getDrlExprParser(LanguageLevelOption.DRL6);
     }
 
     @AfterEach
-    public void tearDown() throws Exception {
+    public void tearDown() {
         this.parser = null;
     }
 
     @Test
-    public void testSimpleExpression() throws Exception {
+    public void testSimpleExpression() {
         String source = "a > b";
         ConstraintConnectiveDescr result = parser.parse( source );
         assertThat(parser.hasErrors()).as(parser.getErrors().toString()).isFalse();
@@ -387,13 +389,26 @@ public class DRLExprParserTest {
         assertThat(parser.hasErrors()).isTrue();
         assertThat(parser.getErrors()).hasSize(1);
         DroolsParserException exception = parser.getErrors().get(0);
-        assertThat(exception.getErrorCode()).isEqualTo("ERR 102");
-        assertThat(exception.getLineNumber()).isEqualTo(1);
-        assertThat(exception.getColumn()).isEqualTo(1);
-        assertThat(exception.getOffset()).isEqualTo(1);
-        assertThat(exception.getMessage())
-                .startsWithIgnoringCase("[ERR 102] Line 1:1 mismatched input '<EOF>' expecting ")
-                .contains("TIME_INTERVAL", "DRL_STRING_LITERAL", "?/", "boolean", "byte", "char", "double", "float", "int", "long", "new", "short", "super", "DECIMAL_LITERAL", "HEX_LITERAL", "FLOAT_LITERAL", "BOOL_LITERAL", "STRING_LITERAL", "null", "(", "[", ".", "<", "!", "~", "++", "--", "+", "-", "*", "/", "IDENTIFIER");
+
+        // Backward Compatibility Notes:
+        //   Antlr4 gives a different error code/message from antlr3 for this case.
+        //   Backward compatibility doesn't seem to be required in this case.
+        if (DrlParser.ANTLR4_PARSER_ENABLED) {
+            assertThat(exception.getErrorCode()).isEqualTo("ERR 102");
+            assertThat(exception.getLineNumber()).isEqualTo(1);
+            assertThat(exception.getColumn()).isEqualTo(1);
+            assertThat(exception.getOffset()).isEqualTo(1);
+            assertThat(exception.getMessage())
+                    .startsWithIgnoringCase("[ERR 102] Line 1:1 mismatched input '<EOF>' expecting ")
+                    .contains("TIME_INTERVAL", "DRL_STRING_LITERAL", "?/", "boolean", "byte", "char", "double", "float", "int", "long", "new", "short", "super", "DECIMAL_LITERAL", "HEX_LITERAL", "FLOAT_LITERAL", "BOOL_LITERAL", "STRING_LITERAL", "null", "(", "[", ".", "<", "!", "~", "++", "--", "+", "-", "*", "/", "IDENTIFIER");
+        } else {
+            assertThat(exception.getErrorCode()).isEqualTo("ERR 101");
+            assertThat(exception.getLineNumber()).isEqualTo(1);
+            assertThat(exception.getColumn()).isEqualTo(1);
+            assertThat(exception.getOffset()).isEqualTo(1);
+            assertThat(exception.getMessage())
+                    .isEqualToIgnoringCase("[ERR 101] Line 1:1 no viable alternative at input '<eof>'");
+        }
     }
 
     @Test
@@ -403,26 +418,48 @@ public class DRLExprParserTest {
         assertThat(parser.hasErrors()).isTrue();
         assertThat(parser.getErrors()).hasSize(1);
         DroolsParserException exception = parser.getErrors().get(0);
-        assertThat(exception.getErrorCode()).isEqualTo("ERR 109");
-        assertThat(exception.getLineNumber()).isEqualTo(1);
-        assertThat(exception.getColumn()).isEqualTo(3);
-        assertThat(exception.getOffset()).isEqualTo(3);
-        assertThat(exception.getMessage())
-                .startsWithIgnoringCase("[ERR 109] Line 1:3 extraneous input ';' expecting ")
-                .contains("TIME_INTERVAL", "DRL_STRING_LITERAL", "?/", "boolean", "byte", "char", "double", "float", "int", "long", "new", "short", "super", "DECIMAL_LITERAL", "HEX_LITERAL", "FLOAT_LITERAL", "BOOL_LITERAL", "STRING_LITERAL", "null", "(", "[", ".", "<", "!", "~", "++", "--", "+", "-", "*", "/", "IDENTIFIER");
+
+        // Backward Compatibility Notes:
+        //   Antlr4 gives a different error code/message from antlr3 for this case.
+        //   Backward compatibility doesn't seem to be required in this case.
+        if (DrlParser.ANTLR4_PARSER_ENABLED) {
+            assertThat(exception.getErrorCode()).isEqualTo("ERR 109");
+            assertThat(exception.getLineNumber()).isEqualTo(1);
+            assertThat(exception.getColumn()).isEqualTo(3);
+            assertThat(exception.getOffset()).isEqualTo(3);
+            assertThat(exception.getMessage())
+                    .startsWithIgnoringCase("[ERR 109] Line 1:3 extraneous input ';' expecting ")
+                    .contains("TIME_INTERVAL", "DRL_STRING_LITERAL", "?/", "boolean", "byte", "char", "double", "float", "int", "long", "new", "short", "super", "DECIMAL_LITERAL", "HEX_LITERAL", "FLOAT_LITERAL", "BOOL_LITERAL", "STRING_LITERAL", "null", "(", "[", ".", "<", "!", "~", "++", "--", "+", "-", "*", "/", "IDENTIFIER");
+        } else {
+            assertThat(exception.getErrorCode()).isEqualTo("ERR 101");
+            assertThat(exception.getLineNumber()).isEqualTo(1);
+            assertThat(exception.getColumn()).isEqualTo(3);
+            assertThat(exception.getOffset()).isEqualTo(3);
+            assertThat(exception.getMessage())
+                    .isEqualToIgnoringCase("[ERR 101] Line 1:3 no viable alternative at input ';'");
+        }
     }
+
     @Test
     public void testNoViableAlt() {
         String source = "x.int";
         parser.parse(source);
-        assertThat(parser.hasErrors()).isTrue();
-        assertThat(parser.getErrors()).hasSize(1);
-        DroolsParserException exception = parser.getErrors().get(0);
-        assertThat(exception.getErrorCode()).isEqualTo("ERR 101");
-        assertThat(exception.getLineNumber()).isEqualTo(1);
-        assertThat(exception.getColumn()).isEqualTo(2);
-        assertThat(exception.getOffset()).isEqualTo(2);
-        assertThat(exception.getMessage())
-                .isEqualToIgnoringCase("[ERR 101] Line 1:2 no viable alternative at input '.int'");
+
+        // Backward Compatibility Notes:
+        //   Old expr parser (DRL6Expressions) allows this expression because it's too tolerant (fail at runtime anyway).
+        //   Backward compatibility doesn't seem to be required in this case. (But we may align with the old tolerant behavior.)
+        if (DrlParser.ANTLR4_PARSER_ENABLED) {
+            assertThat(parser.hasErrors()).isTrue();
+            assertThat(parser.getErrors()).hasSize(1);
+            DroolsParserException exception = parser.getErrors().get(0);
+            assertThat(exception.getErrorCode()).isEqualTo("ERR 101");
+            assertThat(exception.getLineNumber()).isEqualTo(1);
+            assertThat(exception.getColumn()).isEqualTo(2);
+            assertThat(exception.getOffset()).isEqualTo(2);
+            assertThat(exception.getMessage())
+                    .isEqualToIgnoringCase("[ERR 101] Line 1:2 no viable alternative at input '.int'");
+        } else {
+            assertThat(parser.hasErrors()).isFalse();
+        }
     }
 }

--- a/drools-drl/drools-drl-parser-tests/src/test/java/org/drools/drl/parser/antlr4/DRLParserTest.java
+++ b/drools-drl/drools-drl-parser-tests/src/test/java/org/drools/drl/parser/antlr4/DRLParserTest.java
@@ -17,6 +17,9 @@ import static org.drools.drl.parser.antlr4.DRLParserHelper.computeTokenIndex;
 import static org.drools.drl.parser.antlr4.DRLParserHelper.createDrlParser;
 import static org.drools.drl.parser.antlr4.DRLParserHelper.parse;
 
+/**
+ * This test class is specific to new antlr4 parser.
+ */
 class DRLParserTest {
 
     private static final String drl =

--- a/drools-drl/drools-drl-parser-tests/src/test/java/org/drools/drl/parser/antlr4/DescrCommonPropertyTest.java
+++ b/drools-drl/drools-drl-parser-tests/src/test/java/org/drools/drl/parser/antlr4/DescrCommonPropertyTest.java
@@ -1,3 +1,21 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
 package org.drools.drl.parser.antlr4;
 
 import org.drools.drl.ast.descr.AccumulateDescr;
@@ -30,6 +48,8 @@ import org.drools.drl.ast.descr.TypeFieldDescr;
 import org.drools.drl.ast.descr.UnitDescr;
 import org.drools.drl.ast.descr.WindowDeclarationDescr;
 import org.drools.drl.ast.descr.WindowReferenceDescr;
+import org.drools.drl.parser.DrlParser;
+import org.drools.drl.parser.DroolsParserException;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -41,15 +61,21 @@ import static org.assertj.core.api.Assertions.assertThat;
  */
 class DescrCommonPropertyTest {
 
-    private DRLParserWrapper parser;
+    private DrlParser parser;
 
     @BeforeEach
     public void setUp() {
-        parser = new DRLParserWrapper();
+        parser = ParserTestUtils.getParser();
     }
 
-    @AfterEach
-    public void tearDown() {
+    private PackageDescr parseAndGetPackageDescr(String drl) {
+        try {
+            PackageDescr pkg =  parser.parse(null, drl);
+            assertThat(parser.hasErrors()).as(parser.getErrors().toString()).isFalse();
+            return pkg;
+        } catch (DroolsParserException e) {
+            throw new RuntimeException(e);
+        }
     }
 
     private void assertProperties(BaseDescr descr, int startCharacter, int endCharacter, int line, int column, int endLine, int endColumn) {
@@ -64,8 +90,8 @@ class DescrCommonPropertyTest {
     @Test
     void packageDescr() {
         final String source = "package foo.bar.baz";
-        final PackageDescr pkg = parser.parse(source);
-        assertProperties(pkg, 0, 18, 1, 0, 1, 18);
+        final PackageDescr pkg = parseAndGetPackageDescr(source);
+        assertProperties(pkg, 0, 19, 1, 0, 1, 18);
     }
 
     @Test
@@ -74,17 +100,18 @@ class DescrCommonPropertyTest {
                 "  when\n" +
                 "  then\n" +
                 "end";
-        final PackageDescr pkg = parser.parse(source);
+        final PackageDescr pkg = parseAndGetPackageDescr(source);
         final RuleDescr rule = pkg.getRules().get(0);
-        assertProperties(rule, 0, 30, 1, 0, 4, 2);
+        assertProperties(rule, 0, 31, 1, 0, 4, 2);
     }
 
     @Test
     void unitDescr() {
-        final String source = "unit Foo;";
-        final PackageDescr pkg = parser.parse(source);
+        final String source = "package abc;\n" +
+                "unit Foo;";
+        final PackageDescr pkg = parseAndGetPackageDescr(source);
         final UnitDescr unit = pkg.getUnit();
-        assertProperties(unit, 0, 8, 1, 0, 1, 8);
+        assertProperties(unit, 13, 22, 2, 0, 2, 8);
     }
 
     @Test
@@ -92,9 +119,9 @@ class DescrCommonPropertyTest {
         final String source = "query \"MyQuery\"\n" +
                 "  Foo()\n" +
                 "end";
-        final PackageDescr pkg = parser.parse(source);
+        final PackageDescr pkg = parseAndGetPackageDescr(source);
         final QueryDescr query = (QueryDescr) pkg.getRules().get(0);
-        assertProperties(query, 0, 26, 1, 0, 3, 2);
+        assertProperties(query, 0, 27, 1, 0, 3, 2);
     }
 
     @Test
@@ -102,41 +129,41 @@ class DescrCommonPropertyTest {
         final String source = "function void myFunction(String data) {\n" +
                 "  foo();\n" +
                 "}";
-        final PackageDescr pkg = parser.parse(source);
+        final PackageDescr pkg = parseAndGetPackageDescr(source);
         final FunctionDescr function = pkg.getFunctions().get(0);
-        assertProperties(function, 0, 49, 1, 0, 3, 0);
+        assertProperties(function, 0, 50, 1, 0, 3, 0);
     }
 
     @Test
     void globalDescr() {
         final String source = "global java.util.List myList";
-        final PackageDescr pkg = parser.parse(source);
+        final PackageDescr pkg = parseAndGetPackageDescr(source);
         final GlobalDescr global = pkg.getGlobals().get(0);
-        assertProperties(global, 0, 27, 1, 0, 1, 27);
+        assertProperties(global, 0, 28, 1, 0, 1, 27);
     }
 
     @Test
     void functionImportDescr() {
         final String source = "import function org.drools.core.util.DateUtils.*";
-        final PackageDescr pkg = parser.parse(source);
+        final PackageDescr pkg = parseAndGetPackageDescr(source);
         final FunctionImportDescr functionImport = pkg.getFunctionImports().get(0);
-        assertProperties(functionImport, 0, 47, 1, 0, 1, 47);
+        assertProperties(functionImport, 0, 48, 1, 0, 1, 47);
     }
 
     @Test
     void importDescr() {
         final String source = "import org.drools.core.util.DateUtils";
-        final PackageDescr pkg = parser.parse(source);
+        final PackageDescr pkg = parseAndGetPackageDescr(source);
         final ImportDescr importDescr = pkg.getImports().get(0);
-        assertProperties(importDescr, 0, 36, 1, 0, 1, 36);
+        assertProperties(importDescr, 0, 37, 1, 0, 1, 36);
     }
 
     @Test
     void accumulateImportDescr() {
         final String source = "import accumulate org.example.MyAccUtils.sum mySum";
-        final PackageDescr pkg = parser.parse(source);
+        final PackageDescr pkg = parseAndGetPackageDescr(source);
         final AccumulateImportDescr accumulateImport = pkg.getAccumulateImports().get(0);
-        assertProperties(accumulateImport, 0, 49, 1, 0, 1, 49);
+        assertProperties(accumulateImport, 0, 50, 1, 0, 1, 49);
     }
 
     @Test
@@ -144,11 +171,11 @@ class DescrCommonPropertyTest {
         final String source = "declare MyType\n" +
                 "  name : String\n" +
                 "end";
-        final PackageDescr pkg = parser.parse(source);
+        final PackageDescr pkg = parseAndGetPackageDescr(source);
         final TypeDeclarationDescr typeDeclaration = pkg.getTypeDeclarations().get(0);
 
         // startCharacter = 8 looks a little odd ("declare" is not included in the Descr), but it keeps the same as the old implementation. We may change it in the future.
-        assertProperties(typeDeclaration, 8, 33, 1, 8, 3, 2);
+        assertProperties(typeDeclaration, 8, 34, 1, 8, 3, 2);
     }
 
     @Test
@@ -156,9 +183,9 @@ class DescrCommonPropertyTest {
         final String source = "declare entry-point MyEntryPoint\n" +
                 "  @foo( true )\n" +
                 "end";
-        final PackageDescr pkg = parser.parse(source);
+        final PackageDescr pkg = parseAndGetPackageDescr(source);
         final EntryPointDeclarationDescr entryPointDeclaration = pkg.getEntryPointDeclarations().stream().findFirst().get();
-        assertProperties(entryPointDeclaration, 8, 50, 1, 8, 3, 2);
+        assertProperties(entryPointDeclaration, 8, 51, 1, 8, 3, 2);
     }
 
     @Test
@@ -168,9 +195,9 @@ class DescrCommonPropertyTest {
                 "       over window:length( 10, $s.symbol )\n" +
                 "       from entry-point stStream\n" +
                 "end";
-        final PackageDescr pkg = parser.parse(source);
+        final PackageDescr pkg = parseAndGetPackageDescr(source);
         final WindowDeclarationDescr windowDeclaration = pkg.getWindowDeclarations().stream().findFirst().get();
-        assertProperties(windowDeclaration, 8, 139, 1, 8, 5, 2);
+        assertProperties(windowDeclaration, 8, 140, 1, 8, 5, 2);
     }
 
     @Test
@@ -181,10 +208,10 @@ class DescrCommonPropertyTest {
                 "  $p : Person( name == \"Mario\" ) @watch(!*, age)\n" +
                 "then\n" +
                 "end\n";
-        final PackageDescr pkg = parser.parse(source);
+        final PackageDescr pkg = parseAndGetPackageDescr(source);
         final RuleDescr rule = pkg.getRules().get(0);
         AnnotationDescr annotation = rule.getLhs().getAllPatternDescr().get(0).getAnnotations().stream().findFirst().get();
-        assertProperties(annotation, 65, 79, 4, 33, 4, 47);
+        assertProperties(annotation, 65, 80, 4, 33, 4, 47);
     }
 
     @Test
@@ -192,10 +219,17 @@ class DescrCommonPropertyTest {
         final String source = "declare MyType\n" +
                 "  name : String\n" +
                 "end";
-        final PackageDescr pkg = parser.parse(source);
+        final PackageDescr pkg = parseAndGetPackageDescr(source);
         final TypeDeclarationDescr typeDeclaration = pkg.getTypeDeclarations().get(0);
         TypeFieldDescr typeField = typeDeclaration.getFields().get("name");
-        assertProperties(typeField, 17, 29, 2, 2, 2, 14);
+        // Backward Compatibility Notes:
+        //   The old DRL6Parser uses only the attribute value token for common properties (seem to be wrong), so startCharacter and column are different between old and new parser.
+        //   Backward compatibility doesn't seem to be required in this case.
+        if (DrlParser.ANTLR4_PARSER_ENABLED) {
+            assertProperties(typeField, 17, 30, 2, 2, 2, 14);
+        } else {
+            assertProperties(typeField, 24, 30, 2, 9, 2, 14);
+        }
     }
 
     @Test
@@ -206,10 +240,19 @@ class DescrCommonPropertyTest {
                 "  when\n" +
                 "  then\n" +
                 "end";
-        final PackageDescr pkg = parser.parse(source);
+        final PackageDescr pkg = parseAndGetPackageDescr(source);
         final RuleDescr rule = pkg.getRules().get(0);
-        assertProperties(rule.getAttributes().get("salience"), 10, 20, 2, 2, 2, 12);
-        assertProperties(rule.getAttributes().get("agenda-group"), 24, 46, 3, 2, 3, 24);
+
+        // Backward Compatibility Notes:
+        //   The old DRL6Parser uses only the attribute value token for common properties (seem to be wrong), so startCharacter and column are different between old and new parser.
+        //   Backward compatibility doesn't seem to be required in this case. (If do it, the code would be unnecessarily complicated.)
+        if (DrlParser.ANTLR4_PARSER_ENABLED) {
+            assertProperties(rule.getAttributes().get("salience"), 10, 21, 2, 2, 2, 12);
+            assertProperties(rule.getAttributes().get("agenda-group"), 24, 47, 3, 2, 3, 24);
+        } else {
+            assertProperties(rule.getAttributes().get("salience"), 19, 21, 2, 11, 2, 12);
+            assertProperties(rule.getAttributes().get("agenda-group"), 37, 47, 3, 15, 3, 24);
+        }
     }
 
     @Test
@@ -219,10 +262,10 @@ class DescrCommonPropertyTest {
                 "    $p : Person( name == \"Mario\" )\n" +
                 "  then\n" +
                 "end";
-        final PackageDescr pkg = parser.parse(source);
+        final PackageDescr pkg = parseAndGetPackageDescr(source);
         final RuleDescr rule = pkg.getRules().get(0);
         PatternDescr pattern = (PatternDescr) rule.getLhs().getDescrs().get(0);
-        assertProperties(pattern, 19, 48, 3, 4, 3, 33);
+        assertProperties(pattern, 19, 49, 3, 4, 3, 33);
     }
 
     @Test
@@ -232,10 +275,10 @@ class DescrCommonPropertyTest {
                 "    ( $p : Person( name == \"Mario\" ) or $p : Person( name == \"Luigi\" ) )\n" +
                 "  then\n" +
                 "end";
-        final PackageDescr pkg = parser.parse(source);
+        final PackageDescr pkg = parseAndGetPackageDescr(source);
         final RuleDescr rule = pkg.getRules().get(0);
         OrDescr or = (OrDescr) rule.getLhs().getDescrs().get(0);
-        assertProperties(or, 21, 84, 3, 6, 3, 69);
+        assertProperties(or, 21, 85, 3, 6, 3, 69);
     }
 
     @Test
@@ -245,10 +288,10 @@ class DescrCommonPropertyTest {
                 "    ( $p1 : Person( name == \"Mario\" ) and $p2 : Person( name == \"Luigi\" ) )\n" +
                 "  then\n" +
                 "end";
-        final PackageDescr pkg = parser.parse(source);
+        final PackageDescr pkg = parseAndGetPackageDescr(source);
         final RuleDescr rule = pkg.getRules().get(0);
         AndDescr and = rule.getLhs();
-        assertProperties(and, 21, 87, 3, 6, 3, 72);
+        assertProperties(and, 19, 90, 3, 4, 3, 74);
     }
 
     @Test
@@ -258,10 +301,10 @@ class DescrCommonPropertyTest {
                 "    forall( $p : Person( name == \"Mario\" ) )\n" +
                 "  then\n" +
                 "end";
-        final PackageDescr pkg = parser.parse(source);
+        final PackageDescr pkg = parseAndGetPackageDescr(source);
         final RuleDescr rule = pkg.getRules().get(0);
         ForallDescr forall = (ForallDescr) rule.getLhs().getDescrs().get(0);
-        assertProperties(forall, 19, 58, 3, 4, 3, 43);
+        assertProperties(forall, 19, 59, 3, 4, 3, 43);
     }
 
     @Test
@@ -271,23 +314,23 @@ class DescrCommonPropertyTest {
                 "    accumulate( $p : Person( name == \"Mario\" ), $sum : sum($p.getAge()) )\n" +
                 "  then\n" +
                 "end";
-        final PackageDescr pkg = parser.parse(source);
+        final PackageDescr pkg = parseAndGetPackageDescr(source);
         final RuleDescr rule = pkg.getRules().get(0);
         PatternDescr pattern = (PatternDescr) rule.getLhs().getDescrs().get(0);
         AccumulateDescr accumulate = (AccumulateDescr) pattern.getSource();
-        assertProperties(accumulate, 19, 87, 3, 4, 3, 72);
+        assertProperties(accumulate, 19, 88, 3, 4, 3, 72);
     }
 
     @Test
     void behaviorDescr() {
         final String source = "rule X when StockTick( symbol==\"ACME\") over window:length(10) then end";;
-        final PackageDescr pkg = parser.parse(source);
+        final PackageDescr pkg = parseAndGetPackageDescr(source);
         final RuleDescr rule = pkg.getRules().get(0);
         PatternDescr pattern = (PatternDescr) rule.getLhs().getDescrs().get(0);
         BehaviorDescr behavior = pattern.getBehaviors().get(0);
 
         // "over" is not included in BehaviorDescr
-        assertProperties(behavior, 44, 60, 1, 44, 1, 60);
+        assertProperties(behavior, 44, 61, 1, 44, 1, 60);
     }
 
     @Test
@@ -298,13 +341,20 @@ class DescrCommonPropertyTest {
                 "    Child() from $children\n" +
                 "  then\n" +
                 "end";;
-        final PackageDescr pkg = parser.parse(source);
+        final PackageDescr pkg = parseAndGetPackageDescr(source);
         final RuleDescr rule = pkg.getRules().get(0);
         PatternDescr pattern = (PatternDescr) rule.getLhs().getDescrs().get(1);
         FromDescr from = (FromDescr)  pattern.getSource();
 
-        // "from" is not included in FromDescr
-        assertProperties(from, 64, 72, 4, 17, 4, 25);
+        // Backward Compatibility Notes:
+        //   The old DRL6Parser doesn't populate common properties of FromDescr (seem to be wrong).
+        //   Backward compatibility doesn't seem to be required in this case.
+        if (DrlParser.ANTLR4_PARSER_ENABLED) {
+            // "from" is not included in FromDescr
+            assertProperties(from, 64, 73, 4, 17, 4, 25);
+        } else {
+            assertProperties(from, -1, -1, -1, -1, -1, -1);
+        }
     }
 
     @Test
@@ -314,12 +364,12 @@ class DescrCommonPropertyTest {
                 "    ArrayList() from collect( Person( age > 21 ) );\n" +
                 "  then\n" +
                 "end";
-        final PackageDescr pkg = parser.parse(source);
+        final PackageDescr pkg = parseAndGetPackageDescr(source);
         final RuleDescr rule = pkg.getRules().get(0);
         PatternDescr pattern = (PatternDescr) rule.getLhs().getDescrs().get(0);
         CollectDescr collect = (CollectDescr)  pattern.getSource();
 
-        assertProperties(collect, 35, 63, 3, 21, 3, 49);
+        assertProperties(collect, 35, 64, 3, 21, 3, 49);
     }
 
     @Test
@@ -329,11 +379,19 @@ class DescrCommonPropertyTest {
                 "    StockTick() from entry-point \"stream\"\n" +
                 "  then\n" +
                 "end";
-        final PackageDescr pkg = parser.parse(source);
+        final PackageDescr pkg = parseAndGetPackageDescr(source);
         final RuleDescr rule = pkg.getRules().get(0);
         PatternDescr pattern = (PatternDescr) rule.getLhs().getDescrs().get(0);
         EntryPointDescr entryPoint = (EntryPointDescr) pattern.getSource();
-        assertProperties(entryPoint, 35, 54, 3, 21, 3, 40);
+
+        // Backward Compatibility Notes:
+        //   The old DRL6Parser doesn't populate common properties of EntryPointDescr (seem to be wrong).
+        //   Backward compatibility doesn't seem to be required in this case.
+        if (DrlParser.ANTLR4_PARSER_ENABLED) {
+            assertProperties(entryPoint, 35, 55, 3, 21, 3, 40);
+        } else {
+            assertProperties(entryPoint, -1, -1, -1, -1, -1, -1);
+        }
     }
 
     @Test
@@ -343,11 +401,18 @@ class DescrCommonPropertyTest {
                 "    StockTick() from window MyWindow\n" +
                 "  then\n" +
                 "end";
-        final PackageDescr pkg = parser.parse(source);
+        final PackageDescr pkg = parseAndGetPackageDescr(source);
         final RuleDescr rule = pkg.getRules().get(0);
         PatternDescr pattern = (PatternDescr) rule.getLhs().getDescrs().get(0);
         WindowReferenceDescr windowReference = (WindowReferenceDescr) pattern.getSource();
-        assertProperties(windowReference, 35, 49, 3, 21, 3, 35);
+        // Backward Compatibility Notes:
+        //   The old DRL6Parser doesn't populate common properties of WindowReferenceDescr (seem to be wrong).
+        //   Backward compatibility doesn't seem to be required in this case.
+        if (DrlParser.ANTLR4_PARSER_ENABLED) {
+            assertProperties(windowReference, 35, 50, 3, 21, 3, 35);
+        } else {
+            assertProperties(windowReference, -1, -1, -1, -1, -1, -1);
+        }
     }
 
     @Test
@@ -357,11 +422,11 @@ class DescrCommonPropertyTest {
                 "    Person( age > 21 )\n" +
                 "  then\n" +
                 "end";
-        final PackageDescr pkg = parser.parse(source);
+        final PackageDescr pkg = parseAndGetPackageDescr(source);
         final RuleDescr rule = pkg.getRules().get(0);
         PatternDescr pattern = (PatternDescr) rule.getLhs().getDescrs().get(0);
         ExprConstraintDescr exprConstraint = (ExprConstraintDescr) pattern.getDescrs().get(0);
-        assertProperties(exprConstraint, 26, 33, 3, 12, 3, 19);
+        assertProperties(exprConstraint, 26, 33, 3, 12, 3, 18);
     }
 
     @Test
@@ -371,10 +436,10 @@ class DescrCommonPropertyTest {
                 "    exists( Person( age > 21 ) )\n" +
                 "  then\n" +
                 "end";
-        final PackageDescr pkg = parser.parse(source);
+        final PackageDescr pkg = parseAndGetPackageDescr(source);
         final RuleDescr rule = pkg.getRules().get(0);
         ExistsDescr exists = (ExistsDescr) rule.getLhs().getDescrs().get(0);
-        assertProperties(exists, 18, 45, 3, 4, 3, 31);
+        assertProperties(exists, 18, 46, 3, 4, 3, 31);
     }
 
     @Test
@@ -384,10 +449,10 @@ class DescrCommonPropertyTest {
                 "    not( Person( age > 21 ) )\n" +
                 "  then\n" +
                 "end";
-        final PackageDescr pkg = parser.parse(source);
+        final PackageDescr pkg = parseAndGetPackageDescr(source);
         final RuleDescr rule = pkg.getRules().get(0);
         NotDescr not = (NotDescr) rule.getLhs().getDescrs().get(0);
-        assertProperties(not, 18, 42, 3, 4, 3, 28);
+        assertProperties(not, 18, 43, 3, 4, 3, 28);
     }
 
     @Test
@@ -397,9 +462,9 @@ class DescrCommonPropertyTest {
                 "    eval( 1 + 1 == 2 )\n" +
                 "  then\n" +
                 "end";
-        final PackageDescr pkg = parser.parse(source);
+        final PackageDescr pkg = parseAndGetPackageDescr(source);
         final RuleDescr rule = pkg.getRules().get(0);
         EvalDescr eval = (EvalDescr) rule.getLhs().getDescrs().get(0);
-        assertProperties(eval, 18, 35, 3, 4, 3, 21);
+        assertProperties(eval, 18, 36, 3, 4, 3, 21);
     }
 }

--- a/drools-drl/drools-drl-parser-tests/src/test/java/org/drools/drl/parser/antlr4/DescrCommonPropertyTest.java
+++ b/drools-drl/drools-drl-parser-tests/src/test/java/org/drools/drl/parser/antlr4/DescrCommonPropertyTest.java
@@ -40,7 +40,6 @@ import org.drools.drl.ast.descr.NotDescr;
 import org.drools.drl.ast.descr.OrDescr;
 import org.drools.drl.ast.descr.PackageDescr;
 import org.drools.drl.ast.descr.PatternDescr;
-import org.drools.drl.ast.descr.PatternSourceDescr;
 import org.drools.drl.ast.descr.QueryDescr;
 import org.drools.drl.ast.descr.RuleDescr;
 import org.drools.drl.ast.descr.TypeDeclarationDescr;
@@ -50,7 +49,6 @@ import org.drools.drl.ast.descr.WindowDeclarationDescr;
 import org.drools.drl.ast.descr.WindowReferenceDescr;
 import org.drools.drl.parser.DrlParser;
 import org.drools.drl.parser.DroolsParserException;
-import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 

--- a/drools-drl/drools-drl-parser-tests/src/test/java/org/drools/drl/parser/antlr4/DescrDumperTest.java
+++ b/drools-drl/drools-drl-parser-tests/src/test/java/org/drools/drl/parser/antlr4/DescrDumperTest.java
@@ -26,6 +26,7 @@ import org.drools.drl.ast.descr.AtomicExprDescr;
 import org.drools.drl.ast.descr.BindingDescr;
 import org.drools.drl.ast.descr.ConstraintConnectiveDescr;
 import org.drools.drl.parser.DrlExprParser;
+import org.drools.drl.parser.DrlExprParserFactory;
 import org.drools.mvel.evaluators.MatchesEvaluatorsDefinition;
 import org.drools.mvel.evaluators.SetEvaluatorsDefinition;
 import org.junit.jupiter.api.BeforeEach;
@@ -358,7 +359,7 @@ public class DescrDumperTest {
     }
 
     public ConstraintConnectiveDescr parse( final String constraint ) {
-        DrlExprParser parser = new Drl6ExprParserAntlr4(LanguageLevelOption.DRL6);
+        DrlExprParser parser = DrlExprParserFactory.getDrlExprParser(LanguageLevelOption.DRL6);
         ConstraintConnectiveDescr result = parser.parse( constraint );
         assertThat(parser.hasErrors()).as(parser.getErrors().toString()).isFalse();
 

--- a/drools-drl/drools-drl-parser-tests/src/test/java/org/drools/drl/parser/antlr4/ParserTestUtils.java
+++ b/drools-drl/drools-drl-parser-tests/src/test/java/org/drools/drl/parser/antlr4/ParserTestUtils.java
@@ -18,9 +18,7 @@
  */
 package org.drools.drl.parser.antlr4;
 
-import org.drools.drl.ast.descr.PackageDescr;
 import org.drools.drl.parser.DrlParser;
-import org.drools.drl.parser.DroolsParserException;
 
 public class ParserTestUtils {
 

--- a/drools-drl/drools-drl-parser-tests/src/test/java/org/drools/drl/parser/antlr4/ParserTestUtils.java
+++ b/drools-drl/drools-drl-parser-tests/src/test/java/org/drools/drl/parser/antlr4/ParserTestUtils.java
@@ -1,0 +1,37 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.drools.drl.parser.antlr4;
+
+import org.drools.drl.ast.descr.PackageDescr;
+import org.drools.drl.parser.DrlParser;
+import org.drools.drl.parser.DroolsParserException;
+
+public class ParserTestUtils {
+
+    private ParserTestUtils() {
+        // It is a utility class, so it should not be instantiated.
+    }
+
+    /**
+     * Returns a DrlParser which encapsulates an old or new parser depending on system property
+     */
+    public static DrlParser getParser() {
+        return new DrlParser();
+    }
+}

--- a/drools-drl/drools-drl-parser/src/main/antlr4/org/drools/drl/parser/antlr4/DRLLexer.g4
+++ b/drools-drl/drools-drl-parser/src/main/antlr4/org/drools/drl/parser/antlr4/DRLLexer.g4
@@ -12,6 +12,10 @@ import JavaLexer;
         }
         return input;
     }
+
+    public boolean isRhsDrlEnd() {
+        return new LexerHelper(_input).isRhsDrlEnd();
+    }
 }
 
 /////////////////
@@ -164,7 +168,8 @@ DrlUnicodeEscape
 
 mode RHS;
 RHS_WS : [ \t\r\n\u000C]+ -> channel(HIDDEN);
-DRL_RHS_END : 'end' [ \t]* SEMI? [ \t]* ('\n' | '\r\n' | EOF) {setText("end");} -> popMode;
+//DRL_RHS_END : 'end' [ \t]* SEMI? [ \t]* ('\n' | '\r\n' | EOF) { setText("end"); } -> popMode;
+DRL_RHS_END : {isRhsDrlEnd()}? DRL_END -> popMode;
 
 RHS_STRING_LITERAL
       // cannot reuse DRL_STRING_LITERAL because Actions are ignored in referenced rules

--- a/drools-drl/drools-drl-parser/src/main/antlr4/org/drools/drl/parser/antlr4/DRLParser.g4
+++ b/drools-drl/drools-drl-parser/src/main/antlr4/org/drools/drl/parser/antlr4/DRLParser.g4
@@ -17,24 +17,24 @@ import DRL6Expressions, JavaParser;
 compilationUnit : packagedef? unitdef? drlStatementdef* ;
 
 drlStatementdef
-    : importdef
-    | globaldef
-    | declaredef
-    | ruledef
-    | attributes
-    | functiondef
-    | querydef
+    : importdef SEMI?
+    | globaldef SEMI?
+    | declaredef SEMI?
+    | ruledef SEMI?
+    | attributes SEMI?
+    | functiondef SEMI?
+    | querydef SEMI?
     ;
 
 packagedef : PACKAGE name=drlQualifiedName SEMI? ;
 
 unitdef : DRL_UNIT name=drlQualifiedName SEMI? ;
 
-importdef : IMPORT (DRL_FUNCTION|STATIC)? drlQualifiedName (DOT MUL)? SEMI?         #importStandardDef
-          | IMPORT (DRL_ACCUMULATE|DRL_ACC) drlQualifiedName IDENTIFIER SEMI?       #importAccumulateDef
+importdef : IMPORT (DRL_FUNCTION|STATIC)? drlQualifiedName (DOT MUL)?          #importStandardDef
+          | IMPORT (DRL_ACCUMULATE|DRL_ACC) drlQualifiedName IDENTIFIER        #importAccumulateDef
           ;
 
-globaldef : DRL_GLOBAL type drlIdentifier SEMI? ;
+globaldef : DRL_GLOBAL type drlIdentifier ;
 
 /**
  * declare := DECLARE
@@ -60,15 +60,15 @@ declaredef : DRL_DECLARE (
  *                     END
  */
 
-typeDeclaration : DRL_TRAIT? name=drlQualifiedName (EXTENDS superTypes+=drlQualifiedName (COMMA superTypes+=drlQualifiedName)* )? drlAnnotation* field* DRL_END SEMI?;
+typeDeclaration : DRL_TRAIT? name=drlQualifiedName (EXTENDS superTypes+=drlQualifiedName (COMMA superTypes+=drlQualifiedName)* )? drlAnnotation* field* DRL_END ;
 
 // entryPointDeclaration := ENTRY-POINT stringId annotation* END
 
-entryPointDeclaration : DRL_ENTRY_POINT name=stringId drlAnnotation* DRL_END SEMI?;
+entryPointDeclaration : DRL_ENTRY_POINT name=stringId drlAnnotation* DRL_END ;
 
 // windowDeclaration := WINDOW ID annotation* lhsPatternBind END
 
-windowDeclaration : DRL_WINDOW name=IDENTIFIER drlAnnotation* lhsPatternBind DRL_END SEMI?;
+windowDeclaration : DRL_WINDOW name=IDENTIFIER drlAnnotation* lhsPatternBind DRL_END ;
 
 // field := label fieldType (EQUALS_ASSIGN conditionalExpression)? annotation* SEMICOLON?
 
@@ -76,11 +76,11 @@ field : label type (ASSIGN initExpr=conditionalOrExpression)? drlAnnotation* SEM
 
 // rule := RULE stringId (EXTENDS stringId)? annotation* attributes? lhs? rhs END
 
-ruledef : DRL_RULE name=stringId (EXTENDS parentName=stringId)? drlAnnotation* attributes? lhs rhs DRL_RHS_END ;
+ruledef : DRL_RULE name=stringId (EXTENDS parentName=stringId)? drlAnnotation* attributes? lhs? rhs DRL_RHS_END ;
 
 // query := QUERY stringId parameters? annotation* lhsExpression END
 
-querydef : DRL_QUERY name=stringId parameters? drlAnnotation* lhsExpression+ DRL_END SEMI?;
+querydef : DRL_QUERY name=stringId parameters? drlAnnotation* lhsExpression+ DRL_END ;
 
 // parameters := LEFT_PAREN ( parameter ( COMMA parameter )* )? RIGHT_PAREN
 parameters : LPAREN ( parameter ( COMMA parameter )* )? RPAREN ;

--- a/drools-drl/drools-drl-parser/src/main/java/org/drools/drl/parser/DrlParser.java
+++ b/drools-drl/drools-drl-parser/src/main/java/org/drools/drl/parser/DrlParser.java
@@ -60,7 +60,9 @@ public class DrlParser {
     private Resource                resource              = null;
 
     public static final String ANTLR4_PARSER_ENABLED_PROPERTY = "drools.drl.antlr4.parser.enabled";
-    public static final boolean ANTLR4_PARSER_ENABLED = Boolean.parseBoolean(System.getProperty(ANTLR4_PARSER_ENABLED_PROPERTY, "true")); // default is true
+
+    // TODO: temporarily removed 'final' for testing purposes. This should be final
+    public static boolean ANTLR4_PARSER_ENABLED = Boolean.parseBoolean(System.getProperty(ANTLR4_PARSER_ENABLED_PROPERTY, "true")); // default is true
 
     public static final LanguageLevelOption DEFAULT_LANGUAGE_LEVEL = LanguageLevelOption.DRL6;
     private final LanguageLevelOption languageLevel;

--- a/drools-drl/drools-drl-parser/src/main/java/org/drools/drl/parser/antlr4/DRLVisitorImpl.java
+++ b/drools-drl/drools-drl-parser/src/main/java/org/drools/drl/parser/antlr4/DRLVisitorImpl.java
@@ -149,6 +149,11 @@ public class DRLVisitorImpl extends DRLParserBaseVisitor<Object> {
     }
 
     @Override
+    public BaseDescr visitDrlStatementdef(DRLParser.DrlStatementdefContext ctx) {
+        return visitDescrChildren(ctx).get(0); // only one child. Ignore SEMICOLON
+    }
+
+    @Override
     public GlobalDescr visitGlobaldef(DRLParser.GlobaldefContext ctx) {
         return BaseDescrFactory.builder(new GlobalDescr(ctx.drlIdentifier().getText(), ctx.type().getText()))
                 .withParserRuleContext(ctx)
@@ -290,7 +295,9 @@ public class DRLVisitorImpl extends DRLParserBaseVisitor<Object> {
             List<BaseDescr> lhsDescrList = visitLhs(ctx.lhs());
             lhsDescrList.forEach(descr -> rootDescr.addDescr(descr));
             slimLhsRootDescr(rootDescr);
-            DescrHelper.refreshRootProperties(rootDescr);
+            DescrHelper.populateCommonProperties(rootDescr, ctx.lhs().lhsExpression());
+        } else {
+            ruleDescr.setLhs(new AndDescr());
         }
 
         if (ctx.rhs() != null) {

--- a/drools-drl/drools-drl-parser/src/main/java/org/drools/drl/parser/antlr4/LexerHelper.java
+++ b/drools-drl/drools-drl-parser/src/main/java/org/drools/drl/parser/antlr4/LexerHelper.java
@@ -92,20 +92,10 @@ public class LexerHelper {
     }
 
     private void skipSemiAndWSAndComment() {
-        while (true) {
+        do {
+            // skip semi and WS, and repeat that so long as it's followed by a valid and skipped comment
             skipSemiAndWS();
-            if (input.LA(lookAheadCounter) == '/') {
-                boolean skipped = skipComment();
-                if (!skipped) {
-                    // found non-comment token
-                    break;
-                }
-                // if comment is found and skipped, continue to skip semi and WS
-            } else {
-                // found non-comment token
-                break;
-            }
-        }
+        } while (skipComment());
     }
 
     private void skipSemiAndWS() {

--- a/drools-drl/drools-drl-parser/src/main/java/org/drools/drl/parser/antlr4/LexerHelper.java
+++ b/drools-drl/drools-drl-parser/src/main/java/org/drools/drl/parser/antlr4/LexerHelper.java
@@ -1,0 +1,171 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.drools.drl.parser.antlr4;
+
+import java.util.List;
+
+import org.antlr.v4.runtime.CharStream;
+import org.antlr.v4.runtime.IntStream;
+import org.drools.drl.parser.lang.DroolsSoftKeywords;
+
+/**
+ * Helper class for lexer. It requires instance creation to keep track of the lookahead counter.
+ */
+public class LexerHelper {
+
+    private static final List<Character> semiAndWS = List.of(';', ' ', '\t', '\n', '\r');
+    private static final List<String> statementKeywordsList = List.of(ParserHelper.statementKeywords);
+    private static final List<String> attributeKeywordsList = List.of(DroolsSoftKeywords.SALIENCE,
+                                                                      DroolsSoftKeywords.ENABLED,
+                                                                      DroolsSoftKeywords.NO + "-" + DroolsSoftKeywords.LOOP,
+                                                                      DroolsSoftKeywords.AUTO + "-" + DroolsSoftKeywords.FOCUS,
+                                                                      DroolsSoftKeywords.LOCK + "-" + DroolsSoftKeywords.ON + "-" + DroolsSoftKeywords.ACTIVE,
+                                                                      DroolsSoftKeywords.AGENDA + "-" + DroolsSoftKeywords.GROUP,
+                                                                      DroolsSoftKeywords.ACTIVATION + "-" + DroolsSoftKeywords.GROUP,
+                                                                      DroolsSoftKeywords.RULEFLOW + "-" + DroolsSoftKeywords.GROUP,
+                                                                      DroolsSoftKeywords.DATE + "-" + DroolsSoftKeywords.EFFECTIVE,
+                                                                      DroolsSoftKeywords.DATE + "-" + DroolsSoftKeywords.EXPIRES,
+                                                                      DroolsSoftKeywords.DIALECT,
+                                                                      DroolsSoftKeywords.CALENDARS,
+                                                                      DroolsSoftKeywords.TIMER,
+                                                                      DroolsSoftKeywords.DURATION,
+                                                                      DroolsSoftKeywords.REFRACT,
+                                                                      DroolsSoftKeywords.DIRECT);
+
+    private final CharStream input;
+    private int lookAheadCounter;
+
+    public LexerHelper(CharStream input) {
+        this.input = input;
+        this.lookAheadCounter = 1;
+    }
+
+    /**
+     * Determine if the current token is the end of a RHS DRL by lookahead.
+     * 1. 'end'
+     * 2. skip semi, WS, and comment
+     * 3. next token should be EOF or statement or attribute keyword
+     *
+     * TODO: This method is low-level and may be too complex in order to keep backward compatibility.
+     *       This could be refactored by going back to a parser rather than the lexer island mode.
+     */
+    boolean isRhsDrlEnd() {
+        if (!validateDrlEnd()) {
+            return false;
+        }
+        skipSemiAndWSAndComment();
+
+        return validateEOForNextStatement();
+    }
+
+    private boolean validateDrlEnd() {
+        return captureNextToken().equals(DroolsSoftKeywords.END);
+    }
+
+    private String captureNextToken() {
+        StringBuilder sb = new StringBuilder();
+        while (true) {
+            int la = input.LA(lookAheadCounter);
+            if (semiAndWS.contains((char) la) || la == IntStream.EOF) {
+                break;
+            }
+            sb.append((char) la);
+            lookAheadCounter++;
+        }
+        return sb.toString(); // never null
+    }
+
+    private void skipSemiAndWSAndComment() {
+        while (true) {
+            skipSemiAndWS();
+            if (input.LA(lookAheadCounter) == '/') {
+                boolean skipped = skipComment();
+                if (!skipped) {
+                    // found non-comment token
+                    break;
+                }
+                // if comment is found and skipped, continue to skip semi and WS
+            } else {
+                // found non-comment token
+                break;
+            }
+        }
+    }
+
+    private void skipSemiAndWS() {
+        while (true) {
+            int la = input.LA(lookAheadCounter);
+            if (!semiAndWS.contains((char) la)) {
+                break;
+            }
+            lookAheadCounter++;
+        }
+    }
+
+    // if comment is found, skip it and return true
+    private boolean skipComment() {
+        boolean skipped = false;
+        // skip single line comment
+        int la1 = input.LA(lookAheadCounter);
+        int la2 = input.LA(lookAheadCounter + 1);
+        if (la1 == '/' && la2 == '/') {
+            // skip single line comment
+            skipSingleLineComment();
+            skipped = true;
+        } else if (la1 == '/' && la2 == '*') {
+            // skip multi line comment
+            skipMultiLineComment();
+            skipped = true;
+        }
+
+        return skipped;
+    }
+
+    private void skipSingleLineComment() {
+        while (true) {
+            int la = input.LA(lookAheadCounter);
+            if (la == '\n' || la == IntStream.EOF) { // this can handle `\r\n` as well
+                break;
+            }
+            lookAheadCounter++;
+        }
+    }
+
+    private void skipMultiLineComment() {
+        while (true) {
+            int la = input.LA(lookAheadCounter);
+            if (la == IntStream.EOF) {
+                break;
+            }
+            if (la == '*' && input.LA(lookAheadCounter + 1) == '/') {
+                lookAheadCounter += 2;
+                break;
+            }
+            lookAheadCounter++;
+        }
+    }
+
+    private boolean validateEOForNextStatement() {
+        if (input.LA(lookAheadCounter) == IntStream.EOF) {
+            return true;
+        }
+        String nextToken = captureNextToken();
+        return statementKeywordsList.contains(nextToken) || attributeKeywordsList.contains(nextToken);
+    }
+}

--- a/drools-drl/drools-drl-parser/src/main/java/org/drools/drl/parser/antlr4/ParserHelper.java
+++ b/drools-drl/drools-drl-parser/src/main/java/org/drools/drl/parser/antlr4/ParserHelper.java
@@ -91,7 +91,7 @@ import org.kie.internal.builder.conf.LanguageLevelOption;
  * by the DRL parser
  */
 public class ParserHelper {
-    public final String[]                             statementKeywords        = new String[]{
+    public static final String[]                      statementKeywords        = new String[]{
                                                                                DroolsSoftKeywords.PACKAGE,
                                                                                DroolsSoftKeywords.UNIT,
                                                                                DroolsSoftKeywords.IMPORT,


### PR DESCRIPTION
- Old and new parser coverage using 2 surefire test executions
- Fixed Descr common property issue to keep backward compatibility
- A few test cases remaining without backward compatibility ("Backward Compatibility Notes" left) because the old parser seems to be wrong.
- A few expr test cases remaining without backward compatibility ("Backward Compatibility Notes" left). Error code/message difference comes from antlr4 and 3 difference. Also the new parser ones are better.

**Issue**: 

* https://github.com/apache/incubator-kie-drools/issues/5854

### Before PR in `drools-model-codegen`
```
[ERROR] Tests run: 2434, Failures: 97, Errors: 0, Skipped: 9
```

### After PR in `drools-model-codegen`
```
[ERROR] Tests run: 2434, Failures: 90, Errors: 0, Skipped: 9
```