### PR TITLE
[new-parser] Set namespace of qualified declared types

### DIFF
--- a/drools-drl/drools-drl-parser-tests/src/test/java/org/drools/drl/parser/antlr4/MiscDRLParserTest.java
+++ b/drools-drl/drools-drl-parser-tests/src/test/java/org/drools/drl/parser/antlr4/MiscDRLParserTest.java
@@ -3072,6 +3072,20 @@ class MiscDRLParserTest {
     }
 
     @Test
+    public void parse_QualifiedTypeDeclaration() throws Exception {
+        final PackageDescr pkg = parseAndGetPackageDescrFromFile(
+                                                               "qualified_type_declaration.drl" );
+
+        TypeDeclarationDescr someFact = pkg.getTypeDeclarations().get( 0 );
+        assertThat(someFact.getTypeName()).isEqualTo("SomeFact");
+        assertThat(someFact.getNamespace()).isEqualTo("com.sample1");
+
+        EnumDeclarationDescr color = pkg.getEnumDeclarations().get( 0 );
+        assertThat(color.getTypeName()).isEqualTo("Color");
+        assertThat(color.getNamespace()).isEqualTo("com.sample2");
+    }
+
+    @Test
     public void parenthesesOneLevelNestWithThreeSiblings() throws Exception {
         final PackageDescr pkg = parseAndGetPackageDescrFromFile( "Rule_with_nested_LHS.drl" );
 

--- a/drools-drl/drools-drl-parser-tests/src/test/resources/org/drools/drl/parser/antlr4/qualified_type_declaration.drl
+++ b/drools-drl/drools-drl-parser-tests/src/test/resources/org/drools/drl/parser/antlr4/qualified_type_declaration.drl
@@ -1,0 +1,27 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.drools.compiler.test;
+
+declare com.sample1.SomeFact
+    name : String
+    age: Integer
+end
+
+declare enum com.sample2.Color
+    WHITE;
+end

--- a/drools-drl/drools-drl-parser/src/main/java/org/drools/drl/parser/antlr4/DRLVisitorImpl.java
+++ b/drools-drl/drools-drl-parser/src/main/java/org/drools/drl/parser/antlr4/DRLVisitorImpl.java
@@ -235,9 +235,12 @@ public class DRLVisitorImpl extends DRLParserBaseVisitor<Object> {
 
     @Override
     public TypeDeclarationDescr visitTypeDeclaration(DRLParser.TypeDeclarationContext ctx) {
-        TypeDeclarationDescr typeDeclarationDescr = BaseDescrFactory.builder(new TypeDeclarationDescr(ctx.name.getText()))
+        TypeDeclarationDescr typeDeclarationDescr = BaseDescrFactory.builder(new TypeDeclarationDescr())
                 .withParserRuleContext(ctx)
                 .build();
+
+        typeDeclarationDescr.setTypeName(ctx.name.getText());
+
         if (ctx.DRL_TRAIT() != null) {
             typeDeclarationDescr.setTrait(true);
         }
@@ -257,9 +260,12 @@ public class DRLVisitorImpl extends DRLParserBaseVisitor<Object> {
 
     @Override
     public EnumDeclarationDescr visitEnumDeclaration(DRLParser.EnumDeclarationContext ctx) {
-        EnumDeclarationDescr enumDeclarationDescr = BaseDescrFactory.builder(new EnumDeclarationDescr(ctx.name.getText()))
+        EnumDeclarationDescr enumDeclarationDescr = BaseDescrFactory.builder(new EnumDeclarationDescr())
                 .withParserRuleContext(ctx)
                 .build();
+
+        enumDeclarationDescr.setTypeName(ctx.name.getText());
+
         ctx.drlAnnotation().stream()
                 .map(this::visitDrlAnnotation)
                 .forEach(enumDeclarationDescr::addAnnotation);


### PR DESCRIPTION
- Fixes #5900.
- Fixes 4 failing tests in `org.drools.mvel.compiler.compiler.TypeDeclarationTest`.

<details>
<summary>
How to replicate CI configuration locally?
</summary>

Build Chain tool does "simple" maven build(s), the builds are just Maven commands, but because the repositories relates and depends on each other and any change in API or class method could affect several of those repositories there is a need to use [build-chain tool](https://github.com/kiegroup/github-action-build-chain) to handle cross repository builds and be sure that we always use latest version of the code for each repository.
 
[build-chain tool](https://github.com/kiegroup/github-action-build-chain) is a build tool which can be used on command line locally or in Github Actions workflow(s), in case you need to change multiple repositories and send multiple dependent pull requests related with a change you can easily reproduce the same build by executing it on Github hosted environment or locally in your development environment. See [local execution](https://github.com/kiegroup/github-action-build-chain#local-execution) details to get more information about it.
</details>

<details>
<summary>
How to retest this PR or trigger a specific build:
</summary>

- for <b>pull request and downstream checks</b>  
  - Push a new commit to the PR. An empty commit would be enough.

- for a <b>full downstream build</b>
  - for <b>github actions</b> job: add the label `run_fdb`

- for <b>Jenkins PR check only</b>
  - If you are an ASF committer for KIE podling, login to Jenkins (https://ci-builds.apache.org/job/KIE/job/drools/), go to the specific PR job, and click on `Build Now` button.
</details>
