### PR TITLE
[incubator-kie-drools-5784] Review DRLParser.g4 and DRL6Expressions.g…

### DIFF
--- a/drools-drl/drools-drl-parser-tests/src/test/java/org/drools/drl/parser/antlr4/DRLParserIdentifierTest.java
+++ b/drools-drl/drools-drl-parser-tests/src/test/java/org/drools/drl/parser/antlr4/DRLParserIdentifierTest.java
@@ -18,17 +18,6 @@
  */
 package org.drools.drl.parser.antlr4;
 
-import java.io.BufferedReader;
-import java.io.IOException;
-import java.io.UncheckedIOException;
-import java.net.URISyntaxException;
-import java.nio.charset.StandardCharsets;
-import java.nio.file.Files;
-import java.nio.file.Path;
-import java.nio.file.Paths;
-import java.util.List;
-import java.util.Optional;
-
 import org.drools.drl.ast.descr.AccumulateDescr;
 import org.drools.drl.ast.descr.AccumulateImportDescr;
 import org.drools.drl.ast.descr.AnnotationDescr;
@@ -38,7 +27,6 @@ import org.drools.drl.ast.descr.FunctionDescr;
 import org.drools.drl.ast.descr.GlobalDescr;
 import org.drools.drl.ast.descr.PackageDescr;
 import org.drools.drl.ast.descr.PatternDescr;
-import org.drools.drl.ast.descr.QueryDescr;
 import org.drools.drl.ast.descr.RuleDescr;
 import org.drools.drl.ast.descr.WindowDeclarationDescr;
 import org.drools.drl.ast.descr.WindowReferenceDescr;
@@ -50,7 +38,6 @@ import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.drools.drl.parser.antlr4.ParserTestUtils.enableOldParser;
 
 /*
  * This test class is to test parse rules to accept drlIdentifier insteadof IDENTIFIER. (e.g. drl keyword like "contains")
@@ -64,25 +51,6 @@ class DRLParserIdentifierTest {
         parser = ParserTestUtils.getParser();
     }
 
-    private String readResource(final String filename) {
-        Path path;
-        try {
-            path = Paths.get(getClass().getResource(filename).toURI());
-        } catch (URISyntaxException e) {
-            throw new RuntimeException(e);
-        }
-        final StringBuilder sb = new StringBuilder();
-        try (BufferedReader br = Files.newBufferedReader(path, StandardCharsets.UTF_8)) {
-            for (String line; (line = br.readLine()) != null; ) {
-                sb.append(line);
-                sb.append("\n");
-            }
-        } catch (IOException e) {
-            throw new UncheckedIOException(e);
-        }
-        return sb.toString();
-    }
-
     private PackageDescr parseAndGetPackageDescr(String drl) {
         try {
             PackageDescr pkg = parser.parse(null, drl);
@@ -93,26 +61,10 @@ class DRLParserIdentifierTest {
         }
     }
 
-    private PackageDescr parseAndGetPackageDescrWithoutErrorCheck(String drl) {
-        try {
-            return parser.parse(null, drl);
-        } catch (DroolsParserException e) {
-            throw new RuntimeException(e);
-        }
-    }
-
     private RuleDescr parseAndGetFirstRuleDescr(String drl) {
         PackageDescr pkg = parseAndGetPackageDescr(drl);
         assertThat(pkg.getRules()).isNotEmpty();
         return pkg.getRules().get(0);
-    }
-
-    private QueryDescr parseAndGetFirstQueryDescr(String drl) {
-        PackageDescr pkg = parseAndGetPackageDescr(drl);
-        assertThat(pkg.getRules()).isNotEmpty();
-        Optional<QueryDescr> optQuery = pkg.getRules().stream().filter(QueryDescr.class::isInstance).map(QueryDescr.class::cast).findFirst();
-        assertThat(optQuery).isPresent();
-        return optQuery.get();
     }
 
     @Test

--- a/drools-drl/drools-drl-parser-tests/src/test/java/org/drools/drl/parser/antlr4/DRLParserIdentifierTest.java
+++ b/drools-drl/drools-drl-parser-tests/src/test/java/org/drools/drl/parser/antlr4/DRLParserIdentifierTest.java
@@ -1,0 +1,373 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.drools.drl.parser.antlr4;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.UncheckedIOException;
+import java.net.URISyntaxException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.List;
+import java.util.Optional;
+
+import org.drools.drl.ast.descr.AccumulateDescr;
+import org.drools.drl.ast.descr.AccumulateImportDescr;
+import org.drools.drl.ast.descr.AnnotationDescr;
+import org.drools.drl.ast.descr.BehaviorDescr;
+import org.drools.drl.ast.descr.ExprConstraintDescr;
+import org.drools.drl.ast.descr.FunctionDescr;
+import org.drools.drl.ast.descr.GlobalDescr;
+import org.drools.drl.ast.descr.PackageDescr;
+import org.drools.drl.ast.descr.PatternDescr;
+import org.drools.drl.ast.descr.QueryDescr;
+import org.drools.drl.ast.descr.RuleDescr;
+import org.drools.drl.ast.descr.WindowDeclarationDescr;
+import org.drools.drl.ast.descr.WindowReferenceDescr;
+import org.drools.drl.parser.DrlParser;
+import org.drools.drl.parser.DroolsParserException;
+import org.drools.drl.parser.impl.Operator;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.drools.drl.parser.antlr4.ParserTestUtils.enableOldParser;
+
+/*
+ * This test class is to test parse rules to accept drlIdentifier insteadof IDENTIFIER. (e.g. drl keyword like "contains")
+ */
+class DRLParserIdentifierTest {
+
+    private DrlParser parser;
+
+    @BeforeEach
+    public void setUp() {
+        parser = ParserTestUtils.getParser();
+    }
+
+    private String readResource(final String filename) {
+        Path path;
+        try {
+            path = Paths.get(getClass().getResource(filename).toURI());
+        } catch (URISyntaxException e) {
+            throw new RuntimeException(e);
+        }
+        final StringBuilder sb = new StringBuilder();
+        try (BufferedReader br = Files.newBufferedReader(path, StandardCharsets.UTF_8)) {
+            for (String line; (line = br.readLine()) != null; ) {
+                sb.append(line);
+                sb.append("\n");
+            }
+        } catch (IOException e) {
+            throw new UncheckedIOException(e);
+        }
+        return sb.toString();
+    }
+
+    private PackageDescr parseAndGetPackageDescr(String drl) {
+        try {
+            PackageDescr pkg = parser.parse(null, drl);
+            assertThat(parser.hasErrors()).as(parser.getErrors().toString()).isFalse();
+            return pkg;
+        } catch (DroolsParserException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    private PackageDescr parseAndGetPackageDescrWithoutErrorCheck(String drl) {
+        try {
+            return parser.parse(null, drl);
+        } catch (DroolsParserException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    private RuleDescr parseAndGetFirstRuleDescr(String drl) {
+        PackageDescr pkg = parseAndGetPackageDescr(drl);
+        assertThat(pkg.getRules()).isNotEmpty();
+        return pkg.getRules().get(0);
+    }
+
+    private QueryDescr parseAndGetFirstQueryDescr(String drl) {
+        PackageDescr pkg = parseAndGetPackageDescr(drl);
+        assertThat(pkg.getRules()).isNotEmpty();
+        Optional<QueryDescr> optQuery = pkg.getRules().stream().filter(QueryDescr.class::isInstance).map(QueryDescr.class::cast).findFirst();
+        assertThat(optQuery).isPresent();
+        return optQuery.get();
+    }
+
+    @Test
+    void importAccumulate() {
+        final String source = "import accumulate org.example.MyFunction contains;";
+        final PackageDescr pkg = parseAndGetPackageDescr(source);
+        AccumulateImportDescr accumulateImportDescr = pkg.getAccumulateImports().get(0);
+        assertThat(accumulateImportDescr.getTarget()).isEqualTo("org.example.MyFunction");
+        assertThat(accumulateImportDescr.getFunctionName()).isEqualTo("contains");
+    }
+
+    @Test
+    void windowDeclaration() {
+        final String text =
+                "declare window contains\n" +
+                        "    $s : StockTick( source == \"NYSE\" )\n" +
+                        "        over window:length( 10 )\n" +
+                        "end";
+        PackageDescr pkg = parseAndGetPackageDescr(text);
+        WindowDeclarationDescr windowDeclarationDescr = pkg.getWindowDeclarations().iterator().next();
+        assertThat(windowDeclarationDescr.getName()).isEqualTo("contains");
+    }
+
+    @Test
+    void nestedConstraint() {
+        final String text =
+                "rule R\n" +
+                        "when\n" +
+                        " Person( contains.matches.( city == \"london\", country == \"uk\"))\n" +
+                        "then\n" +
+                        "end";
+        RuleDescr rule = parseAndGetFirstRuleDescr(text);
+        assertThat(rule.getLhs().getDescrs().get(0)).isInstanceOfSatisfying(PatternDescr.class, patternDescr -> {
+            assertThat(patternDescr.getConstraint().getDescrs().get(0)).isInstanceOfSatisfying(ExprConstraintDescr.class, exprConstraintDescr -> {
+                assertThat(exprConstraintDescr.getExpression()).isEqualTo("contains.matches.city == \"london\"");
+            });
+            assertThat(patternDescr.getConstraint().getDescrs().get(1)).isInstanceOfSatisfying(ExprConstraintDescr.class, exprConstraintDescr -> {
+                assertThat(exprConstraintDescr.getExpression()).isEqualTo("contains.matches.country == \"uk\"");
+            });
+        });
+    }
+
+    @Test
+    public void function() {
+        final String text = "function boolean contains(String s) { return true; }";
+        PackageDescr packageDescr = parseAndGetPackageDescr(text);
+        FunctionDescr function = packageDescr.getFunctions().get(0);
+        assertThat(function.getName()).isEqualTo("contains");
+    }
+
+    @Test
+    public void patternFilter() {
+        final String text = "rule X when StockTick( symbol==\"ACME\") over window:contains(10) then end";
+        RuleDescr rule = parseAndGetFirstRuleDescr(text);
+        PatternDescr pattern = (PatternDescr) rule.getLhs().getDescrs().get(0);
+        BehaviorDescr behavior = pattern.getBehaviors().get(0);
+        assertThat(behavior.getType()).isEqualTo("window");
+        assertThat(behavior.getSubType()).isEqualTo("contains");
+        assertThat(behavior.getParameters().get(0)).isEqualTo("10");
+    }
+
+    @Test
+    public void accumulateFunction() {
+        final String text = "rule R1\n" +
+                "when\n" +
+                "     accumulate( Person( $age : age > 21 ), $ave : contains( $age ) );\n" +
+                "then\n" +
+                "end";
+        RuleDescr rule = parseAndGetFirstRuleDescr(text);
+        final PatternDescr out = (PatternDescr) rule.getLhs().getDescrs().get(0);
+        final AccumulateDescr accumulate = (AccumulateDescr) out.getSource();
+        assertThat(accumulate.getFunctions().get(0).getFunction()).isEqualToIgnoringWhitespace("contains");
+    }
+
+    @Test
+    public void fromWindow() {
+        final String text =
+                "rule X\n" +
+                        "when\n" +
+                        "    StockTick() from window contains\n" +
+                        "then\n" +
+                        "end\n";
+        RuleDescr rule = parseAndGetFirstRuleDescr(text);
+        PatternDescr pattern = (PatternDescr) rule.getLhs().getDescrs().get(0);
+        assertThat(pattern.getSource()).isInstanceOfSatisfying(WindowReferenceDescr.class, windowReferenceDescr -> {
+            assertThat(windowReferenceDescr.getName()).isEqualTo("contains");
+        });
+    }
+
+    @Test
+    public void type() {
+        final String text = "global contains.matches bbb";
+        PackageDescr pkg = parseAndGetPackageDescr(text);
+        GlobalDescr global = pkg.getGlobals().get(0);
+        assertThat(global.getType()).isEqualTo("contains.matches");
+        assertThat(global.getIdentifier()).isEqualTo("bbb");
+    }
+
+    @Test
+    public void unification() throws Exception {
+        final String text = "rule X\n" +
+                "when\n" +
+                "  contains := Person()\n" +
+                "then\n" +
+                "end";
+        PatternDescr pattern = (PatternDescr) parseAndGetFirstRuleDescr(text).getLhs().getDescrs().get(0);
+        assertThat(pattern.getIdentifier()).isEqualTo("contains");
+        assertThat(pattern.isUnification()).isTrue();
+    }
+
+    @Test
+    public void annotation() {
+        final String text = "rule R\n" +
+                "@contains.matches(soundslike=\"abc\")\n" +
+                "when\n" +
+                "then\n" +
+                "end";
+        RuleDescr rule = parseAndGetFirstRuleDescr(text);
+        AnnotationDescr annotation = rule.getAnnotation("contains.matches");
+        assertThat(annotation.getValue("soundslike")).isEqualTo("\"abc\"");
+    }
+
+    @Test
+    public void constraintBoundVariable() {
+        final String text = "rule X\n" +
+                "when\n" +
+                "  Person( contains : age > 20)\n" +
+                "then\n" +
+                "end";
+        PatternDescr pattern = (PatternDescr) parseAndGetFirstRuleDescr(text).getLhs().getDescrs().get(0);
+        ExprConstraintDescr exprConstraintDescr = (ExprConstraintDescr) pattern.getConstraint().getDescrs().get(0);
+        assertThat(exprConstraintDescr.getExpression()).isEqualTo("contains : age > 20");
+    }
+
+    @Test
+    public void constraintBoundVariableUnify() {
+        final String text = "rule X\n" +
+                "when\n" +
+                "  Person( contains := age > 20)\n" +
+                "then\n" +
+                "end";
+        PatternDescr pattern = (PatternDescr) parseAndGetFirstRuleDescr(text).getLhs().getDescrs().get(0);
+        ExprConstraintDescr exprConstraintDescr = (ExprConstraintDescr) pattern.getConstraint().getDescrs().get(0);
+        assertThat(exprConstraintDescr.getExpression()).isEqualTo("contains := age > 20");
+    }
+
+    @Test
+    void xpathChunk() {
+        final String text =
+                "rule R when\n" +
+                        " $man: Man( /contains.matches#soundslike[memberOf > 10] )\n" +
+                        "then\n" +
+                        "end\n";
+        PatternDescr pattern = (PatternDescr) parseAndGetFirstRuleDescr(text).getLhs().getDescrs().get(0);
+        ExprConstraintDescr exprConstraintDescr = (ExprConstraintDescr) pattern.getConstraint().getDescrs().get(0);
+        assertThat(exprConstraintDescr.getExpression()).isEqualTo("/contains.matches#soundslike[memberOf > 10]");
+    }
+
+    @Test
+    void createdName() {
+        final String text =
+                "rule X\n" +
+                        "when\n" +
+                        "  Person( age > new contains.matches(10))\n" +
+                        "then\n" +
+                        "end";
+        PatternDescr pattern = (PatternDescr) parseAndGetFirstRuleDescr(text).getLhs().getDescrs().get(0);
+        ExprConstraintDescr exprConstraintDescr = (ExprConstraintDescr) pattern.getConstraint().getDescrs().get(0);
+        assertThat(exprConstraintDescr.getExpression()).isEqualTo("age > new contains.matches(10)");
+    }
+
+    @Test
+    void explicitGenericInvocationSuffix() {
+        final String text =
+                "rule X\n" +
+                        "when\n" +
+                        "  Person( name == <String>contains())\n" +
+                        "then\n" +
+                        "end";
+        PatternDescr pattern = (PatternDescr) parseAndGetFirstRuleDescr(text).getLhs().getDescrs().get(0);
+        ExprConstraintDescr exprConstraintDescr = (ExprConstraintDescr) pattern.getConstraint().getDescrs().get(0);
+        assertThat(exprConstraintDescr.getExpression()).isEqualTo("name == <String>contains()");
+    }
+
+    @Disabled("Old parser does not support this syntax")
+    @Test
+    void innerCreator() {
+        final String text =
+                "rule X\n" +
+                        "when\n" +
+                        "  Person( outer.new contains() != null )\n" +
+                        "then\n" +
+                        "end";
+        PatternDescr pattern = (PatternDescr) parseAndGetFirstRuleDescr(text).getLhs().getDescrs().get(0);
+        ExprConstraintDescr exprConstraintDescr = (ExprConstraintDescr) pattern.getConstraint().getDescrs().get(0);
+        assertThat(exprConstraintDescr.getExpression()).isEqualTo("outer.new contains() != null");
+    }
+
+    @Test
+    void superSuffix() {
+        final String text =
+                "rule X\n" +
+                        "when\n" +
+                        "  Person( address.super.contains() == 10 )\n" +
+                        "then\n" +
+                        "end";
+        PatternDescr pattern = (PatternDescr) parseAndGetFirstRuleDescr(text).getLhs().getDescrs().get(0);
+        ExprConstraintDescr exprConstraintDescr = (ExprConstraintDescr) pattern.getConstraint().getDescrs().get(0);
+        assertThat(exprConstraintDescr.getExpression()).isEqualTo("address.super.contains() == 10");
+    }
+
+    @Disabled("To be done by https://github.com/apache/incubator-kie-drools/issues/5874")
+    @Test
+    void operator_key() {
+        final String text =
+                "rule X\n" +
+                        "when\n" +
+                        "  Person( age provides 10 )\n" +
+                        "then\n" +
+                        "end";
+        // PROVIDES is not IDENTIFIER, but included in drlIdentifier
+        Operator.addOperatorToRegistry("provides", false);
+        PatternDescr pattern = (PatternDescr) parseAndGetFirstRuleDescr(text).getLhs().getDescrs().get(0);
+        ExprConstraintDescr exprConstraintDescr = (ExprConstraintDescr) pattern.getConstraint().getDescrs().get(0);
+        assertThat(exprConstraintDescr.getExpression()).isEqualTo("age provides 10");
+    }
+
+    @Disabled("To be done by https://github.com/apache/incubator-kie-drools/issues/5874")
+    @Test
+    void neg_operator_key() {
+        final String text =
+                "rule X\n" +
+                        "when\n" +
+                        "  Person( age not provides 10 )\n" +
+                        "then\n" +
+                        "end";
+        // PROVIDES is not IDENTIFIER, but included in drlIdentifier
+        Operator.addOperatorToRegistry("provides", true);
+        PatternDescr pattern = (PatternDescr) parseAndGetFirstRuleDescr(text).getLhs().getDescrs().get(0);
+        ExprConstraintDescr exprConstraintDescr = (ExprConstraintDescr) pattern.getConstraint().getDescrs().get(0);
+        assertThat(exprConstraintDescr.getExpression()).isEqualTo("age not provides 10");
+    }
+
+    @Test
+    void operator_key_temporal() {
+        // This test (and MiscDRLParserTest.parse_PluggableOperators) fails when adapting drlIdentifier to operator_key and neg_operator_key in DRL6Expressions.g4
+        // See https://github.com/apache/incubator-kie-drools/issues/5874
+        final String text =
+                "rule X\n" +
+                        "when\n" +
+                        "  Person( this after[1,10] $a || this not after[15,20] $a )\n" +
+                        "then\n" +
+                        "end";
+        PatternDescr pattern = (PatternDescr) parseAndGetFirstRuleDescr(text).getLhs().getDescrs().get(0);
+        ExprConstraintDescr exprConstraintDescr = (ExprConstraintDescr) pattern.getConstraint().getDescrs().get(0);
+        assertThat(exprConstraintDescr.getExpression()).isEqualTo("this after[1,10] $a || this not after[15,20] $a");
+    }
+}

--- a/drools-drl/drools-drl-parser-tests/src/test/java/org/drools/drl/parser/antlr4/DRLParserTest.java
+++ b/drools-drl/drools-drl-parser-tests/src/test/java/org/drools/drl/parser/antlr4/DRLParserTest.java
@@ -1,3 +1,21 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
 package org.drools.drl.parser.antlr4;
 
 import java.util.List;

--- a/drools-drl/drools-drl-parser-tests/src/test/java/org/drools/drl/parser/antlr4/MiscDRLParserTest.java
+++ b/drools-drl/drools-drl-parser-tests/src/test/java/org/drools/drl/parser/antlr4/MiscDRLParserTest.java
@@ -1,3 +1,21 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
 package org.drools.drl.parser.antlr4;
 
 import java.io.BufferedReader;

--- a/drools-drl/drools-drl-parser-tests/src/test/java/org/drools/drl/parser/antlr4/ParserTestUtils.java
+++ b/drools-drl/drools-drl-parser-tests/src/test/java/org/drools/drl/parser/antlr4/ParserTestUtils.java
@@ -32,4 +32,11 @@ public class ParserTestUtils {
     public static DrlParser getParser() {
         return new DrlParser();
     }
+
+    /**
+     * Enables the old parser. Just for quick testing purposes.
+     */
+    public static void enableOldParser() {
+        DrlParser.ANTLR4_PARSER_ENABLED = false;
+    }
 }

--- a/drools-drl/drools-drl-parser/src/main/antlr4/org/drools/drl/parser/antlr4/DRL6Expressions.g4
+++ b/drools-drl/drools-drl-parser/src/main/antlr4/org/drools/drl/parser/antlr4/DRL6Expressions.g4
@@ -146,7 +146,7 @@ type
 
 typeMatch
     : primitiveType (LBRACK RBRACK)*
-    |	IDENTIFIER (typeArguments)? (DOT IDENTIFIER (typeArguments)? )* (LBRACK RBRACK)*
+    |	drlIdentifier (typeArguments)? (DOT drlIdentifier (typeArguments)? )* (LBRACK RBRACK)*
     ;
 
 typeArguments
@@ -282,7 +282,7 @@ finally { ternOp--; }
 
 fullAnnotation [AnnotatedDescrBuilder inDescrBuilder] returns [AnnotationDescr result]
 @init{ String n = ""; AnnotationDescrBuilder annoBuilder = null; }
-  : AT name=IDENTIFIER { n = $name.text; } ( DOT x=IDENTIFIER { n += "." + $x.text; } )*
+  : AT name=drlIdentifier { n = $name.text; } ( DOT x=drlIdentifier { n += "." + $x.text; } )*
         { if( buildDescr ) {
                 if ( inDescrBuilder == null ) {
                     $result = new AnnotationDescr( n );
@@ -310,7 +310,7 @@ annotationElementValuePairs [AnnotationDescr descr, AnnotatedDescrBuilder inDesc
   ;
 
 annotationElementValuePair [AnnotationDescr descr, AnnotatedDescrBuilder inDescrBuilder]
-  : key=IDENTIFIER ASSIGN val=annotationValue[inDescrBuilder] { if ( buildDescr ) { $descr.setKeyValue( $key.text, $val.result ); } }
+  : key=drlIdentifier ASSIGN val=annotationValue[inDescrBuilder] { if ( buildDescr ) { $descr.setKeyValue( $key.text, $val.result ); } }
   ;
 
 annotationValue[AnnotatedDescrBuilder inDescrBuilder] returns [Object result]
@@ -615,10 +615,10 @@ unaryExpressionNotPlusMinus returns [BaseDescr result]
     |   castExpression
     |   backReferenceExpression
     |   { isLeft = helper.getLeftMostExpr() == null;}
-        ( ({inMap == 0 && ternOp == 0 && _input.LA(2) == DRLLexer.COLON}? (var=IDENTIFIER COLON
-                { hasBindings = true; helper.emit($var, DroolsEditorType.IDENTIFIER_VARIABLE); helper.emit($COLON, DroolsEditorType.SYMBOL); if( buildDescr ) { bind = new BindingDescr($var.text, null, false); helper.setStart( bind, $var ); } } ))
-        | ({inMap == 0 && ternOp == 0 && _input.LA(2) == DRLLexer.DRL_UNIFY}? (var=IDENTIFIER DRL_UNIFY
-                { hasBindings = true; helper.emit($var, DroolsEditorType.IDENTIFIER_VARIABLE); helper.emit($DRL_UNIFY, DroolsEditorType.SYMBOL); if( buildDescr ) { bind = new BindingDescr($var.text, null, true); helper.setStart( bind, $var ); } } ))
+        ( ({inMap == 0 && ternOp == 0 && _input.LA(2) == DRLLexer.COLON}? (var=drlIdentifier COLON
+                { hasBindings = true; helper.emit($var.token, DroolsEditorType.IDENTIFIER_VARIABLE); helper.emit($COLON, DroolsEditorType.SYMBOL); if( buildDescr ) { bind = new BindingDescr($var.text, null, false); helper.setStart( bind, $var.token ); } } ))
+        | ({inMap == 0 && ternOp == 0 && _input.LA(2) == DRLLexer.DRL_UNIFY}? (var=drlIdentifier DRL_UNIFY
+                { hasBindings = true; helper.emit($var.token, DroolsEditorType.IDENTIFIER_VARIABLE); helper.emit($DRL_UNIFY, DroolsEditorType.SYMBOL); if( buildDescr ) { bind = new BindingDescr($var.text, null, true); helper.setStart( bind, $var.token ); } } ))
         )?
 
         ( left2=xpathPrimary { if( buildDescr ) { $result = $left2.result; } }
@@ -677,7 +677,7 @@ xpathPrimary returns [BaseDescr result]
     ;
 
 xpathChunk returns [BaseDescr result]
-    : xpathSeparator IDENTIFIER (DOT IDENTIFIER)* (HASH IDENTIFIER)? (LBRACK xpathExpressionList RBRACK)?
+    : xpathSeparator drlIdentifier (DOT drlIdentifier)* (HASH drlIdentifier)? (LBRACK xpathExpressionList RBRACK)?
     ;
 
 xpathExpressionList returns [java.util.List<String> exprs]
@@ -761,13 +761,14 @@ creator
     ;
 
 createdName
-    :	IDENTIFIER typeArguments?
-        ( DOT IDENTIFIER typeArguments?)*
+    :	drlIdentifier typeArguments?
+        ( DOT drlIdentifier typeArguments?)*
         |	primitiveType
     ;
 
+// Old parser cannot parse innerCreator with selector expression (outer.new InnerClass() != null) TODO: Delete this after investigation
 innerCreator
-    :	{!(helper.validateIdentifierKey(DroolsSoftKeywords.INSTANCEOF))}? IDENTIFIER classCreatorRest
+    :	{!(helper.validateIdentifierKey(DroolsSoftKeywords.INSTANCEOF))}? drlIdentifier classCreatorRest
     ;
 
 arrayCreatorRest
@@ -800,7 +801,7 @@ nonWildcardTypeArguments
 
 explicitGenericInvocationSuffix
     :	super_key superSuffix
-    |   	IDENTIFIER arguments
+    |   	drlIdentifier arguments
     ;
 
 selector
@@ -820,7 +821,7 @@ selector
 
 superSuffix
     :	arguments
-    |   	DOT IDENTIFIER (arguments)?
+    |   	DOT drlIdentifier (arguments)?
     ;
 
 squareArguments returns [java.util.List<String> args]

--- a/drools-drl/drools-drl-parser/src/main/antlr4/org/drools/drl/parser/antlr4/DRLParser.g4
+++ b/drools-drl/drools-drl-parser/src/main/antlr4/org/drools/drl/parser/antlr4/DRLParser.g4
@@ -31,7 +31,7 @@ packagedef : PACKAGE name=drlQualifiedName SEMI? ;
 unitdef : DRL_UNIT name=drlQualifiedName SEMI? ;
 
 importdef : IMPORT (DRL_FUNCTION|STATIC)? drlQualifiedName (DOT MUL)?          #importStandardDef
-          | IMPORT (DRL_ACCUMULATE|DRL_ACC) drlQualifiedName IDENTIFIER        #importAccumulateDef
+          | IMPORT (DRL_ACCUMULATE|DRL_ACC) drlQualifiedName drlIdentifier     #importAccumulateDef
           ;
 
 globaldef : DRL_GLOBAL type drlIdentifier ;
@@ -69,7 +69,7 @@ entryPointDeclaration : DRL_ENTRY_POINT name=stringId drlAnnotation* DRL_END ;
 
 // windowDeclaration := WINDOW ID annotation* lhsPatternBind END
 
-windowDeclaration : DRL_WINDOW name=IDENTIFIER drlAnnotation* lhsPatternBind DRL_END ;
+windowDeclaration : DRL_WINDOW name=drlIdentifier drlAnnotation* lhsPatternBind DRL_END ;
 
 // (enum)typeDeclaration := [ENUM] qualifiedIdentifier annotation* enumerative+ field* END
 
@@ -149,7 +149,7 @@ lhsPattern : QUESTION? objectType=drlQualifiedName LPAREN positionalConstraints?
 positionalConstraints : constraint (COMMA constraint)* SEMI ;
 constraints : constraint (COMMA constraint)* ;
 constraint : ( nestedConstraint | conditionalOrExpression ) ;
-nestedConstraint : ( IDENTIFIER ( DOT | NULL_SAFE_DOT | HASH ) )* IDENTIFIER (DOT | NULL_SAFE_DOT ) LPAREN constraints RPAREN ;
+nestedConstraint : ( drlIdentifier ( DOT | NULL_SAFE_DOT | HASH ) )* drlIdentifier (DOT | NULL_SAFE_DOT ) LPAREN constraints RPAREN ;
 
 // named consequence
 
@@ -184,7 +184,7 @@ relationalOperator
 drlRelationalOperator : DRL_NOT? builtInOperator ;
 
 /* function := FUNCTION type? ID parameters(typed) chunk_{_} */
-functiondef : DRL_FUNCTION typeTypeOrVoid? IDENTIFIER formalParameters drlBlock ;
+functiondef : DRL_FUNCTION typeTypeOrVoid? drlIdentifier formalParameters drlBlock ;
 
 
 /* extending JavaParser qualifiedName */
@@ -307,7 +307,7 @@ mapEntry
  patternFilter :=   OVER filterDef
  filterDef := label ID LEFT_PAREN parameters RIGHT_PAREN
 */
-patternFilter : DRL_WINDOW COLON IDENTIFIER LPAREN expressionList RPAREN ;
+patternFilter : DRL_WINDOW COLON drlIdentifier LPAREN expressionList RPAREN ;
 
 /*
  patternSource := FROM
@@ -346,7 +346,7 @@ blockStatements : drlBlockStatement* ;
 /*
 accumulateFunction := label? ID parameters
 */
-accumulateFunction : label? IDENTIFIER LPAREN drlExpression RPAREN;
+accumulateFunction : label? drlIdentifier LPAREN drlExpression RPAREN;
 
 // fromCollect := COLLECT LEFT_PAREN lhsPatternBind RIGHT_PAREN
 
@@ -355,7 +355,7 @@ fromCollect : DRL_COLLECT LPAREN lhsPatternBind RPAREN ;
 fromEntryPoint : DRL_ENTRY_POINT stringId ;
 
 // fromWindow := WINDOW ID
-fromWindow : DRL_WINDOW IDENTIFIER ;
+fromWindow : DRL_WINDOW drlIdentifier ;
 
 /*
  lhsExists := EXISTS
@@ -418,8 +418,7 @@ namedConsequence : RHS_NAMED_CONSEQUENCE_THEN consequenceBody ;
 
 stringId : ( drlIdentifier | DRL_STRING_LITERAL ) ;
 
-type : (classOrInterfaceType | primitiveType) typeArguments? ( DOT IDENTIFIER typeArguments? )* (LBRACK RBRACK)* ;
-
+//type := ID typeArguments? ( DOT ID typeArguments? )* (LEFT_SQUARE RIGHT_SQUARE)*
 //typeArguments : LT typeArgument (COMMA typeArgument)* GT ;
 //typeArgument : QUESTION (( EXTENDS | SUPER ) type )? |  type ;
 
@@ -456,7 +455,7 @@ assignmentOperator : ASSIGN
                    |   LT LT ASSIGN ;
 
 label : drlIdentifier COLON ;
-unif : IDENTIFIER DRL_UNIFY ;
+unif : drlIdentifier DRL_UNIFY ;
 
 /* extending JavaParser variableInitializer */
 drlVariableInitializer

--- a/drools-drl/drools-drl-parser/src/main/java/org/drools/drl/parser/antlr4/DRLVisitorImpl.java
+++ b/drools-drl/drools-drl-parser/src/main/java/org/drools/drl/parser/antlr4/DRLVisitorImpl.java
@@ -188,7 +188,7 @@ public class DRLVisitorImpl extends DRLParserBaseVisitor<Object> {
                 .withParserRuleContext(ctx)
                 .build();
         accumulateImportDescr.setTarget(ctx.drlQualifiedName().getText());
-        accumulateImportDescr.setFunctionName(ctx.IDENTIFIER().getText());
+        accumulateImportDescr.setFunctionName(ctx.drlIdentifier().getText());
         return accumulateImportDescr;
     }
 
@@ -202,7 +202,7 @@ public class DRLVisitorImpl extends DRLParserBaseVisitor<Object> {
         } else {
             functionDescr.setReturnType("void");
         }
-        functionDescr.setName(ctx.IDENTIFIER().getText());
+        functionDescr.setName(ctx.drlIdentifier().getText());
 
         // add function parameters
         DRLParser.FormalParametersContext formalParametersContext = ctx.formalParameters();
@@ -547,7 +547,7 @@ public class DRLVisitorImpl extends DRLParserBaseVisitor<Object> {
         if (ctx.label() != null) {
             patternDescr.setIdentifier(ctx.label().drlIdentifier().getText());
         } else if (ctx.unif() != null) {
-            patternDescr.setIdentifier(ctx.unif().IDENTIFIER().getText());
+            patternDescr.setIdentifier(ctx.unif().drlIdentifier().getText());
             patternDescr.setUnification(true);
         }
         DescrHelper.refreshPatternDescrProperties(patternDescr, ctx);
@@ -706,7 +706,7 @@ public class DRLVisitorImpl extends DRLParserBaseVisitor<Object> {
                 .withParserRuleContext(ctx)
                 .build();
         behaviorDescr.setType(ctx.DRL_WINDOW().getText());
-        behaviorDescr.setSubType(ctx.IDENTIFIER().getText());
+        behaviorDescr.setSubType(ctx.drlIdentifier().getText());
         List<DRLParser.ExpressionContext> expressionContexts = ctx.expressionList().expression();
         List<String> parameters = expressionContexts.stream().map(Antlr4ParserStringUtils::getTextPreservingWhitespace).collect(Collectors.toList());
         behaviorDescr.setParameters(parameters);
@@ -754,7 +754,7 @@ public class DRLVisitorImpl extends DRLParserBaseVisitor<Object> {
 
     @Override
     public AccumulateDescr.AccumulateFunctionCallDescr visitAccumulateFunction(DRLParser.AccumulateFunctionContext ctx) {
-        String function = ctx.IDENTIFIER().getText();
+        String function = ctx.drlIdentifier().getText();
         String bind = ctx.label() == null ? null : ctx.label().drlIdentifier().getText();
         String[] params = new String[]{getTextPreservingWhitespace(ctx.drlExpression())};
         return new AccumulateDescr.AccumulateFunctionCallDescr(function, bind, false, params);
@@ -769,7 +769,7 @@ public class DRLVisitorImpl extends DRLParserBaseVisitor<Object> {
 
     @Override
     public WindowReferenceDescr visitFromWindow(DRLParser.FromWindowContext ctx) {
-        return BaseDescrFactory.builder(new WindowReferenceDescr(ctx.IDENTIFIER().getText()))
+        return BaseDescrFactory.builder(new WindowReferenceDescr(ctx.drlIdentifier().getText()))
                 .withParserRuleContext(ctx)
                 .build();
     }


### PR DESCRIPTION
…4 to replace IDENTIFIER with drlIdentifier

**Issue**:

* https://github.com/apache/incubator-kie-drools/issues/5784


### Before PR in `drools-model-codegen`
```
[ERROR] Tests run: 2434, Failures: 74, Errors: 0, Skipped: 9
```

### After PR in `drools-model-codegen`
```
[ERROR] Tests run: 2434, Failures: 72, Errors: 0, Skipped: 9
```

The main purpose is to hardening backward compatibility with the new test `DRLParserIdentifierTest`.