### PR TITLE
[new-parser] Strip double quotes from declared entry-point ID

### DIFF
--- a/drools-drl/drools-drl-parser-tests/src/test/java/org/drools/drl/parser/antlr4/MiscDRLParserTest.java
+++ b/drools-drl/drools-drl-parser-tests/src/test/java/org/drools/drl/parser/antlr4/MiscDRLParserTest.java
@@ -32,6 +32,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.regex.Pattern;
+import java.util.stream.Stream;
 
 import org.drools.drl.ast.descr.AccumulateDescr;
 import org.drools.drl.ast.descr.AccumulateImportDescr;
@@ -74,6 +75,8 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
 import org.junit.jupiter.params.provider.ValueSource;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -3458,10 +3461,18 @@ class MiscDRLParserTest {
 
     }
 
-    @Test
-    public void parse_EntryPointDeclaration() throws Exception {
+    public static Stream<Arguments> entryPointIds() {
+        return Stream.of(
+                Arguments.of("eventStream", "eventStream"),
+                Arguments.of("\"My entry-point 'ID'\"", "My entry-point 'ID'")
+        );
+    }
+
+    @ParameterizedTest
+    @MethodSource("entryPointIds")
+    public void parse_EntryPointDeclaration(String sourceId, String expectedId) throws Exception {
         final String text = "package org.drools\n" +
-                "declare entry-point eventStream\n" +
+                "declare entry-point " + sourceId + "\n" +
                 "    @source(\"jndi://queues/events\")\n" +
                 "    @foo( true )\n" +
                 "end";
@@ -3473,7 +3484,7 @@ class MiscDRLParserTest {
 
         EntryPointDeclarationDescr epd = pkg.getEntryPointDeclarations().iterator().next();
 
-        assertThat(epd.getEntryPointId()).isEqualTo("eventStream");
+        assertThat(epd.getEntryPointId()).isEqualTo(expectedId);
         assertThat(epd.getAnnotations().size()).isEqualTo(2);
         assertThat(epd.getAnnotation("source").getValue()).isEqualTo("\"jndi://queues/events\"");
         assertThat(epd.getAnnotation("foo").getValue()).isEqualTo("true");

--- a/drools-drl/drools-drl-parser/src/main/java/org/drools/drl/parser/antlr4/DRLVisitorImpl.java
+++ b/drools-drl/drools-drl-parser/src/main/java/org/drools/drl/parser/antlr4/DRLVisitorImpl.java
@@ -292,7 +292,7 @@ public class DRLVisitorImpl extends DRLParserBaseVisitor<Object> {
         EntryPointDeclarationDescr entryPointDeclarationDescr = BaseDescrFactory.builder(new EntryPointDeclarationDescr())
                 .withParserRuleContext(ctx)
                 .build();
-        entryPointDeclarationDescr.setEntryPointId(ctx.name.getText());
+        entryPointDeclarationDescr.setEntryPointId(safeStripStringDelimiters(ctx.name.getText()));
         ctx.drlAnnotation().stream()
                 .map(this::visitDrlAnnotation)
                 .forEach(entryPointDeclarationDescr::addAnnotation);


### PR DESCRIPTION
- Fixes #5904.

The issue (#5904) is currently blocked by another issue (#5879). By merging this PR we fix something that doesn't yet manifest in the build but when we have a fix for #5879, `kie-dmn-validation` build will be green without mixing the two fixes together. Moreover, #5879 is difficult and we might need to try different approaches. This one, on the other hand, is straightforward and fixing it beforehand will help us focus on #5879.

<details>
<summary>
How to replicate CI configuration locally?
</summary>

Build Chain tool does "simple" maven build(s), the builds are just Maven commands, but because the repositories relates and depends on each other and any change in API or class method could affect several of those repositories there is a need to use [build-chain tool](https://github.com/kiegroup/github-action-build-chain) to handle cross repository builds and be sure that we always use latest version of the code for each repository.
 
[build-chain tool](https://github.com/kiegroup/github-action-build-chain) is a build tool which can be used on command line locally or in Github Actions workflow(s), in case you need to change multiple repositories and send multiple dependent pull requests related with a change you can easily reproduce the same build by executing it on Github hosted environment or locally in your development environment. See [local execution](https://github.com/kiegroup/github-action-build-chain#local-execution) details to get more information about it.
</details>

<details>
<summary>
How to retest this PR or trigger a specific build:
</summary>

- for <b>pull request and downstream checks</b>  
  - Push a new commit to the PR. An empty commit would be enough.

- for a <b>full downstream build</b>
  - for <b>github actions</b> job: add the label `run_fdb`

- for <b>Jenkins PR check only</b>
  - If you are an ASF committer for KIE podling, login to Jenkins (https://ci-builds.apache.org/job/KIE/job/drools/), go to the specific PR job, and click on `Build Now` button.
</details>
