### PR TITLE
[kie-issues#1410] Fix type check for decision service input parameters.

### DIFF
--- a/kie-dmn/kie-dmn-core/src/main/java/org/kie/dmn/core/ast/DMNDecisionServiceFunctionDefinitionEvaluator.java
+++ b/kie-dmn/kie-dmn-core/src/main/java/org/kie/dmn/core/ast/DMNDecisionServiceFunctionDefinitionEvaluator.java
@@ -160,7 +160,7 @@ public class DMNDecisionServiceFunctionDefinitionEvaluator implements DMNExpress
                                                            dsFormalParameter.type,
                                                            typeCheck,
                                                            (rx, tx) -> MsgUtil.reportMessage(LOG,
-                                                                                             DMNMessage.Severity.WARN,
+                                                                                             DMNMessage.Severity.ERROR,
                                                                                              null,
                                                                                              resultContext,
                                                                                              null,
@@ -169,7 +169,11 @@ public class DMNDecisionServiceFunctionDefinitionEvaluator implements DMNExpress
                                                                                              dsFormalParameter.name,
                                                                                              tx,
                                                                                              MsgUtil.clipString(rx.toString(), 50)));
-            return result;
+            if (param != null && result == null) {
+                throw new IllegalArgumentException("Parameter " + param + " cannot be assigned to parameter of type " + dsFormalParameter.type + "!");
+            } else {
+                return result;
+            }
         }
 
         @Override

--- a/kie-dmn/kie-dmn-core/src/test/java/org/kie/dmn/core/decisionservices/DMNDecisionServicesTest.java
+++ b/kie-dmn/kie-dmn-core/src/test/java/org/kie/dmn/core/decisionservices/DMNDecisionServicesTest.java
@@ -633,8 +633,8 @@ public class DMNDecisionServicesTest extends BaseInterpretedVsCompiledTest {
         final DMNResult dmnResult = runtime.evaluateAll(dmnModel, emptyContext);
         LOG.debug("{}", dmnResult);
         dmnResult.getDecisionResults().forEach(x -> LOG.debug("{}", x));
-        assertThat(dmnResult.hasErrors()).as(DMNRuntimeUtil.formatMessages(dmnResult.getMessages())).isFalse();
-        assertThat((Map<String, Object>) dmnResult.getDecisionResultByName("my invoke DS1").getResult()).containsEntry("outDS1", true);
+        assertThat(dmnResult.hasErrors()).as(DMNRuntimeUtil.formatMessages(dmnResult.getMessages())).isTrue();
+        assertThat((Map<String, Object>) dmnResult.getDecisionResultByName("my invoke DS1").getResult()).isNull();
     }
 
     @ParameterizedTest


### PR DESCRIPTION
Fixes https://github.com/apache/incubator-kie-issues/issues/1410

This PR fixes a DMN TCK failure around type checks for decision service input parameters. 