### PR TITLE
[NO_ISSUE] Cleanup incubator-kie-issues#1504 - Conditionally build all  or only reproducible modules based on only.reproducible flag

### DIFF
--- a/drools-drlonyaml-parent/pom.xml
+++ b/drools-drlonyaml-parent/pom.xml
@@ -31,6 +31,15 @@
   <name>Drools :: DRL on YAML</name>
   <packaging>pom</packaging>
 
+
+  <modules>
+    <module>drools-drlonyaml-schemagen</module>
+    <module>drools-drlonyaml-model</module>
+    <module>drools-drlonyaml-todrl</module>
+    <module>drools-drlonyaml-cli</module>
+    <module>drools-drlonyaml-cli-tests</module>
+  </modules>
+
   <profiles>
     <profile>
       <id>allSubmodules</id>
@@ -40,28 +49,7 @@
       </property>
       </activation>
       <modules>
-        <module>drools-drlonyaml-schemagen</module>
-        <module>drools-drlonyaml-model</module>
-        <module>drools-drlonyaml-todrl</module>
-        <module>drools-drlonyaml-cli</module>
-        <module>drools-drlonyaml-cli-tests</module>
         <module>drools-drlonyaml-integration-tests</module>
-      </modules>
-    </profile>
-
-    <profile>
-      <id>onlyReproducible</id>
-      <activation>
-        <property>
-          <name>only.reproducible</name>
-        </property>
-      </activation>
-      <modules>
-        <module>drools-drlonyaml-schemagen</module>
-        <module>drools-drlonyaml-model</module>
-        <module>drools-drlonyaml-todrl</module>
-        <module>drools-drlonyaml-cli</module>
-        <module>drools-drlonyaml-cli-tests</module>
       </modules>
     </profile>
   </profiles>


### PR DESCRIPTION
Refactoring of https://github.com/apache/incubator-kie-drools/pull/6108

Keep the same behavior, but better written

<details>
<summary>
How to replicate CI configuration locally?
</summary>

Build Chain tool does "simple" maven build(s), the builds are just Maven commands, but because the repositories relates and depends on each other and any change in API or class method could affect several of those repositories there is a need to use [build-chain tool](https://github.com/kiegroup/github-action-build-chain) to handle cross repository builds and be sure that we always use latest version of the code for each repository.
 
[build-chain tool](https://github.com/kiegroup/github-action-build-chain) is a build tool which can be used on command line locally or in Github Actions workflow(s), in case you need to change multiple repositories and send multiple dependent pull requests related with a change you can easily reproduce the same build by executing it on Github hosted environment or locally in your development environment. See [local execution](https://github.com/kiegroup/github-action-build-chain#local-execution) details to get more information about it.
</details>

<details>
<summary>
How to retest this PR or trigger a specific build:
</summary>

- for <b>pull request and downstream checks</b>  
  - Push a new commit to the PR. An empty commit would be enough.

- for a <b>full downstream build</b>
  - for <b>github actions</b> job: add the label `run_fdb`

- for <b>Jenkins PR check only</b>
  - If you are an ASF committer for KIE podling, login to Jenkins (https://ci-builds.apache.org/job/KIE/job/drools/), go to the specific PR job, and click on `Build Now` button.
</details>
