### PR TITLE
NO-ISSUE: `dependabot.yml` fixed

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -17,6 +17,7 @@
 # under the License.
 #
 
+version: 2
 updates:
 - package-ecosystem: maven
   directory: "/"


### PR DESCRIPTION
Fixing `dependabot.yml` configuration

```
Your .github/dependabot.yml contained invalid details

Dependabot encountered the following error when parsing your .github/dependabot.yml:

The property '#/' did not contain a required property of 'version'
```
