### PR TITLE
CI duplicate maven configuration entries

### DIFF
--- a/.ci/jenkins/config/branch.yaml
+++ b/.ci/jenkins/config/branch.yaml
@@ -77,7 +77,11 @@ buildchain_config:
     file_path: .ci/pull-request-config.yaml
     token_credentials_id: kie-ci3-token
 maven:
-  settings_file_id: kie-release-settings
+  settings:
+    nightly:
+      config_file_id: kie-nightly-settings
+    release:
+      config_file_id: kie-release-settings
   nexus:
     release_url: TO_DEFINE
     release_repository: TO_DEFINE
@@ -86,8 +90,12 @@ maven:
     build_promotion_profile_id: TO_DEFINE
   artifacts_repository: ''
   artifacts_upload_repository:
-    url: https://repository.apache.org/content/repositories/snapshots
-    creds_id: apache-nexus-kie-deploy-credentials
+    nightly:
+      url: https://repository.apache.org/content/repositories/snapshots
+      creds_id: apache-nexus-kie-deploy-credentials
+    release:
+      url: https://repository.apache.org/service/local/staging/deploy/maven2
+      creds_id: jenkins-deploy-to-nexus-staging
 cloud:
   image:
     registry_user_credentials_id: DOCKERHUB_USER

--- a/.ci/jenkins/dsl/jobs.groovy
+++ b/.ci/jenkins/dsl/jobs.groovy
@@ -250,8 +250,8 @@ setupSpecificBuildChainNightlyJob('sonarcloud', setupSonarProjectKeyEnv(nightlyJ
 // Quarkus 3 nightly is exported to Kogito pipelines for easier integration
 
 // Release jobs
-setupDeployJob(JobType.RELEASE)
-setupPromoteJob(JobType.RELEASE)
+setupDeployJob()
+setupPromoteJob()
 
 // Weekly deploy job
 setupWeeklyDeployJob()
@@ -287,7 +287,7 @@ void createSetupBranchJob() {
         GIT_AUTHOR_CREDS_ID: "${GIT_AUTHOR_CREDENTIALS_ID}",
         GIT_AUTHOR_PUSH_CREDS_ID: "${GIT_AUTHOR_PUSH_CREDENTIALS_ID}",
 
-        MAVEN_SETTINGS_CONFIG_FILE_ID: "${MAVEN_SETTINGS_FILE_ID}",
+        MAVEN_SETTINGS_CONFIG_FILE_ID: Utils.getMavenSettingsConfigFileId(this, JobType.NIGHTLY.name),
 
         IS_MAIN_BRANCH: "${Utils.isMainBranch(this)}",
         DROOLS_STREAM: Utils.getStream(this),
@@ -305,8 +305,8 @@ void createSetupBranchJob() {
     }
 }
 
-void setupDeployJob(JobType jobType) {
-    def jobParams = JobParamsUtils.getBasicJobParams(this, 'drools-deploy', jobType, "${jenkins_path}/Jenkinsfile.deploy", 'Drools Deploy')
+void setupDeployJob() {
+    def jobParams = JobParamsUtils.getBasicJobParams(this, 'drools-deploy', JobType.RELEASE, "${jenkins_path}/Jenkinsfile.deploy", 'Drools Deploy')
     JobParamsUtils.setupJobParamsAgentDockerBuilderImageConfiguration(this, jobParams)
     jobParams.env.putAll([
         PROPERTIES_FILE_NAME: 'deployment.properties',
@@ -316,10 +316,10 @@ void setupDeployJob(JobType jobType) {
         GIT_AUTHOR_CREDS_ID: "${GIT_AUTHOR_CREDENTIALS_ID}",
         GIT_AUTHOR_PUSH_CREDS_ID: "${GIT_AUTHOR_PUSH_CREDENTIALS_ID}",
 
-        MAVEN_SETTINGS_CONFIG_FILE_ID: "${MAVEN_SETTINGS_FILE_ID}",
+        MAVEN_SETTINGS_CONFIG_FILE_ID: Utils.getMavenSettingsConfigFileId(this, JobType.RELEASE.name),
         MAVEN_DEPENDENCIES_REPOSITORY: "${MAVEN_ARTIFACTS_REPOSITORY}",
-        MAVEN_DEPLOY_REPOSITORY: "${MAVEN_ARTIFACTS_UPLOAD_REPOSITORY_URL}",
-        MAVEN_REPO_CREDS_ID: "${MAVEN_ARTIFACTS_UPLOAD_REPOSITORY_CREDS_ID}",
+        MAVEN_DEPLOY_REPOSITORY: Utils.getMavenArtifactsUploadRepositoryUrl(this, JobType.RELEASE.name),
+        MAVEN_REPO_CREDS_ID: Utils.getMavenArtifactsUploadRepositoryCredentialsId(this, JobType.RELEASE.name),
 
         DROOLS_STREAM: Utils.getStream(this),
 
@@ -343,8 +343,8 @@ void setupDeployJob(JobType jobType) {
     }
 }
 
-void setupPromoteJob(JobType jobType) {
-    def jobParams = JobParamsUtils.getBasicJobParams(this, 'drools-promote', jobType, "${jenkins_path}/Jenkinsfile.promote", 'Drools Promote')
+void setupPromoteJob() {
+    def jobParams = JobParamsUtils.getBasicJobParams(this, 'drools-promote', JobType.RELEASE, "${jenkins_path}/Jenkinsfile.promote", 'Drools Promote')
     JobParamsUtils.setupJobParamsAgentDockerBuilderImageConfiguration(this, jobParams)
     jobParams.env.putAll([
         PROPERTIES_FILE_NAME: 'deployment.properties',
@@ -354,7 +354,7 @@ void setupPromoteJob(JobType jobType) {
         GIT_AUTHOR_CREDS_ID: "${GIT_AUTHOR_CREDENTIALS_ID}",
         GIT_AUTHOR_PUSH_CREDS_ID: "${GIT_AUTHOR_PUSH_CREDENTIALS_ID}",
 
-        MAVEN_SETTINGS_CONFIG_FILE_ID: "${MAVEN_SETTINGS_FILE_ID}",
+        MAVEN_SETTINGS_CONFIG_FILE_ID: Utils.getMavenSettingsConfigFileId(this, JobType.RELEASE.name),
         MAVEN_DEPENDENCIES_REPOSITORY: "${MAVEN_ARTIFACTS_REPOSITORY}",
         MAVEN_DEPLOY_REPOSITORY: "${MAVEN_ARTIFACTS_REPOSITORY}",
 
@@ -385,10 +385,10 @@ void setupWeeklyDeployJob() {
         GIT_AUTHOR_CREDS_ID: "${GIT_AUTHOR_CREDENTIALS_ID}",
         GIT_AUTHOR_PUSH_CREDS_ID: "${GIT_AUTHOR_PUSH_CREDENTIALS_ID}",
 
-        MAVEN_SETTINGS_CONFIG_FILE_ID: "${MAVEN_SETTINGS_FILE_ID}",
+        MAVEN_SETTINGS_CONFIG_FILE_ID: Utils.getMavenSettingsConfigFileId(this, JobType.NIGHTLY.name),
         MAVEN_DEPENDENCIES_REPOSITORY: "${MAVEN_ARTIFACTS_REPOSITORY}",
-        MAVEN_DEPLOY_REPOSITORY: "${MAVEN_ARTIFACTS_UPLOAD_REPOSITORY_URL}",
-        MAVEN_REPO_CREDS_ID: "${MAVEN_ARTIFACTS_UPLOAD_REPOSITORY_CREDS_ID}",
+        MAVEN_DEPLOY_REPOSITORY: Utils.getMavenArtifactsUploadRepositoryUrl(this, JobType.NIGHTLY.name),
+        MAVEN_REPO_CREDS_ID: Utils.getMavenArtifactsUploadRepositoryCredentialsId(this, JobType.NIGHTLY.name),
 
         DROOLS_STREAM: Utils.getStream(this),
     ])


### PR DESCRIPTION
Adjusting branch.yaml configuration to split maven related configurations for nightly and release.

Part of ensemble:

- apache/incubator-kie-kogito-pipelines#1259
- apache/incubator-kie-drools#6132
- apache/incubator-kie-optaplanner#3135
- apache/incubator-kie-optaplanner-quickstarts#635
- apache/incubator-kie-kogito-runtimes#3738
- apache/incubator-kie-kogito-apps#2121
- apache/incubator-kie-kogito-examples#2026

The scope of changes:

- maven settings.xml reference (config file id pointing at pre-defined config file in jenkins)
- artifacts upload repository
  - url - mostly informational, should not be needed for deploy itself (inheriting that configuration from apache parent)
  - credentials-id - the important part, allowing to configure different credentials for nightly and release.

Notes:
- in some places the configuration variants denoted as nightly are used in other places too (e.g. setup-branch).
