### PR TITLE
[incubator-kie-drools-6098] apache-rat-plugin license check for drools

### DIFF
--- a/drools-drlonyaml-parent/drools-drlonyaml-model/src/test/resources/smoketests/ruleunit.drl.txt
+++ b/drools-drlonyaml-parent/drools-drlonyaml-model/src/test/resources/smoketests/ruleunit.drl.txt
@@ -1,3 +1,21 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
 // this is only syntactically valid DRL, so not ending with purely .drl
 package org.drools.unit;
 

--- a/drools-drlonyaml-parent/drools-drlonyaml-model/src/test/resources/smoketests/smoke1.drl.txt
+++ b/drools-drlonyaml-parent/drools-drlonyaml-model/src/test/resources/smoketests/smoke1.drl.txt
@@ -1,3 +1,21 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
 // this is only syntactically valid DRL, so not ending with purely .drl
 package ciao;
 import java.lang.Number;

--- a/drools-drlonyaml-parent/drools-drlonyaml-model/src/test/resources/smoketests/smoke10.drl.txt
+++ b/drools-drlonyaml-parent/drools-drlonyaml-model/src/test/resources/smoketests/smoke10.drl.txt
@@ -1,3 +1,21 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
 // this is only syntactically valid DRL, so not ending with purely .drl
 rule "Fix the PersistentVolume Claim Pod PENDING"
 when

--- a/drools-drlonyaml-parent/drools-drlonyaml-model/src/test/resources/smoketests/smoke2.drl.txt
+++ b/drools-drlonyaml-parent/drools-drlonyaml-model/src/test/resources/smoketests/smoke2.drl.txt
@@ -1,3 +1,21 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
 // this is only syntactically valid DRL, so not ending with purely .drl
 rule "Relax the ResourceQuota limits Deployment PENDING"
 when

--- a/drools-drlonyaml-parent/drools-drlonyaml-model/src/test/resources/smoketests/smoke3.drl.txt
+++ b/drools-drlonyaml-parent/drools-drlonyaml-model/src/test/resources/smoketests/smoke3.drl.txt
@@ -1,3 +1,21 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
 // this is only syntactically valid DRL, so not ending with purely .drl
 rule "Relax the ResourceQuota limits StatefulSet PENDING"
 when

--- a/drools-drlonyaml-parent/drools-drlonyaml-model/src/test/resources/smoketests/smoke4.drl.txt
+++ b/drools-drlonyaml-parent/drools-drlonyaml-model/src/test/resources/smoketests/smoke4.drl.txt
@@ -1,3 +1,21 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
 // this is only syntactically valid DRL, so not ending with purely .drl
 rule "Fix the Service targetPort and the containerPort"
 when

--- a/drools-drlonyaml-parent/drools-drlonyaml-model/src/test/resources/smoketests/smoke5.drl.txt
+++ b/drools-drlonyaml-parent/drools-drlonyaml-model/src/test/resources/smoketests/smoke5.drl.txt
@@ -1,3 +1,21 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
 // this is only syntactically valid DRL, so not ending with purely .drl
 function boolean mapContains(Map left, Map right) {
     if (left == null) {

--- a/drools-drlonyaml-parent/drools-drlonyaml-model/src/test/resources/smoketests/smoke6.drl.txt
+++ b/drools-drlonyaml-parent/drools-drlonyaml-model/src/test/resources/smoketests/smoke6.drl.txt
@@ -1,3 +1,21 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
 // this is only syntactically valid DRL, so not ending with purely .drl
 rule "Fix the Service selector No Pod found for selector"
 when

--- a/drools-drlonyaml-parent/drools-drlonyaml-model/src/test/resources/smoketests/smoke7.drl.txt
+++ b/drools-drlonyaml-parent/drools-drlonyaml-model/src/test/resources/smoketests/smoke7.drl.txt
@@ -1,3 +1,21 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
 // this is only syntactically valid DRL, so not ending with purely .drl
 rule "Fix the Service selector matches Pod name, but other selectors don't"
 when

--- a/drools-drlonyaml-parent/drools-drlonyaml-model/src/test/resources/smoketests/smoke8.drl.txt
+++ b/drools-drlonyaml-parent/drools-drlonyaml-model/src/test/resources/smoketests/smoke8.drl.txt
@@ -1,3 +1,21 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
 // this is only syntactically valid DRL, so not ending with purely .drl
 rule "Fix the Service selector sounds like Pod name but not an exact match"
 when

--- a/drools-drlonyaml-parent/drools-drlonyaml-model/src/test/resources/smoketests/smoke9.drl.txt
+++ b/drools-drlonyaml-parent/drools-drlonyaml-model/src/test/resources/smoketests/smoke9.drl.txt
@@ -1,3 +1,21 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
 // this is only syntactically valid DRL, so not ending with purely .drl
 rule "Relax the ResourceQuota limits Deployment PENDING"
 when

--- a/kie-dmn/Developer_Guide.md
+++ b/kie-dmn/Developer_Guide.md
@@ -1,3 +1,22 @@
+<!--
+  Licensed to the Apache Software Foundation (ASF) under one
+  or more contributor license agreements.  See the NOTICE file
+  distributed with this work for additional information
+  regarding copyright ownership.  The ASF licenses this file
+  to you under the Apache License, Version 2.0 (the
+  "License"); you may not use this file except in compliance
+  with the License.  You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing,
+  software distributed under the License is distributed on an
+  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+  KIND, either express or implied.  See the License for the
+  specific language governing permissions and limitations
+  under the License.
+  -->
+
 # kie-dmn - Developer Guide
 
 This module (and all its submodules) contains the code that make up the DMN engine.

--- a/kie-dmn/kie-dmn-core/src/test/resources/org/kie/dmn/core/0089-nested-inputdata-imports.dmn
+++ b/kie-dmn/kie-dmn-core/src/test/resources/org/kie/dmn/core/0089-nested-inputdata-imports.dmn
@@ -1,4 +1,23 @@
 <?xml version="1.0" encoding="utf-8" standalone="yes"?>
+<!--
+  Licensed to the Apache Software Foundation (ASF) under one
+  or more contributor license agreements.  See the NOTICE file
+  distributed with this work for additional information
+  regarding copyright ownership.  The ASF licenses this file
+  to you under the Apache License, Version 2.0 (the
+  "License"); you may not use this file except in compliance
+  with the License.  You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing,
+  software distributed under the License is distributed on an
+  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+  KIND, either express or implied.  See the License for the
+  specific language governing permissions and limitations
+  under the License.
+  -->
+
 <definitions xmlns:semantic="https://www.omg.org/spec/DMN/20211108/MODEL/" 
                       xmlns:dmn11="http://www.omg.org/spec/DMN/20151101/dmn.xsd" 
                       xmlns:rss="http://purl.org/rss/2.0/" 

--- a/kie-dmn/kie-dmn-core/src/test/resources/org/kie/dmn/core/Model_B.dmn
+++ b/kie-dmn/kie-dmn-core/src/test/resources/org/kie/dmn/core/Model_B.dmn
@@ -1,4 +1,23 @@
 <?xml version="1.0" encoding="utf-8" standalone="yes"?>
+<!--
+  Licensed to the Apache Software Foundation (ASF) under one
+  or more contributor license agreements.  See the NOTICE file
+  distributed with this work for additional information
+  regarding copyright ownership.  The ASF licenses this file
+  to you under the Apache License, Version 2.0 (the
+  "License"); you may not use this file except in compliance
+  with the License.  You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing,
+  software distributed under the License is distributed on an
+  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+  KIND, either express or implied.  See the License for the
+  specific language governing permissions and limitations
+  under the License.
+  -->
+
 <definitions xmlns:semantic="https://www.omg.org/spec/DMN/20211108/MODEL/" 
                       xmlns:dmn11="http://www.omg.org/spec/DMN/20151101/dmn.xsd" 
                       xmlns:rss="http://purl.org/rss/2.0/" 

--- a/kie-dmn/kie-dmn-core/src/test/resources/org/kie/dmn/core/Model_B2.dmn
+++ b/kie-dmn/kie-dmn-core/src/test/resources/org/kie/dmn/core/Model_B2.dmn
@@ -1,4 +1,23 @@
 <?xml version="1.0" encoding="utf-8" standalone="yes"?>
+<!--
+  Licensed to the Apache Software Foundation (ASF) under one
+  or more contributor license agreements.  See the NOTICE file
+  distributed with this work for additional information
+  regarding copyright ownership.  The ASF licenses this file
+  to you under the Apache License, Version 2.0 (the
+  "License"); you may not use this file except in compliance
+  with the License.  You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing,
+  software distributed under the License is distributed on an
+  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+  KIND, either express or implied.  See the License for the
+  specific language governing permissions and limitations
+  under the License.
+  -->
+
 <definitions xmlns:semantic="https://www.omg.org/spec/DMN/20211108/MODEL/" 
                       xmlns:dmn11="http://www.omg.org/spec/DMN/20151101/dmn.xsd" 
                       xmlns:rss="http://purl.org/rss/2.0/" 

--- a/kie-dmn/kie-dmn-core/src/test/resources/org/kie/dmn/core/Say_hello_1ID1D.dmn
+++ b/kie-dmn/kie-dmn-core/src/test/resources/org/kie/dmn/core/Say_hello_1ID1D.dmn
@@ -1,4 +1,23 @@
 <?xml version="1.0" encoding="utf-8" standalone="yes"?>
+<!--
+  Licensed to the Apache Software Foundation (ASF) under one
+  or more contributor license agreements.  See the NOTICE file
+  distributed with this work for additional information
+  regarding copyright ownership.  The ASF licenses this file
+  to you under the Apache License, Version 2.0 (the
+  "License"); you may not use this file except in compliance
+  with the License.  You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing,
+  software distributed under the License is distributed on an
+  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+  KIND, either express or implied.  See the License for the
+  specific language governing permissions and limitations
+  under the License.
+  -->
+
 <definitions xmlns:semantic="https://www.omg.org/spec/DMN/20211108/MODEL/"
                       xmlns:dmn11="http://www.omg.org/spec/DMN/20151101/dmn.xsd" 
                       xmlns:rss="http://purl.org/rss/2.0/" 

--- a/kie-dmn/kie-dmn-test-resources/src/test/resources/valid_models/DMNv1_5/LocalHrefs.dmn
+++ b/kie-dmn/kie-dmn-test-resources/src/test/resources/valid_models/DMNv1_5/LocalHrefs.dmn
@@ -1,4 +1,23 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+  <!--
+  Licensed to the Apache Software Foundation (ASF) under one
+  or more contributor license agreements.  See the NOTICE file
+  distributed with this work for additional information
+  regarding copyright ownership.  The ASF licenses this file
+  to you under the Apache License, Version 2.0 (the
+  "License"); you may not use this file except in compliance
+  with the License.  You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing,
+  software distributed under the License is distributed on an
+  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+  KIND, either express or implied.  See the License for the
+  specific language governing permissions and limitations
+  under the License.
+  -->
+
 <definitions namespace="http://www.montera.com.au/spec/DMN/local-hrefs"
              name="LocalHrefs"
              xmlns="https://www.omg.org/spec/DMN/20230324/MODEL/">

--- a/pom.xml
+++ b/pom.xml
@@ -136,7 +136,11 @@
           <configuration>
             <excludes>
               <exclude>.git-blame-ignore-revs</exclude>
+              <exclude>**/dependency-reduced-pom.xml</exclude>
               <exclude>**/lunr-2.3.9.min.js</exclude>
+              <exclude>**/search-ui.js</exclude>
+              <exclude>**/branch.yaml</exclude>
+              <exclude>**/main.yaml</exclude>
               <exclude>**/mvel.jj</exclude>
               <exclude>**/*.csv</exclude>
               <exclude>**/*.sdo</exclude>
@@ -159,7 +163,6 @@
               <exclude>**/*.log</exclude>
               <exclude>**/*.lst</exclude>
               <exclude>**/checkstyle-cachefile</exclude>
-              <exclude>**/smoke*.drl.txt</exclude>
               <exclude>**/test*.txt</exclude>
               <exclude>**/test*.yml</exclude>
               <exclude>**/drl.ftl</exclude>


### PR DESCRIPTION
**Issue**: 

* https://github.com/apache/incubator-kie-drools/issues/6098

This is a forward-port PR of https://github.com/apache/incubator-kie-drools/pull/6099 for main
Plus, adding some license headers for files which were recently added.