### PR TITLE
Fix ActionFieldValue clone

### DIFF
--- a/drools-workbench-models/drools-workbench-models-guided-dtable/src/main/java/org/drools/workbench/models/guided/dtable/backend/util/GuidedDTBRDRLPersistence.java
+++ b/drools-workbench-models/drools-workbench-models-guided-dtable/src/main/java/org/drools/workbench/models/guided/dtable/backend/util/GuidedDTBRDRLPersistence.java
@@ -337,7 +337,7 @@ public class GuidedDTBRDRLPersistence extends RuleModelDRLPersistenceImpl {
                     final ActionFieldFunction afvClone = new ActionFieldFunction();
                     afvClone.setMethod(((ActionFieldFunction) fieldValue).getMethod());
                     afvClone.setField(fieldValue.getField());
-                    afvClone.setNature(BaseSingleFieldConstraint.TYPE_LITERAL);
+                    afvClone.setNature(fieldValue.getNature());
                     afvClone.setType(fieldValue.getType());
                     String value = fieldValue.getValue();
                     String templateKeyValue = rowDataProvider.getTemplateKeyValue(value);

--- a/drools-workbench-models/drools-workbench-models-guided-dtable/src/main/java/org/drools/workbench/models/guided/dtable/backend/util/GuidedDTBRDRLPersistence.java
+++ b/drools-workbench-models/drools-workbench-models-guided-dtable/src/main/java/org/drools/workbench/models/guided/dtable/backend/util/GuidedDTBRDRLPersistence.java
@@ -337,13 +337,14 @@ public class GuidedDTBRDRLPersistence extends RuleModelDRLPersistenceImpl {
                     final ActionFieldFunction afvClone = new ActionFieldFunction();
                     afvClone.setMethod(((ActionFieldFunction) fieldValue).getMethod());
                     afvClone.setField(fieldValue.getField());
-                    afvClone.setNature(fieldValue.getNature());
                     afvClone.setType(fieldValue.getType());
                     String value = fieldValue.getValue();
                     String templateKeyValue = rowDataProvider.getTemplateKeyValue(value);
                     if (Objects.equals("", templateKeyValue)) {
+                        afvClone.setNature(fieldValue.getNature());
                         afvClone.setValue(value);
                     } else {
+                        afvClone.setNature(BaseSingleFieldConstraint.TYPE_LITERAL);
                         afvClone.setValue(templateKeyValue);
                     }
 

--- a/drools-workbench-models/drools-workbench-models-guided-dtable/src/test/java/org/drools/workbench/models/guided/dtable/backend/BRLRuleModelTest.java
+++ b/drools-workbench-models/drools-workbench-models-guided-dtable/src/test/java/org/drools/workbench/models/guided/dtable/backend/BRLRuleModelTest.java
@@ -1384,7 +1384,7 @@ public class BRLRuleModelTest {
                 "when\n" +
                 "  x : Context( )\n" +
                 "then\n" +
-                "  x.add( \"test\" );\n" +
+                "  x.add( @{test} );\n" +
                 "end\n";
 
         assertEqualsIgnoreWhitespace(expected,

--- a/drools-workbench-models/drools-workbench-models-guided-dtable/src/test/java/org/drools/workbench/models/guided/dtable/backend/BRLRuleModelTest.java
+++ b/drools-workbench-models/drools-workbench-models-guided-dtable/src/test/java/org/drools/workbench/models/guided/dtable/backend/BRLRuleModelTest.java
@@ -1384,7 +1384,7 @@ public class BRLRuleModelTest {
                 "when\n" +
                 "  x : Context( )\n" +
                 "then\n" +
-                "  x.add( @{test} );\n" +
+                "  x.add( \"test\" );\n" +
                 "end\n";
 
         assertEqualsIgnoreWhitespace(expected,


### PR DESCRIPTION
Fixes wrong clone of ActionFieldValue

<details>
<summary>
How to replicate CI configuration locally?
</summary>

Build Chain tool does "simple" maven build(s), the builds are just Maven commands, but because the repositories relates and depends on each other and any change in API or class method could affect several of those repositories there is a need to use [build-chain tool](https://github.com/kiegroup/github-action-build-chain) to handle cross repository builds and be sure that we always use latest version of the code for each repository.
 
[build-chain tool](https://github.com/kiegroup/github-action-build-chain) is a build tool which can be used on command line locally or in Github Actions workflow(s), in case you need to change multiple repositories and send multiple dependent pull requests related with a change you can easily reproduce the same build by executing it on Github hosted environment or locally in your development environment. See [local execution](https://github.com/kiegroup/github-action-build-chain#local-execution) details to get more information about it.
</details>

<details>
<summary>
How to retest this PR or trigger a specific build:
</summary>

- for <b>pull request and downstream checks</b>  
  - Push a new commit to the PR. An empty commit would be enough.

- for a <b>full downstream build</b>
  - for <b>github actions</b> job: add the label `run_fdb`

- for <b>Jenkins PR check only</b>
  - If you are an ASF committer for KIE podling, login to Jenkins (https://ci-builds.apache.org/job/KIE/job/drools/), go to the specific PR job, and click on `Build Now` button.
</details>
