### PR TITLE
kie-issues#1213: configure for dockerhub registry

### DIFF
--- a/.ci/jenkins/config/branch.yaml
+++ b/.ci/jenkins/config/branch.yaml
@@ -90,7 +90,8 @@ maven:
     creds_id: apache-nexus-kie-deploy-credentials
 cloud:
   image:
-    registry_credentials: dockerhub_apache_kie_registry_token
+    registry_user_credentials_id: DOCKERHUB_USER
+    registry_token_credentials_id: DOCKERHUB_TOKEN
     registry: docker.io
     namespace: apache
     latest_git_branch: main

--- a/.ci/jenkins/config/branch.yaml
+++ b/.ci/jenkins/config/branch.yaml
@@ -90,16 +90,16 @@ maven:
     creds_id: apache-nexus-kie-deploy-credentials
 cloud:
   image:
-    registry_credentials: tradisso_registry_token # TODO set to `kogito-quay-token`
-    registry: quay.io
-    namespace: tradisso
+    registry_credentials: dockerhub_apache_kie_registry_token
+    registry: docker.io
+    namespace: apache
     latest_git_branch: main
 jenkins:
   email_creds_id: DROOLS_CI_NOTIFICATION_EMAILS
   agent:
     docker:
       builder:
-        image: quay.io/kiegroup/kogito-ci-build:main-latest
+        image: docker.io/apache/incubator-kie-kogito-ci-build:main-latest
         args: --privileged --group-add docker
   default_tools:
     jdk: jdk_17_latest


### PR DESCRIPTION
Fixes:
* apache/incubator-kie-issues#1213

Depends on `docker.io/apache/incubator-kie-kogito-ci-build:main-latest` being released first (after #1197 is merged and pipeline execution succeeds).

Part of PR group:
* apache/incubator-kie-kogito-pipelines#1198
* apache/incubator-kie-drools#5952
* apache/incubator-kie-optaplanner#3087