### PR TITLE
[NO-ISSUE] Use apache-release profile when doing a release build

### DIFF
--- a/.ci/jenkins/Jenkinsfile.deploy
+++ b/.ci/jenkins/Jenkinsfile.deploy
@@ -126,7 +126,6 @@ pipeline {
                            .withOptions(env.BUILD_MVN_OPTS_CURRENT ? [ env.BUILD_MVN_OPTS_CURRENT ] : [])
                            .withProperty('maven.test.failure.ignore', true)
                            .skipTests(params.SKIP_TESTS)
-                           .withSettingsXmlFile(MAVEN_SETTINGS_FILE)
 
                         if (isRelease()) {
                             withCredentials([file(credentialsId: 'asf-release-gpg-signing-key', variable: 'SIGNING_KEY')]) {
@@ -143,7 +142,7 @@ pipeline {
                         }
 
                         configFileProvider([configFile(fileId: env.MAVEN_SETTINGS_CONFIG_FILE_ID, variable: 'MAVEN_SETTINGS_FILE')]){
-                            mavenCommand.run("clean $installOrDeploy")
+                            mavenCommand.withSettingsXmlFile(MAVEN_SETTINGS_FILE).run("clean $installOrDeploy")
                         }
                     }
                 }

--- a/.ci/jenkins/Jenkinsfile.deploy
+++ b/.ci/jenkins/Jenkinsfile.deploy
@@ -130,11 +130,14 @@ pipeline {
 
                         if (isRelease()) {
                             withCredentials([file(credentialsId: 'asf-release-gpg-signing-key', variable: 'SIGNING_KEY')]) {
-                                // copy the key to singkey.gpg file in *plain text* so we can import it
-                                sh ('cat $SIGNING_KEY > $WORKSPACE/signkey.gpg')
-                                // import the key into the gpg keyring
-                                sh ('gpg --allow-secret-key-import --import signkey.gpg')
-                                sh ('rm $WORKSPACE/signkey.gpg')
+                                withCredentials([file(credentialsId: 'asf-release-gpg-signing-key-password', variable: 'SIGNING_KEY_PASSWORD')]) {
+                                    // copy the key to singkey.gpg file in *plain text* so we can import it
+                                    sh ('cat $SIGNING_KEY > $WORKSPACE/signkey.gpg')
+                                    // Please do not remove list keys command. When gpg is run for the first time, it may initialize some internals.
+                                    sh ('gpg --list-keys')
+                                    sh ("gpg --batch --pinentry-mode=loopback --passphrase \"${SIGNING_KEY_PASSWORD}\" --import signkey.gpg")
+                                    sh ('rm $WORKSPACE/signkey.gpg')
+                                }
                             }
                             mavenCommand.withProfiles(['apache-release'])
                         }

--- a/.ci/jenkins/Jenkinsfile.deploy
+++ b/.ci/jenkins/Jenkinsfile.deploy
@@ -138,13 +138,18 @@ pipeline {
                                     sh ("rm \"${WORKSPACE}\"/signkey.gpg")
 
                                     mavenCommand.withProperty('gpg.passphrase', SIGNING_KEY_PASSWORD)
+                                        .withProfiles(['apache-release'])
+
+                                    // If there are passwords, this needs to be duplicated within the withCredentials block.
+                                    configFileProvider([configFile(fileId: env.MAVEN_SETTINGS_CONFIG_FILE_ID, variable: 'MAVEN_SETTINGS_FILE')]) {
+                                        mavenCommand.withSettingsXmlFile(MAVEN_SETTINGS_FILE).run("clean $installOrDeploy")
+                                    }
                                 }
                             }
-                            mavenCommand.withProfiles(['apache-release'])
-                        }
-
-                        configFileProvider([configFile(fileId: env.MAVEN_SETTINGS_CONFIG_FILE_ID, variable: 'MAVEN_SETTINGS_FILE')]){
-                            mavenCommand.withSettingsXmlFile(MAVEN_SETTINGS_FILE).run("clean $installOrDeploy")
+                        } else {
+                            configFileProvider([configFile(fileId: env.MAVEN_SETTINGS_CONFIG_FILE_ID, variable: 'MAVEN_SETTINGS_FILE')]) {
+                                mavenCommand.withSettingsXmlFile(MAVEN_SETTINGS_FILE).run("clean $installOrDeploy")
+                            }
                         }
                     }
                 }

--- a/.ci/jenkins/Jenkinsfile.deploy
+++ b/.ci/jenkins/Jenkinsfile.deploy
@@ -132,11 +132,11 @@ pipeline {
                             withCredentials([file(credentialsId: 'asf-release-gpg-signing-key', variable: 'SIGNING_KEY')]) {
                                 withCredentials([file(credentialsId: 'asf-release-gpg-signing-key-password', variable: 'SIGNING_KEY_PASSWORD')]) {
                                     // copy the key to singkey.gpg file in *plain text* so we can import it
-                                    sh ('cat $SIGNING_KEY > $WORKSPACE/signkey.gpg')
+                                    sh ("cat \"${SIGNING_KEY}\" > \"${WORKSPACE}\"/signkey.gpg")
                                     // Please do not remove list keys command. When gpg is run for the first time, it may initialize some internals.
                                     sh ('gpg --list-keys')
-                                    sh ("gpg --batch --pinentry-mode=loopback --passphrase \"${SIGNING_KEY_PASSWORD}\" --import signkey.gpg")
-                                    sh ('rm $WORKSPACE/signkey.gpg')
+                                    sh ("gpg --batch --pinentry-mode=loopback --passphrase \"${SIGNING_KEY_PASSWORD}\" --import  \"${WORKSPACE}\"/signkey.gpg")
+                                    sh ("rm \"${WORKSPACE}\"/signkey.gpg")
                                 }
                             }
                             mavenCommand.withProfiles(['apache-release'])

--- a/.ci/jenkins/Jenkinsfile.deploy
+++ b/.ci/jenkins/Jenkinsfile.deploy
@@ -121,14 +121,26 @@ pipeline {
                         } else {
                             installOrDeploy = 'install'
                         }
+                        def mavenCommand = getMavenCommand()
+                           .withOptions(env.DROOLS_BUILD_MVN_OPTS ? [ env.DROOLS_BUILD_MVN_OPTS ] : [])
+                           .withOptions(env.BUILD_MVN_OPTS_CURRENT ? [ env.BUILD_MVN_OPTS_CURRENT ] : [])
+                           .withProperty('maven.test.failure.ignore', true)
+                           .skipTests(params.SKIP_TESTS)
+                           .withSettingsXmlFile(MAVEN_SETTINGS_FILE)
+
+                        if (isRelease()) {
+                            withCredentials([file(credentialsId: 'asf-release-gpg-signing-key', variable: 'SIGNING_KEY')]) {
+                                // copy the key to singkey.gpg file in *plain text* so we can import it
+                                sh ('cat $SIGNING_KEY > $WORKSPACE/signkey.gpg')
+                                // import the key into the gpg keyring
+                                sh ('gpg --allow-secret-key-import --import signkey.gpg')
+                                sh ('rm $WORKSPACE/signkey.gpg')
+                            }
+                            mavenCommand.withProfiles(['apache-release'])
+                        }
+
                         configFileProvider([configFile(fileId: env.MAVEN_SETTINGS_CONFIG_FILE_ID, variable: 'MAVEN_SETTINGS_FILE')]){
-                            getMavenCommand()
-                                .withOptions(env.DROOLS_BUILD_MVN_OPTS ? [ env.DROOLS_BUILD_MVN_OPTS ] : [])
-                                .withOptions(env.BUILD_MVN_OPTS_CURRENT ? [ env.BUILD_MVN_OPTS_CURRENT ] : [])
-                                .withProperty('maven.test.failure.ignore', true)
-                                .skipTests(params.SKIP_TESTS)
-                                .withSettingsXmlFile(MAVEN_SETTINGS_FILE)
-                                .run("clean $installOrDeploy")
+                            mavenCommand.run("clean $installOrDeploy")
                         }
                     }
                 }

--- a/.ci/jenkins/Jenkinsfile.deploy
+++ b/.ci/jenkins/Jenkinsfile.deploy
@@ -136,6 +136,8 @@ pipeline {
                                     sh ('gpg --list-keys')
                                     sh ("gpg --batch --pinentry-mode=loopback --passphrase \"${SIGNING_KEY_PASSWORD}\" --import  \"${WORKSPACE}\"/signkey.gpg")
                                     sh ("rm \"${WORKSPACE}\"/signkey.gpg")
+
+                                    mavenCommand.withProperty('gpg.passphrase', SIGNING_KEY_PASSWORD)
                                 }
                             }
                             mavenCommand.withProfiles(['apache-release'])


### PR DESCRIPTION
Adds gpg setup and apache-release Maven profile to the release build.

Similar (can be merged separately) PRs:
- [kogito-runtimes](https://github.com/apache/incubator-kie-kogito-runtimes/pull/3530)
- [kogito-apps](https://github.com/apache/incubator-kie-kogito-apps/pull/2062)
- [optaplanner](https://github.com/apache/incubator-kie-optaplanner/pull/3093)