### PR TITLE
[incubator-kie-drools-5741] [new-parser] Broken enum declaration

### DIFF
--- a/drools-drl/drools-drl-parser-tests/src/test/java/org/drools/drl/parser/antlr4/MiscDRLParserTest.java
+++ b/drools-drl/drools-drl-parser-tests/src/test/java/org/drools/drl/parser/antlr4/MiscDRLParserTest.java
@@ -25,6 +25,8 @@ import org.drools.drl.ast.descr.CollectDescr;
 import org.drools.drl.ast.descr.ConditionalBranchDescr;
 import org.drools.drl.ast.descr.EntryPointDeclarationDescr;
 import org.drools.drl.ast.descr.EntryPointDescr;
+import org.drools.drl.ast.descr.EnumDeclarationDescr;
+import org.drools.drl.ast.descr.EnumLiteralDescr;
 import org.drools.drl.ast.descr.EvalDescr;
 import org.drools.drl.ast.descr.ExistsDescr;
 import org.drools.drl.ast.descr.ExprConstraintDescr;
@@ -4359,5 +4361,38 @@ class MiscDRLParserTest {
                                         });
                             });
                 });
+    }
+
+    @Test
+    public void enumDeclaration() {
+        final String text =
+                "declare enum PersonAge\n" +
+                        "    @doc(author=\"Bob\")\n" +
+                        "    ELEVEN(11, \"XI\"), TWELVE(12, \"XII\");\n" +
+                        "\n" +
+                        "    key: int\n" +
+                        "    romanStr : String\n" +
+                        "end";
+        PackageDescr pkg = parseAndGetPackageDescr(text);
+
+        List<EnumDeclarationDescr> descrList = pkg.getEnumDeclarations();
+        EnumDeclarationDescr enumDeclarationDescr = descrList.get(0);
+        assertThat(enumDeclarationDescr.getTypeName()).isEqualTo("PersonAge");
+
+        assertThat(enumDeclarationDescr.getAnnotation("doc").getValue("author")).isEqualTo("\"Bob\"");
+
+        List<EnumLiteralDescr> literals = enumDeclarationDescr.getLiterals();
+        EnumLiteralDescr enumLiteralDescr0 = literals.get(0);
+        assertThat(enumLiteralDescr0.getName()).isEqualTo("ELEVEN");
+        assertThat(enumLiteralDescr0.getConstructorArgs()).containsExactly("11", "\"XI\"");
+        EnumLiteralDescr enumLiteralDescr1 = literals.get(1);
+        assertThat(enumLiteralDescr1.getName()).isEqualTo("TWELVE");
+        assertThat(enumLiteralDescr1.getConstructorArgs()).containsExactly("12", "\"XII\"");
+
+        TypeFieldDescr key = enumDeclarationDescr.getFields().get("key");
+        assertThat(key.getPattern().getObjectType()).isEqualTo("int");
+
+        TypeFieldDescr romanStr = enumDeclarationDescr.getFields().get("romanStr");
+        assertThat(romanStr.getPattern().getObjectType()).isEqualTo("String");
     }
 }

--- a/drools-drl/drools-drl-parser/src/main/antlr4/org/drools/drl/parser/antlr4/DRLParser.g4
+++ b/drools-drl/drools-drl-parser/src/main/antlr4/org/drools/drl/parser/antlr4/DRLParser.g4
@@ -50,6 +50,7 @@ declaredef : DRL_DECLARE (
                          | entryPointDeclaration
                          | windowDeclaration
                          | typeDeclaration
+                         | enumDeclaration
                          )
                          ; // DRL_END belongs to entryPointDeclaration etc.
 
@@ -69,6 +70,16 @@ entryPointDeclaration : DRL_ENTRY_POINT name=stringId drlAnnotation* DRL_END ;
 // windowDeclaration := WINDOW ID annotation* lhsPatternBind END
 
 windowDeclaration : DRL_WINDOW name=IDENTIFIER drlAnnotation* lhsPatternBind DRL_END ;
+
+// (enum)typeDeclaration := [ENUM] qualifiedIdentifier annotation* enumerative+ field* END
+
+enumDeclaration : ENUM name=drlQualifiedName drlAnnotation* enumeratives SEMI field* DRL_END ;
+
+enumeratives : enumerative (COMMA enumerative)* ;
+
+// enumerative := ID ( LEFT_PAREN expression (COMMA expression)* RIGHT_PAREN )?
+
+enumerative: drlIdentifier ( LPAREN expression ( COMMA expression )* RPAREN )? ;
 
 // field := label fieldType (EQUALS_ASSIGN conditionalExpression)? annotation* SEMICOLON?
 


### PR DESCRIPTION
**Issue**:

* https://github.com/apache/incubator-kie-drools/issues/5741


### Before PR in `drools-model-codegen`
```
[ERROR] Tests run: 2434, Failures: 76, Errors: 0, Skipped: 9
```

### After PR in `drools-model-codegen`
```
[ERROR] Tests run: 2434, Failures: 74, Errors: 0, Skipped: 9
```