### PR TITLE
[new-parser] Avoid IndexOutOfBoundsException in lhsUnary

### DIFF
--- a/drools-drl/drools-drl-parser/src/main/java/org/drools/drl/parser/antlr4/DRLVisitorImpl.java
+++ b/drools-drl/drools-drl-parser/src/main/java/org/drools/drl/parser/antlr4/DRLVisitorImpl.java
@@ -1087,9 +1087,10 @@ public class DRLVisitorImpl extends DRLParserBaseVisitor<Object> {
                     .build();
             children.forEach(andDescr::addDescr);
             return andDescr;
-        } else {
-            // size == 1. children never be empty
+        } else if (children.size() == 1) {
             return children.get(0);
+        } else {
+            return null; // only caused by a parser error
         }
     }
 


### PR DESCRIPTION
- Fixes #5955.
- Caused by #5950 and the fact that `test-compiler-integration` is still blocked by
  - #5818
  - #5867
  
  We should prioritize these before we continue fixing tests in `test-compiler-integration`.
<details>
<summary>
How to replicate CI configuration locally?
</summary>

Build Chain tool does "simple" maven build(s), the builds are just Maven commands, but because the repositories relates and depends on each other and any change in API or class method could affect several of those repositories there is a need to use [build-chain tool](https://github.com/kiegroup/github-action-build-chain) to handle cross repository builds and be sure that we always use latest version of the code for each repository.
 
[build-chain tool](https://github.com/kiegroup/github-action-build-chain) is a build tool which can be used on command line locally or in Github Actions workflow(s), in case you need to change multiple repositories and send multiple dependent pull requests related with a change you can easily reproduce the same build by executing it on Github hosted environment or locally in your development environment. See [local execution](https://github.com/kiegroup/github-action-build-chain#local-execution) details to get more information about it.
</details>

<details>
<summary>
How to retest this PR or trigger a specific build:
</summary>

- for <b>pull request and downstream checks</b>  
  - Push a new commit to the PR. An empty commit would be enough.

- for a <b>full downstream build</b>
  - for <b>github actions</b> job: add the label `run_fdb`

- for <b>Jenkins PR check only</b>
  - If you are an ASF committer for KIE podling, login to Jenkins (https://ci-builds.apache.org/job/KIE/job/drools/), go to the specific PR job, and click on `Build Now` button.
</details>
