### PR TITLE
[incubator-kie-issues#1382] Fix identifier retrieval for quoted strings

### DIFF
--- a/drools-mvel/src/main/java/org/drools/mvel/MVELConstraint.java
+++ b/drools-mvel/src/main/java/org/drools/mvel/MVELConstraint.java
@@ -553,7 +553,7 @@ public class MVELConstraint extends MutableTypeConstraint<ContextEntry> implemen
     private int nextPropertyName(String expression, List<String> names, int cursor) {
         StringBuilder propertyNameBuilder = new StringBuilder();
         cursor = extractFirstIdentifier(expression, propertyNameBuilder, cursor);
-        if (propertyNameBuilder.length() == 0) {
+        if (propertyNameBuilder.isEmpty()) {
             return cursor;
         }
 

--- a/drools-util/src/main/java/org/drools/util/StringUtils.java
+++ b/drools-util/src/main/java/org/drools/util/StringUtils.java
@@ -964,8 +964,23 @@ public class StringUtils {
         return builder.toString();
     }
 
+    /**
+     * Method that tries to extract <b>identifiers</b> from a Srting.
+     * First, it tries to identify "quoted" part, that should be ignored.
+     * Then, it tries to extract a String that is valid as java identifier.
+     * If an identifier is found, returns the last index of the identifier itself, otherwise the length of the string itself
+     *
+     * {@link Character#isJavaIdentifierStart}
+     * {@link Character#isJavaIdentifierPart}
+     * @param string
+     * @param builder
+     * @param start
+     * @return
+     */
     public static int extractFirstIdentifier(String string, StringBuilder builder, int start) {
         boolean isQuoted = false;
+        boolean isDoubleQuoted = false;
+        boolean isSingleQuoted = false;
         boolean started = false;
         int i = start;
         for (; i < string.length(); i++) {
@@ -973,13 +988,16 @@ public class StringUtils {
             if (!isQuoted && Character.isJavaIdentifierStart(ch)) {
                 builder.append(ch);
                 started = true;
-            } else if (ch == '"' || ch == '\'') {
-                isQuoted = !isQuoted;
+            } else if (ch == '"') {
+                isDoubleQuoted = !isQuoted && !isDoubleQuoted;
+            } else if (ch == '\'') {
+                isSingleQuoted = !isQuoted && !isSingleQuoted;
             } else if (started && Character.isJavaIdentifierPart(ch)) {
                 builder.append(ch);
             } else if (started) {
                 break;
             }
+            isQuoted = isDoubleQuoted || isSingleQuoted;
         }
         return i;
     }

--- a/drools-util/src/test/java/org/drools/util/StringUtilsTest.java
+++ b/drools-util/src/test/java/org/drools/util/StringUtilsTest.java
@@ -240,6 +240,111 @@ public class StringUtilsTest {
     }
 
     @Test
+    public void testExtractFirstIdentifierWithStringBuilder() {
+        // Not-quoted string, interpreted as identifier
+        String string = "IDENTIFIER";
+        String expected = string;
+        StringBuilder builder = new StringBuilder();
+        int start = 0;
+        int retrieved = StringUtils.extractFirstIdentifier(string, builder, start);
+        assertThat(retrieved).isEqualTo(string.length()); // retrieved size is equals to the length of given string
+        assertThat(builder.toString()).isEqualTo(expected);
+
+        // Quoted string, not interpreted as identifier
+        string = "\"IDENTIFIER\"";
+        expected = "";
+        builder = new StringBuilder();
+        retrieved = StringUtils.extractFirstIdentifier(string, builder, start);
+        assertThat(retrieved).isEqualTo(string.length());
+        assertThat(builder.toString()).isEqualTo(expected);
+
+        // Only the not-quoted string, and its size, is returned
+        string = "IDENTIFIER \"";
+        expected = "IDENTIFIER";
+        builder = new StringBuilder();
+        retrieved = StringUtils.extractFirstIdentifier(string, builder, start);
+        assertThat(retrieved).isEqualTo(expected.length()); // it returns the index where the identifier ends
+        assertThat(builder.toString()).isEqualTo(expected);
+
+        string = "IDENTIFIER \"the_identifier";
+        expected = "IDENTIFIER";
+        builder = new StringBuilder();
+        retrieved = StringUtils.extractFirstIdentifier(string, builder, start);
+        assertThat(retrieved).isEqualTo(expected.length()); // it returns the index where the identifier ends
+        assertThat(builder.toString()).isEqualTo(expected);
+
+        string = "\"the_identifier\" IDENTIFIER";
+        expected = "IDENTIFIER";
+        builder = new StringBuilder();
+        retrieved = StringUtils.extractFirstIdentifier(string, builder, start);
+        assertThat(retrieved).isEqualTo(string.length()); // it returns the index where the identifier ends
+        assertThat(builder.toString()).isEqualTo(expected);
+
+        // Quoted string, not interpreted as identifier, starting at arbitrary position
+        string = "THIS IS BEFORE \"IDENTIFIER\"";
+        expected = "";
+        builder = new StringBuilder();
+        start = 14;
+        retrieved = StringUtils.extractFirstIdentifier(string, builder, start);
+        assertThat(retrieved).isEqualTo(string.length());
+        assertThat(builder.toString()).isEqualTo(expected);
+
+        // Only the not-quoted string, and its size, is returned, starting at arbitrary position
+        string = "THIS IS BEFORE IDENTIFIER \"";
+        expected = "IDENTIFIER";
+        builder = new StringBuilder();
+        retrieved = StringUtils.extractFirstIdentifier(string, builder, start);
+        assertThat(retrieved).isEqualTo(25); // it returns the index where the identifier ends
+        assertThat(builder.toString()).isEqualTo(expected);
+
+        string = "IDENTIFIER \"the_identifier";
+        expected = "";
+        builder = new StringBuilder();
+        start = 10;
+        retrieved = StringUtils.extractFirstIdentifier(string, builder, start);
+        assertThat(retrieved).isEqualTo(string.length()); // it returns the index where the identifier ends
+        assertThat(builder.toString()).isEqualTo(expected);
+
+        string = "IDENTIFIER \"the_identifier";
+        expected = "";
+        builder = new StringBuilder();
+        start = 10;
+        retrieved = StringUtils.extractFirstIdentifier(string, builder, start);
+        assertThat(retrieved).isEqualTo(string.length()); // it returns the index where the identifier ends
+        assertThat(builder.toString()).isEqualTo(expected);
+
+        string = "\"not an ' identifier\"";
+        expected = "";
+        builder = new StringBuilder();
+        start = 0;
+        retrieved = StringUtils.extractFirstIdentifier(string, builder, start);
+        assertThat(retrieved).isEqualTo(string.length()); // it returns the whole string length
+        assertThat(builder.toString()).isEqualTo(expected);
+
+        string = "'not an \" identifier'";
+        expected = "";
+        builder = new StringBuilder();
+        retrieved = StringUtils.extractFirstIdentifier(string, builder, start);
+        assertThat(retrieved).isEqualTo(string.length()); // it returns the whole string length
+        assertThat(builder.toString()).isEqualTo(expected);
+
+        string = "'not an \" identifier\"'";
+        expected = "";
+        builder = new StringBuilder();
+        retrieved = StringUtils.extractFirstIdentifier(string, builder, start);
+        assertThat(retrieved).isEqualTo(string.length()); // it returns the whole string length
+        assertThat(builder.toString()).isEqualTo(expected);
+
+        string = "\"an \" IDENTIFIER";
+        expected = "IDENTIFIER";
+        builder = new StringBuilder();
+        retrieved = StringUtils.extractFirstIdentifier(string, builder, start);
+        assertThat(retrieved).isEqualTo(string.length()); // it returns the index where the identifier ends
+        assertThat(builder.toString()).isEqualTo(expected);
+
+    }
+
+    @Test
     public void testSplitStatements() {
         String text =
                 "System.out.println(\"'\");" +


### PR DESCRIPTION
Fixes https://github.com/apache/incubator-kie-issues/issues/1382



<details>
<summary>
How to replicate CI configuration locally?
</summary>

Build Chain tool does "simple" maven build(s), the builds are just Maven commands, but because the repositories relates and depends on each other and any change in API or class method could affect several of those repositories there is a need to use [build-chain tool](https://github.com/kiegroup/github-action-build-chain) to handle cross repository builds and be sure that we always use latest version of the code for each repository.
 
[build-chain tool](https://github.com/kiegroup/github-action-build-chain) is a build tool which can be used on command line locally or in Github Actions workflow(s), in case you need to change multiple repositories and send multiple dependent pull requests related with a change you can easily reproduce the same build by executing it on Github hosted environment or locally in your development environment. See [local execution](https://github.com/kiegroup/github-action-build-chain#local-execution) details to get more information about it.
</details>

<details>
<summary>
How to retest this PR or trigger a specific build:
</summary>

- for <b>pull request and downstream checks</b>  
  - Push a new commit to the PR. An empty commit would be enough.

- for a <b>full downstream build</b>
  - for <b>github actions</b> job: add the label `run_fdb`

- for <b>Jenkins PR check only</b>
  - If you are an ASF committer for KIE podling, login to Jenkins (https://ci-builds.apache.org/job/KIE/job/drools/), go to the specific PR job, and click on `Build Now` button.
</details>
