### PR TITLE
[incubator-kie-issues#1150] Improve Import Resolver error messages to be more user friendly - Part II

### DIFF
--- a/kie-dmn/kie-dmn-core/src/main/java/org/kie/dmn/core/compiler/ImportDMNResolverUtil.java
+++ b/kie-dmn/kie-dmn-core/src/main/java/org/kie/dmn/core/compiler/ImportDMNResolverUtil.java
@@ -21,7 +21,6 @@ package org.kie.dmn.core.compiler;
 import java.util.Collection;
 import java.util.List;
 import java.util.function.Function;
-import java.util.stream.Collectors;
 
 import javax.xml.namespace.QName;
 
@@ -51,27 +50,27 @@ public class ImportDMNResolverUtil {
 
         LOGGER.debug("Resolving an Import in DMN Model with name={} and namespace={}. " +
                         "Importing a DMN model with namespace={} name={} locationURI={}, modelName={}",
-                importerDMNNamespace, importerDMNName, importNamespace, importName, importLocationURI, importModelName);
+                importerDMNName, importerDMNNamespace, importNamespace, importName, importLocationURI, importModelName);
 
         List<T> matchingDMNList = dmns.stream()
                 .filter(m -> idExtractor.apply(m).getNamespaceURI().equals(importNamespace))
-                .collect(Collectors.toList());
+                .toList();
         if (matchingDMNList.size() == 1) {
             T located = matchingDMNList.get(0);
             // Check if the located DMN Model in the NS, correspond for the import `drools:modelName`. 
             if (importModelName == null || idExtractor.apply(located).getLocalPart().equals(importModelName)) {
                 LOGGER.debug("DMN Model with name={} and namespace={} successfully imported a DMN " +
                                 "with namespace={} name={} locationURI={}, modelName={}",
-                        importerDMNNamespace, importerDMNName, importNamespace, importName, importLocationURI, importModelName);
+                        importerDMNName, importerDMNNamespace, importNamespace, importName, importLocationURI, importModelName);
                 return Either.ofRight(located);
             } else {
                 LOGGER.error("DMN Model with name={} and namespace={} can't import a DMN with namespace={}, name={}, modelName={}, " +
                                 "located within namespace only {} but does not match for the actual modelName",
-                        importerDMNNamespace, importerDMNName, importNamespace, importName, importModelName, idExtractor.apply(located));
+                        importerDMNName, importerDMNNamespace, importNamespace, importName, importModelName, idExtractor.apply(located));
                 return Either.ofLeft(String.format(
                         "DMN Model with name=%s and namespace=%s can't import a DMN with namespace=%s, name=%s, modelName=%s, " +
                                 "located within namespace only %s but does not match for the actual modelName",
-                        importerDMNNamespace, importerDMNName, importNamespace, importName, importModelName, idExtractor.apply(located)));
+                        importerDMNName, importerDMNNamespace, importNamespace, importName, importModelName, idExtractor.apply(located)));
             }
         } else {
             List<T> usingNSandName = matchingDMNList.stream()
@@ -80,22 +79,22 @@ public class ImportDMNResolverUtil {
             if (usingNSandName.size() == 1) {
                 LOGGER.debug("DMN Model with name={} and namespace={} successfully imported a DMN " +
                                 "with namespace={} name={} locationURI={}, modelName={}",
-                        importerDMNNamespace, importerDMNName, importNamespace, importName, importLocationURI, importModelName);
+                        importerDMNName, importerDMNNamespace, importNamespace, importName, importLocationURI, importModelName);
                 return Either.ofRight(usingNSandName.get(0));
             } else if (usingNSandName.isEmpty()) {
                 LOGGER.error("DMN Model with name={} and namespace={} failed to import a DMN with namespace={} name={} locationURI={}, modelName={}.",
-                        importerDMNNamespace, importerDMNName, importNamespace, importName, importLocationURI, importModelName);
+                        importerDMNName, importerDMNNamespace, importNamespace, importName, importLocationURI, importModelName);
                 return Either.ofLeft(String.format(
                         "DMN Model with name=%s and namespace=%s failed to import a DMN with namespace=%s name=%s locationURI=%s, modelName=%s. ",
-                        importerDMNNamespace, importerDMNName, importNamespace, importName, importLocationURI, importModelName));
+                        importerDMNName, importerDMNNamespace, importNamespace, importName, importLocationURI, importModelName));
             } else {
                 LOGGER.error("DMN Model with name={} and namespace={} detected a collision ({} elements) trying to import a DMN with namespace={} name={} locationURI={}, modelName={}",
-                        importerDMNNamespace, importerDMNName, usingNSandName.size(), importNamespace, importName, importLocationURI, importModelName);
+                        importerDMNName, importerDMNNamespace, usingNSandName.size(), importNamespace, importName, importLocationURI, importModelName);
                 return Either.ofLeft(String.format(
                         "DMN Model with name=%s and namespace=%s detected a collision trying to import a DMN with %s namespace, " +
                                 "%s name and modelName %s. There are %s DMN files with the same namespace in your project. " +
                                 "Please change the DMN namespaces and make them unique to fix this issue.",
-                        importerDMNNamespace, importerDMNName, importNamespace, importName, importModelName, usingNSandName.size()));
+                        importerDMNName, importerDMNNamespace, importNamespace, importName, importModelName, usingNSandName.size()));
             }
         }
     }


### PR DESCRIPTION
Follow-up of https://github.com/apache/incubator-kie-drools/pull/6014

Fixing wrong variables ordering for Logs and Error messages



<details>
<summary>
How to replicate CI configuration locally?
</summary>

Build Chain tool does "simple" maven build(s), the builds are just Maven commands, but because the repositories relates and depends on each other and any change in API or class method could affect several of those repositories there is a need to use [build-chain tool](https://github.com/kiegroup/github-action-build-chain) to handle cross repository builds and be sure that we always use latest version of the code for each repository.
 
[build-chain tool](https://github.com/kiegroup/github-action-build-chain) is a build tool which can be used on command line locally or in Github Actions workflow(s), in case you need to change multiple repositories and send multiple dependent pull requests related with a change you can easily reproduce the same build by executing it on Github hosted environment or locally in your development environment. See [local execution](https://github.com/kiegroup/github-action-build-chain#local-execution) details to get more information about it.
</details>

<details>
<summary>
How to retest this PR or trigger a specific build:
</summary>

- for <b>pull request and downstream checks</b>  
  - Push a new commit to the PR. An empty commit would be enough.

- for a <b>full downstream build</b>
  - for <b>github actions</b> job: add the label `run_fdb`

- for <b>Jenkins PR check only</b>
  - If you are an ASF committer for KIE podling, login to Jenkins (https://ci-builds.apache.org/job/KIE/job/drools/), go to the specific PR job, and click on `Build Now` button.
</details>
