### PR TITLE
[kie-issues#1154] Make KieSession auto-closeable

### DIFF
--- a/drools-alphanetwork-compiler/src/test/java/org/drools/ancompiler/AlphaNetworkCompilerTest.java
+++ b/drools-alphanetwork-compiler/src/test/java/org/drools/ancompiler/AlphaNetworkCompilerTest.java
@@ -453,7 +453,6 @@ public class AlphaNetworkCompilerTest extends BaseModelTest {
                         "then\n" +
                         "end";
 
-        ;
         try (KieSession ksession = getKieSession(str)) {
             ksession.insert(new Person("Mario", 45));
             assertThat(ksession.fireAllRules()).isEqualTo(0);

--- a/drools-alphanetwork-compiler/src/test/java/org/drools/ancompiler/AlphaNetworkCompilerTest.java
+++ b/drools-alphanetwork-compiler/src/test/java/org/drools/ancompiler/AlphaNetworkCompilerTest.java
@@ -453,12 +453,10 @@ public class AlphaNetworkCompilerTest extends BaseModelTest {
                         "then\n" +
                         "end";
 
-        KieSession ksession = getKieSession(str);
-        try {
+        ;
+        try (KieSession ksession = getKieSession(str)) {
             ksession.insert(new Person("Mario", 45));
             assertThat(ksession.fireAllRules()).isEqualTo(0);
-        } finally {
-            ksession.dispose();
         }
     }
 

--- a/drools-alphanetwork-compiler/src/test/java/org/drools/ancompiler/LargeAlphaNetworkTest.java
+++ b/drools-alphanetwork-compiler/src/test/java/org/drools/ancompiler/LargeAlphaNetworkTest.java
@@ -43,21 +43,18 @@ public class LargeAlphaNetworkTest extends BaseModelTest {
             rule.append(ruleWithIndex(i));
         }
 
-        KieSession ksession = getKieSession(rule.toString());
-        ArrayList<Object> results = new ArrayList<>();
-        ksession.setGlobal("results", results);
-        Person a = new Person("a", 1);
-        Person b = new Person("b", 0);
-        Person c = new Person("a", 7);
-        ksession.insert(a);
-        ksession.insert(b);
-        ksession.insert(c);
+        try (KieSession ksession = getKieSession(rule.toString())) {
+            ArrayList<Object> results = new ArrayList<>();
+            ksession.setGlobal("results", results);
+            Person a = new Person("a", 1);
+            Person b = new Person("b", 0);
+            Person c = new Person("a", 7);
+            ksession.insert(a);
+            ksession.insert(b);
+            ksession.insert(c);
 
-        try {
             ksession.fireAllRules();
             assertThat(results).contains(a, b, c);
-        } finally {
-            ksession.dispose();
         }
     }
 

--- a/drools-alphanetwork-compiler/src/test/java/org/drools/ancompiler/MixedConstraintsTest.java
+++ b/drools-alphanetwork-compiler/src/test/java/org/drools/ancompiler/MixedConstraintsTest.java
@@ -46,21 +46,18 @@ public class MixedConstraintsTest extends BaseModelTest {
             rule.append(ruleWithIndex(i));
         }
 
-        KieSession ksession = getKieSession(rule.toString());
-        ArrayList<Object> results = new ArrayList<>();
-        ksession.setGlobal("results", results);
-        Person a = new Person("a", 1);
-        Person b = new Person("b", 0);
-        Person c = new Person("a", 7);
-        ksession.insert(a);
-        ksession.insert(b);
-        ksession.insert(c);
+        try (KieSession ksession = getKieSession(rule.toString())) {
+            ArrayList<Object> results = new ArrayList<>();
+            ksession.setGlobal("results", results);
+            Person a = new Person("a", 1);
+            Person b = new Person("b", 0);
+            Person c = new Person("a", 7);
+            ksession.insert(a);
+            ksession.insert(b);
+            ksession.insert(c);
 
-        try {
             ksession.fireAllRules();
             assertThat(results).contains(a, b, c);
-        } finally {
-            ksession.dispose();
         }
     }
 

--- a/drools-alphanetwork-compiler/src/test/java/org/drools/ancompiler/MultipleIndexableConstraintsTest.java
+++ b/drools-alphanetwork-compiler/src/test/java/org/drools/ancompiler/MultipleIndexableConstraintsTest.java
@@ -45,21 +45,18 @@ public class MultipleIndexableConstraintsTest extends BaseModelTest {
             rule.append(ruleWithIndex(i));
         }
 
-        KieSession ksession = getKieSession(rule.toString());
-        ArrayList<Object> results = new ArrayList<>();
-        ksession.setGlobal("results", results);
-        Person a = new Person("a", 1);
-        Person b = new Person("b", 0);
-        Person c = new Person("a", 7);
-        ksession.insert(a);
-        ksession.insert(b);
-        ksession.insert(c);
+        try (KieSession ksession = getKieSession(rule.toString())) {
+            ArrayList<Object> results = new ArrayList<>();
+            ksession.setGlobal("results", results);
+            Person a = new Person("a", 1);
+            Person b = new Person("b", 0);
+            Person c = new Person("a", 7);
+            ksession.insert(a);
+            ksession.insert(b);
+            ksession.insert(c);
 
-        try {
             ksession.fireAllRules();
             assertThat(results).contains(a, b, c);
-        } finally {
-            ksession.dispose();
         }
     }
 

--- a/kie-api/src/main/java/org/kie/api/runtime/KieSession.java
+++ b/kie-api/src/main/java/org/kie/api/runtime/KieSession.java
@@ -94,7 +94,8 @@ public interface KieSession
         StatefulRuleSession,
         StatefulProcessSession,
         CommandExecutor,
-        KieRuntime {
+        KieRuntime,
+        AutoCloseable {
 
     /**
      * Deprecated. use {@link #getIdentifier()} instead
@@ -114,6 +115,14 @@ public interface KieSession
      */
     void dispose();
 
+    /**
+     * Disposes the KieSession when used as AutoClosable. Wrapper method that calls {@link #dispose()}.
+     * To see more details, please see documentation on the method {@link #dispose()}.
+     */
+    @Override
+    default void close() {
+        dispose();
+    }
 
     /**
      * Destroys session permanently. In case of session state being persisted in data store


### PR DESCRIPTION
Fixes: https://github.com/apache/incubator-kie-issues/issues/1154

Makes KieSession implement the AutoCloseable interface, so it can be used in try-with-resources code blocks. No new tests added, because KieSession does not have any listener for dispose events. Therefore, some tests were changed to use try-with-resources to dispose the KieSession. 