### PR TITLE
[incubator-kie-drools-5714] Broken QueryTest#testRecursiveQueryWithBa…

### DIFF
--- a/drools-drl/drools-drl-parser-tests/src/test/java/org/drools/drl/parser/antlr4/MiscDRLParserTest.java
+++ b/drools-drl/drools-drl-parser-tests/src/test/java/org/drools/drl/parser/antlr4/MiscDRLParserTest.java
@@ -4287,13 +4287,13 @@ class MiscDRLParserTest {
                                 assertThat(patternDescr.getObjectType()).isEqualTo("Location");
                                 assertThat(patternDescr.getConstraint().getDescrs().get(0))
                                         .isInstanceOfSatisfying(ExprConstraintDescr.class, constraint -> {
-                                            assertThat(constraint.getExpression().toString()).isEqualTo("x");
+                                            assertThat(constraint.getExpression()).isEqualTo("x");
                                             assertThat(constraint.getType()).isEqualTo(ExprConstraintDescr.Type.POSITIONAL);
                                             assertThat(constraint.getPosition()).isEqualTo(0);
                                         });
                                 assertThat(patternDescr.getConstraint().getDescrs().get(1))
                                         .isInstanceOfSatisfying(ExprConstraintDescr.class, constraint -> {
-                                            assertThat(constraint.getExpression().toString()).isEqualTo("y");
+                                            assertThat(constraint.getExpression()).isEqualTo("y");
                                             assertThat(constraint.getType()).isEqualTo(ExprConstraintDescr.Type.POSITIONAL);
                                             assertThat(constraint.getPosition()).isEqualTo(1);
                                         });
@@ -4307,13 +4307,13 @@ class MiscDRLParserTest {
                                             assertThat(patternDescr.getObjectType()).isEqualTo("Location");
                                             assertThat(patternDescr.getConstraint().getDescrs().get(0))
                                                     .isInstanceOfSatisfying(ExprConstraintDescr.class, constraint -> {
-                                                        assertThat(constraint.getExpression().toString()).isEqualTo("z");
+                                                        assertThat(constraint.getExpression()).isEqualTo("z");
                                                         assertThat(constraint.getType()).isEqualTo(ExprConstraintDescr.Type.POSITIONAL);
                                                         assertThat(constraint.getPosition()).isEqualTo(0);
                                                     });
                                             assertThat(patternDescr.getConstraint().getDescrs().get(1))
                                                     .isInstanceOfSatisfying(ExprConstraintDescr.class, constraint -> {
-                                                        assertThat(constraint.getExpression().toString()).isEqualTo("y");
+                                                        assertThat(constraint.getExpression()).isEqualTo("y");
                                                         assertThat(constraint.getType()).isEqualTo(ExprConstraintDescr.Type.POSITIONAL);
                                                         assertThat(constraint.getPosition()).isEqualTo(1);
                                                     });
@@ -4325,13 +4325,13 @@ class MiscDRLParserTest {
                                             assertThat(patternDescr.getObjectType()).isEqualTo("isContainedIn");
                                             assertThat(patternDescr.getConstraint().getDescrs().get(0))
                                                     .isInstanceOfSatisfying(ExprConstraintDescr.class, constraint -> {
-                                                        assertThat(constraint.getExpression().toString()).isEqualTo("x");
+                                                        assertThat(constraint.getExpression()).isEqualTo("x");
                                                         assertThat(constraint.getType()).isEqualTo(ExprConstraintDescr.Type.POSITIONAL);
                                                         assertThat(constraint.getPosition()).isEqualTo(0);
                                                     });
                                             assertThat(patternDescr.getConstraint().getDescrs().get(1))
                                                     .isInstanceOfSatisfying(ExprConstraintDescr.class, constraint -> {
-                                                        assertThat(constraint.getExpression().toString()).isEqualTo("z");
+                                                        assertThat(constraint.getExpression()).isEqualTo("z");
                                                         assertThat(constraint.getType()).isEqualTo(ExprConstraintDescr.Type.POSITIONAL);
                                                         assertThat(constraint.getPosition()).isEqualTo(1);
                                                     });

--- a/drools-drl/drools-drl-parser/src/main/antlr4/org/drools/drl/parser/antlr4/DRLParser.g4
+++ b/drools-drl/drools-drl-parser/src/main/antlr4/org/drools/drl/parser/antlr4/DRLParser.g4
@@ -80,7 +80,7 @@ ruledef : DRL_RULE name=stringId (EXTENDS parentName=stringId)? drlAnnotation* a
 
 // query := QUERY stringId parameters? annotation* lhsExpression END
 
-querydef : DRL_QUERY name=stringId parameters? drlAnnotation* lhsExpression+ DRL_END ;
+querydef : DRL_QUERY name=stringId parameters? drlAnnotation* queryLhs DRL_END ;
 
 // parameters := LEFT_PAREN ( parameter ( COMMA parameter )* )? RIGHT_PAREN
 parameters : LPAREN ( parameter ( COMMA parameter )* )? RPAREN ;
@@ -89,6 +89,8 @@ parameters : LPAREN ( parameter ( COMMA parameter )* )? RPAREN ;
 parameter : type? drlIdentifier ; // type is optional. Removed (LEFT_SQUARE RIGHT_SQUARE)* as it doesn't make sense in the grammar
 
 lhs : DRL_WHEN lhsExpression* ;
+
+queryLhs : lhsExpression+ ;
 
 lhsExpression : LPAREN lhsExpression RPAREN namedConsequenceInvocation? #lhsExpressionEnclosed
               | lhsUnary                                                #lhsUnarySingle

--- a/drools-drl/drools-drl-parser/src/main/java/org/drools/drl/parser/antlr4/DRLVisitorImpl.java
+++ b/drools-drl/drools-drl-parser/src/main/java/org/drools/drl/parser/antlr4/DRLVisitorImpl.java
@@ -352,11 +352,11 @@ public class DRLVisitorImpl extends DRLParserBaseVisitor<Object> {
 
         ctx.drlAnnotation().stream().map(this::visitDrlAnnotation).forEach(queryDescr::addAnnotation);
 
-        ctx.lhsExpression().stream()
-                           .flatMap(lhsExpressionContext -> visitDescrChildren(lhsExpressionContext).stream())
-                           .forEach(descr -> queryDescr.getLhs().addDescr(descr));
-
-        slimLhsRootDescr(queryDescr.getLhs());
+        final AndDescr rootDescr = queryDescr.getLhs();
+        List<BaseDescr> lhsDescrList = visitDescrChildren(ctx.queryLhs()); // queryLhs never be null
+        lhsDescrList.forEach(descr -> rootDescr.addDescr(descr));
+        slimLhsRootDescr(rootDescr);
+        DescrHelper.populateCommonProperties(rootDescr, ctx.queryLhs());
 
         return queryDescr;
     }

--- a/drools-drl/drools-drl-parser/src/main/java/org/drools/drl/parser/antlr4/DRLVisitorImpl.java
+++ b/drools-drl/drools-drl-parser/src/main/java/org/drools/drl/parser/antlr4/DRLVisitorImpl.java
@@ -293,8 +293,19 @@ public class DRLVisitorImpl extends DRLParserBaseVisitor<Object> {
         if (ctx.lhs() != null) {
             final AndDescr rootDescr = ruleDescr.getLhs();
             List<BaseDescr> lhsDescrList = visitLhs(ctx.lhs());
-            lhsDescrList.forEach(descr -> rootDescr.addDescr(descr));
-            slimLhsRootDescr(rootDescr);
+            // Root Descr is always AndDescr.
+            // For example, if there are nested AndDescr like
+            //  AndDescr
+            //  /\
+            // P  AndDescr
+            //     /\
+            //    P  P
+            // is slimmed down to
+            //  AndDescr
+            //  / | \
+            // P  P  P
+            // by addOrMerge() method.
+            lhsDescrList.forEach(rootDescr::addOrMerge);
             DescrHelper.populateCommonProperties(rootDescr, ctx.lhs().lhsExpression());
         } else {
             ruleDescr.setLhs(new AndDescr());
@@ -317,23 +328,6 @@ public class DRLVisitorImpl extends DRLParserBaseVisitor<Object> {
         return ruleDescr;
     }
 
-    private void slimLhsRootDescr(AndDescr root) {
-        // Root Descr is always AndDescr.
-        // For example, if there are nested AndDescr like
-        //  AndDescr
-        //  /\
-        // P  AndDescr
-        //     /\
-        //    P  P
-        // is slimmed down to
-        //  AndDescr
-        //  / | \
-        // P  P  P
-        List<BaseDescr> descrList = new ArrayList<>(root.getDescrs());
-        root.getDescrs().clear();
-        descrList.forEach(root::addOrMerge);
-    }
-
     @Override
     public QueryDescr visitQuerydef(DRLParser.QuerydefContext ctx) {
         QueryDescr queryDescr = BaseDescrFactory.builder(new QueryDescr(safeStripStringDelimiters(ctx.name.getText())))
@@ -354,8 +348,7 @@ public class DRLVisitorImpl extends DRLParserBaseVisitor<Object> {
 
         final AndDescr rootDescr = queryDescr.getLhs();
         List<BaseDescr> lhsDescrList = visitDescrChildren(ctx.queryLhs()); // queryLhs never be null
-        lhsDescrList.forEach(descr -> rootDescr.addDescr(descr));
-        slimLhsRootDescr(rootDescr);
+        lhsDescrList.forEach(rootDescr::addOrMerge);
         DescrHelper.populateCommonProperties(rootDescr, ctx.queryLhs());
 
         return queryDescr;


### PR DESCRIPTION
…tchCommand

**Issue**:

* https://github.com/apache/incubator-kie-drools/issues/5714

### Before PR in `drools-model-codegen`
```
[ERROR] Tests run: 2434, Failures: 86, Errors: 0, Skipped: 9
```

### After PR in `drools-model-codegen`
```
[ERROR] Tests run: 2434, Failures: 78, Errors: 0, Skipped: 9
```