### PR TITLE
Cache compiled dtables during the building of a KieProject

### DIFF
--- a/drools-compiler/src/main/java/org/drools/compiler/kie/builder/impl/KieBuilderImpl.java
+++ b/drools-compiler/src/main/java/org/drools/compiler/kie/builder/impl/KieBuilderImpl.java
@@ -298,6 +298,12 @@ public class KieBuilderImpl
                 kieRepository.addKieModule( kDep );
             }
         }
+
+        clearBuilderCache();
+    }
+
+    private static void clearBuilderCache() {
+        DecisionTableFactory.clearCompilerCache();
     }
 
     private void addKBasesFilesToTrg() {

--- a/drools-decisiontables/src/main/java/org/drools/decisiontable/DecisionTableProviderImpl.java
+++ b/drools-decisiontables/src/main/java/org/drools/decisiontable/DecisionTableProviderImpl.java
@@ -27,6 +27,7 @@ import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
 
 import org.drools.decisiontable.parser.xls.PropertiesSheetListener;
 import org.drools.drl.extensions.DecisionTableProvider;
@@ -44,7 +45,7 @@ public class DecisionTableProviderImpl
 
     private static final Logger logger = LoggerFactory.getLogger( DecisionTableProviderImpl.class );
 
-    private Map<String, String> compiledDtablesCache = new HashMap<>();
+    private Map<String, String> compiledDtablesCache = new ConcurrentHashMap<>();
 
     @Override
     public String loadFromResource(Resource resource,

--- a/drools-decisiontables/src/main/java/org/drools/decisiontable/DecisionTableProviderImpl.java
+++ b/drools-decisiontables/src/main/java/org/drools/decisiontable/DecisionTableProviderImpl.java
@@ -79,10 +79,11 @@ public class DecisionTableProviderImpl
     }
 
     private String compileResource(Resource resource, DecisionTableConfiguration configuration) {
-        String resourcePath = resource.getSourcePath();
-        return resourcePath == null ?
-                internalCompileResource(resource, configuration) :
-                compiledDtablesCache.computeIfAbsent(resourcePath, path -> internalCompileResource(resource, configuration));
+        if (resource.getSourcePath() == null) {
+            return internalCompileResource(resource, configuration);
+        }
+        String resourceKey = resource.getSourcePath() + "?trimCell=" + configuration.isTrimCell() + "&worksheetName=" + configuration.getWorksheetName();
+        return compiledDtablesCache.computeIfAbsent(resourceKey, path -> internalCompileResource(resource, configuration));
     }
 
     private String internalCompileResource(Resource resource, DecisionTableConfiguration configuration) throws UncheckedIOException {

--- a/drools-decisiontables/src/main/java/org/drools/decisiontable/DecisionTableProviderImpl.java
+++ b/drools-decisiontables/src/main/java/org/drools/decisiontable/DecisionTableProviderImpl.java
@@ -42,7 +42,9 @@ public class DecisionTableProviderImpl
     implements
     DecisionTableProvider {
 
-    private static final transient Logger logger = LoggerFactory.getLogger( DecisionTableProviderImpl.class );
+    private static final Logger logger = LoggerFactory.getLogger( DecisionTableProviderImpl.class );
+
+    private Map<String, String> compiledDtablesCache = new HashMap<>();
 
     @Override
     public String loadFromResource(Resource resource,
@@ -50,8 +52,6 @@ public class DecisionTableProviderImpl
 
         try {
             return compileResource( resource, configuration );
-        } catch (IOException e) {
-            throw new UncheckedIOException( e );
         } catch (Exception e) {
             throw new DecisionTableParseException(resource, e);
         }
@@ -78,27 +78,43 @@ public class DecisionTableProviderImpl
         return drls;
     }
 
-    private String compileResource(Resource resource,
-                                   DecisionTableConfiguration configuration) throws IOException {
+    private String compileResource(Resource resource, DecisionTableConfiguration configuration) {
+        String resourcePath = resource.getSourcePath();
+        return resourcePath == null ?
+                internalCompileResource(resource, configuration) :
+                compiledDtablesCache.computeIfAbsent(resourcePath, path -> internalCompileResource(resource, configuration));
+    }
+
+    private String internalCompileResource(Resource resource, DecisionTableConfiguration configuration) throws UncheckedIOException {
         SpreadsheetCompiler compiler = new SpreadsheetCompiler(configuration.isTrimCell());
 
         switch ( configuration.getInputType() ) {
             case XLS :
             case XLSX :
                 if ( StringUtils.isEmpty( configuration.getWorksheetName() ) ) {
-                    return compiler.compile( resource,
-                                             InputType.XLS );
+                    return compiler.compile( resource, InputType.XLS );
                 } else {
-                    return compiler.compile( resource.getInputStream(),
-                                             configuration.getWorksheetName() );
+                    try {
+                        return compiler.compile( resource.getInputStream(), configuration.getWorksheetName() );
+                    } catch (IOException e) {
+                        throw new UncheckedIOException(e);
+                    }
                 }
             case CSV : {
-                return compiler.compile( resource.getInputStream(),
-                                         InputType.CSV );
+                try {
+                    return compiler.compile( resource.getInputStream(), InputType.CSV );
+                } catch (IOException e) {
+                    throw new UncheckedIOException(e);
+                }
             }
         }
 
         return null;
+    }
+
+    @Override
+    public void clearCompilerCache() {
+        compiledDtablesCache.clear();
     }
 
     @Override

--- a/drools-drl/drools-drl-extensions/src/main/java/org/drools/drl/extensions/DecisionTableFactory.java
+++ b/drools-drl/drools-drl-extensions/src/main/java/org/drools/drl/extensions/DecisionTableFactory.java
@@ -42,6 +42,12 @@ public class DecisionTableFactory {
         return getDecisionTableProvider().loadFromInputStreamWithTemplates( resource, configuration );
     }
 
+    public static void clearCompilerCache() {
+        if (provider != null) {
+            provider.clearCompilerCache();
+        }
+    }
+
     public static synchronized void setDecisionTableProvider(DecisionTableProvider provider) {
         DecisionTableFactory.provider = provider;
     }

--- a/drools-drl/drools-drl-extensions/src/main/java/org/drools/drl/extensions/DecisionTableProvider.java
+++ b/drools-drl/drools-drl-extensions/src/main/java/org/drools/drl/extensions/DecisionTableProvider.java
@@ -29,13 +29,13 @@ import org.kie.internal.builder.DecisionTableConfiguration;
 
 public interface DecisionTableProvider extends KieService {
 
-    String loadFromResource(Resource resource,
-                            DecisionTableConfiguration configuration);
+    String loadFromResource(Resource resource, DecisionTableConfiguration configuration);
 
-    List<String> loadFromInputStreamWithTemplates(Resource resource,
-                                                  DecisionTableConfiguration configuration);
+    List<String> loadFromInputStreamWithTemplates(Resource resource, DecisionTableConfiguration configuration);
 
     Map<String,List<String[]>> loadPropertiesFromFile(File file, DecisionTableConfiguration configuration);
 
     Map<String,List<String[]>> loadPropertiesFromInputStream(InputStream inputStream, DecisionTableConfiguration configuration);
+
+    void clearCompilerCache();
 }


### PR DESCRIPTION
Fixes https://github.com/apache/incubator-kie-drools/issues/6088 and provide an alternative solution to what implemented in https://github.com/apache/incubator-kie-drools/pull/6089.

I believe this is a better solution for a twofold reason:

1. The cache is confined in the dtable module and only exists when dtables are actually used.
2. With the other solution the xls -> drl conversion was still performed twice, once for the actual compilation and the other to retrieve the package name, while moving the cache to a lower level allows to effectively compile a dtable only once.