### PR TITLE
[incubator-kie-issues#6118] Fix flaky tests in AccumulateTest

### DIFF
--- a/drools-model/drools-model-codegen/src/main/java/org/drools/model/codegen/execmodel/generator/Consequence.java
+++ b/drools-model/drools-model-codegen/src/main/java/org/drools/model/codegen/execmodel/generator/Consequence.java
@@ -23,10 +23,12 @@ import java.util.Collection;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
+import java.util.LinkedHashSet;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
 import java.util.regex.Pattern;
+import java.util.stream.Collectors;
 
 import com.github.javaparser.ParseProblemException;
 import com.github.javaparser.ast.Modifier;
@@ -65,7 +67,6 @@ import org.drools.mvelcompiler.PreprocessCompiler;
 import org.drools.util.StringUtils;
 
 import static com.github.javaparser.StaticJavaParser.parseExpression;
-import static java.util.stream.Collectors.toSet;
 import static org.drools.model.codegen.execmodel.PackageModel.DOMAIN_CLASSESS_METADATA_FILE_NAME;
 import static org.drools.model.codegen.execmodel.PackageModel.DOMAIN_CLASS_METADATA_INSTANCE;
 import static org.drools.model.codegen.execmodel.generator.DrlxParseUtil.addCurlyBracesToBlock;
@@ -251,7 +252,7 @@ public class Consequence {
     }
 
     private Set<String> extractUsedDeclarations(BlockStmt ruleConsequence, String consequenceString) {
-        Set<String> existingDecls = new HashSet<>();
+        Set<String> existingDecls = new LinkedHashSet<>();
         existingDecls.addAll(context.getAvailableBindings());
         existingDecls.addAll(context.getGlobals().keySet());
         if (context.getRuleUnitDescr() != null) {
@@ -259,10 +260,14 @@ public class Consequence {
         }
 
         if (context.getRuleDialect() == RuleContext.RuleDialect.MVEL) {
-            return existingDecls.stream().filter(d -> containsWord(d, consequenceString)).collect(toSet());
+            return existingDecls.stream()
+                                .filter(d -> containsWord(d, consequenceString))
+                                .collect(Collectors.toCollection(LinkedHashSet::new));
         } else if (ruleConsequence != null) {
-            Set<String> declUsedInRHS = ruleConsequence.findAll(NameExpr.class).stream().map(NameExpr::getNameAsString).collect(toSet());
-            return existingDecls.stream().filter(declUsedInRHS::contains).collect(toSet());
+            Set<String> declUsedInRHS = ruleConsequence.findAll(NameExpr.class).stream().map(NameExpr::getNameAsString).collect(Collectors.toCollection(LinkedHashSet::new));
+            return existingDecls.stream()
+                                .filter(declUsedInRHS::contains)
+                                .collect(Collectors.toCollection(LinkedHashSet::new));
         }
 
         throw new IllegalArgumentException("Unknown rule dialect " + context.getRuleDialect() + "!");


### PR DESCRIPTION
### Description 
 
I encountered non-deterministic behavior while running the following tests using NonDex:

	1.	org.drools.model.codegen.execmodel.AccumulateTest.testInlineAccumulateWithAnd()
	2.	org.drools.model.codegen.execmodel.AccumulateTest.testBindingOrderWithInlineAccumulateAndLists()

### Steps to reproduce

NonDex: https://github.com/TestingResearchIllinois/NonDex
Run the tests with NonDex: 
```
mvn -pl drools-model/drools-model-codegen edu.illinois:nondex-maven-plugin:2.1.7:nondex -Dtest=org.drools.model.codegen.execmodel.AccumulateTest#testInlineAccumulateWithAnd
```

The error message shows:

<details>
  <summary>Click to view</summary>

```
[ERROR] Failures:
[ERROR]   AccumulateTest.testInlineAccumulateWithAnd:2752->BaseModelTest.getKieSession:105->BaseModelTest.getKieSession:109->BaseModelTest.getKieContainer:113->BaseModelTest.getKieContainer:120->BaseModelTest.createKieBuilder:131->BaseModelTest.createKieBuilder:156 [Message [id=1, level=ERROR, path=src/main/java/defaultpkg/RulesFCB815F80535171A856D047578567E4ARuleMethods0.java, line=57, column=7042
   text=The method execute(Block2<List,BigDecimal>) in the type ConsequenceBuilder._2<List,BigDecimal> is not applicable for the arguments (LambdaConsequence5A97B91F758DE5E929A604F8AF538731)], Message [id=2, level=ERROR, path=src/main/java/defaultpkg/RulesFCB815F80535171A856D047578567E4ARuleMethods0.java, line=0, column=0
   text=Java source of src/main/java/defaultpkg/RulesFCB815F80535171A856D047578567E4ARuleMethods0.java in error:
package defaultpkg;

import org.drools.modelcompiler.dsl.pattern.D;
import org.drools.model.Index.ConstraintType;
import org.drools.model.codegen.execmodel.AccumulateTest.Order;
import java.math.BigDecimal;
import org.drools.model.codegen.execmodel.AccumulateTest.Car;
import static defaultpkg.RulesFCB815F80535171A856D047578567E4A.*;
import static defaultpkg.RulesFCB815F80535171A856D047578567E4A.*;

public class RulesFCB815F80535171A856D047578567E4ARuleMethods0 {

    /**
     * Rule name: R
     */
    public static org.drools.model.Rule rule_R() {
        final org.drools.model.Variable<java.math.BigDecimal> var_$total = D.declarationOf(java.math.BigDecimal.class,
                                                                                           DomainClassesMetadataFCB815F80535171A856D047578567E4A.java_math_BigDecimal_Metadata_INSTANCE,
                                                                                           "$total");
        final org.drools.model.Variable<org.drools.model.codegen.execmodel.AccumulateTest.Car> var_$car_1_sCoPe = D.declarationOf(org.drools.model.codegen.execmodel.AccumulateTest.Car.class,
                                                                                                                                  DomainClassesMetadataFCB815F80535171A856D047578567E4A.org_drools_model_codegen_execmodel_AccumulateTest_Car_Metadata_INSTANCE,
                                                                                                                                  "$car_1_sCoPe");
        final org.drools.model.Variable<org.drools.model.codegen.execmodel.AccumulateTest.Order> var_GENERATED_$pattern_Order$2$ = D.declarationOf(org.drools.model.codegen.execmodel.AccumulateTest.Order.class,
                                                                                                                                                   DomainClassesMetadataFCB815F80535171A856D047578567E4A.org_drools_model_codegen_execmodel_AccumulateTest_Order_Metadata_INSTANCE,
                                                                                                                                                   "GENERATED_$pattern_Order$2$");
        final org.drools.model.Variable<java.math.BigDecimal> var_$price_1_sCoPe = D.declarationOf(java.math.BigDecimal.class,
                                                                                                   DomainClassesMetadataFCB815F80535171A856D047578567E4A.java_math_BigDecimal_Metadata_INSTANCE,
                                                                                                   "$price_1_sCoPe");
        final org.drools.model.Variable<java.math.BigDecimal> var_total = D.declarationOf(java.math.BigDecimal.class,
                                                                                          DomainClassesMetadataFCB815F80535171A856D047578567E4A.java_math_BigDecimal_Metadata_INSTANCE,
                                                                                          "total");
        org.drools.model.Rule rule = D.rule("R")
                                      .build(D.pattern(var_$total),
                                             D.accumulate(D.and(D.pattern(var_$car_1_sCoPe).expr("GENERATED_9B0C55783F006C0E62C1D71652E2D1F6",
                                                                                                 defaultpkg.P30.LambdaPredicate30E28C5B6FC1EE01A1A5E80C4BD31C35.INSTANCE,
                                                                                                 D.alphaIndexedBy(boolean.class,
                                                                                                                  org.drools.model.Index.ConstraintType.EQUAL,
                                                                                                                  DomainClassesMetadataFCB815F80535171A856D047578567E4A.org_drools_model_codegen_execmodel_AccumulateTest_Car_Metadata_INSTANCE.getPropertyIndex("discontinued"),
                                                                                                                  defaultpkg.P51.LambdaExtractor519DC0D2200DB8C0CE09AEB4B0C3EA93.INSTANCE,
                                                                                                                  true),
                                                                                                 D.reactOn("discontinued")),
                                                                D.pattern(var_GENERATED_$pattern_Order$2$).expr("GENERATED_19C0B6B21686A8E04442698566247F3B",
                                                                                                                var_$car_1_sCoPe,
                                                                                                                defaultpkg.PEF.LambdaPredicateEF21722F0A1FCC0E95ACD94C1A6B2117.INSTANCE,
                                                                                                                D.betaIndexedBy(org.drools.model.codegen.execmodel.AccumulateTest.Car.class,
                                                                                                                                org.drools.model.Index.ConstraintType.EQUAL,
                                                                                                                                DomainClassesMetadataFCB815F80535171A856D047578567E4A.org_drools_model_codegen_execmodel_AccumulateTest_Order_Metadata_INSTANCE.getPropertyIndex("item"),
                                                                                                                                defaultpkg.P77.LambdaExtractor77565E1C1F219C6B34657CAF2D3078EB.INSTANCE,
                                                                                                                                defaultpkg.PBB.LambdaExtractorBBD0304C512D0A3ECA630EC377552F10.INSTANCE,
                                                                                                                                org.drools.model.codegen.execmodel.AccumulateTest.Car.class),
                                                                                                                D.reactOn("item")).bind(var_$price_1_sCoPe,
                                                                                                                                        defaultpkg.PC7.LambdaExtractorC7CBBC8CF2638092C1BDE953A419E4DE.INSTANCE,
                                                                                                                                        D.reactOn("price"))),
                                                          D.accFunction(RAccumulate3::new,
                                                                        var_$price_1_sCoPe).as(var_$total)),
                                             D.on(var_result,
                                                  var_$total).execute(defaultpkg.P5A.LambdaConsequence5A97B91F758DE5E929A604F8AF538731.INSTANCE));
        return rule;
    }
}
]]
```

</details>

### Proposed Solution

The issue occurs due to non-deterministic behavior in the LambdaConsequence generated by `MethodCallExpr` and `Consequence`, where the execute() method’s parameters are passed in an inconsistent order. This causes Drools to fail to compile the generated Java file when running above test cases. 

The root cause lies in the `extractUsedDeclarations` method in the `Consequence` object uses a Set to track and filter arguments, and this results the non-deterministic behavior. 

To fix this, I replaced the Set with a LinkedHashSet in the **extractUsedDeclarations** method to ensure consistent ordering of declarations during rule compilation.
