### PR TITLE
[new-parser] Allow soft keywords in chained method calls

### DIFF
--- a/drools-drl/drools-drl-parser-tests/src/test/java/org/drools/drl/parser/antlr4/DRLExprParserTest.java
+++ b/drools-drl/drools-drl-parser-tests/src/test/java/org/drools/drl/parser/antlr4/DRLExprParserTest.java
@@ -248,11 +248,11 @@ public class DRLExprParserTest {
 
     @ParameterizedTest
     @EnumSource(Operator.BuiltInOperator.class)
-    public void testDrlKeywordMethodCallBinding(Operator.BuiltInOperator operator) throws Exception {
+    public void testDrlKeywordInChainedMethodCallWithBinding(Operator.BuiltInOperator operator) throws Exception {
         // Skip operators that cannot be used as method names (==, !=, <, etc.).
         assumeFalse(nonKeywordBuiltInOperators.contains(operator));
 
-        String expressionSource = String.format("x.%s( 1, a )", operator.getSymbol());
+        String expressionSource = String.format("x.%s( 1, a ).%s(\"\")", operator.getSymbol(), operator.getSymbol());
         String bindingVariableSource = "$x";
         String source = bindingVariableSource + " : " + expressionSource;
         ConstraintConnectiveDescr result = parser.parse( source );

--- a/drools-drl/drools-drl-parser/src/main/antlr4/org/drools/drl/parser/antlr4/DRL6Expressions.g4
+++ b/drools-drl/drools-drl-parser/src/main/antlr4/org/drools/drl/parser/antlr4/DRL6Expressions.g4
@@ -807,10 +807,10 @@ selector
     :   DOT { helper.emit($DOT, DroolsEditorType.SYMBOL); } super_key superSuffix
     |   DOT { helper.emit($DOT, DroolsEditorType.SYMBOL); } new_key (nonWildcardTypeArguments)? innerCreator
     |   DOT { helper.emit($DOT, DroolsEditorType.SYMBOL); }
-                  IDENTIFIER { helper.emit($IDENTIFIER, DroolsEditorType.IDENTIFIER); }
+                  id=drlIdentifier { helper.emit($id.token, DroolsEditorType.IDENTIFIER); }
                   (arguments)?
     |   NULL_SAFE_DOT { helper.emit($NULL_SAFE_DOT, DroolsEditorType.SYMBOL); }
-                  IDENTIFIER { helper.emit($IDENTIFIER, DroolsEditorType.IDENTIFIER); }
+                  id=drlIdentifier { helper.emit($id.token, DroolsEditorType.IDENTIFIER); }
                   (arguments)?
     //|   DOT this_key
     |   LBRACK { helper.emit($LBRACK, DroolsEditorType.SYMBOL); }


### PR DESCRIPTION
- Fixes #5862.


### Before PR in `drools-model-codegen`
```
[ERROR] Tests run: 2434, Failures: 86, Errors: 0, Skipped: 9
```

### After PR in `drools-model-codegen`
```
[ERROR] Tests run: 2434, Failures: 84, Errors: 0, Skipped: 9
```

Affected expression:
```
$fact.getStrValue().matches(".*[^a-zA-Z0-9].*"))
```

The reason `selector` rule needs updating to fix this is because `$fact.getStrValue()` is `primary` and the rest is `selector`. Parse tree explains that:

![parseTree](https://github.com/apache/incubator-kie-drools/assets/673386/339534d9-1957-4bdf-a9ee-89df92be0600)


<details>
<summary>
How to replicate CI configuration locally?
</summary>

Build Chain tool does "simple" maven build(s), the builds are just Maven commands, but because the repositories relates and depends on each other and any change in API or class method could affect several of those repositories there is a need to use [build-chain tool](https://github.com/kiegroup/github-action-build-chain) to handle cross repository builds and be sure that we always use latest version of the code for each repository.
 
[build-chain tool](https://github.com/kiegroup/github-action-build-chain) is a build tool which can be used on command line locally or in Github Actions workflow(s), in case you need to change multiple repositories and send multiple dependent pull requests related with a change you can easily reproduce the same build by executing it on Github hosted environment or locally in your development environment. See [local execution](https://github.com/kiegroup/github-action-build-chain#local-execution) details to get more information about it.
</details>

<details>
<summary>
How to retest this PR or trigger a specific build:
</summary>

- for <b>pull request and downstream checks</b>  
  - Push a new commit to the PR. An empty commit would be enough.

- for a <b>full downstream build</b>
  - for <b>github actions</b> job: add the label `run_fdb`

- for <b>Jenkins PR check only</b>
  - If you are an ASF committer for KIE podling, login to Jenkins (https://ci-builds.apache.org/job/KIE/job/drools/), go to the specific PR job, and click on `Build Now` button.
</details>
