### PR TITLE
[incubator-kie-issues#1627] Change log level from error to debug inside ImportDMNResolverUtil

### DIFF
--- a/kie-dmn/kie-dmn-core/src/main/java/org/kie/dmn/core/compiler/ImportDMNResolverUtil.java
+++ b/kie-dmn/kie-dmn-core/src/main/java/org/kie/dmn/core/compiler/ImportDMNResolverUtil.java
@@ -82,13 +82,13 @@ public class ImportDMNResolverUtil {
                         importerDMNName, importerDMNNamespace, importNamespace, importName, importLocationURI, importModelName);
                 return Either.ofRight(usingNSandName.get(0));
             } else if (usingNSandName.isEmpty()) {
-                LOGGER.error("DMN Model with name={} and namespace={} failed to import a DMN with namespace={} name={} locationURI={}, modelName={}.",
+                LOGGER.debug("DMN Model with name={} and namespace={} failed to import a DMN with namespace={} name={} locationURI={}, modelName={}.",
                         importerDMNName, importerDMNNamespace, importNamespace, importName, importLocationURI, importModelName);
                 return Either.ofLeft(String.format(
                         "DMN Model with name=%s and namespace=%s failed to import a DMN with namespace=%s name=%s locationURI=%s, modelName=%s. ",
                         importerDMNName, importerDMNNamespace, importNamespace, importName, importLocationURI, importModelName));
             } else {
-                LOGGER.error("DMN Model with name={} and namespace={} detected a collision ({} elements) trying to import a DMN with namespace={} name={} locationURI={}, modelName={}",
+                LOGGER.debug("DMN Model with name={} and namespace={} detected a collision ({} elements) trying to import a DMN with namespace={} name={} locationURI={}, modelName={}",
                         importerDMNName, importerDMNNamespace, usingNSandName.size(), importNamespace, importName, importLocationURI, importModelName);
                 return Either.ofLeft(String.format(
                         "DMN Model with name=%s and namespace=%s detected a collision trying to import a DMN with %s namespace, " +

--- a/kie-dmn/kie-dmn-core/src/main/java/org/kie/dmn/core/compiler/ImportDMNResolverUtil.java
+++ b/kie-dmn/kie-dmn-core/src/main/java/org/kie/dmn/core/compiler/ImportDMNResolverUtil.java
@@ -52,6 +52,10 @@ public class ImportDMNResolverUtil {
                         "Importing a DMN model with namespace={} name={} locationURI={}, modelName={}",
                 importerDMNName, importerDMNNamespace, importNamespace, importName, importLocationURI, importModelName);
 
+        if (dmns.isEmpty()) {
+            return Either.ofLeft("Impossible to resolve an import against an empty DMN collection");
+        }
+
         List<T> matchingDMNList = dmns.stream()
                 .filter(m -> idExtractor.apply(m).getNamespaceURI().equals(importNamespace))
                 .toList();
@@ -64,7 +68,7 @@ public class ImportDMNResolverUtil {
                         importerDMNName, importerDMNNamespace, importNamespace, importName, importLocationURI, importModelName);
                 return Either.ofRight(located);
             } else {
-                LOGGER.debug("DMN Model with name={} and namespace={} can't import a DMN with namespace={}, name={}, modelName={}, " +
+                LOGGER.error("DMN Model with name={} and namespace={} can't import a DMN with namespace={}, name={}, modelName={}, " +
                                 "located within namespace only {} but does not match for the actual modelName",
                         importerDMNName, importerDMNNamespace, importNamespace, importName, importModelName, idExtractor.apply(located));
                 return Either.ofLeft(String.format(
@@ -82,13 +86,13 @@ public class ImportDMNResolverUtil {
                         importerDMNName, importerDMNNamespace, importNamespace, importName, importLocationURI, importModelName);
                 return Either.ofRight(usingNSandName.get(0));
             } else if (usingNSandName.isEmpty()) {
-                LOGGER.debug("DMN Model with name={} and namespace={} failed to import a DMN with namespace={} name={} locationURI={}, modelName={}.",
+                LOGGER.error("DMN Model with name={} and namespace={} failed to import a DMN with namespace={} name={} locationURI={}, modelName={}.",
                         importerDMNName, importerDMNNamespace, importNamespace, importName, importLocationURI, importModelName);
                 return Either.ofLeft(String.format(
                         "DMN Model with name=%s and namespace=%s failed to import a DMN with namespace=%s name=%s locationURI=%s, modelName=%s. ",
                         importerDMNName, importerDMNNamespace, importNamespace, importName, importLocationURI, importModelName));
             } else {
-                LOGGER.debug("DMN Model with name={} and namespace={} detected a collision ({} elements) trying to import a DMN with namespace={} name={} locationURI={}, modelName={}",
+                LOGGER.error("DMN Model with name={} and namespace={} detected a collision ({} elements) trying to import a DMN with namespace={} name={} locationURI={}, modelName={}",
                         importerDMNName, importerDMNNamespace, usingNSandName.size(), importNamespace, importName, importLocationURI, importModelName);
                 return Either.ofLeft(String.format(
                         "DMN Model with name=%s and namespace=%s detected a collision trying to import a DMN with %s namespace, " +

--- a/kie-dmn/kie-dmn-core/src/test/java/org/kie/dmn/core/compiler/ImportDMNResolverUtilTest.java
+++ b/kie-dmn/kie-dmn-core/src/test/java/org/kie/dmn/core/compiler/ImportDMNResolverUtilTest.java
@@ -18,7 +18,11 @@
  */
 package org.kie.dmn.core.compiler;
 
-import java.util.*;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
 import java.util.function.Function;
 
 import javax.xml.namespace.QName;

--- a/kie-dmn/kie-dmn-core/src/test/java/org/kie/dmn/core/compiler/ImportDMNResolverUtilTest.java
+++ b/kie-dmn/kie-dmn-core/src/test/java/org/kie/dmn/core/compiler/ImportDMNResolverUtilTest.java
@@ -18,10 +18,7 @@
  */
 package org.kie.dmn.core.compiler;
 
-import java.util.Arrays;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
+import java.util.*;
 import java.util.function.Function;
 
 import javax.xml.namespace.QName;
@@ -156,12 +153,18 @@ class ImportDMNResolverUtilTest {
 
     @Test
     void locateInNSAliasedBadScenario() {
-        // this is a BAD scenario are in namespace `nsA` there are 2 models with the same name.
         final Import i = makeImport("nsA", "aliased", "mA");
         final List<QName> available = Arrays.asList(new QName("nsA", "mA"),
                                                     new QName("nsA", "mA"),
                                                     new QName("nsB", "m3"));
         final Either<String, QName> result = ImportDMNResolverUtil.resolveImportDMN(i, available, Function.identity());
+        assertThat(result.isLeft()).isTrue();
+    }
+
+    @Test
+    void emptyDMNCollection() {
+        final Import i = makeImport("nsA", "aliased", "mA");
+        final Either<String, QName> result = ImportDMNResolverUtil.resolveImportDMN(i, Collections.emptyList(), Function.identity());
         assertThat(result.isLeft()).isTrue();
     }
 


### PR DESCRIPTION
Closes https://github.com/apache/incubator-kie-issues/issues/1627

Follow up of https://github.com/apache/incubator-kie-drools/pull/6150, discovered during https://github.com/apache/incubator-kie-issues/issues/1627 testing. 

Based on the current architecture, the `resolveImportDMN(Import, Collection<T>, Function<T, QName>)` is called twice, which means that an error logged in the first call is inconsistent with the second call, where the behavior works as expected.

As a consequence, all log levels should be set as DEBUG, until a definitive fix in the architecture.