### PR TITLE
[DROOLS-7631] unify coercion checks between plain drl and executable model

### DIFF
--- a/drools-model/drools-model-codegen/src/test/java/org/drools/model/codegen/execmodel/generator/drlxparse/CoercedExpressionTest.java
+++ b/drools-model/drools-model-codegen/src/test/java/org/drools/model/codegen/execmodel/generator/drlxparse/CoercedExpressionTest.java
@@ -127,9 +127,9 @@ public class CoercedExpressionTest {
     @Test
     public void castMaps() {
         final TypedExpression left = expr(THIS_PLACEHOLDER + ".getAge()", Integer.class);
-        final TypedExpression right = expr("$m.get(\"age\")", java.util.Map.class);
+        final TypedExpression right = expr("$m.get(\"age\")", Object.class);
         final CoercedExpression.CoercedExpressionResult coerce = new CoercedExpression(left, right, false).coerce();
-        assertThat(coerce.getCoercedRight()).isEqualTo(expr("(java.lang.Integer)$m.get(\"age\")", Map.class));
+        assertThat(coerce.getCoercedRight()).isEqualTo(expr("$m.get(\"age\")", Object.class));
     }
 
     @Test


### PR DESCRIPTION
Fix for https://issues.redhat.com/browse/DROOLS-7631

The plain drl compilation already reports the compile time error

`Error: Comparison operation requires compatible types. Found class java.time.LocalDateTime and class java.util.Date`

but this doesn't happen when generating the executable model than then fails at runtime with the `ClassCastException` reported in that jira.

The purpose of this pull request is reusing the same code for coercion checks for both plain drl compilation and executable model generation.