### PR TITLE
[NO-ISSUE] Remove a redundant license header

### DIFF
--- a/.rat-excludes
+++ b/.rat-excludes
@@ -6,6 +6,7 @@ ui-bundle\.zip
 dependency-reduced-pom\.xml
 lunr-2\.3\.9\.min\.js
 search-ui\.js
+search\.css
 branch\.yaml
 main\.yaml
 mvel\.jj

--- a/drools-docs/supplemental-ui/css/search.css
+++ b/drools-docs/supplemental-ui/css/search.css
@@ -1,23 +1,4 @@
 /*
- * Licensed to the Apache Software Foundation (ASF) under one
- * or more contributor license agreements.  See the NOTICE file
- * distributed with this work for additional information
- * regarding copyright ownership.  The ASF licenses this file
- * to you under the Apache License, Version 2.0 (the
- * "License"); you may not use this file except in compliance
- * with the License.  You may obtain a copy of the License at
- *
- *   http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing,
- * software distributed under the License is distributed on an
- * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
- * KIND, either express or implied.  See the License for the
- * specific language governing permissions and limitations
- * under the License.
- */
-
-/*
  * This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/.


### PR DESCRIPTION
I happened to find this one.

I'm not sure how we can detect this kind of issue (e.g. with a shell script). So far, I manually checked by grep "MPL" and "BSD", and I found no other redundant license header in those ("MPL" and "BSD" licensed) files in the drools repo.