### PR TITLE
[incubator-kie-issues#1473] Add withTransactional method to  DependencyInjectionAnnotator

### DIFF
--- a/drools-model/drools-codegen-common/src/main/java/org/drools/codegen/common/di/DependencyInjectionAnnotator.java
+++ b/drools-model/drools-codegen-common/src/main/java/org/drools/codegen/common/di/DependencyInjectionAnnotator.java
@@ -161,6 +161,13 @@ public interface DependencyInjectionAnnotator {
     <T extends NodeWithAnnotations<?>> T withConfigInjection(T node, String configKey, String defaultValue);
 
     /**
+     * Annotates given node with Transactional annotation
+     *
+     * @param node node to be annotated
+     */
+    <T extends NodeWithAnnotations<?>> T withTransactional(T node);
+
+    /**
      * Annotates and enhances method used to produce messages
      *
      * @param produceMethod method to be annotated

--- a/drools-model/drools-codegen-common/src/main/java/org/drools/codegen/common/di/DependencyInjectionAnnotator.java
+++ b/drools-model/drools-codegen-common/src/main/java/org/drools/codegen/common/di/DependencyInjectionAnnotator.java
@@ -165,7 +165,12 @@ public interface DependencyInjectionAnnotator {
      *
      * @param node node to be annotated
      */
-    <T extends NodeWithAnnotations<?>> T withTransactional(T node);
+    default <T extends NodeWithAnnotations<?>> T withTransactional(T node)  {
+        node.addAnnotation(getTransactionalAnnotation());
+        return node;
+    }
+
+    String getTransactionalAnnotation();
 
     /**
      * Annotates and enhances method used to produce messages

--- a/drools-model/drools-codegen-common/src/main/java/org/drools/codegen/common/di/impl/CDIDependencyInjectionAnnotator.java
+++ b/drools-model/drools-codegen-common/src/main/java/org/drools/codegen/common/di/impl/CDIDependencyInjectionAnnotator.java
@@ -179,6 +179,12 @@ public class CDIDependencyInjectionAnnotator implements DependencyInjectionAnnot
     }
 
     @Override
+    public <T extends NodeWithAnnotations<?>> T withTransactional(T node) {
+        node.addAnnotation("jakarta.transaction.Transactional");
+        return node;
+    }
+
+    @Override
     public <T extends NodeWithAnnotations<?>> T withTagAnnotation(T node, NodeList<MemberValuePair> attributes) {
         node.addAnnotation(new NormalAnnotationExpr(new Name("org.eclipse.microprofile.openapi.annotations.tags.Tag"), attributes));
         return node;

--- a/drools-model/drools-codegen-common/src/main/java/org/drools/codegen/common/di/impl/CDIDependencyInjectionAnnotator.java
+++ b/drools-model/drools-codegen-common/src/main/java/org/drools/codegen/common/di/impl/CDIDependencyInjectionAnnotator.java
@@ -45,8 +45,7 @@ public class CDIDependencyInjectionAnnotator implements DependencyInjectionAnnot
 
     @Override
     public <T extends NodeWithAnnotations<?>> T withNamed(T node, String name) {
-        node.addAnnotation(new SingleMemberAnnotationExpr(new Name("jakarta.inject.Named"),
-                                                          new StringLiteralExpr(name)));
+        node.addAnnotation(new SingleMemberAnnotationExpr(new Name("jakarta.inject.Named"), new StringLiteralExpr(name)));
         return node;
     }
 
@@ -90,17 +89,13 @@ public class CDIDependencyInjectionAnnotator implements DependencyInjectionAnnot
 
     @Override
     public <T extends NodeWithAnnotations<?>> T withIncomingMessage(T node, String channel) {
-        node.addAnnotation(new SingleMemberAnnotationExpr(new Name("org.eclipse.microprofile.reactive.messaging" +
-                                                                           ".Incoming"),
-                                                          new StringLiteralExpr(channel)));
+        node.addAnnotation(new SingleMemberAnnotationExpr(new Name("org.eclipse.microprofile.reactive.messaging.Incoming"), new StringLiteralExpr(channel)));
         return node;
     }
 
     @Override
     public <T extends NodeWithAnnotations<?>> T withOutgoingMessage(T node, String channel) {
-        node.addAnnotation(new SingleMemberAnnotationExpr(new Name("org.eclipse.microprofile.reactive.messaging" +
-                                                                           ".Channel"),
-                                                          new StringLiteralExpr(channel)));
+        node.addAnnotation(new SingleMemberAnnotationExpr(new Name("org.eclipse.microprofile.reactive.messaging.Channel"), new StringLiteralExpr(channel)));
         return node;
     }
 
@@ -190,8 +185,7 @@ public class CDIDependencyInjectionAnnotator implements DependencyInjectionAnnot
 
     @Override
     public <T extends NodeWithAnnotations<?>> T withTagAnnotation(T node, NodeList<MemberValuePair> attributes) {
-        node.addAnnotation(new NormalAnnotationExpr(new Name("org.eclipse.microprofile.openapi.annotations.tags.Tag")
-                , attributes));
+        node.addAnnotation(new NormalAnnotationExpr(new Name("org.eclipse.microprofile.openapi.annotations.tags.Tag"), attributes));
         return node;
     }
 }

--- a/drools-model/drools-codegen-common/src/main/java/org/drools/codegen/common/di/impl/CDIDependencyInjectionAnnotator.java
+++ b/drools-model/drools-codegen-common/src/main/java/org/drools/codegen/common/di/impl/CDIDependencyInjectionAnnotator.java
@@ -45,7 +45,8 @@ public class CDIDependencyInjectionAnnotator implements DependencyInjectionAnnot
 
     @Override
     public <T extends NodeWithAnnotations<?>> T withNamed(T node, String name) {
-        node.addAnnotation(new SingleMemberAnnotationExpr(new Name("jakarta.inject.Named"), new StringLiteralExpr(name)));
+        node.addAnnotation(new SingleMemberAnnotationExpr(new Name("jakarta.inject.Named"),
+                                                          new StringLiteralExpr(name)));
         return node;
     }
 
@@ -89,13 +90,17 @@ public class CDIDependencyInjectionAnnotator implements DependencyInjectionAnnot
 
     @Override
     public <T extends NodeWithAnnotations<?>> T withIncomingMessage(T node, String channel) {
-        node.addAnnotation(new SingleMemberAnnotationExpr(new Name("org.eclipse.microprofile.reactive.messaging.Incoming"), new StringLiteralExpr(channel)));
+        node.addAnnotation(new SingleMemberAnnotationExpr(new Name("org.eclipse.microprofile.reactive.messaging" +
+                                                                           ".Incoming"),
+                                                          new StringLiteralExpr(channel)));
         return node;
     }
 
     @Override
     public <T extends NodeWithAnnotations<?>> T withOutgoingMessage(T node, String channel) {
-        node.addAnnotation(new SingleMemberAnnotationExpr(new Name("org.eclipse.microprofile.reactive.messaging.Channel"), new StringLiteralExpr(channel)));
+        node.addAnnotation(new SingleMemberAnnotationExpr(new Name("org.eclipse.microprofile.reactive.messaging" +
+                                                                           ".Channel"),
+                                                          new StringLiteralExpr(channel)));
         return node;
     }
 
@@ -179,14 +184,14 @@ public class CDIDependencyInjectionAnnotator implements DependencyInjectionAnnot
     }
 
     @Override
-    public <T extends NodeWithAnnotations<?>> T withTransactional(T node) {
-        node.addAnnotation("jakarta.transaction.Transactional");
-        return node;
+    public String getTransactionalAnnotation() {
+        return "jakarta.transaction.Transactional";
     }
 
     @Override
     public <T extends NodeWithAnnotations<?>> T withTagAnnotation(T node, NodeList<MemberValuePair> attributes) {
-        node.addAnnotation(new NormalAnnotationExpr(new Name("org.eclipse.microprofile.openapi.annotations.tags.Tag"), attributes));
+        node.addAnnotation(new NormalAnnotationExpr(new Name("org.eclipse.microprofile.openapi.annotations.tags.Tag")
+                , attributes));
         return node;
     }
 }

--- a/drools-model/drools-codegen-common/src/main/java/org/drools/codegen/common/di/impl/SpringDependencyInjectionAnnotator.java
+++ b/drools-model/drools-codegen-common/src/main/java/org/drools/codegen/common/di/impl/SpringDependencyInjectionAnnotator.java
@@ -182,6 +182,12 @@ public class SpringDependencyInjectionAnnotator implements DependencyInjectionAn
     }
 
     @Override
+    public <T extends NodeWithAnnotations<?>> T withTransactional(T node) {
+        node.addAnnotation("org.springframework.transaction.annotation.Transactional");
+        return node;
+    }
+
+    @Override
     public <T extends NodeWithAnnotations<?>> T withFactoryMethod(T node) {
         node.addAnnotation("org.springframework.context.annotation.Bean");
         return node;

--- a/drools-model/drools-codegen-common/src/main/java/org/drools/codegen/common/di/impl/SpringDependencyInjectionAnnotator.java
+++ b/drools-model/drools-codegen-common/src/main/java/org/drools/codegen/common/di/impl/SpringDependencyInjectionAnnotator.java
@@ -53,8 +53,7 @@ public class SpringDependencyInjectionAnnotator implements DependencyInjectionAn
 
     @Override
     public <T extends NodeWithAnnotations<?>> T withNamed(T node, String name) {
-        node.addAnnotation(new SingleMemberAnnotationExpr(new Name("org.springframework.beans.factory.annotation" +
-                                                                           ".Qualifier"), new StringLiteralExpr(name)));
+        node.addAnnotation(new SingleMemberAnnotationExpr(new Name("org.springframework.beans.factory.annotation.Qualifier"), new StringLiteralExpr(name)));
         return node;
     }
 
@@ -66,8 +65,7 @@ public class SpringDependencyInjectionAnnotator implements DependencyInjectionAn
 
     @Override
     public <T extends NodeWithAnnotations<?>> T withNamedApplicationComponent(T node, String name) {
-        node.addAnnotation(new SingleMemberAnnotationExpr(new Name("org.springframework.stereotype.Component"),
-                                                          new StringLiteralExpr(name)));
+        node.addAnnotation(new SingleMemberAnnotationExpr(new Name("org.springframework.stereotype.Component"), new StringLiteralExpr(name)));
         return node;
     }
 
@@ -98,18 +96,14 @@ public class SpringDependencyInjectionAnnotator implements DependencyInjectionAn
     @Override
     public <T extends NodeWithAnnotations<?>> T withOptionalInjection(T node) {
         node.addAnnotation(
-                new NormalAnnotationExpr(new Name("org.springframework.beans.factory.annotation.Autowired"),
-                                         NodeList.nodeList(new MemberValuePair("required",
-                                                                               new BooleanLiteralExpr(false)))));
+                new NormalAnnotationExpr(new Name("org.springframework.beans.factory.annotation.Autowired"), NodeList.nodeList(new MemberValuePair("required", new BooleanLiteralExpr(false)))));
         node.addAnnotation("org.springframework.context.annotation.Lazy");
         return node;
     }
 
     @Override
     public <T extends NodeWithAnnotations<?>> T withIncomingMessage(T node, String channel) {
-        node.addAnnotation(new NormalAnnotationExpr(new Name("org.springframework.kafka.annotation.KafkaListener"),
-                                                    NodeList.nodeList(new MemberValuePair("topics",
-                                                                                          new StringLiteralExpr(channel)))));
+        node.addAnnotation(new NormalAnnotationExpr(new Name("org.springframework.kafka.annotation.KafkaListener"), NodeList.nodeList(new MemberValuePair("topics", new StringLiteralExpr(channel)))));
         return node;
     }
 
@@ -145,8 +139,7 @@ public class SpringDependencyInjectionAnnotator implements DependencyInjectionAn
         return new ConditionalExpr(
                 new BinaryExpr(new NameExpr(fieldName), new NullLiteralExpr(), BinaryExpr.Operator.NOT_EQUALS),
                 new NameExpr(fieldName),
-                new MethodCallExpr(new TypeExpr(new ClassOrInterfaceType(null, Collections.class.getCanonicalName()))
-                        , "emptyList"));
+                new MethodCallExpr(new TypeExpr(new ClassOrInterfaceType(null, Collections.class.getCanonicalName())), "emptyList"));
     }
 
     @Override
@@ -161,22 +154,19 @@ public class SpringDependencyInjectionAnnotator implements DependencyInjectionAn
 
     @Override
     public <T extends NodeWithAnnotations<?>> T withConfigInjection(T node, String configKey) {
-        node.addAnnotation(new SingleMemberAnnotationExpr(new Name("org.springframework.beans.factory.annotation" +
-                                                                           ".Value"),
-                                                          new StringLiteralExpr("${" + configKey + ":#{null}}")));
+        node.addAnnotation(new SingleMemberAnnotationExpr(new Name("org.springframework.beans.factory.annotation.Value"), new StringLiteralExpr("${" + configKey + ":#{null}}")));
         return node;
     }
 
     @Override
     public <T extends NodeWithAnnotations<?>> T withConfigInjection(T node, String configKey, String defaultValue) {
-        node.addAnnotation(new SingleMemberAnnotationExpr(new Name("org.springframework.beans.factory.annotation" +
-                                                                           ".Value"),
-                                                          new StringLiteralExpr("${" + configKey + ":" + defaultValue + "}")));
+        node.addAnnotation(new SingleMemberAnnotationExpr(new Name("org.springframework.beans.factory.annotation.Value"), new StringLiteralExpr("${" + configKey + ":" + defaultValue + "}")));
         return node;
     }
 
     /**
      * no-op, Spring beans are not lazy by default.
+     *
      * @param node node to be annotated
      * @return
      */

--- a/drools-model/drools-codegen-common/src/main/java/org/drools/codegen/common/di/impl/SpringDependencyInjectionAnnotator.java
+++ b/drools-model/drools-codegen-common/src/main/java/org/drools/codegen/common/di/impl/SpringDependencyInjectionAnnotator.java
@@ -18,6 +18,10 @@
  */
 package org.drools.codegen.common.di.impl;
 
+import java.util.Collection;
+import java.util.Collections;
+import java.util.Optional;
+
 import com.github.javaparser.ast.NodeList;
 import com.github.javaparser.ast.expr.BinaryExpr;
 import com.github.javaparser.ast.expr.BooleanLiteralExpr;
@@ -36,10 +40,6 @@ import com.github.javaparser.ast.nodeTypes.NodeWithAnnotations;
 import com.github.javaparser.ast.type.ClassOrInterfaceType;
 import org.drools.codegen.common.di.DependencyInjectionAnnotator;
 
-import java.util.Collection;
-import java.util.Collections;
-import java.util.Optional;
-
 public class SpringDependencyInjectionAnnotator implements DependencyInjectionAnnotator {
 
     @Override
@@ -53,7 +53,8 @@ public class SpringDependencyInjectionAnnotator implements DependencyInjectionAn
 
     @Override
     public <T extends NodeWithAnnotations<?>> T withNamed(T node, String name) {
-        node.addAnnotation(new SingleMemberAnnotationExpr(new Name("org.springframework.beans.factory.annotation.Qualifier"), new StringLiteralExpr(name)));
+        node.addAnnotation(new SingleMemberAnnotationExpr(new Name("org.springframework.beans.factory.annotation" +
+                                                                           ".Qualifier"), new StringLiteralExpr(name)));
         return node;
     }
 
@@ -65,7 +66,8 @@ public class SpringDependencyInjectionAnnotator implements DependencyInjectionAn
 
     @Override
     public <T extends NodeWithAnnotations<?>> T withNamedApplicationComponent(T node, String name) {
-        node.addAnnotation(new SingleMemberAnnotationExpr(new Name("org.springframework.stereotype.Component"), new StringLiteralExpr(name)));
+        node.addAnnotation(new SingleMemberAnnotationExpr(new Name("org.springframework.stereotype.Component"),
+                                                          new StringLiteralExpr(name)));
         return node;
     }
 
@@ -96,14 +98,18 @@ public class SpringDependencyInjectionAnnotator implements DependencyInjectionAn
     @Override
     public <T extends NodeWithAnnotations<?>> T withOptionalInjection(T node) {
         node.addAnnotation(
-                new NormalAnnotationExpr(new Name("org.springframework.beans.factory.annotation.Autowired"), NodeList.nodeList(new MemberValuePair("required", new BooleanLiteralExpr(false)))));
+                new NormalAnnotationExpr(new Name("org.springframework.beans.factory.annotation.Autowired"),
+                                         NodeList.nodeList(new MemberValuePair("required",
+                                                                               new BooleanLiteralExpr(false)))));
         node.addAnnotation("org.springframework.context.annotation.Lazy");
         return node;
     }
 
     @Override
     public <T extends NodeWithAnnotations<?>> T withIncomingMessage(T node, String channel) {
-        node.addAnnotation(new NormalAnnotationExpr(new Name("org.springframework.kafka.annotation.KafkaListener"), NodeList.nodeList(new MemberValuePair("topics", new StringLiteralExpr(channel)))));
+        node.addAnnotation(new NormalAnnotationExpr(new Name("org.springframework.kafka.annotation.KafkaListener"),
+                                                    NodeList.nodeList(new MemberValuePair("topics",
+                                                                                          new StringLiteralExpr(channel)))));
         return node;
     }
 
@@ -139,7 +145,8 @@ public class SpringDependencyInjectionAnnotator implements DependencyInjectionAn
         return new ConditionalExpr(
                 new BinaryExpr(new NameExpr(fieldName), new NullLiteralExpr(), BinaryExpr.Operator.NOT_EQUALS),
                 new NameExpr(fieldName),
-                new MethodCallExpr(new TypeExpr(new ClassOrInterfaceType(null, Collections.class.getCanonicalName())), "emptyList"));
+                new MethodCallExpr(new TypeExpr(new ClassOrInterfaceType(null, Collections.class.getCanonicalName()))
+                        , "emptyList"));
     }
 
     @Override
@@ -154,19 +161,22 @@ public class SpringDependencyInjectionAnnotator implements DependencyInjectionAn
 
     @Override
     public <T extends NodeWithAnnotations<?>> T withConfigInjection(T node, String configKey) {
-        node.addAnnotation(new SingleMemberAnnotationExpr(new Name("org.springframework.beans.factory.annotation.Value"), new StringLiteralExpr("${" + configKey + ":#{null}}")));
+        node.addAnnotation(new SingleMemberAnnotationExpr(new Name("org.springframework.beans.factory.annotation" +
+                                                                           ".Value"),
+                                                          new StringLiteralExpr("${" + configKey + ":#{null}}")));
         return node;
     }
 
     @Override
     public <T extends NodeWithAnnotations<?>> T withConfigInjection(T node, String configKey, String defaultValue) {
-        node.addAnnotation(new SingleMemberAnnotationExpr(new Name("org.springframework.beans.factory.annotation.Value"), new StringLiteralExpr("${" + configKey + ":" + defaultValue + "}")));
+        node.addAnnotation(new SingleMemberAnnotationExpr(new Name("org.springframework.beans.factory.annotation" +
+                                                                           ".Value"),
+                                                          new StringLiteralExpr("${" + configKey + ":" + defaultValue + "}")));
         return node;
     }
 
     /**
      * no-op, Spring beans are not lazy by default.
-     *
      * @param node node to be annotated
      * @return
      */
@@ -182,9 +192,8 @@ public class SpringDependencyInjectionAnnotator implements DependencyInjectionAn
     }
 
     @Override
-    public <T extends NodeWithAnnotations<?>> T withTransactional(T node) {
-        node.addAnnotation("org.springframework.transaction.annotation.Transactional");
-        return node;
+    public String getTransactionalAnnotation() {
+        return "org.springframework.transaction.annotation.Transactional";
     }
 
     @Override

--- a/drools-model/drools-codegen-common/src/main/java/org/drools/codegen/common/rest/impl/CDIRestAnnotator.java
+++ b/drools-model/drools-codegen-common/src/main/java/org/drools/codegen/common/rest/impl/CDIRestAnnotator.java
@@ -29,7 +29,7 @@ public class CDIRestAnnotator implements RestAnnotator {
 
     @Override
     public <T extends NodeWithAnnotations<?>> boolean isRestAnnotated(T node) {
-        return Stream.of("POST", "GET", "PUT", "DELETE")
+        return Stream.of("POST", "GET", "PUT", "DELETE", "PATCH")
                 .map(node::getAnnotationByName)
                 .anyMatch(Optional::isPresent);
     }

--- a/drools-model/drools-codegen-common/src/main/java/org/drools/codegen/common/rest/impl/SpringRestAnnotator.java
+++ b/drools-model/drools-codegen-common/src/main/java/org/drools/codegen/common/rest/impl/SpringRestAnnotator.java
@@ -29,7 +29,7 @@ public class SpringRestAnnotator implements RestAnnotator {
 
     @Override
     public <T extends NodeWithAnnotations<?>> boolean isRestAnnotated(T node) {
-        return Stream.of("PostMapping", "GetMapping", "PutMapping", "DeleteMapping")
+        return Stream.of("PostMapping", "GetMapping", "PutMapping", "DeleteMapping", "PatchMapping")
                 .map(node::getAnnotationByName)
                 .anyMatch(Optional::isPresent);
     }


### PR DESCRIPTION
Fixes https://github.com/apache/incubator-kie-issues/issues/1473

Needed by https://github.com/apache/incubator-kie-kogito-runtimes/pull/3671


<details>
<summary>
How to replicate CI configuration locally?
</summary>

Build Chain tool does "simple" maven build(s), the builds are just Maven commands, but because the repositories relates and depends on each other and any change in API or class method could affect several of those repositories there is a need to use [build-chain tool](https://github.com/kiegroup/github-action-build-chain) to handle cross repository builds and be sure that we always use latest version of the code for each repository.
 
[build-chain tool](https://github.com/kiegroup/github-action-build-chain) is a build tool which can be used on command line locally or in Github Actions workflow(s), in case you need to change multiple repositories and send multiple dependent pull requests related with a change you can easily reproduce the same build by executing it on Github hosted environment or locally in your development environment. See [local execution](https://github.com/kiegroup/github-action-build-chain#local-execution) details to get more information about it.
</details>

<details>
<summary>
How to retest this PR or trigger a specific build:
</summary>

- for <b>pull request and downstream checks</b>  
  - Push a new commit to the PR. An empty commit would be enough.

- for a <b>full downstream build</b>
  - for <b>github actions</b> job: add the label `run_fdb`

- for <b>Jenkins PR check only</b>
  - If you are an ASF committer for KIE podling, login to Jenkins (https://ci-builds.apache.org/job/KIE/job/drools/), go to the specific PR job, and click on `Build Now` button.
</details>
