### PR TITLE
NO ISSUE: Replaces junit assertions with assertj assertions in kie-dmn-openapi

### DIFF
--- a/kie-dmn/kie-dmn-openapi/src/test/java/org/kie/dmn/openapi/impl/DMNTypeSchemasTest.java
+++ b/kie-dmn/kie-dmn-openapi/src/test/java/org/kie/dmn/openapi/impl/DMNTypeSchemasTest.java
@@ -29,9 +29,7 @@ import org.junit.jupiter.api.Test;
 import org.kie.dmn.core.impl.SimpleTypeImpl;
 import org.kie.dmn.feel.lang.types.BuiltInType;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.kie.dmn.openapi.impl.SchemaMapperTestUtils.FEEL_NUMBER;
 import static org.kie.dmn.openapi.impl.SchemaMapperTestUtils.FEEL_STRING;
 import static org.kie.dmn.openapi.impl.SchemaMapperTestUtils.getSchemaForSimpleType;
@@ -49,25 +47,23 @@ class DMNTypeSchemasTest {
         SimpleTypeImpl toRead = getSimpleType(allowedValuesString, null, FEEL_STRING, BuiltInType.STRING);
         AtomicReference<Schema> toPopulate = new AtomicReference<>(getSchemaForSimpleType(toRead));
         DMNTypeSchemas.populateSchemaWithConstraints(toPopulate.get(), toRead);
-        assertEquals(enumBase.size(), toPopulate.get().getEnumeration().size());
-        enumBase.forEach(en -> assertTrue(toPopulate.get().getEnumeration().contains(en)));
-        assertTrue(toPopulate.get().getExtensions().containsKey(DMNOASConstants.X_DMN_ALLOWED_VALUES));
+        assertThat(toPopulate.get().getEnumeration()).hasSameSizeAs(enumBase).containsAll(enumBase);
+        assertThat(toPopulate.get().getExtensions()).containsKey(DMNOASConstants.X_DMN_ALLOWED_VALUES);
         String retrieved =
                 ((String) toPopulate.get().getExtensions().get(DMNOASConstants.X_DMN_ALLOWED_VALUES)).replace(" ", "");
-        assertEquals(allowedValuesString, retrieved);
+        assertThat(retrieved).isEqualTo(allowedValuesString);
 
-        toEnum = Arrays.asList(1, 3, 6, 78);
+        toEnum = Arrays.asList(BigDecimal.valueOf(1), BigDecimal.valueOf(3), BigDecimal.valueOf(6), BigDecimal.valueOf(78));
         allowedValuesString = String.join(",", toEnum.stream().map(toMap -> String.format("%s", toMap)).toList());
 
         toRead = getSimpleType(allowedValuesString, null, FEEL_NUMBER, BuiltInType.NUMBER);
         toPopulate.set(getSchemaForSimpleType(toRead));
         DMNTypeSchemas.populateSchemaWithConstraints(toPopulate.get(), toRead);
-        assertEquals(toEnum.size(), toPopulate.get().getEnumeration().size());
-        toEnum.stream().map(i -> BigDecimal.valueOf((int) i)).forEach(en -> assertTrue(toPopulate.get().getEnumeration().contains(en)));
-        assertTrue(toPopulate.get().getExtensions().containsKey(DMNOASConstants.X_DMN_ALLOWED_VALUES));
+        assertThat(toPopulate.get().getEnumeration()).hasSameSizeAs(toEnum).containsAll(toEnum);
+        assertThat(toPopulate.get().getExtensions()).containsKey(DMNOASConstants.X_DMN_ALLOWED_VALUES);
         retrieved = ((String) toPopulate.get().getExtensions().get(DMNOASConstants.X_DMN_ALLOWED_VALUES)).replace(" "
                 , "");
-        assertEquals(allowedValuesString, retrieved);
+        assertThat(retrieved).isEqualTo(allowedValuesString);
     }
 
     @Test
@@ -80,26 +76,24 @@ class DMNTypeSchemasTest {
         SimpleTypeImpl toRead = getSimpleType(null, typeConstraintsString, FEEL_STRING, BuiltInType.STRING);
         AtomicReference<Schema> toPopulate = new AtomicReference<>(getSchemaForSimpleType(toRead));
         DMNTypeSchemas.populateSchemaWithConstraints(toPopulate.get(), toRead);
-        assertEquals(enumBase.size(), toPopulate.get().getEnumeration().size());
-        enumBase.forEach(en -> assertTrue(toPopulate.get().getEnumeration().contains(en)));
-        assertTrue(toPopulate.get().getExtensions().containsKey(DMNOASConstants.X_DMN_TYPE_CONSTRAINTS));
+        assertThat(toPopulate.get().getEnumeration()).hasSameSizeAs(enumBase).containsAll(enumBase);
+        assertThat(toPopulate.get().getExtensions()).containsKey(DMNOASConstants.X_DMN_TYPE_CONSTRAINTS);
         String retrieved =
                 ((String) toPopulate.get().getExtensions().get(DMNOASConstants.X_DMN_TYPE_CONSTRAINTS)).replace(" ",
                                                                                                                 "");
-        assertEquals(typeConstraintsString, retrieved);
+        assertThat(retrieved).isEqualTo(typeConstraintsString);
 
-        toEnum = Arrays.asList(1, 3, 6, 78);
+        toEnum = Arrays.asList(BigDecimal.valueOf(1), BigDecimal.valueOf(3), BigDecimal.valueOf(6), BigDecimal.valueOf(78));
         typeConstraintsString = String.join(",", toEnum.stream().map(toMap -> String.format("%s", toMap)).toList());
 
         toRead = getSimpleType(null, typeConstraintsString, FEEL_NUMBER, BuiltInType.NUMBER);
         toPopulate.set(getSchemaForSimpleType(toRead));
         DMNTypeSchemas.populateSchemaWithConstraints(toPopulate.get(), toRead);
-        assertEquals(toEnum.size(), toPopulate.get().getEnumeration().size());
-        toEnum.stream().map(i -> BigDecimal.valueOf((int) i)).forEach(en -> assertTrue(toPopulate.get().getEnumeration().contains(en)));
-        assertTrue(toPopulate.get().getExtensions().containsKey(DMNOASConstants.X_DMN_TYPE_CONSTRAINTS));
+        assertThat(toPopulate.get().getEnumeration()).hasSameSizeAs(toEnum).containsAll(toEnum);
+        assertThat(toPopulate.get().getExtensions()).containsKey(DMNOASConstants.X_DMN_TYPE_CONSTRAINTS);
         retrieved = ((String) toPopulate.get().getExtensions().get(DMNOASConstants.X_DMN_TYPE_CONSTRAINTS)).replace(
                 " ", "");
-        assertEquals(typeConstraintsString, retrieved);
+        assertThat(retrieved).isEqualTo(typeConstraintsString);
     }
 
     @Test
@@ -110,15 +104,15 @@ class DMNTypeSchemasTest {
         SimpleTypeImpl toRead = getSimpleType(allowedValuesString, null, FEEL_STRING, BuiltInType.STRING);
         AtomicReference<Schema> toPopulate = new AtomicReference<>(getSchemaForSimpleType(toRead));
         DMNTypeSchemas.populateSchemaWithConstraints(toPopulate.get(), toRead);
-        assertEquals(BigDecimal.ONE, toPopulate.get().getMinimum());
-        assertTrue(toPopulate.get().getExclusiveMinimum());
-        assertEquals(BigDecimal.TEN, toPopulate.get().getMaximum());
-        assertFalse(toPopulate.get().getExclusiveMaximum());
-        assertTrue(toPopulate.get().getExtensions().containsKey(DMNOASConstants.X_DMN_ALLOWED_VALUES));
+        assertThat(toPopulate.get().getMinimum()).isEqualTo(BigDecimal.ONE);
+        assertThat(toPopulate.get().getExclusiveMinimum()).isTrue();
+        assertThat(toPopulate.get().getMaximum()).isEqualTo(BigDecimal.TEN);
+        assertThat(toPopulate.get().getExclusiveMaximum()).isFalse();
+        assertThat(toPopulate.get().getExtensions()).containsKey(DMNOASConstants.X_DMN_ALLOWED_VALUES);
         String retrieved =
                 ((String) toPopulate.get().getExtensions().get(DMNOASConstants.X_DMN_ALLOWED_VALUES)).replace(" ", "");
         String expected = allowedValuesString.replace("(", "").replace(")", "");
-        assertEquals(expected, retrieved);
+        assertThat(retrieved).isEqualTo(expected);
     }
 
     @Test
@@ -129,15 +123,15 @@ class DMNTypeSchemasTest {
         SimpleTypeImpl toRead = getSimpleType(null, typeConstraintsString, FEEL_STRING, BuiltInType.STRING);
         AtomicReference<Schema> toPopulate = new AtomicReference<>(getSchemaForSimpleType(toRead));
         DMNTypeSchemas.populateSchemaWithConstraints(toPopulate.get(), toRead);
-        assertEquals(BigDecimal.ONE, toPopulate.get().getMinimum());
-        assertTrue(toPopulate.get().getExclusiveMinimum());
-        assertEquals(BigDecimal.TEN, toPopulate.get().getMaximum());
-        assertFalse(toPopulate.get().getExclusiveMaximum());
-        assertTrue(toPopulate.get().getExtensions().containsKey(DMNOASConstants.X_DMN_TYPE_CONSTRAINTS));
+        assertThat(toPopulate.get().getMinimum()).isEqualTo(BigDecimal.ONE);
+        assertThat(toPopulate.get().getExclusiveMinimum()).isTrue();
+        assertThat(toPopulate.get().getMaximum()).isEqualTo(BigDecimal.TEN);
+        assertThat(toPopulate.get().getExclusiveMaximum()).isFalse();
+        assertThat(toPopulate.get().getExtensions().containsKey(DMNOASConstants.X_DMN_TYPE_CONSTRAINTS)).isTrue();
         String retrieved =
                 ((String) toPopulate.get().getExtensions().get(DMNOASConstants.X_DMN_TYPE_CONSTRAINTS)).replace(" ",
                                                                                                                 "");
         String expected = typeConstraintsString.replace("(", "").replace(")", "");
-        assertEquals(expected, retrieved);
+        assertThat(retrieved).isEqualTo(expected);
     }
 }

--- a/kie-dmn/kie-dmn-openapi/src/test/java/org/kie/dmn/openapi/impl/FEELFunctionSchemaMapperTest.java
+++ b/kie-dmn/kie-dmn-openapi/src/test/java/org/kie/dmn/openapi/impl/FEELFunctionSchemaMapperTest.java
@@ -29,7 +29,7 @@ import org.kie.dmn.feel.lang.ast.InfixOperator;
 import org.kie.dmn.feel.lang.types.BuiltInType;
 import org.kie.dmn.feel.runtime.functions.CountFunction;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.kie.dmn.openapi.impl.SchemaMapperTestUtils.FEEL_NUMBER;
 import static org.kie.dmn.openapi.impl.SchemaMapperTestUtils.getSchemaForSimpleType;
 
@@ -55,8 +55,8 @@ class FEELFunctionSchemaMapperTest {
                     expectedMaximum = rightValue;
                 }
             }
-            assertEquals(expectedMinimum, toPopulate.getMinItems());
-            assertEquals(expectedMaximum, toPopulate.getMaxItems());
+            assertThat(toPopulate.getMinItems()).isEqualTo(expectedMinimum);
+            assertThat(toPopulate.getMaxItems()).isEqualTo(expectedMaximum);
         });
     }
 }

--- a/kie-dmn/kie-dmn-openapi/src/test/java/org/kie/dmn/openapi/impl/InfixOpNodeSchemaMapperTest.java
+++ b/kie-dmn/kie-dmn-openapi/src/test/java/org/kie/dmn/openapi/impl/InfixOpNodeSchemaMapperTest.java
@@ -29,7 +29,8 @@ import org.kie.dmn.feel.lang.ast.InfixOperator;
 import org.kie.dmn.feel.lang.types.BuiltInType;
 import org.kie.dmn.feel.runtime.functions.CountFunction;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.kie.dmn.openapi.impl.SchemaMapperTestUtils.FEEL_NUMBER;
 import static org.kie.dmn.openapi.impl.SchemaMapperTestUtils.getBaseNode;
 import static org.kie.dmn.openapi.impl.SchemaMapperTestUtils.getSchemaForSimpleType;
@@ -57,8 +58,8 @@ class InfixOpNodeSchemaMapperTest {
                     expectedMaximum = rightValue;
                 }
             }
-            assertEquals(expectedMinimum, toPopulate.getMinItems());
-            assertEquals(expectedMaximum, toPopulate.getMaxItems());
+            assertThat(toPopulate.getMinItems()).isEqualTo(expectedMinimum);
+            assertThat(toPopulate.getMaxItems()).isEqualTo(expectedMaximum);
         });
     }
 }

--- a/kie-dmn/kie-dmn-openapi/src/test/java/org/kie/dmn/openapi/impl/RangeNodeSchemaMapperTest.java
+++ b/kie-dmn/kie-dmn-openapi/src/test/java/org/kie/dmn/openapi/impl/RangeNodeSchemaMapperTest.java
@@ -33,9 +33,6 @@ import org.kie.dmn.feel.runtime.Range;
 import org.kie.dmn.feel.runtime.impl.RangeImpl;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.kie.dmn.openapi.impl.SchemaMapperTestUtils.getBaseNodes;
 
 class RangeNodeSchemaMapperTest {
@@ -48,10 +45,10 @@ class RangeNodeSchemaMapperTest {
         List<RangeNode> ranges = getBaseNodes(toRange, RangeNode.class);
         Schema toPopulate = OASFactory.createObject(Schema.class);
         RangeNodeSchemaMapper.populateSchemaFromListOfRanges(toPopulate, ranges);
-        assertEquals(BigDecimal.ONE, toPopulate.getMinimum());
-        assertTrue(toPopulate.getExclusiveMinimum());
-        assertEquals(BigDecimal.TEN, toPopulate.getMaximum());
-        assertFalse(toPopulate.getExclusiveMaximum());
+        assertThat(toPopulate.getMinimum()).isEqualTo(BigDecimal.ONE);
+        assertThat(toPopulate.getExclusiveMinimum()).isTrue();
+        assertThat(toPopulate.getMaximum()).isEqualTo(BigDecimal.TEN);
+        assertThat(toPopulate.getExclusiveMaximum()).isFalse();
     }
 
     @Test
@@ -66,10 +63,10 @@ class RangeNodeSchemaMapperTest {
 
         Schema toPopulate = OASFactory.createObject(Schema.class);
         RangeNodeSchemaMapper.populateSchemaFromListOfRanges(toPopulate, ranges);
-        assertEquals(expectedDates.get(0), toPopulate.getExtensions().get(DMNOASConstants.X_DMN_MINIMUM_VALUE));
-        assertTrue(toPopulate.getExclusiveMinimum());
-        assertEquals(expectedDates.get(1), toPopulate.getExtensions().get(DMNOASConstants.X_DMN_MAXIMUM_VALUE));
-        assertFalse(toPopulate.getExclusiveMaximum());
+        assertThat(toPopulate.getExtensions().get(DMNOASConstants.X_DMN_MINIMUM_VALUE)).isEqualTo(expectedDates.get(0));
+        assertThat(toPopulate.getExclusiveMinimum()).isTrue();
+        assertThat(toPopulate.getExtensions().get(DMNOASConstants.X_DMN_MAXIMUM_VALUE)).isEqualTo(expectedDates.get(1));
+        assertThat(toPopulate.getExclusiveMaximum()).isFalse();
     }
 
     @Test


### PR DESCRIPTION
Cleanup to remove junit assertions and use instead assertj assertions in kie-dmn-openapi.

<!--
  Licensed to the Apache Software Foundation (ASF) under one
  or more contributor license agreements.  See the NOTICE file
  distributed with this work for additional information
  regarding copyright ownership.  The ASF licenses this file
  to you under the Apache License, Version 2.0 (the
  "License"); you may not use this file except in compliance
  with the License.  You may obtain a copy of the License at

    http://www.apache.org/licenses/LICENSE-2.0

  Unless required by applicable law or agreed to in writing,
  software distributed under the License is distributed on an
  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
  KIND, either express or implied.  See the License for the
  specific language governing permissions and limitations
  under the License.
  -->


<details>
<summary>
How to replicate CI configuration locally?
</summary>

Build Chain tool does "simple" maven build(s), the builds are just Maven commands, but because the repositories relates and depends on each other and any change in API or class method could affect several of those repositories there is a need to use [build-chain tool](https://github.com/kiegroup/github-action-build-chain) to handle cross repository builds and be sure that we always use latest version of the code for each repository.
 
[build-chain tool](https://github.com/kiegroup/github-action-build-chain) is a build tool which can be used on command line locally or in Github Actions workflow(s), in case you need to change multiple repositories and send multiple dependent pull requests related with a change you can easily reproduce the same build by executing it on Github hosted environment or locally in your development environment. See [local execution](https://github.com/kiegroup/github-action-build-chain#local-execution) details to get more information about it.
</details>

<details>
<summary>
How to retest this PR or trigger a specific build:
</summary>

- for <b>pull request and downstream checks</b>  
  - Push a new commit to the PR. An empty commit would be enough.

- for a <b>full downstream build</b>
  - for <b>github actions</b> job: add the label `run_fdb`

- for <b>Jenkins PR check only</b>
  - If you are an ASF committer for KIE podling, login to Jenkins (https://ci-builds.apache.org/job/KIE/job/drools/), go to the specific PR job, and click on `Build Now` button.
</details>
