### PR TITLE
[incubator-kie-drools-5818] [new-parser] Parsing fails if a Java keyw…

### DIFF
--- a/drools-drl/drools-drl-parser-tests/src/test/java/org/drools/drl/parser/antlr4/DRLExprParserTest.java
+++ b/drools-drl/drools-drl-parser-tests/src/test/java/org/drools/drl/parser/antlr4/DRLExprParserTest.java
@@ -441,29 +441,6 @@ public class DRLExprParserTest {
     }
 
     @Test
-    public void testNoViableAlt() {
-        String source = "x.int";
-        parser.parse(source);
-
-        // Backward Compatibility Notes:
-        //   Old expr parser (DRL6Expressions) allows this expression because it's too tolerant (fail at runtime anyway).
-        //   Backward compatibility doesn't seem to be required in this case. (But we may align with the old tolerant behavior.)
-        if (DrlParser.ANTLR4_PARSER_ENABLED) {
-            assertThat(parser.hasErrors()).isTrue();
-            assertThat(parser.getErrors()).hasSize(1);
-            DroolsParserException exception = parser.getErrors().get(0);
-            assertThat(exception.getErrorCode()).isEqualTo("ERR 101");
-            assertThat(exception.getLineNumber()).isEqualTo(1);
-            assertThat(exception.getColumn()).isEqualTo(2);
-            assertThat(exception.getOffset()).isEqualTo(2);
-            assertThat(exception.getMessage())
-                    .isEqualToIgnoringCase("[ERR 101] Line 1:2 no viable alternative at input '.int'");
-        } else {
-            assertThat(parser.hasErrors()).isFalse();
-        }
-    }
-
-    @Test
     void orWithMethodCall() {
         String source = "value == 10 || someMethod() == 4";
         ConstraintConnectiveDescr result = parser.parse(source);

--- a/drools-drl/drools-drl-parser-tests/src/test/java/org/drools/drl/parser/antlr4/MiscDRLParserTest.java
+++ b/drools-drl/drools-drl-parser-tests/src/test/java/org/drools/drl/parser/antlr4/MiscDRLParserTest.java
@@ -5103,4 +5103,23 @@ class MiscDRLParserTest {
         assertThat(parser.hasErrors()).isTrue();
         assertThat(parser.getErrors()).extracting(DroolsError::getMessage).doesNotContain("");
     }
+
+    @ParameterizedTest
+    @MethodSource("org.drools.drl.parser.antlr4.ParserTestUtils#javaKeywords")
+    void javaKeywordsInPackage(String keyword) {
+        String pkgName = "org.drools." + keyword;
+        String text = "package " + pkgName + "\n" +
+                "rule R\n" +
+                "when\n" +
+                "  $p : Person()\n" +
+                "then\n" +
+                "end\n";
+
+        PackageDescr pkg = parseAndGetPackageDescr(text);
+
+        assertThat(pkg.getName()).isEqualTo(pkgName);
+        assertThat(pkg.getRules()).hasSize(1);
+
+        assertThat(pkg.getRules().get(0).getName()).isEqualTo("R");
+    }
 }

--- a/drools-drl/drools-drl-parser-tests/src/test/java/org/drools/drl/parser/antlr4/ParserTestUtils.java
+++ b/drools-drl/drools-drl-parser-tests/src/test/java/org/drools/drl/parser/antlr4/ParserTestUtils.java
@@ -25,12 +25,14 @@ import org.drools.drl.parser.DrlParser;
 
 public class ParserTestUtils {
 
+    // 'new' is not included because it cannot be included in drlIdentifier.
+    // See https://github.com/apache/incubator-kie-drools/pull/5958
     public static List<String> javaKeywords =
             Arrays.asList(
                     "abstract", "assert", "boolean", "break", "byte", "case", "catch", "char", "class", "const",
                     "continue", "default", "do", "double", "else", "enum", "extends", "final", "finally", "float",
                     "for", "goto", "if", "implements", "import", "instanceof", "int", "interface", "long", "native",
-                    "new", "package", "private", "protected", "public", "return", "short", "static", "strictfp",
+                    "package", "private", "protected", "public", "return", "short", "static", "strictfp",
                     "super", "switch", "synchronized", "this", "throw", "throws", "transient", "try", "void", "volatile",
                     "while"
             );

--- a/drools-drl/drools-drl-parser-tests/src/test/java/org/drools/drl/parser/antlr4/ParserTestUtils.java
+++ b/drools-drl/drools-drl-parser-tests/src/test/java/org/drools/drl/parser/antlr4/ParserTestUtils.java
@@ -18,9 +18,22 @@
  */
 package org.drools.drl.parser.antlr4;
 
+import java.util.Arrays;
+import java.util.List;
+
 import org.drools.drl.parser.DrlParser;
 
 public class ParserTestUtils {
+
+    public static List<String> javaKeywords =
+            Arrays.asList(
+                    "abstract", "assert", "boolean", "break", "byte", "case", "catch", "char", "class", "const",
+                    "continue", "default", "do", "double", "else", "enum", "extends", "final", "finally", "float",
+                    "for", "goto", "if", "implements", "import", "instanceof", "int", "interface", "long", "native",
+                    "new", "package", "private", "protected", "public", "return", "short", "static", "strictfp",
+                    "super", "switch", "synchronized", "this", "throw", "throws", "transient", "try", "void", "volatile",
+                    "while"
+            );
 
     private ParserTestUtils() {
         // It is a utility class, so it should not be instantiated.
@@ -38,5 +51,9 @@ public class ParserTestUtils {
      */
     public static void enableOldParser() {
         DrlParser.ANTLR4_PARSER_ENABLED = false;
+    }
+
+    public static List<String> javaKeywords() {
+        return javaKeywords;
     }
 }

--- a/drools-drl/drools-drl-parser/src/main/antlr4/org/drools/drl/parser/antlr4/DRL6Expressions.g4
+++ b/drools-drl/drools-drl-parser/src/main/antlr4/org/drools/drl/parser/antlr4/DRL6Expressions.g4
@@ -193,7 +193,7 @@ drlIdentifier returns [Token token]
     | INTERFACE
     | LONG
     | NATIVE
-    | NEW
+//    | NEW     // avoid ambiguity with 'new_key creator' and 'drlIdentifier' in 'primary'
     | PACKAGE
     | PRIVATE
     | PROTECTED

--- a/drools-drl/drools-drl-parser/src/main/antlr4/org/drools/drl/parser/antlr4/DRL6Expressions.g4
+++ b/drools-drl/drools-drl-parser/src/main/antlr4/org/drools/drl/parser/antlr4/DRL6Expressions.g4
@@ -162,6 +162,58 @@ typeArgument
 drlIdentifier returns [Token token]
     : drlKeywords
     | IDENTIFIER
+    // java keywords
+    | ABSTRACT
+    | ASSERT
+    | BOOLEAN
+    | BREAK
+    | BYTE
+    | CASE
+    | CATCH
+    | CHAR
+    | CLASS
+    | CONST
+    | CONTINUE
+    | DEFAULT
+    | DO
+    | DOUBLE
+    | ELSE
+    | ENUM
+    | EXTENDS
+    | FINAL
+    | FINALLY
+    | FLOAT
+    | FOR
+    | IF
+    | GOTO
+    | IMPLEMENTS
+    | IMPORT
+    | INSTANCEOF
+    | INT
+    | INTERFACE
+    | LONG
+    | NATIVE
+    | NEW
+    | PACKAGE
+    | PRIVATE
+    | PROTECTED
+    | PUBLIC
+    | RETURN
+    | SHORT
+    | STATIC
+    | STRICTFP
+    | SUPER
+    | SWITCH
+    | SYNCHRONIZED
+    | THIS
+    | THROW
+    | THROWS
+    | TRANSIENT
+    | TRY
+    | VOID
+    | VOLATILE
+    | WHILE
+    // Module related keywords
     | MODULE
     | OPEN
     | REQUIRES
@@ -172,12 +224,13 @@ drlIdentifier returns [Token token]
     | PROVIDES
     | WITH
     | TRANSITIVE
+    // other java keywords
+    | VAR
     | YIELD
+    | RECORD
     | SEALED
     | PERMITS
-    | RECORD
-    | VAR
-    | THIS
+    | NON_SEALED
     ;
 
 // matches any drl keywords


### PR DESCRIPTION
…ord appears in a qualified name

## Issue
- https://github.com/apache/incubator-kie-drools/issues/5818
    - `org.kie.declarativetypes.JavaBeansEventRoleTest#testImportBean`
    - `org.drools.mvel.integrationtests.ExtendsTest#testDeclareExtendsWithFullyQualifiedName`
are fixed

Also
- https://github.com/apache/incubator-kie-drools/issues/5917
    - `org.drools.mvel.integrationtests.ExtendsTest#testExtendsBasic`
is fixed.

- https://github.com/apache/incubator-kie-drools/issues/5910
    - `org.drools.mvel.integrationtests.VarargsTest#testVarargs`  
is fixed