### PR TITLE
[incubator-kie-drools-6136] Migrate droos test coverage module to JUnit5 - #1

### DIFF
--- a/drools-test-coverage/test-compiler-integration/pom.xml
+++ b/drools-test-coverage/test-compiler-integration/pom.xml
@@ -101,7 +101,26 @@
       <artifactId>xstream</artifactId>
       <scope>test</scope>
     </dependency>
-
+        <dependency>
+            <groupId>org.junit.vintage</groupId>
+            <artifactId>junit-vintage-engine</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-api</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-engine</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-params</artifactId>
+            <scope>test</scope>
+        </dependency>
     <dependency>
       <groupId>org.assertj</groupId>
       <artifactId>assertj-core</artifactId>

--- a/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/compiler/integrationtests/AccumulateCepTest.java
+++ b/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/compiler/integrationtests/AccumulateCepTest.java
@@ -19,19 +19,18 @@
 package org.drools.compiler.integrationtests;
 
 import java.util.ArrayList;
-import java.util.Collection;
 import java.util.List;
 import java.util.concurrent.TimeUnit;
+import java.util.stream.Stream;
 
 import org.drools.compiler.integrationtests.incrementalcompilation.TestUtil;
 import org.drools.kiesession.rulebase.InternalKnowledgeBase;
 import org.drools.core.impl.RuleBaseFactory;
 import org.drools.testcoverage.common.util.KieBaseTestConfiguration;
 import org.drools.testcoverage.common.util.KieBaseUtil;
-import org.drools.testcoverage.common.util.TestParametersUtil;
-import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.junit.runners.Parameterized;
+import org.drools.testcoverage.common.util.TestParametersUtil2;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
 import org.kie.api.KieBase;
 import org.kie.api.definition.type.FactType;
 import org.kie.api.runtime.KieSession;
@@ -42,7 +41,6 @@ import org.kie.api.time.SessionPseudoClock;
 import static java.util.Arrays.asList;
 import static org.assertj.core.api.Assertions.assertThat;
 
-@RunWith(Parameterized.class)
 public class AccumulateCepTest {
 
     public static final String TEST_MANY_SLIDING_WINDOWS_DRL = "package com.sample;\n" +
@@ -72,19 +70,13 @@ public class AccumulateCepTest {
                 "end\n" +
                 "\n";
 
-    private final KieBaseTestConfiguration kieBaseTestConfiguration;
-
-    public AccumulateCepTest(final KieBaseTestConfiguration kieBaseTestConfiguration) {
-        this.kieBaseTestConfiguration = kieBaseTestConfiguration;
+    public static Stream<KieBaseTestConfiguration> parameters() {
+        return  TestParametersUtil2.getKieBaseStreamConfigurations(true).stream();
     }
 
-    @Parameterized.Parameters(name = "KieBase type={0}")
-    public static Collection<Object[]> getParameters() {
-        return TestParametersUtil.getKieBaseStreamConfigurations(true);
-    }
-
-    @Test
-    public void testAccumulatesExpireVsCancel() throws Exception {
+    @ParameterizedTest
+	@MethodSource("parameters")
+    public void testAccumulatesExpireVsCancel(KieBaseTestConfiguration kieBaseTestConfiguration) throws Exception {
         // JBRULES-3201
         final String drl = "package com.sample;\n" +
                 "\n" +
@@ -134,8 +126,9 @@ public class AccumulateCepTest {
         }
     }
 
-    @Test
-    public void testManySlidingWindows() {
+    @ParameterizedTest
+	@MethodSource("parameters")
+    public void testManySlidingWindows(KieBaseTestConfiguration kieBaseTestConfiguration) {
 
         final KieBase kbase = KieBaseUtil.getKieBaseFromKieModuleFromDrl("accumulate-test", kieBaseTestConfiguration,
                                                                          TEST_MANY_SLIDING_WINDOWS_DRL);

--- a/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/compiler/integrationtests/AccumulateConsistencyTest.java
+++ b/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/compiler/integrationtests/AccumulateConsistencyTest.java
@@ -23,14 +23,15 @@ import java.util.Collection;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.stream.Stream;
 
 import org.drools.testcoverage.common.model.MyFact;
 import org.drools.testcoverage.common.model.Person;
 import org.drools.testcoverage.common.util.KieBaseTestConfiguration;
 import org.drools.testcoverage.common.util.KieBaseUtil;
-import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.junit.runners.Parameterized;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
 import org.kie.api.KieBase;
 import org.kie.api.KieServices;
 import org.kie.api.runtime.KieSession;
@@ -40,31 +41,25 @@ import org.kie.api.runtime.rule.QueryResults;
 import org.kie.api.runtime.rule.Variable;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.params.provider.Arguments.arguments;
 
-@RunWith(Parameterized.class)
 public class AccumulateConsistencyTest {
 
-    private final KieBaseTestConfiguration kieBaseTestConfiguration;
-    private final boolean accumulateNullPropagation;
 
-    public AccumulateConsistencyTest(final KieBaseTestConfiguration kieBaseTestConfiguration, boolean accumulateNullPropagation) {
-        this.kieBaseTestConfiguration = kieBaseTestConfiguration;
-        this.accumulateNullPropagation = accumulateNullPropagation;
-    }
 
     // accumulateNullPropagation is false by default in drools 7.x
-    @Parameterized.Parameters(name = "KieBase type={0}, accumulateNullPropagation= {1}")
-    public static Collection<Object[]> getParameters() {
-        Collection<Object[]> parameters = new ArrayList<>();
-        parameters.add(new Object[]{KieBaseTestConfiguration.CLOUD_IDENTITY, false});
-        parameters.add(new Object[]{KieBaseTestConfiguration.CLOUD_IDENTITY_MODEL_PATTERN, false});
-        parameters.add(new Object[]{KieBaseTestConfiguration.CLOUD_IDENTITY, true});
-        parameters.add(new Object[]{KieBaseTestConfiguration.CLOUD_IDENTITY_MODEL_PATTERN, true});
-        return parameters;
+    public static Stream<Arguments> parameters() {
+        Collection<Arguments> parameters = new ArrayList<>();
+        parameters.add(arguments(KieBaseTestConfiguration.CLOUD_IDENTITY, false));
+        parameters.add(arguments(KieBaseTestConfiguration.CLOUD_IDENTITY_MODEL_PATTERN, false));
+        parameters.add(arguments(KieBaseTestConfiguration.CLOUD_IDENTITY, true));
+        parameters.add(arguments(KieBaseTestConfiguration.CLOUD_IDENTITY_MODEL_PATTERN, true));
+        return parameters.stream();
     }
 
-    @Test
-    public void testMinNoMatch() {
+    @ParameterizedTest(name = "KieBase type={0}, accumulateNullPropagation= {1}")
+    @MethodSource("parameters")
+    public void testMinNoMatch(KieBaseTestConfiguration kieBaseTestConfiguration, boolean accumulateNullPropagation) {
         final String drl =
                 "package org.drools.compiler.integrationtests;\n" +
                            "import " + Person.class.getCanonicalName() + ";\n" +
@@ -93,8 +88,9 @@ public class AccumulateConsistencyTest {
         }
     }
 
-    @Test
-    public void testMaxNoMatch() {
+    @ParameterizedTest(name = "KieBase type={0}, accumulateNullPropagation= {1}")
+	@MethodSource("parameters")
+    public void testMaxNoMatch(KieBaseTestConfiguration kieBaseTestConfiguration, boolean accumulateNullPropagation) {
         final String drl =
                 "package org.drools.compiler.integrationtests;\n" +
                            "import " + Person.class.getCanonicalName() + ";\n" +
@@ -123,8 +119,9 @@ public class AccumulateConsistencyTest {
         }
     }
 
-    @Test
-    public void testAveNoMatch() {
+    @ParameterizedTest(name = "KieBase type={0}, accumulateNullPropagation= {1}")
+	@MethodSource("parameters")
+    public void testAveNoMatch(KieBaseTestConfiguration kieBaseTestConfiguration, boolean accumulateNullPropagation) {
         final String drl =
                 "package org.drools.compiler.integrationtests;\n" +
                            "import " + Person.class.getCanonicalName() + ";\n" +
@@ -153,8 +150,9 @@ public class AccumulateConsistencyTest {
         }
     }
 
-    @Test
-    public void testSumNoMatch() {
+    @ParameterizedTest(name = "KieBase type={0}, accumulateNullPropagation= {1}")
+	@MethodSource("parameters")
+    public void testSumNoMatch(KieBaseTestConfiguration kieBaseTestConfiguration, boolean accumulateNullPropagation) {
         final String drl =
                 "package org.drools.compiler.integrationtests;\n" +
                            "import " + Person.class.getCanonicalName() + ";\n" +
@@ -179,8 +177,9 @@ public class AccumulateConsistencyTest {
         }
     }
 
-    @Test
-    public void testCountNoMatch() {
+    @ParameterizedTest(name = "KieBase type={0}, accumulateNullPropagation= {1}")
+	@MethodSource("parameters")
+    public void testCountNoMatch(KieBaseTestConfiguration kieBaseTestConfiguration, boolean accumulateNullPropagation) {
         final String drl =
                 "package org.drools.compiler.integrationtests;\n" +
                            "import " + Person.class.getCanonicalName() + ";\n" +
@@ -205,8 +204,9 @@ public class AccumulateConsistencyTest {
         }
     }
 
-    @Test
-    public void testMinMaxNoMatch() {
+    @ParameterizedTest(name = "KieBase type={0}, accumulateNullPropagation= {1}")
+	@MethodSource("parameters")
+    public void testMinMaxNoMatch(KieBaseTestConfiguration kieBaseTestConfiguration, boolean accumulateNullPropagation) {
         final String drl =
                 "package org.drools.compiler.integrationtests;\n" +
                            "import " + Person.class.getCanonicalName() + ";\n" +
@@ -232,8 +232,9 @@ public class AccumulateConsistencyTest {
         }
     }
 
-    @Test
-    public void testMinMaxMatch() {
+    @ParameterizedTest(name = "KieBase type={0}, accumulateNullPropagation= {1}")
+	@MethodSource("parameters")
+    public void testMinMaxMatch(KieBaseTestConfiguration kieBaseTestConfiguration, boolean accumulateNullPropagation) {
         final String drl =
                 "package org.drools.compiler.integrationtests;\n" +
                            "import " + Person.class.getCanonicalName() + ";\n" +
@@ -269,8 +270,9 @@ public class AccumulateConsistencyTest {
         }
     }
 
-    @Test
-    public void testMinNoMatchAccFrom() {
+    @ParameterizedTest(name = "KieBase type={0}, accumulateNullPropagation= {1}")
+	@MethodSource("parameters")
+    public void testMinNoMatchAccFrom(KieBaseTestConfiguration kieBaseTestConfiguration, boolean accumulateNullPropagation) {
 
         final String drl =
                 "package org.drools.compiler.integrationtests;\n" +
@@ -300,8 +302,9 @@ public class AccumulateConsistencyTest {
         }
     }
 
-    @Test
-    public void testMinMatchUnification() {
+    @ParameterizedTest(name = "KieBase type={0}, accumulateNullPropagation= {1}")
+	@MethodSource("parameters")
+    public void testMinMatchUnification(KieBaseTestConfiguration kieBaseTestConfiguration, boolean accumulateNullPropagation) {
 
         final String drl =
                 "package org.drools.compiler.integrationtests;\n" +
@@ -330,8 +333,9 @@ public class AccumulateConsistencyTest {
         }
     }
 
-    @Test
-    public void testMinNoMatchUnification() {
+    @ParameterizedTest(name = "KieBase type={0}, accumulateNullPropagation= {1}")
+	@MethodSource("parameters")
+    public void testMinNoMatchUnification(KieBaseTestConfiguration kieBaseTestConfiguration, boolean accumulateNullPropagation) {
         final String drl =
                 "package org.drools.compiler.integrationtests;\n" +
                            "import " + Person.class.getCanonicalName() + ";\n" +
@@ -363,8 +367,9 @@ public class AccumulateConsistencyTest {
         }
     }
 
-    @Test
-    public void testMinMatchUnificationQuery() {
+    @ParameterizedTest(name = "KieBase type={0}, accumulateNullPropagation= {1}")
+	@MethodSource("parameters")
+    public void testMinMatchUnificationQuery(KieBaseTestConfiguration kieBaseTestConfiguration, boolean accumulateNullPropagation) {
 
         final String drl =
                 "package org.drools.compiler.integrationtests;\n" +

--- a/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/compiler/integrationtests/AnnotationsCepTest.java
+++ b/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/compiler/integrationtests/AnnotationsCepTest.java
@@ -18,37 +18,29 @@
  */
 package org.drools.compiler.integrationtests;
 
-import java.util.Collection;
+import java.util.stream.Stream;
 
 import org.drools.testcoverage.common.model.Person;
 import org.drools.testcoverage.common.util.KieBaseTestConfiguration;
 import org.drools.testcoverage.common.util.KieBaseUtil;
-import org.drools.testcoverage.common.util.TestParametersUtil;
-import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.junit.runners.Parameterized;
+import org.drools.testcoverage.common.util.TestParametersUtil2;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
 import org.kie.api.KieBase;
 import org.kie.api.conf.MBeansOption;
 import org.kie.api.definition.rule.Rule;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-@RunWith(Parameterized.class)
 public class AnnotationsCepTest {
 
-    private final KieBaseTestConfiguration kieBaseTestConfiguration;
-
-    public AnnotationsCepTest(final KieBaseTestConfiguration kieBaseTestConfiguration) {
-        this.kieBaseTestConfiguration = kieBaseTestConfiguration;
+    public static Stream<KieBaseTestConfiguration> parameters() {
+        return TestParametersUtil2.getKieBaseStreamConfigurations(true).stream();
     }
 
-    @Parameterized.Parameters(name = "KieBase type={0}")
-    public static Collection<Object[]> getParameters() {
-        return TestParametersUtil.getKieBaseStreamConfigurations(true);
-    }
-
-    @Test
-    public void testRuleAnnotation() {
+    @ParameterizedTest(name = "KieBase type={0}")
+	@MethodSource("parameters")
+    public void testRuleAnnotation(KieBaseTestConfiguration kieBaseTestConfiguration) {
         final String drl = "package org.drools.compiler.integrationtests\n" +
                 "import " + Person.class.getCanonicalName() + "; \n" +
                 "rule X\n" +
@@ -74,8 +66,9 @@ public class AnnotationsCepTest {
 
     }
 
-    @Test
-    public void testRuleAnnotation2() {
+    @ParameterizedTest(name = "KieBase type={0}")
+	@MethodSource("parameters")
+    public void testRuleAnnotation2(KieBaseTestConfiguration kieBaseTestConfiguration) {
         final String drl = "package org.drools.compiler.integrationtests\n" +
                 "import " + Person.class.getCanonicalName() + "; \n" +
                 "rule X\n" +

--- a/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/compiler/integrationtests/AnnotationsOnPatternTest.java
+++ b/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/compiler/integrationtests/AnnotationsOnPatternTest.java
@@ -19,9 +19,9 @@
 package org.drools.compiler.integrationtests;
 
 import java.util.Arrays;
-import java.util.Collection;
 import java.util.List;
 import java.util.Map;
+import java.util.stream.Stream;
 
 import org.drools.base.definitions.rule.impl.RuleImpl;
 import org.drools.base.factmodel.AnnotationDefinition;
@@ -30,32 +30,24 @@ import org.drools.base.rule.RuleConditionElement;
 import org.drools.testcoverage.common.util.KieBaseTestConfiguration;
 import org.drools.testcoverage.common.util.KieBaseUtil;
 import org.drools.testcoverage.common.util.KieUtil;
-import org.drools.testcoverage.common.util.TestParametersUtil;
-import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.junit.runners.Parameterized;
+import org.drools.testcoverage.common.util.TestParametersUtil2;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
 import org.kie.api.KieBase;
 import org.kie.api.builder.KieBuilder;
 import org.kie.api.definition.rule.Rule;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-@RunWith(Parameterized.class)
 public class AnnotationsOnPatternTest {
 
-    private final KieBaseTestConfiguration kieBaseTestConfiguration;
-
-    public AnnotationsOnPatternTest(final KieBaseTestConfiguration kieBaseTestConfiguration) {
-        this.kieBaseTestConfiguration = kieBaseTestConfiguration;
+    public static Stream<KieBaseTestConfiguration> parameters() {
+        return TestParametersUtil2.getKieBaseCloudConfigurations(false).stream();
     }
 
-    @Parameterized.Parameters(name = "KieBase type={0}")
-    public static Collection<Object[]> getParameters() {
-        return TestParametersUtil.getKieBaseCloudConfigurations(false);
-    }
-
-    @Test
-    public void testAnnotationWithUnknownProperty() {
+    @ParameterizedTest(name = "KieBase type={0}")
+	@MethodSource("parameters")
+    public void testAnnotationWithUnknownProperty(KieBaseTestConfiguration kieBaseTestConfiguration) {
         final String drl = "package org.drools.test; " +
                 "import " + Outer.class.getName().replace("$", ".") + "; " +
                 "import " + Inner.class.getName().replace("$", ".") + "; " +
@@ -70,8 +62,9 @@ public class AnnotationsOnPatternTest {
         assertThat(kieBuilder.getResults().getMessages()).hasSize(1);
     }
 
-    @Test
-    public void testAnnotationWithUnknownClass() {
+    @ParameterizedTest(name = "KieBase type={0}")
+	@MethodSource("parameters")
+    public void testAnnotationWithUnknownClass(KieBaseTestConfiguration kieBaseTestConfiguration) {
         final String drl = "package org.drools.test; " +
                 "import " + Outer.class.getName().replace("$", ".") + "; " +
 
@@ -85,8 +78,9 @@ public class AnnotationsOnPatternTest {
         assertThat(kieBuilder.getResults().getMessages()).hasSize(1);
     }
 
-    @Test
-    public void testAnnotationWithQualifiandClass() {
+    @ParameterizedTest(name = "KieBase type={0}")
+	@MethodSource("parameters")
+    public void testAnnotationWithQualifiandClass(KieBaseTestConfiguration kieBaseTestConfiguration) {
         final String drl = "package org.drools.test; " +
                 "import " + Outer.class.getName().replace("$", ".") + "; " +
 
@@ -107,8 +101,9 @@ public class AnnotationsOnPatternTest {
         assertThat(adef).isNotNull();
     }
 
-    @Test
-    public void testNestedAnnotations() {
+    @ParameterizedTest(name = "KieBase type={0}")
+	@MethodSource("parameters")
+    public void testNestedAnnotations(KieBaseTestConfiguration kieBaseTestConfiguration) {
         final String drl = "package org.drools.test; " +
                 "import " + Outer.class.getName().replace("$", ".") + "; " +
                 "import " + Inner.class.getName().replace("$", ".") + "; " +
@@ -136,8 +131,9 @@ public class AnnotationsOnPatternTest {
         assertThat(inner.getPropertyValue("text")).isEqualTo("world");
     }
 
-    @Test
-    public void testNestedAnnotationsWithMultiplicity() {
+    @ParameterizedTest(name = "KieBase type={0}")
+	@MethodSource("parameters")
+    public void testNestedAnnotationsWithMultiplicity(KieBaseTestConfiguration kieBaseTestConfiguration) {
         final String drl = "package org.drools.test; " +
                 "import " + Outer.class.getName().replace("$", ".") + "; " +
                 "import " + Inner.class.getName().replace("$", ".") + "; " +
@@ -162,8 +158,9 @@ public class AnnotationsOnPatternTest {
         assertThat(val instanceof AnnotationDefinition[]).isTrue();
     }
 
-    @Test
-    public void testRuleAnnotations() {
+    @ParameterizedTest(name = "KieBase type={0}")
+	@MethodSource("parameters")
+    public void testRuleAnnotations(KieBaseTestConfiguration kieBaseTestConfiguration) {
         final String drl = "package org.drools.test; " +
                 "import " + Inner.class.getName().replace("$", ".") + "; " +
 
@@ -185,8 +182,9 @@ public class AnnotationsOnPatternTest {
         assertThat(((Map) obj).get("text")).isEqualTo("a");
     }
 
-    @Test
-    public void testTypedSimpleArrays() {
+    @ParameterizedTest(name = "KieBase type={0}")
+	@MethodSource("parameters")
+    public void testTypedSimpleArrays(KieBaseTestConfiguration kieBaseTestConfiguration) {
         final String drl = "package org.drools.test; " +
                 "import " + AnnotationsTest.Simple.class.getName().replace("$", ".") + "; " +
 
@@ -209,8 +207,9 @@ public class AnnotationsOnPatternTest {
         assertThat(val instanceof int[]).isTrue();
     }
 
-    @Test
-    public void testCollectAnnotationsParsingAndBuilding() {
+    @ParameterizedTest(name = "KieBase type={0}")
+	@MethodSource("parameters")
+    public void testCollectAnnotationsParsingAndBuilding(KieBaseTestConfiguration kieBaseTestConfiguration) {
 
         final String packageName = "org.drools.compiler.integrationtests";
 

--- a/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/compiler/integrationtests/AnnotationsTest.java
+++ b/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/compiler/integrationtests/AnnotationsTest.java
@@ -24,15 +24,14 @@ import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 import java.lang.reflect.Field;
-import java.util.Collection;
+import java.util.stream.Stream;
 
 import org.drools.testcoverage.common.util.KieBaseTestConfiguration;
 import org.drools.testcoverage.common.util.KieBaseUtil;
 import org.drools.testcoverage.common.util.KieUtil;
-import org.drools.testcoverage.common.util.TestParametersUtil;
-import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.junit.runners.Parameterized;
+import org.drools.testcoverage.common.util.TestParametersUtil2;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
 import org.kie.api.KieBase;
 import org.kie.api.builder.KieBuilder;
 import org.kie.api.definition.type.FactType;
@@ -43,18 +42,10 @@ import org.kie.api.definition.type.Role;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.fail;
 
-@RunWith(Parameterized.class)
 public class AnnotationsTest {
 
-    private final KieBaseTestConfiguration kieBaseTestConfiguration;
-
-    public AnnotationsTest(final KieBaseTestConfiguration kieBaseTestConfiguration) {
-        this.kieBaseTestConfiguration = kieBaseTestConfiguration;
-    }
-
-    @Parameterized.Parameters(name = "KieBase type={0}")
-    public static Collection<Object[]> getParameters() {
-        return TestParametersUtil.getKieBaseCloudConfigurations(true);
+    public static Stream<KieBaseTestConfiguration> parameters() {
+        return TestParametersUtil2.getKieBaseCloudConfigurations(true).stream();
     }
 
     public enum AnnPropEnum {
@@ -97,8 +88,9 @@ public class AnnotationsTest {
         AnnPropEnum[] enumArrProp() default {AnnPropEnum.TWO, AnnPropEnum.THREE};
     }
 
-    @Test
-    public void annotationTest() {
+    @ParameterizedTest(name = "KieBase type={0}")
+	@MethodSource("parameters")
+    public void annotationTest(KieBaseTestConfiguration kieBaseTestConfiguration) {
 
         final String drl = "package org.drools.compiler.test;\n " +
                 "" +
@@ -192,8 +184,9 @@ public class AnnotationsTest {
         assertThat(ann2.enumArrProp()).isEqualTo(new AnnPropEnum[]{AnnPropEnum.TWO, AnnPropEnum.THREE});
     }
 
-    @Test
-    public void annotationErrorTest() {
+    @ParameterizedTest(name = "KieBase type={0}")
+	@MethodSource("parameters")
+    public void annotationErrorTest(KieBaseTestConfiguration kieBaseTestConfiguration) {
 
         final String drl = "package org.drools.compiler.test;\n " +
                 "" +
@@ -221,8 +214,9 @@ public class AnnotationsTest {
         assertThat(kieBuilder2.getResults().getMessages()).hasSize(3);
     }
 
-    @Test
-    public void testAnnotationNameClash() {
+    @ParameterizedTest(name = "KieBase type={0}")
+    @MethodSource("parameters")
+    public void testAnnotationNameClash(KieBaseTestConfiguration kieBaseTestConfiguration) {
         final String drl = "package org.drools.test\n" +
                 "" +
                 "declare Annot\n" +
@@ -256,8 +250,9 @@ public class AnnotationsTest {
 
     }
 
-    @Test
-    public void testAnnotationNameClashWithRegularClass() {
+    @ParameterizedTest(name = "KieBase type={0}")
+	@MethodSource("parameters")
+    public void testAnnotationNameClashWithRegularClass(KieBaseTestConfiguration kieBaseTestConfiguration) {
         final String drl = "package org.drools.test\n" +
                 "import " + Duration.class.getCanonicalName() + "; " +
 
@@ -278,8 +273,9 @@ public class AnnotationsTest {
         int[] numbers();
     }
 
-    @Test
-    public void testAnnotationOnLHSAndMerging() {
+    @ParameterizedTest(name = "KieBase type={0}")
+	@MethodSource("parameters")
+    public void testAnnotationOnLHSAndMerging(KieBaseTestConfiguration kieBaseTestConfiguration) {
         final String drl =
                 "package org.drools.compiler; " +
                         " " +

--- a/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/compiler/integrationtests/ArrayTest.java
+++ b/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/compiler/integrationtests/ArrayTest.java
@@ -19,39 +19,31 @@
 package org.drools.compiler.integrationtests;
 
 import java.util.ArrayList;
-import java.util.Collection;
 import java.util.List;
+import java.util.stream.Stream;
 
 import org.drools.testcoverage.common.model.Primitives;
 import org.drools.testcoverage.common.model.TestParam;
 import org.drools.testcoverage.common.util.KieBaseTestConfiguration;
 import org.drools.testcoverage.common.util.KieBaseUtil;
-import org.drools.testcoverage.common.util.TestParametersUtil;
-import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.junit.runners.Parameterized;
+import org.drools.testcoverage.common.util.TestParametersUtil2;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
 import org.kie.api.KieBase;
 import org.kie.api.runtime.KieSession;
 import org.kie.api.runtime.rule.FactHandle;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-@RunWith(Parameterized.class)
 public class ArrayTest {
 
-    private final KieBaseTestConfiguration kieBaseTestConfiguration;
-
-    public ArrayTest(final KieBaseTestConfiguration kieBaseTestConfiguration) {
-        this.kieBaseTestConfiguration = kieBaseTestConfiguration;
+    public static Stream<KieBaseTestConfiguration> parameters() {
+        return TestParametersUtil2.getKieBaseCloudConfigurations(true).stream();
     }
 
-    @Parameterized.Parameters(name = "KieBase type={0}")
-    public static Collection<Object[]> getParameters() {
-        return TestParametersUtil.getKieBaseCloudConfigurations(true);
-    }
-
-    @Test
-    public void testEqualsOnIntArray() {
+    @ParameterizedTest(name = "KieBase type={0}")
+	@MethodSource("parameters")
+    public void testEqualsOnIntArray(KieBaseTestConfiguration kieBaseTestConfiguration) {
 
         final String drl =
             "package org.drools.compiler;\n" +
@@ -82,8 +74,9 @@ public class ArrayTest {
         }
     }
 
-    @Test
-    public void testContainsBooleanArray() {
+    @ParameterizedTest(name = "KieBase type={0}")
+	@MethodSource("parameters")
+    public void testContainsBooleanArray(KieBaseTestConfiguration kieBaseTestConfiguration) {
 
         final KieBase kbase = KieBaseUtil.getKieBaseFromKieModuleFromDrl("array-test", kieBaseTestConfiguration,
                                                                          getDrl("Boolean", false, "true"));
@@ -106,8 +99,9 @@ public class ArrayTest {
         }
     }
     
-    @Test
-    public void testNotContainsBooleanArray() {
+    @ParameterizedTest(name = "KieBase type={0}")
+	@MethodSource("parameters")
+    public void testNotContainsBooleanArray(KieBaseTestConfiguration kieBaseTestConfiguration) {
         final String drl =
             "package org.drools.compiler;\n" +
             "import " + Primitives.class.getCanonicalName() + ";\n" +
@@ -145,8 +139,9 @@ public class ArrayTest {
         }
     }
     
-    @Test
-    public void testContainsByteArray() {
+    @ParameterizedTest(name = "KieBase type={0}")
+	@MethodSource("parameters")
+    public void testContainsByteArray(KieBaseTestConfiguration kieBaseTestConfiguration) {
         final KieBase kbase = KieBaseUtil.getKieBaseFromKieModuleFromDrl("array-test", kieBaseTestConfiguration,
                                                                          getDrl("Byte", false, "1"));
         final KieSession kieSession = kbase.newKieSession();
@@ -168,8 +163,9 @@ public class ArrayTest {
         }
     }
     
-    @Test
-    public void testNotContainsByteArray() {
+    @ParameterizedTest(name = "KieBase type={0}")
+	@MethodSource("parameters")
+    public void testNotContainsByteArray(KieBaseTestConfiguration kieBaseTestConfiguration) {
         final KieBase kbase = KieBaseUtil.getKieBaseFromKieModuleFromDrl("array-test", kieBaseTestConfiguration,
                                                                          getDrl("Byte", true, "1"));
         final KieSession kieSession = kbase.newKieSession();
@@ -191,8 +187,9 @@ public class ArrayTest {
         }
     }
     
-    @Test
-    public void testContainsShortArray() {
+    @ParameterizedTest(name = "KieBase type={0}")
+	@MethodSource("parameters")
+    public void testContainsShortArray(KieBaseTestConfiguration kieBaseTestConfiguration) {
         final KieBase kbase = KieBaseUtil.getKieBaseFromKieModuleFromDrl("array-test", kieBaseTestConfiguration,
                                                                          getDrl("Short", false, "1"));
         final KieSession kieSession = kbase.newKieSession();
@@ -214,8 +211,9 @@ public class ArrayTest {
         }
     }
     
-    @Test
-    public void testNotContainsShortArray() {
+    @ParameterizedTest(name = "KieBase type={0}")
+	@MethodSource("parameters")
+    public void testNotContainsShortArray(KieBaseTestConfiguration kieBaseTestConfiguration) {
         final KieBase kbase = KieBaseUtil.getKieBaseFromKieModuleFromDrl("array-test", kieBaseTestConfiguration,
                                                                          getDrl("Short", true, "1"));
         final KieSession kieSession = kbase.newKieSession();
@@ -237,8 +235,9 @@ public class ArrayTest {
         }
     }
     
-    @Test
-    public void testContainsCharArray() {
+    @ParameterizedTest(name = "KieBase type={0}")
+	@MethodSource("parameters")
+    public void testContainsCharArray(KieBaseTestConfiguration kieBaseTestConfiguration) {
         final KieBase kbase = KieBaseUtil.getKieBaseFromKieModuleFromDrl("array-test", kieBaseTestConfiguration,
                                                                          getDrl("Character", false, "'c'"));
         final KieSession kieSession = kbase.newKieSession();
@@ -260,8 +259,9 @@ public class ArrayTest {
         }
     }
     
-    @Test
-    public void testNotContainsCharArray() {
+    @ParameterizedTest(name = "KieBase type={0}")
+	@MethodSource("parameters")
+    public void testNotContainsCharArray(KieBaseTestConfiguration kieBaseTestConfiguration) {
         final KieBase kbase = KieBaseUtil.getKieBaseFromKieModuleFromDrl("array-test", kieBaseTestConfiguration,
                                                                          getDrl("Character", true, "'c'"));
         final KieSession kieSession = kbase.newKieSession();
@@ -283,8 +283,9 @@ public class ArrayTest {
         }
     }
     
-    @Test
-    public void testContainsIntArray() {
+    @ParameterizedTest(name = "KieBase type={0}")
+	@MethodSource("parameters")
+    public void testContainsIntArray(KieBaseTestConfiguration kieBaseTestConfiguration) {
         final KieBase kbase = KieBaseUtil.getKieBaseFromKieModuleFromDrl("array-test", kieBaseTestConfiguration,
                                                                          getDrl("Integer", false, "10"));
         final KieSession kieSession = kbase.newKieSession();
@@ -306,8 +307,9 @@ public class ArrayTest {
         }
     }
     
-    @Test
-    public void testNotContainsIntArray() {
+    @ParameterizedTest(name = "KieBase type={0}")
+	@MethodSource("parameters")
+    public void testNotContainsIntArray(KieBaseTestConfiguration kieBaseTestConfiguration) {
         final KieBase kbase = KieBaseUtil.getKieBaseFromKieModuleFromDrl("array-test", kieBaseTestConfiguration,
                                                                          getDrl("Integer", true, "10"));
         final KieSession kieSession = kbase.newKieSession();
@@ -329,8 +331,9 @@ public class ArrayTest {
         }
     }
     
-    @Test
-    public void testContainsLongArray() {
+    @ParameterizedTest(name = "KieBase type={0}")
+	@MethodSource("parameters")
+    public void testContainsLongArray(KieBaseTestConfiguration kieBaseTestConfiguration) {
         final KieBase kbase = KieBaseUtil.getKieBaseFromKieModuleFromDrl("array-test", kieBaseTestConfiguration,
                                                                          getDrl("Long", false, "10"));
         final KieSession kieSession = kbase.newKieSession();
@@ -352,8 +355,9 @@ public class ArrayTest {
         }
     }
     
-    @Test
-    public void testNotContainsLongArray() {
+    @ParameterizedTest(name = "KieBase type={0}")
+	@MethodSource("parameters")
+    public void testNotContainsLongArray(KieBaseTestConfiguration kieBaseTestConfiguration) {
         final KieBase kbase = KieBaseUtil.getKieBaseFromKieModuleFromDrl("array-test", kieBaseTestConfiguration,
                                                                          getDrl("Long", true, "10"));
         final KieSession kieSession = kbase.newKieSession();
@@ -375,8 +379,9 @@ public class ArrayTest {
         }
     }
     
-    @Test
-    public void testContainsFloatArray() {
+    @ParameterizedTest(name = "KieBase type={0}")
+	@MethodSource("parameters")
+    public void testContainsFloatArray(KieBaseTestConfiguration kieBaseTestConfiguration) {
         final KieBase kbase = KieBaseUtil.getKieBaseFromKieModuleFromDrl("array-test", kieBaseTestConfiguration,
                                                                          getDrl("Float", false, "10f"));
         final KieSession kieSession = kbase.newKieSession();
@@ -398,8 +403,9 @@ public class ArrayTest {
         }
     }
     
-    @Test
-    public void testNotContainsFloatArray() {
+    @ParameterizedTest(name = "KieBase type={0}")
+	@MethodSource("parameters")
+    public void testNotContainsFloatArray(KieBaseTestConfiguration kieBaseTestConfiguration) {
         final KieBase kbase = KieBaseUtil.getKieBaseFromKieModuleFromDrl("array-test", kieBaseTestConfiguration,
                                                                          getDrl("Float", true, "10f"));
         final KieSession kieSession = kbase.newKieSession();
@@ -421,8 +427,9 @@ public class ArrayTest {
         }
     }
 
-    @Test
-    public void testContainsDoubleArray() {
+    @ParameterizedTest(name = "KieBase type={0}")
+	@MethodSource("parameters")
+    public void testContainsDoubleArray(KieBaseTestConfiguration kieBaseTestConfiguration) {
         final KieBase kbase = KieBaseUtil.getKieBaseFromKieModuleFromDrl("array-test", kieBaseTestConfiguration,
                                                                          getDrl("Double", false, "10"));
         final KieSession kieSession = kbase.newKieSession();
@@ -444,8 +451,9 @@ public class ArrayTest {
         }
     }
     
-    @Test
-    public void testNotContainsDoubleArray() {
+    @ParameterizedTest(name = "KieBase type={0}")
+	@MethodSource("parameters")
+    public void testNotContainsDoubleArray(KieBaseTestConfiguration kieBaseTestConfiguration) {
         final KieBase kbase = KieBaseUtil.getKieBaseFromKieModuleFromDrl("array-test", kieBaseTestConfiguration,
                                                                          getDrl("Double", true, "10"));
         final KieSession kieSession = kbase.newKieSession();
@@ -528,8 +536,9 @@ public class ArrayTest {
         assertThat(resultsList.size()).isEqualTo(2);
     }
 
-    @Test
-    public void testPrimitiveArray() {
+    @ParameterizedTest(name = "KieBase type={0}")
+	@MethodSource("parameters")
+    public void testPrimitiveArray(KieBaseTestConfiguration kieBaseTestConfiguration) {
         final String drl = "package org.drools.compiler\n" +
                 "import " + Primitives.class.getCanonicalName() + "\n" +
                 "global java.util.List result;\n" +
@@ -587,8 +596,9 @@ public class ArrayTest {
         }
     }
 
-    @Test
-    public void testArrayUsage() {
+    @ParameterizedTest(name = "KieBase type={0}")
+	@MethodSource("parameters")
+    public void testArrayUsage(KieBaseTestConfiguration kieBaseTestConfiguration) {
         final String drl =
                 "import " + TestParam.class.getCanonicalName() + "\n" +
                 "global java.util.List list;\n" +

--- a/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/compiler/integrationtests/BetaTest.java
+++ b/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/compiler/integrationtests/BetaTest.java
@@ -19,40 +19,33 @@
 package org.drools.compiler.integrationtests;
 
 import java.util.ArrayList;
-import java.util.Collection;
 import java.util.List;
+import java.util.stream.Stream;
 
 import org.drools.testcoverage.common.model.FirstClass;
 import org.drools.testcoverage.common.model.SecondClass;
 import org.drools.testcoverage.common.util.KieBaseTestConfiguration;
 import org.drools.testcoverage.common.util.KieBaseUtil;
 import org.drools.testcoverage.common.util.KieUtil;
-import org.drools.testcoverage.common.util.TestParametersUtil;
-import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.junit.runners.Parameterized;
+import org.drools.testcoverage.common.util.TestParametersUtil2;
+import org.junit.jupiter.api.Timeout;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
 import org.kie.api.KieBase;
 import org.kie.api.runtime.KieSession;
 import org.kie.api.runtime.rule.FactHandle;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-@RunWith(Parameterized.class)
 public class BetaTest {
 
-    private final KieBaseTestConfiguration kieBaseTestConfiguration;
-
-    public BetaTest(final KieBaseTestConfiguration kieBaseTestConfiguration) {
-        this.kieBaseTestConfiguration = kieBaseTestConfiguration;
+    public static Stream<KieBaseTestConfiguration> parameters() {
+        return TestParametersUtil2.getKieBaseCloudConfigurations(true).stream();
     }
 
-    @Parameterized.Parameters(name = "KieBase type={0}")
-    public static Collection<Object[]> getParameters() {
-        return TestParametersUtil.getKieBaseCloudConfigurations(true);
-    }
-
-    @Test
-    public void testDefaultBetaConstrains() {
+    @ParameterizedTest(name = "KieBase type={0}")
+	@MethodSource("parameters")
+    public void testDefaultBetaConstrains(KieBaseTestConfiguration kieBaseTestConfiguration) {
 
         final String drl = "package org.drools.compiler\n" +
                 "import " + FirstClass.class.getCanonicalName() + "\n" +
@@ -132,8 +125,10 @@ public class BetaTest {
         }
     }
 
-    @Test(timeout = 5000)
-    public void testEfficientBetaNodeNetworkUpdate() {
+    @ParameterizedTest(name = "KieBase type={0}")
+	@MethodSource("parameters")
+    @Timeout(5000)
+    public void testEfficientBetaNodeNetworkUpdate(KieBaseTestConfiguration kieBaseTestConfiguration) {
         // [JBRULES-3372]
         final String drl =
                 "declare SimpleMembership\n" +

--- a/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/compiler/integrationtests/BigRuleSetCompilationTest.java
+++ b/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/compiler/integrationtests/BigRuleSetCompilationTest.java
@@ -23,7 +23,7 @@ import java.util.Collection;
 
 import org.drools.io.ByteArrayResource;
 import org.drools.model.codegen.ExecutableModelProject;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.kie.api.KieServices;
 import org.kie.api.builder.KieBuilder;
 import org.kie.api.builder.KieFileSystem;

--- a/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/compiler/integrationtests/CalendarTest.java
+++ b/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/compiler/integrationtests/CalendarTest.java
@@ -20,35 +20,27 @@ package org.drools.compiler.integrationtests;
 
 import java.util.ArrayList;
 import java.util.Calendar;
-import java.util.Collection;
+import java.util.stream.Stream;
 
 import org.drools.testcoverage.common.util.KieBaseTestConfiguration;
 import org.drools.testcoverage.common.util.KieBaseUtil;
-import org.drools.testcoverage.common.util.TestParametersUtil;
-import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.junit.runners.Parameterized;
+import org.drools.testcoverage.common.util.TestParametersUtil2;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
 import org.kie.api.KieBase;
 import org.kie.api.runtime.KieSession;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-@RunWith(Parameterized.class)
 public class CalendarTest {
 
-    private final KieBaseTestConfiguration kieBaseTestConfiguration;
-
-    public CalendarTest(final KieBaseTestConfiguration kieBaseTestConfiguration) {
-        this.kieBaseTestConfiguration = kieBaseTestConfiguration;
+    public static Stream<KieBaseTestConfiguration> parameters() {
+        return TestParametersUtil2.getKieBaseCloudConfigurations(true).stream();
     }
 
-    @Parameterized.Parameters(name = "KieBase type={0}")
-    public static Collection<Object[]> getParameters() {
-        return TestParametersUtil.getKieBaseCloudConfigurations(true);
-    }
-
-    @Test
-    public void test() {
+    @ParameterizedTest(name = "KieBase type={0}")
+    @MethodSource("parameters")
+    public void test(KieBaseTestConfiguration kieBaseTestConfiguration) {
         // BZ-1007385
         final String drl = "package org.drools.compiler.integrationtests;\n" +
                      "\n" +

--- a/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/compiler/integrationtests/CepEspNegativeCloudTest.java
+++ b/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/compiler/integrationtests/CepEspNegativeCloudTest.java
@@ -18,17 +18,17 @@
  */
 package org.drools.compiler.integrationtests;
 
-import java.util.Collection;
 import java.util.concurrent.TimeUnit;
+import java.util.stream.Stream;
 
 import org.drools.testcoverage.common.model.StockTick;
 import org.drools.testcoverage.common.util.KieBaseTestConfiguration;
 import org.drools.testcoverage.common.util.KieBaseUtil;
 import org.drools.testcoverage.common.util.KieSessionTestConfiguration;
-import org.drools.testcoverage.common.util.TestParametersUtil;
-import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.junit.runners.Parameterized;
+import org.drools.testcoverage.common.util.TestParametersUtil2;
+import org.junit.jupiter.api.Timeout;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
 import org.kie.api.KieBase;
 import org.kie.api.definition.type.FactType;
 import org.kie.api.runtime.KieSession;
@@ -39,22 +39,16 @@ import org.kie.api.time.SessionPseudoClock;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.fail;
 
-@RunWith(Parameterized.class)
 public class CepEspNegativeCloudTest {
 
-    private final KieBaseTestConfiguration kieBaseTestConfiguration;
-
-    public CepEspNegativeCloudTest(final KieBaseTestConfiguration kieBaseTestConfiguration) {
-        this.kieBaseTestConfiguration = kieBaseTestConfiguration;
+    public static Stream<KieBaseTestConfiguration> parameters() {
+        return TestParametersUtil2.getKieBaseCloudConfigurations(true).stream();
     }
 
-    @Parameterized.Parameters(name = "KieBase type={0}")
-    public static Collection<Object[]> getParameters() {
-        return TestParametersUtil.getKieBaseCloudConfigurations(true);
-    }
-
-    @Test(timeout=10000)
-    public void testCloudModeExpiration() throws InstantiationException, IllegalAccessException, InterruptedException {
+    @ParameterizedTest
+	@MethodSource("parameters")
+	@Timeout(10000)
+    public void testCloudModeExpiration(KieBaseTestConfiguration kieBaseTestConfiguration) throws InstantiationException, IllegalAccessException, InterruptedException {
         final String drl = "package org.drools.cloud\n" +
                      "import " + StockTick.class.getCanonicalName() + "\n" +
                      "declare Event\n" +
@@ -105,8 +99,9 @@ public class CepEspNegativeCloudTest {
         }
     }
 
-    @Test
-    public void testThrowsWhenCreatingKieBaseUsingWindowsInCloudMode() {
+    @ParameterizedTest
+	@MethodSource("parameters")
+    public void testThrowsWhenCreatingKieBaseUsingWindowsInCloudMode(KieBaseTestConfiguration kieBaseTestConfiguration) {
         final String drl =
             "declare TestEvent\n" +
             "    @role( event )\n" +
@@ -126,8 +121,9 @@ public class CepEspNegativeCloudTest {
         }
     }
 
-    @Test
-    public void testTemporalQuery() {
+    @ParameterizedTest
+	@MethodSource("parameters")
+    public void testTemporalQuery(KieBaseTestConfiguration kieBaseTestConfiguration) {
         // BZ-967441
         final String drl =
                  "package org.drools.compiler.integrationtests;\n" +

--- a/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/compiler/integrationtests/CepJavaTypeTest.java
+++ b/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/compiler/integrationtests/CepJavaTypeTest.java
@@ -19,15 +19,16 @@
 package org.drools.compiler.integrationtests;
 
 import java.util.Collection;
+import java.util.stream.Stream;
 
 import org.drools.testcoverage.common.util.KieBaseTestConfiguration;
 import org.drools.testcoverage.common.util.KieBaseUtil;
 import org.drools.testcoverage.common.util.KieUtil;
-import org.drools.testcoverage.common.util.TestParametersUtil;
+import org.drools.testcoverage.common.util.TestParametersUtil2;
 import org.drools.testcoverage.common.util.TimeUtil;
-import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.junit.runners.Parameterized;
+import org.junit.jupiter.api.Timeout;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
 import org.kie.api.KieBase;
 import org.kie.api.builder.KieBuilder;
 import org.kie.api.definition.type.Expires;
@@ -37,25 +38,18 @@ import org.kie.api.runtime.KieSession;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-@RunWith(Parameterized.class)
 public class CepJavaTypeTest {
 
-    private final KieBaseTestConfiguration kieBaseTestConfiguration;
-
-    public CepJavaTypeTest(final KieBaseTestConfiguration kieBaseTestConfiguration) {
-        this.kieBaseTestConfiguration = kieBaseTestConfiguration;
-    }
-
-    @Parameterized.Parameters(name = "KieBase type={0}")
-    public static Collection<Object[]> getParameters() {
-        return TestParametersUtil.getKieBaseStreamConfigurations(true);
+    public static Stream<KieBaseTestConfiguration> parameters() {
+        return TestParametersUtil2.getKieBaseStreamConfigurations(true).stream();
     }
 
     @Role(value = Role.Type.EVENT)
     public static class Event { }
 
-    @Test
-    public void testJavaTypeAnnotatedWithRole_WindowTime() {
+    @ParameterizedTest(name = "KieBase type={0}")
+	@MethodSource("parameters")
+    public void testJavaTypeAnnotatedWithRole_WindowTime(KieBaseTestConfiguration kieBaseTestConfiguration) {
         final String drl = "package org.drools.compiler.integrationtests\n"
                 + "\n"
                 + "import " + CepJavaTypeTest.Event.class.getCanonicalName() + ";\n"
@@ -70,8 +64,9 @@ public class CepJavaTypeTest {
         assertThat(kieBuilder.getResults().getMessages()).isEmpty();
     }
 
-    @Test
-    public void testJavaTypeAnnotatedWithRole_WindowLength() {
+    @ParameterizedTest(name = "KieBase type={0}")
+	@MethodSource("parameters")
+    public void testJavaTypeAnnotatedWithRole_WindowLength(KieBaseTestConfiguration kieBaseTestConfiguration) {
         final String drl = "package org.drools.compiler.integrationtests\n"
                 + "\n"
                 + "import " + CepJavaTypeTest.Event.class.getCanonicalName() + ";\n"
@@ -104,8 +99,10 @@ public class CepJavaTypeTest {
         public long getTs() { return ts; }
     }
 
-    @Test(timeout = 5000)
-    public void testEventWithShortExpiration() throws InterruptedException {
+    @ParameterizedTest(name = "KieBase type={0}")
+	@MethodSource("parameters")
+    @Timeout(5000)
+    public void testEventWithShortExpiration(KieBaseTestConfiguration kieBaseTestConfiguration) throws InterruptedException {
         // BZ-1265773
         final String drl = "import " + MyMessage.class.getCanonicalName() +"\n" +
                      "rule \"Rule A Start\"\n" +

--- a/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/compiler/integrationtests/ClassLoaderTest.java
+++ b/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/compiler/integrationtests/ClassLoaderTest.java
@@ -26,7 +26,7 @@ import java.util.List;
 import org.drools.testcoverage.common.util.KieBaseTestConfiguration;
 import org.drools.testcoverage.common.util.KieSessionTestConfiguration;
 import org.drools.testcoverage.common.util.KieUtil;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.kie.api.KieServices;
 import org.kie.api.builder.KieBuilder;
 import org.kie.api.builder.KieFileSystem;

--- a/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/compiler/integrationtests/CommandsTest.java
+++ b/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/compiler/integrationtests/CommandsTest.java
@@ -18,17 +18,16 @@
  */
 package org.drools.compiler.integrationtests;
 
-import java.util.Collection;
 import java.util.concurrent.TimeUnit;
+import java.util.stream.Stream;
 
 import org.drools.testcoverage.common.model.Cheese;
 import org.drools.testcoverage.common.util.KieBaseTestConfiguration;
 import org.drools.testcoverage.common.util.KieBaseUtil;
 import org.drools.testcoverage.common.util.KieSessionTestConfiguration;
-import org.drools.testcoverage.common.util.TestParametersUtil;
-import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.junit.runners.Parameterized;
+import org.drools.testcoverage.common.util.TestParametersUtil2;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
 import org.kie.api.KieBase;
 import org.kie.api.KieServices;
 import org.kie.api.command.KieCommands;
@@ -36,22 +35,15 @@ import org.kie.api.runtime.KieSession;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-@RunWith(Parameterized.class)
 public class CommandsTest {
 
-    private final KieBaseTestConfiguration kieBaseTestConfiguration;
-
-    public CommandsTest(final KieBaseTestConfiguration kieBaseTestConfiguration) {
-        this.kieBaseTestConfiguration = kieBaseTestConfiguration;
+    public static Stream<KieBaseTestConfiguration> parameters() {
+        return TestParametersUtil2.getKieBaseCloudConfigurations(true).stream();
     }
 
-    @Parameterized.Parameters(name = "KieBase type={0}")
-    public static Collection<Object[]> getParameters() {
-        return TestParametersUtil.getKieBaseCloudConfigurations(true);
-    }
-
-    @Test
-    public void testSessionTimeCommands() {
+    @ParameterizedTest(name = "KieBase type={0}")
+	@MethodSource("parameters")
+    public void testSessionTimeCommands(KieBaseTestConfiguration kieBaseTestConfiguration) {
         final String drl =
             "package org.drools.compiler.integrationtests \n" +
             "import " + Cheese.class.getCanonicalName() + " \n" +

--- a/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/compiler/integrationtests/ConditionLimitTest.java
+++ b/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/compiler/integrationtests/ConditionLimitTest.java
@@ -18,32 +18,23 @@
  */
 package org.drools.compiler.integrationtests;
 
-import java.util.Collection;
+import java.util.stream.Stream;
 
 import org.drools.testcoverage.common.util.KieBaseTestConfiguration;
 import org.drools.testcoverage.common.util.KieBaseUtil;
-import org.drools.testcoverage.common.util.TestParametersUtil;
-import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.junit.runners.Parameterized;
+import org.drools.testcoverage.common.util.TestParametersUtil2;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
 import org.kie.api.KieBase;
 import org.kie.api.runtime.KieSession;
 import org.kie.api.runtime.rule.FactHandle;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-@RunWith(Parameterized.class)
 public class ConditionLimitTest {
 
-    private final KieBaseTestConfiguration kieBaseTestConfiguration;
-
-    public ConditionLimitTest(final KieBaseTestConfiguration kieBaseTestConfiguration) {
-        this.kieBaseTestConfiguration = kieBaseTestConfiguration;
-    }
-
-    @Parameterized.Parameters(name = "KieBase type={0}")
-    public static Collection<Object[]> getParameters() {
-        return TestParametersUtil.getKieBaseStreamConfigurations(true);
+    public static Stream<KieBaseTestConfiguration> parameters() {
+        return TestParametersUtil2.getKieBaseStreamConfigurations(true).stream();
     }
 
     public static class FieldObject {
@@ -69,8 +60,9 @@ public class ConditionLimitTest {
         }
     }
 
-    @Test
-    public void testEvalErrorHandling() {
+    @ParameterizedTest(name = "KieBase type={0}")
+	@MethodSource("parameters")
+    public void testEvalErrorHandling(KieBaseTestConfiguration kieBaseTestConfiguration) {
         // DROOLS-6856
         final int INPUT_COUNT = 65;
 

--- a/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/compiler/integrationtests/ConsequenceOffsetTest.java
+++ b/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/compiler/integrationtests/ConsequenceOffsetTest.java
@@ -20,7 +20,7 @@ package org.drools.compiler.integrationtests;
 
 import org.drools.compiler.builder.impl.KnowledgeBuilderImpl;
 import org.drools.drl.ast.descr.RuleDescr;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.kie.api.io.ResourceType;
 import org.kie.internal.builder.KnowledgeBuilder;
 import org.kie.internal.builder.KnowledgeBuilderFactory;

--- a/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/compiler/integrationtests/ConsequenceTypeTest.java
+++ b/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/compiler/integrationtests/ConsequenceTypeTest.java
@@ -19,35 +19,27 @@
 
 package org.drools.compiler.integrationtests;
 
-import java.util.Collection;
+import java.util.stream.Stream;
 
 import org.drools.testcoverage.common.util.KieBaseTestConfiguration;
 import org.drools.testcoverage.common.util.KieBaseUtil;
-import org.drools.testcoverage.common.util.TestParametersUtil;
-import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.junit.runners.Parameterized;
+import org.drools.testcoverage.common.util.TestParametersUtil2;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
 import org.kie.api.KieBase;
 import org.kie.api.runtime.KieSession;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-@RunWith(Parameterized.class)
 public class ConsequenceTypeTest {
 
-    private final KieBaseTestConfiguration kieBaseTestConfiguration;
-
-    public ConsequenceTypeTest(final KieBaseTestConfiguration kieBaseTestConfiguration) {
-        this.kieBaseTestConfiguration = kieBaseTestConfiguration;
+    public static Stream<KieBaseTestConfiguration> parameters() {
+        return TestParametersUtil2.getKieBaseCloudConfigurations(true).stream();
     }
 
-    @Parameterized.Parameters(name = "KieBase type={0}")
-    public static Collection<Object[]> getParameters() {
-        return TestParametersUtil.getKieBaseCloudConfigurations(true);
-    }
-
-    @Test
-    public void test() {
+    @ParameterizedTest(name = "KieBase type={0}")
+	@MethodSource("parameters")
+    public void test(KieBaseTestConfiguration kieBaseTestConfiguration) {
         // KIE-1133
 
         int ruleNr = 100;

--- a/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/compiler/integrationtests/ConstraintsTest.java
+++ b/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/compiler/integrationtests/ConstraintsTest.java
@@ -19,11 +19,11 @@
 package org.drools.compiler.integrationtests;
 
 import java.util.ArrayList;
-import java.util.Collection;
 import java.util.Date;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.stream.Stream;
 
 import org.drools.testcoverage.common.model.Cheese;
 import org.drools.testcoverage.common.model.Message;
@@ -32,32 +32,24 @@ import org.drools.testcoverage.common.model.StockTick;
 import org.drools.testcoverage.common.util.KieBaseTestConfiguration;
 import org.drools.testcoverage.common.util.KieBaseUtil;
 import org.drools.testcoverage.common.util.KieUtil;
-import org.drools.testcoverage.common.util.TestParametersUtil;
-import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.junit.runners.Parameterized;
+import org.drools.testcoverage.common.util.TestParametersUtil2;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
 import org.kie.api.KieBase;
 import org.kie.api.builder.KieBuilder;
 import org.kie.api.runtime.KieSession;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-@RunWith(Parameterized.class)
 public class ConstraintsTest {
-
-    private final KieBaseTestConfiguration kieBaseTestConfiguration;
-
-    public ConstraintsTest(final KieBaseTestConfiguration kieBaseTestConfiguration) {
-        this.kieBaseTestConfiguration = kieBaseTestConfiguration;
+	
+    public static Stream<KieBaseTestConfiguration> parameters() {
+        return TestParametersUtil2.getKieBaseCloudConfigurations(true).stream();
     }
 
-    @Parameterized.Parameters(name = "KieBase type={0}")
-    public static Collection<Object[]> getParameters() {
-        return TestParametersUtil.getKieBaseCloudConfigurations(true);
-    }
-
-    @Test
-    public void testExpressionConstraints1() {
+    @ParameterizedTest(name = "KieBase type={0}")
+	@MethodSource("parameters")
+    public void testExpressionConstraints1(KieBaseTestConfiguration kieBaseTestConfiguration) {
         final String drl = "package org.drools.compiler.integrationtests\n" +
                 "import " + Mailbox.FolderType.class.getCanonicalName() + ";\n" +
                 "import " + Mailbox.class.getCanonicalName() + ";\n" +
@@ -77,11 +69,12 @@ public class ConstraintsTest {
                 "    then\n" +
                 "end\n";
 
-        testExpressionConstraints(drl);
+        testExpressionConstraints(kieBaseTestConfiguration, drl);
     }
 
-    @Test
-    public void testExpressionConstraints2() {
+    @ParameterizedTest(name = "KieBase type={0}")
+	@MethodSource("parameters")
+    public void testExpressionConstraints2(KieBaseTestConfiguration kieBaseTestConfiguration) {
         final String drl = "package org.drools.compiler.integrationtests\n" +
                 "import " + Mailbox.FolderType.class.getCanonicalName() + ";\n" +
                 "import " + Mailbox.class.getCanonicalName() + ";\n" +
@@ -106,11 +99,12 @@ public class ConstraintsTest {
                 "    then\n" +
                 "end\n";
 
-        testExpressionConstraints(drl);
+        testExpressionConstraints(kieBaseTestConfiguration, drl);
     }
 
-    @Test
-    public void testExpressionConstraints3() {
+    @ParameterizedTest(name = "KieBase type={0}")
+	@MethodSource("parameters")
+    public void testExpressionConstraints3(KieBaseTestConfiguration kieBaseTestConfiguration) {
         final String drl = "package org.drools.compiler.integrationtests\n" +
                 "import " + Mailbox.FolderType.class.getCanonicalName() + ";\n" +
                 "import " + Mailbox.class.getCanonicalName() + ";\n" +
@@ -144,10 +138,10 @@ public class ConstraintsTest {
                 "    then\n" +
                 "end";
 
-        testExpressionConstraints(drl);
+        testExpressionConstraints(kieBaseTestConfiguration, drl);
     }
 
-    private void testExpressionConstraints(final String drl) {
+    private void testExpressionConstraints(KieBaseTestConfiguration kieBaseTestConfiguration, final String drl) {
         final KieBase kbase = KieBaseUtil.getKieBaseFromKieModuleFromDrl("constraints-test", kieBaseTestConfiguration, drl);
         final KieSession ksession = kbase.newKieSession();
         try {
@@ -165,8 +159,9 @@ public class ConstraintsTest {
         }
     }
 
-    @Test
-    public void testExpressionConstraints4() {
+    @ParameterizedTest(name = "KieBase type={0}")
+	@MethodSource("parameters")
+    public void testExpressionConstraints4(KieBaseTestConfiguration kieBaseTestConfiguration) {
         final String drl = "package org.drools.compiler.integrationtests\n" +
                 "import " + Mailbox.FolderType.class.getCanonicalName() + ";\n" +
                 "import " + Mailbox.class.getCanonicalName() + ";\n" +
@@ -196,8 +191,9 @@ public class ConstraintsTest {
         }
     }
 
-    @Test
-    public void testDeeplyNestedCompactExpressions() {
+    @ParameterizedTest(name = "KieBase type={0}")
+	@MethodSource("parameters")
+    public void testDeeplyNestedCompactExpressions(KieBaseTestConfiguration kieBaseTestConfiguration) {
         final String drl = "package org.drools\n" +
                 "rule R1\n" +
                 " when\n" +
@@ -212,8 +208,9 @@ public class ConstraintsTest {
         assertThat(kieBuilder.getResults().getMessages()).isNotEmpty();
     }
 
-    @Test
-    public void testConstraintConnectors() {
+    @ParameterizedTest(name = "KieBase type={0}")
+	@MethodSource("parameters")
+    public void testConstraintConnectors(KieBaseTestConfiguration kieBaseTestConfiguration) {
         final KieBase kbase = KieBaseUtil.getKieBaseFromClasspathResources("constraints-test", kieBaseTestConfiguration,
                                                                            "org/drools/compiler/integrationtests/test_ConstraintConnectors.drl");
         final KieSession ksession = kbase.newKieSession();
@@ -268,8 +265,9 @@ public class ConstraintsTest {
         }
     }
 
-    @Test
-    public void testConnectorsAndOperators() {
+    @ParameterizedTest(name = "KieBase type={0}")
+	@MethodSource("parameters")
+    public void testConnectorsAndOperators(KieBaseTestConfiguration kieBaseTestConfiguration) {
         final String drl = "package org.drools.compiler\n" +
                 "\n" +
                 "import " + StockTick.class.getCanonicalName() + ";\n" +
@@ -298,8 +296,9 @@ public class ConstraintsTest {
         }
     }
 
-    @Test
-    public void testConstraintExpression() {
+    @ParameterizedTest(name = "KieBase type={0}")
+	@MethodSource("parameters")
+    public void testConstraintExpression(KieBaseTestConfiguration kieBaseTestConfiguration) {
         final String drl = "package org.drools.compiler\n" +
                 "import " + Person.class.getCanonicalName() + ";\n" +
                 "rule \"test\"\n" +
@@ -318,8 +317,9 @@ public class ConstraintsTest {
         }
     }
 
-    @Test
-    public void testMethodConstraint() {
+    @ParameterizedTest(name = "KieBase type={0}")
+	@MethodSource("parameters")
+    public void testMethodConstraint(KieBaseTestConfiguration kieBaseTestConfiguration) {
         final String drl = "package org.drools.compiler\n" +
                 "import " + Person.class.getCanonicalName() + ";\n" +
                 "rule \"test\"\n" +
@@ -340,8 +340,9 @@ public class ConstraintsTest {
         }
     }
 
-    @Test
-    public void testDeepNestedConstraints() {
+    @ParameterizedTest(name = "KieBase type={0}")
+	@MethodSource("parameters")
+    public void testDeepNestedConstraints(KieBaseTestConfiguration kieBaseTestConfiguration) {
         final String drl = "package org.drools.compiler\n" +
                 "import " + Person.class.getCanonicalName() + ";\n" +
                 "import " + Cheese.class.getCanonicalName() + ";\n" +
@@ -372,8 +373,9 @@ public class ConstraintsTest {
         }
     }
 
-    @Test
-    public void testMultiRestrictionFieldConstraint() {
+    @ParameterizedTest(name = "KieBase type={0}")
+	@MethodSource("parameters")
+    public void testMultiRestrictionFieldConstraint(KieBaseTestConfiguration kieBaseTestConfiguration) {
         final KieBase kbase = KieBaseUtil.getKieBaseFromClasspathResources("constraints-test", kieBaseTestConfiguration,
                                                                            "org/drools/compiler/integrationtests/test_MultiRestrictionFieldConstraint.drl");
         final KieSession ksession = kbase.newKieSession();
@@ -438,8 +440,9 @@ public class ConstraintsTest {
         }
     }
 
-    @Test
-    public void testNonBooleanConstraint() {
+    @ParameterizedTest(name = "KieBase type={0}")
+	@MethodSource("parameters")
+    public void testNonBooleanConstraint(KieBaseTestConfiguration kieBaseTestConfiguration) {
         final String drl = "package org.drools.compiler\n" +
                 "import java.util.List\n" +
                 "import " + Person.class.getCanonicalName() + ";\n" +
@@ -457,8 +460,9 @@ public class ConstraintsTest {
                 .isNotEmpty();
     }
 
-    @Test
-    public void testVarargConstraint() {
+    @ParameterizedTest(name = "KieBase type={0}")
+	@MethodSource("parameters")
+    public void testVarargConstraint(KieBaseTestConfiguration kieBaseTestConfiguration) {
         // JBRULES-3268
         final String drl = "package org.drools.compiler.test;\n" +
                 "import " + VarargBean.class.getCanonicalName() + ";\n" +

--- a/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/compiler/integrationtests/CustomOperatorOnlyDrlTest.java
+++ b/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/compiler/integrationtests/CustomOperatorOnlyDrlTest.java
@@ -21,7 +21,7 @@ package org.drools.compiler.integrationtests;
 import java.io.IOException;
 import java.io.ObjectInput;
 import java.io.ObjectOutput;
-import java.util.Collection;
+import java.util.stream.Stream;
 
 import org.drools.base.base.ValueResolver;
 import org.drools.base.base.ValueType;
@@ -34,30 +34,22 @@ import org.drools.mvel.evaluators.BaseEvaluator;
 import org.drools.mvel.evaluators.VariableRestriction;
 import org.drools.testcoverage.common.util.KieBaseTestConfiguration;
 import org.drools.testcoverage.common.util.KieBaseUtil;
-import org.drools.testcoverage.common.util.TestParametersUtil;
-import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.junit.runners.Parameterized;
+import org.drools.testcoverage.common.util.TestParametersUtil2;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
 import org.kie.api.runtime.rule.FactHandle;
 import org.kie.internal.builder.conf.EvaluatorOption;
 
-@RunWith(Parameterized.class)
 public class CustomOperatorOnlyDrlTest {
 
-    private final KieBaseTestConfiguration kieBaseTestConfiguration;
-
-    public CustomOperatorOnlyDrlTest(final KieBaseTestConfiguration kieBaseTestConfiguration) {
-        this.kieBaseTestConfiguration = kieBaseTestConfiguration;
-    }
-
-    @Parameterized.Parameters(name = "KieBase type={0}")
-    public static Collection<Object[]> getParameters() {
+    public static Stream<KieBaseTestConfiguration> parameters() {
         // TODO EM DROOLS-6302
-        return TestParametersUtil.getKieBaseCloudConfigurations(false);
+        return TestParametersUtil2.getKieBaseCloudConfigurations(false).stream();
     }
 
-    @Test
-    public void testCustomOperatorCombiningConstraints() {
+    @ParameterizedTest(name = "KieBase type={0}")
+	@MethodSource("parameters")
+    public void testCustomOperatorCombiningConstraints(KieBaseTestConfiguration kieBaseTestConfiguration) {
         // JBRULES-3517
         final String drl =
                 "declare GN\n" +

--- a/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/compiler/integrationtests/CustomOperatorTest.java
+++ b/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/compiler/integrationtests/CustomOperatorTest.java
@@ -22,6 +22,7 @@ import java.io.IOException;
 import java.io.ObjectInput;
 import java.io.ObjectOutput;
 import java.util.Collection;
+import java.util.stream.Stream;
 
 import org.drools.base.base.ValueResolver;
 import org.drools.base.base.ValueType;
@@ -36,10 +37,9 @@ import org.drools.testcoverage.common.model.Address;
 import org.drools.testcoverage.common.model.Person;
 import org.drools.testcoverage.common.util.KieBaseTestConfiguration;
 import org.drools.testcoverage.common.util.KieBaseUtil;
-import org.drools.testcoverage.common.util.TestParametersUtil;
-import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.junit.runners.Parameterized;
+import org.drools.testcoverage.common.util.TestParametersUtil2;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
 import org.kie.api.KieBase;
 import org.kie.api.runtime.KieSession;
 import org.kie.api.runtime.rule.FactHandle;
@@ -47,50 +47,45 @@ import org.kie.internal.builder.conf.EvaluatorOption;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-@RunWith(Parameterized.class)
 public class CustomOperatorTest {
 
-    private final KieBaseTestConfiguration kieBaseTestConfiguration;
-
-    public CustomOperatorTest(final KieBaseTestConfiguration kieBaseTestConfiguration) {
-        this.kieBaseTestConfiguration = kieBaseTestConfiguration;
+    public static Stream<KieBaseTestConfiguration> parameters() {
+        return TestParametersUtil2.getKieBaseCloudConfigurations(true).stream();
     }
 
-    @Parameterized.Parameters(name = "KieBase type={0}")
-    public static Collection<Object[]> getParameters() {
-        return TestParametersUtil.getKieBaseCloudConfigurations(true);
-    }
-
-    @Test
-    public void testCustomOperatorUsingCollections() {
+    @ParameterizedTest(name = "KieBase type={0}")
+	@MethodSource("parameters")
+    public void testCustomOperatorUsingCollections(KieBaseTestConfiguration kieBaseTestConfiguration) {
         String constraints =
                 "    $alice : Person(name == \"Alice\")\n" +
                 "    $bob : Person(name == \"Bob\", addresses supersetOf $alice.addresses)\n";
-        customOperatorUsingCollections(constraints);
+        customOperatorUsingCollections(kieBaseTestConfiguration, constraints);
     }
 
-    @Test
-    public void testNoOperatorInstancesCreatedAtRuntime() {
+    @ParameterizedTest(name = "KieBase type={0}")
+	@MethodSource("parameters")
+    public void testNoOperatorInstancesCreatedAtRuntime(KieBaseTestConfiguration kieBaseTestConfiguration) {
         String constraints =
                 "    $alice : Person(name == \"Alice\")\n" +
                 "    $bob : Person(name == \"Bob\", addresses supersetOf $alice.addresses)\n" +
                 "    Person(name == \"Bob\", addresses supersetOf $alice.addresses)\n";
 
-        customOperatorUsingCollections(constraints);
+        customOperatorUsingCollections(kieBaseTestConfiguration, constraints);
 
         assertThat(SupersetOfEvaluatorDefinition.INSTANCES_COUNTER).isEqualTo(0);
     }
 
-    @Test
-    public void testCustomOperatorUsingCollectionsInverted() {
+    @ParameterizedTest(name = "KieBase type={0}")
+	@MethodSource("parameters")
+    public void testCustomOperatorUsingCollectionsInverted(KieBaseTestConfiguration kieBaseTestConfiguration) {
         // DROOLS-6983
         String constraints =
                 "    $bob : Person(name == \"Bob\")\n" +
                 "    $alice : Person(name == \"Alice\", $bob.addresses supersetOf this.addresses)\n";
-        customOperatorUsingCollections(constraints);
+        customOperatorUsingCollections(kieBaseTestConfiguration, constraints);
     }
 
-    private void customOperatorUsingCollections(String constraints) {
+    private void customOperatorUsingCollections(KieBaseTestConfiguration kieBaseTestConfiguration, String constraints) {
         final String drl =
                 "import " + Address.class.getCanonicalName() + ";\n" +
                         "import " + Person.class.getCanonicalName() + ";\n" +
@@ -210,8 +205,9 @@ public class CustomOperatorTest {
         }
     }
 
-    @Test
-    public void testCustomOperatorOnKieModule() {
+    @ParameterizedTest(name = "KieBase type={0}")
+	@MethodSource("parameters")
+    public void testCustomOperatorOnKieModule(KieBaseTestConfiguration kieBaseTestConfiguration) {
         final String drl = "import " + Address.class.getCanonicalName() + ";\n" +
                 "import " + Person.class.getCanonicalName() + ";\n" +
                 "rule R when\n" +

--- a/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/compiler/integrationtests/ErrorOnInsertLogicalTest.java
+++ b/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/compiler/integrationtests/ErrorOnInsertLogicalTest.java
@@ -24,7 +24,7 @@ import java.util.stream.Collectors;
 
 import org.drools.compiler.builder.impl.KnowledgeBuilderImpl;
 import org.drools.io.ReaderResource;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.kie.api.KieBase;
 import org.kie.api.KieBaseConfiguration;
 import org.kie.api.KieServices;

--- a/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/compiler/integrationtests/FromSharingTest.java
+++ b/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/compiler/integrationtests/FromSharingTest.java
@@ -19,39 +19,31 @@
 package org.drools.compiler.integrationtests;
 
 import java.util.ArrayList;
-import java.util.Collection;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.stream.Stream;
 
 import org.drools.testcoverage.common.model.Person;
 import org.drools.testcoverage.common.util.KieBaseTestConfiguration;
 import org.drools.testcoverage.common.util.KieBaseUtil;
-import org.drools.testcoverage.common.util.TestParametersUtil;
-import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.junit.runners.Parameterized;
+import org.drools.testcoverage.common.util.TestParametersUtil2;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
 import org.kie.api.KieBase;
 import org.kie.api.runtime.KieSession;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-@RunWith(Parameterized.class)
 public class FromSharingTest {
 
-    private final KieBaseTestConfiguration kieBaseTestConfiguration;
-
-    public FromSharingTest(final KieBaseTestConfiguration kieBaseTestConfiguration) {
-        this.kieBaseTestConfiguration = kieBaseTestConfiguration;
+    public static Stream<KieBaseTestConfiguration> parameters() {
+        return TestParametersUtil2.getKieBaseCloudConfigurations(true).stream();
     }
 
-    @Parameterized.Parameters(name = "KieBase type={0}")
-    public static Collection<Object[]> getParameters() {
-        return TestParametersUtil.getKieBaseCloudConfigurations(true);
-    }
-
-    @Test
-    public void testSharingFromWithoutHashCodeEquals() {
+    @ParameterizedTest(name = "KieBase type={0}")
+	@MethodSource("parameters")
+    public void testSharingFromWithoutHashCodeEquals(KieBaseTestConfiguration kieBaseTestConfiguration) {
         // DROOLS-2557
         final String drl =
                 "import " + PersonWithoutHashCodeEquals.class.getCanonicalName() + "\n" +
@@ -189,8 +181,9 @@ public class FromSharingTest {
         }
     }
 
-    @Test
-    public void testFromSharingWithPropReactvityOnItsConstraint() {
+    @ParameterizedTest(name = "KieBase type={0}")
+	@MethodSource("parameters")
+    public void testFromSharingWithPropReactvityOnItsConstraint(KieBaseTestConfiguration kieBaseTestConfiguration) {
         // DROOLS-3606
         final String drl =
                 "import " + Person.class.getCanonicalName() + "\n" +

--- a/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/compiler/integrationtests/ImmutableFactsTest.java
+++ b/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/compiler/integrationtests/ImmutableFactsTest.java
@@ -18,15 +18,14 @@
  */
 package org.drools.compiler.integrationtests;
 
-import java.util.ArrayList;
 import java.util.Collection;
+import java.util.stream.Stream;
 
 import org.drools.testcoverage.common.model.Person;
 import org.drools.testcoverage.common.util.KieBaseTestConfiguration;
 import org.drools.testcoverage.common.util.KieBaseUtil;
-import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.junit.runners.Parameterized;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
 import org.kie.api.KieBase;
 import org.kie.api.runtime.ClassObjectFilter;
 import org.kie.api.runtime.KieSession;
@@ -34,25 +33,15 @@ import org.kie.api.runtime.rule.FactHandle;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-@RunWith(Parameterized.class)
 public class ImmutableFactsTest {
 
-    private final KieBaseTestConfiguration kieBaseTestConfiguration;
-
-    public ImmutableFactsTest(final KieBaseTestConfiguration kieBaseTestConfiguration) {
-        this.kieBaseTestConfiguration = kieBaseTestConfiguration;
+    public static Stream<KieBaseTestConfiguration> parameters() {
+    	return Stream.of(KieBaseTestConfiguration.CLOUD_IDENTITY_IMMUTABLE, KieBaseTestConfiguration.CLOUD_IDENTITY_IMMUTABLE_MODEL_PATTERN);
     }
 
-    @Parameterized.Parameters(name = "KieBase type={0}")
-    public static Collection<Object[]> getParameters() {
-        Collection<Object[]> parameters = new ArrayList<>();
-        parameters.add(new Object[]{KieBaseTestConfiguration.CLOUD_IDENTITY_IMMUTABLE});
-        parameters.add(new Object[]{KieBaseTestConfiguration.CLOUD_IDENTITY_IMMUTABLE_MODEL_PATTERN});
-        return parameters;
-    }
-
-    @Test
-    public void testAlphaConstraint() {
+    @ParameterizedTest(name = "KieBase type={0}")
+	@MethodSource("parameters")
+    public void testAlphaConstraint(KieBaseTestConfiguration kieBaseTestConfiguration) {
         final String drl = "package org.drools.compiler\n" +
                 "import " + Person.class.getCanonicalName() + ";\n" +
                 "rule R when\n" +
@@ -95,8 +84,9 @@ public class ImmutableFactsTest {
         }
     }
 
-    @Test
-    public void testBetaConstraint() {
+    @ParameterizedTest(name = "KieBase type={0}")
+	@MethodSource("parameters")
+    public void testBetaConstraint(KieBaseTestConfiguration kieBaseTestConfiguration) {
         final String drl = "package org.drools.compiler\n" +
                 "import " + Person.class.getCanonicalName() + ";\n" +
                 "rule R when\n" +

--- a/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/compiler/integrationtests/IndexingTest.java
+++ b/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/compiler/integrationtests/IndexingTest.java
@@ -20,10 +20,10 @@ package org.drools.compiler.integrationtests;
 
 import java.math.BigDecimal;
 import java.util.ArrayList;
-import java.util.Collection;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.stream.Stream;
 
 import org.drools.ancompiler.CompiledNetwork;
 import org.drools.base.base.DroolsQuery;
@@ -54,10 +54,10 @@ import org.drools.testcoverage.common.model.Person;
 import org.drools.testcoverage.common.util.KieBaseTestConfiguration;
 import org.drools.testcoverage.common.util.KieBaseUtil;
 import org.drools.testcoverage.common.util.KieUtil;
-import org.drools.testcoverage.common.util.TestParametersUtil;
-import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.junit.runners.Parameterized;
+import org.drools.testcoverage.common.util.TestParametersUtil2;
+import org.junit.jupiter.api.Timeout;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
 import org.kie.api.KieBase;
 import org.kie.api.definition.rule.Rule;
 import org.kie.api.definition.type.FactType;
@@ -70,22 +70,15 @@ import org.kie.api.runtime.rule.ViewChangedEventListener;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.drools.core.util.DroolsTestUtil.rulestoMap;
 
-@RunWith(Parameterized.class)
 public class IndexingTest {
 
-    private final KieBaseTestConfiguration kieBaseTestConfiguration;
-
-    public IndexingTest(final KieBaseTestConfiguration kieBaseTestConfiguration) {
-        this.kieBaseTestConfiguration = kieBaseTestConfiguration;
+    public static Stream<KieBaseTestConfiguration> parameters() {
+        return TestParametersUtil2.getKieBaseCloudConfigurations(true).stream();
     }
 
-    @Parameterized.Parameters(name = "KieBase type={0}")
-    public static Collection<Object[]> getParameters() {
-        return TestParametersUtil.getKieBaseCloudConfigurations(true);
-    }
-
-    @Test()
-    public void testAlphaNodeSharing() {
+    @ParameterizedTest(name = "KieBase type={0}")
+	@MethodSource("parameters")
+    public void testAlphaNodeSharing(KieBaseTestConfiguration kieBaseTestConfiguration) {
         final String drl =
                 "package org.drools.compiler.test\n" +
                         "import " + Person.class.getCanonicalName() + "\n" +
@@ -135,8 +128,10 @@ public class IndexingTest {
         }
     }
 
-    @Test(timeout = 10000)
-    public void testBuildsIndexedAlphaNodes() {
+    @ParameterizedTest(name = "KieBase type={0}")
+	@MethodSource("parameters")
+	@Timeout(10000)
+    public void testBuildsIndexedAlphaNodes(KieBaseTestConfiguration kieBaseTestConfiguration) {
         final String drl =
                 "package org.drools.compiler.test\n" +
                         "import " + Person.class.getCanonicalName() + "\n" +
@@ -168,8 +163,10 @@ public class IndexingTest {
         }
     }
 
-    @Test(timeout = 10000)
-    public void testBuildsIndexedMemory() {
+    @ParameterizedTest(name = "KieBase type={0}")
+	@MethodSource("parameters")
+	@Timeout(10000)
+    public void testBuildsIndexedMemory(KieBaseTestConfiguration kieBaseTestConfiguration) {
         // tests indexes are correctly built        
         final String drl =
                 "package org.drools.compiler.test\n" +
@@ -247,8 +244,10 @@ public class IndexingTest {
         }
     }
 
-    @Test(timeout = 10000)
-    public void testIndexingOnQueryUnification() {
+    @ParameterizedTest(name = "KieBase type={0}")
+	@MethodSource("parameters")
+	@Timeout(10000)
+    public void testIndexingOnQueryUnification(KieBaseTestConfiguration kieBaseTestConfiguration) {
         final String drl =
                 "package org.drools.compiler.test  \n" +
                         "import " + Person.class.getCanonicalName() + "\n" +
@@ -283,8 +282,10 @@ public class IndexingTest {
         }
     }
 
-    @Test(timeout = 10000)
-    public void testIndexingOnQueryUnificationWithNot() {
+    @ParameterizedTest(name = "KieBase type={0}")
+	@MethodSource("parameters")
+	@Timeout(10000)
+    public void testIndexingOnQueryUnificationWithNot(KieBaseTestConfiguration kieBaseTestConfiguration) {
         final String drl =
                 "package org.drools.compiler.test  \n" +
                         "import " + Person.class.getCanonicalName() + "\n" +
@@ -416,8 +417,10 @@ public class IndexingTest {
         assertThat(insertUpdateDeleteMap.get("deleted").intValue()).isEqualTo(expectedDeleted);
     }
 
-    @Test(timeout = 10000)
-    public void testFullFastIteratorResume() {
+    @ParameterizedTest(name = "KieBase type={0}")
+	@MethodSource("parameters")
+	@Timeout(10000)
+    public void testFullFastIteratorResume(KieBaseTestConfiguration kieBaseTestConfiguration) {
         final String drl =
                 "package org.drools.compiler.test  \n" +
                         "import " + Person.class.getCanonicalName() + "\n" +
@@ -496,8 +499,10 @@ public class IndexingTest {
         }
     }
 
-    @Test(timeout = 10000)
-    public void testRangeIndex() {
+    @ParameterizedTest(name = "KieBase type={0}")
+	@MethodSource("parameters")
+	@Timeout(10000)
+    public void testRangeIndex(KieBaseTestConfiguration kieBaseTestConfiguration) {
         final String drl = "import " + Cheese.class.getCanonicalName() + ";\n" +
                 "rule R1\n" +
                 "when\n" +
@@ -519,8 +524,10 @@ public class IndexingTest {
         }
     }
 
-    @Test(timeout = 10000)
-    public void testRangeIndex2() {
+    @ParameterizedTest(name = "KieBase type={0}")
+	@MethodSource("parameters")
+	@Timeout(10000)
+    public void testRangeIndex2(KieBaseTestConfiguration kieBaseTestConfiguration) {
         final String drl = "import " + Cheese.class.getCanonicalName() + ";\n" +
                 "rule R1\n" +
                 "when\n" +
@@ -542,8 +549,10 @@ public class IndexingTest {
         }
     }
 
-    @Test(timeout = 10000)
-    public void testNotNode() {
+    @ParameterizedTest(name = "KieBase type={0}")
+	@MethodSource("parameters")
+	@Timeout(10000)
+    public void testNotNode(KieBaseTestConfiguration kieBaseTestConfiguration) {
         final String drl = "import " + Cheese.class.getCanonicalName() + ";\n" +
                 "import " + Person.class.getCanonicalName() + ";\n" +
                 "rule R1 salience 10\n" +
@@ -570,8 +579,10 @@ public class IndexingTest {
         }
     }
 
-    @Test(timeout = 10000)
-    public void testNotNodeModifyRight() {
+    @ParameterizedTest(name = "KieBase type={0}")
+	@MethodSource("parameters")
+	@Timeout(10000)
+    public void testNotNodeModifyRight(KieBaseTestConfiguration kieBaseTestConfiguration) {
         final String drl = "import " + Cheese.class.getCanonicalName() + ";\n" +
                 "import " + Person.class.getCanonicalName() + ";\n" +
                 "rule R1 salience 10 when\n" +
@@ -597,8 +608,10 @@ public class IndexingTest {
         }
     }
 
-    @Test(timeout = 10000)
-    public void testRange() {
+    @ParameterizedTest(name = "KieBase type={0}")
+	@MethodSource("parameters")
+	@Timeout(10000)
+    public void testRange(KieBaseTestConfiguration kieBaseTestConfiguration) {
         final String drl = "import " + Cheese.class.getCanonicalName() + ";\n" +
                 "import " + Person.class.getCanonicalName() + ";\n" +
                 "rule R1 salience 10 when\n" +
@@ -624,8 +637,10 @@ public class IndexingTest {
         }
     }
 
-    @Test(timeout = 10000)
-    public void testRange2() throws IllegalAccessException, InstantiationException {
+    @ParameterizedTest(name = "KieBase type={0}")
+	@MethodSource("parameters")
+	@Timeout(10000)
+    public void testRange2(KieBaseTestConfiguration kieBaseTestConfiguration) throws IllegalAccessException, InstantiationException {
         final String drl = "package org.drools.compiler.test\n" +
                 "declare A\n" +
                 "    a: int\n" +
@@ -674,8 +689,9 @@ public class IndexingTest {
         }
     }
 
-    @Test
-    public void testHashingAfterRemoveRightTuple() {
+    @ParameterizedTest(name = "KieBase type={0}")
+	@MethodSource("parameters")
+    public void testHashingAfterRemoveRightTuple(KieBaseTestConfiguration kieBaseTestConfiguration) {
         // DROOLS-1326
         final String drl = "package " + this.getClass().getPackage().getName() + ";\n" +
                 "import " + MyPojo.class.getCanonicalName() + "\n" +
@@ -776,8 +792,9 @@ public class IndexingTest {
         }
     }
 
-    @Test
-    public void testRequireLeftReorderingWithRangeIndex() {
+    @ParameterizedTest(name = "KieBase type={0}")
+	@MethodSource("parameters")
+    public void testRequireLeftReorderingWithRangeIndex(KieBaseTestConfiguration kieBaseTestConfiguration) {
         // DROOLS-1326
         final String drl = "import " + Queen.class.getCanonicalName() + ";\n"
                 + "rule \"multipleQueensHorizontal\"\n"
@@ -846,8 +863,10 @@ public class IndexingTest {
         }
     }
 
-    @Test(timeout = 10000)
-    public void testBuildsIndexedMemoryWithThis() {
+    @ParameterizedTest(name = "KieBase type={0}")
+	@MethodSource("parameters")
+	@Timeout(10000)
+    public void testBuildsIndexedMemoryWithThis(KieBaseTestConfiguration kieBaseTestConfiguration) {
         // tests indexes are correctly built
         final String drl =
                 "package org.drools.compiler.test\n" +
@@ -879,8 +898,9 @@ public class IndexingTest {
         }
     }
 
-    @Test
-    public void testAlphaIndexWithBigDecimalCoercion() {
+    @ParameterizedTest(name = "KieBase type={0}")
+	@MethodSource("parameters")
+    public void testAlphaIndexWithBigDecimalCoercion(KieBaseTestConfiguration kieBaseTestConfiguration) {
         final String drl =
                 "package org.drools.compiler.test\n" +
                         "import " + Person.class.getCanonicalName() + "\n" +
@@ -909,7 +929,7 @@ public class IndexingTest {
 
         try {
             // BigDecimal Index is disabled
-            assertAlphaIndex(kbase, Person.class, 0);
+            assertAlphaIndex(kieBaseTestConfiguration, kbase, Person.class, 0);
 
             List<String> list = new ArrayList<>();
             ksession.setGlobal("list", list);
@@ -924,8 +944,9 @@ public class IndexingTest {
         }
     }
 
-    @Test
-    public void testBeta() {
+    @ParameterizedTest(name = "KieBase type={0}")
+	@MethodSource("parameters")
+    public void testBeta(KieBaseTestConfiguration kieBaseTestConfiguration) {
 
         final String drl =
                 "package org.drools.compiler.test\n" +
@@ -962,11 +983,11 @@ public class IndexingTest {
         }
     }
 
-    private void assertAlphaIndex(KieBase kbase, Class<?> clazz, int hashedSize) {
+    private void assertAlphaIndex(KieBaseTestConfiguration kieBaseTestConfiguration, KieBase kbase, Class<?> clazz, int hashedSize) {
         final ObjectTypeNode otn = KieUtil.getObjectTypeNode(kbase, clazz);
         assertThat(otn).isNotNull();
         ObjectSinkPropagator objectSinkPropagator = otn.getObjectSinkPropagator();
-        if (this.kieBaseTestConfiguration.useAlphaNetworkCompiler()) {
+        if (kieBaseTestConfiguration.useAlphaNetworkCompiler()) {
             objectSinkPropagator = ((CompiledNetwork) objectSinkPropagator).getOriginalSinkPropagator();
         }
         CompositeObjectSinkAdapter sinkAdapter = (CompositeObjectSinkAdapter) objectSinkPropagator;
@@ -978,8 +999,9 @@ public class IndexingTest {
         }
     }
 
-    @Test
-    public void testAlphaIndexWithBigDecimalDifferentScale() {
+    @ParameterizedTest(name = "KieBase type={0}")
+	@MethodSource("parameters")
+    public void testAlphaIndexWithBigDecimalDifferentScale(KieBaseTestConfiguration kieBaseTestConfiguration) {
         final String drl =
                 "package org.drools.compiler.test\n" +
                         "import " + Person.class.getCanonicalName() + "\n" +
@@ -1008,7 +1030,7 @@ public class IndexingTest {
 
         try {
             // BigDecimal Index is disabled
-            assertAlphaIndex(kbase, Person.class, 0);
+            assertAlphaIndex(kieBaseTestConfiguration, kbase, Person.class, 0);
 
             List<String> list = new ArrayList<>();
             ksession.setGlobal("list", list);
@@ -1023,8 +1045,9 @@ public class IndexingTest {
         }
     }
 
-    @Test
-    public void testBetaIndexWithBigDecimalDifferentScale() {
+    @ParameterizedTest(name = "KieBase type={0}")
+	@MethodSource("parameters")
+    public void testBetaIndexWithBigDecimalDifferentScale(KieBaseTestConfiguration kieBaseTestConfiguration) {
         final String drl =
                 "package org.drools.compiler.test\n" +
                         "import " + Person.class.getCanonicalName() + "\n" +
@@ -1057,8 +1080,9 @@ public class IndexingTest {
         }
     }
 
-    @Test
-    public void testAlphaIndexOnField() {
+    @ParameterizedTest(name = "KieBase type={0}")
+	@MethodSource("parameters")
+    public void testAlphaIndexOnField(KieBaseTestConfiguration kieBaseTestConfiguration) {
         final String drl =
                 "package org.drools.compiler.test\n" +
                 "import " + Person.class.getCanonicalName() + "\n" +
@@ -1086,7 +1110,7 @@ public class IndexingTest {
         KieSession ksession = kbase.newKieSession();
 
         try {
-            assertAlphaIndex(kbase, Person.class, 3);
+            assertAlphaIndex(kieBaseTestConfiguration, kbase, Person.class, 3);
 
             List<String> list = new ArrayList<>();
             ksession.setGlobal("list", list);
@@ -1100,8 +1124,9 @@ public class IndexingTest {
         }
     }
 
-    @Test
-    public void testAlphaIndexOnThis() {
+    @ParameterizedTest(name = "KieBase type={0}")
+	@MethodSource("parameters")
+    public void testAlphaIndexOnThis(KieBaseTestConfiguration kieBaseTestConfiguration) {
         final String drl =
                 "package org.drools.compiler.test\n" +
                 "global java.util.List list\n" +
@@ -1128,7 +1153,7 @@ public class IndexingTest {
         KieSession ksession = kbase.newKieSession();
 
         try {
-            assertAlphaIndex(kbase, Integer.class, 3);
+            assertAlphaIndex(kieBaseTestConfiguration, kbase, Integer.class, 3);
 
             List<String> list = new ArrayList<>();
             ksession.setGlobal("list", list);
@@ -1141,41 +1166,47 @@ public class IndexingTest {
         }
     }
 
-    public void betaIndexWithBigDecimalAndInt() {
+    @ParameterizedTest(name = "KieBase type={0}")
+	@MethodSource("parameters")    
+    public void betaIndexWithBigDecimalAndInt(KieBaseTestConfiguration kieBaseTestConfiguration) {
         String constraints = "salary == $p1.salary, age == $p1.age";
-        betaIndexWithBigDecimalWithAdditionalBetaConstraint(constraints, new Person("John", 30, new BigDecimal("10")), new Person("Paul", 30, new BigDecimal("10")), true, 1);
-        betaIndexWithBigDecimalWithAdditionalBetaConstraint(constraints, new Person("John", 30, new BigDecimal("10")), new Person("Paul", 28, new BigDecimal("10")), false, 1);
+        betaIndexWithBigDecimalWithAdditionalBetaConstraint(kieBaseTestConfiguration, constraints, new Person("John", 30, new BigDecimal("10")), new Person("Paul", 30, new BigDecimal("10")), true, 1);
+        betaIndexWithBigDecimalWithAdditionalBetaConstraint(kieBaseTestConfiguration, constraints, new Person("John", 30, new BigDecimal("10")), new Person("Paul", 28, new BigDecimal("10")), false, 1);
     }
 
-    @Test
-    public void betaIndexWithIntAndBigDecimal() {
+    @ParameterizedTest(name = "KieBase type={0}")
+	@MethodSource("parameters")
+    public void betaIndexWithIntAndBigDecimal(KieBaseTestConfiguration kieBaseTestConfiguration) {
         String constraints = "age == $p1.age, salary == $p1.salary";
-        betaIndexWithBigDecimalWithAdditionalBetaConstraint(constraints, new Person("John", 30, new BigDecimal("10")), new Person("Paul", 30, new BigDecimal("10")), true, 1);
-        betaIndexWithBigDecimalWithAdditionalBetaConstraint(constraints, new Person("John", 30, new BigDecimal("10")), new Person("Paul", 28, new BigDecimal("10")), false, 1);
+        betaIndexWithBigDecimalWithAdditionalBetaConstraint(kieBaseTestConfiguration, constraints, new Person("John", 30, new BigDecimal("10")), new Person("Paul", 30, new BigDecimal("10")), true, 1);
+        betaIndexWithBigDecimalWithAdditionalBetaConstraint(kieBaseTestConfiguration, constraints, new Person("John", 30, new BigDecimal("10")), new Person("Paul", 28, new BigDecimal("10")), false, 1);
     }
 
-    @Test
-    public void betaIndexWithIntAndBigDecimalAndString() {
+    @ParameterizedTest(name = "KieBase type={0}")
+	@MethodSource("parameters")
+    public void betaIndexWithIntAndBigDecimalAndString(KieBaseTestConfiguration kieBaseTestConfiguration) {
         String constraints = "age == $p1.age, salary == $p1.salary, likes == $p1.likes";
-        betaIndexWithBigDecimalWithAdditionalBetaConstraint(constraints, new Person("John", 30, new BigDecimal("10"), "dog"), new Person("Paul", 30, new BigDecimal("10"), "dog"), true, 2);
-        betaIndexWithBigDecimalWithAdditionalBetaConstraint(constraints, new Person("John", 30, new BigDecimal("10"), "dog"), new Person("Paul", 30, new BigDecimal("10"), "cat"), false, 2);
+        betaIndexWithBigDecimalWithAdditionalBetaConstraint(kieBaseTestConfiguration, constraints, new Person("John", 30, new BigDecimal("10"), "dog"), new Person("Paul", 30, new BigDecimal("10"), "dog"), true, 2);
+        betaIndexWithBigDecimalWithAdditionalBetaConstraint(kieBaseTestConfiguration, constraints, new Person("John", 30, new BigDecimal("10"), "dog"), new Person("Paul", 30, new BigDecimal("10"), "cat"), false, 2);
     }
 
-    @Test
-    public void betaIndexWithIntInequalityAndBigDecimal() {
+    @ParameterizedTest(name = "KieBase type={0}")
+	@MethodSource("parameters")
+    public void betaIndexWithIntInequalityAndBigDecimal(KieBaseTestConfiguration kieBaseTestConfiguration) {
         String constraints = "age > $p1.age, salary == $p1.salary";
-        betaIndexWithBigDecimalWithAdditionalBetaConstraint(constraints, new Person("John", 30, new BigDecimal("10")), new Person("Paul", 40, new BigDecimal("10")), true, 0);
-        betaIndexWithBigDecimalWithAdditionalBetaConstraint(constraints, new Person("John", 30, new BigDecimal("10")), new Person("Paul", 28, new BigDecimal("10")), false, 0);
+        betaIndexWithBigDecimalWithAdditionalBetaConstraint(kieBaseTestConfiguration, constraints, new Person("John", 30, new BigDecimal("10")), new Person("Paul", 40, new BigDecimal("10")), true, 0);
+        betaIndexWithBigDecimalWithAdditionalBetaConstraint(kieBaseTestConfiguration, constraints, new Person("John", 30, new BigDecimal("10")), new Person("Paul", 28, new BigDecimal("10")), false, 0);
     }
 
-    @Test
-    public void betaIndexWithBigDecimalOnly() {
+    @ParameterizedTest(name = "KieBase type={0}")
+	@MethodSource("parameters")
+    public void betaIndexWithBigDecimalOnly(KieBaseTestConfiguration kieBaseTestConfiguration) {
         String constraints = "salary == $p1.salary";
-        betaIndexWithBigDecimalWithAdditionalBetaConstraint(constraints, new Person("John", 30, new BigDecimal("10")), new Person("Paul", 28, new BigDecimal("10")), true, 0);
-        betaIndexWithBigDecimalWithAdditionalBetaConstraint(constraints, new Person("John", 30, new BigDecimal("10")), new Person("Paul", 28, new BigDecimal("20")), false, 0);
+        betaIndexWithBigDecimalWithAdditionalBetaConstraint(kieBaseTestConfiguration, constraints, new Person("John", 30, new BigDecimal("10")), new Person("Paul", 28, new BigDecimal("10")), true, 0);
+        betaIndexWithBigDecimalWithAdditionalBetaConstraint(kieBaseTestConfiguration, constraints, new Person("John", 30, new BigDecimal("10")), new Person("Paul", 28, new BigDecimal("20")), false, 0);
     }
 
-    private void betaIndexWithBigDecimalWithAdditionalBetaConstraint(String constraints, Person firstPerson, Person secondPerson, boolean shouldMatch, int expectedIndexCount) {
+    private void betaIndexWithBigDecimalWithAdditionalBetaConstraint(KieBaseTestConfiguration kieBaseTestConfiguration, String constraints, Person firstPerson, Person secondPerson, boolean shouldMatch, int expectedIndexCount) {
         final String drl =
                 "package org.drools.compiler.test\n" +
                            "import " + Person.class.getCanonicalName() + "\n" +

--- a/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/compiler/integrationtests/KieBaseIncludeTest.java
+++ b/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/compiler/integrationtests/KieBaseIncludeTest.java
@@ -20,14 +20,14 @@ package org.drools.compiler.integrationtests;
 
 import java.io.File;
 import java.io.IOException;
+import java.util.stream.Stream;
 
 import org.drools.compiler.kie.builder.impl.DrlProject;
 import org.drools.compiler.kie.builder.impl.InternalKieModule;
 import org.drools.core.util.FileManager;
 import org.drools.model.codegen.ExecutableModelProject;
-import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.junit.runners.Parameterized;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
 import org.kie.api.KieServices;
 import org.kie.api.builder.KieBuilder;
 import org.kie.api.builder.KieFileSystem;
@@ -40,21 +40,15 @@ import org.kie.api.runtime.KieSession;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-@RunWith(Parameterized.class)
 public class KieBaseIncludeTest {
-    private final Class<? extends KieBuilder.ProjectType> projectType;
 
-    public KieBaseIncludeTest(boolean useModel) {
-        this.projectType = useModel ? ExecutableModelProject.class : DrlProject.class;
+	public static Stream<Class<? extends KieBuilder.ProjectType>> parameters() {
+        return Stream.of(ExecutableModelProject.class, DrlProject.class);
     }
 
-    @Parameterized.Parameters(name = "{0}")
-    public static Object[] params() {
-        return new Object[] {false, true};
-    }
-
-    @Test
-    public void testKJarIncludedDependency() throws Exception {
+    @ParameterizedTest(name = "{0}")
+	@MethodSource("parameters")
+    public void testKJarIncludedDependency(Class<? extends KieBuilder.ProjectType> projectType) throws Exception {
         String rule = "package org.test rule R when String() then end";
 
         KieServices ks = KieServices.Factory.get();
@@ -64,7 +58,7 @@ public class KieBaseIncludeTest {
         FileManager fileManager = new FileManager();
         fileManager.setUp();
 
-        InternalKieModule kJar1 = createKieJar( ks, includedReleaseId, rule );
+        InternalKieModule kJar1 = createKieJar(projectType, ks, includedReleaseId, rule );
 
         fileManager.tearDown();
         fileManager = new FileManager();
@@ -90,7 +84,7 @@ public class KieBaseIncludeTest {
         fileManager.tearDown();
     }
 
-    private InternalKieModule createKieJar(KieServices ks, ReleaseId releaseId, String... rules) throws IOException {
+    private InternalKieModule createKieJar(Class<? extends KieBuilder.ProjectType> projectType, KieServices ks, ReleaseId releaseId, String... rules) throws IOException {
         KieModuleModel kproj = ks.newKieModuleModel();
         KieBaseModel kieBaseModel1 = kproj.newKieBaseModel("KBase1");
         KieSessionModel ksession1 = kieBaseModel1.newKieSessionModel("KSession1");

--- a/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/compiler/integrationtests/MultiSheetsTest.java
+++ b/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/compiler/integrationtests/MultiSheetsTest.java
@@ -39,7 +39,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 public class MultiSheetsTest {
 
-    public static Stream<KieBaseTestConfiguration> getParameters() {
+    public static Stream<KieBaseTestConfiguration> parameters() {
         return TestParametersUtil2.getKieBaseCloudConfigurations(true).stream();
     }
 

--- a/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/compiler/integrationtests/MultiSheetsTest.java
+++ b/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/compiler/integrationtests/MultiSheetsTest.java
@@ -18,16 +18,15 @@
  */
 package org.drools.compiler.integrationtests;
 
-import java.util.Collection;
+import java.util.stream.Stream;
 
 import org.drools.compiler.kie.builder.impl.DrlProject;
 import org.drools.testcoverage.common.model.Person;
 import org.drools.testcoverage.common.model.Result;
 import org.drools.testcoverage.common.util.KieBaseTestConfiguration;
-import org.drools.testcoverage.common.util.TestParametersUtil;
-import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.junit.runners.Parameterized;
+import org.drools.testcoverage.common.util.TestParametersUtil2;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
 import org.kie.api.KieServices;
 import org.kie.api.builder.KieBuilder;
 import org.kie.api.builder.KieFileSystem;
@@ -38,41 +37,37 @@ import org.kie.api.runtime.KieSession;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-@RunWith(Parameterized.class)
 public class MultiSheetsTest {
 
-    private final KieBaseTestConfiguration kieBaseTestConfiguration;
-
-    public MultiSheetsTest(final KieBaseTestConfiguration kieBaseTestConfiguration) {
-        this.kieBaseTestConfiguration = kieBaseTestConfiguration;
+    public static Stream<KieBaseTestConfiguration> getParameters() {
+        return TestParametersUtil2.getKieBaseCloudConfigurations(true).stream();
     }
 
-    @Parameterized.Parameters(name = "KieBase type={0}")
-    public static Collection<Object[]> getParameters() {
-        return TestParametersUtil.getKieBaseCloudConfigurations(true);
+    @ParameterizedTest(name = "KieBase type={0}")
+	@MethodSource("parameters")
+    public void testNoSheet(KieBaseTestConfiguration kieBaseTestConfiguration) {
+        check(kieBaseTestConfiguration, null, "Mario can drink");
     }
 
-    @Test
-    public void testNoSheet() {
-        check(null, "Mario can drink");
+    @ParameterizedTest(name = "KieBase type={0}")
+	@MethodSource("parameters")
+    public void testSheet1(KieBaseTestConfiguration kieBaseTestConfiguration) {
+        check(kieBaseTestConfiguration, "Sheet1", "Mario can drink");
     }
 
-    @Test
-    public void testSheet1() {
-        check("Sheet1", "Mario can drink");
+    @ParameterizedTest(name = "KieBase type={0}")
+	@MethodSource("parameters")
+    public void testSheet2(KieBaseTestConfiguration kieBaseTestConfiguration) {
+        check(kieBaseTestConfiguration, "Sheet2", "Mario can drive");
     }
 
-    @Test
-    public void testSheet2() {
-        check("Sheet2", "Mario can drive");
+    @ParameterizedTest(name = "KieBase type={0}")
+	@MethodSource("parameters")
+    public void testSheet12(KieBaseTestConfiguration kieBaseTestConfiguration) {
+        check(kieBaseTestConfiguration, "Sheet1,Sheet2", "Mario can drink", "Mario can drive");
     }
 
-    @Test
-    public void testSheet12() {
-        check("Sheet1,Sheet2", "Mario can drink", "Mario can drive");
-    }
-
-    private void check(String sheets, String... results) {
+    private void check(KieBaseTestConfiguration kieBaseTestConfiguration, String sheets, String... results) {
         KieServices ks = KieServices.get();
         KieResources kr = ks.getResources();
 
@@ -89,7 +84,7 @@ public class MultiSheetsTest {
 
         kfs.writeKModuleXML( kproj.toXML() );
 
-        KieBuilder kb = buildDTable( ks, kfs );
+        KieBuilder kb = buildDTable(kieBaseTestConfiguration, ks, kfs);
         KieContainer kc = ks.newKieContainer(kb.getKieModule().getReleaseId());
 
         KieSession sessionDtable = kc.newKieSession( "dtable" );
@@ -102,7 +97,7 @@ public class MultiSheetsTest {
         }
     }
 
-    private KieBuilder buildDTable( KieServices ks, KieFileSystem kfs ) {
+    private KieBuilder buildDTable(KieBaseTestConfiguration kieBaseTestConfiguration, KieServices ks, KieFileSystem kfs) {
         if (kieBaseTestConfiguration.getExecutableModelProjectClass().isPresent()) {
             return ks.newKieBuilder( kfs ).buildAll(kieBaseTestConfiguration.getExecutableModelProjectClass().get());
         } else {

--- a/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/compiler/integrationtests/PassivePatternTest.java
+++ b/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/compiler/integrationtests/PassivePatternTest.java
@@ -19,37 +19,29 @@
 package org.drools.compiler.integrationtests;
 
 import java.util.ArrayList;
-import java.util.Collection;
 import java.util.List;
+import java.util.stream.Stream;
 
 import org.drools.testcoverage.common.util.KieBaseTestConfiguration;
 import org.drools.testcoverage.common.util.KieBaseUtil;
-import org.drools.testcoverage.common.util.TestParametersUtil;
-import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.junit.runners.Parameterized;
+import org.drools.testcoverage.common.util.TestParametersUtil2;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
 import org.kie.api.KieBase;
 import org.kie.api.runtime.KieSession;
 
 import static java.util.Arrays.asList;
 import static org.assertj.core.api.Assertions.assertThat;
 
-@RunWith(Parameterized.class)
 public class PassivePatternTest {
 
-    private final KieBaseTestConfiguration kieBaseTestConfiguration;
-
-    public PassivePatternTest(final KieBaseTestConfiguration kieBaseTestConfiguration) {
-        this.kieBaseTestConfiguration = kieBaseTestConfiguration;
+    public static Stream<KieBaseTestConfiguration> parameters() {
+        return TestParametersUtil2.getKieBaseCloudConfigurations(true).stream();
     }
 
-    @Parameterized.Parameters(name = "KieBase type={0}")
-    public static Collection<Object[]> getParameters() {
-        return TestParametersUtil.getKieBaseCloudConfigurations(true);
-    }
-
-    @Test
-    public void testPassiveInsert() {
+    @ParameterizedTest(name = "KieBase type={0}")
+	@MethodSource("parameters")
+    public void testPassiveInsert(KieBaseTestConfiguration kieBaseTestConfiguration) {
         final String drl =
                 "global java.util.List list\n" +
                         "rule R when\n" +

--- a/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/compiler/integrationtests/PropertyChangeSupportTest.java
+++ b/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/compiler/integrationtests/PropertyChangeSupportTest.java
@@ -21,7 +21,7 @@ package org.drools.compiler.integrationtests;
 import java.beans.PropertyChangeListener;
 import java.beans.PropertyChangeSupport;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.kie.api.io.ResourceType;
 import org.kie.api.runtime.KieSession;
 import org.kie.internal.utils.KieHelper;

--- a/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/compiler/integrationtests/PropertyReactivityTest.java
+++ b/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/compiler/integrationtests/PropertyReactivityTest.java
@@ -18,18 +18,17 @@
  */
 package org.drools.compiler.integrationtests;
 
-import java.util.Collection;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.stream.Stream;
 
 import org.drools.testcoverage.common.model.Person;
 import org.drools.testcoverage.common.util.KieBaseTestConfiguration;
 import org.drools.testcoverage.common.util.KieSessionTestConfiguration;
 import org.drools.testcoverage.common.util.KieUtil;
-import org.drools.testcoverage.common.util.TestParametersUtil;
-import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.junit.runners.Parameterized;
+import org.drools.testcoverage.common.util.TestParametersUtil2;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
 import org.kie.api.KieBase;
 import org.kie.api.KieServices;
 import org.kie.api.builder.KieModule;
@@ -41,22 +40,15 @@ import org.kie.internal.builder.conf.PropertySpecificOption;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-@RunWith(Parameterized.class)
 public class PropertyReactivityTest {
 
-    private final KieBaseTestConfiguration kieBaseTestConfiguration;
-
-    public PropertyReactivityTest(final KieBaseTestConfiguration kieBaseTestConfiguration) {
-        this.kieBaseTestConfiguration = kieBaseTestConfiguration;
+    public static Stream<KieBaseTestConfiguration> parameters() {
+        return TestParametersUtil2.getKieBaseCloudConfigurations(true).stream();
     }
 
-    @Parameterized.Parameters(name = "KieBase type={0}")
-    public static Collection<Object[]> getParameters() {
-        return TestParametersUtil.getKieBaseCloudConfigurations(true);
-    }
-
-    @Test
-    public void testDisablePropertyReactivity() {
+    @ParameterizedTest(name = "KieBase type={0}")
+	@MethodSource("parameters")
+    public void testDisablePropertyReactivity(KieBaseTestConfiguration kieBaseTestConfiguration) {
         // DROOLS-5746
         final String drl =
                 "import " + Person.class.getCanonicalName() + "\n" +

--- a/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/compiler/integrationtests/RuleChainingTest.java
+++ b/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/compiler/integrationtests/RuleChainingTest.java
@@ -20,10 +20,9 @@ package org.drools.compiler.integrationtests;
 
 import org.drools.testcoverage.common.util.KieBaseTestConfiguration;
 import org.drools.testcoverage.common.util.KieBaseUtil;
-import org.drools.testcoverage.common.util.TestParametersUtil;
-import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.junit.runners.Parameterized;
+import org.drools.testcoverage.common.util.TestParametersUtil2;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
 import org.kie.api.KieBase;
 import org.kie.api.event.rule.AfterMatchFiredEvent;
 import org.kie.api.event.rule.AgendaEventListener;
@@ -34,8 +33,8 @@ import org.kie.api.runtime.KieSession;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Mockito;
 
-import java.util.Collection;
 import java.util.List;
+import java.util.stream.Stream;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
@@ -43,22 +42,15 @@ import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 
-@RunWith(Parameterized.class)
 public class RuleChainingTest {
 
-    private final KieBaseTestConfiguration kieBaseTestConfiguration;
-
-    public RuleChainingTest(final KieBaseTestConfiguration kieBaseTestConfiguration) {
-        this.kieBaseTestConfiguration = kieBaseTestConfiguration;
+    public static Stream<KieBaseTestConfiguration> parameters() {
+        return TestParametersUtil2.getKieBaseCloudConfigurations(true).stream();
     }
 
-    @Parameterized.Parameters(name = "KieBase type={0}")
-    public static Collection<Object[]> getParameters() {
-        return TestParametersUtil.getKieBaseCloudConfigurations(true);
-    }
-
-    @Test
-    public void testRuleChainingWithLogicalInserts() {
+    @ParameterizedTest(name = "KieBase type={0}")
+	@MethodSource("parameters")
+    public void testRuleChainingWithLogicalInserts(KieBaseTestConfiguration kieBaseTestConfiguration) {
         final String drl = "package com.sample\n" +
                 " \n" +
                 "declare Some\n" +
@@ -126,8 +118,9 @@ public class RuleChainingTest {
         }
     }
 
-    @Test
-    public void testDoubleInsertLogical() {
+    @ParameterizedTest(name = "KieBase type={0}")
+	@MethodSource("parameters")
+    public void testDoubleInsertLogical(KieBaseTestConfiguration kieBaseTestConfiguration) {
         // DROOLS-7525
         final String drl =
                 "package org.test;\n" +

--- a/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/compiler/integrationtests/SharingTest.java
+++ b/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/compiler/integrationtests/SharingTest.java
@@ -20,8 +20,8 @@ package org.drools.compiler.integrationtests;
 
 import java.math.BigDecimal;
 import java.util.ArrayList;
-import java.util.Collection;
 import java.util.List;
+import java.util.stream.Stream;
 
 import org.drools.base.base.ClassObjectType;
 import org.drools.kiesession.rulebase.InternalKnowledgeBase;
@@ -36,28 +36,19 @@ import org.drools.testcoverage.common.model.FactWithList;
 import org.drools.testcoverage.common.model.Person;
 import org.drools.testcoverage.common.util.KieBaseTestConfiguration;
 import org.drools.testcoverage.common.util.KieBaseUtil;
-import org.drools.testcoverage.common.util.TestParametersUtil;
-import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.junit.runners.Parameterized;
+import org.drools.testcoverage.common.util.TestParametersUtil2;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
 import org.kie.api.KieBase;
 import org.kie.api.runtime.KieSession;
 import org.kie.api.runtime.rule.Agenda;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-@RunWith(Parameterized.class)
 public class SharingTest {
-
-    private final KieBaseTestConfiguration kieBaseTestConfiguration;
-
-    public SharingTest(final KieBaseTestConfiguration kieBaseTestConfiguration) {
-        this.kieBaseTestConfiguration = kieBaseTestConfiguration;
-    }
-
-    @Parameterized.Parameters(name = "KieBase type={0}")
-    public static Collection<Object[]> getParameters() {
-        return TestParametersUtil.getKieBaseCloudConfigurations(true);
+	
+    public static Stream<KieBaseTestConfiguration> parameters() {
+        return TestParametersUtil2.getKieBaseCloudConfigurations(true).stream();
     }
 
     public static class TestStaticUtils {
@@ -81,8 +72,9 @@ public class SharingTest {
         CCC;
     }
 
-    @Test
-    public void testDontShareAlphaWithStaticMethod() {
+    @ParameterizedTest(name = "KieBase type={0}")
+	@MethodSource("parameters")
+    public void testDontShareAlphaWithStaticMethod(KieBaseTestConfiguration kieBaseTestConfiguration) {
         // DROOLS-6418
         final String drl1 = "package c;\n" +
                             "import " + TestObject.class.getCanonicalName() + "\n" +
@@ -148,8 +140,9 @@ public class SharingTest {
         }
     }
 
-    @Test
-    public void testDontShareAlphaWithNonFinalField() {
+    @ParameterizedTest(name = "KieBase type={0}")
+	@MethodSource("parameters")
+    public void testDontShareAlphaWithNonFinalField(KieBaseTestConfiguration kieBaseTestConfiguration) {
         // DROOLS-6418
         final String drl = "package com.example;\n" +
                            "import " + TestObject.class.getCanonicalName() + "\n" +
@@ -184,8 +177,9 @@ public class SharingTest {
         }
     }
 
-    @Test
-    public void testShareAlphaWithFinalField() {
+    @ParameterizedTest(name = "KieBase type={0}")
+	@MethodSource("parameters")
+    public void testShareAlphaWithFinalField(KieBaseTestConfiguration kieBaseTestConfiguration) {
         // DROOLS-6418
         final String drl = "package com.example;\n" +
                            "import " + TestObject.class.getCanonicalName() + "\n" +
@@ -225,8 +219,9 @@ public class SharingTest {
         }
     }
 
-    @Test
-    public void testShareAlphaWithNestedFinalField() {
+    @ParameterizedTest(name = "KieBase type={0}")
+	@MethodSource("parameters")
+    public void testShareAlphaWithNestedFinalField(KieBaseTestConfiguration kieBaseTestConfiguration) {
         // DROOLS-6418
         final String drl = "package com.example;\n" +
                            "import " + TestObject.class.getCanonicalName() + "\n" +
@@ -263,8 +258,9 @@ public class SharingTest {
         }
     }
 
-    @Test
-    public void testShareAlphaWithEnum() {
+    @ParameterizedTest(name = "KieBase type={0}")
+	@MethodSource("parameters")
+    public void testShareAlphaWithEnum(KieBaseTestConfiguration kieBaseTestConfiguration) {
         // DROOLS-6418
         final String drl = "package com.example;\n" +
                            "import " + TestObject.class.getCanonicalName() + "\n" +
@@ -298,8 +294,9 @@ public class SharingTest {
         }
     }
 
-    @Test
-    public void testDontShareAlphaWithBigDecimalConstructor() {
+    @ParameterizedTest(name = "KieBase type={0}")
+	@MethodSource("parameters")
+    public void testDontShareAlphaWithBigDecimalConstructor(KieBaseTestConfiguration kieBaseTestConfiguration) {
         // DROOLS-6418
         final String drl = "package com.example;\n" +
                            "import " + Person.class.getCanonicalName() + "\n" +
@@ -333,8 +330,9 @@ public class SharingTest {
         }
     }
 
-    @Test
-    public void testShouldAlphaShareNotEqualsInDifferentPackages() {
+    @ParameterizedTest(name = "KieBase type={0}")
+	@MethodSource("parameters")
+    public void testShouldAlphaShareNotEqualsInDifferentPackages(KieBaseTestConfiguration kieBaseTestConfiguration) {
         // DROOLS-1404
         final String drl1 = "package c;\n" +
                             "import " + TestObject.class.getCanonicalName() + "\n" +
@@ -369,8 +367,9 @@ public class SharingTest {
         }
     }
 
-    @Test
-    public void testShouldAlphaShareNotEqualsInDifferentPackages2() {
+    @ParameterizedTest(name = "KieBase type={0}")
+	@MethodSource("parameters")
+    public void testShouldAlphaShareNotEqualsInDifferentPackages2(KieBaseTestConfiguration kieBaseTestConfiguration) {
         // DROOLS-1404
         final String drl1 = "package c;\n" +
                             "import " + FactWithList.class.getCanonicalName() + "\n" +
@@ -408,8 +407,9 @@ public class SharingTest {
         }
     }
 
-    @Test
-    public void testSubnetworkSharing() {
+    @ParameterizedTest(name = "KieBase type={0}")
+	@MethodSource("parameters")
+    public void testSubnetworkSharing(KieBaseTestConfiguration kieBaseTestConfiguration) {
         final String drl =
                 "import " + A.class.getCanonicalName() + "\n" +
                            "import " + B.class.getCanonicalName() + "\n" +

--- a/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/compiler/integrationtests/StreamsTest.java
+++ b/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/compiler/integrationtests/StreamsTest.java
@@ -22,6 +22,7 @@ import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
 import java.util.concurrent.TimeUnit;
+import java.util.stream.Stream;
 
 import org.drools.base.base.ClassObjectType;
 import org.drools.core.common.InternalFactHandle;
@@ -36,10 +37,10 @@ import org.drools.testcoverage.common.util.KieBaseTestConfiguration;
 import org.drools.testcoverage.common.util.KieBaseUtil;
 import org.drools.testcoverage.common.util.KieSessionTestConfiguration;
 import org.drools.testcoverage.common.util.KieUtil;
-import org.drools.testcoverage.common.util.TestParametersUtil;
-import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.junit.runners.Parameterized;
+import org.drools.testcoverage.common.util.TestParametersUtil2;
+import org.junit.jupiter.api.Timeout;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
 import org.kie.api.KieBase;
 import org.kie.api.builder.KieBuilder;
 import org.kie.api.definition.type.FactType;
@@ -61,22 +62,16 @@ import static org.mockito.Mockito.verify;
 /**
  * Tests related to the stream support features
  */
-@RunWith(Parameterized.class)
 public class StreamsTest {
 
-    private final KieBaseTestConfiguration kieBaseTestConfiguration;
-
-    public StreamsTest(final KieBaseTestConfiguration kieBaseTestConfiguration) {
-        this.kieBaseTestConfiguration = kieBaseTestConfiguration;
+    public static Stream<KieBaseTestConfiguration> parameters() {
+        return TestParametersUtil2.getKieBaseStreamConfigurations(true).stream();
     }
 
-    @Parameterized.Parameters(name = "KieBase type={0}")
-    public static Collection<Object[]> getParameters() {
-        return TestParametersUtil.getKieBaseStreamConfigurations(true);
-    }
-
-    @Test(timeout = 10000)
-    public void testEventAssertion() {
+    @ParameterizedTest(name = "KieBase type={0}")
+	@MethodSource("parameters")
+	@Timeout(10000)
+    public void testEventAssertion(KieBaseTestConfiguration kieBaseTestConfiguration) {
         final String drl = "package org.drools.compiler\n" +
                 "\n" +
                 "import " + StockTick.class.getCanonicalName() + ";\n" +
@@ -155,8 +150,9 @@ public class StreamsTest {
         }
     }
 
-    @Test
-    public void testEntryPointReference() {
+    @ParameterizedTest(name = "KieBase type={0}")
+	@MethodSource("parameters")
+    public void testEntryPointReference(KieBaseTestConfiguration kieBaseTestConfiguration) {
         final KieBase kbase = KieBaseUtil.getKieBaseFromClasspathResources("stream-test", kieBaseTestConfiguration,
                                                                            "org/drools/compiler/integrationtests/test_EntryPointReference.drl");
         final KieSession session = kbase.newKieSession();
@@ -195,8 +191,10 @@ public class StreamsTest {
         }
     }
 
-    @Test(timeout = 10000)
-    public void testModifyRetracOnEntryPointFacts() {
+    @ParameterizedTest(name = "KieBase type={0}")
+	@MethodSource("parameters")
+	@Timeout(10000)
+    public void testModifyRetracOnEntryPointFacts(KieBaseTestConfiguration kieBaseTestConfiguration) {
 
         final String drl = "package org.drools.compiler\n" +
                 "import " + StockTick.class.getCanonicalName() + ";\n" +
@@ -265,8 +263,9 @@ public class StreamsTest {
         }
     }
 
-    @Test
-    public void testModifyOnEntryPointFacts() {
+    @ParameterizedTest(name = "KieBase type={0}")
+	@MethodSource("parameters")
+    public void testModifyOnEntryPointFacts(KieBaseTestConfiguration kieBaseTestConfiguration) {
         final String drl = "package org.drools.compiler\n" +
                 "import " + StockTick.class.getCanonicalName() + ";\n" +
                 "declare StockTick\n" +
@@ -322,8 +321,10 @@ public class StreamsTest {
         }
     }
 
-    @Test(timeout = 10000)
-    public void testEntryPointWithAccumulateAndMVEL() {
+    @ParameterizedTest(name = "KieBase type={0}")
+	@MethodSource("parameters")
+	@Timeout(10000)
+    public void testEntryPointWithAccumulateAndMVEL(KieBaseTestConfiguration kieBaseTestConfiguration) {
         final String drl = "package org.drools.compiler\n" +
                 "import " + StockTick.class.getCanonicalName() + ";\n" +
                 "rule R1 dialect 'mvel'\n" +
@@ -356,8 +357,10 @@ public class StreamsTest {
         }
     }
 
-    @Test(timeout = 10000)
-    public void testGetEntryPointList() {
+    @ParameterizedTest(name = "KieBase type={0}")
+	@MethodSource("parameters")
+	@Timeout(10000)
+    public void testGetEntryPointList(KieBaseTestConfiguration kieBaseTestConfiguration) {
         final KieBase kbase = KieBaseUtil.getKieBaseFromClasspathResources("stream-test", kieBaseTestConfiguration,
                                                                            "org/drools/compiler/integrationtests/test_EntryPointReference.drl");
         final KieSession session = kbase.newKieSession();
@@ -378,8 +381,10 @@ public class StreamsTest {
         }
     }
 
-    @Test(timeout = 10000)
-    public void testEventDoesNotExpireIfNotInPattern() {
+    @ParameterizedTest(name = "KieBase type={0}")
+	@MethodSource("parameters")
+	@Timeout(10000)
+    public void testEventDoesNotExpireIfNotInPattern(KieBaseTestConfiguration kieBaseTestConfiguration) {
         final String drl = "package org.drools.compiler\n" +
                 "import " + StockTick.class.getCanonicalName() + ";\n" +
                 "declare StockTick\n" +
@@ -423,8 +428,10 @@ public class StreamsTest {
         }
     }
 
-    @Test(timeout = 10000)
-    public void testEventExpirationSetToZero() {
+    @ParameterizedTest(name = "KieBase type={0}")
+	@MethodSource("parameters")
+	@Timeout(10000)
+    public void testEventExpirationSetToZero(KieBaseTestConfiguration kieBaseTestConfiguration) {
         final String drl = "package org.drools.compiler\n" +
                 "import " + StockTick.class.getCanonicalName() + ";\n" +
                 "declare StockTick\n" +
@@ -471,8 +478,10 @@ public class StreamsTest {
         }
     }
 
-    @Test(timeout = 10000)
-    public void testEventExpirationValue() {
+    @ParameterizedTest(name = "KieBase type={0}")
+	@MethodSource("parameters")
+	@Timeout(10000)
+    public void testEventExpirationValue(KieBaseTestConfiguration kieBaseTestConfiguration) {
         final String drl1 = "package org.drools.pkg1\n" +
                 "import " + StockTick.class.getCanonicalName() + ";\n" +
                 "declare StockTick\n" +
@@ -505,8 +514,10 @@ public class StreamsTest {
         }
     }
 
-    @Test(timeout = 10000)
-    public void testDeclaredEntryPoint() {
+    @ParameterizedTest(name = "KieBase type={0}")
+	@MethodSource("parameters")
+	@Timeout(10000)
+    public void testDeclaredEntryPoint(KieBaseTestConfiguration kieBaseTestConfiguration) {
         final String drl = "package org.jboss.qa.brms.declaredep\n" +
                 "declare entry-point UnusedEntryPoint\n" +
                 "end\n" +
@@ -527,8 +538,9 @@ public class StreamsTest {
         }
     }
 
-    @Test
-    public void testWindowDeclaration() {
+    @ParameterizedTest(name = "KieBase type={0}")
+	@MethodSource("parameters")
+    public void testWindowDeclaration(KieBaseTestConfiguration kieBaseTestConfiguration) {
         final String drl = "package org.drools.compiler\n" +
                 "import " + StockTick.class.getCanonicalName() + ";\n" +
                 "declare StockTick\n" +
@@ -576,8 +588,10 @@ public class StreamsTest {
         }
     }
 
-    @Test(timeout = 10000)
-    public void testWindowDeclaration2() {
+    @ParameterizedTest(name = "KieBase type={0}")
+	@MethodSource("parameters")
+	@Timeout(10000)
+    public void testWindowDeclaration2(KieBaseTestConfiguration kieBaseTestConfiguration) {
         final String drl = "package org.drools.compiler\n" +
                 "declare Double\n" +
                 "    @role(event)\n" +
@@ -618,8 +632,10 @@ public class StreamsTest {
         }
     }
 
-    @Test(timeout = 10000)
-    public void testMultipleWindows() {
+    @ParameterizedTest(name = "KieBase type={0}")
+	@MethodSource("parameters")
+	@Timeout(10000)
+    public void testMultipleWindows(KieBaseTestConfiguration kieBaseTestConfiguration) {
         final String drl = "package org.drools.compiler\n" +
                 "import " + StockTick.class.getCanonicalName() + ";\n" +
                 "declare StockTick\n" +
@@ -656,8 +672,9 @@ public class StreamsTest {
         }
     }
 
-    @Test
-    public void testWindowWithEntryPointCompilationError() {
+    @ParameterizedTest(name = "KieBase type={0}")
+	@MethodSource("parameters")
+    public void testWindowWithEntryPointCompilationError(KieBaseTestConfiguration kieBaseTestConfiguration) {
         final String drl = "import " + Cheese.class.getCanonicalName() + ";\n" +
                 "declare window X\n" +
                 "   Cheese( type == \"gorgonzola\" ) over window:time(1m) from entry-point Z\n" +
@@ -674,8 +691,10 @@ public class StreamsTest {
                 .isNotEmpty();
     }
 
-    @Test(timeout = 10000)
-    public void testAtomicActivationFiring() throws Exception {
+    @ParameterizedTest(name = "KieBase type={0}")
+	@MethodSource("parameters")
+	@Timeout(10000)
+    public void testAtomicActivationFiring(KieBaseTestConfiguration kieBaseTestConfiguration) throws Exception {
         // JBRULES-3383
         final String drl = "package org.drools.compiler.test\n" +
                 "declare Event\n" +

--- a/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/compiler/integrationtests/SubnetworkCEPTest.java
+++ b/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/compiler/integrationtests/SubnetworkCEPTest.java
@@ -18,34 +18,26 @@
  */
 package org.drools.compiler.integrationtests;
 
-import java.util.Collection;
+import java.util.stream.Stream;
 
 import org.drools.testcoverage.common.util.KieBaseTestConfiguration;
 import org.drools.testcoverage.common.util.KieBaseUtil;
-import org.drools.testcoverage.common.util.TestParametersUtil;
-import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.junit.runners.Parameterized;
+import org.drools.testcoverage.common.util.TestParametersUtil2;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
 import org.kie.api.KieBase;
 import org.kie.api.runtime.KieSession;
 import org.kie.api.runtime.rule.FactHandle;
 
-@RunWith(Parameterized.class)
 public class SubnetworkCEPTest {
 
-    private final KieBaseTestConfiguration kieBaseTestConfiguration;
-
-    public SubnetworkCEPTest(final KieBaseTestConfiguration kieBaseTestConfiguration) {
-        this.kieBaseTestConfiguration = kieBaseTestConfiguration;
+    public static Stream<KieBaseTestConfiguration> parameters() {
+        return TestParametersUtil2.getKieBaseStreamConfigurations(true).stream();
     }
 
-    @Parameterized.Parameters(name = "KieBase type={0}")
-    public static Collection<Object[]> getParameters() {
-        return TestParametersUtil.getKieBaseStreamConfigurations(true);
-    }
-
-    @Test
-    public void testNPEOnFlushingOfUnlinkedPmem() {
+    @ParameterizedTest(name = "KieBase type={0}")
+	@MethodSource("parameters")
+    public void testNPEOnFlushingOfUnlinkedPmem(KieBaseTestConfiguration kieBaseTestConfiguration) {
         // DROOLS-1285
         final String drl =
                 "import " + SubnetworkTest.A.class.getCanonicalName() + "\n" +

--- a/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/compiler/integrationtests/SubnetworkTest.java
+++ b/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/compiler/integrationtests/SubnetworkTest.java
@@ -20,10 +20,10 @@ package org.drools.compiler.integrationtests;
 
 import org.drools.testcoverage.common.util.KieBaseTestConfiguration;
 import org.drools.testcoverage.common.util.KieBaseUtil;
-import org.drools.testcoverage.common.util.TestParametersUtil;
-import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.junit.runners.Parameterized;
+import org.drools.testcoverage.common.util.TestParametersUtil2;
+import org.junit.jupiter.api.Timeout;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
 import org.kie.api.KieBase;
 import org.kie.api.definition.type.Role;
 import org.kie.api.runtime.KieSession;
@@ -33,25 +33,17 @@ import org.kie.api.runtime.rule.QueryResults;
 
 import java.awt.Dimension;
 import java.util.ArrayList;
-import java.util.Collection;
 import java.util.List;
 import java.util.concurrent.atomic.AtomicInteger;
+import java.util.stream.Stream;
 
 import static java.util.Arrays.asList;
 import static org.assertj.core.api.Assertions.assertThat;
 
-@RunWith(Parameterized.class)
 public class SubnetworkTest {
 
-    private final KieBaseTestConfiguration kieBaseTestConfiguration;
-
-    public SubnetworkTest(final KieBaseTestConfiguration kieBaseTestConfiguration) {
-        this.kieBaseTestConfiguration = kieBaseTestConfiguration;
-    }
-
-    @Parameterized.Parameters(name = "KieBase type={0}")
-    public static Collection<Object[]> getParameters() {
-        return TestParametersUtil.getKieBaseCloudConfigurations(true);
+    public static Stream<KieBaseTestConfiguration> parameters() {
+        return TestParametersUtil2.getKieBaseCloudConfigurations(true).stream();
     }
 
     @Role(Role.Type.EVENT)
@@ -69,8 +61,10 @@ public class SubnetworkTest {
 
     }
 
-    @Test(timeout = 10000)
-    public void testRightStagingOnSharedSubnetwork() {
+    @ParameterizedTest(name = "KieBase type={0}")
+	@MethodSource("parameters")
+	@Timeout(10000)
+    public void testRightStagingOnSharedSubnetwork(KieBaseTestConfiguration kieBaseTestConfiguration) {
         // RHBRMS-2624
         final String drl =
                 "import " + AtomicInteger.class.getCanonicalName() + ";\n" +
@@ -107,8 +101,10 @@ public class SubnetworkTest {
         }
     }
 
-    @Test(timeout = 10000)
-    public void testUpdateOnSharedSubnetwork() {
+    @ParameterizedTest(name = "KieBase type={0}")
+	@MethodSource("parameters")
+	@Timeout(10000)
+    public void testUpdateOnSharedSubnetwork(KieBaseTestConfiguration kieBaseTestConfiguration) {
         // DROOLS-1360
         final String drl =
                 "import " + AtomicInteger.class.getCanonicalName() + ";\n" +
@@ -154,8 +150,10 @@ public class SubnetworkTest {
         }
     }
 
-    @Test(timeout = 10000)
-    public void testSubNeworkNotRemoveRightRemove() {
+    @ParameterizedTest(name = "KieBase type={0}")
+	@MethodSource("parameters")
+	@Timeout(10000)
+    public void testSubNeworkNotRemoveRightRemove(KieBaseTestConfiguration kieBaseTestConfiguration) {
         final String drl =
               "import " + Dimension.class.getCanonicalName() + ";\n" +
               "global java.util.List list;\n" +
@@ -188,8 +186,10 @@ public class SubnetworkTest {
         }
     }
 
-    @Test(timeout = 10000)
-    public void testSubNeworkNotRemoveLeftRemove() {
+    @ParameterizedTest(name = "KieBase type={0}")
+	@MethodSource("parameters")
+	@Timeout(10000)
+    public void testSubNeworkNotRemoveLeftRemove(KieBaseTestConfiguration kieBaseTestConfiguration) {
         final String drl =
               "import " + Dimension.class.getCanonicalName() + ";\n" +
               "global java.util.List list;\n" +
@@ -226,8 +226,10 @@ public class SubnetworkTest {
         }
     }
 
-    @Test(timeout = 10000)
-    public void testSubNeworkQueryTest() {
+    @ParameterizedTest(name = "KieBase type={0}")
+	@MethodSource("parameters")
+	@Timeout(10000)
+    public void testSubNeworkQueryTest(KieBaseTestConfiguration kieBaseTestConfiguration) {
         final String drl =
               "import " + Dimension.class.getCanonicalName() + ";\n" +
               "global java.util.List list;\n" +
@@ -273,16 +275,20 @@ public class SubnetworkTest {
         }
     }
 
-    @Test(timeout = 10000)
-    public void testSubNetworks() {
+    @ParameterizedTest(name = "KieBase type={0}")
+	@MethodSource("parameters")
+	@Timeout(10000)
+    public void testSubNetworks(KieBaseTestConfiguration kieBaseTestConfiguration) {
         final KieBase kieBase = KieBaseUtil.getKieBaseFromClasspathResources("subnetwork-test", kieBaseTestConfiguration,
                                                                              "org/drools/compiler/integrationtests/test_SubNetworks.drl");
         final KieSession session = kieBase.newKieSession();
         session.dispose();
     }
 
-    @Test(timeout = 10000)
-    public void testSubnetworkSharingWith2SinksFromLia() {
+    @ParameterizedTest(name = "KieBase type={0}")
+	@MethodSource("parameters")
+	@Timeout(10000)
+    public void testSubnetworkSharingWith2SinksFromLia(KieBaseTestConfiguration kieBaseTestConfiguration) {
         // DROOLS-1656
         final String drl =
                 "import " + X.class.getCanonicalName() + "\n" +
@@ -340,8 +346,10 @@ public class SubnetworkTest {
         }
     }
 
-    @Test(timeout = 10000)
-    public void testSubnetworkSharingWith2SinksAfterLia() {
+    @ParameterizedTest(name = "KieBase type={0}")
+	@MethodSource("parameters")
+	@Timeout(10000)
+    public void testSubnetworkSharingWith2SinksAfterLia(KieBaseTestConfiguration kieBaseTestConfiguration) {
         // DROOLS-1656
         final String drl =
               "import " + X.class.getCanonicalName() + "\n" +
@@ -460,19 +468,21 @@ public class SubnetworkTest {
         }
     }
 
-    @Test
-    public void subnetworkSharingWith2SinksAndRightTupleDelete_shouldNotThrowNPE() {
+    @ParameterizedTest(name = "KieBase type={0}")
+	@MethodSource("parameters")
+    public void subnetworkSharingWith2SinksAndRightTupleDelete_shouldNotThrowNPE(KieBaseTestConfiguration kieBaseTestConfiguration) {
         // DROOLS-7420
-        testFromCollectInSubnetwork(true);
+        testFromCollectInSubnetwork(kieBaseTestConfiguration, true);
     }
 
-    @Test
-    public void subnetworkNoSharingWith2SinksAndRightTupleDelete_shouldNotThrowNPE() {
+    @ParameterizedTest(name = "KieBase type={0}")
+	@MethodSource("parameters")
+    public void subnetworkNoSharingWith2SinksAndRightTupleDelete_shouldNotThrowNPE(KieBaseTestConfiguration kieBaseTestConfiguration) {
         // DROOLS-7420
-        testFromCollectInSubnetwork(false);
+        testFromCollectInSubnetwork(kieBaseTestConfiguration, false);
     }
 
-    private void testFromCollectInSubnetwork(boolean nodeSharing) {
+    private void testFromCollectInSubnetwork(KieBaseTestConfiguration kieBaseTestConfiguration, boolean nodeSharing) {
         String accConstraint = nodeSharing ? "" : "size > 0";
         final String drl =
                 "import " + List.class.getCanonicalName() + ";\n" +

--- a/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/compiler/integrationtests/UnexpectedLoopTest.java
+++ b/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/compiler/integrationtests/UnexpectedLoopTest.java
@@ -18,39 +18,32 @@
  */
 package org.drools.compiler.integrationtests;
 
-import java.util.Collection;
 import java.util.List;
+import java.util.stream.Stream;
 
 import org.drools.compiler.integrationtests.model.CalcFact;
 import org.drools.compiler.integrationtests.model.Item;
 import org.drools.compiler.integrationtests.model.RecordFact;
 import org.drools.testcoverage.common.util.KieBaseTestConfiguration;
 import org.drools.testcoverage.common.util.KieBaseUtil;
-import org.drools.testcoverage.common.util.TestParametersUtil;
-import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.junit.runners.Parameterized;
+import org.drools.testcoverage.common.util.TestParametersUtil2;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
 import org.kie.api.KieBase;
 import org.kie.api.runtime.KieSession;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-@RunWith(Parameterized.class)
 public class UnexpectedLoopTest {
 
-    private final KieBaseTestConfiguration kieBaseTestConfiguration;
 
-    public UnexpectedLoopTest(final KieBaseTestConfiguration kieBaseTestConfiguration) {
-        this.kieBaseTestConfiguration = kieBaseTestConfiguration;
+    public static Stream<KieBaseTestConfiguration> parameters() {
+        return TestParametersUtil2.getKieBaseCloudConfigurations(true).stream();
     }
 
-    @Parameterized.Parameters(name = "KieBase type={0}")
-    public static Collection<Object[]> getParameters() {
-        return TestParametersUtil.getKieBaseCloudConfigurations(true);
-    }
-
-    @Test
-    public void joinFromFromPeerUpdate_shouldNotLoop() {
+    @ParameterizedTest(name = "KieBase type={0}")
+	@MethodSource("parameters")
+    public void joinFromFromPeerUpdate_shouldNotLoop(KieBaseTestConfiguration kieBaseTestConfiguration) {
 
         final KieBase kieBase = KieBaseUtil.getKieBaseFromClasspathResources(getClass(), kieBaseTestConfiguration,
                                                                              "org/drools/compiler/integrationtests/joinFromFrom.drl");

--- a/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/compiler/integrationtests/operators/AndTest.java
+++ b/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/compiler/integrationtests/operators/AndTest.java
@@ -19,38 +19,30 @@
 package org.drools.compiler.integrationtests.operators;
 
 import java.util.ArrayList;
-import java.util.Collection;
 import java.util.List;
+import java.util.stream.Stream;
 
 import org.drools.testcoverage.common.model.Cheese;
 import org.drools.testcoverage.common.model.Message;
 import org.drools.testcoverage.common.util.KieBaseTestConfiguration;
 import org.drools.testcoverage.common.util.KieBaseUtil;
-import org.drools.testcoverage.common.util.TestParametersUtil;
-import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.junit.runners.Parameterized;
+import org.drools.testcoverage.common.util.TestParametersUtil2;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
 import org.kie.api.KieBase;
 import org.kie.api.runtime.KieSession;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-@RunWith(Parameterized.class)
 public class AndTest {
 
-    private final KieBaseTestConfiguration kieBaseTestConfiguration;
-
-    public AndTest(final KieBaseTestConfiguration kieBaseTestConfiguration) {
-        this.kieBaseTestConfiguration = kieBaseTestConfiguration;
+    public static Stream<KieBaseTestConfiguration> parameters() {
+        return TestParametersUtil2.getKieBaseCloudConfigurations(true).stream();
     }
 
-    @Parameterized.Parameters(name = "KieBase type={0}")
-    public static Collection<Object[]> getParameters() {
-        return TestParametersUtil.getKieBaseCloudConfigurations(true);
-    }
-
-    @Test
-    public void testExplicitAnd() {
+    @ParameterizedTest(name = "KieBase type={0}")
+	@MethodSource("parameters")
+    public void testExplicitAnd(KieBaseTestConfiguration kieBaseTestConfiguration) {
         final String drl = "package HelloWorld\n" +
                 " \n" +
                 "import " + Message.class.getCanonicalName() + ";\n" +

--- a/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/compiler/integrationtests/operators/ContainsTest.java
+++ b/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/compiler/integrationtests/operators/ContainsTest.java
@@ -19,8 +19,8 @@
 package org.drools.compiler.integrationtests.operators;
 
 import java.util.ArrayList;
-import java.util.Collection;
 import java.util.List;
+import java.util.stream.Stream;
 
 import org.drools.testcoverage.common.model.Cheese;
 import org.drools.testcoverage.common.model.Cheesery;
@@ -29,31 +29,23 @@ import org.drools.testcoverage.common.model.OrderItem;
 import org.drools.testcoverage.common.model.Primitives;
 import org.drools.testcoverage.common.util.KieBaseTestConfiguration;
 import org.drools.testcoverage.common.util.KieBaseUtil;
-import org.drools.testcoverage.common.util.TestParametersUtil;
-import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.junit.runners.Parameterized;
+import org.drools.testcoverage.common.util.TestParametersUtil2;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
 import org.kie.api.KieBase;
 import org.kie.api.runtime.KieSession;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-@RunWith(Parameterized.class)
 public class ContainsTest {
 
-    private final KieBaseTestConfiguration kieBaseTestConfiguration;
-
-    public ContainsTest(final KieBaseTestConfiguration kieBaseTestConfiguration) {
-        this.kieBaseTestConfiguration = kieBaseTestConfiguration;
+    public static Stream<KieBaseTestConfiguration> parameters() {
+        return TestParametersUtil2.getKieBaseCloudConfigurations(true).stream();
     }
 
-    @Parameterized.Parameters(name = "KieBase type={0}")
-    public static Collection<Object[]> getParameters() {
-        return TestParametersUtil.getKieBaseCloudConfigurations(true);
-    }
-
-    @Test
-    public void testContainsCheese() {
+    @ParameterizedTest(name = "KieBase type={0}")
+	@MethodSource("parameters")
+    public void testContainsCheese(KieBaseTestConfiguration kieBaseTestConfiguration) {
         final String drl = "package org.drools.compiler.integrationtests.operators;\n" +
                 "\n" +
                 "import " + Cheese.class.getCanonicalName() + ";\n" +
@@ -106,8 +98,9 @@ public class ContainsTest {
         }
     }
 
-    @Test
-    public void testContainsInArray() {
+    @ParameterizedTest(name = "KieBase type={0}")
+	@MethodSource("parameters")
+    public void testContainsInArray(KieBaseTestConfiguration kieBaseTestConfiguration) {
 
          final String drl = "package org.drools.compiler.integrationtests.operators\n" +
                  "import " + Primitives.class.getCanonicalName() + " ;\n" +
@@ -151,8 +144,9 @@ public class ContainsTest {
         }
     }
 
-    @Test
-    public void testNotContainsOperator() {
+    @ParameterizedTest(name = "KieBase type={0}")
+	@MethodSource("parameters")
+    public void testNotContainsOperator(KieBaseTestConfiguration kieBaseTestConfiguration) {
         // JBRULES-2404: "not contains" operator doesn't work on nested fields
         final String str = "package org.drools.compiler.integrationtests.operators\n" +
                 "import " + Order.class.getCanonicalName() + " ;\n" +

--- a/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/compiler/integrationtests/operators/EnabledTest.java
+++ b/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/compiler/integrationtests/operators/EnabledTest.java
@@ -19,17 +19,17 @@
 package org.drools.compiler.integrationtests.operators;
 
 import java.util.ArrayList;
-import java.util.Collection;
 import java.util.List;
+import java.util.stream.Stream;
 
 import org.drools.testcoverage.common.model.MyFact;
 import org.drools.testcoverage.common.model.Person;
 import org.drools.testcoverage.common.util.KieBaseTestConfiguration;
 import org.drools.testcoverage.common.util.KieBaseUtil;
 import org.drools.testcoverage.common.util.KieUtil;
-import org.drools.testcoverage.common.util.TestParametersUtil;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.drools.testcoverage.common.util.TestParametersUtil2;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
 import org.junit.runners.Parameterized;
 import org.kie.api.KieBase;
 import org.kie.api.KieServices;
@@ -45,22 +45,16 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 
-@RunWith(Parameterized.class)
 public class EnabledTest {
 
-    private final KieBaseTestConfiguration kieBaseTestConfiguration;
-
-    public EnabledTest(final KieBaseTestConfiguration kieBaseTestConfiguration) {
-        this.kieBaseTestConfiguration = kieBaseTestConfiguration;
-    }
-
     @Parameterized.Parameters(name = "KieBase type={0}")
-    public static Collection<Object[]> getParameters() {
-        return TestParametersUtil.getKieBaseCloudConfigurations(false);
+    public static Stream<KieBaseTestConfiguration> parameters() {
+        return TestParametersUtil2.getKieBaseCloudConfigurations(false).stream();
     }
 
-    @Test
-    public void testEnabledExpression() {
+    @ParameterizedTest(name = "KieBase type={0}")
+	@MethodSource("parameters")
+    public void testEnabledExpression(KieBaseTestConfiguration kieBaseTestConfiguration) {
 
         final String drl = "package org.drools.compiler.integrationtests.operators;\n" +
                 "import " + Person.class.getCanonicalName() + ";\n" +
@@ -129,8 +123,9 @@ public class EnabledTest {
         }
     }
 
-    @Test
-    public void testEnabledExpression2() {
+    @ParameterizedTest(name = "KieBase type={0}")
+	@MethodSource("parameters")
+    public void testEnabledExpression2(KieBaseTestConfiguration kieBaseTestConfiguration) {
         final String drl = "import " + MyFact.class.getName() + ";\n" +
                 "rule R1\n" +
                 "    enabled( rule.name == $f.name )" +

--- a/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/compiler/integrationtests/operators/EqualsTest.java
+++ b/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/compiler/integrationtests/operators/EqualsTest.java
@@ -27,30 +27,22 @@ import org.drools.testcoverage.common.model.Primitives;
 import org.drools.testcoverage.common.util.KieBaseTestConfiguration;
 import org.drools.testcoverage.common.util.KieBaseUtil;
 import org.drools.testcoverage.common.util.TestParametersUtil;
-import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.junit.runners.Parameterized;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
 import org.kie.api.KieBase;
 import org.kie.api.runtime.KieSession;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-@RunWith(Parameterized.class)
 public class EqualsTest {
 
-    private final KieBaseTestConfiguration kieBaseTestConfiguration;
-
-    public EqualsTest(final KieBaseTestConfiguration kieBaseTestConfiguration) {
-        this.kieBaseTestConfiguration = kieBaseTestConfiguration;
-    }
-
-    @Parameterized.Parameters(name = "KieBase type={0}")
-    public static Collection<Object[]> getParameters() {
+    public static Collection<Object[]> parameters() {
         return TestParametersUtil.getKieBaseCloudConfigurations(true);
     }
 
-    @Test
-    public void testEqualitySupport() {
+    @ParameterizedTest(name = "KieBase type={0}")
+	@MethodSource("parameters")
+    public void testEqualitySupport(KieBaseTestConfiguration kieBaseTestConfiguration) {
 
         final String drl = "package org.drools.compiler.integrationtests.operators\n" +
                 "import " + PersonWithSpecificEquals.class.getCanonicalName() + " ;\n" +
@@ -92,8 +84,9 @@ public class EqualsTest {
         }
     }
 
-    @Test
-    public void testNotEqualsOperator() {
+    @ParameterizedTest(name = "KieBase type={0}")
+	@MethodSource("parameters")
+    public void testNotEqualsOperator(KieBaseTestConfiguration kieBaseTestConfiguration) {
         // JBRULES-3003: restriction evaluation returns 'false' for "trueField != falseField"
 
         final String str = "package org.drools.compiler.integrationtests.operators\n" +
@@ -124,8 +117,9 @@ public class EqualsTest {
         }
     }
 
-    @Test
-    public void testCharComparisons() {
+    @ParameterizedTest(name = "KieBase type={0}")
+	@MethodSource("parameters")
+    public void testCharComparisons(KieBaseTestConfiguration kieBaseTestConfiguration) {
 
         final String drl = "package org.drools.compiler.integrationtests.operators\n" +
                 "import " + Primitives.class.getCanonicalName() + " ;\n" +

--- a/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/compiler/integrationtests/operators/EvalRewriteTest.java
+++ b/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/compiler/integrationtests/operators/EvalRewriteTest.java
@@ -19,38 +19,30 @@
 package org.drools.compiler.integrationtests.operators;
 
 import java.util.ArrayList;
-import java.util.Collection;
 import java.util.List;
+import java.util.stream.Stream;
 
 import org.drools.testcoverage.common.model.Order;
 import org.drools.testcoverage.common.model.OrderItem;
 import org.drools.testcoverage.common.util.KieBaseTestConfiguration;
 import org.drools.testcoverage.common.util.KieBaseUtil;
-import org.drools.testcoverage.common.util.TestParametersUtil;
-import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.junit.runners.Parameterized;
+import org.drools.testcoverage.common.util.TestParametersUtil2;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
 import org.kie.api.KieBase;
 import org.kie.api.runtime.KieSession;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-@RunWith(Parameterized.class)
 public class EvalRewriteTest {
 
-    private final KieBaseTestConfiguration kieBaseTestConfiguration;
-
-    public EvalRewriteTest(final KieBaseTestConfiguration kieBaseTestConfiguration) {
-        this.kieBaseTestConfiguration = kieBaseTestConfiguration;
+    public static Stream<KieBaseTestConfiguration> parameters() {
+        return TestParametersUtil2.getKieBaseCloudConfigurations(true).stream();
     }
 
-    @Parameterized.Parameters(name = "KieBase type={0}")
-    public static Collection<Object[]> getParameters() {
-        return TestParametersUtil.getKieBaseCloudConfigurations(true);
-    }
-
-    @Test
-    public void testEvalRewrite() {
+    @ParameterizedTest(name = "KieBase type={0}")
+	@MethodSource("parameters")
+    public void testEvalRewrite(KieBaseTestConfiguration kieBaseTestConfiguration) {
 
         final String drl = "package org.drools.compiler.integrationtests.operators\n" +
                 "import " + OrderItem.class.getCanonicalName() + " ;\n" +
@@ -147,8 +139,9 @@ public class EvalRewriteTest {
         }
     }
 
-    @Test
-    public void testEvalRewriteMatches() {
+    @ParameterizedTest(name = "KieBase type={0}")
+	@MethodSource("parameters")
+    public void testEvalRewriteMatches(KieBaseTestConfiguration kieBaseTestConfiguration) {
 
         final String drl = "package org.drools.compiler.integrationtests.operators;\n" +
                 "import " + OrderItem.class.getCanonicalName() + " ;\n" +
@@ -199,8 +192,9 @@ public class EvalRewriteTest {
         }
     }
 
-    @Test
-    public void testEvalRewriteWithSpecialOperators() {
+    @ParameterizedTest(name = "KieBase type={0}")
+	@MethodSource("parameters")
+    public void testEvalRewriteWithSpecialOperators(KieBaseTestConfiguration kieBaseTestConfiguration) {
 
         final String drl = "package org.drools.compiler\n" +
                 "import " + OrderItem.class.getCanonicalName() + " ;\n" +

--- a/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/compiler/integrationtests/operators/EvalTest.java
+++ b/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/compiler/integrationtests/operators/EvalTest.java
@@ -21,8 +21,8 @@ package org.drools.compiler.integrationtests.operators;
 import java.lang.reflect.InvocationTargetException;
 import java.math.BigDecimal;
 import java.util.ArrayList;
-import java.util.Collection;
 import java.util.List;
+import java.util.stream.Stream;
 
 import org.drools.core.reteoo.ReteDumper;
 import org.drools.testcoverage.common.model.Cheese;
@@ -33,10 +33,9 @@ import org.drools.testcoverage.common.model.Person;
 import org.drools.testcoverage.common.util.KieBaseTestConfiguration;
 import org.drools.testcoverage.common.util.KieBaseUtil;
 import org.drools.testcoverage.common.util.KieUtil;
-import org.drools.testcoverage.common.util.TestParametersUtil;
-import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.junit.runners.Parameterized;
+import org.drools.testcoverage.common.util.TestParametersUtil2;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
 import org.kie.api.KieBase;
 import org.kie.api.KieServices;
 import org.kie.api.builder.KieModule;
@@ -47,22 +46,15 @@ import org.kie.api.runtime.rule.FactHandle;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.fail;
 
-@RunWith(Parameterized.class)
 public class EvalTest {
 
-    private final KieBaseTestConfiguration kieBaseTestConfiguration;
-
-    public EvalTest(final KieBaseTestConfiguration kieBaseTestConfiguration) {
-        this.kieBaseTestConfiguration = kieBaseTestConfiguration;
+    public static Stream<KieBaseTestConfiguration> parameters() {
+        return TestParametersUtil2.getKieBaseCloudConfigurations(true).stream();
     }
 
-    @Parameterized.Parameters(name = "KieBase type={0}")
-    public static Collection<Object[]> getParameters() {
-        return TestParametersUtil.getKieBaseCloudConfigurations(true);
-    }
-
-    @Test
-    public void testEvalDefaultCompiler() {
+    @ParameterizedTest(name = "KieBase type={0}")
+	@MethodSource("parameters")
+    public void testEvalDefaultCompiler(KieBaseTestConfiguration kieBaseTestConfiguration) {
         final String drl = "package org.drools.compiler.integrationtests.operators;\n" +
                 "import " + Cheese.class.getCanonicalName() + ";\n" +
                 "global java.util.List list;\n" +
@@ -96,8 +88,9 @@ public class EvalTest {
         }
     }
 
-    @Test
-    public void testEvalNoPatterns() {
+    @ParameterizedTest(name = "KieBase type={0}")
+	@MethodSource("parameters")
+    public void testEvalNoPatterns(KieBaseTestConfiguration kieBaseTestConfiguration) {
         final String drl = "package org.drools.compiler.integrationtests.operators\n" +
                 "global java.util.List list\n" +
                 "rule \"no patterns1\"\n" +
@@ -145,8 +138,9 @@ public class EvalTest {
         }
     }
 
-    @Test
-    public void testEvalMore() {
+    @ParameterizedTest(name = "KieBase type={0}")
+	@MethodSource("parameters")
+    public void testEvalMore(KieBaseTestConfiguration kieBaseTestConfiguration) {
 
         final String drl = "package org.drools.compiler.integrationtests.operators\n" +
                 "import " + Cheese.class.getCanonicalName() + ";\n" +
@@ -186,8 +180,9 @@ public class EvalTest {
         }
     }
 
-    @Test
-    public void testEvalCE() {
+    @ParameterizedTest(name = "KieBase type={0}")
+	@MethodSource("parameters")
+    public void testEvalCE(KieBaseTestConfiguration kieBaseTestConfiguration) {
         final String drl = "package org.drools.compiler.integrationtests.operators\n" +
                 "import " + Person.class.getCanonicalName() + ";\n" +
                 "rule \"inline eval\"\n" +
@@ -217,8 +212,9 @@ public class EvalTest {
         }
     }
 
-    @Test
-    public void testEvalException() {
+    @ParameterizedTest(name = "KieBase type={0}")
+	@MethodSource("parameters")
+    public void testEvalException(KieBaseTestConfiguration kieBaseTestConfiguration) {
         final String drl = "package org.drools.compiler.integrationtests.operators;\n" +
                 "import " + Cheese.class.getCanonicalName() + ";\n" +
                 "function boolean throwException(Object object) {\n" +
@@ -251,8 +247,9 @@ public class EvalTest {
         }
     }
 
-    @Test
-    public void testEvalInline() {
+    @ParameterizedTest(name = "KieBase type={0}")
+	@MethodSource("parameters")
+    public void testEvalInline(KieBaseTestConfiguration kieBaseTestConfiguration) {
         final String drl = "package org.drools.compiler.integrationtests.operators;\n" +
                 "import " + Person.class.getCanonicalName() + ";\n" +
                 "rule \"inline eval\"\n" +
@@ -281,8 +278,9 @@ public class EvalTest {
         }
     }
 
-    @Test
-    public void testEvalWithLineBreaks() {
+    @ParameterizedTest(name = "KieBase type={0}")
+	@MethodSource("parameters")
+    public void testEvalWithLineBreaks(KieBaseTestConfiguration kieBaseTestConfiguration) {
         final String drl = "package org.drools.compiler.integrationtests.operators;\n" +
                 "\n" +
                 "global java.util.List results\n" +
@@ -317,8 +315,9 @@ public class EvalTest {
         }
     }
 
-    @Test
-    public void testEvalWithBigDecimal() {
+    @ParameterizedTest(name = "KieBase type={0}")
+	@MethodSource("parameters")
+    public void testEvalWithBigDecimal(KieBaseTestConfiguration kieBaseTestConfiguration) {
         final String drl = 
                 "package org.drools.compiler.integrationtests.operators;\n" +
                 "import java.math.BigDecimal; \n" +
@@ -350,8 +349,9 @@ public class EvalTest {
         }
     }
 
-    @Test
-    public void testFieldBiningsAndEvalSharing() {
+    @ParameterizedTest(name = "KieBase type={0}")
+	@MethodSource("parameters")
+    public void testFieldBiningsAndEvalSharing(KieBaseTestConfiguration kieBaseTestConfiguration) {
         final String drl = "package org.drools.compiler\n" +
                 "import " + Person.class.getCanonicalName() + ";\n" +
                 "global java.util.List list;\n" +
@@ -373,11 +373,12 @@ public class EvalTest {
                 "    then\n" +
                 "        list.add(\"rule2 fired\");\n" +
                 "end ";
-        evalSharingTest(drl);
+        evalSharingTest(kieBaseTestConfiguration, drl);
     }
 
-    @Test
-    public void testFieldBiningsAndPredicateSharing() {
+    @ParameterizedTest(name = "KieBase type={0}")
+	@MethodSource("parameters")
+    public void testFieldBiningsAndPredicateSharing(KieBaseTestConfiguration kieBaseTestConfiguration) {
         final String drl = "package org.drools.compiler.integrationtests.operators;\n" +
                 "import " + Person.class.getCanonicalName() + ";\n" +
                 "global java.util.List list;\n" +
@@ -397,10 +398,10 @@ public class EvalTest {
                 "    then\n" +
                 "        list.add(\"rule2 fired\");\n" +
                 "end";
-        evalSharingTest(drl);
+        evalSharingTest(kieBaseTestConfiguration, drl);
     }
 
-    private void evalSharingTest(final String drl) {
+    private void evalSharingTest(KieBaseTestConfiguration kieBaseTestConfiguration, final String drl) {
         final KieBase kbase = KieBaseUtil.getKieBaseFromKieModuleFromDrl("eval-test",
                                                                          kieBaseTestConfiguration,
                                                                          drl);
@@ -423,8 +424,9 @@ public class EvalTest {
         }
     }
 
-    @Test
-    public void testCastingInsideEvals() {
+    @ParameterizedTest(name = "KieBase type={0}")
+	@MethodSource("parameters")
+    public void testCastingInsideEvals(KieBaseTestConfiguration kieBaseTestConfiguration) {
         final String drl = "package org.drools.compiler.integrationtests.operators\n" +
                 "\n" +
                 "global java.lang.Integer value;\n" +
@@ -452,8 +454,9 @@ public class EvalTest {
         }
     }
 
-    @Test
-    public void testAlphaEvalWithOrCE() {
+    @ParameterizedTest(name = "KieBase type={0}")
+	@MethodSource("parameters")
+    public void testAlphaEvalWithOrCE(KieBaseTestConfiguration kieBaseTestConfiguration) {
         final String drl = "package org.drools.compiler.integrationtests.operators;\n" +
                 "import " + FactA.class.getCanonicalName() + ";\n" +
                 "import " + FactB.class.getCanonicalName() + ";\n" +
@@ -491,8 +494,9 @@ public class EvalTest {
         }
     }
 
-    @Test
-    public void testModifyWithLiaToEval() {
+    @ParameterizedTest(name = "KieBase type={0}")
+	@MethodSource("parameters")
+    public void testModifyWithLiaToEval(KieBaseTestConfiguration kieBaseTestConfiguration) {
         final String drl =
             "package org.drools.compiler.integrationtests.operators;\n" +
             "import " + Person.class.getCanonicalName() + "\n" +
@@ -527,8 +531,9 @@ public class EvalTest {
         }
     }
 
-    @Test
-    public void testBigDecimalWithFromAndEval() {
+    @ParameterizedTest(name = "KieBase type={0}")
+	@MethodSource("parameters")
+    public void testBigDecimalWithFromAndEval(KieBaseTestConfiguration kieBaseTestConfiguration) {
         final String drl = "package org.drools.compiler.integrationtests.operators;\n" +
             "rule \"Test Rule\"\n" +
             "when\n" +
@@ -548,8 +553,9 @@ public class EvalTest {
         }
     }
 
-    @Test
-    public void testPredicate() {
+    @ParameterizedTest(name = "KieBase type={0}")
+	@MethodSource("parameters")
+    public void testPredicate(KieBaseTestConfiguration kieBaseTestConfiguration) {
         final String drl = "package org.drools.compiler.integrationtests.operators;\n" +
                 "import " + Person.class.getCanonicalName() + "\n" +
                 "global java.util.List list;\n" +
@@ -588,8 +594,9 @@ public class EvalTest {
         }
     }
 
-    @Test
-    public void testPredicateException() {
+    @ParameterizedTest(name = "KieBase type={0}")
+	@MethodSource("parameters")
+    public void testPredicateException(KieBaseTestConfiguration kieBaseTestConfiguration) {
         final String drl = "package org.drools.compiler.integrationtests.operators;\n" +
                 "import " + Cheese.class.getCanonicalName() + ";\n" +
                 "function boolean throwException(Object object) {\n" +

--- a/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/compiler/integrationtests/operators/ExistsTest.java
+++ b/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/compiler/integrationtests/operators/ExistsTest.java
@@ -20,39 +20,31 @@ package org.drools.compiler.integrationtests.operators;
 
 import java.math.BigDecimal;
 import java.util.ArrayList;
-import java.util.Collection;
 import java.util.List;
+import java.util.stream.Stream;
 
 import org.drools.testcoverage.common.model.AFact;
 import org.drools.testcoverage.common.model.Cheese;
 import org.drools.testcoverage.common.util.KieBaseTestConfiguration;
 import org.drools.testcoverage.common.util.KieBaseUtil;
-import org.drools.testcoverage.common.util.TestParametersUtil;
-import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.junit.runners.Parameterized;
+import org.drools.testcoverage.common.util.TestParametersUtil2;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
 import org.kie.api.KieBase;
 import org.kie.api.runtime.KieSession;
 import org.kie.api.runtime.rule.FactHandle;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-@RunWith(Parameterized.class)
 public class ExistsTest {
 
-    private final KieBaseTestConfiguration kieBaseTestConfiguration;
-
-    public ExistsTest(final KieBaseTestConfiguration kieBaseTestConfiguration) {
-        this.kieBaseTestConfiguration = kieBaseTestConfiguration;
+    public static Stream<KieBaseTestConfiguration> parameters() {
+        return TestParametersUtil2.getKieBaseCloudConfigurations(true).stream();
     }
 
-    @Parameterized.Parameters(name = "KieBase type={0}")
-    public static Collection<Object[]> getParameters() {
-        return TestParametersUtil.getKieBaseCloudConfigurations(true);
-    }
-
-    @Test
-    public void testExistsIterativeModifyBug() {
+    @ParameterizedTest(name = "KieBase type={0}")
+	@MethodSource("parameters")
+    public void testExistsIterativeModifyBug(KieBaseTestConfiguration kieBaseTestConfiguration) {
         // JBRULES-2809
         // This bug occurs when a tuple is modified, the remove/add puts it onto the memory end
         // However before this was done it would attempt to find the next tuple, starting from itself
@@ -113,8 +105,9 @@ public class ExistsTest {
         }
     }
 
-    @Test
-    public void testNodeSharingNotExists() {
+    @ParameterizedTest(name = "KieBase type={0}")
+	@MethodSource("parameters")
+    public void testNodeSharingNotExists(KieBaseTestConfiguration kieBaseTestConfiguration) {
 
         final String drl = "package org.drools.compiler.integrationtests.operators;\n" +
                 "import " + Cheese.class.getCanonicalName() + ";\n" +
@@ -156,8 +149,9 @@ public class ExistsTest {
         }
     }
 
-    @Test
-    public void testLastMemoryEntryExistsBug() {
+    @ParameterizedTest(name = "KieBase type={0}")
+	@MethodSource("parameters")
+    public void testLastMemoryEntryExistsBug(KieBaseTestConfiguration kieBaseTestConfiguration) {
         // JBRULES-2809
         // This occurs when a blocker is the last in the node's memory, or if there is only one fact in the node
         // And it gets no opportunity to rematch with itself
@@ -208,8 +202,9 @@ public class ExistsTest {
         }
     }
 
-    @Test
-    public void testExistsWithOrAndSubnetwork() {
+    @ParameterizedTest(name = "KieBase type={0}")
+	@MethodSource("parameters")
+    public void testExistsWithOrAndSubnetwork(KieBaseTestConfiguration kieBaseTestConfiguration) {
         // DROOLS-6550
         final String drl =
             "package org.drools.compiler.integrationtests.operators;\n" +
@@ -245,8 +240,9 @@ public class ExistsTest {
         }
     }
 
-    @Test
-    public void testSharedExistsWithNot() {
+    @ParameterizedTest(name = "KieBase type={0}")
+	@MethodSource("parameters")
+    public void testSharedExistsWithNot(KieBaseTestConfiguration kieBaseTestConfiguration) {
         // DROOLS-6710
         final String drl =
             "package org.drools.compiler.integrationtests.operators;\n" +
@@ -289,8 +285,9 @@ public class ExistsTest {
         }
     }
 
-    @Test
-    public void existsAndNotWithSingleCoercion_shouldNotMatchExists() {
+    @ParameterizedTest(name = "KieBase type={0}")
+	@MethodSource("parameters")
+    public void existsAndNotWithSingleCoercion_shouldNotMatchExists(KieBaseTestConfiguration kieBaseTestConfiguration) {
         // KIE-766
         final String drl =
                 "package org.drools.compiler.integrationtests.operators;\n" +
@@ -331,8 +328,9 @@ public class ExistsTest {
         }
     }
 
-    @Test
-    public void existsAndNotWithMultipleCoercion_shouldNotMatchExists() {
+    @ParameterizedTest(name = "KieBase type={0}")
+	@MethodSource("parameters")
+    public void existsAndNotWithMultipleCoercion_shouldNotMatchExists(KieBaseTestConfiguration kieBaseTestConfiguration) {
         // KIE-766
         final String drl =
                 "package org.drools.compiler.integrationtests.operators;\n" +
@@ -373,8 +371,9 @@ public class ExistsTest {
         }
     }
 
-    @Test
-    public void existsAndNotWithBigDecimals_shouldNotMatchExists() {
+    @ParameterizedTest(name = "KieBase type={0}")
+	@MethodSource("parameters")
+    public void existsAndNotWithBigDecimals_shouldNotMatchExists(KieBaseTestConfiguration kieBaseTestConfiguration) {
         // KIE-766
         final String drl =
                 "package org.drools.compiler.integrationtests.operators;\n" +

--- a/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/compiler/integrationtests/operators/ForAllTest.java
+++ b/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/compiler/integrationtests/operators/ForAllTest.java
@@ -20,131 +20,138 @@ package org.drools.compiler.integrationtests.operators;
 
 import java.text.SimpleDateFormat;
 import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.Collection;
 import java.util.Collections;
 import java.util.Date;
 import java.util.List;
 import java.util.Locale;
+import java.util.stream.Stream;
 
 import org.drools.testcoverage.common.model.Person;
 import org.drools.testcoverage.common.util.KieBaseTestConfiguration;
 import org.drools.testcoverage.common.util.KieBaseUtil;
-import org.drools.testcoverage.common.util.TestParametersUtil;
-import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.junit.runners.Parameterized;
+import org.drools.testcoverage.common.util.TestParametersUtil2;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
 import org.kie.api.KieBase;
 import org.kie.api.definition.type.FactType;
 import org.kie.api.runtime.KieSession;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-@RunWith(Parameterized.class)
 public class ForAllTest {
 
-    private final KieBaseTestConfiguration kieBaseTestConfiguration;
-
-    public ForAllTest(final KieBaseTestConfiguration kieBaseTestConfiguration) {
-        this.kieBaseTestConfiguration = kieBaseTestConfiguration;
+    public static Stream<KieBaseTestConfiguration> parameters() {
+        return TestParametersUtil2.getKieBaseCloudConfigurations(true).stream();
     }
 
-    @Parameterized.Parameters(name = "KieBase type={0}")
-    public static Collection<Object[]> getParameters() {
-        return TestParametersUtil.getKieBaseCloudConfigurations(true);
+    @ParameterizedTest(name = "KieBase type={0}")
+	@MethodSource("parameters")
+    public void test1P1CFiring1(KieBaseTestConfiguration kieBaseTestConfiguration) {
+        check(kieBaseTestConfiguration, "age >= 18", 1, new Person("Mario", 45));
     }
 
-    @Test
-    public void test1P1CFiring1() {
-        check("age >= 18", 1, new Person("Mario", 45));
+    @ParameterizedTest(name = "KieBase type={0}")
+	@MethodSource("parameters")
+    public void test1P1CFiring2(KieBaseTestConfiguration kieBaseTestConfiguration) {
+        check(kieBaseTestConfiguration, "age == 8 || == 45", 1, new Person("Mario", 45), new Person("Sofia", 8));
     }
 
-    @Test
-    public void test1P1CFiring2() {
-        check("age == 8 || == 45", 1, new Person("Mario", 45), new Person("Sofia", 8));
+    @ParameterizedTest(name = "KieBase type={0}")
+	@MethodSource("parameters")
+    public void test1P1CNotFiring(KieBaseTestConfiguration kieBaseTestConfiguration) {
+        check(kieBaseTestConfiguration, "age >= 18", 0, new Person("Sofia", 8));
     }
 
-    @Test
-    public void test1P1CNotFiring() {
-        check("age >= 18", 0, new Person("Sofia", 8));
+    @ParameterizedTest(name = "KieBase type={0}")
+	@MethodSource("parameters")
+    public void test1P1CNotFiringWithAnd(KieBaseTestConfiguration kieBaseTestConfiguration) {
+        check(kieBaseTestConfiguration, "name == \"Sofia\" && age >= 18", 0, new Person("Sofia", 8));
     }
 
-    @Test
-    public void test1P1CNotFiringWithAnd() {
-        check("name == \"Sofia\" && age >= 18", 0, new Person("Sofia", 8));
+    @ParameterizedTest(name = "KieBase type={0}")
+	@MethodSource("parameters")
+    public void test1P1CNotFiringWithParenthesis(KieBaseTestConfiguration kieBaseTestConfiguration) {
+        check(kieBaseTestConfiguration, "(name == \"Sofia\" && age >= 18)", 0, new Person("Sofia", 8));
     }
 
-    @Test
-    public void test1P1CNotFiringWithParenthesis() {
-        check("(name == \"Sofia\" && age >= 18)", 0, new Person("Sofia", 8));
+    @ParameterizedTest(name = "KieBase type={0}")
+	@MethodSource("parameters")
+    public void test1P1CNotFiringWithOr(KieBaseTestConfiguration kieBaseTestConfiguration) {
+        check(kieBaseTestConfiguration, "age >= 18 || name == \"Mario\"", 0, new Person("Sofia", 8));
     }
 
-    @Test
-    public void test1P1CNotFiringWithOr() {
-        check("age >= 18 || name == \"Mario\"", 0, new Person("Sofia", 8));
+    @ParameterizedTest(name = "KieBase type={0}")
+	@MethodSource("parameters")
+    public void test1P1CNotFiringWithParenthesisAndOr(KieBaseTestConfiguration kieBaseTestConfiguration) {
+        check(kieBaseTestConfiguration, "(name == \"Sofia\" && age >= 18) || name == \"Mario\"", 0, new Person("Sofia", 8));
     }
 
-    @Test
-    public void test1P1CNotFiringWithParenthesisAndOr() {
-        check("(name == \"Sofia\" && age >= 18) || name == \"Mario\"", 0, new Person("Sofia", 8));
+    @ParameterizedTest(name = "KieBase type={0}")
+	@MethodSource("parameters")
+    public void test1P2CFiring(KieBaseTestConfiguration kieBaseTestConfiguration) {
+        check(kieBaseTestConfiguration, "age >= 18, name.startsWith(\"M\")", 1, new Person("Mario", 45), new Person("Mark", 43));
     }
 
-    @Test
-    public void test1P2CFiring() {
-        check("age >= 18, name.startsWith(\"M\")", 1, new Person("Mario", 45), new Person("Mark", 43));
+    @ParameterizedTest(name = "KieBase type={0}")
+	@MethodSource("parameters")
+    public void test1P2CFiringWithIn(KieBaseTestConfiguration kieBaseTestConfiguration) {
+        check(kieBaseTestConfiguration, "age >= 18, name in(\"Mario\", \"Mark\")", 1, new Person("Mario", 45), new Person("Mark", 43));
     }
 
-    @Test
-    public void test1P2CFiringWithIn() {
-        check("age >= 18, name in(\"Mario\", \"Mark\")", 1, new Person("Mario", 45), new Person("Mark", 43));
+    @ParameterizedTest(name = "KieBase type={0}")
+	@MethodSource("parameters")
+    public void test1P2CNotFiring1(KieBaseTestConfiguration kieBaseTestConfiguration) {
+        check(kieBaseTestConfiguration, "age >= 18, name.startsWith(\"M\")", 0, new Person("Mario", 45), new Person("Mark", 43), new Person("Edson", 40));
     }
 
-    @Test
-    public void test1P2CNotFiring1() {
-        check("age >= 18, name.startsWith(\"M\")", 0, new Person("Mario", 45), new Person("Mark", 43), new Person("Edson", 40));
+    @ParameterizedTest(name = "KieBase type={0}")
+	@MethodSource("parameters")
+    public void test1P2CNotFiring2(KieBaseTestConfiguration kieBaseTestConfiguration) {
+        check(kieBaseTestConfiguration, "age < 18, name.startsWith(\"M\")", 0, new Person("Sofia", 8));
     }
 
-    @Test
-    public void test1P2CNotFiring2() {
-        check("age < 18, name.startsWith(\"M\")", 0, new Person("Sofia", 8));
+    @ParameterizedTest(name = "KieBase type={0}")
+	@MethodSource("parameters")
+    public void test2P1CFiring(KieBaseTestConfiguration kieBaseTestConfiguration) {
+        check(kieBaseTestConfiguration, "age >= 18", "name.startsWith(\"M\")", 1, new Person("Mario", 45), new Person("Sofia", 8));
     }
 
-    @Test
-    public void test2P1CFiring() {
-        check("age >= 18", "name.startsWith(\"M\")", 1, new Person("Mario", 45), new Person("Sofia", 8));
+    @ParameterizedTest(name = "KieBase type={0}")
+	@MethodSource("parameters")
+    public void test2P1CNotFiring(KieBaseTestConfiguration kieBaseTestConfiguration) {
+        check(kieBaseTestConfiguration, "age >= 1", "name.startsWith(\"M\")", 0, new Person("Mario", 45), new Person("Sofia", 8));
     }
 
-    @Test
-    public void test2P1CNotFiring() {
-        check("age >= 1", "name.startsWith(\"M\")", 0, new Person("Mario", 45), new Person("Sofia", 8));
+    @ParameterizedTest(name = "KieBase type={0}")
+	@MethodSource("parameters")
+    public void test2P2CFiring(KieBaseTestConfiguration kieBaseTestConfiguration) {
+        check(kieBaseTestConfiguration, "", "age >= 18, name.startsWith(\"M\")", 1, new Person("Mario", 45), new Person("Mark", 43));
     }
 
-    @Test
-    public void test2P2CFiring() {
-        check("", "age >= 18, name.startsWith(\"M\")", 1, new Person("Mario", 45), new Person("Mark", 43));
+    @ParameterizedTest(name = "KieBase type={0}")
+	@MethodSource("parameters")
+    public void test2P2CNotFiring1(KieBaseTestConfiguration kieBaseTestConfiguration) {
+        check(kieBaseTestConfiguration, "", "age >= 18, name.startsWith(\"M\")", 0, new Person("Mario", 45), new Person("Mark", 43), new Person("Edson", 40));
     }
 
-    @Test
-    public void test2P2CNotFiring1() {
-        check("", "age >= 18, name.startsWith(\"M\")", 0, new Person("Mario", 45), new Person("Mark", 43), new Person("Edson", 40));
+    @ParameterizedTest(name = "KieBase type={0}")
+	@MethodSource("parameters")
+    public void test2P3CFiring(KieBaseTestConfiguration kieBaseTestConfiguration) {
+        check(kieBaseTestConfiguration, "name.length() < 6", "age >= 18, name.startsWith(\"M\")", 1, new Person("Mario", 45), new Person("Mark", 43), new Person("Daniele", 43));
     }
 
-    @Test
-    public void test2P3CFiring() {
-        check("name.length() < 6", "age >= 18, name.startsWith(\"M\")", 1, new Person("Mario", 45), new Person("Mark", 43), new Person("Daniele", 43));
-    }
-
-    @Test
-    public void testNoFiring() {
+    @ParameterizedTest(name = "KieBase type={0}")
+	@MethodSource("parameters")
+    public void testNoFiring(KieBaseTestConfiguration kieBaseTestConfiguration) {
         // DROOLS-5915
-        check("", "age >= 18", 0);
+        check(kieBaseTestConfiguration, "", "age >= 18", 0);
     }
 
-    private void check(String constraints1, int expectedFires, Object... objs) {
-        check( constraints1, null, expectedFires, objs );
+    private void check(KieBaseTestConfiguration kieBaseTestConfiguration, String constraints1, int expectedFires, Object... objs) {
+        check( kieBaseTestConfiguration, constraints1, null, expectedFires, objs );
     }
 
-    private void check(String constraints1, String constraints2, int expectedFires, Object... objs) {
+    private void check(KieBaseTestConfiguration kieBaseTestConfiguration, String constraints1, String constraints2, int expectedFires, Object... objs) {
         final String drl =
                 "package org.drools.compiler.integrationtests.operators;\n" +
                 "import " + Person.class.getCanonicalName() + ";\n" +
@@ -173,8 +180,9 @@ public class ForAllTest {
         }
     }
 
-    @Test
-    public void testWithDate() throws Exception {
+    @ParameterizedTest(name = "KieBase type={0}")
+	@MethodSource("parameters")
+    public void testWithDate(KieBaseTestConfiguration kieBaseTestConfiguration) throws Exception {
         // DROOLS-4925
 
         String pkg = "org.drools.compiler.integrationtests.operators";
@@ -206,8 +214,9 @@ public class ForAllTest {
         assertThat(ksession.fireAllRules()).isEqualTo(1);
     }
 
-    @Test
-    public void testWithIndexedAlpha() throws Exception {
+    @ParameterizedTest(name = "KieBase type={0}")
+	@MethodSource("parameters")
+    public void testWithIndexedAlpha(KieBaseTestConfiguration kieBaseTestConfiguration) throws Exception {
         // DROOLS-5019
 
         String pkg = "org.drools.compiler.integrationtests.operators";
@@ -237,8 +246,9 @@ public class ForAllTest {
         assertThat(ksession2.fireAllRules()).isEqualTo(0);
     }
 
-    @Test
-    public void testForallWithNotEqualConstraint() throws Exception {
+    @ParameterizedTest(name = "KieBase type={0}")
+	@MethodSource("parameters")
+    public void testForallWithNotEqualConstraint(KieBaseTestConfiguration kieBaseTestConfiguration) throws Exception {
         // DROOLS-5100
 
         String drl =
@@ -256,8 +266,9 @@ public class ForAllTest {
         assertThat(ksession.fireAllRules()).isEqualTo(1);
     }
 
-    @Test
-    public void testForallWithNotEqualConstraintOnDate() throws Exception {
+    @ParameterizedTest(name = "KieBase type={0}")
+	@MethodSource("parameters")
+    public void testForallWithNotEqualConstraintOnDate(KieBaseTestConfiguration kieBaseTestConfiguration) throws Exception {
         // DROOLS-5224
 
         String drl =
@@ -316,17 +327,19 @@ public class ForAllTest {
         }
     }
 
-    @Test
-    public void testForallWithEmptyListConstraintCombinedWithOrFiring() throws Exception {
-        checkForallWithEmptyListConstraintCombinedWithOrFiring(true);
+    @ParameterizedTest(name = "KieBase type={0}")
+	@MethodSource("parameters")
+    public void testForallWithEmptyListConstraintCombinedWithOrFiring(KieBaseTestConfiguration kieBaseTestConfiguration) throws Exception {
+        checkForallWithEmptyListConstraintCombinedWithOrFiring(kieBaseTestConfiguration, true);
     }
 
-    @Test
-    public void testForallWithEmptyListConstraintCombinedWithOrNotFiring() throws Exception {
-        checkForallWithEmptyListConstraintCombinedWithOrFiring(false);
+    @ParameterizedTest(name = "KieBase type={0}")
+	@MethodSource("parameters")
+    public void testForallWithEmptyListConstraintCombinedWithOrNotFiring(KieBaseTestConfiguration kieBaseTestConfiguration) throws Exception {
+        checkForallWithEmptyListConstraintCombinedWithOrFiring(kieBaseTestConfiguration, false);
     }
 
-    private void checkForallWithEmptyListConstraintCombinedWithOrFiring(boolean firing) {
+    private void checkForallWithEmptyListConstraintCombinedWithOrFiring(KieBaseTestConfiguration kieBaseTestConfiguration, boolean firing) {
         // DROOLS-5682
 
         String drl =
@@ -348,39 +361,45 @@ public class ForAllTest {
         assertThat(ksession.fireAllRules()).isEqualTo(firing ? 1 : 0);
     }
 
-    @Test
-    public void testForallWithMultipleConstraints() throws Exception {
-        checkForallWithComplexExpression("value > 1, value < 10");
+    @ParameterizedTest(name = "KieBase type={0}")
+	@MethodSource("parameters")
+    public void testForallWithMultipleConstraints(KieBaseTestConfiguration kieBaseTestConfiguration) throws Exception {
+        checkForallWithComplexExpression(kieBaseTestConfiguration, "value > 1, value < 10");
     }
 
-    @Test
-    public void testForallWithAnd() throws Exception {
-        checkForallWithComplexExpression("value > 1 && value < 10");
+    @ParameterizedTest(name = "KieBase type={0}")
+	@MethodSource("parameters")
+    public void testForallWithAnd(KieBaseTestConfiguration kieBaseTestConfiguration) throws Exception {
+        checkForallWithComplexExpression(kieBaseTestConfiguration, "value > 1 && value < 10");
     }
 
-    @Test
-    public void testForallWithAndInMultipleConstraints() throws Exception {
-        checkForallWithComplexExpression("value > 1, value > 2 && value < 10");
+    @ParameterizedTest(name = "KieBase type={0}")
+	@MethodSource("parameters")
+    public void testForallWithAndInMultipleConstraints(KieBaseTestConfiguration kieBaseTestConfiguration) throws Exception {
+        checkForallWithComplexExpression(kieBaseTestConfiguration, "value > 1, value > 2 && value < 10");
     }
 
-    @Test
-    public void testForallWithOr() throws Exception {
-        checkForallWithComplexExpression("value < 1 || value > 50");
+    @ParameterizedTest(name = "KieBase type={0}")
+	@MethodSource("parameters")
+    public void testForallWithOr(KieBaseTestConfiguration kieBaseTestConfiguration) throws Exception {
+        checkForallWithComplexExpression(kieBaseTestConfiguration, "value < 1 || value > 50");
     }
 
-    @Test
-    public void testForallWithIn() throws Exception {
+    @ParameterizedTest(name = "KieBase type={0}")
+	@MethodSource("parameters")
+    public void testForallWithIn(KieBaseTestConfiguration kieBaseTestConfiguration) throws Exception {
         // DROOLS-6560
-        checkForallWithComplexExpression("value in (1, 43)");
+        checkForallWithComplexExpression(kieBaseTestConfiguration, "value in (1, 43)");
     }
 
-    @Test
-    public void testForallWithNotIn() throws Exception {
+    @ParameterizedTest(name = "KieBase type={0}")
+	@MethodSource("parameters")
+    public void testForallWithNotIn(KieBaseTestConfiguration kieBaseTestConfiguration) throws Exception {
         // DROOLS-6560
-        checkForallWithComplexExpression("value not in (1, 42)");
+        checkForallWithComplexExpression(kieBaseTestConfiguration, "value not in (1, 42)");
     }
 
-    private void checkForallWithComplexExpression(String expression) throws Exception {
+    private void checkForallWithComplexExpression(KieBaseTestConfiguration kieBaseTestConfiguration, String expression) throws Exception {
         // DROOLS-6469
         String drl =
                 "package test\n" +

--- a/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/compiler/integrationtests/operators/FormulaTest.java
+++ b/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/compiler/integrationtests/operators/FormulaTest.java
@@ -18,36 +18,28 @@
  */
 package org.drools.compiler.integrationtests.operators;
 
-import java.util.Collection;
+import java.util.stream.Stream;
 
 import org.drools.testcoverage.common.model.Person;
 import org.drools.testcoverage.common.util.KieBaseTestConfiguration;
 import org.drools.testcoverage.common.util.KieBaseUtil;
-import org.drools.testcoverage.common.util.TestParametersUtil;
-import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.junit.runners.Parameterized;
+import org.drools.testcoverage.common.util.TestParametersUtil2;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
 import org.kie.api.KieBase;
 import org.kie.api.runtime.KieSession;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-@RunWith(Parameterized.class)
 public class FormulaTest {
 
-    private final KieBaseTestConfiguration kieBaseTestConfiguration;
-
-    public FormulaTest(final KieBaseTestConfiguration kieBaseTestConfiguration) {
-        this.kieBaseTestConfiguration = kieBaseTestConfiguration;
+    public static Stream<KieBaseTestConfiguration> parameters() {
+        return TestParametersUtil2.getKieBaseCloudConfigurations(true).stream();
     }
 
-    @Parameterized.Parameters(name = "KieBase type={0}")
-    public static Collection<Object[]> getParameters() {
-        return TestParametersUtil.getKieBaseCloudConfigurations(true);
-    }
-
-    @Test
-    public void testConstants() {
+    @ParameterizedTest(name = "KieBase type={0}")
+	@MethodSource("parameters")
+    public void testConstants(KieBaseTestConfiguration kieBaseTestConfiguration) {
 
         final String drl = "package org.drools.compiler.integrationtests.operators;\n" +
                 "import " + Person.class.getCanonicalName() + ";\n" +
@@ -74,8 +66,9 @@ public class FormulaTest {
         }
     }
 
-    @Test
-    public void testBoundField() {
+    @ParameterizedTest(name = "KieBase type={0}")
+	@MethodSource("parameters")
+    public void testBoundField(KieBaseTestConfiguration kieBaseTestConfiguration) {
 
         final String drl = "package org.drools.compiler.integrationtests.operators;\n" +
                 "import " + Person.class.getCanonicalName() + ";\n" +

--- a/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/compiler/integrationtests/operators/FromOnlyExecModelTest.java
+++ b/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/compiler/integrationtests/operators/FromOnlyExecModelTest.java
@@ -18,34 +18,28 @@
  */
 package org.drools.compiler.integrationtests.operators;
 
-import java.util.Collection;
 import java.util.HashMap;
+import java.util.stream.Stream;
 
 import org.drools.testcoverage.common.util.KieBaseTestConfiguration;
 import org.drools.model.functions.NativeImageTestUtil;
-import org.drools.testcoverage.common.util.TestParametersUtil;
-import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.junit.runners.Parameterized;
+import org.drools.testcoverage.common.util.TestParametersUtil2;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
 
 import static org.drools.compiler.integrationtests.operators.FromTest.testFromSharingCommon;
 
-@RunWith(Parameterized.class)
 public class FromOnlyExecModelTest {
 
-    protected final KieBaseTestConfiguration kieBaseTestConfiguration;
 
-    public FromOnlyExecModelTest(KieBaseTestConfiguration kieBaseTestConfiguration1) {
-        this.kieBaseTestConfiguration = kieBaseTestConfiguration1;
+    public static Stream<KieBaseTestConfiguration> parameters() {
+        return TestParametersUtil2.getKieBaseCloudOnlyExecModelConfiguration().stream();
     }
 
-    @Parameterized.Parameters(name = "KieBase type={0}")
-    public static Collection<Object[]> getParameters() {
-        return TestParametersUtil.getKieBaseCloudOnlyExecModelConfiguration();
-    }
-
-    @Test // KOGITO-3771
-    public void testFromSharingWithNativeImage() {
+    // KOGITO-3771
+    @ParameterizedTest
+	@MethodSource("parameters")
+    public void testFromSharingWithNativeImage(KieBaseTestConfiguration kieBaseTestConfiguration) {
         try {
             NativeImageTestUtil.setNativeImage();
             testFromSharingCommon(kieBaseTestConfiguration, new HashMap<>(), 2, 2);
@@ -55,8 +49,9 @@ public class FromOnlyExecModelTest {
     }
 
     // This test that the node sharing isn't working without lambda externalisation
-    @Test
-    public void testFromSharingWithNativeImageWithoutLambdaExternalisation() {
+    @ParameterizedTest(name = "KieBase type={0}")
+	@MethodSource("parameters")
+    public void testFromSharingWithNativeImageWithoutLambdaExternalisation(KieBaseTestConfiguration kieBaseTestConfiguration) {
         try {
             NativeImageTestUtil.setNativeImage();
             HashMap<String, String> properties = new HashMap<>();

--- a/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/compiler/integrationtests/operators/FromTest.java
+++ b/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/compiler/integrationtests/operators/FromTest.java
@@ -20,7 +20,6 @@ package org.drools.compiler.integrationtests.operators;
 
 import java.util.ArrayList;
 import java.util.Arrays;
-import java.util.Collection;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -50,11 +49,10 @@ import org.drools.testcoverage.common.util.KieBaseTestConfiguration;
 import org.drools.testcoverage.common.util.KieBaseUtil;
 import org.drools.testcoverage.common.util.KieSessionTestConfiguration;
 import org.drools.testcoverage.common.util.KieUtil;
-import org.drools.testcoverage.common.util.TestParametersUtil;
-import org.junit.Ignore;
-import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.junit.runners.Parameterized;
+import org.drools.testcoverage.common.util.TestParametersUtil2;
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
 import org.kie.api.KieBase;
 import org.kie.api.KieBaseConfiguration;
 import org.kie.api.KieServices;
@@ -70,18 +68,10 @@ import org.kie.internal.builder.conf.PropertySpecificOption;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-@RunWith(Parameterized.class)
 public class FromTest {
 
-    private final KieBaseTestConfiguration kieBaseTestConfiguration;
-
-    public FromTest(final KieBaseTestConfiguration kieBaseTestConfiguration) {
-        this.kieBaseTestConfiguration = kieBaseTestConfiguration;
-    }
-
-    @Parameterized.Parameters(name = "KieBase type={0}")
-    public static Collection<Object[]> getParameters() {
-        return TestParametersUtil.getKieBaseCloudConfigurations(true);
+    public static Stream<KieBaseTestConfiguration> parameters() {
+        return TestParametersUtil2.getKieBaseCloudConfigurations(true).stream();
     }
 
     public static class ListsContainer {
@@ -97,8 +87,9 @@ public class FromTest {
     }
 
 
-    @Test
-    public void testFromSharing() {
+    @ParameterizedTest(name = "KieBase type={0}")
+	@MethodSource("parameters")
+    public void testFromSharing(KieBaseTestConfiguration kieBaseTestConfiguration) {
         testFromSharingCommon(kieBaseTestConfiguration, new HashMap<>(), 2, 2);
     }
 
@@ -144,8 +135,9 @@ public class FromTest {
         }
     }
 
-    @Test
-    public void testFromSharingWithPropertyReactive() {
+    @ParameterizedTest(name = "KieBase type={0}")
+	@MethodSource("parameters")
+    public void testFromSharingWithPropertyReactive(KieBaseTestConfiguration kieBaseTestConfiguration) {
         // As above but with property reactive as default
         final String drl = fromSharingRule();
         // property reactive as default:
@@ -218,8 +210,9 @@ public class FromTest {
         return epn.getObjectTypeNodes().get(new ClassObjectType(ListsContainer.class));
     }
 
-    @Test
-    public void testFromSharingWithAccumulate() {
+    @ParameterizedTest(name = "KieBase type={0}")
+	@MethodSource("parameters")
+    public void testFromSharingWithAccumulate(KieBaseTestConfiguration kieBaseTestConfiguration) {
         final String drl =
                 "package org.drools.compiler.integrationtests.operators;\n" +
                         "\n" +
@@ -299,8 +292,9 @@ public class FromTest {
         }
     }
 
-    @Test
-    public void testFromWithSingleValue() {
+    @ParameterizedTest(name = "KieBase type={0}")
+	@MethodSource("parameters")
+    public void testFromWithSingleValue(KieBaseTestConfiguration kieBaseTestConfiguration) {
         // DROOLS-1243
         final String drl =
                 "import " + ListsContainer.class.getCanonicalName() + "\n" +
@@ -330,8 +324,9 @@ public class FromTest {
         }
     }
 
-    @Test
-    public void testFromWithSingleValueAndIncompatibleType() {
+    @ParameterizedTest(name = "KieBase type={0}")
+	@MethodSource("parameters")
+    public void testFromWithSingleValueAndIncompatibleType(KieBaseTestConfiguration kieBaseTestConfiguration) {
         // DROOLS-1243
         final String drl =
                 "import " + ListsContainer.class.getCanonicalName() + "\n" +
@@ -358,8 +353,9 @@ public class FromTest {
             return this.wrapped;
         }
     }
-    @Test
-    public void testFromWithInterfaceAndAbstractClass() {
+    @ParameterizedTest(name = "KieBase type={0}")
+	@MethodSource("parameters")
+    public void testFromWithInterfaceAndAbstractClass(KieBaseTestConfiguration kieBaseTestConfiguration) {
         final String drl =
                 "import " + Container2.class.getCanonicalName() + "\n" +
                         "import " + Comparable.class.getCanonicalName() + "\n" +
@@ -411,8 +407,9 @@ public class FromTest {
             super(initialValue);
         }
     }
-    @Test
-    public void testFromWithInterfaceAndConcreteClass() {
+    @ParameterizedTest(name = "KieBase type={0}")
+	@MethodSource("parameters")
+    public void testFromWithInterfaceAndConcreteClass(KieBaseTestConfiguration kieBaseTestConfiguration) {
         final String drl =
                 "import " + Container2b.class.getCanonicalName() + "\n" +
                         "import " + CustomIntegerMarker.class.getCanonicalName() + "\n" +
@@ -459,8 +456,9 @@ public class FromTest {
         }
     }
 
-    @Test
-    public void testFromWithInterfaceAndFinalClass() {
+    @ParameterizedTest(name = "KieBase type={0}")
+	@MethodSource("parameters")
+    public void testFromWithInterfaceAndFinalClass(KieBaseTestConfiguration kieBaseTestConfiguration) {
         final String drl =
                 "import " + Container3.class.getCanonicalName() + "\n" +
                         "import " + CustomIntegerMarker.class.getCanonicalName() + "\n" +
@@ -478,8 +476,9 @@ public class FromTest {
         assertThat(kieBuilder.getResults().getMessages()).isNotEmpty();
     }
 
-    @Test
-    public void testBasicFrom() {
+    @ParameterizedTest(name = "KieBase type={0}")
+	@MethodSource("parameters")
+    public void testBasicFrom(KieBaseTestConfiguration kieBaseTestConfiguration) {
 
         final String drl = "package org.drools.compiler.integrationtests.operators;\n" +
                 "import " + Cheese.class.getCanonicalName() + ";\n" +
@@ -578,8 +577,10 @@ public class FromTest {
         }
     }
 
-    @Test @Ignore
-    public void testFromWithParams() {
+    @ParameterizedTest(name = "KieBase type={0}")
+	@MethodSource("parameters")
+    @Disabled
+    public void testFromWithParams(KieBaseTestConfiguration kieBaseTestConfiguration) {
 
         final String drl = "package org.drools.compiler.integrationtests.operators;\n" +
                 " \n" +
@@ -666,8 +667,9 @@ public class FromTest {
         }
     }
 
-    @Test
-    public void testFromWithNewConstructor() {
+    @ParameterizedTest(name = "KieBase type={0}")
+	@MethodSource("parameters")
+    public void testFromWithNewConstructor(KieBaseTestConfiguration kieBaseTestConfiguration) {
 
         final String drl = "package org.drools.compiler.integrationtests.operators\n" +
                 "\n" +
@@ -693,8 +695,9 @@ public class FromTest {
     /**
      * JBRULES-1415 Certain uses of from causes NullPointerException in WorkingMemoryLogger
      */
-    @Test
-    public void testFromDeclarationWithWorkingMemoryLogger() {
+    @ParameterizedTest(name = "KieBase type={0}")
+	@MethodSource("parameters")
+    public void testFromDeclarationWithWorkingMemoryLogger(KieBaseTestConfiguration kieBaseTestConfiguration) {
         final String drl = "package org.drools.compiler.integrationtests.operators;\n" +
             "import " + Cheesery.class.getCanonicalName() + ";\n" +
             "import " + Cheese.class.getCanonicalName() + ";\n" +
@@ -729,8 +732,9 @@ public class FromTest {
         }
     }
 
-    @Test
-    public void testFromArrayIteration() {
+    @ParameterizedTest(name = "KieBase type={0}")
+	@MethodSource("parameters")
+    public void testFromArrayIteration(KieBaseTestConfiguration kieBaseTestConfiguration) {
 
         final String drl = "package org.drools.compiler.integrationtests.operators;\n" +
                 "import " + DomainObject.class.getCanonicalName() + ";\n" +
@@ -766,8 +770,9 @@ public class FromTest {
         }
     }
 
-    @Test
-    public void testFromExprFollowedByNot() {
+    @ParameterizedTest(name = "KieBase type={0}")
+	@MethodSource("parameters")
+    public void testFromExprFollowedByNot(KieBaseTestConfiguration kieBaseTestConfiguration) {
         final String drl =
                     "package org.drools.compiler.integrationtests.operators;\n" +
                     "import " + Person.class.getCanonicalName() + ";\n" +
@@ -802,8 +807,9 @@ public class FromTest {
         }
     }
 
-    @Test
-    public void testFromNestedAccessors() {
+    @ParameterizedTest(name = "KieBase type={0}")
+	@MethodSource("parameters")
+    public void testFromNestedAccessors(KieBaseTestConfiguration kieBaseTestConfiguration) {
 
         final String drl = "package org.drools.compiler.integrationtests.operators;\n" +
                 "import " + Order.class.getCanonicalName() + ";\n" +
@@ -843,8 +849,9 @@ public class FromTest {
         }
     }
 
-    @Test
-    public void testFromNodeWithMultipleBetas() {
+    @ParameterizedTest(name = "KieBase type={0}")
+	@MethodSource("parameters")
+    public void testFromNodeWithMultipleBetas(KieBaseTestConfiguration kieBaseTestConfiguration) {
         final String drl = "import " + Person.class.getCanonicalName() + ";\n" +
                 "import " + Cheese.class.getCanonicalName() + ";\n" +
                 "import " + Address.class.getCanonicalName() + ";\n" +
@@ -872,8 +879,9 @@ public class FromTest {
         }
     }
 
-    @Test
-    public void testFromWithStrictModeOn() {
+    @ParameterizedTest(name = "KieBase type={0}")
+	@MethodSource("parameters")
+    public void testFromWithStrictModeOn(KieBaseTestConfiguration kieBaseTestConfiguration) {
         // JBRULES-3533
         final String drl =
                 "import java.util.Map;\n" +
@@ -892,17 +900,19 @@ public class FromTest {
         assertThat(kieBuilder.getResults().getMessages()).isNotEmpty();
     }
 
-    @Test
-    public void testJavaImplicitWithFrom() {
-        testDialectWithFrom("java");
+    @ParameterizedTest(name = "KieBase type={0}")
+	@MethodSource("parameters")
+    public void testJavaImplicitWithFrom(KieBaseTestConfiguration kieBaseTestConfiguration) {
+        testDialectWithFrom(kieBaseTestConfiguration, "java");
     }
 
-    @Test
-    public void testMVELImplicitWithFrom() {
-        testDialectWithFrom("mvel");
+    @ParameterizedTest(name = "KieBase type={0}")
+	@MethodSource("parameters")
+    public void testMVELImplicitWithFrom(KieBaseTestConfiguration kieBaseTestConfiguration) {
+        testDialectWithFrom(kieBaseTestConfiguration, "mvel");
     }
 
-    private void testDialectWithFrom(final String dialect) {
+    private void testDialectWithFrom(KieBaseTestConfiguration kieBaseTestConfiguration, final String dialect) {
         final String drl = "" +
                 "package org.drools.compiler.test \n" +
                 "import java.util.List \n" +
@@ -931,8 +941,9 @@ public class FromTest {
         }
     }
 
-    @Test
-    public void testMultipleFroms() {
+    @ParameterizedTest(name = "KieBase type={0}")
+	@MethodSource("parameters")
+    public void testMultipleFroms(KieBaseTestConfiguration kieBaseTestConfiguration) {
 
         final String drl = "package org.drools.compiler.integrationtests.operators;\n" +
                 "import java.util.List;\n" +
@@ -975,8 +986,9 @@ public class FromTest {
         }
     }
 
-    @Test
-    public void testNetworkBuildErrorAcrossEntryPointsAndFroms() {
+    @ParameterizedTest(name = "KieBase type={0}")
+	@MethodSource("parameters")
+    public void testNetworkBuildErrorAcrossEntryPointsAndFroms(KieBaseTestConfiguration kieBaseTestConfiguration) {
         final String drl = "package org.drools.compiler.integrationtests.operators;\n" +
                 "import " + Person.class.getCanonicalName() + ";\n" +
                 "import " + Cheese.class.getCanonicalName() + ";\n" +
@@ -1016,8 +1028,9 @@ public class FromTest {
         }
     }
 
-    @Test
-    public void testUpdateFromCollect() {
+    @ParameterizedTest(name = "KieBase type={0}")
+	@MethodSource("parameters")
+    public void testUpdateFromCollect(KieBaseTestConfiguration kieBaseTestConfiguration) {
         // DROOLS-6504
         final String drl =
                 "import " + List.class.getCanonicalName() + ";\n" +
@@ -1088,25 +1101,27 @@ public class FromTest {
                                           "       modify($p){setAge(10)};\n" +
                                           "end\n";
 
-    @Test
-    public void testJoinAndFrom() {
+    @ParameterizedTest(name = "KieBase type={0}")
+	@MethodSource("parameters")
+    public void testJoinAndFrom(KieBaseTestConfiguration kieBaseTestConfiguration) {
         // DROOLS-6821
         // Add JoinNode first
-        runKSessionWithAgendaGroup(RULE_HEAD +
+        runKSessionWithAgendaGroup(kieBaseTestConfiguration, RULE_HEAD +
                                    RULE_WITH_JOIN +
                                    RULE_WITH_FROM);
     }
 
-    @Test
-    public void testFromAndJoin() {
+    @ParameterizedTest(name = "KieBase type={0}")
+	@MethodSource("parameters")
+    public void testFromAndJoin(KieBaseTestConfiguration kieBaseTestConfiguration) {
         // DROOLS-6821
         // Add FromNode first
-        runKSessionWithAgendaGroup(RULE_HEAD +
+        runKSessionWithAgendaGroup(kieBaseTestConfiguration, RULE_HEAD +
                                    RULE_WITH_FROM +
                                    RULE_WITH_JOIN);
     }
 
-    private void runKSessionWithAgendaGroup(String drl) {
+    private void runKSessionWithAgendaGroup(KieBaseTestConfiguration kieBaseTestConfiguration, String drl) {
         final KieBase kbase = KieBaseUtil.getKieBaseFromKieModuleFromDrl("from-test",
                                                                          kieBaseTestConfiguration,
                                                                          drl);

--- a/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/compiler/integrationtests/operators/InTest.java
+++ b/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/compiler/integrationtests/operators/InTest.java
@@ -18,36 +18,29 @@
  */
 package org.drools.compiler.integrationtests.operators;
 
-import java.util.Collection;
+import java.util.stream.Stream;
 
 import org.drools.testcoverage.common.model.Person;
 import org.drools.testcoverage.common.util.KieBaseTestConfiguration;
 import org.drools.testcoverage.common.util.KieBaseUtil;
-import org.drools.testcoverage.common.util.TestParametersUtil;
-import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.junit.runners.Parameterized;
+import org.drools.testcoverage.common.util.TestParametersUtil2;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
 import org.kie.api.KieBase;
 import org.kie.api.runtime.KieSession;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-@RunWith(Parameterized.class)
 public class InTest {
 
-    private final KieBaseTestConfiguration kieBaseTestConfiguration;
 
-    public InTest(final KieBaseTestConfiguration kieBaseTestConfiguration) {
-        this.kieBaseTestConfiguration = kieBaseTestConfiguration;
+    public static Stream<KieBaseTestConfiguration> parameters() {
+        return TestParametersUtil2.getKieBaseCloudConfigurations(true).stream();
     }
 
-    @Parameterized.Parameters(name = "KieBase type={0}")
-    public static Collection<Object[]> getParameters() {
-        return TestParametersUtil.getKieBaseCloudConfigurations(true);
-    }
-
-    @Test
-    public void testInOperator() {
+    @ParameterizedTest(name = "KieBase type={0}")
+	@MethodSource("parameters")
+    public void testInOperator(KieBaseTestConfiguration kieBaseTestConfiguration) {
         final String drl = "package org.drools.compiler.integrationtests.operators;\n" +
                 "import " + Person.class.getCanonicalName() + ";\n" +
                 "rule \"test in\"\n" +
@@ -78,8 +71,9 @@ public class InTest {
         }
     }
 
-    @Test
-    public void testNegatedIn() {
+    @ParameterizedTest(name = "KieBase type={0}")
+	@MethodSource("parameters")
+    public void testNegatedIn(KieBaseTestConfiguration kieBaseTestConfiguration) {
         final String drl = "package org.drools.compiler.integrationtests.operators;\n" +
                 "import " + Person.class.getCanonicalName() + ";\n" +
                 "rule \"test negated in\"\n" +

--- a/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/compiler/integrationtests/operators/InstanceOfTest.java
+++ b/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/compiler/integrationtests/operators/InstanceOfTest.java
@@ -18,37 +18,29 @@
  */
 package org.drools.compiler.integrationtests.operators;
 
-import java.util.Collection;
+import java.util.stream.Stream;
 
 import org.drools.testcoverage.common.model.LongAddress;
 import org.drools.testcoverage.common.model.Person;
 import org.drools.testcoverage.common.util.KieBaseTestConfiguration;
 import org.drools.testcoverage.common.util.KieBaseUtil;
-import org.drools.testcoverage.common.util.TestParametersUtil;
-import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.junit.runners.Parameterized;
+import org.drools.testcoverage.common.util.TestParametersUtil2;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
 import org.kie.api.KieBase;
 import org.kie.api.runtime.KieSession;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-@RunWith(Parameterized.class)
 public class InstanceOfTest {
 
-    private final KieBaseTestConfiguration kieBaseTestConfiguration;
-
-    public InstanceOfTest(final KieBaseTestConfiguration kieBaseTestConfiguration) {
-        this.kieBaseTestConfiguration = kieBaseTestConfiguration;
+    public static Stream<KieBaseTestConfiguration> parameters() {
+        return TestParametersUtil2.getKieBaseCloudConfigurations(true).stream();
     }
 
-    @Parameterized.Parameters(name = "KieBase type={0}")
-    public static Collection<Object[]> getParameters() {
-        return TestParametersUtil.getKieBaseCloudConfigurations(true);
-    }
-
-    @Test
-    public void testInstanceof() {
+    @ParameterizedTest(name = "KieBase type={0}")
+	@MethodSource("parameters")
+    public void testInstanceof(KieBaseTestConfiguration kieBaseTestConfiguration) {
         // JBRULES-3591
         final String drl = "import " + Person.class.getCanonicalName() + ";\n" +
                 "import " + LongAddress.class.getCanonicalName() + ";\n" +

--- a/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/compiler/integrationtests/operators/MatchesTest.java
+++ b/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/compiler/integrationtests/operators/MatchesTest.java
@@ -19,7 +19,6 @@
 package org.drools.compiler.integrationtests.operators;
 
 import java.util.ArrayList;
-import java.util.Collection;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;

--- a/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/compiler/integrationtests/operators/MatchesTest.java
+++ b/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/compiler/integrationtests/operators/MatchesTest.java
@@ -23,36 +23,29 @@ import java.util.Collection;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.stream.Stream;
 
 import org.drools.testcoverage.common.model.Cheese;
 import org.drools.testcoverage.common.model.Person;
 import org.drools.testcoverage.common.util.KieBaseTestConfiguration;
 import org.drools.testcoverage.common.util.KieBaseUtil;
-import org.drools.testcoverage.common.util.TestParametersUtil;
-import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.junit.runners.Parameterized;
+import org.drools.testcoverage.common.util.TestParametersUtil2;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
 import org.kie.api.KieBase;
 import org.kie.api.runtime.KieSession;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-@RunWith(Parameterized.class)
 public class MatchesTest {
 
-    private final KieBaseTestConfiguration kieBaseTestConfiguration;
-
-    public MatchesTest(final KieBaseTestConfiguration kieBaseTestConfiguration) {
-        this.kieBaseTestConfiguration = kieBaseTestConfiguration;
+    public static Stream<KieBaseTestConfiguration> parameters() {
+        return TestParametersUtil2.getKieBaseCloudConfigurations(true).stream();
     }
 
-    @Parameterized.Parameters(name = "KieBase type={0}")
-    public static Collection<Object[]> getParameters() {
-        return TestParametersUtil.getKieBaseCloudConfigurations(true);
-    }
-
-    @Test
-    public void testMatchesMVEL() {
+    @ParameterizedTest(name = "KieBase type={0}")
+	@MethodSource("parameters")
+    public void testMatchesMVEL(KieBaseTestConfiguration kieBaseTestConfiguration) {
 
         final String drl = "package org.drools.compiler.integrationtests.operators;\n" +
                 "import java.util.Map;\n" +
@@ -107,8 +100,9 @@ public class MatchesTest {
                 "end";
     }
 
-    @Test
-    public void testMatchesMVEL2() {
+    @ParameterizedTest(name = "KieBase type={0}")
+	@MethodSource("parameters")
+    public void testMatchesMVEL2(KieBaseTestConfiguration kieBaseTestConfiguration) {
         final KieBase kbase = KieBaseUtil.getKieBaseFromKieModuleFromDrl("matches-test",
                                                                          kieBaseTestConfiguration,
                                                                          getMatchesDRL());
@@ -125,8 +119,9 @@ public class MatchesTest {
         }
     }
 
-    @Test
-    public void testMatchesMVEL3() {
+    @ParameterizedTest(name = "KieBase type={0}")
+	@MethodSource("parameters")
+    public void testMatchesMVEL3(KieBaseTestConfiguration kieBaseTestConfiguration) {
         final KieBase kbase = KieBaseUtil.getKieBaseFromKieModuleFromDrl("matches-test",
                                                                          kieBaseTestConfiguration,
                                                                          getMatchesDRL());
@@ -143,8 +138,9 @@ public class MatchesTest {
         }
     }
 
-    @Test
-    public void testMatchesNotMatchesCheese() {
+    @ParameterizedTest(name = "KieBase type={0}")
+	@MethodSource("parameters")
+    public void testMatchesNotMatchesCheese(KieBaseTestConfiguration kieBaseTestConfiguration) {
 
         final String drl = "package org.drools.compiler.integrationtests.operators;\n" +
                 "import " + Cheese.class.getCanonicalName() + ";\n" +
@@ -222,19 +218,21 @@ public class MatchesTest {
         }
     }
 
-    @Test
-    public void testNotMatchesSucceeds() {
+    @ParameterizedTest(name = "KieBase type={0}")
+	@MethodSource("parameters")
+    public void testNotMatchesSucceeds(KieBaseTestConfiguration kieBaseTestConfiguration) {
         // JBRULES-2914: Rule misfires due to "not matches" not working
-        testMatchesSuccessFail("-..x..xrwx", 0);
+        testMatchesSuccessFail(kieBaseTestConfiguration, "-..x..xrwx", 0);
     }
 
-    @Test
-    public void testNotMatchesFails() {
+    @ParameterizedTest(name = "KieBase type={0}")
+	@MethodSource("parameters")
+    public void testNotMatchesFails(KieBaseTestConfiguration kieBaseTestConfiguration) {
         // JBRULES-2914: Rule misfires due to "not matches" not working
-        testMatchesSuccessFail("d..x..xrwx", 1);
+        testMatchesSuccessFail(kieBaseTestConfiguration, "d..x..xrwx", 1);
     }
 
-    private void testMatchesSuccessFail(final String personName, final int expectedFireCount) {
+    private void testMatchesSuccessFail(KieBaseTestConfiguration kieBaseTestConfiguration, final String personName, final int expectedFireCount) {
         final String drl = "package org.drools.compiler.integrationtests.operators;\n" +
                 "import " + Person.class.getCanonicalName() + ";\n" +
                 "rule NotMatches\n" +

--- a/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/compiler/integrationtests/operators/MathTest.java
+++ b/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/compiler/integrationtests/operators/MathTest.java
@@ -20,39 +20,31 @@ package org.drools.compiler.integrationtests.operators;
 
 import java.io.Serializable;
 import java.util.ArrayList;
-import java.util.Collection;
 import java.util.List;
 import java.util.Random;
+import java.util.stream.Stream;
 
 import org.drools.testcoverage.common.model.Person;
 import org.drools.testcoverage.common.util.KieBaseTestConfiguration;
 import org.drools.testcoverage.common.util.KieBaseUtil;
-import org.drools.testcoverage.common.util.TestParametersUtil;
-import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.junit.runners.Parameterized;
+import org.drools.testcoverage.common.util.TestParametersUtil2;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
 import org.kie.api.KieBase;
 import org.kie.api.runtime.KieSession;
 import org.kie.api.runtime.rule.FactHandle;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-@RunWith(Parameterized.class)
 public class MathTest {
 
-    private final KieBaseTestConfiguration kieBaseTestConfiguration;
-
-    public MathTest(final KieBaseTestConfiguration kieBaseTestConfiguration) {
-        this.kieBaseTestConfiguration = kieBaseTestConfiguration;
+    public static Stream<KieBaseTestConfiguration> parameters() {
+        return TestParametersUtil2.getKieBaseCloudConfigurations(true).stream();
     }
 
-    @Parameterized.Parameters(name = "KieBase type={0}")
-    public static Collection<Object[]> getParameters() {
-        return TestParametersUtil.getKieBaseCloudConfigurations(true);
-    }
-
-    @Test
-    public void testAddition() {
+    @ParameterizedTest(name = "KieBase type={0}")
+	@MethodSource("parameters")
+    public void testAddition(KieBaseTestConfiguration kieBaseTestConfiguration) {
 
         final String drl = "package org.drools.compiler.integrationtests.operators;\n" +
                 "import " + Person.class.getCanonicalName() + ";\n" +
@@ -118,8 +110,9 @@ public class MathTest {
 
     }
 
-    @Test
-    public void testNumberComparisons() {
+    @ParameterizedTest(name = "KieBase type={0}")
+	@MethodSource("parameters")
+    public void testNumberComparisons(KieBaseTestConfiguration kieBaseTestConfiguration) {
         final String drl = "package org.drools.compiler.integrationtests.operators;\n" +
                 "import " + RandomNumber.class.getCanonicalName() + ";\n" +
                 "import " + Guess.class.getCanonicalName() + ";\n" +
@@ -197,8 +190,9 @@ public class MathTest {
         }
     }
 
-    @Test
-    public void testShiftOperator()  {
+    @ParameterizedTest(name = "KieBase type={0}")
+	@MethodSource("parameters")
+    public void testShiftOperator(KieBaseTestConfiguration kieBaseTestConfiguration) {
         final String drl = "dialect \"mvel\"\n" +
                 "rule kickOff\n" +
                 "when\n" +

--- a/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/compiler/integrationtests/operators/MemberOfTest.java
+++ b/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/compiler/integrationtests/operators/MemberOfTest.java
@@ -19,8 +19,8 @@
 package org.drools.compiler.integrationtests.operators;
 
 import java.util.ArrayList;
-import java.util.Collection;
 import java.util.List;
+import java.util.stream.Stream;
 
 import org.drools.testcoverage.common.model.Cheese;
 import org.drools.testcoverage.common.model.Cheesery;
@@ -28,16 +28,14 @@ import org.drools.testcoverage.common.model.Person;
 import org.drools.testcoverage.common.model.Pet;
 import org.drools.testcoverage.common.util.KieBaseTestConfiguration;
 import org.drools.testcoverage.common.util.KieBaseUtil;
-import org.drools.testcoverage.common.util.TestParametersUtil;
-import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.junit.runners.Parameterized;
+import org.drools.testcoverage.common.util.TestParametersUtil2;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
 import org.kie.api.KieBase;
 import org.kie.api.runtime.KieSession;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-@RunWith(Parameterized.class)
 public class MemberOfTest {
 
     private final KieBaseTestConfiguration kieBaseTestConfiguration;
@@ -46,13 +44,13 @@ public class MemberOfTest {
         this.kieBaseTestConfiguration = kieBaseTestConfiguration;
     }
 
-    @Parameterized.Parameters(name = "KieBase type={0}")
-    public static Collection<Object[]> getParameters() {
-        return TestParametersUtil.getKieBaseCloudConfigurations(true);
+    public static Stream<KieBaseTestConfiguration> getParameters() {
+        return TestParametersUtil2.getKieBaseCloudConfigurations(true).stream();
     }
 
-    @Test
-    public void testMemberOfAndNotMemberOf() {
+    @ParameterizedTest(name = "KieBase type={0}")
+	@MethodSource("parameters")
+    public void testMemberOfAndNotMemberOf(KieBaseTestConfiguration kieBaseTestConfiguration) {
 
         final String drl = "package org.drools.compiler.test;\n" +
                 "\n" +
@@ -108,8 +106,9 @@ public class MemberOfTest {
         }
     }
 
-    @Test
-    public void testMemberOfWithOr() {
+    @ParameterizedTest(name = "KieBase type={0}")
+	@MethodSource("parameters")
+    public void testMemberOfWithOr(KieBaseTestConfiguration kieBaseTestConfiguration) {
 
         final String drl =
             "package org.drools.compiler.integrationtests.operators;\n" +

--- a/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/compiler/integrationtests/operators/MemberOfTest.java
+++ b/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/compiler/integrationtests/operators/MemberOfTest.java
@@ -38,13 +38,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 public class MemberOfTest {
 
-    private final KieBaseTestConfiguration kieBaseTestConfiguration;
-
-    public MemberOfTest(final KieBaseTestConfiguration kieBaseTestConfiguration) {
-        this.kieBaseTestConfiguration = kieBaseTestConfiguration;
-    }
-
-    public static Stream<KieBaseTestConfiguration> getParameters() {
+    public static Stream<KieBaseTestConfiguration> parameters() {
         return TestParametersUtil2.getKieBaseCloudConfigurations(true).stream();
     }
 

--- a/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/compiler/integrationtests/operators/NotTest.java
+++ b/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/compiler/integrationtests/operators/NotTest.java
@@ -20,8 +20,8 @@ package org.drools.compiler.integrationtests.operators;
 
 import java.math.BigDecimal;
 import java.util.ArrayList;
-import java.util.Collection;
 import java.util.List;
+import java.util.stream.Stream;
 
 import org.drools.base.base.ClassObjectType;
 import org.drools.core.common.InternalFactHandle;
@@ -40,10 +40,9 @@ import org.drools.testcoverage.common.model.Cheese;
 import org.drools.testcoverage.common.model.Person;
 import org.drools.testcoverage.common.util.KieBaseTestConfiguration;
 import org.drools.testcoverage.common.util.KieBaseUtil;
-import org.drools.testcoverage.common.util.TestParametersUtil;
-import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.junit.runners.Parameterized;
+import org.drools.testcoverage.common.util.TestParametersUtil2;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
 import org.kie.api.KieBase;
 import org.kie.api.runtime.KieSession;
 import org.kie.api.runtime.rule.FactHandle;
@@ -51,22 +50,15 @@ import org.kie.api.runtime.rule.FactHandle;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.fail;
 
-@RunWith(Parameterized.class)
 public class NotTest {
 
-    private final KieBaseTestConfiguration kieBaseTestConfiguration;
-
-    public NotTest(final KieBaseTestConfiguration kieBaseTestConfiguration) {
-        this.kieBaseTestConfiguration = kieBaseTestConfiguration;
+    public static Stream<KieBaseTestConfiguration> parameters() {
+        return TestParametersUtil2.getKieBaseCloudConfigurations(true).stream();
     }
 
-    @Parameterized.Parameters(name = "KieBase type={0}")
-    public static Collection<Object[]> getParameters() {
-        return TestParametersUtil.getKieBaseCloudConfigurations(true);
-    }
-
-    @Test
-    public void testLastMemoryEntryNotBug() {
+    @ParameterizedTest(name = "KieBase type={0}")
+	@MethodSource("parameters")
+    public void testLastMemoryEntryNotBug(KieBaseTestConfiguration kieBaseTestConfiguration) {
         // JBRULES-2809
         // This occurs when a blocker is the last in the node's memory, or if there is only one fact in the node
         // And it gets no opportunity to rematch with itself
@@ -117,8 +109,9 @@ public class NotTest {
         }
     }
 
-    @Test
-    public void testNegatedConstaintInNot() {
+    @ParameterizedTest(name = "KieBase type={0}")
+	@MethodSource("parameters")
+    public void testNegatedConstaintInNot(KieBaseTestConfiguration kieBaseTestConfiguration) {
 
         final String drl =
                 "package org.drools.compiler.integrationtests.operators;\n" +
@@ -140,8 +133,9 @@ public class NotTest {
         }
     }
 
-    @Test
-    public void testMissingRootBlockerEquality() {
+    @ParameterizedTest(name = "KieBase type={0}")
+	@MethodSource("parameters")
+    public void testMissingRootBlockerEquality(KieBaseTestConfiguration kieBaseTestConfiguration) {
         // DROOLS-6636
         final String drl =
                 "package org.drools.compiler.integrationtests.operators;\n" +
@@ -270,8 +264,9 @@ public class NotTest {
         }
     }
 
-    @Test
-    public void testNotWithInnerJoin() {
+    @ParameterizedTest(name = "KieBase type={0}")
+	@MethodSource("parameters")
+    public void testNotWithInnerJoin(KieBaseTestConfiguration kieBaseTestConfiguration) {
         // DROOLS-6652
         final String drl =
                 "package org.drools.compiler.integrationtests.operators;\n" +
@@ -312,8 +307,9 @@ public class NotTest {
         assertThat(results.get(0)).isEqualTo("Paris");
     }
 
-    @Test
-    public void testNotWithUnification() {
+    @ParameterizedTest(name = "KieBase type={0}")
+	@MethodSource("parameters")
+    public void testNotWithUnification(KieBaseTestConfiguration kieBaseTestConfiguration) {
         // DROOLS-7629
         final String drl =
                 "package org.drools.compiler.integrationtests.operators;\n" +

--- a/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/compiler/integrationtests/operators/OrTest.java
+++ b/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/compiler/integrationtests/operators/OrTest.java
@@ -19,8 +19,8 @@
 package org.drools.compiler.integrationtests.operators;
 
 import java.util.ArrayList;
-import java.util.Collection;
 import java.util.List;
+import java.util.stream.Stream;
 
 import org.drools.core.common.InternalFactHandle;
 import org.drools.testcoverage.common.model.Cheese;
@@ -32,10 +32,9 @@ import org.drools.testcoverage.common.model.Person;
 import org.drools.testcoverage.common.util.KieBaseTestConfiguration;
 import org.drools.testcoverage.common.util.KieBaseUtil;
 import org.drools.testcoverage.common.util.KieUtil;
-import org.drools.testcoverage.common.util.TestParametersUtil;
-import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.junit.runners.Parameterized;
+import org.drools.testcoverage.common.util.TestParametersUtil2;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
 import org.kie.api.KieBase;
 import org.kie.api.builder.KieBuilder;
 import org.kie.api.definition.type.FactType;
@@ -44,22 +43,15 @@ import org.kie.api.runtime.rule.FactHandle;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-@RunWith(Parameterized.class)
 public class OrTest {
 
-    private final KieBaseTestConfiguration kieBaseTestConfiguration;
-
-    public OrTest(final KieBaseTestConfiguration kieBaseTestConfiguration) {
-        this.kieBaseTestConfiguration = kieBaseTestConfiguration;
+    public static Stream<KieBaseTestConfiguration> parameters() {
+        return TestParametersUtil2.getKieBaseCloudConfigurations(true).stream();
     }
 
-    @Parameterized.Parameters(name = "KieBase type={0}")
-    public static Collection<Object[]> getParameters() {
-        return TestParametersUtil.getKieBaseCloudConfigurations(true);
-    }
-
-    @Test
-    public void testOr() {
+    @ParameterizedTest(name = "KieBase type={0}")
+	@MethodSource("parameters")
+    public void testOr(KieBaseTestConfiguration kieBaseTestConfiguration) {
 
         final String drl = "package org.drools.compiler.integrationtests.operators;\n" +
                 "import " + Cheese.class.getCanonicalName() + ";\n" +
@@ -105,8 +97,9 @@ public class OrTest {
         }
     }
 
-    @Test
-    public void testOrCE() {
+    @ParameterizedTest(name = "KieBase type={0}")
+	@MethodSource("parameters")
+    public void testOrCE(KieBaseTestConfiguration kieBaseTestConfiguration) {
 
         final String drl = "package org.drools.compiler.integrationtests.operators;\n" +
                 "import " + Cheese.class.getCanonicalName() + ";\n" +
@@ -148,8 +141,9 @@ public class OrTest {
         }
     }
 
-    @Test
-    public void testOrCEFollowedByEval() {
+    @ParameterizedTest(name = "KieBase type={0}")
+	@MethodSource("parameters")
+    public void testOrCEFollowedByEval(KieBaseTestConfiguration kieBaseTestConfiguration) {
         final String drl = "package org.drools.compiler.integrationtests.operators;\n" +
                 "import " + FactA.class.getCanonicalName() + ";\n" +
                 "import " + FactB.class.getCanonicalName() + ";\n" +
@@ -184,8 +178,9 @@ public class OrTest {
         }
     }
 
-    @Test
-    public void testOrWithAndUsingNestedBindings() {
+    @ParameterizedTest(name = "KieBase type={0}")
+	@MethodSource("parameters")
+    public void testOrWithAndUsingNestedBindings(KieBaseTestConfiguration kieBaseTestConfiguration) {
         final String drl = "package org.drools.compiler.integrationtests.operators;\n" +
                 "import " + Person.class.getCanonicalName() + ";\n" +
                 "global java.util.List mlist\n" +
@@ -268,8 +263,9 @@ public class OrTest {
         }
     }
 
-    @Test
-    public void testOrWithBinding() {
+    @ParameterizedTest(name = "KieBase type={0}")
+	@MethodSource("parameters")
+    public void testOrWithBinding(KieBaseTestConfiguration kieBaseTestConfiguration) {
 
         final String drl =  "package org.drools.compiler.integrationtests.operators;\n" +
                 "import " + Cheese.class.getCanonicalName() + ";\n" +
@@ -314,8 +310,9 @@ public class OrTest {
         }
     }
 
-    @Test
-    public void testOrWithFrom() {
+    @ParameterizedTest(name = "KieBase type={0}")
+	@MethodSource("parameters")
+    public void testOrWithFrom(KieBaseTestConfiguration kieBaseTestConfiguration) {
         // JBRULES-2274: Rule does not fire as expected using deep object model and nested 'or' clause
         final String drl = "package org.drools.compiler.integrationtests.operators;\n"
                 + "import " + Order.class.getCanonicalName() + ";\n"
@@ -354,8 +351,9 @@ public class OrTest {
         }
     }
 
-    @Test
-    public void testOrWithReturnValueRestriction() {
+    @ParameterizedTest(name = "KieBase type={0}")
+	@MethodSource("parameters")
+    public void testOrWithReturnValueRestriction(KieBaseTestConfiguration kieBaseTestConfiguration) {
 
         final String drl =
                 "package org.drools.compiler.integrationtests.operators;\n" +
@@ -385,8 +383,9 @@ public class OrTest {
         }
     }
 
-    @Test
-    public void testBindingsWithOr() throws InstantiationException, IllegalAccessException {
+    @ParameterizedTest(name = "KieBase type={0}")
+	@MethodSource("parameters")
+    public void testBindingsWithOr(KieBaseTestConfiguration kieBaseTestConfiguration) throws InstantiationException, IllegalAccessException {
         // JBRULES-2917: matching of field==v1 || field==v2 breaks when variable binding is added
         final String drl = "package org.drools.compiler.integrationtests.operators;\n" +
                 "declare Assignment\n" +
@@ -424,8 +423,9 @@ public class OrTest {
         }
     }
 
-    @Test
-    public void testConstraintConnectorOr() {
+    @ParameterizedTest(name = "KieBase type={0}")
+	@MethodSource("parameters")
+    public void testConstraintConnectorOr(KieBaseTestConfiguration kieBaseTestConfiguration) {
 
         final String drl = "package org.drools.compiler.integrationtests.operators;\n" +
                 "import " + Person.class.getCanonicalName() + ";\n" +
@@ -478,8 +478,9 @@ public class OrTest {
         }
     }
 
-    @Test
-    public void testVariableBindingWithOR() throws Exception{
+    @ParameterizedTest(name = "KieBase type={0}")
+	@MethodSource("parameters")
+    public void testVariableBindingWithOR(KieBaseTestConfiguration kieBaseTestConfiguration) throws Exception{
         // JBRULES-3390
         final String drl1 = "package org.drools.compiler.integrationtests.operators; \n" +
                 "declare A\n" +
@@ -549,8 +550,9 @@ public class OrTest {
         }
     }
 
-    @Test
-    public void testRestrictionsWithOr() {
+    @ParameterizedTest(name = "KieBase type={0}")
+	@MethodSource("parameters")
+    public void testRestrictionsWithOr(KieBaseTestConfiguration kieBaseTestConfiguration) {
         // JBRULES-2203: NullPointerException When Using Conditional Element "or" in LHS Together with a Return Value Restriction
         final String drl = "package org.drools.compiler.integrationtests.operators;\n" +
                 "import " + Cheese.class.getCanonicalName() + ";\n" +
@@ -577,8 +579,9 @@ public class OrTest {
         }
     }
 
-    @Test
-    public void testEmptyIdentifier() {
+    @ParameterizedTest(name = "KieBase type={0}")
+	@MethodSource("parameters")
+    public void testEmptyIdentifier(KieBaseTestConfiguration kieBaseTestConfiguration) {
 
         final String drl = "package org.drools.compiler.integrationtests.operators;\n" +
                 "import " + Cheese.class.getCanonicalName() + ";\n" +
@@ -635,8 +638,9 @@ public class OrTest {
         }
     }
 
-    @Test
-    public void testIndexAfterOr() {
+    @ParameterizedTest(name = "KieBase type={0}")
+	@MethodSource("parameters")
+    public void testIndexAfterOr(KieBaseTestConfiguration kieBaseTestConfiguration) {
         // DROOLS-1604
         final String drl =
                 "import " + Person.class.getCanonicalName() + ";" +
@@ -674,8 +678,9 @@ public class OrTest {
         }
     }
 
-    @Test
-    public void testOrWithDifferenceOffsetsForConsequence() {
+    @ParameterizedTest(name = "KieBase type={0}")
+	@MethodSource("parameters")
+    public void testOrWithDifferenceOffsetsForConsequence(KieBaseTestConfiguration kieBaseTestConfiguration) {
         // DROOLS-1604
         final String drl =
               "import " + Person.class.getCanonicalName() + ";" +

--- a/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/compiler/integrationtests/operators/SoundsLikeTest.java
+++ b/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/compiler/integrationtests/operators/SoundsLikeTest.java
@@ -18,40 +18,31 @@
  */
 package org.drools.compiler.integrationtests.operators;
 
-import java.util.Collection;
 import java.util.stream.Stream;
 
 import org.drools.testcoverage.common.model.Person;
 import org.drools.testcoverage.common.util.KieBaseTestConfiguration;
 import org.drools.testcoverage.common.util.KieBaseUtil;
-import org.drools.testcoverage.common.util.TestParametersUtil;
-import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.junit.runners.Parameterized;
+import org.drools.testcoverage.common.util.TestParametersUtil2;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
 import org.kie.api.KieBase;
 import org.kie.api.runtime.KieSession;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-@RunWith(Parameterized.class)
 public class SoundsLikeTest {
 
-    private final KieBaseTestConfiguration kieBaseTestConfiguration;
-
-    public SoundsLikeTest(final KieBaseTestConfiguration kieBaseTestConfiguration) {
-        this.kieBaseTestConfiguration = kieBaseTestConfiguration;
+    public static Stream<KieBaseTestConfiguration> parameters() {
+        return TestParametersUtil2.getKieBaseCloudConfigurations(true).stream();
     }
 
-    @Parameterized.Parameters(name = "KieBase type={0}")
-    public static Collection<Object[]> getParameters() {
-        return TestParametersUtil.getKieBaseCloudConfigurations(true);
-    }
-
-    @Test
-    public void testSoundsLike() {
+    @ParameterizedTest(name = "KieBase type={0}")
+	@MethodSource("parameters")
+    public void testSoundsLike(KieBaseTestConfiguration kieBaseTestConfiguration) {
         // JBRULES-2991: Operator soundslike is broken
 
-        testFiredRules("package org.drools.compiler.integrationtests.operators;\n" +
+        testFiredRules(kieBaseTestConfiguration, "package org.drools.compiler.integrationtests.operators;\n" +
                             "import " + Person.class.getCanonicalName() + ";\n" +
                                "rule SoundsLike\n" +
                                "when\n" +
@@ -63,11 +54,12 @@ public class SoundsLikeTest {
                        "Bob");
     }
 
-    @Test
-    public void testSoundsLikeNegativeCase() {
+    @ParameterizedTest(name = "KieBase type={0}")
+	@MethodSource("parameters")
+    public void testSoundsLikeNegativeCase(KieBaseTestConfiguration kieBaseTestConfiguration) {
         // JBRULES-2991: Operator soundslike is broken
 
-        testFiredRules("package org.drools.compiler.integrationtests.operators;\n" +
+        testFiredRules(kieBaseTestConfiguration, "package org.drools.compiler.integrationtests.operators;\n" +
                                "import " + Person.class.getCanonicalName() + ";\n" +
                                "rule SoundsLike\n" +
                                "when\n" +
@@ -78,11 +70,12 @@ public class SoundsLikeTest {
                        "Mark");
     }
 
-    @Test
-    public void testNotSoundsLike() {
+    @ParameterizedTest(name = "KieBase type={0}")
+	@MethodSource("parameters")
+    public void testNotSoundsLike(KieBaseTestConfiguration kieBaseTestConfiguration) {
         // JBRULES-2991: Operator soundslike is broken
 
-        testFiredRules("package org.drools.compiler.integrationtests.operators;\n" +
+        testFiredRules(kieBaseTestConfiguration, "package org.drools.compiler.integrationtests.operators;\n" +
                                "import " + Person.class.getCanonicalName() + ";\n" +
                                "rule NotSoundsLike\n" +
                                "when\n" +
@@ -93,11 +86,12 @@ public class SoundsLikeTest {
                        "John");
     }
 
-    @Test
-    public void testNotSoundsLikeNegativeCase() {
+    @ParameterizedTest(name = "KieBase type={0}")
+	@MethodSource("parameters")
+    public void testNotSoundsLikeNegativeCase(KieBaseTestConfiguration kieBaseTestConfiguration) {
         // JBRULES-2991: Operator soundslike is broken
 
-        testFiredRules("package org.drools.compiler.integrationtests.operators;\n" +
+        testFiredRules(kieBaseTestConfiguration, "package org.drools.compiler.integrationtests.operators;\n" +
                                "import " + Person.class.getCanonicalName() + ";\n" +
                                "rule NotSoundsLike\n" +
                                "when\n" +
@@ -108,7 +102,8 @@ public class SoundsLikeTest {
                        "Bob");
     }
 
-    private void testFiredRules(final String rule,
+    private void testFiredRules(KieBaseTestConfiguration kieBaseTestConfiguration, 
+    							final String rule,
                                 final int firedRulesCount,
                                 final String... persons) {
         final KieBase kbase = KieBaseUtil.getKieBaseFromKieModuleFromDrl("sounds-like-test",

--- a/drools-test-coverage/test-suite/src/test/java/org/drools/testcoverage/common/util/TestParametersUtil2.java
+++ b/drools-test-coverage/test-suite/src/test/java/org/drools/testcoverage/common/util/TestParametersUtil2.java
@@ -1,0 +1,324 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.drools.testcoverage.common.util;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+import org.drools.model.codegen.ExecutableModelProject;
+
+/**
+ * Utility class that holds default tests parameters.
+ */
+public final class TestParametersUtil2 {
+
+    private static final boolean TEST_WITH_ALPHA_NETWORK = Boolean.valueOf(System.getProperty("alphanetworkCompilerEnabled"));
+
+    /**
+     * Get all KieBaseConfigurations for tests based on specified engine configurations.
+     * @param engineConfigurations Engine configurations for tests. They should contain every configuration that
+     * should be tested. What is not specified, is not returned as part of KieBaseConfigurations.
+     * @return
+     */
+    public static Collection<KieBaseTestConfiguration> getKieBaseConfigurations(final EngineTestConfiguration... engineConfigurations) {
+        if (engineConfigurations == null || engineConfigurations.length == 0) {
+            throw new IllegalArgumentException("No parameters specified! Please provide some required parameters");
+        }
+        final Collection<KieBaseTestConfiguration> parameters = new ArrayList<>();
+        for (final KieBaseTestConfiguration testConfiguration : KieBaseTestConfiguration.values()) {
+            if (isTestConfigurationValid(testConfiguration, engineConfigurations)) {
+                parameters.add(testConfiguration);
+            }
+        }
+        return parameters;
+    }
+
+    /**
+     * Checks, if a test configuration matches specified engine configurations. Take note that the engine configurations
+     * can contain contradictory configurations on first sight. This is because they should include all
+     * configurations requested for tests. E.g. a test could require both combinations with executable model on and also off.
+     *
+     * @param testConfiguration A configuration that is checked if it matches the specified engine configurations
+     * @param engineConfigurations Specified engine configurations for tests
+     * @return true, if the test configuration is valid for specified engine configurations, otherwise false
+     */
+    private static boolean isTestConfigurationValid(final KieBaseTestConfiguration testConfiguration,
+                                                    final EngineTestConfiguration[] engineConfigurations) {
+        final Set<EngineTestConfiguration> engineTestConfigurationSet = new HashSet<>(Arrays.asList(engineConfigurations));
+
+        if (testConfiguration.isImmutable() && !engineTestConfigurationSet.contains(EngineTestConfiguration.IMMUTABLE_KIE_BASE)) {
+            return false;
+        }
+
+        if (testConfiguration.isStreamMode() && !engineTestConfigurationSet.contains(EngineTestConfiguration.STREAM_MODE)) {
+            return false;
+        }
+
+        if (!testConfiguration.isStreamMode() && !engineTestConfigurationSet.contains(EngineTestConfiguration.CLOUD_MODE)) {
+            return false;
+        }
+
+        if (testConfiguration.isIdentity() && !engineTestConfigurationSet.contains(EngineTestConfiguration.IDENTITY_MODE)) {
+            return false;
+        }
+
+        if (!testConfiguration.isIdentity() && !engineTestConfigurationSet.contains(EngineTestConfiguration.EQUALITY_MODE)) {
+            return false;
+        }
+
+        if (testConfiguration.useAlphaNetworkCompiler()
+                && !engineTestConfigurationSet.contains(EngineTestConfiguration.ALPHA_NETWORK_COMPILER_TRUE)) {
+            return false;
+        }
+
+        if (!testConfiguration.useAlphaNetworkCompiler()
+                && !engineTestConfigurationSet.contains(EngineTestConfiguration.ALPHA_NETWORK_COMPILER_FALSE)) {
+            return false;
+        }
+
+        if (!testConfiguration.getExecutableModelProjectClass().isPresent()
+                && !engineTestConfigurationSet.contains(EngineTestConfiguration.EXECUTABLE_MODEL_OFF)) {
+            return false;
+        }
+
+        if (testConfiguration.getExecutableModelProjectClass().isPresent()) {
+            if (testConfiguration.getExecutableModelProjectClass().get().equals(ExecutableModelProject.class)
+                    && !engineTestConfigurationSet.contains(EngineTestConfiguration.EXECUTABLE_MODEL_PATTERN)) {
+                return false;
+            }
+        }
+        return true;
+    }
+
+    /**
+     * Prepares collection of KieBaseTestConfiguration.
+     * @return Collection of KieBaseTestConfiguration for parameterized tests.
+     */
+    public static Collection<KieBaseTestConfiguration> getKieBaseConfigurations() {
+        final List<EngineTestConfiguration> engineTestConfigurations = Arrays.stream(EngineTestConfiguration.values())
+                .filter(config -> (TEST_WITH_ALPHA_NETWORK || config != EngineTestConfiguration.ALPHA_NETWORK_COMPILER_TRUE)
+                        && config != EngineTestConfiguration.EQUALITY_MODE
+                        && config != EngineTestConfiguration.IMMUTABLE_KIE_BASE)
+                .collect(Collectors.toList());
+        return getKieBaseConfigurations(engineTestConfigurations.toArray(new EngineTestConfiguration[]{}));
+    }
+
+    /**
+     * Prepares collection of stream KieBaseTestConfiguration.
+     * @return Collection of KieBaseTestConfiguration for parameterized tests.
+     * @param testAlsoExecutableModel If true, the configurations returned contain configurations with executable model.
+     */
+    public static Collection<KieBaseTestConfiguration> getKieBaseStreamConfigurations(final boolean testAlsoExecutableModel) {
+        return getKieBaseStreamOrCloudConfigurations(EngineTestConfiguration.STREAM_MODE, testAlsoExecutableModel);
+    }
+
+    /**
+     * Prepares collection of stream KieBaseTestConfiguration.
+     * @return Collection of KieBaseTestConfiguration for parameterized tests.
+     * @param testAlsoExecutableModel If true, the configurations returned contain configurations with executable model.
+     * @param testEquality If true, the configurations returned contain configurations with EQUALITY_MODE instead of IDENTITY_MODE.
+     */
+    public static Collection<KieBaseTestConfiguration> getKieBaseStreamConfigurations(final boolean testAlsoExecutableModel, final boolean testEquality) {
+        return getKieBaseStreamOrCloudConfigurations(EngineTestConfiguration.STREAM_MODE, testAlsoExecutableModel, testEquality);
+    }
+
+    /**
+     * Prepares collection of stream KieBaseTestConfiguration.
+     * @return Collection of KieBaseTestConfiguration for parameterized tests.
+     * @param testAlsoExecutableModel If true, the configurations returned contain configurations with executable model.
+     */
+    public static Collection<KieBaseTestConfiguration> getKieBaseCloudConfigurations(final boolean testAlsoExecutableModel) {
+        return getKieBaseStreamOrCloudConfigurations(EngineTestConfiguration.CLOUD_MODE, testAlsoExecutableModel);
+    }
+
+    /**
+     * Prepares collection of stream KieBaseTestConfiguration.
+     * @return Collection of KieBaseTestConfiguration for parameterized tests.
+     * @param testAlsoExecutableModel If true, the configurations returned contain configurations with executable model.
+     * @param testEquality If true, the configurations returned contain configurations with EQUALITY_MODE instead of IDENTITY_MODE.
+     */
+    public static Collection<KieBaseTestConfiguration> getKieBaseCloudConfigurations(final boolean testAlsoExecutableModel, final boolean testEquality) {
+        return getKieBaseStreamOrCloudConfigurations(EngineTestConfiguration.CLOUD_MODE, testAlsoExecutableModel, testEquality);
+    }
+
+    private static Collection<KieBaseTestConfiguration> getKieBaseStreamOrCloudConfigurations(final EngineTestConfiguration streamOrCloudConfig,
+                                                                              final boolean testAlsoExecutableModel) {
+        // Testing just IDENTITY_MODE by default, leaving EQUALITY_MODE to specialized tests.
+        return getKieBaseStreamOrCloudConfigurations(streamOrCloudConfig, testAlsoExecutableModel, false);
+    }
+
+    private static Collection<KieBaseTestConfiguration> getKieBaseStreamOrCloudConfigurations(final EngineTestConfiguration streamOrCloudConfig,
+                                                                              final boolean testAlsoExecutableModel, final boolean testEquality) {
+        final List<EngineTestConfiguration> engineTestConfigurations = new ArrayList<>();
+        engineTestConfigurations.add(streamOrCloudConfig);
+        if (testEquality) {
+            engineTestConfigurations.add(EngineTestConfiguration.EQUALITY_MODE);
+        } else {
+            engineTestConfigurations.add(EngineTestConfiguration.IDENTITY_MODE);
+        }
+        engineTestConfigurations.add(EngineTestConfiguration.EXECUTABLE_MODEL_OFF);
+        engineTestConfigurations.add(EngineTestConfiguration.ALPHA_NETWORK_COMPILER_FALSE);
+
+        if (TEST_WITH_ALPHA_NETWORK) {
+            engineTestConfigurations.add(EngineTestConfiguration.ALPHA_NETWORK_COMPILER_TRUE);
+        }
+
+        if (testAlsoExecutableModel) {
+            engineTestConfigurations.add(EngineTestConfiguration.EXECUTABLE_MODEL_PATTERN);
+        }
+
+        return getKieBaseConfigurations(engineTestConfigurations.toArray(new EngineTestConfiguration[]{}));
+    }
+
+    public static Collection<KieBaseTestConfiguration> getKieBaseCloudOnlyExecModelConfiguration() {
+        final List<EngineTestConfiguration> engineTestConfigurations = new ArrayList<>();
+        engineTestConfigurations.add(EngineTestConfiguration.CLOUD_MODE);
+        engineTestConfigurations.add(EngineTestConfiguration.IDENTITY_MODE);
+        engineTestConfigurations.add(EngineTestConfiguration.ALPHA_NETWORK_COMPILER_FALSE);
+        engineTestConfigurations.add(EngineTestConfiguration.EXECUTABLE_MODEL_PATTERN);
+
+        return getKieBaseConfigurations(engineTestConfigurations.toArray(new EngineTestConfiguration[]{}));
+    }
+
+    /**
+     * Prepares various combinations of KieBaseTestConfiguration and KieSessionTestConfiguration.
+     * @return Collection of combinations for parameterized tests.
+     */
+    public static Collection<Object[]> getKieBaseAndKieSessionConfigurations() {
+        final Collection<Object[]> parameters = new ArrayList<>();
+        // These are wrapped in an array, because these are parameters for JUnit Parameterized runner.
+        Collection<KieBaseTestConfiguration> kieBaseConfigurations = getKieBaseCloudConfigurations(true);
+        for (final KieSessionTestConfiguration kieSessionTestConfiguration : KieSessionTestConfiguration.values()) {
+            for (final KieBaseTestConfiguration kieBaseConfigWrapped : kieBaseConfigurations) {
+                parameters.add(new Object[]{kieBaseConfigWrapped, kieSessionTestConfiguration});
+            }
+        }
+
+        kieBaseConfigurations = getKieBaseStreamConfigurations(true);
+        for (final KieBaseTestConfiguration kieBaseConfigWrapped : kieBaseConfigurations) {
+            parameters.add(new Object[]{kieBaseConfigWrapped, KieSessionTestConfiguration.STATEFUL_REALTIME});
+            parameters.add(new Object[]{kieBaseConfigWrapped, KieSessionTestConfiguration.STATEFUL_PSEUDO});
+        }
+
+        return parameters;
+    }
+
+    /**
+     * Prepares various combinations of KieBaseTestConfiguration and KieSessionTestConfiguration.
+     * Use only stateful kie sessions.
+     * @return Collection of combinations for parameterized tests.
+     */
+    public static Collection<Object[]> getKieBaseAndStatefulKieSessionConfigurations() {
+        final Collection<Object[]> parameters = new ArrayList<>();
+        final Collection<KieBaseTestConfiguration> kieBaseConfigurations = getKieBaseConfigurations();
+        for (final KieBaseTestConfiguration kieBaseConfigWrapped : kieBaseConfigurations) {
+            parameters.add(new Object[]{kieBaseConfigWrapped, KieSessionTestConfiguration.STATEFUL_REALTIME});
+            if ((kieBaseConfigWrapped).isStreamMode()) {
+                parameters.add(new Object[]{kieBaseConfigWrapped, KieSessionTestConfiguration.STATEFUL_PSEUDO});
+            }
+        }
+
+        return parameters;
+    }
+
+    /**
+     * Prepares various combinations of KieBaseTestConfiguration and KieSessionTestConfiguration.
+     * Use only stream kie bases and stateful kie sessions.
+     * @return Collection of combinations for parameterized tests.
+     */
+    public static Collection<Object[]> getStreamKieBaseAndStatefulKieSessionConfigurations() {
+        final Collection<Object[]> parameters = new ArrayList<>();
+        final Collection<KieBaseTestConfiguration> kieBaseConfigurations = getKieBaseStreamConfigurations(true);
+        for (final KieBaseTestConfiguration kieBaseConfigWrapped : kieBaseConfigurations) {
+            parameters.add(new Object[]{kieBaseConfigWrapped, KieSessionTestConfiguration.STATEFUL_REALTIME});
+            parameters.add(new Object[]{kieBaseConfigWrapped, KieSessionTestConfiguration.STATEFUL_PSEUDO});
+        }
+
+        return parameters;
+    }
+
+    /**
+     * Returns KieBaseTestConfiguration instance with Equality while other properties are the same as original.
+     */
+    public static KieBaseTestConfiguration getEqualityInstanceOf(KieBaseTestConfiguration orig) {
+        for (final KieBaseTestConfiguration config : KieBaseTestConfiguration.values()) {
+            if (!config.isIdentity()
+                    && config.isStreamMode() == orig.isStreamMode()
+                    && config.useAlphaNetworkCompiler() == orig.useAlphaNetworkCompiler()
+                    && config.getExecutableModelProjectClass().equals(orig.getExecutableModelProjectClass())) {
+                return config;
+            }
+        }
+        throw new RuntimeException("Cannot find Equality instance of " + orig);
+    }
+
+    /**
+     * Returns KieBaseTestConfiguration instance with Identity while other properties are the same as original.
+     */
+    public static KieBaseTestConfiguration getIdentityInstanceOf(KieBaseTestConfiguration orig) {
+        for (final KieBaseTestConfiguration config : KieBaseTestConfiguration.values()) {
+            if (config.isIdentity()
+                    && config.isStreamMode() == orig.isStreamMode()
+                    && config.useAlphaNetworkCompiler() == orig.useAlphaNetworkCompiler()
+                    && config.getExecutableModelProjectClass().equals(orig.getExecutableModelProjectClass())) {
+                return config;
+            }
+        }
+        throw new RuntimeException("Cannot find Identity instance of " + orig);
+    }
+
+    /**
+     * Returns KieBaseTestConfiguration instance with Stream while other properties are the same as original.
+     */
+    public static KieBaseTestConfiguration getStreamInstanceOf(KieBaseTestConfiguration orig) {
+        for (final KieBaseTestConfiguration config : KieBaseTestConfiguration.values()) {
+            if (config.isStreamMode()
+                    && config.isIdentity() == orig.isIdentity()
+                    && config.useAlphaNetworkCompiler() == orig.useAlphaNetworkCompiler()
+                    && config.getExecutableModelProjectClass().equals(orig.getExecutableModelProjectClass())) {
+                return config;
+            }
+        }
+        throw new RuntimeException("Cannot find Stream instance of " + orig);
+    }
+
+    /**
+     * Returns KieBaseTestConfiguration instance with Cloud while other properties are the same as original.
+     */
+    public static KieBaseTestConfiguration getCloudInstanceOf(KieBaseTestConfiguration orig) {
+        for (final KieBaseTestConfiguration config : KieBaseTestConfiguration.values()) {
+            if (!config.isStreamMode()
+                    && config.isIdentity() == orig.isIdentity()
+                    && config.useAlphaNetworkCompiler() == orig.useAlphaNetworkCompiler()
+                    && config.getExecutableModelProjectClass().equals(orig.getExecutableModelProjectClass())) {
+                return config;
+            }
+        }
+        throw new RuntimeException("Cannot find Cloud instance of " + orig);
+    }
+
+    private TestParametersUtil2() {
+        // Creating instances of util classes should not be possible.
+    }
+}


### PR DESCRIPTION
<!--
  Licensed to the Apache Software Foundation (ASF) under one
  or more contributor license agreements.  See the NOTICE file
  distributed with this work for additional information
  regarding copyright ownership.  The ASF licenses this file
  to you under the Apache License, Version 2.0 (the
  "License"); you may not use this file except in compliance
  with the License.  You may obtain a copy of the License at

    http://www.apache.org/licenses/LICENSE-2.0

  Unless required by applicable law or agreed to in writing,
  software distributed under the License is distributed on an
  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
  KIND, either express or implied.  See the License for the
  specific language governing permissions and limitations
  under the License.
  -->
First group of tests migrated to JUnit5. 
Nothing really interesting to note.

**Issue**: 

* [apache/incubator-kie-drools/issues/6136] 

<details>
<summary>
How to replicate CI configuration locally?
</summary>

Build Chain tool does "simple" maven build(s), the builds are just Maven commands, but because the repositories relates and depends on each other and any change in API or class method could affect several of those repositories there is a need to use [build-chain tool](https://github.com/kiegroup/github-action-build-chain) to handle cross repository builds and be sure that we always use latest version of the code for each repository.
 
[build-chain tool](https://github.com/kiegroup/github-action-build-chain) is a build tool which can be used on command line locally or in Github Actions workflow(s), in case you need to change multiple repositories and send multiple dependent pull requests related with a change you can easily reproduce the same build by executing it on Github hosted environment or locally in your development environment. See [local execution](https://github.com/kiegroup/github-action-build-chain#local-execution) details to get more information about it.
</details>

<details>
<summary>
How to retest this PR or trigger a specific build:
</summary>

- for <b>pull request and downstream checks</b>  
  - Push a new commit to the PR. An empty commit would be enough.

- for a <b>full downstream build</b>
  - for <b>github actions</b> job: add the label `run_fdb`

- for <b>Jenkins PR check only</b>
  - If you are an ASF committer for KIE podling, login to Jenkins (https://ci-builds.apache.org/job/KIE/job/drools/), go to the specific PR job, and click on `Build Now` button.
</details>
