### PR TITLE
[Incubator-kie-issues#1345] It shouldn't be possible to add\subtract a DateTime with a number

### DIFF
--- a/kie-dmn/kie-dmn-feel/src/main/java/org/kie/dmn/feel/lang/ast/infixexecutors/AddExecutor.java
+++ b/kie-dmn/kie-dmn-feel/src/main/java/org/kie/dmn/feel/lang/ast/infixexecutors/AddExecutor.java
@@ -22,7 +22,6 @@ import java.math.BigDecimal;
 import java.math.MathContext;
 import java.time.Duration;
 import java.time.LocalDate;
-import java.time.Period;
 import java.time.chrono.ChronoPeriod;
 import java.time.temporal.Temporal;
 import java.time.temporal.TemporalAmount;

--- a/kie-dmn/kie-dmn-feel/src/main/java/org/kie/dmn/feel/lang/ast/infixexecutors/AddExecutor.java
+++ b/kie-dmn/kie-dmn-feel/src/main/java/org/kie/dmn/feel/lang/ast/infixexecutors/AddExecutor.java
@@ -90,10 +90,6 @@ public class AddExecutor implements InfixExecutor {
             if (right instanceof TemporalAmount temporalAmount) {
                 return temporal.plus(temporalAmount);
             }
-            if (right instanceof BigDecimal bigDecimal) {
-                Period toAdd = Period.ofDays(bigDecimal.intValue());
-                return temporal.plus(toAdd);
-            }
         } else if (left instanceof TemporalAmount temporalAmount) {
             if (right instanceof Temporal temporal) {
                 return temporal.plus(temporalAmount);

--- a/kie-dmn/kie-dmn-feel/src/test/java/org/kie/dmn/feel/runtime/FEEL12ExtendedForLoopTest.java
+++ b/kie-dmn/kie-dmn-feel/src/test/java/org/kie/dmn/feel/runtime/FEEL12ExtendedForLoopTest.java
@@ -21,6 +21,7 @@ package org.kie.dmn.feel.runtime;
 import java.math.BigDecimal;
 import java.time.LocalDate;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collection;
 import java.util.List;
 import java.util.stream.Collectors;
@@ -45,15 +46,11 @@ public class FEEL12ExtendedForLoopTest extends BaseFEELTest {
     }
 
     private static Collection<Object[]> data() {
-        List<Integer> nullObject = new ArrayList<>();
-        nullObject.add(null);
-        nullObject.add(null);
-        nullObject.add(null);
         final Object[][] cases = new Object[][] {
           //normal:
           {"for x in [1, 2, 3] return x+1", Stream.of(1, 2, 3 ).map(x -> BigDecimal.valueOf(x + 1 ) ).collect(Collectors.toList() ), null},
                 {"for x in @\"2021-01-01\"..@\"2021-01-03\" return x + @\"P1D\"", Stream.of("2021-01-02", "2021-01-03", "2021-01-04" ).map(LocalDate::parse).collect(Collectors.toList() ), null},
-                {"for x in @\"2021-01-01\"..@\"2021-01-03\" return x+1", nullObject, FEELEvent.Severity.ERROR},
+                {"for x in @\"2021-01-01\"..@\"2021-01-03\" return x+1", Arrays.asList(null, null, null), FEELEvent.Severity.ERROR},
 
           //extended:
           {"for x in 1..3 return x+1", Stream.of(1, 2, 3).map(x -> BigDecimal.valueOf(x + 1)).collect(Collectors.toList()), null},

--- a/kie-dmn/kie-dmn-feel/src/test/java/org/kie/dmn/feel/runtime/FEEL12ExtendedForLoopTest.java
+++ b/kie-dmn/kie-dmn-feel/src/test/java/org/kie/dmn/feel/runtime/FEEL12ExtendedForLoopTest.java
@@ -45,10 +45,15 @@ public class FEEL12ExtendedForLoopTest extends BaseFEELTest {
     }
 
     private static Collection<Object[]> data() {
+        List<Integer> nullObject = new ArrayList<>();
+        nullObject.add(null);
+        nullObject.add(null);
+        nullObject.add(null);
         final Object[][] cases = new Object[][] {
           //normal:
           {"for x in [1, 2, 3] return x+1", Stream.of(1, 2, 3 ).map(x -> BigDecimal.valueOf(x + 1 ) ).collect(Collectors.toList() ), null},
-          {"for x in @\"2021-01-01\"..@\"2021-01-03\" return x+1", Stream.of("2021-01-02", "2021-01-03", "2021-01-04" ).map(LocalDate::parse).collect(Collectors.toList() ), null},
+                {"for x in @\"2021-01-01\"..@\"2021-01-03\" return x + @\"P1D\"", Stream.of("2021-01-02", "2021-01-03", "2021-01-04" ).map(LocalDate::parse).collect(Collectors.toList() ), null},
+                {"for x in @\"2021-01-01\"..@\"2021-01-03\" return x+1", nullObject, FEELEvent.Severity.ERROR},
 
           //extended:
           {"for x in 1..3 return x+1", Stream.of(1, 2, 3).map(x -> BigDecimal.valueOf(x + 1)).collect(Collectors.toList()), null},

--- a/kie-dmn/kie-dmn-feel/src/test/java/org/kie/dmn/feel/runtime/FEELDateTimeDurationTest.java
+++ b/kie-dmn/kie-dmn-feel/src/test/java/org/kie/dmn/feel/runtime/FEELDateTimeDurationTest.java
@@ -51,6 +51,8 @@ public class FEELDateTimeDurationTest extends BaseFEELTest {
     private static Collection<Object[]> data() {
         final Object[][] cases = new Object[][] {
                 // date/time/duration function invocations
+                { "@\"2021-01-01\" + 10", null , FEELEvent.Severity.ERROR},
+                { "@\"2021-01-01T10:10:10\" + 10", null , FEELEvent.Severity.ERROR},
                 { "date(\"2016-07-29\")", DateTimeFormatter.ISO_DATE.parse( "2016-07-29", LocalDate::from ) , null},
                 { "@\"2016-07-29\"", DateTimeFormatter.ISO_DATE.parse( "2016-07-29", LocalDate::from ) , null},
                 { "date(\"-0105-07-29\")", DateTimeFormatter.ISO_DATE.parse( "-0105-07-29", LocalDate::from ) , null}, // 105 BC

--- a/kie-dmn/kie-dmn-test-resources/src/test/resources/valid_models/DMNv1_5/ForLoopDatesEvaluate.dmn
+++ b/kie-dmn/kie-dmn-test-resources/src/test/resources/valid_models/DMNv1_5/ForLoopDatesEvaluate.dmn
@@ -40,7 +40,7 @@
     <dmn:extensionElements/>
     <dmn:variable id="_4608E42A-977F-4786-AD2A-DE62804DECBA" name="forloopdates" typeRef="tDates"/>
     <dmn:literalExpression id="_3BC54643-D567-4148-8931-7A5892E5863F">
-      <dmn:text>for x in @"2021-01-01"..@"2021-01-03" return x+1</dmn:text>
+      <dmn:text>for x in @"2021-01-01"..@"2021-01-03" return x + duration("P1D")</dmn:text>
     </dmn:literalExpression>
   </dmn:decision>
   <dmndi:DMNDI>


### PR DESCRIPTION
Fixes https://github.com/apache/incubator-kie-issues/issues/1345

It was possible to add a number with a Temporal and was returning the result, which was not right. According to DMN specification, addition of Temporal with a number shouldn't be supported. This PR has the changes to bring the behavior supported by DMN spec.

