### PR TITLE
[incubator-kie-issues#1367] The `context` function should throw an error when providing objects with the same keys

### DIFF
--- a/kie-dmn/kie-dmn-feel/src/main/java/org/kie/dmn/feel/runtime/functions/extended/ContextFunction.java
+++ b/kie-dmn/kie-dmn-feel/src/main/java/org/kie/dmn/feel/runtime/functions/extended/ContextFunction.java
@@ -63,6 +63,9 @@ public class ContextFunction extends BaseFEELFunction {
                 } else {
                     return FEELFnResult.ofError(new InvalidParametersEvent(FEELEvent.Severity.ERROR, "entry of index " + (h_index) + " is missing a `value` entry"));
                 }
+                if (result.containsKey(key)) {
+                    return FEELFnResult.ofError(new InvalidParametersEvent(FEELEvent.Severity.ERROR, "entry of index " + (h_index) + " contains duplicate key"));
+                }
                 result.put(key, value);
             } else {
                 return FEELFnResult.ofError(new InvalidParametersEvent(FEELEvent.Severity.ERROR, "entry of index " + (h_index) + " is not a valid context"));

--- a/kie-dmn/kie-dmn-feel/src/test/java/org/kie/dmn/feel/runtime/KieFEELExtendedFunctionsTest.java
+++ b/kie-dmn/kie-dmn-feel/src/test/java/org/kie/dmn/feel/runtime/KieFEELExtendedFunctionsTest.java
@@ -43,7 +43,7 @@ public class KieFEELExtendedFunctionsTest extends BaseFEELTest {
 
     private static Collection<Object[]> data() {
         final Object[][] cases = new Object[][] {
-                { "string(\"Happy %.0fth birthday, Mr %s!\", 38, \"Doe\")", "Happy 38th birthday, Mr Doe!", null},
+                /*{ "string(\"Happy %.0fth birthday, Mr %s!\", 38, \"Doe\")", "Happy 38th birthday, Mr Doe!", null},
                 { "now()", ZonedDateTime.class , null},
                 { "today()", LocalDate.class, null },
                 { "string join([\"a\",\"b\",\"c\"], \"_and_\")", "a_and_b_and_c", null},
@@ -127,9 +127,9 @@ public class KieFEELExtendedFunctionsTest extends BaseFEELTest {
                 { "context merge([{name: \"John Doe\", age: 0}, {age: 47}])", mapOf(entry("name", "John Doe"),entry("age", new BigDecimal(47))), null },
                 { "context([{key: \"name\", value: \"John Doe\"},{\"key\":\"age\", \"value\":47}])", mapOf(entry("name", "John Doe"),entry("age", new BigDecimal(47))), null },
                 { "context([{key: \"name\", value: \"John Doe\"},{\"key\":\"age\", \"value\":47, \"something\":\"else\"}])", mapOf(entry("name", "John Doe"),entry("age", new BigDecimal(47))), null },
-                { "context([{key: \"name\", value: \"John Doe\"},{\"key\":\"age\"}])", null, FEELEvent.Severity.ERROR },
-                { "context([{key: \"name\", value: \"John Doe\"},{\"key\": \"name\" \"value\": \"Doe John\"}])", null, FEELEvent.Severity.ERROR },
-                { "time(10, 20, 30)", LocalTime.of(10, 20, 30), null },
+                { "context([{key: \"name\", value: \"John Doe\"},{\"key\":\"age\"}])", null, FEELEvent.Severity.ERROR }, */
+                { "context([{key: \"name\", value: \"John Doe\"},{key: \"name\", value: \"Doe John\"}])", null, FEELEvent.Severity.ERROR },
+                /*{ "time(10, 20, 30)", LocalTime.of(10, 20, 30), null },
                 { "date( 2020, 2, 31 )", null, FEELEvent.Severity.ERROR},
                 { "date( \"2020-02-31\" )", null, FEELEvent.Severity.ERROR},
                 { "range(\"[1..10]\")", Range.class, null },
@@ -143,7 +143,7 @@ public class KieFEELExtendedFunctionsTest extends BaseFEELTest {
                 { "range(\"[1..10[\").end included", false, null },
                 { "range(\"[date(\\\"2022-01-01\\\")..date(\\\"2023-01-01\\\"))\")", Range.class, null },
                 { "range(\"[date(\\\"2022-01-01\\\")..date(\\\"2023-01-01\\\"))\").end included", false, null },
-                { "range(\"[date(\\\"2022-01-01\\\")..date(\\\"2023-01-01\\\"))\").end.year", new BigDecimal("2023"), null },
+                { "range(\"[date(\\\"2022-01-01\\\")..date(\\\"2023-01-01\\\"))\").end.year", new BigDecimal("2023"), null },*/
         };
         return addAdditionalParameters(cases, true);
     }

--- a/kie-dmn/kie-dmn-feel/src/test/java/org/kie/dmn/feel/runtime/KieFEELExtendedFunctionsTest.java
+++ b/kie-dmn/kie-dmn-feel/src/test/java/org/kie/dmn/feel/runtime/KieFEELExtendedFunctionsTest.java
@@ -43,7 +43,7 @@ public class KieFEELExtendedFunctionsTest extends BaseFEELTest {
 
     private static Collection<Object[]> data() {
         final Object[][] cases = new Object[][] {
-                /*{ "string(\"Happy %.0fth birthday, Mr %s!\", 38, \"Doe\")", "Happy 38th birthday, Mr Doe!", null},
+                { "string(\"Happy %.0fth birthday, Mr %s!\", 38, \"Doe\")", "Happy 38th birthday, Mr Doe!", null},
                 { "now()", ZonedDateTime.class , null},
                 { "today()", LocalDate.class, null },
                 { "string join([\"a\",\"b\",\"c\"], \"_and_\")", "a_and_b_and_c", null},
@@ -127,9 +127,9 @@ public class KieFEELExtendedFunctionsTest extends BaseFEELTest {
                 { "context merge([{name: \"John Doe\", age: 0}, {age: 47}])", mapOf(entry("name", "John Doe"),entry("age", new BigDecimal(47))), null },
                 { "context([{key: \"name\", value: \"John Doe\"},{\"key\":\"age\", \"value\":47}])", mapOf(entry("name", "John Doe"),entry("age", new BigDecimal(47))), null },
                 { "context([{key: \"name\", value: \"John Doe\"},{\"key\":\"age\", \"value\":47, \"something\":\"else\"}])", mapOf(entry("name", "John Doe"),entry("age", new BigDecimal(47))), null },
-                { "context([{key: \"name\", value: \"John Doe\"},{\"key\":\"age\"}])", null, FEELEvent.Severity.ERROR }, */
+                { "context([{key: \"name\", value: \"John Doe\"},{\"key\":\"age\"}])", null, FEELEvent.Severity.ERROR },
                 { "context([{key: \"name\", value: \"John Doe\"},{key: \"name\", value: \"Doe John\"}])", null, FEELEvent.Severity.ERROR },
-                /*{ "time(10, 20, 30)", LocalTime.of(10, 20, 30), null },
+                { "time(10, 20, 30)", LocalTime.of(10, 20, 30), null },
                 { "date( 2020, 2, 31 )", null, FEELEvent.Severity.ERROR},
                 { "date( \"2020-02-31\" )", null, FEELEvent.Severity.ERROR},
                 { "range(\"[1..10]\")", Range.class, null },
@@ -143,7 +143,7 @@ public class KieFEELExtendedFunctionsTest extends BaseFEELTest {
                 { "range(\"[1..10[\").end included", false, null },
                 { "range(\"[date(\\\"2022-01-01\\\")..date(\\\"2023-01-01\\\"))\")", Range.class, null },
                 { "range(\"[date(\\\"2022-01-01\\\")..date(\\\"2023-01-01\\\"))\").end included", false, null },
-                { "range(\"[date(\\\"2022-01-01\\\")..date(\\\"2023-01-01\\\"))\").end.year", new BigDecimal("2023"), null },*/
+                { "range(\"[date(\\\"2022-01-01\\\")..date(\\\"2023-01-01\\\"))\").end.year", new BigDecimal("2023"), null },
         };
         return addAdditionalParameters(cases, true);
     }

--- a/kie-dmn/kie-dmn-feel/src/test/java/org/kie/dmn/feel/runtime/KieFEELExtendedFunctionsTest.java
+++ b/kie-dmn/kie-dmn-feel/src/test/java/org/kie/dmn/feel/runtime/KieFEELExtendedFunctionsTest.java
@@ -128,6 +128,7 @@ public class KieFEELExtendedFunctionsTest extends BaseFEELTest {
                 { "context([{key: \"name\", value: \"John Doe\"},{\"key\":\"age\", \"value\":47}])", mapOf(entry("name", "John Doe"),entry("age", new BigDecimal(47))), null },
                 { "context([{key: \"name\", value: \"John Doe\"},{\"key\":\"age\", \"value\":47, \"something\":\"else\"}])", mapOf(entry("name", "John Doe"),entry("age", new BigDecimal(47))), null },
                 { "context([{key: \"name\", value: \"John Doe\"},{\"key\":\"age\"}])", null, FEELEvent.Severity.ERROR },
+                { "context([{key: \"name\", value: \"John Doe\"},{\"key\": \"name\" \"value\": \"Doe John\"}])", null, FEELEvent.Severity.ERROR },
                 { "time(10, 20, 30)", LocalTime.of(10, 20, 30), null },
                 { "date( 2020, 2, 31 )", null, FEELEvent.Severity.ERROR},
                 { "date( \"2020-02-31\" )", null, FEELEvent.Severity.ERROR},

--- a/kie-dmn/kie-dmn-feel/src/test/java/org/kie/dmn/feel/runtime/functions/extended/ContextFunctionTest.java
+++ b/kie-dmn/kie-dmn-feel/src/test/java/org/kie/dmn/feel/runtime/functions/extended/ContextFunctionTest.java
@@ -1,0 +1,54 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.kie.dmn.feel.runtime.functions.extended;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import org.kie.dmn.feel.runtime.events.InvalidParametersEvent;
+import org.kie.dmn.feel.runtime.functions.FunctionTestUtil;
+
+import java.util.List;
+
+class ContextFunctionTest {
+
+    private ContextFunction contextFunction;
+    private record ContextEntry(String key, Object value) {}
+
+    @BeforeEach
+    void setUp() {
+        contextFunction = new ContextFunction();
+    }
+
+    @Test
+    void invokeListNull() {
+        FunctionTestUtil.assertResultError(contextFunction.invoke(null), InvalidParametersEvent.class);
+    }
+
+    @Test
+    void invokeContainsNull() {
+        FunctionTestUtil.assertResultError(contextFunction.invoke(List.of(new ContextEntry("name", null))), InvalidParametersEvent.class);
+        FunctionTestUtil.assertResultError(contextFunction.invoke(List.of(new ContextEntry(null, "John Doe"))), InvalidParametersEvent.class);
+    }
+
+    @Test
+    void invokeDuplicateKey() {
+        FunctionTestUtil.assertResultError(contextFunction.invoke(List.of(new ContextEntry("name", "John Doe"), new ContextEntry("name", "Doe John"))), InvalidParametersEvent.class);
+    }
+}

--- a/kie-dmn/kie-dmn-feel/src/test/java/org/kie/dmn/feel/runtime/functions/extended/ContextFunctionTest.java
+++ b/kie-dmn/kie-dmn-feel/src/test/java/org/kie/dmn/feel/runtime/functions/extended/ContextFunctionTest.java
@@ -25,6 +25,7 @@ import org.kie.dmn.feel.runtime.events.InvalidParametersEvent;
 import org.kie.dmn.feel.runtime.functions.FunctionTestUtil;
 
 import java.util.List;
+import java.util.Map;
 
 class ContextFunctionTest {
 
@@ -42,13 +43,19 @@ class ContextFunctionTest {
     }
 
     @Test
-    void invokeContainsNull() {
-        FunctionTestUtil.assertResultError(contextFunction.invoke(List.of(new ContextEntry("name", null))), InvalidParametersEvent.class);
-        FunctionTestUtil.assertResultError(contextFunction.invoke(List.of(new ContextEntry(null, "John Doe"))), InvalidParametersEvent.class);
-    }
+    void invokeContainsNoKeyAndValue() {
+        FunctionTestUtil.assertResultError(contextFunction.invoke(List.of(
+                Map.of("test", "name", "value", "John Doe"),
+                Map.of("key", "name", "test", "John Doe"))), InvalidParametersEvent.class);
+}
 
     @Test
     void invokeDuplicateKey() {
-        FunctionTestUtil.assertResultError(contextFunction.invoke(List.of(new ContextEntry("name", "John Doe"), new ContextEntry("name", "Doe John"))), InvalidParametersEvent.class);
+        FunctionTestUtil.assertResultError(contextFunction.invoke(List.of(
+                Map.of("key", "name", "value", "John Doe"),
+                Map.of("key", "name", "value", "John Doe"))), InvalidParametersEvent.class);
+        FunctionTestUtil.assertResultNotError(contextFunction.invoke(List.of(
+                Map.of("key", "name", "value", "John Doe"),
+                Map.of("key", "age", "value", 12))));
     }
 }


### PR DESCRIPTION
Closes https://github.com/apache/incubator-kie-issues/issues/1367

The `context` function should throw an error when providing objects with the same keys