### PR TITLE
kie-issues#1237: stay on x.y.999-SNAPSHOT in release branches

### DIFF
--- a/.ci/jenkins/project/Jenkinsfile.setup-branch
+++ b/.ci/jenkins/project/Jenkinsfile.setup-branch
@@ -215,7 +215,7 @@ String getDroolsVersion() {
     return params.DROOLS_VERSION ?: getVersionFromReleaseBranch(getBuildBranch())
 }
 
-String getVersionFromReleaseBranch(String releaseBranch, int microVersion = 0, String suffix = 'SNAPSHOT') {
+String getVersionFromReleaseBranch(String releaseBranch, int microVersion = 999, String suffix = 'SNAPSHOT') {
     String [] versionSplit = releaseBranch.split("\\.")
     if (versionSplit.length == 3
         && versionSplit[0].isNumber()


### PR DESCRIPTION
Part of
* apache/incubator-kie-issues#1237

Adjusts the snapshot version changes to happen only in new branch when branching, not in main.

Ensemble:
* apache/incubator-kie-kogito-pipelines#1201
* apache/incubator-kie-drools#5967
* apache/incubator-kie-optaplanner#3089
* apache/incubator-kie-kogito-runtimes#3527
* apache/incubator-kie-kogito-apps#2059
* apache/incubator-kie-kogito-examples#1925
* apache/incubator-kie-optaplanner-quickstarts#630