### PR TITLE
[new-parser] Add missing DRL soft keywords to the drlIdentifier rule

### DIFF
--- a/drools-drl/drools-drl-parser/src/main/antlr4/org/drools/drl/parser/antlr4/DRL6Expressions.g4
+++ b/drools-drl/drools-drl-parser/src/main/antlr4/org/drools/drl/parser/antlr4/DRL6Expressions.g4
@@ -187,6 +187,7 @@ drlKeywords returns [Token token]
     | DRL_FUNCTION
     | DRL_GLOBAL
     | DRL_DECLARE
+    | DRL_TRAIT
     | DRL_RULE
     | DRL_QUERY
     | DRL_WHEN
@@ -198,6 +199,7 @@ drlKeywords returns [Token token]
     | DRL_NOT
     | DRL_IN
     | DRL_FROM
+    | DRL_COLLECT
     | DRL_ACCUMULATE
     | DRL_ACC
     | DRL_INIT
@@ -206,6 +208,8 @@ drlKeywords returns [Token token]
     | DRL_RESULT
     | DRL_ENTRY_POINT
     | DRL_EVAL
+    | DRL_FORALL
+    | DRL_OVER
     | DRL_SALIENCE
     | DRL_ENABLED
     | DRL_NO_LOOP
@@ -222,6 +226,7 @@ drlKeywords returns [Token token]
     | DRL_CALENDARS
     | DRL_TIMER
     | DRL_DURATION
+    | DRL_WINDOW
     ;
 
 builtInOperator returns[Token token]

--- a/drools-drl/drools-drl-parser/src/main/antlr4/org/drools/drl/parser/antlr4/DRLParser.g4
+++ b/drools-drl/drools-drl-parser/src/main/antlr4/org/drools/drl/parser/antlr4/DRLParser.g4
@@ -403,7 +403,7 @@ consequenceBody : ( RHS_STRING_LITERAL | RHS_CHUNK )* ;
 // THEN LEFT_SQUARE ID RIGHT_SQUARE chunk
 namedConsequence : RHS_NAMED_CONSEQUENCE_THEN consequenceBody ;
 
-stringId : ( IDENTIFIER | DRL_STRING_LITERAL ) ;
+stringId : ( drlIdentifier | DRL_STRING_LITERAL ) ;
 
 type : (classOrInterfaceType | primitiveType) typeArguments? ( DOT IDENTIFIER typeArguments? )* (LBRACK RBRACK)* ;
 


### PR DESCRIPTION
- Fixes #5713.
- Fixes a number of traits tests using rules that have `trait` in the package name.


### Before PR in `drools-model-codegen`
```
[ERROR] Tests run: 2434, Failures: 97, Errors: 0, Skipped: 9
```

### After PR in `drools-model-codegen`
```
[ERROR] Tests run: 2434, Failures: 93, Errors: 0, Skipped: 9
```


### Before PR in `drools-traits`
```
[ERROR] Tests run: 363, Failures: 34, Errors: 54, Skipped: 6
```

### After PR in `drools-traits`
```
[ERROR] Tests run: 363, Failures: 10, Errors: 32, Skipped: 6
```


<details>
<summary>
How to replicate CI configuration locally?
</summary>

Build Chain tool does "simple" maven build(s), the builds are just Maven commands, but because the repositories relates and depends on each other and any change in API or class method could affect several of those repositories there is a need to use [build-chain tool](https://github.com/kiegroup/github-action-build-chain) to handle cross repository builds and be sure that we always use latest version of the code for each repository.
 
[build-chain tool](https://github.com/kiegroup/github-action-build-chain) is a build tool which can be used on command line locally or in Github Actions workflow(s), in case you need to change multiple repositories and send multiple dependent pull requests related with a change you can easily reproduce the same build by executing it on Github hosted environment or locally in your development environment. See [local execution](https://github.com/kiegroup/github-action-build-chain#local-execution) details to get more information about it.
</details>

<details>
<summary>
How to retest this PR or trigger a specific build:
</summary>

- for <b>pull request and downstream checks</b>  
  - Push a new commit to the PR. An empty commit would be enough.

- for a <b>full downstream build</b>
  - for <b>github actions</b> job: add the label `run_fdb`

- for <b>Jenkins PR check only</b>
  - If you are an ASF committer for KIE podling, login to Jenkins (https://ci-builds.apache.org/job/KIE/job/drools/), go to the specific PR job, and click on `Build Now` button.
</details>
