### PR TITLE
[new-parser] Avoid error when there is no space between rule keyword and rule name

### DIFF
--- a/drools-drl/drools-drl-parser-tests/src/test/java/org/drools/drl/parser/antlr4/MiscDRLParserTest.java
+++ b/drools-drl/drools-drl-parser-tests/src/test/java/org/drools/drl/parser/antlr4/MiscDRLParserTest.java
@@ -4666,4 +4666,15 @@ class MiscDRLParserTest {
         assertThat(children).isNotEmpty(); // Make sure that every child type is represented.
         assertThat(children).allSatisfy(baseDescr -> assertThat(baseDescr.getNamespace()).isEqualTo(namespace));
     }
+
+    @Test
+    public void noWhitespaceBetweenRuleKeywordAndName() {
+        final String text = "rule X when then end rule\"Y\" when then end rule'Z'when then end";
+
+        PackageDescr pkg = parseAndGetPackageDescr(text);
+
+        assertThat(pkg.getRules())
+                .map(RuleDescr::getName)
+                .containsExactly("X", "Y", "Z");
+    }
 }

--- a/drools-drl/drools-drl-parser/src/main/java/org/drools/drl/parser/antlr4/LexerHelper.java
+++ b/drools-drl/drools-drl-parser/src/main/java/org/drools/drl/parser/antlr4/LexerHelper.java
@@ -18,7 +18,7 @@
  */
 package org.drools.drl.parser.antlr4;
 
-import java.util.List;
+import java.util.Set;
 
 import org.antlr.v4.runtime.CharStream;
 import org.antlr.v4.runtime.IntStream;
@@ -29,9 +29,10 @@ import org.drools.drl.parser.lang.DroolsSoftKeywords;
  */
 public class LexerHelper {
 
-    private static final List<Character> semiAndWS = List.of(';', ' ', '\t', '\n', '\r');
-    private static final List<String> statementKeywordsList = List.of(ParserHelper.statementKeywords);
-    private static final List<String> attributeKeywordsList = List.of(DroolsSoftKeywords.SALIENCE,
+    private static final Set<Character> semiAndWS = Set.of(';', ' ', '\t', '\n', '\r');
+    private static final Set<Character> delimiters = Set.of(';', ' ', '\t', '\n', '\r', '"', '\'');
+    private static final Set<String> statementKeywordsList = Set.of(ParserHelper.statementKeywords);
+    private static final Set<String> attributeKeywordsList = Set.of(DroolsSoftKeywords.SALIENCE,
                                                                       DroolsSoftKeywords.ENABLED,
                                                                       DroolsSoftKeywords.NO + "-" + DroolsSoftKeywords.LOOP,
                                                                       DroolsSoftKeywords.AUTO + "-" + DroolsSoftKeywords.FOCUS,
@@ -82,7 +83,7 @@ public class LexerHelper {
         StringBuilder sb = new StringBuilder();
         while (true) {
             int la = input.LA(lookAheadCounter);
-            if (semiAndWS.contains((char) la) || la == IntStream.EOF) {
+            if (delimiters.contains((char) la) || la == IntStream.EOF) {
                 break;
             }
             sb.append((char) la);

--- a/drools-drl/drools-drl-parser/src/main/java/org/drools/drl/parser/util/ParserStringUtils.java
+++ b/drools-drl/drools-drl-parser/src/main/java/org/drools/drl/parser/util/ParserStringUtils.java
@@ -33,7 +33,10 @@ public class ParserStringUtils {
     public static String safeStripStringDelimiters(String value) {
         if (value != null) {
             value = value.trim();
-            if (value.length() >= 2 && value.startsWith("\"") && value.endsWith("\"")) {
+            if (value.length() >= 2 && (
+                    value.startsWith("\"") && value.endsWith("\"")
+                    || value.startsWith("'") && value.endsWith("'")
+            )) {
                 value = value.substring(1, value.length() - 1);
             }
         }

--- a/drools-test-coverage/test-suite/src/test/java/org/drools/testcoverage/functional/parser/DrlParserTest.java
+++ b/drools-test-coverage/test-suite/src/test/java/org/drools/testcoverage/functional/parser/DrlParserTest.java
@@ -34,7 +34,7 @@ public class DrlParserTest extends ParserTest {
         super(file, kieBaseTestConfiguration);
     }
 
-    @Parameters
+    @Parameters(name = "{index}: {0}, {1}")
     public static Collection<Object[]> getParameters() {
         return getTestParamsFromFiles(getFiles("drl"));
     }


### PR DESCRIPTION
Another corner case.

- Fixes #5895.

<details>
<summary>
How to replicate CI configuration locally?
</summary>

Build Chain tool does "simple" maven build(s), the builds are just Maven commands, but because the repositories relates and depends on each other and any change in API or class method could affect several of those repositories there is a need to use [build-chain tool](https://github.com/kiegroup/github-action-build-chain) to handle cross repository builds and be sure that we always use latest version of the code for each repository.
 
[build-chain tool](https://github.com/kiegroup/github-action-build-chain) is a build tool which can be used on command line locally or in Github Actions workflow(s), in case you need to change multiple repositories and send multiple dependent pull requests related with a change you can easily reproduce the same build by executing it on Github hosted environment or locally in your development environment. See [local execution](https://github.com/kiegroup/github-action-build-chain#local-execution) details to get more information about it.
</details>

<details>
<summary>
How to retest this PR or trigger a specific build:
</summary>

- for <b>pull request and downstream checks</b>  
  - Push a new commit to the PR. An empty commit would be enough.

- for a <b>full downstream build</b>
  - for <b>github actions</b> job: add the label `run_fdb`

- for <b>Jenkins PR check only</b>
  - If you are an ASF committer for KIE podling, login to Jenkins (https://ci-builds.apache.org/job/KIE/job/drools/), go to the specific PR job, and click on `Build Now` button.
</details>
