### PR TITLE
[new-parser] Match EOF at the end of the compilation unit

### DIFF
--- a/drools-drl/drools-drl-parser/src/main/antlr4/org/drools/drl/parser/antlr4/DRLParser.g4
+++ b/drools-drl/drools-drl-parser/src/main/antlr4/org/drools/drl/parser/antlr4/DRLParser.g4
@@ -14,7 +14,7 @@ import DRL6Expressions, JavaParser;
      *           |  query
      *           ;
      */
-compilationUnit : packagedef? unitdef? drlStatementdef* ;
+compilationUnit : packagedef? unitdef? drlStatementdef* EOF ;
 
 drlStatementdef
     : importdef SEMI?

--- a/drools-drl/drools-drl-parser/src/main/java/org/drools/drl/parser/antlr4/DescrHelper.java
+++ b/drools-drl/drools-drl-parser/src/main/java/org/drools/drl/parser/antlr4/DescrHelper.java
@@ -22,9 +22,6 @@ import java.util.List;
 
 import org.antlr.v4.runtime.ParserRuleContext;
 import org.antlr.v4.runtime.Token;
-import org.antlr.v4.runtime.tree.TerminalNode;
-import org.drools.drl.ast.descr.AndDescr;
-import org.drools.drl.ast.descr.AttributeDescr;
 import org.drools.drl.ast.descr.BaseDescr;
 import org.drools.drl.ast.descr.ExprConstraintDescr;
 import org.drools.drl.ast.descr.PatternDescr;
@@ -58,9 +55,13 @@ public class DescrHelper {
             //   However, it doesn't look reasonable. When we will update LanguageLevel, we can remove this +1.
             descr.setEndCharacter(stopToken.getStopIndex() + 1);
             descr.setLocation(startToken.getLine(), startToken.getCharPositionInLine());
-            descr.setEndLocation(stopToken.getLine(), stopToken.getCharPositionInLine() + stopToken.getText().length() - 1); // last column of the end token
+            descr.setEndLocation(stopToken.getLine(), stopToken.getCharPositionInLine() + stopTokenLength(stopToken) - 1); // last column of the end token
         }
         return descr;
+    }
+
+    private static int stopTokenLength(Token token) {
+        return token.getType() == Token.EOF ? 0 : token.getText().length();
     }
 
     public static <T extends BaseDescr> T populateCommonProperties(T descr, List<? extends ParserRuleContext> ctxList) {


### PR DESCRIPTION
- Fixes #5929.

Without the `EOF`, the parser has no incentive to continue processing input once it encounters a "broken" DRL statement keyword.

For example, if there is a typo in the import statement (`impot`), the parser is simply unable to match `drlStatement` and it "gracefully" quits without reporting any error. Explained in more detail at https://github.com/antlr/antlr4/blob/master/doc/parser-rules.md#start-rules-and-eof.

<details>
<summary>
How to replicate CI configuration locally?
</summary>

Build Chain tool does "simple" maven build(s), the builds are just Maven commands, but because the repositories relates and depends on each other and any change in API or class method could affect several of those repositories there is a need to use [build-chain tool](https://github.com/kiegroup/github-action-build-chain) to handle cross repository builds and be sure that we always use latest version of the code for each repository.
 
[build-chain tool](https://github.com/kiegroup/github-action-build-chain) is a build tool which can be used on command line locally or in Github Actions workflow(s), in case you need to change multiple repositories and send multiple dependent pull requests related with a change you can easily reproduce the same build by executing it on Github hosted environment or locally in your development environment. See [local execution](https://github.com/kiegroup/github-action-build-chain#local-execution) details to get more information about it.
</details>

<details>
<summary>
How to retest this PR or trigger a specific build:
</summary>

- for <b>pull request and downstream checks</b>  
  - Push a new commit to the PR. An empty commit would be enough.

- for a <b>full downstream build</b>
  - for <b>github actions</b> job: add the label `run_fdb`

- for <b>Jenkins PR check only</b>
  - If you are an ASF committer for KIE podling, login to Jenkins (https://ci-builds.apache.org/job/KIE/job/drools/), go to the specific PR job, and click on `Build Now` button.
</details>
