### PR TITLE
[new-parser] Allow OOPath as a LHS pattern

### DIFF
--- a/drools-drl/drools-drl-parser-tests/src/test/java/org/drools/drl/parser/antlr4/MiscDRLParserTest.java
+++ b/drools-drl/drools-drl-parser-tests/src/test/java/org/drools/drl/parser/antlr4/MiscDRLParserTest.java
@@ -4091,6 +4091,28 @@ class MiscDRLParserTest {
     }
 
     @Test
+    void ooPathLhsPattern() {
+        final String text = "package org.drools\n"
+                + "rule PlainNot when\n"
+                + "    not( /strings [ this == \"It Does Work\" ] )\n"
+                + "then\n"
+                + "end\n";
+        PackageDescr packageDescr = parseAndGetPackageDescr(text);
+        RuleDescr ruleDescr = packageDescr.getRules().get(0);
+        assertThat(ruleDescr.getLhs().getDescrs().get(0)).isInstanceOfSatisfying(NotDescr.class, notDescr -> {
+            assertThat(notDescr.getDescrs()).hasSize(1);
+            assertThat(notDescr.getDescrs().get(0)).isInstanceOfSatisfying(PatternDescr.class, patternDescr -> {
+               assertThat(patternDescr.getConstraint().getDescrs()).hasSize(1);
+               assertThat(patternDescr.getConstraint().getDescrs().get(0)).isInstanceOfSatisfying(ExprConstraintDescr.class, exprConstraintDescr -> {
+                   assertThat(exprConstraintDescr.getExpression()).isEqualTo("/strings [ this == \"It Does Work\" ]");
+                   assertThat(exprConstraintDescr.getType()).isEqualTo(ExprConstraintDescr.Type.NAMED);
+                   assertThat(exprConstraintDescr.getPosition()).isEqualTo(0);
+               });
+            });
+        });
+    }
+
+    @Test
     void inlineCast() {
         final String text = "package org.drools\n" +
                 "rule R1\n" +

--- a/drools-drl/drools-drl-parser-tests/src/test/resources/org/drools/drl/parser/antlr4/package_children.drl
+++ b/drools-drl/drools-drl-parser-tests/src/test/resources/org/drools/drl/parser/antlr4/package_children.drl
@@ -1,0 +1,53 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.drools.compiler.test
+
+unit TestUnit
+
+import org.drools.compiler.Cheese
+
+import function abc.def.x
+
+import accumulate foo.Bar2 baz2
+
+global List result
+
+declare Person end
+
+declare enum Color WHITE; end
+
+declare entry-point EntryPoint end
+
+declare window Window
+  Double() over window:length( 10 )
+end
+
+query MyQuery
+  Cheese()
+end
+
+function String doSomething() {}
+
+enabled true;
+
+dialect "java"
+
+rule "My Rule"
+when
+then
+end

--- a/drools-drl/drools-drl-parser/src/main/antlr4/org/drools/drl/parser/antlr4/DRLParser.g4
+++ b/drools-drl/drools-drl-parser/src/main/antlr4/org/drools/drl/parser/antlr4/DRLParser.g4
@@ -147,7 +147,10 @@ lhsPattern : xpathPrimary (OVER patternFilter)? |
              ( QUESTION? qualifiedIdentifier LPAREN positionalConstraints? constraints? RPAREN (OVER patternFilter)? (FROM patternSource)? ) ;
 */
 
-lhsPattern : QUESTION? objectType=drlQualifiedName LPAREN positionalConstraints? constraints? RPAREN drlAnnotation* (DRL_OVER patternFilter)? (DRL_FROM patternSource)? ;
+lhsPattern
+  : xpathPrimary (DRL_OVER patternFilter)?
+  | QUESTION? objectType=drlQualifiedName LPAREN positionalConstraints? constraints? RPAREN drlAnnotation* (DRL_OVER patternFilter)? (DRL_FROM patternSource)?
+  ;
 positionalConstraints : constraint (COMMA constraint)* SEMI ;
 constraints : constraint (COMMA constraint)* ;
 constraint : ( nestedConstraint | conditionalOrExpression ) ;

--- a/drools-drl/drools-drl-parser/src/main/java/org/drools/drl/parser/antlr4/DRLVisitorImpl.java
+++ b/drools-drl/drools-drl-parser/src/main/java/org/drools/drl/parser/antlr4/DRLVisitorImpl.java
@@ -111,14 +111,19 @@ public class DRLVisitorImpl extends DRLParserBaseVisitor<Object> {
         // This bunch of if-blocks will be refactored by DROOLS-7564
         descrList.forEach(descr -> {
             if (descr instanceof UnitDescr) {
+                descr.setNamespace(packageDescr.getNamespace());
                 packageDescr.setUnit((UnitDescr) descr);
             } else if (descr instanceof GlobalDescr) {
+                descr.setNamespace(packageDescr.getNamespace());
                 packageDescr.addGlobal((GlobalDescr) descr);
             } else if (descr instanceof FunctionImportDescr) {
+                descr.setNamespace(packageDescr.getNamespace());
                 packageDescr.addFunctionImport((FunctionImportDescr) descr);
             } else if (descr instanceof AccumulateImportDescr) {
+                descr.setNamespace(packageDescr.getNamespace());
                 packageDescr.addAccumulateImport((AccumulateImportDescr) descr);
             } else if (descr instanceof ImportDescr) {
+                descr.setNamespace(packageDescr.getNamespace());
                 packageDescr.addImport((ImportDescr) descr);
             } else if (descr instanceof FunctionDescr) {
                 FunctionDescr functionDescr = (FunctionDescr) descr;
@@ -137,12 +142,14 @@ public class DRLVisitorImpl extends DRLParserBaseVisitor<Object> {
             } else if (descr instanceof EnumDeclarationDescr) {
                 packageDescr.addEnumDeclaration((EnumDeclarationDescr) descr);
             } else if (descr instanceof AttributeDescr) {
+                descr.setNamespace(packageDescr.getNamespace());
                 packageDescr.addAttribute((AttributeDescr) descr);
             } else if (descr instanceof RuleDescr) { // QueryDescr extends RuleDescr
                 RuleDescr ruleDescr = (RuleDescr) descr;
                 packageDescr.addRule(ruleDescr);
                 packageDescr.afterRuleAdded(ruleDescr);
                 ruleDescr.setNamespace(packageDescr.getNamespace());
+                ruleDescr.setUnit(packageDescr.getUnit());
             }
         });
     }

--- a/drools-drl/drools-drl-parser/src/main/java/org/drools/drl/parser/antlr4/DRLVisitorImpl.java
+++ b/drools-drl/drools-drl-parser/src/main/java/org/drools/drl/parser/antlr4/DRLVisitorImpl.java
@@ -579,6 +579,20 @@ public class DRLVisitorImpl extends DRLParserBaseVisitor<Object> {
      */
     @Override
     public PatternDescr visitLhsPattern(DRLParser.LhsPatternContext ctx) {
+        if (ctx.xpathPrimary() != null) {
+            String constraint = visitConstraintChildren(ctx);
+            ExprConstraintDescr constraintDescr = BaseDescrFactory.builder(new ExprConstraintDescr(constraint))
+                    .withParserRuleContext(ctx)
+                    .build();
+            constraintDescr.setType(ExprConstraintDescr.Type.NAMED);
+            constraintDescr.setPosition(0);
+            PatternDescr patternDescr = BaseDescrFactory.builder(new PatternDescr())
+                    .withParserRuleContext(ctx)
+                    .build();
+            patternDescr.addConstraint(constraintDescr);
+            return patternDescr;
+        }
+
         PatternDescr patternDescr = BaseDescrFactory.builder(new PatternDescr(ctx.objectType.getText()))
                 .withParserRuleContext(ctx)
                 .build();


### PR DESCRIPTION
- Fixes #5878.
- Makes `drools-ruleunits/drools-ruleunits-impl` build successful.

<details>
<summary>
How to replicate CI configuration locally?
</summary>

Build Chain tool does "simple" maven build(s), the builds are just Maven commands, but because the repositories relates and depends on each other and any change in API or class method could affect several of those repositories there is a need to use [build-chain tool](https://github.com/kiegroup/github-action-build-chain) to handle cross repository builds and be sure that we always use latest version of the code for each repository.
 
[build-chain tool](https://github.com/kiegroup/github-action-build-chain) is a build tool which can be used on command line locally or in Github Actions workflow(s), in case you need to change multiple repositories and send multiple dependent pull requests related with a change you can easily reproduce the same build by executing it on Github hosted environment or locally in your development environment. See [local execution](https://github.com/kiegroup/github-action-build-chain#local-execution) details to get more information about it.
</details>

<details>
<summary>
How to retest this PR or trigger a specific build:
</summary>

- for <b>pull request and downstream checks</b>  
  - Push a new commit to the PR. An empty commit would be enough.

- for a <b>full downstream build</b>
  - for <b>github actions</b> job: add the label `run_fdb`

- for <b>Jenkins PR check only</b>
  - If you are an ASF committer for KIE podling, login to Jenkins (https://ci-builds.apache.org/job/KIE/job/drools/), go to the specific PR job, and click on `Build Now` button.
</details>
