### PR TITLE
flaky test detected

### DIFF
--- a/drools-alphanetwork-compiler/src/test/java/org/drools/ancompiler/AlphaNetworkCompilerTest.java
+++ b/drools-alphanetwork-compiler/src/test/java/org/drools/ancompiler/AlphaNetworkCompilerTest.java
@@ -566,6 +566,7 @@ public class AlphaNetworkCompilerTest extends BaseModelTest {
 
         final List<Person> results = new ArrayList<>();
 
+        // Flakiness detected by nondex
         KieSession ksession = getKieSession(str);
 
         ksession.setGlobal("results", results);


### PR DESCRIPTION
**Summary:**
This PR addresses a flaky test identified using the NonDex tool. The tool detects flakiness in the following test:

`org.drools.ancompiler.AlphaNetworkCompilerTest.testNodeHashingWith2LevelConditionsCheckFirstCondition[PATTERN_DSL]`
I am working within the `drools-alphanetwork-compiler` module. While I was able to identify the root cause of the flakiness, I couldn't fully resolve it due to a lack of context on the specific test and module. I reviewed a similar PR ([#6119](https://github.com/apache/incubator-kie-drools/pull/6119)) that addresses a related issue in the `drools-model/drools-model-codegen` module, but those fixes did not apply to this case.

**Steps taken:**
Used NonDex to detect flaky behavior in the mentioned test.
Investigated potential fixes based on the approach from PR #6119 in another module, but they were not successful in this case.

**Next steps:**
I am open to continuing work on this issue and collaborating with maintainers. I would be happy to iterate on this PR with further feedback or additional context provided by the team.

Looking forward to your input!