### PR TITLE
`for`  expression with a `null` leads to unexpected NPE

### DIFF
--- a/kie-dmn/kie-dmn-core/src/main/java/org/kie/dmn/core/compiler/DMNEvaluatorCompiler.java
+++ b/kie-dmn/kie-dmn-core/src/main/java/org/kie/dmn/core/compiler/DMNEvaluatorCompiler.java
@@ -973,7 +973,7 @@ public class DMNEvaluatorCompiler implements DMNDecisionLogicCompiler {
     private DMNExpressionEvaluator compileIterator(DMNCompilerContext ctx, DMNModelImpl model, DMNBaseNode node, String exprName, Iterator expression) {
         if (expression.getIteratorVariable() == null || expression.getIteratorVariable().isEmpty()) {
             MsgUtil.reportMessage(logger, DMNMessage.Severity.ERROR, node.getSource(), model, null, null, Msg.MISSING_EXPRESSION_FOR_ITERATOR,
-                    expression.getTypeRef().toString().toLowerCase(), node.getIdentifierString());
+                    "iteratorVariable", node.getIdentifierString());
             return null;
         }
 


### PR DESCRIPTION
Closes https://github.com/apache/incubator-kie-issues/issues/1246

<img width="325" alt="Screenshot 2024-05-22 at 16 38 00" src="https://github.com/apache/incubator-kie-drools/assets/16005046/e4bbe45e-c4cd-492d-aeef-af8ce84962c4">

<img width="528" alt="Screenshot 2024-05-22 at 17 12 14" src="https://github.com/apache/incubator-kie-drools/assets/16005046/d262022b-a28c-4685-932a-2cd1c27fd373">

The NPE is thrown because of ´expression.getTypeRef().toString().toLowerCase()`, in such a case the typeRef is null

Considering that: 
- The `typeRef` is an optional parameter  in the `tExpression` 
<img width="633" alt="Screenshot 2024-05-22 at 17 13 56" src="https://github.com/apache/incubator-kie-drools/assets/16005046/0962476b-e596-4def-aef7-5fa65fbb1b4f">

- the `in` and `return` variables are passing a constant for creating the error message ([here](https://github.com/apache/incubator-kie-drools/pull/5968/files#diff-2acea59f51fe53327d046e6af624076137435f8d9ff245ebbe96306f6962b8fcR1001)) and ([here](https://github.com/apache/incubator-kie-drools/pull/5968/files#diff-2acea59f51fe53327d046e6af624076137435f8d9ff245ebbe96306f6962b8fcR1008))

To fix the issue it's enough to pass the constants that represent the variable name (`variableIterator`)

@gitgabrio @baldimir Do you have any idea how I can effectively test this change?

After:
<img width="925" alt="Screenshot 2024-05-22 at 16 38 42" src="https://github.com/apache/incubator-kie-drools/assets/16005046/c3810199-db92-40dc-a90c-b65e3844c4a7">

Before:
<img width="1174" alt="Screenshot 2024-05-22 at 16 54 31" src="https://github.com/apache/incubator-kie-drools/assets/16005046/9a7dc9ff-7761-4e77-b349-4524bbcf43b5">






