### PR TITLE
[incubator-kie-drools-5874] [new-parser] Adapt drlIdentifier to opera…

### DIFF
--- a/drools-drl/drools-drl-parser-tests/src/test/java/org/drools/drl/parser/antlr4/DRLParserIdentifierTest.java
+++ b/drools-drl/drools-drl-parser-tests/src/test/java/org/drools/drl/parser/antlr4/DRLParserIdentifierTest.java
@@ -276,7 +276,6 @@ class DRLParserIdentifierTest {
         assertThat(exprConstraintDescr.getExpression()).isEqualTo("address.super.contains() == 10");
     }
 
-    @Disabled("To be done by https://github.com/apache/incubator-kie-drools/issues/5874")
     @Test
     void operator_key() {
         final String text =
@@ -292,7 +291,6 @@ class DRLParserIdentifierTest {
         assertThat(exprConstraintDescr.getExpression()).isEqualTo("age provides 10");
     }
 
-    @Disabled("To be done by https://github.com/apache/incubator-kie-drools/issues/5874")
     @Test
     void neg_operator_key() {
         final String text =
@@ -310,8 +308,6 @@ class DRLParserIdentifierTest {
 
     @Test
     void operator_key_temporal() {
-        // This test (and MiscDRLParserTest.parse_PluggableOperators) fails when adapting drlIdentifier to operator_key and neg_operator_key in DRL6Expressions.g4
-        // See https://github.com/apache/incubator-kie-drools/issues/5874
         final String text =
                 "rule X\n" +
                         "when\n" +

--- a/drools-drl/drools-drl-parser/src/main/antlr4/org/drools/drl/parser/antlr4/DRL6Expressions.g4
+++ b/drools-drl/drools-drl-parser/src/main/antlr4/org/drools/drl/parser/antlr4/DRL6Expressions.g4
@@ -927,12 +927,10 @@ in_key
     ;
 
 operator_key
-  // IDENTIFIER is required to accept custom operators. We need to keep this semantic predicate for custom operators
-  :      {(helper.isPluggableEvaluator(false))}? id=IDENTIFIER { helper.emit($id, DroolsEditorType.KEYWORD); }
-  |      op=builtInOperator { helper.emit($op.token, DroolsEditorType.KEYWORD); }
+  // drlIdentifier is required to accept custom operators. We need to keep this semantic predicate for custom operators
+  :      {(helper.isPluggableEvaluator(false))}? id=drlIdentifier { helper.emit($id.token, DroolsEditorType.KEYWORD); }
   ;
 
 neg_operator_key
-  :      {(helper.isPluggableEvaluator(true))}? id=IDENTIFIER { helper.emit($id, DroolsEditorType.KEYWORD); }
-  |      op=builtInOperator { helper.emit($op.token, DroolsEditorType.KEYWORD); }
+  :      {(helper.isPluggableEvaluator(true))}? id=drlIdentifier { helper.emit($id.token, DroolsEditorType.KEYWORD); }
   ;


### PR DESCRIPTION
…tor_key and neg_operator_key in DRL6Expressions.g4

## Issue:
- https://github.com/apache/incubator-kie-drools/issues/5874

Thanks to https://github.com/apache/incubator-kie-drools/commit/d57c5da8b785bca3f35e6a32297bc3ba7a69843b , this is no longer an issue, so I adapted `drlIdentifier` and enabled the tests.