### PR TITLE
NO ISSUE: Migrate drools commands to Junit5

### DIFF
--- a/drools-commands/pom.xml
+++ b/drools-commands/pom.xml
@@ -55,11 +55,11 @@
             <artifactId>jakarta.xml.bind-api</artifactId>
             <scope>provided</scope>
         </dependency>
-        <dependency>
-            <groupId>junit</groupId>
-            <artifactId>junit</artifactId>
-            <scope>test</scope>
-        </dependency>
+	    <dependency>
+	      <groupId>org.junit.jupiter</groupId>
+	      <artifactId>junit-jupiter</artifactId>
+	      <scope>test</scope>
+	    </dependency>    
         <dependency>
             <groupId>org.assertj</groupId>
             <artifactId>assertj-core</artifactId>

--- a/drools-commands/src/test/java/org/drools/commands/DeleteCommandTest.java
+++ b/drools-commands/src/test/java/org/drools/commands/DeleteCommandTest.java
@@ -22,9 +22,9 @@ import org.drools.commands.runtime.rule.DeleteCommand;
 import org.drools.commands.runtime.rule.InsertObjectCommand;
 import org.drools.kiesession.rulebase.InternalKnowledgeBase;
 import org.drools.kiesession.rulebase.KnowledgeBaseFactory;
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.kie.api.runtime.Context;
 import org.kie.api.runtime.ExecutableRunner;
 import org.kie.api.runtime.KieSession;
@@ -40,7 +40,7 @@ public class DeleteCommandTest {
     private ExecutableRunner<RequestContext> runner;
     private Context context;
 
-    @Before
+    @BeforeEach
     public void setup() {
         InternalKnowledgeBase kbase = KnowledgeBaseFactory.newKnowledgeBase();
         ksession = kbase.newKieSession();
@@ -48,7 +48,7 @@ public class DeleteCommandTest {
         context = ((RegistryContext) runner.createContext()).register(KieSession.class, ksession);
     }
 
-    @After
+    @AfterEach
     public void cleanUp() {
         ksession.dispose();
     }

--- a/drools-commands/src/test/java/org/drools/commands/ExecuteCommandDisconnectedTest.java
+++ b/drools-commands/src/test/java/org/drools/commands/ExecuteCommandDisconnectedTest.java
@@ -25,7 +25,7 @@ import org.drools.commands.runtime.rule.InsertObjectCommand;
 import org.drools.core.common.DefaultFactHandle;
 import org.drools.commands.runtime.ExecutionResultImpl;
 import org.drools.kiesession.rulebase.KnowledgeBaseFactory;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.kie.api.KieBase;
 import org.kie.api.command.BatchExecutionCommand;
 import org.kie.api.runtime.ExecutableRunner;

--- a/drools-commands/src/test/java/org/drools/commands/FromExternalFactHandleCommandTest.java
+++ b/drools-commands/src/test/java/org/drools/commands/FromExternalFactHandleCommandTest.java
@@ -21,9 +21,8 @@ package org.drools.commands;
 import org.drools.commands.runtime.rule.FromExternalFactHandleCommand;
 import org.drools.kiesession.rulebase.InternalKnowledgeBase;
 import org.drools.kiesession.rulebase.KnowledgeBaseFactory;
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
 import org.kie.api.runtime.Context;
 import org.kie.api.runtime.ExecutableRunner;
 import org.kie.api.runtime.KieSession;
@@ -39,7 +38,7 @@ public class FromExternalFactHandleCommandTest {
     private ExecutableRunner<RequestContext> runner;
     private Context context;
 
-    @Before
+    @BeforeEach
     public void setup() {
         InternalKnowledgeBase kbase = KnowledgeBaseFactory.newKnowledgeBase();
         ksession = kbase.newKieSession();
@@ -47,12 +46,12 @@ public class FromExternalFactHandleCommandTest {
         context = ((RegistryContext) runner.createContext()).register(KieSession.class, ksession);
     }
 
-    @After
+    @AfterEach
     public void cleanUp() {
         ksession.dispose();
     }
 
-    @Test
+    @org.junit.jupiter.api.Test
     public void testFromExternalFactHandleCommandNumberFormatException() {
         // DROOLS-7076 : Just to test not to throw NumberFormatException 
         String externalFormat = "0:2147483648:171497379:-1361525545:2147483648:null:NON_TRAIT:java.lang.String";

--- a/drools-commands/src/test/java/org/drools/commands/GetFactHandlesCommandTest.java
+++ b/drools-commands/src/test/java/org/drools/commands/GetFactHandlesCommandTest.java
@@ -27,9 +27,9 @@ import org.drools.commands.runtime.rule.GetFactHandlesCommand;
 import org.drools.core.common.InternalFactHandle;
 import org.drools.kiesession.rulebase.InternalKnowledgeBase;
 import org.drools.kiesession.rulebase.KnowledgeBaseFactory;
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.kie.api.runtime.Context;
 import org.kie.api.runtime.ExecutableRunner;
 import org.kie.api.runtime.KieSession;
@@ -47,7 +47,7 @@ public class GetFactHandlesCommandTest {
     private Context context;
     private Random random = new Random();
     
-    @Before
+    @BeforeEach
     public void setup() { 
         InternalKnowledgeBase kbase = KnowledgeBaseFactory.newKnowledgeBase();
         ksession = kbase.newKieSession();
@@ -55,7 +55,7 @@ public class GetFactHandlesCommandTest {
         context = ( (RegistryContext) runner.createContext() ).register( KieSession.class, ksession );
     }
     
-    @After
+    @AfterEach
     public void cleanUp() { 
        ksession.dispose(); 
     }

--- a/drools-commands/src/test/java/org/drools/commands/InternalExecutableTest.java
+++ b/drools-commands/src/test/java/org/drools/commands/InternalExecutableTest.java
@@ -25,7 +25,7 @@ import org.drools.commands.fluent.Batch;
 import org.drools.commands.fluent.BatchImpl;
 import org.drools.commands.fluent.InternalExecutable;
 import org.drools.commands.impl.NotTransactionalCommand;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.kie.api.command.ExecutableCommand;
 import org.kie.api.runtime.Context;
 


### PR DESCRIPTION
<!--
  Licensed to the Apache Software Foundation (ASF) under one
  or more contributor license agreements.  See the NOTICE file
  distributed with this work for additional information
  regarding copyright ownership.  The ASF licenses this file
  to you under the Apache License, Version 2.0 (the
  "License"); you may not use this file except in compliance
  with the License.  You may obtain a copy of the License at

    http://www.apache.org/licenses/LICENSE-2.0

  Unless required by applicable law or agreed to in writing,
  software distributed under the License is distributed on an
  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
  KIND, either express or implied.  See the License for the
  specific language governing permissions and limitations
  under the License.
  -->

- migrated tests to Junit5
- cleanup of assertj assertions.

<details>
<summary>
How to replicate CI configuration locally?
</summary>

Build Chain tool does "simple" maven build(s), the builds are just Maven commands, but because the repositories relates and depends on each other and any change in API or class method could affect several of those repositories there is a need to use [build-chain tool](https://github.com/kiegroup/github-action-build-chain) to handle cross repository builds and be sure that we always use latest version of the code for each repository.
 
[build-chain tool](https://github.com/kiegroup/github-action-build-chain) is a build tool which can be used on command line locally or in Github Actions workflow(s), in case you need to change multiple repositories and send multiple dependent pull requests related with a change you can easily reproduce the same build by executing it on Github hosted environment or locally in your development environment. See [local execution](https://github.com/kiegroup/github-action-build-chain#local-execution) details to get more information about it.
</details>

<details>
<summary>
How to retest this PR or trigger a specific build:
</summary>

- for <b>pull request and downstream checks</b>  
  - Push a new commit to the PR. An empty commit would be enough.

- for a <b>full downstream build</b>
  - for <b>github actions</b> job: add the label `run_fdb`

- for <b>Jenkins PR check only</b>
  - If you are an ASF committer for KIE podling, login to Jenkins (https://ci-builds.apache.org/job/KIE/job/drools/), go to the specific PR job, and click on `Build Now` button.
</details>
