### PR TITLE
[KIE-DROOLS-5943] fix property reactivity in mvel constraint when using redundant pattern binding in constraint

### DIFF
--- a/drools-base/src/main/java/org/drools/base/rule/constraint/Constraint.java
+++ b/drools-base/src/main/java/org/drools/base/rule/constraint/Constraint.java
@@ -83,10 +83,6 @@ public interface Constraint
      */
     boolean isTemporal();
 
-    default BitMask getListenedPropertyMask(ObjectType objectType, List<String> settableProperties ) {
-        return getListenedPropertyMask(Optional.empty(), objectType, settableProperties);
-    }
-
     /**
      * Returns property reactivity BitMask of this constraint.
      *

--- a/drools-core/src/main/java/org/drools/core/reteoo/AlphaNode.java
+++ b/drools-core/src/main/java/org/drools/core/reteoo/AlphaNode.java
@@ -19,12 +19,14 @@
 package org.drools.core.reteoo;
 
 import java.util.List;
+import java.util.Optional;
 
 import org.drools.base.base.ObjectType;
 import org.drools.base.common.NetworkNode;
 import org.drools.base.common.RuleBasePartitionId;
 import org.drools.base.reteoo.BaseTerminalNode;
 import org.drools.base.reteoo.NodeTypeEnums;
+import org.drools.base.rule.Pattern;
 import org.drools.base.rule.constraint.AlphaNodeFieldConstraint;
 import org.drools.core.common.InternalFactHandle;
 import org.drools.core.common.InternalWorkingMemory;
@@ -309,8 +311,8 @@ public class AlphaNode extends ObjectSource
         }
     }
 
-    public BitMask calculateDeclaredMask(ObjectType objectType, List<String> settableProperties) {
-        return constraint.getListenedPropertyMask(objectType, settableProperties);
+    public BitMask calculateDeclaredMask(Pattern pattern, ObjectType objectType, List<String> settableProperties) {
+        return constraint.getListenedPropertyMask(Optional.ofNullable(pattern), objectType, settableProperties);
     }
 
     @Override

--- a/drools-core/src/main/java/org/drools/core/reteoo/EntryPointNode.java
+++ b/drools-core/src/main/java/org/drools/core/reteoo/EntryPointNode.java
@@ -29,6 +29,7 @@ import org.drools.base.common.NetworkNode;
 import org.drools.base.common.RuleBasePartitionId;
 import org.drools.base.reteoo.NodeTypeEnums;
 import org.drools.base.rule.EntryPointId;
+import org.drools.base.rule.Pattern;
 import org.drools.core.WorkingMemoryEntryPoint;
 import org.drools.core.common.BaseNode;
 import org.drools.core.common.DefaultEventHandle;
@@ -418,7 +419,7 @@ public class EntryPointNode extends ObjectSource implements ObjectSink {
     }
 
     @Override
-    public BitMask calculateDeclaredMask(ObjectType modifiedType, List<String> settableProperties) {
+    public BitMask calculateDeclaredMask(Pattern pattern, ObjectType modifiedType, List<String> settableProperties) {
         throw new UnsupportedOperationException();
     }
 

--- a/drools-core/src/main/java/org/drools/core/reteoo/FromNode.java
+++ b/drools-core/src/main/java/org/drools/core/reteoo/FromNode.java
@@ -24,6 +24,7 @@ import java.util.Collection;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
+import java.util.Optional;
 
 import org.drools.base.base.ObjectType;
 import org.drools.base.common.NetworkNode;
@@ -182,7 +183,7 @@ public class FromNode<T extends FromNode.FromMemory> extends LeftTupleSource
     @Override
     protected BitMask setNodeConstraintsPropertyReactiveMask( BitMask mask, ObjectType objectType, List<String> accessibleProperties) {
         for (int i = 0; i < alphaConstraints.length; i++) {
-            mask = mask.setAll(alphaConstraints[i].getListenedPropertyMask(objectType, accessibleProperties));
+            mask = mask.setAll(alphaConstraints[i].getListenedPropertyMask(Optional.empty(), objectType, accessibleProperties));
         }
         return mask;
     }

--- a/drools-core/src/main/java/org/drools/core/reteoo/ObjectSource.java
+++ b/drools-core/src/main/java/org/drools/core/reteoo/ObjectSource.java
@@ -121,14 +121,14 @@ public abstract class ObjectSource extends BaseNode {
         
         if ( isPropertyReactive(context.getRuleBase(), objectType) ) {
             List<String> settableProperties = getAccessibleProperties( context.getRuleBase(), objectType );
-            declaredMask = calculateDeclaredMask(objectType, settableProperties);
+            declaredMask = calculateDeclaredMask(pattern, objectType, settableProperties);
         } else {
             // if property specific is not on, then accept all modification propagations
             declaredMask = AllSetBitMask.get();
         }
     }
     
-    public abstract BitMask calculateDeclaredMask(ObjectType modifiedType, List<String> settableProperties);
+    public abstract BitMask calculateDeclaredMask(Pattern pattern, ObjectType modifiedType, List<String> settableProperties);
     
     public void resetInferredMask() {
         this.inferredMask = EmptyBitMask.get();

--- a/drools-core/src/main/java/org/drools/core/reteoo/ObjectTypeNode.java
+++ b/drools-core/src/main/java/org/drools/core/reteoo/ObjectTypeNode.java
@@ -34,6 +34,7 @@ import org.drools.base.common.NetworkNode;
 import org.drools.base.common.RuleBasePartitionId;
 import org.drools.base.reteoo.NodeTypeEnums;
 import org.drools.base.rule.EntryPointId;
+import org.drools.base.rule.Pattern;
 import org.drools.base.time.JobHandle;
 import org.drools.core.common.DefaultFactHandle;
 import org.drools.core.common.InternalFactHandle;
@@ -169,7 +170,7 @@ public class ObjectTypeNode extends ObjectSource implements ObjectSink {
     }
 
     @Override
-    public BitMask calculateDeclaredMask(ObjectType modifiedType, List<String> settableProperties) {
+    public BitMask calculateDeclaredMask(Pattern pattern, ObjectType modifiedType, List<String> settableProperties) {
         return EmptyBitMask.get();
     }
 

--- a/drools-core/src/main/java/org/drools/core/reteoo/Rete.java
+++ b/drools-core/src/main/java/org/drools/core/reteoo/Rete.java
@@ -28,6 +28,7 @@ import org.drools.base.common.NetworkNode;
 import org.drools.base.common.RuleBasePartitionId;
 import org.drools.base.reteoo.NodeTypeEnums;
 import org.drools.base.rule.EntryPointId;
+import org.drools.base.rule.Pattern;
 import org.drools.core.common.InternalFactHandle;
 import org.drools.core.common.InternalWorkingMemory;
 import org.drools.core.common.PropagationContext;
@@ -215,7 +216,7 @@ public class Rete extends ObjectSource implements ObjectSink {
     }   
     
     @Override
-    public BitMask calculateDeclaredMask(ObjectType modifiedType, List<String> settableProperties) {
+    public BitMask calculateDeclaredMask(Pattern pattern, ObjectType modifiedType, List<String> settableProperties) {
         throw new UnsupportedOperationException();
     }    
 }

--- a/drools-core/src/main/java/org/drools/core/reteoo/RightInputAdapterNode.java
+++ b/drools-core/src/main/java/org/drools/core/reteoo/RightInputAdapterNode.java
@@ -27,6 +27,7 @@ import org.drools.base.base.ObjectType;
 import org.drools.base.common.NetworkNode;
 import org.drools.base.definitions.rule.impl.RuleImpl;
 import org.drools.base.reteoo.NodeTypeEnums;
+import org.drools.base.rule.Pattern;
 import org.drools.core.RuleBaseConfiguration;
 import org.drools.core.common.ActivationsManager;
 import org.drools.core.common.InternalFactHandle;
@@ -290,7 +291,7 @@ public class RightInputAdapterNode extends ObjectSource
     }      
     
     @Override
-    public BitMask calculateDeclaredMask(ObjectType modifiedType, List<String> settableProperties) {
+    public BitMask calculateDeclaredMask(Pattern pattern, ObjectType modifiedType, List<String> settableProperties) {
         throw new UnsupportedOperationException();
     }
 

--- a/drools-core/src/main/java/org/drools/core/reteoo/WindowNode.java
+++ b/drools-core/src/main/java/org/drools/core/reteoo/WindowNode.java
@@ -26,6 +26,7 @@ import java.util.List;
 import org.drools.base.base.ObjectType;
 import org.drools.base.reteoo.NodeTypeEnums;
 import org.drools.base.rule.EntryPointId;
+import org.drools.base.rule.Pattern;
 import org.drools.base.rule.constraint.AlphaNodeFieldConstraint;
 import org.drools.core.RuleBaseConfiguration;
 import org.drools.core.common.DefaultEventHandle;
@@ -300,7 +301,7 @@ public class WindowNode extends ObjectSource
     }
 
     @Override
-    public BitMask calculateDeclaredMask(ObjectType modifiedType, List<String> settableProperties) {
+    public BitMask calculateDeclaredMask(Pattern pattern, ObjectType modifiedType, List<String> settableProperties) {
         throw new UnsupportedOperationException();
     }
 

--- a/drools-core/src/test/java/org/drools/core/reteoo/MockObjectSink.java
+++ b/drools-core/src/test/java/org/drools/core/reteoo/MockObjectSink.java
@@ -26,6 +26,7 @@ import org.drools.base.common.NetworkNode;
 import org.drools.base.common.RuleBasePartitionId;
 import org.drools.base.reteoo.BaseTerminalNode;
 import org.drools.base.reteoo.NodeTypeEnums;
+import org.drools.base.rule.Pattern;
 import org.drools.core.common.InternalFactHandle;
 import org.drools.core.common.InternalWorkingMemory;
 import org.drools.core.common.PropagationContext;
@@ -58,7 +59,7 @@ public class MockObjectSink extends ObjectSource
     }
 
     @Override
-    public BitMask calculateDeclaredMask(ObjectType modifiedType, List<String> settableProperties) {
+    public BitMask calculateDeclaredMask(Pattern pattern, ObjectType modifiedType, List<String> settableProperties) {
         return null;
     }
 

--- a/drools-core/src/test/java/org/drools/core/reteoo/MockObjectSource.java
+++ b/drools-core/src/test/java/org/drools/core/reteoo/MockObjectSource.java
@@ -24,6 +24,7 @@ import java.util.List;
 
 import org.drools.base.base.ObjectType;
 import org.drools.base.common.RuleBasePartitionId;
+import org.drools.base.rule.Pattern;
 import org.drools.core.common.InternalFactHandle;
 import org.drools.core.common.InternalWorkingMemory;
 import org.drools.core.common.PropagationContext;
@@ -89,7 +90,7 @@ public class MockObjectSource extends ObjectSource {
     }
     
     @Override
-    public BitMask calculateDeclaredMask(ObjectType modifiedType, List<String> settableProperties) {
+    public BitMask calculateDeclaredMask(Pattern pattern, ObjectType modifiedType, List<String> settableProperties) {
         throw new UnsupportedOperationException();
     }
 }

--- a/drools-model/drools-model-codegen/src/main/java/org/drools/model/codegen/execmodel/generator/DrlxParseUtil.java
+++ b/drools-model/drools-model-codegen/src/main/java/org/drools/model/codegen/execmodel/generator/DrlxParseUtil.java
@@ -117,6 +117,7 @@ import static java.util.stream.Collectors.toList;
 import static org.drools.model.codegen.execmodel.generator.DslMethodNames.PATTERN_CALL;
 import static org.drools.model.codegen.execmodel.generator.DslMethodNames.isDslTopLevelNamespace;
 import static org.drools.model.codegen.execmodel.generator.expressiontyper.ExpressionTyper.findLeftLeafOfNameExprTraversingParent;
+import static org.drools.util.ClassUtils.actualTypeFromGenerics;
 import static org.drools.util.ClassUtils.toRawClass;
 import static org.drools.util.MethodUtils.findMethod;
 
@@ -161,7 +162,7 @@ public class DrlxParseUtil {
         Method accessor = getAccessor(clazz, name, context);
         if (accessor != null) {
             MethodCallExpr body = new MethodCallExpr( scope, accessor.getName() );
-            return new TypedExpression( body, accessor.getGenericReturnType() );
+            return new TypedExpression( body, actualTypeFromGenerics( type, accessor.getGenericReturnType() ) );
         } else {
             // try parse it as inner class
             for (Class<?> declaredClass : clazz.getClasses()) {

--- a/drools-model/drools-model-codegen/src/test/java/org/drools/model/codegen/execmodel/GenericsTest.java
+++ b/drools-model/drools-model-codegen/src/test/java/org/drools/model/codegen/execmodel/GenericsTest.java
@@ -143,6 +143,38 @@ public class GenericsTest extends BaseModelTest {
                 "        update($v);\n" +
                 "end";
 
+        runTestWithGenerics(str);
+    }
+
+    @Test
+    public void testGenericsOnSuperclassWithRedundantVariableDeclaration() {
+        // KIE-DROOLS-5925
+        String str =
+                "import " + DieselCar.class.getCanonicalName() + ";\n " +
+                "dialect \"mvel\"\n" +
+                "\n" +
+                "rule \"Diesel vehicles with more than 95 kW use high-octane fuel (diesel has no octane, this is a test)\"\n" +
+                "    when\n" +
+                "        $v: DieselCar($v.motor.kw > 95, score<=0, !$v.motor.highOctane)\n" +
+                "    then\n" +
+                "        System.out.println(\"Diesel vehicle with more than 95 kW: \" + $v+\", score=\"+$v.score);\n" +
+                "        $v.engine.highOctane = true;\n" +
+                "        update($v);\n" +
+                "end\n" +
+                "\n" +
+                "rule \"High-octane fuel engines newer serial numbers have slightly higher score\"\n" +
+                "    when\n" +
+                "        $v: DieselCar($v.engine.highOctane, $v.score<=1, $v.motor.serialNumber > 50000)\n" +
+                "    then\n" +
+                "        System.out.println(\"High octane engine vehicle with newer serial number: \" + $v.motor.serialNumber);\n" +
+                "        $v.score = $v.score + 1;\n" +
+                "        update($v);\n" +
+                "end";
+
+        runTestWithGenerics(str);
+    }
+
+    private void runTestWithGenerics(String str) {
         KieSession ksession = getKieSession(str);
 
         DieselCar vehicle1 = new DieselCar("Volkswagen", "Passat", 100);

--- a/drools-model/drools-model-codegen/src/test/java/org/drools/model/codegen/execmodel/PropertyReactivityTest.java
+++ b/drools-model/drools-model-codegen/src/test/java/org/drools/model/codegen/execmodel/PropertyReactivityTest.java
@@ -1858,4 +1858,26 @@ public class PropertyReactivityTest extends BaseModelTest {
 
         assertThat(fired).isEqualTo(10);
     }
+
+    @Test
+    public void testPropertyReactivityWithRedundantVariableDeclaration() {
+        // KIE-DROOLS-5943
+        final String str =
+                "import " + Person.class.getCanonicalName() + ";\n" +
+                "\n" +
+                "rule R when\n" +
+                "    $p : Person( $p.name == \"Mario\" )\n" +
+                "then\n" +
+                "    $p.setAge( $p.getAge()+1 );\n" +
+                "    update($p);\n" +
+                "end\n";
+
+        KieSession ksession = getKieSession( str );
+
+        Person p = new Person("Mario", 40);
+        ksession.insert( p );
+        ksession.fireAllRules(3);
+
+        assertThat(p.getAge()).isEqualTo(41);
+    }
 }

--- a/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/model/MockObjectSource.java
+++ b/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/model/MockObjectSource.java
@@ -18,8 +18,13 @@
  */
 package org.drools.mvel.model;
 
+import java.util.ArrayList;
+import java.util.Iterator;
+import java.util.List;
+
 import org.drools.base.base.ObjectType;
 import org.drools.base.common.RuleBasePartitionId;
+import org.drools.base.rule.Pattern;
 import org.drools.core.common.InternalFactHandle;
 import org.drools.core.common.InternalWorkingMemory;
 import org.drools.core.common.PropagationContext;
@@ -27,10 +32,6 @@ import org.drools.core.reteoo.ObjectSink;
 import org.drools.core.reteoo.ObjectSource;
 import org.drools.core.reteoo.builder.BuildContext;
 import org.drools.util.bitmask.BitMask;
-
-import java.util.ArrayList;
-import java.util.Iterator;
-import java.util.List;
 
 public class MockObjectSource extends ObjectSource {
     private static final long serialVersionUID = 510l;
@@ -90,7 +91,7 @@ public class MockObjectSource extends ObjectSource {
     }
     
     @Override
-    public BitMask calculateDeclaredMask(ObjectType modifiedType, List<String> settableProperties) {
+    public BitMask calculateDeclaredMask(Pattern pattern, ObjectType modifiedType, List<String> settableProperties) {
         throw new UnsupportedOperationException();
     }
 }

--- a/drools-traits/src/main/java/org/drools/traits/core/reteoo/TraitAlphaNode.java
+++ b/drools-traits/src/main/java/org/drools/traits/core/reteoo/TraitAlphaNode.java
@@ -19,8 +19,10 @@
 package org.drools.traits.core.reteoo;
 
 import java.util.List;
+import java.util.Optional;
 
 import org.drools.base.base.ObjectType;
+import org.drools.base.rule.Pattern;
 import org.drools.traits.core.base.evaluators.IsAEvaluatorDefinition;
 import org.drools.core.reteoo.AlphaNode;
 import org.drools.core.reteoo.ObjectSource;
@@ -41,8 +43,8 @@ public class TraitAlphaNode extends AlphaNode {
     }
 
     @Override
-    public BitMask calculateDeclaredMask(ObjectType objectType, List<String> settableProperties) {
-        BitMask mask = constraint.getListenedPropertyMask(objectType, settableProperties);
+    public BitMask calculateDeclaredMask(Pattern pattern, ObjectType objectType, List<String> settableProperties) {
+        BitMask mask = constraint.getListenedPropertyMask(Optional.ofNullable(pattern), objectType, settableProperties);
         if (isTraitEvaluator()) {
             return mask.set(PropertySpecificUtil.TRAITABLE_BIT);
         }


### PR DESCRIPTION
Fixes https://github.com/apache/incubator-kie-drools/issues/5943

This time the executable model was behaving correctly so I fixed the property reactivity introspection in the `MvelConstraint`, to make the interpreted drl to behave in the same way.