### PR TITLE
kie-issues#1238: Update Kogito prepare-release Jenkins jobs to trigger nightly and weekly jobs after setting up branches

### DIFF
--- a/.ci/jenkins/project/Jenkinsfile.setup-branch
+++ b/.ci/jenkins/project/Jenkinsfile.setup-branch
@@ -108,6 +108,25 @@ pipeline {
                 }
             }
         }
+
+        // Launch the weekly to deploy all artifacts from the branch
+        stage('Launch the weekly') {
+            when {
+                expression { return params.DEPLOY }
+            }
+            steps {
+                script {
+                    def buildParams = getDefaultBuildParams()
+                    addBooleanParam(buildParams, 'SKIP_TESTS', true)
+                    build(job: '../other/0-weekly', wait: false, parameters: buildParams, propagate: false)
+                }
+            }
+            post {
+                failure {
+                    addFailedStage('weekly')
+                }
+            }
+        }
     }
     post {
         unsuccessful {


### PR DESCRIPTION
This PR is part of the [#1238](https://github.com/apache/incubator-kie-issues/issues/1238) issue.

It adds a trigger for the Drools weekly job as part of the `setup-branch` Jenkins job execution.