### PR TITLE
[new-parser] Avoid NPE when the input DRL is empty

### DIFF
--- a/drools-drl/drools-drl-parser-tests/src/test/java/org/drools/drl/parser/antlr4/MiscDRLParserTest.java
+++ b/drools-drl/drools-drl-parser-tests/src/test/java/org/drools/drl/parser/antlr4/MiscDRLParserTest.java
@@ -153,6 +153,13 @@ class MiscDRLParserTest {
     }
 
     @Test
+    void emptySource() {
+        final String source = "";
+        final PackageDescr pkg = parseAndGetPackageDescr(source);
+        assertThat(pkg.getName()).isEmpty();
+    }
+
+    @Test
     void parse_validPackage() {
         final String source = "package foo.bar.baz";
         final PackageDescr pkg = parseAndGetPackageDescr(source);

--- a/drools-drl/drools-drl-parser/src/main/java/org/drools/drl/parser/antlr4/DescrHelper.java
+++ b/drools-drl/drools-drl-parser/src/main/java/org/drools/drl/parser/antlr4/DescrHelper.java
@@ -21,6 +21,7 @@ package org.drools.drl.parser.antlr4;
 import java.util.List;
 
 import org.antlr.v4.runtime.ParserRuleContext;
+import org.antlr.v4.runtime.Token;
 import org.antlr.v4.runtime.tree.TerminalNode;
 import org.drools.drl.ast.descr.AndDescr;
 import org.drools.drl.ast.descr.AttributeDescr;
@@ -38,23 +39,26 @@ public class DescrHelper {
     }
 
     public static <T extends BaseDescr> T populateCommonProperties(T descr, ParserRuleContext ctx) {
+        Token startToken = ctx.getStart(); // Start token is never null.
+        // If the stop token is null, use the start token as both the start end the end.
+        Token stopToken = ctx.getStop() != null ? ctx.getStop() : startToken;
 
         if (descr instanceof ExprConstraintDescr) {
             // Backward Compatibility Notes:
             //   Old DRL6Parser.constraint() has slightly different behavior for ExprConstraintDescr. Keep it for backward compatibility
             //   When we will update LanguageLevel, we can align this with other Descr.
-            descr.setStartCharacter(ctx.getStart().getStartIndex());
-            descr.setEndCharacter(ctx.getStop().getStopIndex());
-            descr.setLocation(ctx.getStart().getLine(), ctx.getStart().getCharPositionInLine());
-            descr.setEndLocation(ctx.getStop().getLine(), ctx.getStop().getCharPositionInLine());
+            descr.setStartCharacter(startToken.getStartIndex());
+            descr.setEndCharacter(stopToken.getStopIndex());
+            descr.setLocation(startToken.getLine(), startToken.getCharPositionInLine());
+            descr.setEndLocation(stopToken.getLine(), stopToken.getCharPositionInLine());
         } else {
-            descr.setStartCharacter(ctx.getStart().getStartIndex());
+            descr.setStartCharacter(startToken.getStartIndex());
             // Backward Compatibility Notes:
             //   Old DRL6Parser adds +1 for EndCharacter (except ExprConstraintDescr). This new parser follows the same to keep the backward compatibility.
             //   However, it doesn't look reasonable. When we will update LanguageLevel, we can remove this +1.
-            descr.setEndCharacter(ctx.getStop().getStopIndex() + 1);
-            descr.setLocation(ctx.getStart().getLine(), ctx.getStart().getCharPositionInLine());
-            descr.setEndLocation(ctx.getStop().getLine(), ctx.getStop().getCharPositionInLine() + ctx.getStop().getText().length() - 1); // last column of the end token
+            descr.setEndCharacter(stopToken.getStopIndex() + 1);
+            descr.setLocation(startToken.getLine(), startToken.getCharPositionInLine());
+            descr.setEndLocation(stopToken.getLine(), stopToken.getCharPositionInLine() + stopToken.getText().length() - 1); // last column of the end token
         }
         return descr;
     }


### PR DESCRIPTION
- Fixes #5893.

<details>
<summary>
How to replicate CI configuration locally?
</summary>

Build Chain tool does "simple" maven build(s), the builds are just Maven commands, but because the repositories relates and depends on each other and any change in API or class method could affect several of those repositories there is a need to use [build-chain tool](https://github.com/kiegroup/github-action-build-chain) to handle cross repository builds and be sure that we always use latest version of the code for each repository.
 
[build-chain tool](https://github.com/kiegroup/github-action-build-chain) is a build tool which can be used on command line locally or in Github Actions workflow(s), in case you need to change multiple repositories and send multiple dependent pull requests related with a change you can easily reproduce the same build by executing it on Github hosted environment or locally in your development environment. See [local execution](https://github.com/kiegroup/github-action-build-chain#local-execution) details to get more information about it.
</details>

<details>
<summary>
How to retest this PR or trigger a specific build:
</summary>

- for <b>pull request and downstream checks</b>  
  - Push a new commit to the PR. An empty commit would be enough.

- for a <b>full downstream build</b>
  - for <b>github actions</b> job: add the label `run_fdb`

- for <b>Jenkins PR check only</b>
  - If you are an ASF committer for KIE podling, login to Jenkins (https://ci-builds.apache.org/job/KIE/job/drools/), go to the specific PR job, and click on `Build Now` button.
</details>
