### PR TITLE
[incubator-kie-drools-5908] ReteOOWaltzTest 'end' detection issue

### DIFF
--- a/drools-drl/drools-drl-parser-tests/src/test/java/org/drools/drl/parser/antlr4/MiscDRLParserTest.java
+++ b/drools-drl/drools-drl-parser-tests/src/test/java/org/drools/drl/parser/antlr4/MiscDRLParserTest.java
@@ -3747,7 +3747,7 @@ class MiscDRLParserTest {
     }
 
     @Test
-    void endAndNonParingDoubleQuoteInMultiLineCommentInRHS() {
+    void endAndNonPairingDoubleQuoteInMultiLineCommentInRHS() {
         final String text = "package org.drools\n" +
                 "rule R1\n" +
                 "when\n" +

--- a/drools-drl/drools-drl-parser-tests/src/test/java/org/drools/drl/parser/antlr4/MiscDRLParserTest.java
+++ b/drools-drl/drools-drl-parser-tests/src/test/java/org/drools/drl/parser/antlr4/MiscDRLParserTest.java
@@ -3734,7 +3734,7 @@ class MiscDRLParserTest {
                 "when\n" +
                 "    $p : Person()\n" +
                 "then\n" +
-                "    //System.out.println(\");\n" + // non-paring double quote in comment
+                "    //System.out.println(\");\n" + // non-pairing double quote in comment
                 "    retract($p)\n" +
                 "end\n" +
                 "rule \"R2\" when Person() then end";

--- a/drools-drl/drools-drl-parser-tests/src/test/java/org/drools/drl/parser/antlr4/MiscDRLParserTest.java
+++ b/drools-drl/drools-drl-parser-tests/src/test/java/org/drools/drl/parser/antlr4/MiscDRLParserTest.java
@@ -3728,6 +3728,83 @@ class MiscDRLParserTest {
     }
 
     @Test
+    void endAndNonParingDoubleQuoteInSingleLineCommentInRHS() {
+        final String text = "package org.drools\n" +
+                "rule R1\n" +
+                "when\n" +
+                "    $p : Person()\n" +
+                "then\n" +
+                "    //System.out.println(\");\n" + // non-paring double quote in comment
+                "    retract($p)\n" +
+                "end\n" +
+                "rule \"R2\" when Person() then end";
+        PackageDescr packageDescr = parseAndGetPackageDescr(text);
+
+        List<RuleDescr> ruleDescrList = packageDescr.getRules();
+        assertThat(ruleDescrList).hasSize(2);
+        assertThat(ruleDescrList.get(0).getName()).isEqualTo("R1");
+        assertThat(ruleDescrList.get(1).getName()).isEqualTo("R2");
+    }
+
+    @Test
+    void endAndNonParingDoubleQuoteInMultiLineCommentInRHS() {
+        final String text = "package org.drools\n" +
+                "rule R1\n" +
+                "when\n" +
+                "    $p : Person()\n" +
+                "then\n" +
+                "    /*System.out.println\n" +
+                "          (\");*/\n" + // non-paring double quote in comment
+                "    retract($p)\n" +
+                "end\n" +
+                "rule \"R2\" when Person() then end";
+        PackageDescr packageDescr = parseAndGetPackageDescr(text);
+
+        List<RuleDescr> ruleDescrList = packageDescr.getRules();
+        assertThat(ruleDescrList).hasSize(2);
+        assertThat(ruleDescrList.get(0).getName()).isEqualTo("R1");
+        assertThat(ruleDescrList.get(1).getName()).isEqualTo("R2");
+    }
+
+    @Test
+    void endAndDoubleQuotationsInRHS() {
+        final String text = "package org.drools\n" +
+                "rule R1\n" +
+                "when\n" +
+                "    $p : Person()\n" +
+                "then\n" +
+                "    System.out.println(\"Draw \"+$p1+\" \"+$p2);\n" +
+                "    retract($p)\n" +
+                "end\n" +
+                "rule \"R2\" when Person() then end";
+        PackageDescr packageDescr = parseAndGetPackageDescr(text);
+
+        List<RuleDescr> ruleDescrList = packageDescr.getRules();
+        assertThat(ruleDescrList).hasSize(2);
+        assertThat(ruleDescrList.get(0).getName()).isEqualTo("R1");
+        assertThat(ruleDescrList.get(1).getName()).isEqualTo("R2");
+    }
+
+    @Test
+    void endAndsingleQuotationsInRHS() {
+        final String text = "package org.drools\n" +
+                "rule R1\n" +
+                "when\n" +
+                "    $p : Person()\n" +
+                "then\n" +
+                "    System.out.println('Draw '+$p1+' '+$p2);\n" +
+                "    retract($p)\n" +
+                "end\n" +
+                "rule \"R2\" when Person() then end";
+        PackageDescr packageDescr = parseAndGetPackageDescr(text);
+
+        List<RuleDescr> ruleDescrList = packageDescr.getRules();
+        assertThat(ruleDescrList).hasSize(2);
+        assertThat(ruleDescrList.get(0).getName()).isEqualTo("R1");
+        assertThat(ruleDescrList.get(1).getName()).isEqualTo("R2");
+    }
+
+    @Test
     void singleQuoteInRhsWithSpace() {
         String consequence = getResultConsequence("    System.out.println( 'singleQuoteInRhs' );\n");
         assertThat(consequence)

--- a/drools-drl/drools-drl-parser-tests/src/test/java/org/drools/drl/parser/antlr4/MiscDRLParserTest.java
+++ b/drools-drl/drools-drl-parser-tests/src/test/java/org/drools/drl/parser/antlr4/MiscDRLParserTest.java
@@ -3786,7 +3786,7 @@ class MiscDRLParserTest {
     }
 
     @Test
-    void endAndsingleQuotationsInRHS() {
+    void endAndSingleQuotationsInRHS() {
         final String text = "package org.drools\n" +
                 "rule R1\n" +
                 "when\n" +

--- a/drools-drl/drools-drl-parser-tests/src/test/java/org/drools/drl/parser/antlr4/MiscDRLParserTest.java
+++ b/drools-drl/drools-drl-parser-tests/src/test/java/org/drools/drl/parser/antlr4/MiscDRLParserTest.java
@@ -3754,7 +3754,7 @@ class MiscDRLParserTest {
                 "    $p : Person()\n" +
                 "then\n" +
                 "    /*System.out.println\n" +
-                "          (\");*/\n" + // non-paring double quote in comment
+                "          (\");*/\n" + // non-pairing double quote in comment
                 "    retract($p)\n" +
                 "end\n" +
                 "rule \"R2\" when Person() then end";

--- a/drools-drl/drools-drl-parser-tests/src/test/java/org/drools/drl/parser/antlr4/MiscDRLParserTest.java
+++ b/drools-drl/drools-drl-parser-tests/src/test/java/org/drools/drl/parser/antlr4/MiscDRLParserTest.java
@@ -3728,7 +3728,7 @@ class MiscDRLParserTest {
     }
 
     @Test
-    void endAndNonParingDoubleQuoteInSingleLineCommentInRHS() {
+    void endAndNonPairingDoubleQuoteInSingleLineCommentInRHS() {
         final String text = "package org.drools\n" +
                 "rule R1\n" +
                 "when\n" +

--- a/drools-drl/drools-drl-parser/src/main/antlr4/org/drools/drl/parser/antlr4/DRLLexer.g4
+++ b/drools-drl/drools-drl-parser/src/main/antlr4/org/drools/drl/parser/antlr4/DRLLexer.g4
@@ -169,6 +169,9 @@ DrlUnicodeEscape
 
 mode RHS;
 RHS_WS : [ \t\r\n\u000C]+ -> channel(HIDDEN);
+RHS_COMMENT:            '/*' .*? '*/' ;
+RHS_LINE_COMMENT:       '//' ~[\r\n]* ;
+
 //DRL_RHS_END : 'end' [ \t]* SEMI? [ \t]* ('\n' | '\r\n' | EOF) { setText("end"); } -> popMode;
 DRL_RHS_END : {isRhsDrlEnd()}? DRL_END -> popMode;
 
@@ -181,7 +184,7 @@ RHS_STRING_LITERAL
 RHS_NAMED_CONSEQUENCE_THEN : DRL_THEN LBRACK IDENTIFIER RBRACK ;
 
 RHS_CHUNK
-    : ~[ ()[\]{},;\t\r\n\u000C]+ // ;}) could be a delimitter proceding 'end'. ()[]{},; are delimiters to match RHS_STRING_LITERAL
+    : ~[ "'()[\]{},;\t\r\n\u000C]+ // ;}) could be a delimitter proceding 'end'. ()[]{},; are delimiters to match RHS_STRING_LITERAL
     | LPAREN
     | RPAREN
     | LBRACK

--- a/drools-drl/drools-drl-parser/src/main/antlr4/org/drools/drl/parser/antlr4/DRLParser.g4
+++ b/drools-drl/drools-drl-parser/src/main/antlr4/org/drools/drl/parser/antlr4/DRLParser.g4
@@ -420,7 +420,7 @@ groupByKeyBinding : label? conditionalExpression ;
 
 rhs : DRL_THEN consequenceBody namedConsequence* ;
 
-consequenceBody : ( RHS_STRING_LITERAL | RHS_CHUNK )* ;
+consequenceBody : ( RHS_COMMENT | RHS_LINE_COMMENT | RHS_STRING_LITERAL | RHS_CHUNK )* ;
 
 // THEN LEFT_SQUARE ID RIGHT_SQUARE chunk
 namedConsequence : RHS_NAMED_CONSEQUENCE_THEN consequenceBody ;


### PR DESCRIPTION
**Issue**:
* https://github.com/apache/incubator-kie-drools/issues/5908

The issue involved 2 factors:
- `RHS_CHUNK` should not match `"` nor `'`to make `RHS_STRING_LITERAL` work correctly.
- Comment should be matched as Token, so it shouldn't interfere `RHS_STRING_LITERAL` matching