### PR TITLE
[incubator-kie-drools-5915] [new-parser] ctx.lhsPattern().size() == 0

### DIFF
--- a/drools-drl/drools-drl-parser-tests/src/test/java/org/drools/drl/parser/antlr4/MiscDRLParserTest.java
+++ b/drools-drl/drools-drl-parser-tests/src/test/java/org/drools/drl/parser/antlr4/MiscDRLParserTest.java
@@ -69,6 +69,7 @@ import org.drools.drl.ast.descr.TypeDeclarationDescr;
 import org.drools.drl.ast.descr.TypeFieldDescr;
 import org.drools.drl.ast.descr.WindowDeclarationDescr;
 import org.drools.drl.parser.DrlParser;
+import org.drools.drl.parser.DroolsError;
 import org.drools.drl.parser.DroolsParserException;
 import org.drools.drl.parser.impl.Operator;
 import org.junit.jupiter.api.BeforeEach;
@@ -4821,5 +4822,19 @@ class MiscDRLParserTest {
                 });
             });
         });
+    }
+
+    @Test
+    void errorMessage_shouldNotContainEmptyString() {
+        final String text =
+                "rule R\n" +
+                        "when\n" +
+                        "    foo\n" + // parse error
+                        "then\n" +
+                        "end";
+        PackageDescr pkg = parseAndGetPackageDescrWithoutErrorCheck(text);
+        assertThat(pkg).isNull();
+        assertThat(parser.hasErrors()).isTrue();
+        assertThat(parser.getErrors()).extracting(DroolsError::getMessage).doesNotContain("");
     }
 }

--- a/drools-drl/drools-drl-parser/src/main/java/org/drools/drl/parser/antlr4/DRLParserError.java
+++ b/drools-drl/drools-drl-parser/src/main/java/org/drools/drl/parser/antlr4/DRLParserError.java
@@ -36,6 +36,7 @@ public class DRLParserError {
     }
 
     public DRLParserError(Exception exception) {
+        this.message = exception.getMessage();
         this.exception = exception;
     }
 

--- a/drools-drl/drools-drl-parser/src/main/java/org/drools/drl/parser/antlr4/DRLVisitorImpl.java
+++ b/drools-drl/drools-drl-parser/src/main/java/org/drools/drl/parser/antlr4/DRLVisitorImpl.java
@@ -542,7 +542,7 @@ public class DRLVisitorImpl extends DRLParserBaseVisitor<Object> {
         } else if (ctx.lhsPattern().size() > 1) {
             return getOrDescrWithMultiplePatternDescr(ctx);
         } else {
-            throw new IllegalStateException("ctx.lhsPattern().size() == 0 : " + ctx.getText());
+            return null; // only caused by a parser error
         }
     }
 


### PR DESCRIPTION
- Avoid unnecessary IllegalStateException
- Avoid empty error message

**Issue**:
* https://github.com/apache/incubator-kie-drools/issues/5915

This PR actually just removes the IllegalStateException and fixes only `org.drools.compiler.integrationtests.drl.DRLTest#testWithInvalidRule2` in the failing tests in the GH issue . Other tests are explained in the comments of the GH issue and will be dealt by other PRs.
