### PR TITLE
kie-issues#1381: Increase setup-branch job timeout

### DIFF
--- a/.ci/jenkins/Jenkinsfile.setup-branch
+++ b/.ci/jenkins/Jenkinsfile.setup-branch
@@ -33,7 +33,7 @@ pipeline {
 
     options {
         timestamps()
-        timeout(time: 60, unit: 'MINUTES')
+        timeout(time: 180, unit: 'MINUTES')
     }
 
     environment {
@@ -65,7 +65,7 @@ pipeline {
                             maven.mvnVersionsSet(
                                 getMavenCommand().withSettingsXmlFile(MAVEN_SETTINGS_FILE),
                                 getDroolsVersion(),
-                                true
+                                false
                             )
                         }
                     }

--- a/.ci/jenkins/Jenkinsfile.setup-branch
+++ b/.ci/jenkins/Jenkinsfile.setup-branch
@@ -65,7 +65,7 @@ pipeline {
                             maven.mvnVersionsSet(
                                 getMavenCommand().withSettingsXmlFile(MAVEN_SETTINGS_FILE),
                                 getDroolsVersion(),
-                                false
+                                true
                             )
                         }
                     }


### PR DESCRIPTION
As part of our tests for the Apache 10 release we found out that the setup-branch Jenkins job was timing out.

This PR increases the job timeout to 180 minutes to avoid such errors.