### PR TITLE
[NO-ISSUE] mvel.jj license

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -247,11 +247,4 @@ for drools-drl/drools-drl-parser/src/main/antlr4/org/drools/drl/parser/antlr4/Ja
 
  ------------------------------------------------------------------------------------
  for drools-model/drools-mvel-parser/src/main/javacc/mvel.jj
-     JavaParser is under dual license. Apache License Version 2.0 is chosen for mvel.jj
-
- JavaParser is available either under the terms of the LGPL License or the Apache License. You as the user are entitled to choose the terms under which to adopt JavaParser.
-
- For details about the LGPL License please refer to LICENSE.LGPL. Please note
- that LGPL is just an extension to GPL, located in LICENSE.GPL.
-
- For details about the Apache License please refer to LICENSE.APACHE
+     JavaParser is dual licensed under LGPL license. and Apache License Version 2.0 license. We choose the Apache License Version 2.0.

--- a/LICENSE
+++ b/LICENSE
@@ -247,4 +247,4 @@ for drools-drl/drools-drl-parser/src/main/antlr4/org/drools/drl/parser/antlr4/Ja
 
  ------------------------------------------------------------------------------------
  for drools-model/drools-mvel-parser/src/main/javacc/mvel.jj
-     JavaParser is dual licensed under LGPL license. and Apache License Version 2.0 license. We choose the Apache License Version 2.0.
+     JavaParser is dual licensed under LGPL license and Apache License Version 2.0 license. We choose the Apache License Version 2.0.

--- a/LICENSE
+++ b/LICENSE
@@ -244,3 +244,14 @@ for drools-drl/drools-drl-parser/src/main/antlr4/org/drools/drl/parser/antlr4/Ja
  Included by permission of the http://tpop.awl.com/ web site, which says:
  "You may use this code for any purpose, as long as you leave the
  copyright notice and book citation attached."
+
+ ------------------------------------------------------------------------------------
+ for drools-model/drools-mvel-parser/src/main/javacc/mvel.jj
+     JavaParser is under dual license. Apache License Version 2.0 is chosen for mvel.jj
+
+ JavaParser is available either under the terms of the LGPL License or the Apache License. You as the user are entitled to choose the terms under which to adopt JavaParser.
+
+ For details about the LGPL License please refer to LICENSE.LGPL. Please note
+ that LGPL is just an extension to GPL, located in LICENSE.GPL.
+
+ For details about the Apache License please refer to LICENSE.APACHE


### PR DESCRIPTION
`mvel.jj` was taken from https://github.com/javaparser/javaparser/blob/master/javaparser-core/src/main/javacc/java.jj

According to https://issues.apache.org/jira/browse/LEGAL-594 and https://www.apache.org/legal/resolved.html#mutually-exclusive , `state which license you are using and include only the license that you have chosen.`

It's not clear to me how to "state". I have added the file path `drools-model/drools-mvel-parser/src/main/javacc/mvel.jj` and the statement `JavaParser is under dual license. Apache License Version 2.0 is chosen for mvel.jj`, and pasted the content of https://github.com/javaparser/javaparser/blob/master/LICENSE

As the LICENSE says "For details about the Apache License please refer to LICENSE.APACHE", I keep `LICENSE.APACHE` at https://github.com/apache/incubator-kie-drools/blob/main/drools-model/drools-mvel-parser/LICENSE.APACHE