### PR TITLE
[incubator-kie-drools-5896] Update docker-compose for drools-quarkus-…

### DIFF
--- a/drools-quarkus-extension/drools-quarkus-examples/drools-quarkus-examples-reactive/README.md
+++ b/drools-quarkus-extension/drools-quarkus-examples/drools-quarkus-examples-reactive/README.md
@@ -7,12 +7,21 @@ Simply start it with this command from the root of the repo:
 ```
 docker-compose up -d
 ```
+Or, if your docker version supports `docker compose`,
+```
+docker compose up -d
+```
 
 To shutdown the instances.
 
 ```
 docker-compose down
 ```
+or
+```
+docker compose down
+```
+
 
 ### Package and Run in JVM mode
 

--- a/drools-quarkus-extension/drools-quarkus-examples/drools-quarkus-examples-reactive/docker-compose.yml
+++ b/drools-quarkus-extension/drools-quarkus-examples/drools-quarkus-examples-reactive/docker-compose.yml
@@ -22,14 +22,22 @@ version: '2'
 services:
 
   zookeeper:
-    image: wurstmeister/zookeeper:3.4.6
+    image: strimzi/kafka:latest
+    command: [
+      "sh", "-c",
+      "bin/zookeeper-server-start.sh config/zookeeper.properties"
+    ]
     ports:
       - "2181:2181"
     environment:
       LOG_DIR: "/tmp/logs"
 
   kafka:
-    image: wurstmeister/kafka:2.12-2.2.1
+    image: strimzi/kafka:latest
+    command: [
+      "sh", "-c",
+      "bin/kafka-server-start.sh config/server.properties --override inter.broker.listener.name=$${KAFKA_INTER_BROKER_LISTENER_NAME} --override listener.security.protocol.map=$${KAFKA_LISTENER_SECURITY_PROTOCOL_MAP} --override listeners=$${KAFKA_LISTENERS} --override advertised.listeners=$${KAFKA_ADVERTISED_LISTENERS} --override zookeeper.connect=$${KAFKA_ZOOKEEPER_CONNECT}"
+    ]
     depends_on:
       - zookeeper
     ports:


### PR DESCRIPTION
…examples-reactive

**Issue**:

* https://github.com/apache/incubator-kie-drools/issues/5896

`wurstmeister/zookeeper` and `wurstmeister/kafka` no longer exist. Updated docker-compose.yaml to use `strimzi/kafka`.