### PR TITLE
[incubator-kie-drools-5936] [new-parser] || and && should be allowed …

### DIFF
--- a/drools-drl/drools-drl-parser/src/main/antlr4/org/drools/drl/parser/antlr4/DRLParser.g4
+++ b/drools-drl/drools-drl-parser/src/main/antlr4/org/drools/drl/parser/antlr4/DRLParser.g4
@@ -104,16 +104,16 @@ lhs : DRL_WHEN lhsExpression* ;
 queryLhs : lhsExpression* ;
 
 lhsExpression : LPAREN lhsExpression RPAREN                             #lhsExpressionEnclosed
-              | lhsUnary                                                #lhsUnarySingle
-              | DRL_AND drlAnnotation* lhsExpression+                                  #lhsAnd
-              | lhsExpression (DRL_AND drlAnnotation* lhsExpression)+                  #lhsAnd
               | DRL_OR drlAnnotation* lhsExpression+                                   #lhsOr
-              | lhsExpression (DRL_OR drlAnnotation* lhsExpression)+                   #lhsOr
+              | lhsExpression ((DRL_OR|OR) drlAnnotation* lhsExpression)+              #lhsOr
+              | DRL_AND drlAnnotation* lhsExpression+                                  #lhsAnd
+              | lhsExpression ((DRL_AND|AND) drlAnnotation* lhsExpression)+            #lhsAnd
+              | lhsUnary                                                               #lhsUnarySingle
               ;
 
 // lhsAnd is used as a label in lhsExpression rule. But some other rules explicitly use the def, so lhsAndDef is declared.
 lhsAndDef : LPAREN lhsAndDef RPAREN
-          | lhsUnary (DRL_AND lhsUnary)*
+          | lhsUnary ((DRL_AND|AND) lhsUnary)*
           | LPAREN DRL_AND lhsUnary+ RPAREN
           ;
 

--- a/drools-drl/drools-drl-parser/src/main/java/org/drools/drl/parser/antlr4/Antlr4ParserStringUtils.java
+++ b/drools-drl/drools-drl-parser/src/main/java/org/drools/drl/parser/antlr4/Antlr4ParserStringUtils.java
@@ -56,6 +56,9 @@ public class Antlr4ParserStringUtils {
      * Get text from List of ParserRuleContext's CharStream without trimming whitespace
      */
     public static String getTextPreservingWhitespace(List<? extends ParserRuleContext> ctx) {
+        if (ctx == null) {
+            return "";
+        }
         return ctx.stream().map(Antlr4ParserStringUtils::getTextPreservingWhitespace).collect(Collectors.joining());
     }
 
@@ -65,6 +68,9 @@ public class Antlr4ParserStringUtils {
      * Unlike getTextPreservingWhitespace, this method reflects Lexer normalizeString
      */
     public static String getTokenTextPreservingWhitespace(ParserRuleContext ctx, TokenStream tokenStream) {
+        if (ctx == null) {
+            return "";
+        }
         return tokenStream.getText(ctx.start, ctx.stop);
     }
 

--- a/drools-drl/drools-drl-parser/src/main/java/org/drools/drl/parser/antlr4/DRLVisitorImpl.java
+++ b/drools-drl/drools-drl-parser/src/main/java/org/drools/drl/parser/antlr4/DRLVisitorImpl.java
@@ -819,7 +819,7 @@ public class DRLVisitorImpl extends DRLParserBaseVisitor<Object> {
         }
 
         String[] params = ctx.conditionalExpressions().conditionalExpression().stream()
-                .map(RuleContext::getText)
+                .map(Antlr4ParserStringUtils::getTextPreservingWhitespace)
                 .toArray(String[]::new);
         return new AccumulateDescr.AccumulateFunctionCallDescr(function, bind, unify, params);
     }


### PR DESCRIPTION
…as alternatives to infix or and and

**Issue**: 

* https://github.com/apache/incubator-kie-drools/issues/5936

