### PR TITLE
[incubator-kie-issues#6112]Fixing non-deterministic  test 

### DIFF
--- a/drools-model/drools-model-codegen/src/test/java/org/drools/model/codegen/execmodel/PropertyReactivityTest.java
+++ b/drools-model/drools-model-codegen/src/test/java/org/drools/model/codegen/execmodel/PropertyReactivityTest.java
@@ -1313,7 +1313,8 @@ public class PropertyReactivityTest extends BaseModelTest {
                 "rule R dialect \"mvel\" when\n" +
                 "    $p : Person( $age : age < 50 ) @watch(!*)\n" +
                 "then\n" +
-                "    modify($p) { age = $age + 1 };\n" +
+                "    $p.setAge($p.getAge() + 1);\n" +  
+                "    update($p);\n" + 
                 "end\n";
 
         KieSession ksession = getKieSession( str );


### PR DESCRIPTION

Issue: [https://github.com/apache/incubator-kie-drools/issues/6112](https://github.com/apache/incubator-kie-drools/issues/6112)

The fix can be tested using the command:

```
 mvn -pl drools-model/drools-model-codegen     edu.illinois:nondex-maven-plugin:2.1.7:nondex      -Dtest=org.drools.model.codegen.execmodel.PropertyReactivityTest#testUnwatchWithFieldBindingAndMvel
```

