### PR TITLE
NO-ISSUE: Bump `xstream` to version `1.4.21`

### DIFF
--- a/build-parent/pom.xml
+++ b/build-parent/pom.xml
@@ -70,7 +70,7 @@
     <version.com.h2database>2.2.220</version.com.h2database>
     <version.com.networknt.json-schema-validator>1.0.86</version.com.networknt.json-schema-validator>
     <version.com.sun.xml.bind>4.0.4</version.com.sun.xml.bind>
-    <version.com.thoughtworks.xstream>1.4.20</version.com.thoughtworks.xstream>
+    <version.com.thoughtworks.xstream>1.4.21</version.com.thoughtworks.xstream>
     <version.guru.nidi>0.18.0</version.guru.nidi>
     <version.info.picocli>4.7.5</version.info.picocli>
     <version.io.micrometer>1.12.2</version.io.micrometer>


### PR DESCRIPTION
The current `xstream` `1.4.20` is affected by [CVE-2024-47072](https://x-stream.github.io/CVE-2024-47072.html).
Updating `xstream` to ´1.4.21´ resolves the CVE