### PR TITLE
kie-issues#872: use build-chain config from kogito-pipelines in CI

### DIFF
--- a/.ci/jenkins/Jenkinsfile
+++ b/.ci/jenkins/Jenkinsfile
@@ -13,7 +13,7 @@ pipeline {
     }
     environment {
         BUILDCHAIN_PROJECT = 'apache/incubator-kie-drools'
-        BUILDCHAIN_CONFIG_REPO = 'incubator-kie-drools'
+        BUILDCHAIN_CONFIG_REPO = 'incubator-kie-kogito-pipelines'
         BUILDCHAIN_CONFIG_FILE_PATH = '.ci/buildchain-config-pr-cdb.yaml'
 
         ENABLE_SONARCLOUD = 'false'

--- a/.ci/jenkins/config/branch.yaml
+++ b/.ci/jenkins/config/branch.yaml
@@ -54,8 +54,8 @@ git:
   jenkins_config_path: .ci/jenkins
 buildchain_config:
   git:
-    repository: incubator-kie-drools
-    file_path: .ci/buildchain-config.yaml
+    repository: incubator-kie-kogito-pipelines
+    file_path: .ci/pull-request-config.yaml
     token_credentials_id: kie-ci3-token
 maven:
   settings_file_id: kie-release-settings

--- a/.github/workflows/pr-downstream-full.yml
+++ b/.github/workflows/pr-downstream-full.yml
@@ -44,7 +44,7 @@ jobs:
       - name: Build Chain
         uses: apache/incubator-kie-kogito-pipelines/.ci/actions/build-chain@main
         with:
-          definition-file: https://raw.githubusercontent.com/${GROUP:apache}/incubator-kie-drools/${BRANCH:main}/.ci/buildchain-config.yaml
+          definition-file: https://raw.githubusercontent.com/${GROUP:apache}/incubator-kie-kogito-pipelines/${BRANCH:main}/.ci/pull-request-config.yaml
           annotations-prefix: ${{ runner.os }}-${{ matrix.java-version }}/${{ matrix.maven-version }}
           github-token: "${{ secrets.GITHUB_TOKEN }}"
           flow-type: full-downstream

--- a/.github/workflows/pr-downstream.yml
+++ b/.github/workflows/pr-downstream.yml
@@ -20,11 +20,13 @@ jobs:
     timeout-minutes: 180
     strategy:
       matrix:
-        job_name: [ kogito-runtimes, kogito-apps, kogito-quarkus-examples, kogito-springboot-examples, serverless-workflow-examples ]
+        job_name: [ optaplanner, kogito-runtimes, kogito-apps, kogito-quarkus-examples, kogito-springboot-examples, serverless-workflow-examples ]
         os: [ubuntu-latest]
         java-version: [17]
         maven-version: ['3.9.6']
         include:
+          - job_name: optaplanner
+            repository: incubator-kie-optaplanner
           - job_name: kogito-runtimes
             repository: incubator-kie-kogito-runtimes
           - job_name: kogito-apps
@@ -60,7 +62,7 @@ jobs:
       - name: Build Chain
         uses: apache/incubator-kie-kogito-pipelines/.ci/actions/build-chain@main
         with:
-          definition-file: https://raw.githubusercontent.com/${GROUP:apache}/incubator-kie-drools/${BRANCH:main}/.ci/buildchain-config.yaml
+          definition-file: https://raw.githubusercontent.com/${GROUP:apache}/incubator-kie-kogito-pipelines/${BRANCH:main}/.ci/pull-request-config.yaml
           annotations-prefix: ${{ runner.os }}-${{ matrix.java-version }}/${{ matrix.maven-version }}
           starting-project: apache/${{ matrix.repository }}
           github-token: "${{ secrets.GITHUB_TOKEN }}"

--- a/.github/workflows/pr-drools.yml
+++ b/.github/workflows/pr-drools.yml
@@ -45,7 +45,7 @@ jobs:
           BUILD_MVN_OPTS_CURRENT: -Dfull
           MAVEN_OPTS: "-Dfile.encoding=UTF-8"
         with:
-          definition-file: https://raw.githubusercontent.com/${GROUP:apache}/incubator-kie-drools/${BRANCH:main}/.ci/buildchain-config.yaml
+          definition-file: https://raw.githubusercontent.com/${GROUP:apache}/incubator-kie-kogito-pipelines/${BRANCH:main}/.ci/pull-request-config.yaml
           annotations-prefix: ${{ runner.os }}-${{ matrix.java-version }}/${{ matrix.maven-version }}
           github-token: "${{ secrets.GITHUB_TOKEN }}"
       - name: Surefire Report


### PR DESCRIPTION
Part of solution for
* apache/incubator-kie-issues#872


Switching drools to use build-chain configuration from kogito-pipelines now, when all drools, kogito-runtimes and optaplanner have 999-SNAPSHOT dependencies on each other.