### PR TITLE
[DROOLS-7629] Restore correct traversal order when looking for a declaration

### DIFF
--- a/drools-base/src/main/java/org/drools/base/rule/accessor/DeclarationScopeResolver.java
+++ b/drools-base/src/main/java/org/drools/base/rule/accessor/DeclarationScopeResolver.java
@@ -109,7 +109,7 @@ public class DeclarationScopeResolver {
 
     public Declaration getDeclaration(String identifier) {
         // it may be a local bound variable
-        for (final Iterator<RuleConditionElement> iterator = buildList.descendingIterator(); iterator.hasNext();) {
+        for (final Iterator<RuleConditionElement> iterator = buildList.iterator(); iterator.hasNext();) {
             final Declaration declaration = iterator.next().resolveDeclaration( identifier );
             if ( declaration != null ) {
                 return declaration;

--- a/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/compiler/integrationtests/operators/NotTest.java
+++ b/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/compiler/integrationtests/operators/NotTest.java
@@ -311,4 +311,26 @@ public class NotTest {
         assertThat(results.size()).isEqualTo(1);
         assertThat(results.get(0)).isEqualTo("Paris");
     }
+
+    @Test
+    public void testNotWithUnification() {
+        // DROOLS-7629
+        final String drl =
+                "package org.drools.compiler.integrationtests.operators;\n" +
+                "rule R1 when\n" +
+                "      ( not ( $rao_v2 := String() and (\n" +
+                "          $rao_v2 := String()\n" +
+                "      ) ) and (\n" +
+                "         $rao_v2 := String()\n" +
+                "      )\n" +
+                "   )\n" +
+                "then\n" +
+                "end";
+
+        final KieBase kbase = KieBaseUtil.getKieBaseFromKieModuleFromDrl("not-test", kieBaseTestConfiguration, drl);
+        final KieSession ksession = kbase.newKieSession();
+
+        ksession.insert("test");
+        assertThat(ksession.fireAllRules()).isEqualTo(0);
+    }
 }


### PR DESCRIPTION
Fixes https://issues.redhat.com/browse/DROOLS-7629

This fix restores the same declarations traversal order that we had in 7.x and caused the reported NPE in 8.x and main. That said, as commented in the ticket, I believe that the provided rule is totally meaningless and this order shouldn't be relevant for reasonably written rules.