### PR TITLE
[incubator-kie-issues#1326] `string join` function with `list` parameter in string format invocation is missing

### DIFF
--- a/kie-dmn/kie-dmn-core/src/test/java/org/kie/dmn/core/compiler/profiles/ExtendedDMNProfileTest.java
+++ b/kie-dmn/kie-dmn-core/src/test/java/org/kie/dmn/core/compiler/profiles/ExtendedDMNProfileTest.java
@@ -41,26 +41,28 @@ import org.kie.dmn.feel.runtime.functions.SplitFunction;
 import org.kie.dmn.feel.runtime.functions.SqrtFunction;
 import org.kie.dmn.feel.runtime.functions.StddevFunction;
 import org.kie.dmn.feel.runtime.functions.extended.DateFunction;
+import org.kie.dmn.feel.runtime.functions.extended.StringJoinFunction;
 import org.kie.dmn.feel.runtime.functions.extended.TimeFunction;
 
 import static java.math.BigDecimal.valueOf;
 import static org.assertj.core.api.Assertions.assertThat;
 
 class ExtendedDMNProfileTest {
+
     private final DateFunction dateFunction = DateFunction.INSTANCE;
-    private final TimeFunction timeFunction = TimeFunction.INSTANCE;
-    private final SplitFunction splitFunction = SplitFunction.INSTANCE;
-    private final ProductFunction productFunction = ProductFunction.INSTANCE;
-    private final MedianFunction medianFunction = MedianFunction.INSTANCE;
-    private final StddevFunction stddevFunction = StddevFunction.INSTANCE;
-    private final ModeFunction modeFunction = ModeFunction.INSTANCE;
-    private final AbsFunction absFunction = AbsFunction.INSTANCE;
-    private final ModuloFunction moduloFunction = ModuloFunction.INSTANCE;
-    private final SqrtFunction sqrtFunction = SqrtFunction.INSTANCE;
-    private final LogFunction logFunction = LogFunction.INSTANCE;
-    private final ExpFunction expFunction = ExpFunction.INSTANCE;
     private final EvenFunction evenFunction = EvenFunction.INSTANCE;
+    private final ExpFunction expFunction = ExpFunction.INSTANCE;
+    private final LogFunction logFunction = LogFunction.INSTANCE;
+    private final MedianFunction medianFunction = MedianFunction.INSTANCE;
+    private final ModeFunction modeFunction = ModeFunction.INSTANCE;
+    private final ModuloFunction moduloFunction = ModuloFunction.INSTANCE;
     private final OddFunction oddFunction = OddFunction.INSTANCE;
+    private final ProductFunction productFunction = ProductFunction.INSTANCE;
+    private final SplitFunction splitFunction = SplitFunction.INSTANCE;
+    private final SqrtFunction sqrtFunction = SqrtFunction.INSTANCE;
+    private final StddevFunction stddevFunction = StddevFunction.INSTANCE;
+    private final StringJoinFunction stringJoinFunction = StringJoinFunction.INSTANCE;
+    private final TimeFunction timeFunction = TimeFunction.INSTANCE;
 
     @Test
     void dateFunctionInvokeParamStringDateTime() {
@@ -160,6 +162,20 @@ class ExtendedDMNProfileTest {
     void evenFunctionFractional() {
         assertNull(evenFunction.invoke(valueOf(5.5)));
         assertResult(evenFunction.invoke(valueOf(2.0)), Boolean.TRUE);
+    }
+
+    @Test
+    void stringJoinFunction() {
+        assertResult(stringJoinFunction.invoke(Arrays.asList("a", "b", "c"), "_and_"), "a_and_b_and_c");
+        assertResult(stringJoinFunction.invoke(Arrays.asList("a", "b", "c"), ""), "abc");
+        assertResult(stringJoinFunction.invoke(Arrays.asList("a", "b", "c"), null), "abc");
+        assertResult(stringJoinFunction.invoke(Arrays.asList("a"), "X"), "a");
+        assertResult(stringJoinFunction.invoke("a", "X"), "a");
+        assertResult(stringJoinFunction.invoke(Arrays.asList("a", null, "c"), "X"), "aXc");
+        assertResult(stringJoinFunction.invoke(Collections.emptyList(), "X"), "");
+        assertResult(stringJoinFunction.invoke(Arrays.asList("a", "b", "c")), "abc");
+        assertResult(stringJoinFunction.invoke(Arrays.asList("a", null, "c")), "ac");
+        assertResult(stringJoinFunction.invoke(Collections.emptyList()), "");
     }
 
     private static <T> void assertResult(final FEELFnResult<T> result, final T val) {

--- a/kie-dmn/kie-dmn-feel/src/main/java/org/kie/dmn/feel/runtime/functions/extended/StringJoinFunction.java
+++ b/kie-dmn/kie-dmn-feel/src/main/java/org/kie/dmn/feel/runtime/functions/extended/StringJoinFunction.java
@@ -55,6 +55,10 @@ public class StringJoinFunction extends BaseFEELFunction {
         return FEELFnResult.ofResult(sj.toString());
     }
 
+    public FEELFnResult<String> invoke(@ParameterName("list") String stringValue, @ParameterName("delimiter") String delimiter) {
+        return invoke(List.of(stringValue), delimiter);
+    }
+
     public FEELFnResult<String> invoke(@ParameterName("list") List<?> list) {
         return invoke(list, null);
     }

--- a/kie-dmn/kie-dmn-feel/src/main/java/org/kie/dmn/feel/runtime/functions/extended/StringJoinFunction.java
+++ b/kie-dmn/kie-dmn-feel/src/main/java/org/kie/dmn/feel/runtime/functions/extended/StringJoinFunction.java
@@ -56,6 +56,10 @@ public class StringJoinFunction extends BaseFEELFunction {
     }
 
     public FEELFnResult<String> invoke(@ParameterName("list") String stringValue, @ParameterName("delimiter") String delimiter) {
+        if ( stringValue == null ) {
+            return FEELFnResult.ofError(new InvalidParametersEvent(Severity.ERROR, "list", "cannot be null"));
+        }
+
         return invoke(List.of(stringValue), delimiter);
     }
 

--- a/kie-dmn/kie-dmn-feel/src/test/java/org/kie/dmn/feel/runtime/KieFEELExtendedFunctionsTest.java
+++ b/kie-dmn/kie-dmn-feel/src/test/java/org/kie/dmn/feel/runtime/KieFEELExtendedFunctionsTest.java
@@ -50,6 +50,7 @@ public class KieFEELExtendedFunctionsTest extends BaseFEELTest {
                 { "string join([\"a\",\"b\",\"c\"], \"\")", "abc", null},
                 { "string join([\"a\",\"b\",\"c\"], null)", "abc", null},
                 { "string join([\"a\"], \"X\")", "a", null},
+                { "string join(\"a\", \"X\")", "a", null},
                 { "string join([\"a\",null,\"c\"], \"X\")", "aXc", null},
                 { "string join([], \"X\")", "", null},
                 { "string join([\"a\",\"b\",\"c\"])", "abc", null},


### PR DESCRIPTION


The function `string join (list <string>, delimiter <string>)` is missing.

Example `string join("a", ".")`

This is not present in the specs, but there are a couple of TCK tests that require it, probably to manage the case of a single-item list. 

Honestly, I don't see the need to manage such a case (i.e. a string join("a", ".") will produce "a") - Adding it just to fix the TCK tests.

Could make sense to discuss in TCK if that function is required? @gitgabrio @baldimir  

@baldimir Provided the original fix.