### PR TITLE
[incubator-kie-drools-6053] MetricLogUtils forcibly uses Micrometer w…

### DIFF
--- a/drools-docs/src/modules/ROOT/pages/language-reference/_performance-tuning-drl-ref.adoc
+++ b/drools-docs/src/modules/ROOT/pages/language-reference/_performance-tuning-drl-ref.adoc
@@ -144,6 +144,9 @@ Alternatively, you can use `drools-metric` to expose the data using https://asci
 ----
 
 +
+If you want to use logging instead of Micrometer even though Micrometer is available in classpath, you can disable it by setting the system property `drools.metric.micrometer.disabled` to `true`.
+
++
 Regardless of whether you want to use logging or Micrometer, you need to enable `MetricLogUtils` by setting the system property `drools.metric.logger.enabled` to `true`. Optionally, you can change the microseconds threshold of metric reporting by setting the `drools.metric.logger.threshold` system property.
 
 +

--- a/drools-metric/src/test/java/org/drools/metric/AbstractMetricTest.java
+++ b/drools-metric/src/test/java/org/drools/metric/AbstractMetricTest.java
@@ -47,6 +47,4 @@ abstract class AbstractMetricTest extends CommonTestMethodBase {
         MicrometerUtils.INSTANCE.clear();
         registry = null;
     }
-
-
 }

--- a/drools-metric/src/test/java/org/drools/metric/MetricLogUtilsTest.java
+++ b/drools-metric/src/test/java/org/drools/metric/MetricLogUtilsTest.java
@@ -26,6 +26,7 @@ import java.util.stream.IntStream;
 import io.micrometer.core.instrument.Counter;
 import io.micrometer.core.instrument.Timer;
 import io.micrometer.core.instrument.search.Search;
+import org.drools.metric.util.MetricLogUtils;
 import org.drools.mvel.compiler.Address;
 import org.drools.mvel.compiler.Person;
 import org.junit.Test;
@@ -39,6 +40,24 @@ public class MetricLogUtilsTest extends AbstractMetricTest {
     @Test
     public void testJoin() {
 
+        runJoinRules();
+
+        // 2 nodes expected
+        Collection<Timer> timers = Search.in(registry)
+                .name("org.drools.metric.elapsed.time.per.evaluation")
+                .timers();
+        assertThat(timers).hasSize(2);
+        Collection<Timer> timers2 = Search.in(registry)
+                .name("org.drools.metric.elapsed.time")
+                .timers();
+        assertThat(timers2).hasSize(2);
+        Collection<Counter> counters = Search.in(registry)
+                .name("org.drools.metric.evaluation.count")
+                .counters();
+        assertThat(counters).hasSize(2);
+    }
+
+    private void runJoinRules() {
         String str =
                 "import " + Address.class.getCanonicalName() + "\n" +
                         "import " + Person.class.getCanonicalName() + "\n" +
@@ -67,20 +86,26 @@ public class MetricLogUtilsTest extends AbstractMetricTest {
         int fired = ksession.fireAllRules();
         ksession.dispose();
         assertThat(fired).isEqualTo(36);
+    }
 
-        // 2 nodes expected
-        Collection<Timer> timers = Search.in(registry)
-                .name("org.drools.metric.elapsed.time.per.evaluation")
-                .timers();
-        assertThat(timers).hasSize(2);
-        Collection<Timer> timers2 = Search.in(registry)
-                .name("org.drools.metric.elapsed.time")
-                .timers();
-        assertThat(timers2).hasSize(2);
-        Collection<Counter> counters = Search.in(registry)
-                .name("org.drools.metric.evaluation.count")
-                .counters();
-        assertThat(counters).hasSize(2);
+    @Test
+    public void micrometerDisabled() {
+
+        try {
+            System.setProperty(MetricLogUtils.METRIC_MICROMETER_DISABLED, "true");
+            MetricLogUtils.recreateInstance();
+
+            runJoinRules();
+
+            // Micrometer is disabled
+            Collection<Timer> timers = Search.in(registry)
+                    .name("org.drools.metric.elapsed.time.per.evaluation")
+                    .timers();
+            assertThat(timers).isEmpty();
+        } finally {
+            System.clearProperty(MetricLogUtils.METRIC_MICROMETER_DISABLED); // default is false
+            MetricLogUtils.recreateInstance();
+        }
     }
 
     @Test

--- a/drools-metric/src/test/resources/logback-test.xml
+++ b/drools-metric/src/test/resources/logback-test.xml
@@ -30,7 +30,7 @@
   <logger name="org.kie" level="warn"/>
   <logger name="org.drools" level="warn"/>
 
-<!--   <logger name="org.drools.metric.util.MetricLogUtils" level="trace"/> -->
+  <logger name="org.drools.metric.util.MetricLogUtils" level="trace"/>
 
   <root level="warn">
     <appender-ref ref="consoleAppender" />


### PR DESCRIPTION
…hen available in classpath

- Add drools.metric.micrometer.disabled switch

**Issue**: 

* https://github.com/apache/incubator-kie-drools/issues/6053
