### PR TITLE
[new-parser] Improve Verifier's consequence processing resiliency

### DIFF
--- a/drools-verifier/drools-verifier-drl/src/main/java/org/drools/verifier/visitor/RuleDescrVisitor.java
+++ b/drools-verifier/drools-verifier-drl/src/main/java/org/drools/verifier/visitor/RuleDescrVisitor.java
@@ -200,6 +200,10 @@ public class RuleDescrVisitor extends ConditionalElementDescrVisitor {
          * Strip all comments out of the code.
          */
         StringBuilder buffer = new StringBuilder(text);
+
+        // Make sure there is a '\n' at the end of a comment even if it's the last line of the consequence.
+        buffer.append('\n');
+
         int commentIndex = buffer.indexOf("//");
 
         while (commentIndex != -1) {


### PR DESCRIPTION
- Fixes #5886.

This is, in my opinion, a minor bug in `drools-verifier` that manifests due to a slight change of behavior in the new parser.

The Verifier at some point cleans the RHS code by removing comments. While doing that, it assumes that each comment line (`// asdf...`) ends with a new-line character. This is no longer true with the new parser if the comment is the last line before the RHS end or before another named consequence (`then[label]`). This is simply because the whitespace part of the input between the default RHS consequence and any named consequence(s) or RHS end is not part of the consequence RuleContext. This is natural to how the ANTLR parser works.

The old parser's behavior could be replicated with some custom code but in this case, I think it's better to align with the new behavior and adapt the Verifier code to it.

<details>
<summary>
How to replicate CI configuration locally?
</summary>

Build Chain tool does "simple" maven build(s), the builds are just Maven commands, but because the repositories relates and depends on each other and any change in API or class method could affect several of those repositories there is a need to use [build-chain tool](https://github.com/kiegroup/github-action-build-chain) to handle cross repository builds and be sure that we always use latest version of the code for each repository.
 
[build-chain tool](https://github.com/kiegroup/github-action-build-chain) is a build tool which can be used on command line locally or in Github Actions workflow(s), in case you need to change multiple repositories and send multiple dependent pull requests related with a change you can easily reproduce the same build by executing it on Github hosted environment or locally in your development environment. See [local execution](https://github.com/kiegroup/github-action-build-chain#local-execution) details to get more information about it.
</details>

<details>
<summary>
How to retest this PR or trigger a specific build:
</summary>

- for <b>pull request and downstream checks</b>  
  - Push a new commit to the PR. An empty commit would be enough.

- for a <b>full downstream build</b>
  - for <b>github actions</b> job: add the label `run_fdb`

- for <b>Jenkins PR check only</b>
  - If you are an ASF committer for KIE podling, login to Jenkins (https://ci-builds.apache.org/job/KIE/job/drools/), go to the specific PR job, and click on `Build Now` button.
</details>
