### PR TITLE
[incubator-kie-issues#1411] Adapt DMN code to deal with full href definition (namespace#local_part) for local elements.

### DIFF
--- a/kie-dmn/kie-dmn-core/src/main/java/org/kie/dmn/core/compiler/DMNCompilerImpl.java
+++ b/kie-dmn/kie-dmn-core/src/main/java/org/kie/dmn/core/compiler/DMNCompilerImpl.java
@@ -387,7 +387,7 @@ public class DMNCompilerImpl implements DMNCompiler {
             if (id.getItemComponent() != null && !id.getItemComponent().isEmpty()) {
                 DMNCompilerHelper.checkVariableName(model, id, id.getName());
                 CompositeTypeImpl compType = new CompositeTypeImpl(model.getNamespace(), id.getName(), id.getId(), id.isIsCollection());
-                DMNType preregistered = model.getTypeRegistry().registerType(compType);
+                model.getTypeRegistry().registerType(compType);
             }
         }
 
@@ -598,7 +598,31 @@ public class DMNCompilerImpl implements DMNCompiler {
      */
     public static String getId(DMNElementReference er) {
         String href = er.getHref();
-        return href.startsWith("#") ? href.substring(1) : href;
+        if (href.startsWith("#")) {
+            return href.substring(1);
+        } else {
+            Definitions rootElement = getRootElement(er);
+            String toRemove = String.format("%s#", rootElement.getNamespace());
+            return href.replace(toRemove, "");
+        }
+    }
+
+    /**
+     * Recursively navigate the given <code>DMNModelInstrumentedBase</code> until it gets to the root <code>Definitions</code> element.
+     * it throws a <code>RuntimeException</code> if such element could not be found.
+     *
+     * @param toNavigate
+     * @return
+     * @throws RuntimeException
+     */
+    public static Definitions getRootElement(DMNModelInstrumentedBase toNavigate) {
+        if ( toNavigate instanceof Definitions ) {
+            return (Definitions) toNavigate;
+        } else if ( toNavigate.getParent() != null ) {
+            return getRootElement(toNavigate.getParent());
+        } else {
+            throw new RuntimeException("Failed to get Definitions parent for " + toNavigate);
+        }
     }
 
     /**

--- a/kie-dmn/kie-dmn-core/src/test/java/org/kie/dmn/core/compiler/DMNCompilerImplTest.java
+++ b/kie-dmn/kie-dmn-core/src/test/java/org/kie/dmn/core/compiler/DMNCompilerImplTest.java
@@ -1,0 +1,79 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.kie.dmn.core.compiler;
+
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.kie.dmn.model.api.DMNElementReference;
+import org.kie.dmn.model.api.Definitions;
+import org.kie.dmn.model.api.InformationRequirement;
+import org.kie.dmn.model.v1_5.TDMNElementReference;
+import org.kie.dmn.model.v1_5.TDefinitions;
+import org.kie.dmn.model.v1_5.TInformationRequirement;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.*;
+
+class DMNCompilerImplTest {
+
+    private static final String nameSpace = "http://www.montera.com.au/spec/DMN/local-hrefs";
+    private static Definitions parent;
+
+    @BeforeAll
+    static void setup() {
+        String modelName = "LocalHrefs";
+        parent = new TDefinitions();
+        parent.setName(modelName);
+        parent.setNamespace(nameSpace);
+    }
+
+    @Test
+    void getId() {
+        String localPart = "reference";
+        DMNElementReference elementReference = new TDMNElementReference();
+        elementReference.setHref(String.format("%s#%s", nameSpace, localPart));
+        elementReference.setParent(parent);
+        String retrieved = DMNCompilerImpl.getId(elementReference);
+        assertThat(retrieved).isNotNull().isEqualTo(localPart);
+
+        String expected = String.format("%s#%s", "http://a-different-namespace", localPart);
+        elementReference.setHref(expected);
+        retrieved = DMNCompilerImpl.getId(elementReference);
+        assertThat(retrieved).isNotNull().isEqualTo(expected);
+    }
+
+    @Test
+    void getRootElement() {
+        String localPart = "reference";
+        DMNElementReference elementReference = new TDMNElementReference();
+        String href = String.format("%s#%s", nameSpace, localPart);
+        elementReference.setHref(href);
+        elementReference.setParent(parent);
+        Definitions retrieved = DMNCompilerImpl.getRootElement(elementReference);
+        assertThat(retrieved).isNotNull().isEqualTo(parent);
+
+        InformationRequirement informationRequirement = new TInformationRequirement();
+        elementReference.setParent(informationRequirement);
+        assertThrows(RuntimeException.class, () -> DMNCompilerImpl.getRootElement(elementReference));
+
+        informationRequirement.setParent(parent);
+        retrieved = DMNCompilerImpl.getRootElement(elementReference);
+        assertThat(retrieved).isNotNull().isEqualTo(parent);
+    }
+}

--- a/kie-dmn/kie-dmn-test-resources/src/test/resources/valid_models/DMNv1_5/LocalHrefs.dmn
+++ b/kie-dmn/kie-dmn-test-resources/src/test/resources/valid_models/DMNv1_5/LocalHrefs.dmn
@@ -1,0 +1,46 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<definitions namespace="http://www.montera.com.au/spec/DMN/local-hrefs"
+             name="LocalHrefs"
+             xmlns="https://www.omg.org/spec/DMN/20230324/MODEL/">
+
+  <description>Local (non-imported) qualified hrefs</description>
+
+  <inputData name="input_001" id="_input_001">
+    <variable name="input_001" typeRef="string"/>
+  </inputData>
+
+  <decision name="decision_001" id="_decision_001">
+    <variable name="decision_001" typeRef="string"/>
+    <literalExpression>
+      <text>"decision_001"</text>
+    </literalExpression>
+  </decision>
+
+  <businessKnowledgeModel name="bkm_001" id="_bkm_001">
+    <variable name="bkm_001"/>
+    <encapsulatedLogic>
+      <literalExpression>
+        <text>"bkm_001"</text>
+      </literalExpression>
+    </encapsulatedLogic>
+  </businessKnowledgeModel>
+
+  <!-- requirements hrefs refer to elements in this model -->
+  <decision name="decision_002" id="_decision_002">
+    <variable name="decision_002" typeRef="string"/>
+    <informationRequirement>
+      <requiredDecision href="http://www.montera.com.au/spec/DMN/local-hrefs#_decision_001"/>
+    </informationRequirement>
+    <informationRequirement>
+      <requiredInput href="http://www.montera.com.au/spec/DMN/local-hrefs#_input_001"/>
+    </informationRequirement>
+    <knowledgeRequirement>
+      <requiredKnowledge href="http://www.montera.com.au/spec/DMN/local-hrefs#_bkm_001"/>
+    </knowledgeRequirement>
+    <literalExpression>
+      <text>decision_001 + " " + input_001 + " " + bkm_001()</text>
+    </literalExpression>
+  </decision>
+
+</definitions>
+

--- a/kie-dmn/kie-dmn-validation/src/main/resources/org/kie/dmn/validation/DMNv1x/dmn-validation-rules-dmnelementref.drl
+++ b/kie-dmn/kie-dmn-validation/src/main/resources/org/kie/dmn/validation/DMNv1x/dmn-validation-rules-dmnelementref.drl
@@ -20,8 +20,11 @@
 package org.kie.dmn.validation.DMNv1x;
 
 import org.kie.dmn.model.api.*;
+import org.kie.dmn.model.api.DMNElement;
+import org.kie.dmn.model.api.DMNElementReference;
 import org.kie.dmn.api.core.DMNMessage;
 import org.kie.dmn.core.impl.DMNMessageImpl;
+import org.kie.dmn.core.compiler.DMNCompilerImpl;
 import org.kie.dmn.core.util.MsgUtil;
 import org.kie.dmn.feel.lang.types.BuiltInType;
 import org.kie.dmn.feel.parser.feel11.FEELParser;
@@ -45,7 +48,7 @@ end
 rule ELEMREF_NOHASH_p2
 when
   not( Import() )
-  $oc : DMNElementReference(href contains ":", !href.substring(href.indexOf(":") + 1).startsWith('#'))
+  $oc : DMNElementReference(href contains ":", !(href contains "#"))
 then
   reporter.report( DMNMessage.Severity.ERROR,  $oc , Msg.ELEMREF_NOHASH, $oc.getParentDRDElement().getIdentifierString() );
 end
@@ -60,7 +63,7 @@ end
 
 rule ELEMREF_MISSING_p2
 when
-  $elemRef: DMNElementReference(!href.startsWith("#"), $href: href, href.contains("#"), $targetId : rightOfHash(href), $targetNS : leftOfHash(href))
+  $elemRef: DMNElementReference(!href.startsWith("#"), $href: href, href.contains("#"), $targetId : rightOfHash(href), $targetNS : leftOfHash(href), $rootElement: DMNCompilerImpl.getRootElement(this), !$rootElement.namespace.equals($targetNS))
   (not (and Import( $importedNS : namespace )
             $importDef : Definitions( namespace == $importedNS, namespace == $targetNS ) from entry-point "DMNImports"
             DMNElement( id == $targetId ) from $importDef.drgElement

--- a/kie-dmn/kie-dmn-validation/src/test/java/org/kie/dmn/validation/v1_5/DMN15ValidationsTest.java
+++ b/kie-dmn/kie-dmn-validation/src/test/java/org/kie/dmn/validation/v1_5/DMN15ValidationsTest.java
@@ -132,6 +132,12 @@ public class DMN15ValidationsTest {
         evaluate(modelNamespace, modelName, modelFileName, inputData);
     }
 
+    @Test
+    void localHrefsValidation() {
+        String modelFileName = "valid_models/DMNv1_5/LocalHrefs.dmn";
+        validate(modelFileName);
+    }
+
     private void commonUnnamedImportValidation(String importingModelRef, String importedModelRef) {
         String modelName = "Importing empty-named Model";
         String modelNamespace = "http://www.trisotech.com/dmn/definitions/_f79aa7a4-f9a3-410a-ac95-bea496edabgc";


### PR DESCRIPTION
Fixes https://github.com/apache/incubator-kie-issues/issues/1411

@bncriju 

<details>
<summary>
How to replicate CI configuration locally?
</summary>

Build Chain tool does "simple" maven build(s), the builds are just Maven commands, but because the repositories relates and depends on each other and any change in API or class method could affect several of those repositories there is a need to use [build-chain tool](https://github.com/kiegroup/github-action-build-chain) to handle cross repository builds and be sure that we always use latest version of the code for each repository.
 
[build-chain tool](https://github.com/kiegroup/github-action-build-chain) is a build tool which can be used on command line locally or in Github Actions workflow(s), in case you need to change multiple repositories and send multiple dependent pull requests related with a change you can easily reproduce the same build by executing it on Github hosted environment or locally in your development environment. See [local execution](https://github.com/kiegroup/github-action-build-chain#local-execution) details to get more information about it.
</details>

<details>
<summary>
How to retest this PR or trigger a specific build:
</summary>

- for <b>pull request and downstream checks</b>  
  - Push a new commit to the PR. An empty commit would be enough.

- for a <b>full downstream build</b>
  - for <b>github actions</b> job: add the label `run_fdb`

- for <b>Jenkins PR check only</b>
  - If you are an ASF committer for KIE podling, login to Jenkins (https://ci-builds.apache.org/job/KIE/job/drools/), go to the specific PR job, and click on `Build Now` button.
</details>
