### PR TITLE
[NO-ISSUE] License check

### DIFF
--- a/.rat-excludes
+++ b/.rat-excludes
@@ -36,14 +36,6 @@ lunr-2.3.9.min.js
 JavaLexer.g4
 # drools-drl/drools-drl-parser/src/main/antlr4/org/drools/drl/parser/antlr4/JavaParser.g4
 JavaParser.g4
-# drools-drl/drools-drl-parser-tests/src/test/resources/org/drools/drl/parser/antlr4/expander_multiple_constraints.dslr
-expander_multiple_constraints.dslr
-# drools-drl/drools-drl-parser-tests/src/test/resources/org/drools/drl/parser/antlr4/expander_multiple_constraints_flush.dslr
-expander_multiple_constraints_flush.dslr
-# drools-drl/drools-drl-parser-tests/src/test/resources/org/drools/drl/parser/antlr4/expander_spread_lines.dslr
-expander_spread_lines.dslr
-# drools-drlonyaml-parent/drools-drlonyaml-cli-tests/src/test/resources/batch_drl_files/.gitignore
-.gitignore
 # drools-drlonyaml-parent/drools-drlonyaml-cli-tests/src/test/resources/expected/test1.yml
 test1.yml
 # drools-drlonyaml-parent/drools-drlonyaml-cli-tests/src/test/resources/expected/test2.drl.txt
@@ -56,6 +48,8 @@ drl.ftl
 Sample.sdo
 # drools-impact-analysis/drools-impact-analysis-graph/drools-impact-analysis-graph-graphviz/src/test/resources/org/drools/impact/analysis/graph/graphviz/simple.dot
 simple.dot
+# drools-model/drools-canonical-model/src/main/java/org/drools/model/bitmask/OpenBitSet.java
+OpenBitSet.java
 # drools-model/drools-mvel-parser/src/main/javacc/mvel.jj
 mvel.jj
 # drools-quarkus-extension/drools-quarkus-integration-test-hotreload/src/main/resources/org/drools/hotreload/adult.txt
@@ -78,6 +72,8 @@ unicode.drl.csv
 PhoneNumberCategory.drl.csv
 # drools-test-coverage/test-suite/src/test/resources/org/drools/testcoverage/functional/oopath/oopath.drl.csv
 oopath.drl.csv
+# drools-util/src/main/java/org/drools/util/bitmask/OpenBitSet.java
+OpenBitSet.java
 # efesto/documentation/sdt/CompositeKnowledgeBuilderImpl_build.sdt
 CompositeKnowledgeBuilderImpl_build.sdt
 # efesto/documentation/sdt/PMMLAssemblerService_addResourceAfterRules_withoutConfigurations.sdt

--- a/LICENSE
+++ b/LICENSE
@@ -381,6 +381,283 @@ event that testing suites are implemented or approved by Object Management Group
 specification may claim compliance or conformance with the specification only if the software satisfactorily completes
 the testing suites.
 
- ------------------------------------------------------------------------------------
- for drools-model/drools-mvel-parser/src/main/javacc/mvel.jj
-     JavaParser is dual licensed under LGPL license and Apache License Version 2.0 license. We choose the Apache License Version 2.0.
+------------------------------------------------------------------------------------
+for drools-model/drools-mvel-parser/src/main/javacc/mvel.jj
+    JavaParser is dual licensed under LGPL license and Apache License Version 2.0 license. We choose the Apache License Version 2.0.
+
+------------------------------------------------------------------------------------
+for drools-model/drools-canonical-model/src/main/java/org/drools/model/bitmask/OpenBitSet.java
+    drools-util/src/main/java/org/drools/util/bitmask/OpenBitSet.java
+
+A. HISTORY OF THE SOFTWARE
+==========================
+
+Python was created in the early 1990s by Guido van Rossum at Stichting
+Mathematisch Centrum (CWI, see http://www.cwi.nl) in the Netherlands
+as a successor of a language called ABC.  Guido remains Python's
+principal author, although it includes many contributions from others.
+
+In 1995, Guido continued his work on Python at the Corporation for
+National Research Initiatives (CNRI, see http://www.cnri.reston.va.us)
+in Reston, Virginia where he released several versions of the
+software.
+
+In May 2000, Guido and the Python core development team moved to
+BeOpen.com to form the BeOpen PythonLabs team.  In October of the same
+year, the PythonLabs team moved to Digital Creations (now Zope
+Corporation, see http://www.zope.com).  In 2001, the Python Software
+Foundation (PSF, see http://www.python.org/psf/) was formed, a
+non-profit organization created specifically to own Python-related
+Intellectual Property.  Zope Corporation is a sponsoring member of
+the PSF.
+
+All Python releases are Open Source (see http://www.opensource.org for
+the Open Source Definition).  Historically, most, but not all, Python
+releases have also been GPL-compatible; the table below summarizes
+the various releases.
+
+    Release         Derived     Year        Owner       GPL-
+                    from                                compatible? (1)
+
+    0.9.0 thru 1.2              1991-1995   CWI         yes
+    1.3 thru 1.5.2  1.2         1995-1999   CNRI        yes
+    1.6             1.5.2       2000        CNRI        no
+    2.0             1.6         2000        BeOpen.com  no
+    1.6.1           1.6         2001        CNRI        yes (2)
+    2.1             2.0+1.6.1   2001        PSF         no
+    2.0.1           2.0+1.6.1   2001        PSF         yes
+    2.1.1           2.1+2.0.1   2001        PSF         yes
+    2.2             2.1.1       2001        PSF         yes
+    2.1.2           2.1.1       2002        PSF         yes
+    2.1.3           2.1.2       2002        PSF         yes
+    2.2.1           2.2         2002        PSF         yes
+    2.2.2           2.2.1       2002        PSF         yes
+    2.2.3           2.2.2       2003        PSF         yes
+    2.3             2.2.2       2002-2003   PSF         yes
+    2.3.1           2.3         2002-2003   PSF         yes
+    2.3.2           2.3.1       2002-2003   PSF         yes
+    2.3.3           2.3.2       2002-2003   PSF         yes
+    2.3.4           2.3.3       2004        PSF         yes
+    2.3.5           2.3.4       2005        PSF         yes
+    2.4             2.3         2004        PSF         yes
+    2.4.1           2.4.1       2005        PSF         yes
+    2.4.2           2.4.1       2005        PSF         yes
+
+Footnotes:
+
+(1) GPL-compatible doesn't mean that we're distributing Python under
+    the GPL.  All Python licenses, unlike the GPL, let you distribute
+    a modified version without making your changes open source.  The
+    GPL-compatible licenses make it possible to combine Python with
+    other software that is released under the GPL; the others don't.
+
+(2) According to Richard Stallman, 1.6.1 is not GPL-compatible,
+    because its license has a choice of law clause.  According to
+    CNRI, however, Stallman's lawyer has told CNRI's lawyer that 1.6.1
+    is "not incompatible" with the GPL.
+
+Thanks to the many outside volunteers who have worked under Guido's
+direction to make these releases possible.
+
+
+B. TERMS AND CONDITIONS FOR ACCESSING OR OTHERWISE USING PYTHON
+===============================================================
+
+PYTHON SOFTWARE FOUNDATION LICENSE VERSION 2
+--------------------------------------------
+
+1. This LICENSE AGREEMENT is between the Python Software Foundation
+("PSF"), and the Individual or Organization ("Licensee") accessing and
+otherwise using this software ("Python") in source or binary form and
+its associated documentation.
+
+2. Subject to the terms and conditions of this License Agreement, PSF
+hereby grants Licensee a nonexclusive, royalty-free, world-wide
+license to reproduce, analyze, test, perform and/or display publicly,
+prepare derivative works, distribute, and otherwise use Python
+alone or in any derivative version, provided, however, that PSF's
+License Agreement and PSF's notice of copyright, i.e., "Copyright (c)
+2001, 2002, 2003, 2004 Python Software Foundation; All Rights Reserved"
+are retained in Python alone or in any derivative version prepared
+by Licensee.
+
+3. In the event Licensee prepares a derivative work that is based on
+or incorporates Python or any part thereof, and wants to make
+the derivative work available to others as provided herein, then
+Licensee hereby agrees to include in any such work a brief summary of
+the changes made to Python.
+
+4. PSF is making Python available to Licensee on an "AS IS"
+basis.  PSF MAKES NO REPRESENTATIONS OR WARRANTIES, EXPRESS OR
+IMPLIED.  BY WAY OF EXAMPLE, BUT NOT LIMITATION, PSF MAKES NO AND
+DISCLAIMS ANY REPRESENTATION OR WARRANTY OF MERCHANTABILITY OR FITNESS
+FOR ANY PARTICULAR PURPOSE OR THAT THE USE OF PYTHON WILL NOT
+INFRINGE ANY THIRD PARTY RIGHTS.
+
+5. PSF SHALL NOT BE LIABLE TO LICENSEE OR ANY OTHER USERS OF PYTHON
+FOR ANY INCIDENTAL, SPECIAL, OR CONSEQUENTIAL DAMAGES OR LOSS AS
+A RESULT OF MODIFYING, DISTRIBUTING, OR OTHERWISE USING PYTHON,
+OR ANY DERIVATIVE THEREOF, EVEN IF ADVISED OF THE POSSIBILITY THEREOF.
+
+6. This License Agreement will automatically terminate upon a material
+breach of its terms and conditions.
+
+7. Nothing in this License Agreement shall be deemed to create any
+relationship of agency, partnership, or joint venture between PSF and
+Licensee.  This License Agreement does not grant permission to use PSF
+trademarks or trade name in a trademark sense to endorse or promote
+products or services of Licensee, or any third party.
+
+8. By copying, installing or otherwise using Python, Licensee
+agrees to be bound by the terms and conditions of this License
+Agreement.
+
+
+BEOPEN.COM LICENSE AGREEMENT FOR PYTHON 2.0
+-------------------------------------------
+
+BEOPEN PYTHON OPEN SOURCE LICENSE AGREEMENT VERSION 1
+
+1. This LICENSE AGREEMENT is between BeOpen.com ("BeOpen"), having an
+office at 160 Saratoga Avenue, Santa Clara, CA 95051, and the
+Individual or Organization ("Licensee") accessing and otherwise using
+this software in source or binary form and its associated
+documentation ("the Software").
+
+2. Subject to the terms and conditions of this BeOpen Python License
+Agreement, BeOpen hereby grants Licensee a non-exclusive,
+royalty-free, world-wide license to reproduce, analyze, test, perform
+and/or display publicly, prepare derivative works, distribute, and
+otherwise use the Software alone or in any derivative version,
+provided, however, that the BeOpen Python License is retained in the
+Software, alone or in any derivative version prepared by Licensee.
+
+3. BeOpen is making the Software available to Licensee on an "AS IS"
+basis.  BEOPEN MAKES NO REPRESENTATIONS OR WARRANTIES, EXPRESS OR
+IMPLIED.  BY WAY OF EXAMPLE, BUT NOT LIMITATION, BEOPEN MAKES NO AND
+DISCLAIMS ANY REPRESENTATION OR WARRANTY OF MERCHANTABILITY OR FITNESS
+FOR ANY PARTICULAR PURPOSE OR THAT THE USE OF THE SOFTWARE WILL NOT
+INFRINGE ANY THIRD PARTY RIGHTS.
+
+4. BEOPEN SHALL NOT BE LIABLE TO LICENSEE OR ANY OTHER USERS OF THE
+SOFTWARE FOR ANY INCIDENTAL, SPECIAL, OR CONSEQUENTIAL DAMAGES OR LOSS
+AS A RESULT OF USING, MODIFYING OR DISTRIBUTING THE SOFTWARE, OR ANY
+DERIVATIVE THEREOF, EVEN IF ADVISED OF THE POSSIBILITY THEREOF.
+
+5. This License Agreement will automatically terminate upon a material
+breach of its terms and conditions.
+
+6. This License Agreement shall be governed by and interpreted in all
+respects by the law of the State of California, excluding conflict of
+law provisions.  Nothing in this License Agreement shall be deemed to
+create any relationship of agency, partnership, or joint venture
+between BeOpen and Licensee.  This License Agreement does not grant
+permission to use BeOpen trademarks or trade names in a trademark
+sense to endorse or promote products or services of Licensee, or any
+third party.  As an exception, the "BeOpen Python" logos available at
+http://www.pythonlabs.com/logos.html may be used according to the
+permissions granted on that web page.
+
+7. By copying, installing or otherwise using the software, Licensee
+agrees to be bound by the terms and conditions of this License
+Agreement.
+
+
+CNRI LICENSE AGREEMENT FOR PYTHON 1.6.1
+---------------------------------------
+
+1. This LICENSE AGREEMENT is between the Corporation for National
+Research Initiatives, having an office at 1895 Preston White Drive,
+Reston, VA 20191 ("CNRI"), and the Individual or Organization
+("Licensee") accessing and otherwise using Python 1.6.1 software in
+source or binary form and its associated documentation.
+
+2. Subject to the terms and conditions of this License Agreement, CNRI
+hereby grants Licensee a nonexclusive, royalty-free, world-wide
+license to reproduce, analyze, test, perform and/or display publicly,
+prepare derivative works, distribute, and otherwise use Python 1.6.1
+alone or in any derivative version, provided, however, that CNRI's
+License Agreement and CNRI's notice of copyright, i.e., "Copyright (c)
+1995-2001 Corporation for National Research Initiatives; All Rights
+Reserved" are retained in Python 1.6.1 alone or in any derivative
+version prepared by Licensee.  Alternately, in lieu of CNRI's License
+Agreement, Licensee may substitute the following text (omitting the
+quotes): "Python 1.6.1 is made available subject to the terms and
+conditions in CNRI's License Agreement.  This Agreement together with
+Python 1.6.1 may be located on the Internet using the following
+unique, persistent identifier (known as a handle): 1895.22/1013.  This
+Agreement may also be obtained from a proxy server on the Internet
+using the following URL: http://hdl.handle.net/1895.22/1013".
+
+3. In the event Licensee prepares a derivative work that is based on
+or incorporates Python 1.6.1 or any part thereof, and wants to make
+the derivative work available to others as provided herein, then
+Licensee hereby agrees to include in any such work a brief summary of
+the changes made to Python 1.6.1.
+
+4. CNRI is making Python 1.6.1 available to Licensee on an "AS IS"
+basis.  CNRI MAKES NO REPRESENTATIONS OR WARRANTIES, EXPRESS OR
+IMPLIED.  BY WAY OF EXAMPLE, BUT NOT LIMITATION, CNRI MAKES NO AND
+DISCLAIMS ANY REPRESENTATION OR WARRANTY OF MERCHANTABILITY OR FITNESS
+FOR ANY PARTICULAR PURPOSE OR THAT THE USE OF PYTHON 1.6.1 WILL NOT
+INFRINGE ANY THIRD PARTY RIGHTS.
+
+5. CNRI SHALL NOT BE LIABLE TO LICENSEE OR ANY OTHER USERS OF PYTHON
+1.6.1 FOR ANY INCIDENTAL, SPECIAL, OR CONSEQUENTIAL DAMAGES OR LOSS AS
+A RESULT OF MODIFYING, DISTRIBUTING, OR OTHERWISE USING PYTHON 1.6.1,
+OR ANY DERIVATIVE THEREOF, EVEN IF ADVISED OF THE POSSIBILITY THEREOF.
+
+6. This License Agreement will automatically terminate upon a material
+breach of its terms and conditions.
+
+7. This License Agreement shall be governed by the federal
+intellectual property law of the United States, including without
+limitation the federal copyright law, and, to the extent such
+U.S. federal law does not apply, by the law of the Commonwealth of
+Virginia, excluding Virginia's conflict of law provisions.
+Notwithstanding the foregoing, with regard to derivative works based
+on Python 1.6.1 that incorporate non-separable material that was
+previously distributed under the GNU General Public License (GPL), the
+law of the Commonwealth of Virginia shall govern this License
+Agreement only as to issues arising under or with respect to
+Paragraphs 4, 5, and 7 of this License Agreement.  Nothing in this
+License Agreement shall be deemed to create any relationship of
+agency, partnership, or joint venture between CNRI and Licensee.  This
+License Agreement does not grant permission to use CNRI trademarks or
+trade name in a trademark sense to endorse or promote products or
+services of Licensee, or any third party.
+
+8. By clicking on the "ACCEPT" button where indicated, or by copying,
+installing or otherwise using Python 1.6.1, Licensee agrees to be
+bound by the terms and conditions of this License Agreement.
+
+        ACCEPT
+
+
+CWI LICENSE AGREEMENT FOR PYTHON 0.9.0 THROUGH 1.2
+--------------------------------------------------
+
+Copyright (c) 1991 - 1995, Stichting Mathematisch Centrum Amsterdam,
+The Netherlands.  All rights reserved.
+
+Permission to use, copy, modify, and distribute this software and its
+documentation for any purpose and without fee is hereby granted,
+provided that the above copyright notice appear in all copies and that
+both that copyright notice and this permission notice appear in
+supporting documentation, and that the name of Stichting Mathematisch
+Centrum or CWI not be used in advertising or publicity pertaining to
+distribution of the software without specific, written prior
+permission.
+
+STICHTING MATHEMATISCH CENTRUM DISCLAIMS ALL WARRANTIES WITH REGARD TO
+THIS SOFTWARE, INCLUDING ALL IMPLIED WARRANTIES OF MERCHANTABILITY AND
+FITNESS, IN NO EVENT SHALL STICHTING MATHEMATISCH CENTRUM BE LIABLE
+FOR ANY SPECIAL, INDIRECT OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
+ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT
+OF OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+
+------------------------------------------------------------------------------------
+for drools-util/src/main/java/org/drools/util/StringUtils.java
+
+Licensed under the Apache License, Version 2.0 (the "License");

--- a/LICENSE
+++ b/LICENSE
@@ -659,5 +659,6 @@ OF OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
 
 ------------------------------------------------------------------------------------
 for drools-util/src/main/java/org/drools/util/StringUtils.java
+    Borrowed from Spring
 
 Licensed under the Apache License, Version 2.0 (the "License");

--- a/drools-drl/drools-drl-parser-tests/src/test/resources/org/drools/drl/parser/antlr4/expander_multiple_constraints.dslr
+++ b/drools-drl/drools-drl-parser-tests/src/test/resources/org/drools/drl/parser/antlr4/expander_multiple_constraints.dslr
@@ -1,3 +1,21 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
 //created on: 13/04/2006
 package mydsl
 

--- a/drools-drl/drools-drl-parser-tests/src/test/resources/org/drools/drl/parser/antlr4/expander_multiple_constraints_flush.dslr
+++ b/drools-drl/drools-drl-parser-tests/src/test/resources/org/drools/drl/parser/antlr4/expander_multiple_constraints_flush.dslr
@@ -1,3 +1,21 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
 //created on: 13/04/2006
 package mydsl
 

--- a/drools-drl/drools-drl-parser-tests/src/test/resources/org/drools/drl/parser/antlr4/expander_spread_lines.dslr
+++ b/drools-drl/drools-drl-parser-tests/src/test/resources/org/drools/drl/parser/antlr4/expander_spread_lines.dslr
@@ -1,3 +1,21 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
 //created on: 13/04/2006
 package mydsl
 

--- a/drools-drl/drools-drl-parser/src/main/java/org/drools/drl/parser/antlr4/ParserHelper.java
+++ b/drools-drl/drools-drl-parser/src/main/java/org/drools/drl/parser/antlr4/ParserHelper.java
@@ -16,19 +16,6 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-/*
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *      http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
 package org.drools.drl.parser.antlr4;
 
 import java.util.ArrayDeque;

--- a/drools-drlonyaml-parent/drools-drlonyaml-cli-tests/src/test/resources/batch_drl_files/.gitignore
+++ b/drools-drlonyaml-parent/drools-drlonyaml-cli-tests/src/test/resources/batch_drl_files/.gitignore
@@ -1,1 +1,18 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
 *.yml

--- a/drools-model/drools-canonical-model/src/main/java/org/drools/model/bitmask/OpenBitSet.java
+++ b/drools-model/drools-canonical-model/src/main/java/org/drools/model/bitmask/OpenBitSet.java
@@ -1,21 +1,3 @@
-/**
- * Licensed to the Apache Software Foundation (ASF) under one
- * or more contributor license agreements.  See the NOTICE file
- * distributed with this work for additional information
- * regarding copyright ownership.  The ASF licenses this file
- * to you under the Apache License, Version 2.0 (the
- * "License"); you may not use this file except in compliance
- * with the License.  You may obtain a copy of the License at
- *
- *   http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing,
- * software distributed under the License is distributed on an
- * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
- * KIND, either express or implied.  See the License for the
- * specific language governing permissions and limitations
- * under the License.
- */
 package org.drools.model.bitmask;
 
 import java.lang.reflect.Field;

--- a/drools-util/src/main/java/org/drools/util/bitmask/OpenBitSet.java
+++ b/drools-util/src/main/java/org/drools/util/bitmask/OpenBitSet.java
@@ -1,22 +1,3 @@
-/**
- * Licensed to the Apache Software Foundation (ASF) under one
- * or more contributor license agreements.  See the NOTICE file
- * distributed with this work for additional information
- * regarding copyright ownership.  The ASF licenses this file
- * to you under the Apache License, Version 2.0 (the
- * "License"); you may not use this file except in compliance
- * with the License.  You may obtain a copy of the License at
- *
- *   http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing,
- * software distributed under the License is distributed on an
- * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
- * KIND, either express or implied.  See the License for the
- * specific language governing permissions and limitations
- * under the License.
- */
-
 package org.drools.util.bitmask;
 
 import java.lang.reflect.Field;

--- a/kie-dmn/kie-dmn-core/src/test/resources/org/kie/dmn/core/0004-simpletable-U-noinputvalues.dmn
+++ b/kie-dmn/kie-dmn-core/src/test/resources/org/kie/dmn/core/0004-simpletable-U-noinputvalues.dmn
@@ -17,20 +17,6 @@
   specific language governing permissions and limitations
   under the License.
   -->
-
-<!--
-  ~ Licensed under the Apache License, Version 2.0 (the "License");
-  ~ you may not use this file except in compliance with the License.
-  ~ You may obtain a copy of the License at
-  ~
-  ~       http://www.apache.org/licenses/LICENSE-2.0
-  ~
-  ~ Unless required by applicable law or agreed to in writing, software
-  ~ distributed under the License is distributed on an "AS IS" BASIS,
-  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-  ~ See the License for the specific language governing permissions and
-  ~ limitations under the License.
-  -->
 <semantic:definitions xmlns="https://github.com/kiegroup/kie-dmn"
                       xmlns:dc="http://www.omg.org/spec/DMN/20180521/DC/"
                       xmlns:di="http://www.omg.org/spec/DMN/20180521/DI/"

--- a/kie-dmn/kie-dmn-core/src/test/resources/org/kie/dmn/core/0004-simpletable-U.dmn
+++ b/kie-dmn/kie-dmn-core/src/test/resources/org/kie/dmn/core/0004-simpletable-U.dmn
@@ -17,20 +17,6 @@
   specific language governing permissions and limitations
   under the License.
   -->
-
-<!--
-  ~ Licensed under the Apache License, Version 2.0 (the "License");
-  ~ you may not use this file except in compliance with the License.
-  ~ You may obtain a copy of the License at
-  ~
-  ~       http://www.apache.org/licenses/LICENSE-2.0
-  ~
-  ~ Unless required by applicable law or agreed to in writing, software
-  ~ distributed under the License is distributed on an "AS IS" BASIS,
-  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-  ~ See the License for the specific language governing permissions and
-  ~ limitations under the License.
-  -->
 <semantic:definitions xmlns="https://github.com/kiegroup/kie-dmn"
                       xmlns:dc="http://www.omg.org/spec/DMN/20180521/DC/"
                       xmlns:di="http://www.omg.org/spec/DMN/20180521/DI/"

--- a/kie-dmn/kie-dmn-core/src/test/resources/org/kie/dmn/core/0008-LX-arithmetic.dmn
+++ b/kie-dmn/kie-dmn-core/src/test/resources/org/kie/dmn/core/0008-LX-arithmetic.dmn
@@ -17,20 +17,6 @@
   specific language governing permissions and limitations
   under the License.
   -->
-
-<!--
-  ~ Licensed under the Apache License, Version 2.0 (the "License");
-  ~ you may not use this file except in compliance with the License.
-  ~ You may obtain a copy of the License at
-  ~
-  ~       http://www.apache.org/licenses/LICENSE-2.0
-  ~
-  ~ Unless required by applicable law or agreed to in writing, software
-  ~ distributed under the License is distributed on an "AS IS" BASIS,
-  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-  ~ See the License for the specific language governing permissions and
-  ~ limitations under the License.
-  -->
 <semantic:definitions xmlns="https://github.com/kiegroup/kie-dmn"
                       xmlns:dc="http://www.omg.org/spec/DMN/20180521/DC/"
                       xmlns:di="http://www.omg.org/spec/DMN/20180521/DI/"

--- a/kie-dmn/kie-dmn-core/src/test/resources/org/kie/dmn/core/DTABLE_NON_PRIORITY_MISSING_OUTVALS.dmn
+++ b/kie-dmn/kie-dmn-core/src/test/resources/org/kie/dmn/core/DTABLE_NON_PRIORITY_MISSING_OUTVALS.dmn
@@ -17,20 +17,6 @@
   specific language governing permissions and limitations
   under the License.
   -->
-
-<!--
-  ~ Licensed under the Apache License, Version 2.0 (the "License");
-  ~ you may not use this file except in compliance with the License.
-  ~ You may obtain a copy of the License at
-  ~
-  ~       http://www.apache.org/licenses/LICENSE-2.0
-  ~
-  ~ Unless required by applicable law or agreed to in writing, software
-  ~ distributed under the License is distributed on an "AS IS" BASIS,
-  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-  ~ See the License for the specific language governing permissions and
-  ~ limitations under the License.
-  -->
 <semantic:definitions xmlns="https://github.com/kiegroup/kie-dmn"
                       xmlns:dc="http://www.omg.org/spec/DMN/20180521/DC/"
                       xmlns:di="http://www.omg.org/spec/DMN/20180521/DI/"

--- a/kie-dmn/kie-dmn-core/src/test/resources/org/kie/dmn/core/DTABLE_PRIORITY_MISSING_OUTVALS.dmn
+++ b/kie-dmn/kie-dmn-core/src/test/resources/org/kie/dmn/core/DTABLE_PRIORITY_MISSING_OUTVALS.dmn
@@ -17,20 +17,6 @@
   specific language governing permissions and limitations
   under the License.
   -->
-
-<!--
-  ~ Licensed under the Apache License, Version 2.0 (the "License");
-  ~ you may not use this file except in compliance with the License.
-  ~ You may obtain a copy of the License at
-  ~
-  ~       http://www.apache.org/licenses/LICENSE-2.0
-  ~
-  ~ Unless required by applicable law or agreed to in writing, software
-  ~ distributed under the License is distributed on an "AS IS" BASIS,
-  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-  ~ See the License for the specific language governing permissions and
-  ~ limitations under the License.
-  -->
 <semantic:definitions xmlns="https://github.com/kiegroup/kie-dmn"
                       xmlns:dc="http://www.omg.org/spec/DMN/20180521/DC/"
                       xmlns:di="http://www.omg.org/spec/DMN/20180521/DI/"

--- a/kie-dmn/kie-dmn-core/src/test/resources/org/kie/dmn/core/NotificationsTest2.dmn
+++ b/kie-dmn/kie-dmn-core/src/test/resources/org/kie/dmn/core/NotificationsTest2.dmn
@@ -17,20 +17,6 @@
   specific language governing permissions and limitations
   under the License.
   -->
-
-<!--
-  ~ Licensed under the Apache License, Version 2.0 (the "License");
-  ~ you may not use this file except in compliance with the License.
-  ~ You may obtain a copy of the License at
-  ~
-  ~       http://www.apache.org/licenses/LICENSE-2.0
-  ~
-  ~ Unless required by applicable law or agreed to in writing, software
-  ~ distributed under the License is distributed on an "AS IS" BASIS,
-  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-  ~ See the License for the specific language governing permissions and
-  ~ limitations under the License.
-  -->
 <semantic:definitions xmlns="https://github.com/kiegroup/kie-dmn"
                       xmlns:dc="http://www.omg.org/spec/DMN/20180521/DC/"
                       xmlns:di="http://www.omg.org/spec/DMN/20180521/DI/"

--- a/kie-dmn/kie-dmn-legacy-tests/src/test/resources/org/kie/dmn/legacy/tests/core/v1_1/0001-input-data-item-def.dmn
+++ b/kie-dmn/kie-dmn-legacy-tests/src/test/resources/org/kie/dmn/legacy/tests/core/v1_1/0001-input-data-item-def.dmn
@@ -19,25 +19,6 @@
   -->
 
 <!-- THIS IS AN OLD VERSION OF DMN EXAMPLE/TEST, PLEASE USE THE MORE RECENT VERSION -->
-<!--
-  ~ Licensed to the Apache Software Foundation (ASF) under one
-  ~ or more contributor license agreements.  See the NOTICE file
-  ~ distributed with this work for additional information
-  ~ regarding copyright ownership.  The ASF licenses this file
-  ~ to you under the Apache License, Version 2.0 (the
-  ~ "License"); you may not use this file except in compliance
-  ~ with the License.  You may obtain a copy of the License at
-  ~
-  ~   http://www.apache.org/licenses/LICENSE-2.0
-  ~
-  ~ Unless required by applicable law or agreed to in writing,
-  ~ software distributed under the License is distributed on an
-  ~ "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
-  ~ KIND, either express or implied.  See the License for the
-  ~ specific language governing permissions and limitations
-  ~ under the License.
-  -->
-
 <definitions id="0001-input-data-string" name="0001-input-data-string"
              namespace="https://github.com/kiegroup/kie-dmn"
              xmlns="http://www.omg.org/spec/DMN/20151101/dmn.xsd"

--- a/kie-dmn/kie-dmn-legacy-tests/src/test/resources/org/kie/dmn/legacy/tests/core/v1_1/0001-input-data-string-artificial-attributes.dmn
+++ b/kie-dmn/kie-dmn-legacy-tests/src/test/resources/org/kie/dmn/legacy/tests/core/v1_1/0001-input-data-string-artificial-attributes.dmn
@@ -19,25 +19,6 @@
   -->
 
 <!-- THIS IS AN OLD VERSION OF DMN EXAMPLE/TEST, PLEASE USE THE MORE RECENT VERSION -->
-<!--
-  ~ Licensed to the Apache Software Foundation (ASF) under one
-  ~ or more contributor license agreements.  See the NOTICE file
-  ~ distributed with this work for additional information
-  ~ regarding copyright ownership.  The ASF licenses this file
-  ~ to you under the Apache License, Version 2.0 (the
-  ~ "License"); you may not use this file except in compliance
-  ~ with the License.  You may obtain a copy of the License at
-  ~
-  ~   http://www.apache.org/licenses/LICENSE-2.0
-  ~
-  ~ Unless required by applicable law or agreed to in writing,
-  ~ software distributed under the License is distributed on an
-  ~ "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
-  ~ KIND, either express or implied.  See the License for the
-  ~ specific language governing permissions and limitations
-  ~ under the License.
-  -->
-
 <definitions id="_0001-input-data-string" name="0001-input-data-string"
     namespace="https://github.com/kiegroup/drools"
     xmlns="http://www.omg.org/spec/DMN/20151101/dmn.xsd"

--- a/kie-dmn/kie-dmn-legacy-tests/src/test/resources/org/kie/dmn/legacy/tests/core/v1_1/0001-input-data-string-itIT.dmn
+++ b/kie-dmn/kie-dmn-legacy-tests/src/test/resources/org/kie/dmn/legacy/tests/core/v1_1/0001-input-data-string-itIT.dmn
@@ -19,25 +19,6 @@
   -->
 
 <!-- THIS IS AN OLD VERSION OF DMN EXAMPLE/TEST, PLEASE USE THE MORE RECENT VERSION -->
-<!--
-  ~ Licensed to the Apache Software Foundation (ASF) under one
-  ~ or more contributor license agreements.  See the NOTICE file
-  ~ distributed with this work for additional information
-  ~ regarding copyright ownership.  The ASF licenses this file
-  ~ to you under the Apache License, Version 2.0 (the
-  ~ "License"); you may not use this file except in compliance
-  ~ with the License.  You may obtain a copy of the License at
-  ~
-  ~   http://www.apache.org/licenses/LICENSE-2.0
-  ~
-  ~ Unless required by applicable law or agreed to in writing,
-  ~ software distributed under the License is distributed on an
-  ~ "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
-  ~ KIND, either express or implied.  See the License for the
-  ~ specific language governing permissions and limitations
-  ~ under the License.
-  -->
-
 <definitions id="_0001-input-data-string" name="_0001-input-data-string"
              namespace="https://github.com/kiegroup/drools/kie-dmn"
              xmlns="http://www.omg.org/spec/DMN/20151101/dmn.xsd"

--- a/kie-dmn/kie-dmn-legacy-tests/src/test/resources/org/kie/dmn/legacy/tests/core/v1_1/0001-input-data-string.dmn
+++ b/kie-dmn/kie-dmn-legacy-tests/src/test/resources/org/kie/dmn/legacy/tests/core/v1_1/0001-input-data-string.dmn
@@ -19,25 +19,6 @@
   -->
 
 <!-- THIS IS AN OLD VERSION OF DMN EXAMPLE/TEST, PLEASE USE THE MORE RECENT VERSION -->
-<!--
-  ~ Licensed to the Apache Software Foundation (ASF) under one
-  ~ or more contributor license agreements.  See the NOTICE file
-  ~ distributed with this work for additional information
-  ~ regarding copyright ownership.  The ASF licenses this file
-  ~ to you under the Apache License, Version 2.0 (the
-  ~ "License"); you may not use this file except in compliance
-  ~ with the License.  You may obtain a copy of the License at
-  ~
-  ~   http://www.apache.org/licenses/LICENSE-2.0
-  ~
-  ~ Unless required by applicable law or agreed to in writing,
-  ~ software distributed under the License is distributed on an
-  ~ "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
-  ~ KIND, either express or implied.  See the License for the
-  ~ specific language governing permissions and limitations
-  ~ under the License.
-  -->
-
 <definitions id="_0001-input-data-string" name="_0001-input-data-string"
              namespace="https://github.com/kiegroup/drools/kie-dmn"
              xmlns="http://www.omg.org/spec/DMN/20151101/dmn.xsd"

--- a/kie-dmn/kie-dmn-legacy-tests/src/test/resources/org/kie/dmn/legacy/tests/core/v1_1/0002-input-data-number.dmn
+++ b/kie-dmn/kie-dmn-legacy-tests/src/test/resources/org/kie/dmn/legacy/tests/core/v1_1/0002-input-data-number.dmn
@@ -19,25 +19,6 @@
   -->
 
 <!-- THIS IS AN OLD VERSION OF DMN EXAMPLE/TEST, PLEASE USE THE MORE RECENT VERSION -->
-<!--
-  ~ Licensed to the Apache Software Foundation (ASF) under one
-  ~ or more contributor license agreements.  See the NOTICE file
-  ~ distributed with this work for additional information
-  ~ regarding copyright ownership.  The ASF licenses this file
-  ~ to you under the Apache License, Version 2.0 (the
-  ~ "License"); you may not use this file except in compliance
-  ~ with the License.  You may obtain a copy of the License at
-  ~
-  ~   http://www.apache.org/licenses/LICENSE-2.0
-  ~
-  ~ Unless required by applicable law or agreed to in writing,
-  ~ software distributed under the License is distributed on an
-  ~ "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
-  ~ KIND, either express or implied.  See the License for the
-  ~ specific language governing permissions and limitations
-  ~ under the License.
-  -->
-
 <definitions id="_0002-input-data-number" name="0002-input-data-number"
              namespace="https://github.com/kiegroup/kie-dmn"
              xmlns="http://www.omg.org/spec/DMN/20151101/dmn.xsd"

--- a/kie-dmn/kie-dmn-legacy-tests/src/test/resources/org/kie/dmn/legacy/tests/core/v1_1/0003-input-data-string-allowed-values.dmn
+++ b/kie-dmn/kie-dmn-legacy-tests/src/test/resources/org/kie/dmn/legacy/tests/core/v1_1/0003-input-data-string-allowed-values.dmn
@@ -19,25 +19,6 @@
   -->
 
 <!-- THIS IS AN OLD VERSION OF DMN EXAMPLE/TEST, PLEASE USE THE MORE RECENT VERSION -->
-<!--
-  ~ Licensed to the Apache Software Foundation (ASF) under one
-  ~ or more contributor license agreements.  See the NOTICE file
-  ~ distributed with this work for additional information
-  ~ regarding copyright ownership.  The ASF licenses this file
-  ~ to you under the Apache License, Version 2.0 (the
-  ~ "License"); you may not use this file except in compliance
-  ~ with the License.  You may obtain a copy of the License at
-  ~
-  ~   http://www.apache.org/licenses/LICENSE-2.0
-  ~
-  ~ Unless required by applicable law or agreed to in writing,
-  ~ software distributed under the License is distributed on an
-  ~ "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
-  ~ KIND, either express or implied.  See the License for the
-  ~ specific language governing permissions and limitations
-  ~ under the License.
-  -->
-
 <definitions id="_0003-input-data-string-allowed-values" name="0003-input-data-string-allowed-values"
              namespace="https://github.com/kiegroup/kie-dmn"
              xmlns="http://www.omg.org/spec/DMN/20151101/dmn.xsd"

--- a/kie-dmn/kie-dmn-legacy-tests/src/test/resources/org/kie/dmn/legacy/tests/core/v1_1/0004-simpletable-A-non-equal.dmn
+++ b/kie-dmn/kie-dmn-legacy-tests/src/test/resources/org/kie/dmn/legacy/tests/core/v1_1/0004-simpletable-A-non-equal.dmn
@@ -19,39 +19,6 @@
   -->
 
 <!-- THIS IS AN OLD VERSION OF DMN EXAMPLE/TEST, PLEASE USE THE MORE RECENT VERSION -->
-<!--
-  ~ Licensed to the Apache Software Foundation (ASF) under one
-  ~ or more contributor license agreements.  See the NOTICE file
-  ~ distributed with this work for additional information
-  ~ regarding copyright ownership.  The ASF licenses this file
-  ~ to you under the Apache License, Version 2.0 (the
-  ~ "License"); you may not use this file except in compliance
-  ~ with the License.  You may obtain a copy of the License at
-  ~
-  ~   http://www.apache.org/licenses/LICENSE-2.0
-  ~
-  ~ Unless required by applicable law or agreed to in writing,
-  ~ software distributed under the License is distributed on an
-  ~ "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
-  ~ KIND, either express or implied.  See the License for the
-  ~ specific language governing permissions and limitations
-  ~ under the License.
-  -->
-
-<!--
-  ~ Licensed under the Apache License, Version 2.0 (the "License");
-  ~ you may not use this file except in compliance with the License.
-  ~ You may obtain a copy of the License at
-  ~
-  ~       http://www.apache.org/licenses/LICENSE-2.0
-  ~
-  ~ Unless required by applicable law or agreed to in writing, software
-  ~ distributed under the License is distributed on an "AS IS" BASIS,
-  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-  ~ See the License for the specific language governing permissions and
-  ~ limitations under the License.
-  -->
-
 <definitions xmlns="http://www.omg.org/spec/DMN/20151101/dmn.xsd"
              xmlns:feel="http://www.omg.org/spec/FEEL/20140401"
              xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"

--- a/kie-dmn/kie-dmn-legacy-tests/src/test/resources/org/kie/dmn/legacy/tests/core/v1_1/0004-simpletable-A.dmn
+++ b/kie-dmn/kie-dmn-legacy-tests/src/test/resources/org/kie/dmn/legacy/tests/core/v1_1/0004-simpletable-A.dmn
@@ -19,39 +19,6 @@
   -->
 
 <!-- THIS IS AN OLD VERSION OF DMN EXAMPLE/TEST, PLEASE USE THE MORE RECENT VERSION -->
-<!--
-  ~ Licensed to the Apache Software Foundation (ASF) under one
-  ~ or more contributor license agreements.  See the NOTICE file
-  ~ distributed with this work for additional information
-  ~ regarding copyright ownership.  The ASF licenses this file
-  ~ to you under the Apache License, Version 2.0 (the
-  ~ "License"); you may not use this file except in compliance
-  ~ with the License.  You may obtain a copy of the License at
-  ~
-  ~   http://www.apache.org/licenses/LICENSE-2.0
-  ~
-  ~ Unless required by applicable law or agreed to in writing,
-  ~ software distributed under the License is distributed on an
-  ~ "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
-  ~ KIND, either express or implied.  See the License for the
-  ~ specific language governing permissions and limitations
-  ~ under the License.
-  -->
-
-<!--
-  ~ Licensed under the Apache License, Version 2.0 (the "License");
-  ~ you may not use this file except in compliance with the License.
-  ~ You may obtain a copy of the License at
-  ~
-  ~       http://www.apache.org/licenses/LICENSE-2.0
-  ~
-  ~ Unless required by applicable law or agreed to in writing, software
-  ~ distributed under the License is distributed on an "AS IS" BASIS,
-  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-  ~ See the License for the specific language governing permissions and
-  ~ limitations under the License.
-  -->
-
 <definitions xmlns="http://www.omg.org/spec/DMN/20151101/dmn.xsd"
              xmlns:feel="http://www.omg.org/spec/FEEL/20140401"
              xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"

--- a/kie-dmn/kie-dmn-legacy-tests/src/test/resources/org/kie/dmn/legacy/tests/core/v1_1/0004-simpletable-C-count.dmn
+++ b/kie-dmn/kie-dmn-legacy-tests/src/test/resources/org/kie/dmn/legacy/tests/core/v1_1/0004-simpletable-C-count.dmn
@@ -19,39 +19,6 @@
   -->
 
 <!-- THIS IS AN OLD VERSION OF DMN EXAMPLE/TEST, PLEASE USE THE MORE RECENT VERSION -->
-<!--
-  ~ Licensed to the Apache Software Foundation (ASF) under one
-  ~ or more contributor license agreements.  See the NOTICE file
-  ~ distributed with this work for additional information
-  ~ regarding copyright ownership.  The ASF licenses this file
-  ~ to you under the Apache License, Version 2.0 (the
-  ~ "License"); you may not use this file except in compliance
-  ~ with the License.  You may obtain a copy of the License at
-  ~
-  ~   http://www.apache.org/licenses/LICENSE-2.0
-  ~
-  ~ Unless required by applicable law or agreed to in writing,
-  ~ software distributed under the License is distributed on an
-  ~ "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
-  ~ KIND, either express or implied.  See the License for the
-  ~ specific language governing permissions and limitations
-  ~ under the License.
-  -->
-
-<!--
-  ~ Licensed under the Apache License, Version 2.0 (the "License");
-  ~ you may not use this file except in compliance with the License.
-  ~ You may obtain a copy of the License at
-  ~
-  ~       http://www.apache.org/licenses/LICENSE-2.0
-  ~
-  ~ Unless required by applicable law or agreed to in writing, software
-  ~ distributed under the License is distributed on an "AS IS" BASIS,
-  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-  ~ See the License for the specific language governing permissions and
-  ~ limitations under the License.
-  -->
-
 <definitions xmlns="http://www.omg.org/spec/DMN/20151101/dmn.xsd"
              xmlns:feel="http://www.omg.org/spec/FEEL/20140401"
              xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"

--- a/kie-dmn/kie-dmn-legacy-tests/src/test/resources/org/kie/dmn/legacy/tests/core/v1_1/0004-simpletable-C-max.dmn
+++ b/kie-dmn/kie-dmn-legacy-tests/src/test/resources/org/kie/dmn/legacy/tests/core/v1_1/0004-simpletable-C-max.dmn
@@ -19,39 +19,6 @@
   -->
 
 <!-- THIS IS AN OLD VERSION OF DMN EXAMPLE/TEST, PLEASE USE THE MORE RECENT VERSION -->
-<!--
-  ~ Licensed to the Apache Software Foundation (ASF) under one
-  ~ or more contributor license agreements.  See the NOTICE file
-  ~ distributed with this work for additional information
-  ~ regarding copyright ownership.  The ASF licenses this file
-  ~ to you under the Apache License, Version 2.0 (the
-  ~ "License"); you may not use this file except in compliance
-  ~ with the License.  You may obtain a copy of the License at
-  ~
-  ~   http://www.apache.org/licenses/LICENSE-2.0
-  ~
-  ~ Unless required by applicable law or agreed to in writing,
-  ~ software distributed under the License is distributed on an
-  ~ "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
-  ~ KIND, either express or implied.  See the License for the
-  ~ specific language governing permissions and limitations
-  ~ under the License.
-  -->
-
-<!--
-  ~ Licensed under the Apache License, Version 2.0 (the "License");
-  ~ you may not use this file except in compliance with the License.
-  ~ You may obtain a copy of the License at
-  ~
-  ~       http://www.apache.org/licenses/LICENSE-2.0
-  ~
-  ~ Unless required by applicable law or agreed to in writing, software
-  ~ distributed under the License is distributed on an "AS IS" BASIS,
-  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-  ~ See the License for the specific language governing permissions and
-  ~ limitations under the License.
-  -->
-
 <definitions xmlns="http://www.omg.org/spec/DMN/20151101/dmn.xsd"
              xmlns:feel="http://www.omg.org/spec/FEEL/20140401"
              xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"

--- a/kie-dmn/kie-dmn-legacy-tests/src/test/resources/org/kie/dmn/legacy/tests/core/v1_1/0004-simpletable-C-min.dmn
+++ b/kie-dmn/kie-dmn-legacy-tests/src/test/resources/org/kie/dmn/legacy/tests/core/v1_1/0004-simpletable-C-min.dmn
@@ -19,39 +19,6 @@
   -->
 
 <!-- THIS IS AN OLD VERSION OF DMN EXAMPLE/TEST, PLEASE USE THE MORE RECENT VERSION -->
-<!--
-  ~ Licensed to the Apache Software Foundation (ASF) under one
-  ~ or more contributor license agreements.  See the NOTICE file
-  ~ distributed with this work for additional information
-  ~ regarding copyright ownership.  The ASF licenses this file
-  ~ to you under the Apache License, Version 2.0 (the
-  ~ "License"); you may not use this file except in compliance
-  ~ with the License.  You may obtain a copy of the License at
-  ~
-  ~   http://www.apache.org/licenses/LICENSE-2.0
-  ~
-  ~ Unless required by applicable law or agreed to in writing,
-  ~ software distributed under the License is distributed on an
-  ~ "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
-  ~ KIND, either express or implied.  See the License for the
-  ~ specific language governing permissions and limitations
-  ~ under the License.
-  -->
-
-<!--
-  ~ Licensed under the Apache License, Version 2.0 (the "License");
-  ~ you may not use this file except in compliance with the License.
-  ~ You may obtain a copy of the License at
-  ~
-  ~       http://www.apache.org/licenses/LICENSE-2.0
-  ~
-  ~ Unless required by applicable law or agreed to in writing, software
-  ~ distributed under the License is distributed on an "AS IS" BASIS,
-  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-  ~ See the License for the specific language governing permissions and
-  ~ limitations under the License.
-  -->
-
 <definitions xmlns="http://www.omg.org/spec/DMN/20151101/dmn.xsd"
              xmlns:feel="http://www.omg.org/spec/FEEL/20140401"
              xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"

--- a/kie-dmn/kie-dmn-legacy-tests/src/test/resources/org/kie/dmn/legacy/tests/core/v1_1/0004-simpletable-C-sum-multiple-outputs.dmn
+++ b/kie-dmn/kie-dmn-legacy-tests/src/test/resources/org/kie/dmn/legacy/tests/core/v1_1/0004-simpletable-C-sum-multiple-outputs.dmn
@@ -19,39 +19,6 @@
   -->
 
 <!-- THIS IS AN OLD VERSION OF DMN EXAMPLE/TEST, PLEASE USE THE MORE RECENT VERSION -->
-<!--
-  ~ Licensed to the Apache Software Foundation (ASF) under one
-  ~ or more contributor license agreements.  See the NOTICE file
-  ~ distributed with this work for additional information
-  ~ regarding copyright ownership.  The ASF licenses this file
-  ~ to you under the Apache License, Version 2.0 (the
-  ~ "License"); you may not use this file except in compliance
-  ~ with the License.  You may obtain a copy of the License at
-  ~
-  ~   http://www.apache.org/licenses/LICENSE-2.0
-  ~
-  ~ Unless required by applicable law or agreed to in writing,
-  ~ software distributed under the License is distributed on an
-  ~ "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
-  ~ KIND, either express or implied.  See the License for the
-  ~ specific language governing permissions and limitations
-  ~ under the License.
-  -->
-
-<!--
-  ~ Licensed under the Apache License, Version 2.0 (the "License");
-  ~ you may not use this file except in compliance with the License.
-  ~ You may obtain a copy of the License at
-  ~
-  ~       http://www.apache.org/licenses/LICENSE-2.0
-  ~
-  ~ Unless required by applicable law or agreed to in writing, software
-  ~ distributed under the License is distributed on an "AS IS" BASIS,
-  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-  ~ See the License for the specific language governing permissions and
-  ~ limitations under the License.
-  -->
-
 <definitions xmlns="http://www.omg.org/spec/DMN/20151101/dmn.xsd"
              xmlns:feel="http://www.omg.org/spec/FEEL/20140401"
              xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"

--- a/kie-dmn/kie-dmn-legacy-tests/src/test/resources/org/kie/dmn/legacy/tests/core/v1_1/0004-simpletable-C-sum.dmn
+++ b/kie-dmn/kie-dmn-legacy-tests/src/test/resources/org/kie/dmn/legacy/tests/core/v1_1/0004-simpletable-C-sum.dmn
@@ -19,39 +19,6 @@
   -->
 
 <!-- THIS IS AN OLD VERSION OF DMN EXAMPLE/TEST, PLEASE USE THE MORE RECENT VERSION -->
-<!--
-  ~ Licensed to the Apache Software Foundation (ASF) under one
-  ~ or more contributor license agreements.  See the NOTICE file
-  ~ distributed with this work for additional information
-  ~ regarding copyright ownership.  The ASF licenses this file
-  ~ to you under the Apache License, Version 2.0 (the
-  ~ "License"); you may not use this file except in compliance
-  ~ with the License.  You may obtain a copy of the License at
-  ~
-  ~   http://www.apache.org/licenses/LICENSE-2.0
-  ~
-  ~ Unless required by applicable law or agreed to in writing,
-  ~ software distributed under the License is distributed on an
-  ~ "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
-  ~ KIND, either express or implied.  See the License for the
-  ~ specific language governing permissions and limitations
-  ~ under the License.
-  -->
-
-<!--
-  ~ Licensed under the Apache License, Version 2.0 (the "License");
-  ~ you may not use this file except in compliance with the License.
-  ~ You may obtain a copy of the License at
-  ~
-  ~       http://www.apache.org/licenses/LICENSE-2.0
-  ~
-  ~ Unless required by applicable law or agreed to in writing, software
-  ~ distributed under the License is distributed on an "AS IS" BASIS,
-  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-  ~ See the License for the specific language governing permissions and
-  ~ limitations under the License.
-  -->
-
 <definitions xmlns="http://www.omg.org/spec/DMN/20151101/dmn.xsd"
              xmlns:feel="http://www.omg.org/spec/FEEL/20140401"
              xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"

--- a/kie-dmn/kie-dmn-legacy-tests/src/test/resources/org/kie/dmn/legacy/tests/core/v1_1/0004-simpletable-C.dmn
+++ b/kie-dmn/kie-dmn-legacy-tests/src/test/resources/org/kie/dmn/legacy/tests/core/v1_1/0004-simpletable-C.dmn
@@ -19,39 +19,6 @@
   -->
 
 <!-- THIS IS AN OLD VERSION OF DMN EXAMPLE/TEST, PLEASE USE THE MORE RECENT VERSION -->
-<!--
-  ~ Licensed to the Apache Software Foundation (ASF) under one
-  ~ or more contributor license agreements.  See the NOTICE file
-  ~ distributed with this work for additional information
-  ~ regarding copyright ownership.  The ASF licenses this file
-  ~ to you under the Apache License, Version 2.0 (the
-  ~ "License"); you may not use this file except in compliance
-  ~ with the License.  You may obtain a copy of the License at
-  ~
-  ~   http://www.apache.org/licenses/LICENSE-2.0
-  ~
-  ~ Unless required by applicable law or agreed to in writing,
-  ~ software distributed under the License is distributed on an
-  ~ "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
-  ~ KIND, either express or implied.  See the License for the
-  ~ specific language governing permissions and limitations
-  ~ under the License.
-  -->
-
-<!--
-  ~ Licensed under the Apache License, Version 2.0 (the "License");
-  ~ you may not use this file except in compliance with the License.
-  ~ You may obtain a copy of the License at
-  ~
-  ~       http://www.apache.org/licenses/LICENSE-2.0
-  ~
-  ~ Unless required by applicable law or agreed to in writing, software
-  ~ distributed under the License is distributed on an "AS IS" BASIS,
-  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-  ~ See the License for the specific language governing permissions and
-  ~ limitations under the License.
-  -->
-
 <definitions xmlns="http://www.omg.org/spec/DMN/20151101/dmn.xsd"
              xmlns:feel="http://www.omg.org/spec/FEEL/20140401"
              xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"

--- a/kie-dmn/kie-dmn-legacy-tests/src/test/resources/org/kie/dmn/legacy/tests/core/v1_1/0004-simpletable-F.dmn
+++ b/kie-dmn/kie-dmn-legacy-tests/src/test/resources/org/kie/dmn/legacy/tests/core/v1_1/0004-simpletable-F.dmn
@@ -19,39 +19,6 @@
   -->
 
 <!-- THIS IS AN OLD VERSION OF DMN EXAMPLE/TEST, PLEASE USE THE MORE RECENT VERSION -->
-<!--
-  ~ Licensed to the Apache Software Foundation (ASF) under one
-  ~ or more contributor license agreements.  See the NOTICE file
-  ~ distributed with this work for additional information
-  ~ regarding copyright ownership.  The ASF licenses this file
-  ~ to you under the Apache License, Version 2.0 (the
-  ~ "License"); you may not use this file except in compliance
-  ~ with the License.  You may obtain a copy of the License at
-  ~
-  ~   http://www.apache.org/licenses/LICENSE-2.0
-  ~
-  ~ Unless required by applicable law or agreed to in writing,
-  ~ software distributed under the License is distributed on an
-  ~ "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
-  ~ KIND, either express or implied.  See the License for the
-  ~ specific language governing permissions and limitations
-  ~ under the License.
-  -->
-
-<!--
-  ~ Licensed under the Apache License, Version 2.0 (the "License");
-  ~ you may not use this file except in compliance with the License.
-  ~ You may obtain a copy of the License at
-  ~
-  ~       http://www.apache.org/licenses/LICENSE-2.0
-  ~
-  ~ Unless required by applicable law or agreed to in writing, software
-  ~ distributed under the License is distributed on an "AS IS" BASIS,
-  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-  ~ See the License for the specific language governing permissions and
-  ~ limitations under the License.
-  -->
-
 <definitions xmlns="http://www.omg.org/spec/DMN/20151101/dmn.xsd"
              xmlns:feel="http://www.omg.org/spec/FEEL/20140401"
              xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"

--- a/kie-dmn/kie-dmn-legacy-tests/src/test/resources/org/kie/dmn/legacy/tests/core/v1_1/0004-simpletable-O-multiple-outputs.dmn
+++ b/kie-dmn/kie-dmn-legacy-tests/src/test/resources/org/kie/dmn/legacy/tests/core/v1_1/0004-simpletable-O-multiple-outputs.dmn
@@ -19,39 +19,6 @@
   -->
 
 <!-- THIS IS AN OLD VERSION OF DMN EXAMPLE/TEST, PLEASE USE THE MORE RECENT VERSION -->
-<!--
-  ~ Licensed to the Apache Software Foundation (ASF) under one
-  ~ or more contributor license agreements.  See the NOTICE file
-  ~ distributed with this work for additional information
-  ~ regarding copyright ownership.  The ASF licenses this file
-  ~ to you under the Apache License, Version 2.0 (the
-  ~ "License"); you may not use this file except in compliance
-  ~ with the License.  You may obtain a copy of the License at
-  ~
-  ~   http://www.apache.org/licenses/LICENSE-2.0
-  ~
-  ~ Unless required by applicable law or agreed to in writing,
-  ~ software distributed under the License is distributed on an
-  ~ "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
-  ~ KIND, either express or implied.  See the License for the
-  ~ specific language governing permissions and limitations
-  ~ under the License.
-  -->
-
-<!--
-  ~ Licensed under the Apache License, Version 2.0 (the "License");
-  ~ you may not use this file except in compliance with the License.
-  ~ You may obtain a copy of the License at
-  ~
-  ~       http://www.apache.org/licenses/LICENSE-2.0
-  ~
-  ~ Unless required by applicable law or agreed to in writing, software
-  ~ distributed under the License is distributed on an "AS IS" BASIS,
-  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-  ~ See the License for the specific language governing permissions and
-  ~ limitations under the License.
-  -->
-
 <definitions xmlns="http://www.omg.org/spec/DMN/20151101/dmn.xsd"
              xmlns:feel="http://www.omg.org/spec/FEEL/20140401"
              xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"

--- a/kie-dmn/kie-dmn-legacy-tests/src/test/resources/org/kie/dmn/legacy/tests/core/v1_1/0004-simpletable-O.dmn
+++ b/kie-dmn/kie-dmn-legacy-tests/src/test/resources/org/kie/dmn/legacy/tests/core/v1_1/0004-simpletable-O.dmn
@@ -19,39 +19,6 @@
   -->
 
 <!-- THIS IS AN OLD VERSION OF DMN EXAMPLE/TEST, PLEASE USE THE MORE RECENT VERSION -->
-<!--
-  ~ Licensed to the Apache Software Foundation (ASF) under one
-  ~ or more contributor license agreements.  See the NOTICE file
-  ~ distributed with this work for additional information
-  ~ regarding copyright ownership.  The ASF licenses this file
-  ~ to you under the Apache License, Version 2.0 (the
-  ~ "License"); you may not use this file except in compliance
-  ~ with the License.  You may obtain a copy of the License at
-  ~
-  ~   http://www.apache.org/licenses/LICENSE-2.0
-  ~
-  ~ Unless required by applicable law or agreed to in writing,
-  ~ software distributed under the License is distributed on an
-  ~ "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
-  ~ KIND, either express or implied.  See the License for the
-  ~ specific language governing permissions and limitations
-  ~ under the License.
-  -->
-
-<!--
-  ~ Licensed under the Apache License, Version 2.0 (the "License");
-  ~ you may not use this file except in compliance with the License.
-  ~ You may obtain a copy of the License at
-  ~
-  ~       http://www.apache.org/licenses/LICENSE-2.0
-  ~
-  ~ Unless required by applicable law or agreed to in writing, software
-  ~ distributed under the License is distributed on an "AS IS" BASIS,
-  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-  ~ See the License for the specific language governing permissions and
-  ~ limitations under the License.
-  -->
-
 <definitions xmlns="http://www.omg.org/spec/DMN/20151101/dmn.xsd"
              xmlns:feel="http://www.omg.org/spec/FEEL/20140401"
              xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"

--- a/kie-dmn/kie-dmn-legacy-tests/src/test/resources/org/kie/dmn/legacy/tests/core/v1_1/0004-simpletable-P-multiple-outputs-wrong-output.dmn
+++ b/kie-dmn/kie-dmn-legacy-tests/src/test/resources/org/kie/dmn/legacy/tests/core/v1_1/0004-simpletable-P-multiple-outputs-wrong-output.dmn
@@ -19,39 +19,6 @@
   -->
 
 <!-- THIS IS AN OLD VERSION OF DMN EXAMPLE/TEST, PLEASE USE THE MORE RECENT VERSION -->
-<!--
-  ~ Licensed to the Apache Software Foundation (ASF) under one
-  ~ or more contributor license agreements.  See the NOTICE file
-  ~ distributed with this work for additional information
-  ~ regarding copyright ownership.  The ASF licenses this file
-  ~ to you under the Apache License, Version 2.0 (the
-  ~ "License"); you may not use this file except in compliance
-  ~ with the License.  You may obtain a copy of the License at
-  ~
-  ~   http://www.apache.org/licenses/LICENSE-2.0
-  ~
-  ~ Unless required by applicable law or agreed to in writing,
-  ~ software distributed under the License is distributed on an
-  ~ "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
-  ~ KIND, either express or implied.  See the License for the
-  ~ specific language governing permissions and limitations
-  ~ under the License.
-  -->
-
-<!--
-  ~ Licensed under the Apache License, Version 2.0 (the "License");
-  ~ you may not use this file except in compliance with the License.
-  ~ You may obtain a copy of the License at
-  ~
-  ~       http://www.apache.org/licenses/LICENSE-2.0
-  ~
-  ~ Unless required by applicable law or agreed to in writing, software
-  ~ distributed under the License is distributed on an "AS IS" BASIS,
-  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-  ~ See the License for the specific language governing permissions and
-  ~ limitations under the License.
-  -->
-
 <definitions xmlns="http://www.omg.org/spec/DMN/20151101/dmn.xsd"
              xmlns:feel="http://www.omg.org/spec/FEEL/20140401"
              xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"

--- a/kie-dmn/kie-dmn-legacy-tests/src/test/resources/org/kie/dmn/legacy/tests/core/v1_1/0004-simpletable-P-multiple-outputs.dmn
+++ b/kie-dmn/kie-dmn-legacy-tests/src/test/resources/org/kie/dmn/legacy/tests/core/v1_1/0004-simpletable-P-multiple-outputs.dmn
@@ -19,39 +19,6 @@
   -->
 
 <!-- THIS IS AN OLD VERSION OF DMN EXAMPLE/TEST, PLEASE USE THE MORE RECENT VERSION -->
-<!--
-  ~ Licensed to the Apache Software Foundation (ASF) under one
-  ~ or more contributor license agreements.  See the NOTICE file
-  ~ distributed with this work for additional information
-  ~ regarding copyright ownership.  The ASF licenses this file
-  ~ to you under the Apache License, Version 2.0 (the
-  ~ "License"); you may not use this file except in compliance
-  ~ with the License.  You may obtain a copy of the License at
-  ~
-  ~   http://www.apache.org/licenses/LICENSE-2.0
-  ~
-  ~ Unless required by applicable law or agreed to in writing,
-  ~ software distributed under the License is distributed on an
-  ~ "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
-  ~ KIND, either express or implied.  See the License for the
-  ~ specific language governing permissions and limitations
-  ~ under the License.
-  -->
-
-<!--
-  ~ Licensed under the Apache License, Version 2.0 (the "License");
-  ~ you may not use this file except in compliance with the License.
-  ~ You may obtain a copy of the License at
-  ~
-  ~       http://www.apache.org/licenses/LICENSE-2.0
-  ~
-  ~ Unless required by applicable law or agreed to in writing, software
-  ~ distributed under the License is distributed on an "AS IS" BASIS,
-  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-  ~ See the License for the specific language governing permissions and
-  ~ limitations under the License.
-  -->
-
 <definitions xmlns="http://www.omg.org/spec/DMN/20151101/dmn.xsd"
              xmlns:feel="http://www.omg.org/spec/FEEL/20140401"
              xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"

--- a/kie-dmn/kie-dmn-legacy-tests/src/test/resources/org/kie/dmn/legacy/tests/core/v1_1/0004-simpletable-P.dmn
+++ b/kie-dmn/kie-dmn-legacy-tests/src/test/resources/org/kie/dmn/legacy/tests/core/v1_1/0004-simpletable-P.dmn
@@ -19,39 +19,6 @@
   -->
 
 <!-- THIS IS AN OLD VERSION OF DMN EXAMPLE/TEST, PLEASE USE THE MORE RECENT VERSION -->
-<!--
-  ~ Licensed to the Apache Software Foundation (ASF) under one
-  ~ or more contributor license agreements.  See the NOTICE file
-  ~ distributed with this work for additional information
-  ~ regarding copyright ownership.  The ASF licenses this file
-  ~ to you under the Apache License, Version 2.0 (the
-  ~ "License"); you may not use this file except in compliance
-  ~ with the License.  You may obtain a copy of the License at
-  ~
-  ~   http://www.apache.org/licenses/LICENSE-2.0
-  ~
-  ~ Unless required by applicable law or agreed to in writing,
-  ~ software distributed under the License is distributed on an
-  ~ "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
-  ~ KIND, either express or implied.  See the License for the
-  ~ specific language governing permissions and limitations
-  ~ under the License.
-  -->
-
-<!--
-  ~ Licensed under the Apache License, Version 2.0 (the "License");
-  ~ you may not use this file except in compliance with the License.
-  ~ You may obtain a copy of the License at
-  ~
-  ~       http://www.apache.org/licenses/LICENSE-2.0
-  ~
-  ~ Unless required by applicable law or agreed to in writing, software
-  ~ distributed under the License is distributed on an "AS IS" BASIS,
-  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-  ~ See the License for the specific language governing permissions and
-  ~ limitations under the License.
-  -->
-
 <definitions xmlns="http://www.omg.org/spec/DMN/20151101/dmn.xsd"
              xmlns:feel="http://www.omg.org/spec/FEEL/20140401"
              xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"

--- a/kie-dmn/kie-dmn-legacy-tests/src/test/resources/org/kie/dmn/legacy/tests/core/v1_1/0004-simpletable-R.dmn
+++ b/kie-dmn/kie-dmn-legacy-tests/src/test/resources/org/kie/dmn/legacy/tests/core/v1_1/0004-simpletable-R.dmn
@@ -19,39 +19,6 @@
   -->
 
 <!-- THIS IS AN OLD VERSION OF DMN EXAMPLE/TEST, PLEASE USE THE MORE RECENT VERSION -->
-<!--
-  ~ Licensed to the Apache Software Foundation (ASF) under one
-  ~ or more contributor license agreements.  See the NOTICE file
-  ~ distributed with this work for additional information
-  ~ regarding copyright ownership.  The ASF licenses this file
-  ~ to you under the Apache License, Version 2.0 (the
-  ~ "License"); you may not use this file except in compliance
-  ~ with the License.  You may obtain a copy of the License at
-  ~
-  ~   http://www.apache.org/licenses/LICENSE-2.0
-  ~
-  ~ Unless required by applicable law or agreed to in writing,
-  ~ software distributed under the License is distributed on an
-  ~ "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
-  ~ KIND, either express or implied.  See the License for the
-  ~ specific language governing permissions and limitations
-  ~ under the License.
-  -->
-
-<!--
-  ~ Licensed under the Apache License, Version 2.0 (the "License");
-  ~ you may not use this file except in compliance with the License.
-  ~ You may obtain a copy of the License at
-  ~
-  ~       http://www.apache.org/licenses/LICENSE-2.0
-  ~
-  ~ Unless required by applicable law or agreed to in writing, software
-  ~ distributed under the License is distributed on an "AS IS" BASIS,
-  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-  ~ See the License for the specific language governing permissions and
-  ~ limitations under the License.
-  -->
-
 <definitions xmlns="http://www.omg.org/spec/DMN/20151101/dmn.xsd"
              xmlns:feel="http://www.omg.org/spec/FEEL/20140401"
              xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"

--- a/kie-dmn/kie-dmn-legacy-tests/src/test/resources/org/kie/dmn/legacy/tests/core/v1_1/0004-simpletable-U-noinputvalues.dmn
+++ b/kie-dmn/kie-dmn-legacy-tests/src/test/resources/org/kie/dmn/legacy/tests/core/v1_1/0004-simpletable-U-noinputvalues.dmn
@@ -19,20 +19,6 @@
   -->
 
 <!-- THIS IS AN OLD VERSION OF DMN EXAMPLE/TEST, PLEASE USE THE MORE RECENT VERSION -->
-<!--
-  ~ Licensed under the Apache License, Version 2.0 (the "License");
-  ~ you may not use this file except in compliance with the License.
-  ~ You may obtain a copy of the License at
-  ~
-  ~       http://www.apache.org/licenses/LICENSE-2.0
-  ~
-  ~ Unless required by applicable law or agreed to in writing, software
-  ~ distributed under the License is distributed on an "AS IS" BASIS,
-  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-  ~ See the License for the specific language governing permissions and
-  ~ limitations under the License.
-  -->
-
 <definitions xmlns="http://www.omg.org/spec/DMN/20151101/dmn.xsd"
              xmlns:feel="http://www.omg.org/spec/FEEL/20140401"
              xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"

--- a/kie-dmn/kie-dmn-legacy-tests/src/test/resources/org/kie/dmn/legacy/tests/core/v1_1/0004-simpletable-U.dmn
+++ b/kie-dmn/kie-dmn-legacy-tests/src/test/resources/org/kie/dmn/legacy/tests/core/v1_1/0004-simpletable-U.dmn
@@ -19,20 +19,6 @@
   -->
 
 <!-- THIS IS AN OLD VERSION OF DMN EXAMPLE/TEST, PLEASE USE THE MORE RECENT VERSION -->
-<!--
-  ~ Licensed under the Apache License, Version 2.0 (the "License");
-  ~ you may not use this file except in compliance with the License.
-  ~ You may obtain a copy of the License at
-  ~
-  ~       http://www.apache.org/licenses/LICENSE-2.0
-  ~
-  ~ Unless required by applicable law or agreed to in writing, software
-  ~ distributed under the License is distributed on an "AS IS" BASIS,
-  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-  ~ See the License for the specific language governing permissions and
-  ~ limitations under the License.
-  -->
-
 <definitions xmlns="http://www.omg.org/spec/DMN/20151101/dmn.xsd"
              xmlns:feel="http://www.omg.org/spec/FEEL/20140401"
              xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"

--- a/kie-dmn/kie-dmn-legacy-tests/src/test/resources/org/kie/dmn/legacy/tests/core/v1_1/0008-LX-arithmetic.dmn
+++ b/kie-dmn/kie-dmn-legacy-tests/src/test/resources/org/kie/dmn/legacy/tests/core/v1_1/0008-LX-arithmetic.dmn
@@ -19,20 +19,6 @@
   -->
 
 <!-- THIS IS AN OLD VERSION OF DMN EXAMPLE/TEST, PLEASE USE THE MORE RECENT VERSION -->
-<!--
-  ~ Licensed under the Apache License, Version 2.0 (the "License");
-  ~ you may not use this file except in compliance with the License.
-  ~ You may obtain a copy of the License at
-  ~
-  ~       http://www.apache.org/licenses/LICENSE-2.0
-  ~
-  ~ Unless required by applicable law or agreed to in writing, software
-  ~ distributed under the License is distributed on an "AS IS" BASIS,
-  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-  ~ See the License for the specific language governing permissions and
-  ~ limitations under the License.
-  -->
-
 <definitions xmlns="http://www.omg.org/spec/DMN/20151101/dmn.xsd"
 						 xmlns:feel="http://www.omg.org/spec/FEEL/20140401"
 						 xmlns:tns="https://github.com/kiegroup/kie-dmn"

--- a/kie-dmn/kie-dmn-legacy-tests/src/test/resources/org/kie/dmn/legacy/tests/core/v1_1/DTABLE_NON_PRIORITY_MISSING_OUTVALS.dmn
+++ b/kie-dmn/kie-dmn-legacy-tests/src/test/resources/org/kie/dmn/legacy/tests/core/v1_1/DTABLE_NON_PRIORITY_MISSING_OUTVALS.dmn
@@ -19,20 +19,6 @@
   -->
 
 <!-- THIS IS AN OLD VERSION OF DMN EXAMPLE/TEST, PLEASE USE THE MORE RECENT VERSION -->
-<!--
-  ~ Licensed under the Apache License, Version 2.0 (the "License");
-  ~ you may not use this file except in compliance with the License.
-  ~ You may obtain a copy of the License at
-  ~
-  ~       http://www.apache.org/licenses/LICENSE-2.0
-  ~
-  ~ Unless required by applicable law or agreed to in writing, software
-  ~ distributed under the License is distributed on an "AS IS" BASIS,
-  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-  ~ See the License for the specific language governing permissions and
-  ~ limitations under the License.
-  -->
-
 <definitions id="DTABLE_NON_PRIORITY_MISSING_OUTVALS" name="DTABLE_NON_PRIORITY_MISSING_OUTVALS"
     namespace="https://github.com/kiegroup/kie-dmn"
     xmlns="http://www.omg.org/spec/DMN/20151101/dmn.xsd"

--- a/kie-dmn/kie-dmn-legacy-tests/src/test/resources/org/kie/dmn/legacy/tests/core/v1_1/DTABLE_PRIORITY_MISSING_OUTVALS.dmn
+++ b/kie-dmn/kie-dmn-legacy-tests/src/test/resources/org/kie/dmn/legacy/tests/core/v1_1/DTABLE_PRIORITY_MISSING_OUTVALS.dmn
@@ -19,20 +19,6 @@
   -->
 
 <!-- THIS IS AN OLD VERSION OF DMN EXAMPLE/TEST, PLEASE USE THE MORE RECENT VERSION -->
-<!--
-  ~ Licensed under the Apache License, Version 2.0 (the "License");
-  ~ you may not use this file except in compliance with the License.
-  ~ You may obtain a copy of the License at
-  ~
-  ~       http://www.apache.org/licenses/LICENSE-2.0
-  ~
-  ~ Unless required by applicable law or agreed to in writing, software
-  ~ distributed under the License is distributed on an "AS IS" BASIS,
-  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-  ~ See the License for the specific language governing permissions and
-  ~ limitations under the License.
-  -->
-
 <definitions id="DTABLE_PRIORITY_MISSING_OUTVALS" name="DTABLE_PRIORITY_MISSING_OUTVALS"
     namespace="https://github.com/kiegroup/kie-dmn"
     xmlns="http://www.omg.org/spec/DMN/20151101/dmn.xsd"

--- a/kie-dmn/kie-dmn-legacy-tests/src/test/resources/org/kie/dmn/legacy/tests/core/v1_1/DTABLE_PRIORITY_ONE_OUTVAL.dmn
+++ b/kie-dmn/kie-dmn-legacy-tests/src/test/resources/org/kie/dmn/legacy/tests/core/v1_1/DTABLE_PRIORITY_ONE_OUTVAL.dmn
@@ -19,39 +19,6 @@
   -->
 
 <!-- THIS IS AN OLD VERSION OF DMN EXAMPLE/TEST, PLEASE USE THE MORE RECENT VERSION -->
-<!--
-  ~ Licensed to the Apache Software Foundation (ASF) under one
-  ~ or more contributor license agreements.  See the NOTICE file
-  ~ distributed with this work for additional information
-  ~ regarding copyright ownership.  The ASF licenses this file
-  ~ to you under the Apache License, Version 2.0 (the
-  ~ "License"); you may not use this file except in compliance
-  ~ with the License.  You may obtain a copy of the License at
-  ~
-  ~   http://www.apache.org/licenses/LICENSE-2.0
-  ~
-  ~ Unless required by applicable law or agreed to in writing,
-  ~ software distributed under the License is distributed on an
-  ~ "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
-  ~ KIND, either express or implied.  See the License for the
-  ~ specific language governing permissions and limitations
-  ~ under the License.
-  -->
-
-<!--
-  ~ Licensed under the Apache License, Version 2.0 (the "License");
-  ~ you may not use this file except in compliance with the License.
-  ~ You may obtain a copy of the License at
-  ~
-  ~       http://www.apache.org/licenses/LICENSE-2.0
-  ~
-  ~ Unless required by applicable law or agreed to in writing, software
-  ~ distributed under the License is distributed on an "AS IS" BASIS,
-  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-  ~ See the License for the specific language governing permissions and
-  ~ limitations under the License.
-  -->
-
 <definitions xmlns="http://www.omg.org/spec/DMN/20151101/dmn.xsd"
              xmlns:feel="http://www.omg.org/spec/FEEL/20140401"
              xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"

--- a/kie-dmn/kie-dmn-legacy-tests/src/test/resources/org/kie/dmn/legacy/tests/core/v1_1/FunctionDefinition.dmn
+++ b/kie-dmn/kie-dmn-legacy-tests/src/test/resources/org/kie/dmn/legacy/tests/core/v1_1/FunctionDefinition.dmn
@@ -19,25 +19,6 @@
   -->
 
 <!-- THIS IS AN OLD VERSION OF DMN EXAMPLE/TEST, PLEASE USE THE MORE RECENT VERSION -->
-<!--
-  ~ Licensed to the Apache Software Foundation (ASF) under one
-  ~ or more contributor license agreements.  See the NOTICE file
-  ~ distributed with this work for additional information
-  ~ regarding copyright ownership.  The ASF licenses this file
-  ~ to you under the Apache License, Version 2.0 (the
-  ~ "License"); you may not use this file except in compliance
-  ~ with the License.  You may obtain a copy of the License at
-  ~
-  ~   http://www.apache.org/licenses/LICENSE-2.0
-  ~
-  ~ Unless required by applicable law or agreed to in writing,
-  ~ software distributed under the License is distributed on an
-  ~ "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
-  ~ KIND, either express or implied.  See the License for the
-  ~ specific language governing permissions and limitations
-  ~ under the License.
-  -->
-
 <semantic:definitions xmlns:semantic="http://www.omg.org/spec/DMN/20151101/dmn.xsd" xmlns="http://www.trisotech.com/dmn/definitions/_0de36357-fec0-4b4e-b7f1-382d381e06e9" xmlns:feel="http://www.omg.org/spec/FEEL/20140401"
                       xmlns:rss="http://purl.org/rss/2.0/" xmlns:triso="http://www.trisotech.com/2015/triso/modeling"
                       exporter="DMN Modeler" exporterVersion="5.0.35.201611211744"

--- a/kie-dmn/kie-dmn-legacy-tests/src/test/resources/org/kie/dmn/legacy/tests/core/v1_1/InvalidInput.dmn
+++ b/kie-dmn/kie-dmn-legacy-tests/src/test/resources/org/kie/dmn/legacy/tests/core/v1_1/InvalidInput.dmn
@@ -19,25 +19,6 @@
   -->
 
 <!-- THIS IS AN OLD VERSION OF DMN EXAMPLE/TEST, PLEASE USE THE MORE RECENT VERSION -->
-<!--
-  ~ Licensed to the Apache Software Foundation (ASF) under one
-  ~ or more contributor license agreements.  See the NOTICE file
-  ~ distributed with this work for additional information
-  ~ regarding copyright ownership.  The ASF licenses this file
-  ~ to you under the Apache License, Version 2.0 (the
-  ~ "License"); you may not use this file except in compliance
-  ~ with the License.  You may obtain a copy of the License at
-  ~
-  ~   http://www.apache.org/licenses/LICENSE-2.0
-  ~
-  ~ Unless required by applicable law or agreed to in writing,
-  ~ software distributed under the License is distributed on an
-  ~ "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
-  ~ KIND, either express or implied.  See the License for the
-  ~ specific language governing permissions and limitations
-  ~ under the License.
-  -->
-
 <semantic:definitions xmlns:semantic="http://www.omg.org/spec/DMN/20151101/dmn.xsd"
                       xmlns="http://www.trisotech.com/dmn/definitions/_cdf29af2-959b-4004-8271-82a9f5a62147"
                       xmlns:feel="http://www.omg.org/spec/FEEL/20140401"

--- a/kie-dmn/kie-dmn-legacy-tests/src/test/resources/org/kie/dmn/legacy/tests/core/v1_1/NotificationsTest2.dmn
+++ b/kie-dmn/kie-dmn-legacy-tests/src/test/resources/org/kie/dmn/legacy/tests/core/v1_1/NotificationsTest2.dmn
@@ -19,20 +19,6 @@
   -->
 
 <!-- THIS IS AN OLD VERSION OF DMN EXAMPLE/TEST, PLEASE USE THE MORE RECENT VERSION -->
-<!--
-  ~ Licensed under the Apache License, Version 2.0 (the "License");
-  ~ you may not use this file except in compliance with the License.
-  ~ You may obtain a copy of the License at
-  ~
-  ~       http://www.apache.org/licenses/LICENSE-2.0
-  ~
-  ~ Unless required by applicable law or agreed to in writing, software
-  ~ distributed under the License is distributed on an "AS IS" BASIS,
-  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-  ~ See the License for the specific language governing permissions and
-  ~ limitations under the License.
-  -->
-
 <definitions xmlns="http://www.omg.org/spec/DMN/20151101/dmn.xsd"
              xmlns:feel="http://www.omg.org/spec/FEEL/20140401"
              xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"

--- a/kie-dmn/kie-dmn-legacy-tests/src/test/resources/org/kie/dmn/legacy/tests/core/v1_1/Recursive.dmn
+++ b/kie-dmn/kie-dmn-legacy-tests/src/test/resources/org/kie/dmn/legacy/tests/core/v1_1/Recursive.dmn
@@ -18,45 +18,7 @@
   under the License.
   -->
 
-<!--
-  Licensed to the Apache Software Foundation (ASF) under one
-  or more contributor license agreements.  See the NOTICE file
-  distributed with this work for additional information
-  regarding copyright ownership.  The ASF licenses this file
-  to you under the Apache License, Version 2.0 (the
-  "License"); you may not use this file except in compliance
-  with the License.  You may obtain a copy of the License at
-
-    http://www.apache.org/licenses/LICENSE-2.0
-
-  Unless required by applicable law or agreed to in writing,
-  software distributed under the License is distributed on an
-  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
-  KIND, either express or implied.  See the License for the
-  specific language governing permissions and limitations
-  under the License.
-  -->
-
 <!-- THIS IS AN OLD VERSION OF DMN EXAMPLE/TEST, PLEASE USE THE MORE RECENT VERSION -->
-<!--
-  ~ Licensed to the Apache Software Foundation (ASF) under one
-  ~ or more contributor license agreements.  See the NOTICE file
-  ~ distributed with this work for additional information
-  ~ regarding copyright ownership.  The ASF licenses this file
-  ~ to you under the Apache License, Version 2.0 (the
-  ~ "License"); you may not use this file except in compliance
-  ~ with the License.  You may obtain a copy of the License at
-  ~
-  ~   http://www.apache.org/licenses/LICENSE-2.0
-  ~
-  ~ Unless required by applicable law or agreed to in writing,
-  ~ software distributed under the License is distributed on an
-  ~ "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
-  ~ KIND, either express or implied.  See the License for the
-  ~ specific language governing permissions and limitations
-  ~ under the License.
-  -->
-
 <definitions id="Recursive" name="Recursive"
     namespace="https://github.com/kiegroup/kie-dmn"
     xmlns="http://www.omg.org/spec/DMN/20151101/dmn.xsd"

--- a/kie-dmn/kie-dmn-legacy-tests/src/test/resources/org/kie/dmn/legacy/tests/core/v1_1/alternative_feel_ns_declaration.dmn
+++ b/kie-dmn/kie-dmn-legacy-tests/src/test/resources/org/kie/dmn/legacy/tests/core/v1_1/alternative_feel_ns_declaration.dmn
@@ -19,25 +19,6 @@
   -->
 
 <!-- THIS IS AN OLD VERSION OF DMN EXAMPLE/TEST, PLEASE USE THE MORE RECENT VERSION -->
-<!--
-  ~ Licensed to the Apache Software Foundation (ASF) under one
-  ~ or more contributor license agreements.  See the NOTICE file
-  ~ distributed with this work for additional information
-  ~ regarding copyright ownership.  The ASF licenses this file
-  ~ to you under the Apache License, Version 2.0 (the
-  ~ "License"); you may not use this file except in compliance
-  ~ with the License.  You may obtain a copy of the License at
-  ~
-  ~   http://www.apache.org/licenses/LICENSE-2.0
-  ~
-  ~ Unless required by applicable law or agreed to in writing,
-  ~ software distributed under the License is distributed on an
-  ~ "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
-  ~ KIND, either express or implied.  See the License for the
-  ~ specific language governing permissions and limitations
-  ~ under the License.
-  -->
-
 <definitions id="0001-input-data-string" name="0001-input-data-string"
 	namespace="https://github.com/kiegroup/kie-dmn"
 	xmlns="http://www.omg.org/spec/DMN/20151101/dmn.xsd">

--- a/kie-dmn/kie-dmn-legacy-tests/src/test/resources/org/kie/dmn/legacy/tests/core/v1_1/business-knowledge-model-required-input.dmn
+++ b/kie-dmn/kie-dmn-legacy-tests/src/test/resources/org/kie/dmn/legacy/tests/core/v1_1/business-knowledge-model-required-input.dmn
@@ -19,25 +19,6 @@
   -->
 
 <!-- THIS IS AN OLD VERSION OF DMN EXAMPLE/TEST, PLEASE USE THE MORE RECENT VERSION -->
-<!--
-  ~ Licensed to the Apache Software Foundation (ASF) under one
-  ~ or more contributor license agreements.  See the NOTICE file
-  ~ distributed with this work for additional information
-  ~ regarding copyright ownership.  The ASF licenses this file
-  ~ to you under the Apache License, Version 2.0 (the
-  ~ "License"); you may not use this file except in compliance
-  ~ with the License.  You may obtain a copy of the License at
-  ~
-  ~   http://www.apache.org/licenses/LICENSE-2.0
-  ~
-  ~ Unless required by applicable law or agreed to in writing,
-  ~ software distributed under the License is distributed on an
-  ~ "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
-  ~ KIND, either express or implied.  See the License for the
-  ~ specific language governing permissions and limitations
-  ~ under the License.
-  -->
-
 <definitions id="business-knowledge-model-required-input" name="business-knowledge-model-required-input"
              namespace="https://github.com/kiegroup/kie-dmn"
              xmlns="http://www.omg.org/spec/DMN/20151101/dmn.xsd"

--- a/kie-dmn/kie-dmn-legacy-tests/src/test/resources/org/kie/dmn/legacy/tests/core/v1_1/compilationThrowsNPE.dmn
+++ b/kie-dmn/kie-dmn-legacy-tests/src/test/resources/org/kie/dmn/legacy/tests/core/v1_1/compilationThrowsNPE.dmn
@@ -19,25 +19,6 @@
   -->
 
 <!-- THIS IS AN OLD VERSION OF DMN EXAMPLE/TEST, PLEASE USE THE MORE RECENT VERSION -->
-<!--
-  ~ Licensed to the Apache Software Foundation (ASF) under one
-  ~ or more contributor license agreements.  See the NOTICE file
-  ~ distributed with this work for additional information
-  ~ regarding copyright ownership.  The ASF licenses this file
-  ~ to you under the Apache License, Version 2.0 (the
-  ~ "License"); you may not use this file except in compliance
-  ~ with the License.  You may obtain a copy of the License at
-  ~
-  ~   http://www.apache.org/licenses/LICENSE-2.0
-  ~
-  ~ Unless required by applicable law or agreed to in writing,
-  ~ software distributed under the License is distributed on an
-  ~ "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
-  ~ KIND, either express or implied.  See the License for the
-  ~ specific language governing permissions and limitations
-  ~ under the License.
-  -->
-
 <definitions xmlns="http://www.omg.org/spec/DMN/20151101/dmn.xsd"
              xmlns:feel="http://www.omg.org/spec/FEEL/20140401"
              xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"

--- a/kie-dmn/kie-dmn-legacy-tests/src/test/resources/org/kie/dmn/legacy/tests/core/v1_1/compiler/extensions/0001-input-data-string-with-extensions.dmn
+++ b/kie-dmn/kie-dmn-legacy-tests/src/test/resources/org/kie/dmn/legacy/tests/core/v1_1/compiler/extensions/0001-input-data-string-with-extensions.dmn
@@ -19,25 +19,6 @@
   -->
 
 <!-- THIS IS AN OLD VERSION OF DMN EXAMPLE/TEST, PLEASE USE THE MORE RECENT VERSION -->
-<!--
-  ~ Licensed to the Apache Software Foundation (ASF) under one
-  ~ or more contributor license agreements.  See the NOTICE file
-  ~ distributed with this work for additional information
-  ~ regarding copyright ownership.  The ASF licenses this file
-  ~ to you under the Apache License, Version 2.0 (the
-  ~ "License"); you may not use this file except in compliance
-  ~ with the License.  You may obtain a copy of the License at
-  ~
-  ~   http://www.apache.org/licenses/LICENSE-2.0
-  ~
-  ~ Unless required by applicable law or agreed to in writing,
-  ~ software distributed under the License is distributed on an
-  ~ "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
-  ~ KIND, either express or implied.  See the License for the
-  ~ specific language governing permissions and limitations
-  ~ under the License.
-  -->
-
 <definitions id="0001-input-data-string" name="0001-input-data-string"
 	namespace="https://github.com/kiegroup/kie-dmn"
 	xmlns="http://www.omg.org/spec/DMN/20151101/dmn.xsd"

--- a/kie-dmn/kie-dmn-legacy-tests/src/test/resources/org/kie/dmn/legacy/tests/core/v1_1/decisiontable-default-value.dmn
+++ b/kie-dmn/kie-dmn-legacy-tests/src/test/resources/org/kie/dmn/legacy/tests/core/v1_1/decisiontable-default-value.dmn
@@ -19,39 +19,6 @@
   -->
 
 <!-- THIS IS AN OLD VERSION OF DMN EXAMPLE/TEST, PLEASE USE THE MORE RECENT VERSION -->
-<!--
-  ~ Licensed to the Apache Software Foundation (ASF) under one
-  ~ or more contributor license agreements.  See the NOTICE file
-  ~ distributed with this work for additional information
-  ~ regarding copyright ownership.  The ASF licenses this file
-  ~ to you under the Apache License, Version 2.0 (the
-  ~ "License"); you may not use this file except in compliance
-  ~ with the License.  You may obtain a copy of the License at
-  ~
-  ~   http://www.apache.org/licenses/LICENSE-2.0
-  ~
-  ~ Unless required by applicable law or agreed to in writing,
-  ~ software distributed under the License is distributed on an
-  ~ "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
-  ~ KIND, either express or implied.  See the License for the
-  ~ specific language governing permissions and limitations
-  ~ under the License.
-  -->
-
-<!--
-  ~ Licensed under the Apache License, Version 2.0 (the "License");
-  ~ you may not use this file except in compliance with the License.
-  ~ You may obtain a copy of the License at
-  ~
-  ~       http://www.apache.org/licenses/LICENSE-2.0
-  ~
-  ~ Unless required by applicable law or agreed to in writing, software
-  ~ distributed under the License is distributed on an "AS IS" BASIS,
-  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-  ~ See the License for the specific language governing permissions and
-  ~ limitations under the License.
-  -->
-
 <definitions xmlns="http://www.omg.org/spec/DMN/20151101/dmn.xsd"
              xmlns:feel="http://www.omg.org/spec/FEEL/20140401"
              xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"

--- a/kie-dmn/kie-dmn-legacy-tests/src/test/resources/org/kie/dmn/legacy/tests/core/v1_1/duplicate.0001-input-data-string.dmn
+++ b/kie-dmn/kie-dmn-legacy-tests/src/test/resources/org/kie/dmn/legacy/tests/core/v1_1/duplicate.0001-input-data-string.dmn
@@ -19,24 +19,6 @@
   -->
 
 <!-- THIS IS AN OLD VERSION OF DMN EXAMPLE/TEST, PLEASE USE THE MORE RECENT VERSION -->
-<!--
-  ~ Licensed to the Apache Software Foundation (ASF) under one
-  ~ or more contributor license agreements.  See the NOTICE file
-  ~ distributed with this work for additional information
-  ~ regarding copyright ownership.  The ASF licenses this file
-  ~ to you under the Apache License, Version 2.0 (the
-  ~ "License"); you may not use this file except in compliance
-  ~ with the License.  You may obtain a copy of the License at
-  ~
-  ~   http://www.apache.org/licenses/LICENSE-2.0
-  ~
-  ~ Unless required by applicable law or agreed to in writing,
-  ~ software distributed under the License is distributed on an
-  ~ "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
-  ~ KIND, either express or implied.  See the License for the
-  ~ specific language governing permissions and limitations
-  ~ under the License.
-  -->
 
 <definitions id="_0001-input-data-string" name="_0001-input-data-string"
              namespace="https://github.com/kiegroup/drools/kie-dmn"

--- a/kie-dmn/kie-dmn-legacy-tests/src/test/resources/org/kie/dmn/legacy/tests/core/v1_1/invalid-variable-names.dmn
+++ b/kie-dmn/kie-dmn-legacy-tests/src/test/resources/org/kie/dmn/legacy/tests/core/v1_1/invalid-variable-names.dmn
@@ -19,24 +19,7 @@
   -->
 
 <!-- THIS IS AN OLD VERSION OF DMN EXAMPLE/TEST, PLEASE USE THE MORE RECENT VERSION -->
-<!--
-  ~ Licensed to the Apache Software Foundation (ASF) under one
-  ~ or more contributor license agreements.  See the NOTICE file
-  ~ distributed with this work for additional information
-  ~ regarding copyright ownership.  The ASF licenses this file
-  ~ to you under the Apache License, Version 2.0 (the
-  ~ "License"); you may not use this file except in compliance
-  ~ with the License.  You may obtain a copy of the License at
-  ~
-  ~   http://www.apache.org/licenses/LICENSE-2.0
-  ~
-  ~ Unless required by applicable law or agreed to in writing,
-  ~ software distributed under the License is distributed on an
-  ~ "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
-  ~ KIND, either express or implied.  See the License for the
-  ~ specific language governing permissions and limitations
-  ~ under the License.
-  -->
+
 
 <definitions id="0001-input-data-string" name="0001-input-data-string"
 	namespace="https://github.com/kiegroup/kie-dmn"

--- a/kie-dmn/kie-dmn-legacy-tests/src/test/resources/org/kie/dmn/legacy/tests/core/v1_1/list-expression.dmn
+++ b/kie-dmn/kie-dmn-legacy-tests/src/test/resources/org/kie/dmn/legacy/tests/core/v1_1/list-expression.dmn
@@ -19,24 +19,7 @@
   -->
 
 <!-- THIS IS AN OLD VERSION OF DMN EXAMPLE/TEST, PLEASE USE THE MORE RECENT VERSION -->
-<!--
-  ~ Licensed to the Apache Software Foundation (ASF) under one
-  ~ or more contributor license agreements.  See the NOTICE file
-  ~ distributed with this work for additional information
-  ~ regarding copyright ownership.  The ASF licenses this file
-  ~ to you under the Apache License, Version 2.0 (the
-  ~ "License"); you may not use this file except in compliance
-  ~ with the License.  You may obtain a copy of the License at
-  ~
-  ~   http://www.apache.org/licenses/LICENSE-2.0
-  ~
-  ~ Unless required by applicable law or agreed to in writing,
-  ~ software distributed under the License is distributed on an
-  ~ "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
-  ~ KIND, either express or implied.  See the License for the
-  ~ specific language governing permissions and limitations
-  ~ under the License.
-  -->
+
 
 <definitions id="_list-expression" name="list-expression"
 	namespace="https://github.com/kiegroup/kie-dmn"

--- a/kie-dmn/kie-dmn-legacy-tests/src/test/resources/org/kie/dmn/legacy/tests/core/v1_1/null_values.dmn
+++ b/kie-dmn/kie-dmn-legacy-tests/src/test/resources/org/kie/dmn/legacy/tests/core/v1_1/null_values.dmn
@@ -19,24 +19,7 @@
   -->
 
 <!-- THIS IS AN OLD VERSION OF DMN EXAMPLE/TEST, PLEASE USE THE MORE RECENT VERSION -->
-<!--
-  ~ Licensed to the Apache Software Foundation (ASF) under one
-  ~ or more contributor license agreements.  See the NOTICE file
-  ~ distributed with this work for additional information
-  ~ regarding copyright ownership.  The ASF licenses this file
-  ~ to you under the Apache License, Version 2.0 (the
-  ~ "License"); you may not use this file except in compliance
-  ~ with the License.  You may obtain a copy of the License at
-  ~
-  ~   http://www.apache.org/licenses/LICENSE-2.0
-  ~
-  ~ Unless required by applicable law or agreed to in writing,
-  ~ software distributed under the License is distributed on an
-  ~ "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
-  ~ KIND, either express or implied.  See the License for the
-  ~ specific language governing permissions and limitations
-  ~ under the License.
-  -->
+
 
 <definitions id="_null_values_model" name="Null values model"
 	namespace="https://github.com/kiegroup/kie-dmn"

--- a/kie-dmn/kie-dmn-legacy-tests/src/test/resources/org/kie/dmn/legacy/tests/core/v1_1/out-of-order-items.dmn
+++ b/kie-dmn/kie-dmn-legacy-tests/src/test/resources/org/kie/dmn/legacy/tests/core/v1_1/out-of-order-items.dmn
@@ -19,24 +19,7 @@
   -->
 
 <!-- THIS IS AN OLD VERSION OF DMN EXAMPLE/TEST, PLEASE USE THE MORE RECENT VERSION -->
-<!--
-  ~ Licensed to the Apache Software Foundation (ASF) under one
-  ~ or more contributor license agreements.  See the NOTICE file
-  ~ distributed with this work for additional information
-  ~ regarding copyright ownership.  The ASF licenses this file
-  ~ to you under the Apache License, Version 2.0 (the
-  ~ "License"); you may not use this file except in compliance
-  ~ with the License.  You may obtain a copy of the License at
-  ~
-  ~   http://www.apache.org/licenses/LICENSE-2.0
-  ~
-  ~ Unless required by applicable law or agreed to in writing,
-  ~ software distributed under the License is distributed on an
-  ~ "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
-  ~ KIND, either express or implied.  See the License for the
-  ~ specific language governing permissions and limitations
-  ~ under the License.
-  -->
+
 
 <definitions id="_out-of-order" name="out-of-order"
 	namespace="https://github.com/kiegroup/kie-dmn"

--- a/kie-dmn/kie-dmn-legacy-tests/src/test/resources/org/kie/dmn/legacy/tests/core/v1_1/relation-expression.dmn
+++ b/kie-dmn/kie-dmn-legacy-tests/src/test/resources/org/kie/dmn/legacy/tests/core/v1_1/relation-expression.dmn
@@ -19,24 +19,7 @@
   -->
 
 <!-- THIS IS AN OLD VERSION OF DMN EXAMPLE/TEST, PLEASE USE THE MORE RECENT VERSION -->
-<!--
-  ~ Licensed to the Apache Software Foundation (ASF) under one
-  ~ or more contributor license agreements.  See the NOTICE file
-  ~ distributed with this work for additional information
-  ~ regarding copyright ownership.  The ASF licenses this file
-  ~ to you under the Apache License, Version 2.0 (the
-  ~ "License"); you may not use this file except in compliance
-  ~ with the License.  You may obtain a copy of the License at
-  ~
-  ~   http://www.apache.org/licenses/LICENSE-2.0
-  ~
-  ~ Unless required by applicable law or agreed to in writing,
-  ~ software distributed under the License is distributed on an
-  ~ "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
-  ~ KIND, either express or implied.  See the License for the
-  ~ specific language governing permissions and limitations
-  ~ under the License.
-  -->
+
 
 <definitions id="_relation-expression" name="relation-expression"
 	namespace="https://github.com/kiegroup/kie-dmn"

--- a/kie-dmn/kie-dmn-legacy-tests/src/test/resources/org/kie/dmn/legacy/tests/core/v1_1/simple-item-def.dmn
+++ b/kie-dmn/kie-dmn-legacy-tests/src/test/resources/org/kie/dmn/legacy/tests/core/v1_1/simple-item-def.dmn
@@ -19,24 +19,7 @@
   -->
 
 <!-- THIS IS AN OLD VERSION OF DMN EXAMPLE/TEST, PLEASE USE THE MORE RECENT VERSION -->
-<!--
-  ~ Licensed to the Apache Software Foundation (ASF) under one
-  ~ or more contributor license agreements.  See the NOTICE file
-  ~ distributed with this work for additional information
-  ~ regarding copyright ownership.  The ASF licenses this file
-  ~ to you under the Apache License, Version 2.0 (the
-  ~ "License"); you may not use this file except in compliance
-  ~ with the License.  You may obtain a copy of the License at
-  ~
-  ~   http://www.apache.org/licenses/LICENSE-2.0
-  ~
-  ~ Unless required by applicable law or agreed to in writing,
-  ~ software distributed under the License is distributed on an
-  ~ "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
-  ~ KIND, either express or implied.  See the License for the
-  ~ specific language governing permissions and limitations
-  ~ under the License.
-  -->
+
 
 <definitions id="_simple-item-def" name="simple-item-def"
 	namespace="https://github.com/kiegroup/kie-dmn/itemdef"

--- a/kie-dmn/kie-dmn-legacy-tests/src/test/resources/org/kie/dmn/legacy/tests/core/v1_1/variableLeadingTrailingSpaces.dmn
+++ b/kie-dmn/kie-dmn-legacy-tests/src/test/resources/org/kie/dmn/legacy/tests/core/v1_1/variableLeadingTrailingSpaces.dmn
@@ -19,24 +19,7 @@
   -->
 
 <!-- THIS IS AN OLD VERSION OF DMN EXAMPLE/TEST, PLEASE USE THE MORE RECENT VERSION -->
-<!--
-  ~ Licensed to the Apache Software Foundation (ASF) under one
-  ~ or more contributor license agreements.  See the NOTICE file
-  ~ distributed with this work for additional information
-  ~ regarding copyright ownership.  The ASF licenses this file
-  ~ to you under the Apache License, Version 2.0 (the
-  ~ "License"); you may not use this file except in compliance
-  ~ with the License.  You may obtain a copy of the License at
-  ~
-  ~   http://www.apache.org/licenses/LICENSE-2.0
-  ~
-  ~ Unless required by applicable law or agreed to in writing,
-  ~ software distributed under the License is distributed on an
-  ~ "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
-  ~ KIND, either express or implied.  See the License for the
-  ~ specific language governing permissions and limitations
-  ~ under the License.
-  -->
+
   
 <definitions id="definitions" 
     name="definitions"

--- a/kie-dmn/kie-dmn-legacy-tests/src/test/resources/org/kie/dmn/legacy/tests/validation/v1_1/DRGELEM_NOT_UNIQUE.dmn
+++ b/kie-dmn/kie-dmn-legacy-tests/src/test/resources/org/kie/dmn/legacy/tests/validation/v1_1/DRGELEM_NOT_UNIQUE.dmn
@@ -19,24 +19,7 @@
   -->
 
 <!-- THIS IS AN OLD VERSION OF DMN EXAMPLE/TEST, PLEASE USE THE MORE RECENT VERSION -->
-<!--
-  ~ Licensed to the Apache Software Foundation (ASF) under one
-  ~ or more contributor license agreements.  See the NOTICE file
-  ~ distributed with this work for additional information
-  ~ regarding copyright ownership.  The ASF licenses this file
-  ~ to you under the Apache License, Version 2.0 (the
-  ~ "License"); you may not use this file except in compliance
-  ~ with the License.  You may obtain a copy of the License at
-  ~
-  ~   http://www.apache.org/licenses/LICENSE-2.0
-  ~
-  ~ Unless required by applicable law or agreed to in writing,
-  ~ software distributed under the License is distributed on an
-  ~ "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
-  ~ KIND, either express or implied.  See the License for the
-  ~ specific language governing permissions and limitations
-  ~ under the License.
-  -->
+
 
 <definitions id="DRGELEM_NOT_UNIQUE" name="DRGELEM_NOT_UNIQUE"
     namespace="https://github.com/kiegroup/kie-dmn"

--- a/kie-dmn/kie-dmn-legacy-tests/src/test/resources/org/kie/dmn/legacy/tests/validation/v1_1/DROOLS-1447.dmn
+++ b/kie-dmn/kie-dmn-legacy-tests/src/test/resources/org/kie/dmn/legacy/tests/validation/v1_1/DROOLS-1447.dmn
@@ -19,24 +19,7 @@
   -->
 
 <!-- THIS IS AN OLD VERSION OF DMN EXAMPLE/TEST, PLEASE USE THE MORE RECENT VERSION -->
-<!--
-  ~ Licensed to the Apache Software Foundation (ASF) under one
-  ~ or more contributor license agreements.  See the NOTICE file
-  ~ distributed with this work for additional information
-  ~ regarding copyright ownership.  The ASF licenses this file
-  ~ to you under the Apache License, Version 2.0 (the
-  ~ "License"); you may not use this file except in compliance
-  ~ with the License.  You may obtain a copy of the License at
-  ~
-  ~   http://www.apache.org/licenses/LICENSE-2.0
-  ~
-  ~ Unless required by applicable law or agreed to in writing,
-  ~ software distributed under the License is distributed on an
-  ~ "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
-  ~ KIND, either express or implied.  See the License for the
-  ~ specific language governing permissions and limitations
-  ~ under the License.
-  -->
+
 <definitions id="DROOLS-1447" name="DROOLS-1447"
   namespace="https://github.com/kiegroup/kie-dmn" xmlns="http://www.omg.org/spec/DMN/20151101/dmn.xsd"
   xmlns:feel="http://www.omg.org/spec/FEEL/20140401" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">

--- a/kie-dmn/kie-dmn-legacy-tests/src/test/resources/org/kie/dmn/legacy/tests/validation/v1_1/DTABLE_EMPTY_ENTRY.dmn
+++ b/kie-dmn/kie-dmn-legacy-tests/src/test/resources/org/kie/dmn/legacy/tests/validation/v1_1/DTABLE_EMPTY_ENTRY.dmn
@@ -19,19 +19,7 @@
   -->
 
 <!-- THIS IS AN OLD VERSION OF DMN EXAMPLE/TEST, PLEASE USE THE MORE RECENT VERSION -->
-<!--
-  ~ Licensed under the Apache License, Version 2.0 (the "License");
-  ~ you may not use this file except in compliance with the License.
-  ~ You may obtain a copy of the License at
-  ~
-  ~       http://www.apache.org/licenses/LICENSE-2.0
-  ~
-  ~ Unless required by applicable law or agreed to in writing, software
-  ~ distributed under the License is distributed on an "AS IS" BASIS,
-  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-  ~ See the License for the specific language governing permissions and
-  ~ limitations under the License.
-  -->
+
 
 <definitions id="DTABLE_PRIORITY_MISSING_OUTVALS" name="DTABLE_PRIORITY_MISSING_OUTVALS"
     namespace="https://github.com/kiegroup/kie-dmn"

--- a/kie-dmn/kie-dmn-legacy-tests/src/test/resources/org/kie/dmn/legacy/tests/validation/v1_1/DTABLE_MULTIPLEOUTPUT_WRONG_OUTPUT.dmn
+++ b/kie-dmn/kie-dmn-legacy-tests/src/test/resources/org/kie/dmn/legacy/tests/validation/v1_1/DTABLE_MULTIPLEOUTPUT_WRONG_OUTPUT.dmn
@@ -19,19 +19,7 @@
   -->
 
 <!-- THIS IS AN OLD VERSION OF DMN EXAMPLE/TEST, PLEASE USE THE MORE RECENT VERSION -->
-<!--
-  ~ Licensed under the Apache License, Version 2.0 (the "License");
-  ~ you may not use this file except in compliance with the License.
-  ~ You may obtain a copy of the License at
-  ~
-  ~       http://www.apache.org/licenses/LICENSE-2.0
-  ~
-  ~ Unless required by applicable law or agreed to in writing, software
-  ~ distributed under the License is distributed on an "AS IS" BASIS,
-  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-  ~ See the License for the specific language governing permissions and
-  ~ limitations under the License.
-  -->
+
 
 <definitions id="DTABLE_MULTIPLEOUTPUT_WRONG_OUTPUT" name="DTABLE_MULTIPLEOUTPUT_WRONG_OUTPUT"
     namespace="https://github.com/kiegroup/kie-dmn"

--- a/kie-dmn/kie-dmn-legacy-tests/src/test/resources/org/kie/dmn/legacy/tests/validation/v1_1/DTABLE_PRIORITY_MISSING_OUTVALS.dmn
+++ b/kie-dmn/kie-dmn-legacy-tests/src/test/resources/org/kie/dmn/legacy/tests/validation/v1_1/DTABLE_PRIORITY_MISSING_OUTVALS.dmn
@@ -19,19 +19,7 @@
   -->
 
 <!-- THIS IS AN OLD VERSION OF DMN EXAMPLE/TEST, PLEASE USE THE MORE RECENT VERSION -->
-<!--
-  ~ Licensed under the Apache License, Version 2.0 (the "License");
-  ~ you may not use this file except in compliance with the License.
-  ~ You may obtain a copy of the License at
-  ~
-  ~       http://www.apache.org/licenses/LICENSE-2.0
-  ~
-  ~ Unless required by applicable law or agreed to in writing, software
-  ~ distributed under the License is distributed on an "AS IS" BASIS,
-  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-  ~ See the License for the specific language governing permissions and
-  ~ limitations under the License.
-  -->
+
 
 <definitions id="DTABLE_PRIORITY_MISSING_OUTVALS" name="DTABLE_PRIORITY_MISSING_OUTVALS"
     namespace="https://github.com/kiegroup/kie-dmn"

--- a/kie-dmn/kie-dmn-legacy-tests/src/test/resources/org/kie/dmn/legacy/tests/validation/v1_1/DTABLE_SINGLEOUTPUT_WRONG_OUTPUT.dmn
+++ b/kie-dmn/kie-dmn-legacy-tests/src/test/resources/org/kie/dmn/legacy/tests/validation/v1_1/DTABLE_SINGLEOUTPUT_WRONG_OUTPUT.dmn
@@ -19,19 +19,7 @@
   -->
 
 <!-- THIS IS AN OLD VERSION OF DMN EXAMPLE/TEST, PLEASE USE THE MORE RECENT VERSION -->
-<!--
-  ~ Licensed under the Apache License, Version 2.0 (the "License");
-  ~ you may not use this file except in compliance with the License.
-  ~ You may obtain a copy of the License at
-  ~
-  ~       http://www.apache.org/licenses/LICENSE-2.0
-  ~
-  ~ Unless required by applicable law or agreed to in writing, software
-  ~ distributed under the License is distributed on an "AS IS" BASIS,
-  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-  ~ See the License for the specific language governing permissions and
-  ~ limitations under the License.
-  -->
+
 
 <definitions id="DTABLE_SINGLEOUTPUT_WRONG_OUTPUT" name="DTABLE_SINGLEOUTPUT_WRONG_OUTPUT"
     namespace="https://github.com/kiegroup/kie-dmn"

--- a/kie-dmn/kie-dmn-legacy-tests/src/test/resources/org/kie/dmn/legacy/tests/validation/v1_1/FORMAL_PARAM_DUPLICATED.dmn
+++ b/kie-dmn/kie-dmn-legacy-tests/src/test/resources/org/kie/dmn/legacy/tests/validation/v1_1/FORMAL_PARAM_DUPLICATED.dmn
@@ -19,24 +19,7 @@
   -->
 
 <!-- THIS IS AN OLD VERSION OF DMN EXAMPLE/TEST, PLEASE USE THE MORE RECENT VERSION -->
-<!--
-  ~ Licensed to the Apache Software Foundation (ASF) under one
-  ~ or more contributor license agreements.  See the NOTICE file
-  ~ distributed with this work for additional information
-  ~ regarding copyright ownership.  The ASF licenses this file
-  ~ to you under the Apache License, Version 2.0 (the
-  ~ "License"); you may not use this file except in compliance
-  ~ with the License.  You may obtain a copy of the License at
-  ~
-  ~   http://www.apache.org/licenses/LICENSE-2.0
-  ~
-  ~ Unless required by applicable law or agreed to in writing,
-  ~ software distributed under the License is distributed on an
-  ~ "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
-  ~ KIND, either express or implied.  See the License for the
-  ~ specific language governing permissions and limitations
-  ~ under the License.
-  -->
+
 
 <definitions id="FORMAL_PARAM_DUPLICATED" name="FORMAL_PARAM_DUPLICATED"
     namespace="https://github.com/kiegroup/kie-dmn"

--- a/kie-dmn/kie-dmn-legacy-tests/src/test/resources/org/kie/dmn/legacy/tests/validation/v1_1/INVOCATION_INCONSISTENT_PARAM_NAMES.dmn
+++ b/kie-dmn/kie-dmn-legacy-tests/src/test/resources/org/kie/dmn/legacy/tests/validation/v1_1/INVOCATION_INCONSISTENT_PARAM_NAMES.dmn
@@ -19,24 +19,7 @@
   -->
 
 <!-- THIS IS AN OLD VERSION OF DMN EXAMPLE/TEST, PLEASE USE THE MORE RECENT VERSION -->
-<!--
-  ~ Licensed to the Apache Software Foundation (ASF) under one
-  ~ or more contributor license agreements.  See the NOTICE file
-  ~ distributed with this work for additional information
-  ~ regarding copyright ownership.  The ASF licenses this file
-  ~ to you under the Apache License, Version 2.0 (the
-  ~ "License"); you may not use this file except in compliance
-  ~ with the License.  You may obtain a copy of the License at
-  ~
-  ~   http://www.apache.org/licenses/LICENSE-2.0
-  ~
-  ~ Unless required by applicable law or agreed to in writing,
-  ~ software distributed under the License is distributed on an
-  ~ "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
-  ~ KIND, either express or implied.  See the License for the
-  ~ specific language governing permissions and limitations
-  ~ under the License.
-  -->
+
 <definitions id="INVOCATION_INCONSISTENT_PARAM_NAMES" name="INVOCATION_INCONSISTENT_PARAM_NAMES"
     namespace="https://github.com/kiegroup/kie-dmn"
     xmlns="http://www.omg.org/spec/DMN/20151101/dmn.xsd"

--- a/kie-dmn/kie-dmn-legacy-tests/src/test/resources/org/kie/dmn/legacy/tests/validation/v1_1/INVOCATION_MISSING_EXPR.dmn
+++ b/kie-dmn/kie-dmn-legacy-tests/src/test/resources/org/kie/dmn/legacy/tests/validation/v1_1/INVOCATION_MISSING_EXPR.dmn
@@ -19,24 +19,7 @@
   -->
 
 <!-- THIS IS AN OLD VERSION OF DMN EXAMPLE/TEST, PLEASE USE THE MORE RECENT VERSION -->
-<!--
-  ~ Licensed to the Apache Software Foundation (ASF) under one
-  ~ or more contributor license agreements.  See the NOTICE file
-  ~ distributed with this work for additional information
-  ~ regarding copyright ownership.  The ASF licenses this file
-  ~ to you under the Apache License, Version 2.0 (the
-  ~ "License"); you may not use this file except in compliance
-  ~ with the License.  You may obtain a copy of the License at
-  ~
-  ~   http://www.apache.org/licenses/LICENSE-2.0
-  ~
-  ~ Unless required by applicable law or agreed to in writing,
-  ~ software distributed under the License is distributed on an
-  ~ "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
-  ~ KIND, either express or implied.  See the License for the
-  ~ specific language governing permissions and limitations
-  ~ under the License.
-  -->
+
 <definitions id="_INVOCATION_MISSING_EXPR" name="INVOCATION_MISSING_EXPR"
     namespace="https://github.com/kiegroup/kie-dmn"
     xmlns="http://www.omg.org/spec/DMN/20151101/dmn.xsd"

--- a/kie-dmn/kie-dmn-legacy-tests/src/test/resources/org/kie/dmn/legacy/tests/validation/v1_1/INVOCATION_MISSING_TARGET.dmn
+++ b/kie-dmn/kie-dmn-legacy-tests/src/test/resources/org/kie/dmn/legacy/tests/validation/v1_1/INVOCATION_MISSING_TARGET.dmn
@@ -19,24 +19,7 @@
   -->
 
 <!-- THIS IS AN OLD VERSION OF DMN EXAMPLE/TEST, PLEASE USE THE MORE RECENT VERSION -->
-<!--
-  ~ Licensed to the Apache Software Foundation (ASF) under one
-  ~ or more contributor license agreements.  See the NOTICE file
-  ~ distributed with this work for additional information
-  ~ regarding copyright ownership.  The ASF licenses this file
-  ~ to you under the Apache License, Version 2.0 (the
-  ~ "License"); you may not use this file except in compliance
-  ~ with the License.  You may obtain a copy of the License at
-  ~
-  ~   http://www.apache.org/licenses/LICENSE-2.0
-  ~
-  ~ Unless required by applicable law or agreed to in writing,
-  ~ software distributed under the License is distributed on an
-  ~ "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
-  ~ KIND, either express or implied.  See the License for the
-  ~ specific language governing permissions and limitations
-  ~ under the License.
-  -->
+
 <definitions id="INVOCATION_MISSING_TARGET" name="INVOCATION_MISSING_TARGET"
     namespace="https://github.com/kiegroup/kie-dmn"
     xmlns="http://www.omg.org/spec/DMN/20151101/dmn.xsd"

--- a/kie-dmn/kie-dmn-legacy-tests/src/test/resources/org/kie/dmn/legacy/tests/validation/v1_1/INVOCATION_MISSING_TARGETbis.dmn
+++ b/kie-dmn/kie-dmn-legacy-tests/src/test/resources/org/kie/dmn/legacy/tests/validation/v1_1/INVOCATION_MISSING_TARGETbis.dmn
@@ -19,24 +19,7 @@
   -->
 
 <!-- THIS IS AN OLD VERSION OF DMN EXAMPLE/TEST, PLEASE USE THE MORE RECENT VERSION -->
-<!--
-  ~ Licensed to the Apache Software Foundation (ASF) under one
-  ~ or more contributor license agreements.  See the NOTICE file
-  ~ distributed with this work for additional information
-  ~ regarding copyright ownership.  The ASF licenses this file
-  ~ to you under the Apache License, Version 2.0 (the
-  ~ "License"); you may not use this file except in compliance
-  ~ with the License.  You may obtain a copy of the License at
-  ~
-  ~   http://www.apache.org/licenses/LICENSE-2.0
-  ~
-  ~ Unless required by applicable law or agreed to in writing,
-  ~ software distributed under the License is distributed on an
-  ~ "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
-  ~ KIND, either express or implied.  See the License for the
-  ~ specific language governing permissions and limitations
-  ~ under the License.
-  -->
+
 <definitions id="INVOCATION_MISSING_TARGETbis" name="INVOCATION_MISSING_TARGETbis"
     namespace="https://github.com/kiegroup/kie-dmn"
     xmlns="http://www.omg.org/spec/DMN/20151101/dmn.xsd"

--- a/kie-dmn/kie-dmn-legacy-tests/src/test/resources/org/kie/dmn/legacy/tests/validation/v1_1/INVOCATION_WRONG_PARAM_COUNT.dmn
+++ b/kie-dmn/kie-dmn-legacy-tests/src/test/resources/org/kie/dmn/legacy/tests/validation/v1_1/INVOCATION_WRONG_PARAM_COUNT.dmn
@@ -19,24 +19,7 @@
   -->
 
 <!-- THIS IS AN OLD VERSION OF DMN EXAMPLE/TEST, PLEASE USE THE MORE RECENT VERSION -->
-<!--
-  ~ Licensed to the Apache Software Foundation (ASF) under one
-  ~ or more contributor license agreements.  See the NOTICE file
-  ~ distributed with this work for additional information
-  ~ regarding copyright ownership.  The ASF licenses this file
-  ~ to you under the Apache License, Version 2.0 (the
-  ~ "License"); you may not use this file except in compliance
-  ~ with the License.  You may obtain a copy of the License at
-  ~
-  ~   http://www.apache.org/licenses/LICENSE-2.0
-  ~
-  ~ Unless required by applicable law or agreed to in writing,
-  ~ software distributed under the License is distributed on an
-  ~ "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
-  ~ KIND, either express or implied.  See the License for the
-  ~ specific language governing permissions and limitations
-  ~ under the License.
-  -->
+
 <definitions id="INVOCATION_WRONG_PARAM_COUNT" name="INVOCATION_WRONG_PARAM_COUNT"
     namespace="https://github.com/kiegroup/kie-dmn"
     xmlns="http://www.omg.org/spec/DMN/20151101/dmn.xsd"

--- a/kie-dmn/kie-dmn-legacy-tests/src/test/resources/org/kie/dmn/legacy/tests/validation/v1_1/ITEMCOMP_DUPLICATED.dmn
+++ b/kie-dmn/kie-dmn-legacy-tests/src/test/resources/org/kie/dmn/legacy/tests/validation/v1_1/ITEMCOMP_DUPLICATED.dmn
@@ -19,24 +19,7 @@
   -->
 
 <!-- THIS IS AN OLD VERSION OF DMN EXAMPLE/TEST, PLEASE USE THE MORE RECENT VERSION -->
-<!--
-  ~ Licensed to the Apache Software Foundation (ASF) under one
-  ~ or more contributor license agreements.  See the NOTICE file
-  ~ distributed with this work for additional information
-  ~ regarding copyright ownership.  The ASF licenses this file
-  ~ to you under the Apache License, Version 2.0 (the
-  ~ "License"); you may not use this file except in compliance
-  ~ with the License.  You may obtain a copy of the License at
-  ~
-  ~   http://www.apache.org/licenses/LICENSE-2.0
-  ~
-  ~ Unless required by applicable law or agreed to in writing,
-  ~ software distributed under the License is distributed on an
-  ~ "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
-  ~ KIND, either express or implied.  See the License for the
-  ~ specific language governing permissions and limitations
-  ~ under the License.
-  -->
+
 
 <definitions id="ITEMCOMP_DUPLICATED" name="ITEMCOMP_DUPLICATED"
     namespace="https://github.com/kiegroup/kie-dmn"

--- a/kie-dmn/kie-dmn-legacy-tests/src/test/resources/org/kie/dmn/legacy/tests/validation/v1_1/ITEMDEF_NOT_UNIQUE.dmn
+++ b/kie-dmn/kie-dmn-legacy-tests/src/test/resources/org/kie/dmn/legacy/tests/validation/v1_1/ITEMDEF_NOT_UNIQUE.dmn
@@ -19,24 +19,7 @@
   -->
 
 <!-- THIS IS AN OLD VERSION OF DMN EXAMPLE/TEST, PLEASE USE THE MORE RECENT VERSION -->
-<!--
-  ~ Licensed to the Apache Software Foundation (ASF) under one
-  ~ or more contributor license agreements.  See the NOTICE file
-  ~ distributed with this work for additional information
-  ~ regarding copyright ownership.  The ASF licenses this file
-  ~ to you under the Apache License, Version 2.0 (the
-  ~ "License"); you may not use this file except in compliance
-  ~ with the License.  You may obtain a copy of the License at
-  ~
-  ~   http://www.apache.org/licenses/LICENSE-2.0
-  ~
-  ~ Unless required by applicable law or agreed to in writing,
-  ~ software distributed under the License is distributed on an
-  ~ "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
-  ~ KIND, either express or implied.  See the License for the
-  ~ specific language governing permissions and limitations
-  ~ under the License.
-  -->
+
 
 <definitions id="ITEMDEF_NOT_UNIQUE" name="ITEMDEF_NOT_UNIQUE"
     namespace="https://github.com/kiegroup/kie-dmn"

--- a/kie-dmn/kie-dmn-legacy-tests/src/test/resources/org/kie/dmn/legacy/tests/validation/v1_1/ITEMDEF_NOT_UNIQUE_DROOLS-1450.dmn
+++ b/kie-dmn/kie-dmn-legacy-tests/src/test/resources/org/kie/dmn/legacy/tests/validation/v1_1/ITEMDEF_NOT_UNIQUE_DROOLS-1450.dmn
@@ -19,24 +19,7 @@
   -->
 
 <!-- THIS IS AN OLD VERSION OF DMN EXAMPLE/TEST, PLEASE USE THE MORE RECENT VERSION -->
-<!--
-  ~ Licensed to the Apache Software Foundation (ASF) under one
-  ~ or more contributor license agreements.  See the NOTICE file
-  ~ distributed with this work for additional information
-  ~ regarding copyright ownership.  The ASF licenses this file
-  ~ to you under the Apache License, Version 2.0 (the
-  ~ "License"); you may not use this file except in compliance
-  ~ with the License.  You may obtain a copy of the License at
-  ~
-  ~   http://www.apache.org/licenses/LICENSE-2.0
-  ~
-  ~ Unless required by applicable law or agreed to in writing,
-  ~ software distributed under the License is distributed on an
-  ~ "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
-  ~ KIND, either express or implied.  See the License for the
-  ~ specific language governing permissions and limitations
-  ~ under the License.
-  -->
+
 
 <definitions id="ITEMDEF_NOT_UNIQUE" name="ITEMDEF_NOT_UNIQUE"
     namespace="https://github.com/kiegroup/kie-dmn"

--- a/kie-dmn/kie-dmn-legacy-tests/src/test/resources/org/kie/dmn/legacy/tests/validation/v1_1/NAME_IS_VALID.dmn
+++ b/kie-dmn/kie-dmn-legacy-tests/src/test/resources/org/kie/dmn/legacy/tests/validation/v1_1/NAME_IS_VALID.dmn
@@ -19,24 +19,7 @@
   -->
 
 <!-- THIS IS AN OLD VERSION OF DMN EXAMPLE/TEST, PLEASE USE THE MORE RECENT VERSION -->
-<!--
-  ~ Licensed to the Apache Software Foundation (ASF) under one
-  ~ or more contributor license agreements.  See the NOTICE file
-  ~ distributed with this work for additional information
-  ~ regarding copyright ownership.  The ASF licenses this file
-  ~ to you under the Apache License, Version 2.0 (the
-  ~ "License"); you may not use this file except in compliance
-  ~ with the License.  You may obtain a copy of the License at
-  ~
-  ~   http://www.apache.org/licenses/LICENSE-2.0
-  ~
-  ~ Unless required by applicable law or agreed to in writing,
-  ~ software distributed under the License is distributed on an
-  ~ "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
-  ~ KIND, either express or implied.  See the License for the
-  ~ specific language governing permissions and limitations
-  ~ under the License.
-  -->
+
   
 <definitions id="NAME_IS_VALID" name="NAME_IS_VALID"
     namespace="https://github.com/kiegroup/kie-dmn"

--- a/kie-dmn/kie-dmn-legacy-tests/src/test/resources/org/kie/dmn/legacy/tests/validation/v1_1/RELATION_DUP_COLUMN.dmn
+++ b/kie-dmn/kie-dmn-legacy-tests/src/test/resources/org/kie/dmn/legacy/tests/validation/v1_1/RELATION_DUP_COLUMN.dmn
@@ -19,24 +19,7 @@
   -->
 
 <!-- THIS IS AN OLD VERSION OF DMN EXAMPLE/TEST, PLEASE USE THE MORE RECENT VERSION -->
-<!--
-  ~ Licensed to the Apache Software Foundation (ASF) under one
-  ~ or more contributor license agreements.  See the NOTICE file
-  ~ distributed with this work for additional information
-  ~ regarding copyright ownership.  The ASF licenses this file
-  ~ to you under the Apache License, Version 2.0 (the
-  ~ "License"); you may not use this file except in compliance
-  ~ with the License.  You may obtain a copy of the License at
-  ~
-  ~   http://www.apache.org/licenses/LICENSE-2.0
-  ~
-  ~ Unless required by applicable law or agreed to in writing,
-  ~ software distributed under the License is distributed on an
-  ~ "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
-  ~ KIND, either express or implied.  See the License for the
-  ~ specific language governing permissions and limitations
-  ~ under the License.
-  -->
+
 <definitions id="RELATION_DUP_COLUMN" name="RELATION_DUP_COLUMN"
              namespace="https://github.com/kiegroup/kie-dmn"
              xmlns="http://www.omg.org/spec/DMN/20151101/dmn.xsd"

--- a/kie-dmn/kie-dmn-legacy-tests/src/test/resources/org/kie/dmn/legacy/tests/validation/v1_1/RELATION_ROW_CELLCOUNTMISMATCH.dmn
+++ b/kie-dmn/kie-dmn-legacy-tests/src/test/resources/org/kie/dmn/legacy/tests/validation/v1_1/RELATION_ROW_CELLCOUNTMISMATCH.dmn
@@ -19,24 +19,7 @@
   -->
 
 <!-- THIS IS AN OLD VERSION OF DMN EXAMPLE/TEST, PLEASE USE THE MORE RECENT VERSION -->
-<!--
-  ~ Licensed to the Apache Software Foundation (ASF) under one
-  ~ or more contributor license agreements.  See the NOTICE file
-  ~ distributed with this work for additional information
-  ~ regarding copyright ownership.  The ASF licenses this file
-  ~ to you under the Apache License, Version 2.0 (the
-  ~ "License"); you may not use this file except in compliance
-  ~ with the License.  You may obtain a copy of the License at
-  ~
-  ~   http://www.apache.org/licenses/LICENSE-2.0
-  ~
-  ~ Unless required by applicable law or agreed to in writing,
-  ~ software distributed under the License is distributed on an
-  ~ "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
-  ~ KIND, either express or implied.  See the License for the
-  ~ specific language governing permissions and limitations
-  ~ under the License.
-  -->
+
 <definitions id="RELATION_ROW_CELLCOUNTMISMATCH" name="RELATION_ROW_CELLCOUNTMISMATCH"
              namespace="https://github.com/kiegroup/kie-dmn"
              xmlns="http://www.omg.org/spec/DMN/20151101/dmn.xsd"

--- a/kie-dmn/kie-dmn-legacy-tests/src/test/resources/org/kie/dmn/legacy/tests/validation/v1_1/RELATION_ROW_CELL_NOTLITERAL.dmn
+++ b/kie-dmn/kie-dmn-legacy-tests/src/test/resources/org/kie/dmn/legacy/tests/validation/v1_1/RELATION_ROW_CELL_NOTLITERAL.dmn
@@ -19,24 +19,7 @@
   -->
 
 <!-- THIS IS AN OLD VERSION OF DMN EXAMPLE/TEST, PLEASE USE THE MORE RECENT VERSION -->
-<!--
-  ~ Licensed to the Apache Software Foundation (ASF) under one
-  ~ or more contributor license agreements.  See the NOTICE file
-  ~ distributed with this work for additional information
-  ~ regarding copyright ownership.  The ASF licenses this file
-  ~ to you under the Apache License, Version 2.0 (the
-  ~ "License"); you may not use this file except in compliance
-  ~ with the License.  You may obtain a copy of the License at
-  ~
-  ~   http://www.apache.org/licenses/LICENSE-2.0
-  ~
-  ~ Unless required by applicable law or agreed to in writing,
-  ~ software distributed under the License is distributed on an
-  ~ "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
-  ~ KIND, either express or implied.  See the License for the
-  ~ specific language governing permissions and limitations
-  ~ under the License.
-  -->
+
 <definitions id="RELATION_ROW_CELL_NOTLITERAL" name="RELATION_ROW_CELL_NOTLITERAL"
              namespace="https://github.com/kiegroup/kie-dmn"
              xmlns="http://www.omg.org/spec/DMN/20151101/dmn.xsd"

--- a/kie-dmn/kie-dmn-legacy-tests/src/test/resources/org/kie/dmn/legacy/tests/validation/v1_1/REQAUTH_NOT_KNOWLEDGESOURCEbis.dmn
+++ b/kie-dmn/kie-dmn-legacy-tests/src/test/resources/org/kie/dmn/legacy/tests/validation/v1_1/REQAUTH_NOT_KNOWLEDGESOURCEbis.dmn
@@ -19,19 +19,7 @@
   -->
 
 <!-- THIS IS AN OLD VERSION OF DMN EXAMPLE/TEST, PLEASE USE THE MORE RECENT VERSION -->
-<!--
-  ~ Licensed under the Apache License, Version 2.0 (the "License");
-  ~ you may not use this file except in compliance with the License.
-  ~ You may obtain a copy of the License at
-  ~
-  ~       http://www.apache.org/licenses/LICENSE-2.0
-  ~
-  ~ Unless required by applicable law or agreed to in writing, software
-  ~ distributed under the License is distributed on an "AS IS" BASIS,
-  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-  ~ See the License for the specific language governing permissions and
-  ~ limitations under the License.
-  -->
+
 
 <definitions id="REQAUTH_NOT_KNOWLEDGESOURCEbis" name="REQAUTH_NOT_KNOWLEDGESOURCEbis"
     namespace="https://github.com/kiegroup/kie-dmn"

--- a/kie-dmn/kie-dmn-legacy-tests/src/test/resources/org/kie/dmn/legacy/tests/validation/v1_1/UNKNOWN_VARIABLE.dmn
+++ b/kie-dmn/kie-dmn-legacy-tests/src/test/resources/org/kie/dmn/legacy/tests/validation/v1_1/UNKNOWN_VARIABLE.dmn
@@ -19,24 +19,7 @@
   -->
 
 <!-- THIS IS AN OLD VERSION OF DMN EXAMPLE/TEST, PLEASE USE THE MORE RECENT VERSION -->
-<!--
-  ~ Licensed to the Apache Software Foundation (ASF) under one
-  ~ or more contributor license agreements.  See the NOTICE file
-  ~ distributed with this work for additional information
-  ~ regarding copyright ownership.  The ASF licenses this file
-  ~ to you under the Apache License, Version 2.0 (the
-  ~ "License"); you may not use this file except in compliance
-  ~ with the License.  You may obtain a copy of the License at
-  ~
-  ~   http://www.apache.org/licenses/LICENSE-2.0
-  ~
-  ~ Unless required by applicable law or agreed to in writing,
-  ~ software distributed under the License is distributed on an
-  ~ "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
-  ~ KIND, either express or implied.  See the License for the
-  ~ specific language governing permissions and limitations
-  ~ under the License.
-  -->
+
   
 <definitions id="NAME_INVALID" name="NAME_INVALID"
     namespace="https://www.drools.org/kie-dmn/definitions"

--- a/kie-dmn/kie-dmn-legacy-tests/src/test/resources/org/kie/dmn/legacy/tests/validation/v1_1/VARIABLE_LEADING_TRAILING_SPACES.dmn
+++ b/kie-dmn/kie-dmn-legacy-tests/src/test/resources/org/kie/dmn/legacy/tests/validation/v1_1/VARIABLE_LEADING_TRAILING_SPACES.dmn
@@ -19,24 +19,7 @@
   -->
 
 <!-- THIS IS AN OLD VERSION OF DMN EXAMPLE/TEST, PLEASE USE THE MORE RECENT VERSION -->
-<!--
-  ~ Licensed to the Apache Software Foundation (ASF) under one
-  ~ or more contributor license agreements.  See the NOTICE file
-  ~ distributed with this work for additional information
-  ~ regarding copyright ownership.  The ASF licenses this file
-  ~ to you under the Apache License, Version 2.0 (the
-  ~ "License"); you may not use this file except in compliance
-  ~ with the License.  You may obtain a copy of the License at
-  ~
-  ~   http://www.apache.org/licenses/LICENSE-2.0
-  ~
-  ~ Unless required by applicable law or agreed to in writing,
-  ~ software distributed under the License is distributed on an
-  ~ "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
-  ~ KIND, either express or implied.  See the License for the
-  ~ specific language governing permissions and limitations
-  ~ under the License.
-  -->
+
   
 <definitions id="NAME_INVALID" name="NAME_INVALID"
     namespace="https://www.drools.org/kie-dmn/definitions"

--- a/kie-dmn/kie-dmn-legacy-tests/src/test/resources/org/kie/dmn/legacy/tests/validation/v1_1/artifact/ASSOC_REFERENCES_NOT_EMPTY.dmn
+++ b/kie-dmn/kie-dmn-legacy-tests/src/test/resources/org/kie/dmn/legacy/tests/validation/v1_1/artifact/ASSOC_REFERENCES_NOT_EMPTY.dmn
@@ -19,24 +19,7 @@
   -->
 
 <!-- THIS IS AN OLD VERSION OF DMN EXAMPLE/TEST, PLEASE USE THE MORE RECENT VERSION -->
-<!--
-  ~ Licensed to the Apache Software Foundation (ASF) under one
-  ~ or more contributor license agreements.  See the NOTICE file
-  ~ distributed with this work for additional information
-  ~ regarding copyright ownership.  The ASF licenses this file
-  ~ to you under the Apache License, Version 2.0 (the
-  ~ "License"); you may not use this file except in compliance
-  ~ with the License.  You may obtain a copy of the License at
-  ~
-  ~   http://www.apache.org/licenses/LICENSE-2.0
-  ~
-  ~ Unless required by applicable law or agreed to in writing,
-  ~ software distributed under the License is distributed on an
-  ~ "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
-  ~ KIND, either express or implied.  See the License for the
-  ~ specific language governing permissions and limitations
-  ~ under the License.
-  -->
+
 
 <definitions id="ASSOC_REFERENCES_NOT_EMPTY" name="ASSOC_REFERENCES_NOT_EMPTY"
              namespace="https://github.com/kiegroup/kie-dmn"

--- a/kie-dmn/kie-dmn-legacy-tests/src/test/resources/org/kie/dmn/legacy/tests/validation/v1_1/authorityrequirement/AUTHREQ_DEP_REQ_AUTH_NOT_KNOWLEDGESOURCE.dmn
+++ b/kie-dmn/kie-dmn-legacy-tests/src/test/resources/org/kie/dmn/legacy/tests/validation/v1_1/authorityrequirement/AUTHREQ_DEP_REQ_AUTH_NOT_KNOWLEDGESOURCE.dmn
@@ -19,19 +19,7 @@
   -->
 
 <!-- THIS IS AN OLD VERSION OF DMN EXAMPLE/TEST, PLEASE USE THE MORE RECENT VERSION -->
-<!--
-  ~ Licensed under the Apache License, Version 2.0 (the "License");
-  ~ you may not use this file except in compliance with the License.
-  ~ You may obtain a copy of the License at
-  ~
-  ~       http://www.apache.org/licenses/LICENSE-2.0
-  ~
-  ~ Unless required by applicable law or agreed to in writing, software
-  ~ distributed under the License is distributed on an "AS IS" BASIS,
-  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-  ~ See the License for the specific language governing permissions and
-  ~ limitations under the License.
-  -->
+
 
 <definitions id="AUTHREQ_DEP_REQ_AUTH_NOT_KNOWLEDGESOURCE" name="AUTHREQ_DEP_REQ_AUTH_NOT_KNOWLEDGESOURCE"
     namespace="https://github.com/kiegroup/kie-dmn"

--- a/kie-dmn/kie-dmn-legacy-tests/src/test/resources/org/kie/dmn/legacy/tests/validation/v1_1/authorityrequirement/AUTHREQ_DEP_REQ_DEC_NOT_DECISION.dmn
+++ b/kie-dmn/kie-dmn-legacy-tests/src/test/resources/org/kie/dmn/legacy/tests/validation/v1_1/authorityrequirement/AUTHREQ_DEP_REQ_DEC_NOT_DECISION.dmn
@@ -19,24 +19,7 @@
   -->
 
 <!-- THIS IS AN OLD VERSION OF DMN EXAMPLE/TEST, PLEASE USE THE MORE RECENT VERSION -->
-<!--
-  ~ Licensed to the Apache Software Foundation (ASF) under one
-  ~ or more contributor license agreements.  See the NOTICE file
-  ~ distributed with this work for additional information
-  ~ regarding copyright ownership.  The ASF licenses this file
-  ~ to you under the Apache License, Version 2.0 (the
-  ~ "License"); you may not use this file except in compliance
-  ~ with the License.  You may obtain a copy of the License at
-  ~
-  ~   http://www.apache.org/licenses/LICENSE-2.0
-  ~
-  ~ Unless required by applicable law or agreed to in writing,
-  ~ software distributed under the License is distributed on an
-  ~ "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
-  ~ KIND, either express or implied.  See the License for the
-  ~ specific language governing permissions and limitations
-  ~ under the License.
-  -->
+
 
 <definitions id="AUTHREQ_DEP_REQ_DEC_NOT_DECISION" name="AUTHREQ_DEP_REQ_DEC_NOT_DECISION"
     namespace="https://github.com/kiegroup/kie-dmn"

--- a/kie-dmn/kie-dmn-legacy-tests/src/test/resources/org/kie/dmn/legacy/tests/validation/v1_1/authorityrequirement/AUTHREQ_DEP_REQ_INPUT_NOT_INPUT.dmn
+++ b/kie-dmn/kie-dmn-legacy-tests/src/test/resources/org/kie/dmn/legacy/tests/validation/v1_1/authorityrequirement/AUTHREQ_DEP_REQ_INPUT_NOT_INPUT.dmn
@@ -19,24 +19,7 @@
   -->
 
 <!-- THIS IS AN OLD VERSION OF DMN EXAMPLE/TEST, PLEASE USE THE MORE RECENT VERSION -->
-<!--
-  ~ Licensed to the Apache Software Foundation (ASF) under one
-  ~ or more contributor license agreements.  See the NOTICE file
-  ~ distributed with this work for additional information
-  ~ regarding copyright ownership.  The ASF licenses this file
-  ~ to you under the Apache License, Version 2.0 (the
-  ~ "License"); you may not use this file except in compliance
-  ~ with the License.  You may obtain a copy of the License at
-  ~
-  ~   http://www.apache.org/licenses/LICENSE-2.0
-  ~
-  ~ Unless required by applicable law or agreed to in writing,
-  ~ software distributed under the License is distributed on an
-  ~ "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
-  ~ KIND, either express or implied.  See the License for the
-  ~ specific language governing permissions and limitations
-  ~ under the License.
-  -->
+
 
 <definitions id="AUTHREQ_DEP_REQ_INPUT_NOT_INPUT" name="AUTHREQ_DEP_REQ_INPUT_NOT_INPUT"
     namespace="https://github.com/kiegroup/kie-dmn"

--- a/kie-dmn/kie-dmn-legacy-tests/src/test/resources/org/kie/dmn/legacy/tests/validation/v1_1/authorityrequirement/AUTHREQ_MISSING_DEPENDENCY_REQ_AUTH.dmn
+++ b/kie-dmn/kie-dmn-legacy-tests/src/test/resources/org/kie/dmn/legacy/tests/validation/v1_1/authorityrequirement/AUTHREQ_MISSING_DEPENDENCY_REQ_AUTH.dmn
@@ -19,24 +19,7 @@
   -->
 
 <!-- THIS IS AN OLD VERSION OF DMN EXAMPLE/TEST, PLEASE USE THE MORE RECENT VERSION -->
-<!--
-  ~ Licensed to the Apache Software Foundation (ASF) under one
-  ~ or more contributor license agreements.  See the NOTICE file
-  ~ distributed with this work for additional information
-  ~ regarding copyright ownership.  The ASF licenses this file
-  ~ to you under the Apache License, Version 2.0 (the
-  ~ "License"); you may not use this file except in compliance
-  ~ with the License.  You may obtain a copy of the License at
-  ~
-  ~   http://www.apache.org/licenses/LICENSE-2.0
-  ~
-  ~ Unless required by applicable law or agreed to in writing,
-  ~ software distributed under the License is distributed on an
-  ~ "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
-  ~ KIND, either express or implied.  See the License for the
-  ~ specific language governing permissions and limitations
-  ~ under the License.
-  -->
+
 
 <definitions id="AUTHREQ_MISSING_DEPENDENCY_REQ_AUTH" name="AUTHREQ_MISSING_DEPENDENCY_REQ_AUTH"
     namespace="https://github.com/kiegroup/kie-dmn"

--- a/kie-dmn/kie-dmn-legacy-tests/src/test/resources/org/kie/dmn/legacy/tests/validation/v1_1/authorityrequirement/AUTHREQ_MISSING_DEPENDENCY_REQ_DEC.dmn
+++ b/kie-dmn/kie-dmn-legacy-tests/src/test/resources/org/kie/dmn/legacy/tests/validation/v1_1/authorityrequirement/AUTHREQ_MISSING_DEPENDENCY_REQ_DEC.dmn
@@ -19,24 +19,7 @@
   -->
 
 <!-- THIS IS AN OLD VERSION OF DMN EXAMPLE/TEST, PLEASE USE THE MORE RECENT VERSION -->
-<!--
-  ~ Licensed to the Apache Software Foundation (ASF) under one
-  ~ or more contributor license agreements.  See the NOTICE file
-  ~ distributed with this work for additional information
-  ~ regarding copyright ownership.  The ASF licenses this file
-  ~ to you under the Apache License, Version 2.0 (the
-  ~ "License"); you may not use this file except in compliance
-  ~ with the License.  You may obtain a copy of the License at
-  ~
-  ~   http://www.apache.org/licenses/LICENSE-2.0
-  ~
-  ~ Unless required by applicable law or agreed to in writing,
-  ~ software distributed under the License is distributed on an
-  ~ "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
-  ~ KIND, either express or implied.  See the License for the
-  ~ specific language governing permissions and limitations
-  ~ under the License.
-  -->
+
 
 <definitions id="AUTHREQ_MISSING_DEPENDENCY_REQ_DEC" name="AUTHREQ_MISSING_DEPENDENCY_REQ_DEC"
     namespace="https://github.com/kiegroup/kie-dmn"

--- a/kie-dmn/kie-dmn-legacy-tests/src/test/resources/org/kie/dmn/legacy/tests/validation/v1_1/authorityrequirement/AUTHREQ_MISSING_DEPENDENCY_REQ_INPUT.dmn
+++ b/kie-dmn/kie-dmn-legacy-tests/src/test/resources/org/kie/dmn/legacy/tests/validation/v1_1/authorityrequirement/AUTHREQ_MISSING_DEPENDENCY_REQ_INPUT.dmn
@@ -19,24 +19,7 @@
   -->
 
 <!-- THIS IS AN OLD VERSION OF DMN EXAMPLE/TEST, PLEASE USE THE MORE RECENT VERSION -->
-<!--
-  ~ Licensed to the Apache Software Foundation (ASF) under one
-  ~ or more contributor license agreements.  See the NOTICE file
-  ~ distributed with this work for additional information
-  ~ regarding copyright ownership.  The ASF licenses this file
-  ~ to you under the Apache License, Version 2.0 (the
-  ~ "License"); you may not use this file except in compliance
-  ~ with the License.  You may obtain a copy of the License at
-  ~
-  ~   http://www.apache.org/licenses/LICENSE-2.0
-  ~
-  ~ Unless required by applicable law or agreed to in writing,
-  ~ software distributed under the License is distributed on an
-  ~ "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
-  ~ KIND, either express or implied.  See the License for the
-  ~ specific language governing permissions and limitations
-  ~ under the License.
-  -->
+
 
 <definitions id="AUTHREQ_MISSING_DEPENDENCY_REQ_INPUT" name="AUTHREQ_MISSING_DEPENDENCY_REQ_INPUT"
     namespace="https://github.com/kiegroup/kie-dmn"

--- a/kie-dmn/kie-dmn-legacy-tests/src/test/resources/org/kie/dmn/legacy/tests/validation/v1_1/businesscontext/ORG_UNIT_DECISION_MADE_WRONG_TYPE.dmn
+++ b/kie-dmn/kie-dmn-legacy-tests/src/test/resources/org/kie/dmn/legacy/tests/validation/v1_1/businesscontext/ORG_UNIT_DECISION_MADE_WRONG_TYPE.dmn
@@ -19,24 +19,7 @@
   -->
 
 <!-- THIS IS AN OLD VERSION OF DMN EXAMPLE/TEST, PLEASE USE THE MORE RECENT VERSION -->
-<!--
-  ~ Licensed to the Apache Software Foundation (ASF) under one
-  ~ or more contributor license agreements.  See the NOTICE file
-  ~ distributed with this work for additional information
-  ~ regarding copyright ownership.  The ASF licenses this file
-  ~ to you under the Apache License, Version 2.0 (the
-  ~ "License"); you may not use this file except in compliance
-  ~ with the License.  You may obtain a copy of the License at
-  ~
-  ~   http://www.apache.org/licenses/LICENSE-2.0
-  ~
-  ~ Unless required by applicable law or agreed to in writing,
-  ~ software distributed under the License is distributed on an
-  ~ "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
-  ~ KIND, either express or implied.  See the License for the
-  ~ specific language governing permissions and limitations
-  ~ under the License.
-  -->
+
 
 <definitions id="ORG_UNIT_DECISION_MADE_WRONG_TYPE" name="ORG_UNIT_DECISION_MADE_WRONG_TYPE"
              namespace="https://github.com/kiegroup/kie-dmn"

--- a/kie-dmn/kie-dmn-legacy-tests/src/test/resources/org/kie/dmn/legacy/tests/validation/v1_1/businesscontext/ORG_UNIT_DECISION_OWNED_WRONG_TYPE.dmn
+++ b/kie-dmn/kie-dmn-legacy-tests/src/test/resources/org/kie/dmn/legacy/tests/validation/v1_1/businesscontext/ORG_UNIT_DECISION_OWNED_WRONG_TYPE.dmn
@@ -19,24 +19,7 @@
   -->
 
 <!-- THIS IS AN OLD VERSION OF DMN EXAMPLE/TEST, PLEASE USE THE MORE RECENT VERSION -->
-<!--
-  ~ Licensed to the Apache Software Foundation (ASF) under one
-  ~ or more contributor license agreements.  See the NOTICE file
-  ~ distributed with this work for additional information
-  ~ regarding copyright ownership.  The ASF licenses this file
-  ~ to you under the Apache License, Version 2.0 (the
-  ~ "License"); you may not use this file except in compliance
-  ~ with the License.  You may obtain a copy of the License at
-  ~
-  ~   http://www.apache.org/licenses/LICENSE-2.0
-  ~
-  ~ Unless required by applicable law or agreed to in writing,
-  ~ software distributed under the License is distributed on an
-  ~ "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
-  ~ KIND, either express or implied.  See the License for the
-  ~ specific language governing permissions and limitations
-  ~ under the License.
-  -->
+
 
 <definitions id="ORG_UNIT_DECISION_OWNED_WRONG_TYPE" name="ORG_UNIT_DECISION_OWNED_WRONG_TYPE"
              namespace="https://github.com/kiegroup/kie-dmn"

--- a/kie-dmn/kie-dmn-legacy-tests/src/test/resources/org/kie/dmn/legacy/tests/validation/v1_1/businesscontext/PERF_INDICATOR_IMP_DECISION_WRONG_TYPE.dmn
+++ b/kie-dmn/kie-dmn-legacy-tests/src/test/resources/org/kie/dmn/legacy/tests/validation/v1_1/businesscontext/PERF_INDICATOR_IMP_DECISION_WRONG_TYPE.dmn
@@ -19,24 +19,7 @@
   -->
 
 <!-- THIS IS AN OLD VERSION OF DMN EXAMPLE/TEST, PLEASE USE THE MORE RECENT VERSION -->
-<!--
-  ~ Licensed to the Apache Software Foundation (ASF) under one
-  ~ or more contributor license agreements.  See the NOTICE file
-  ~ distributed with this work for additional information
-  ~ regarding copyright ownership.  The ASF licenses this file
-  ~ to you under the Apache License, Version 2.0 (the
-  ~ "License"); you may not use this file except in compliance
-  ~ with the License.  You may obtain a copy of the License at
-  ~
-  ~   http://www.apache.org/licenses/LICENSE-2.0
-  ~
-  ~ Unless required by applicable law or agreed to in writing,
-  ~ software distributed under the License is distributed on an
-  ~ "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
-  ~ KIND, either express or implied.  See the License for the
-  ~ specific language governing permissions and limitations
-  ~ under the License.
-  -->
+
 
 <definitions id="PERF_INDICATOR_IMP_DECISION_WRONG_TYPE" name="PERF_INDICATOR_IMP_DECISION_WRONG_TYPE"
              namespace="https://github.com/kiegroup/kie-dmn"

--- a/kie-dmn/kie-dmn-legacy-tests/src/test/resources/org/kie/dmn/legacy/tests/validation/v1_1/businessknowledgemodel/BKM_MISMATCH_VAR.dmn
+++ b/kie-dmn/kie-dmn-legacy-tests/src/test/resources/org/kie/dmn/legacy/tests/validation/v1_1/businessknowledgemodel/BKM_MISMATCH_VAR.dmn
@@ -19,24 +19,7 @@
   -->
 
 <!-- THIS IS AN OLD VERSION OF DMN EXAMPLE/TEST, PLEASE USE THE MORE RECENT VERSION -->
-<!--
-  ~ Licensed to the Apache Software Foundation (ASF) under one
-  ~ or more contributor license agreements.  See the NOTICE file
-  ~ distributed with this work for additional information
-  ~ regarding copyright ownership.  The ASF licenses this file
-  ~ to you under the Apache License, Version 2.0 (the
-  ~ "License"); you may not use this file except in compliance
-  ~ with the License.  You may obtain a copy of the License at
-  ~
-  ~   http://www.apache.org/licenses/LICENSE-2.0
-  ~
-  ~ Unless required by applicable law or agreed to in writing,
-  ~ software distributed under the License is distributed on an
-  ~ "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
-  ~ KIND, either express or implied.  See the License for the
-  ~ specific language governing permissions and limitations
-  ~ under the License.
-  -->
+
 
 <definitions id="BKM_MISSING_VAR" name="BKM_MISSING_VAR"
     namespace="https://github.com/kiegroup/kie-dmn"

--- a/kie-dmn/kie-dmn-legacy-tests/src/test/resources/org/kie/dmn/legacy/tests/validation/v1_1/businessknowledgemodel/BKM_MISSING_EXPR.dmn
+++ b/kie-dmn/kie-dmn-legacy-tests/src/test/resources/org/kie/dmn/legacy/tests/validation/v1_1/businessknowledgemodel/BKM_MISSING_EXPR.dmn
@@ -19,24 +19,7 @@
   -->
 
 <!-- THIS IS AN OLD VERSION OF DMN EXAMPLE/TEST, PLEASE USE THE MORE RECENT VERSION -->
-<!--
-  ~ Licensed to the Apache Software Foundation (ASF) under one
-  ~ or more contributor license agreements.  See the NOTICE file
-  ~ distributed with this work for additional information
-  ~ regarding copyright ownership.  The ASF licenses this file
-  ~ to you under the Apache License, Version 2.0 (the
-  ~ "License"); you may not use this file except in compliance
-  ~ with the License.  You may obtain a copy of the License at
-  ~
-  ~   http://www.apache.org/licenses/LICENSE-2.0
-  ~
-  ~ Unless required by applicable law or agreed to in writing,
-  ~ software distributed under the License is distributed on an
-  ~ "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
-  ~ KIND, either express or implied.  See the License for the
-  ~ specific language governing permissions and limitations
-  ~ under the License.
-  -->
+
 
 <definitions id="BKM_MISSING_EXPR" name="BKM_MISSING_EXPR"
     namespace="https://github.com/kiegroup/kie-dmn"

--- a/kie-dmn/kie-dmn-legacy-tests/src/test/resources/org/kie/dmn/legacy/tests/validation/v1_1/businessknowledgemodel/BKM_MISSING_VAR.dmn
+++ b/kie-dmn/kie-dmn-legacy-tests/src/test/resources/org/kie/dmn/legacy/tests/validation/v1_1/businessknowledgemodel/BKM_MISSING_VAR.dmn
@@ -19,24 +19,7 @@
   -->
 
 <!-- THIS IS AN OLD VERSION OF DMN EXAMPLE/TEST, PLEASE USE THE MORE RECENT VERSION -->
-<!--
-  ~ Licensed to the Apache Software Foundation (ASF) under one
-  ~ or more contributor license agreements.  See the NOTICE file
-  ~ distributed with this work for additional information
-  ~ regarding copyright ownership.  The ASF licenses this file
-  ~ to you under the Apache License, Version 2.0 (the
-  ~ "License"); you may not use this file except in compliance
-  ~ with the License.  You may obtain a copy of the License at
-  ~
-  ~   http://www.apache.org/licenses/LICENSE-2.0
-  ~
-  ~ Unless required by applicable law or agreed to in writing,
-  ~ software distributed under the License is distributed on an
-  ~ "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
-  ~ KIND, either express or implied.  See the License for the
-  ~ specific language governing permissions and limitations
-  ~ under the License.
-  -->
+
 
 <definitions id="BKM_MISSING_VAR" name="BKM_MISSING_VAR"
     namespace="https://github.com/kiegroup/kie-dmn"

--- a/kie-dmn/kie-dmn-legacy-tests/src/test/resources/org/kie/dmn/legacy/tests/validation/v1_1/context/CONTEXT_DUP_ENTRY.dmn
+++ b/kie-dmn/kie-dmn-legacy-tests/src/test/resources/org/kie/dmn/legacy/tests/validation/v1_1/context/CONTEXT_DUP_ENTRY.dmn
@@ -19,24 +19,7 @@
   -->
 
 <!-- THIS IS AN OLD VERSION OF DMN EXAMPLE/TEST, PLEASE USE THE MORE RECENT VERSION -->
-<!--
-  ~ Licensed to the Apache Software Foundation (ASF) under one
-  ~ or more contributor license agreements.  See the NOTICE file
-  ~ distributed with this work for additional information
-  ~ regarding copyright ownership.  The ASF licenses this file
-  ~ to you under the Apache License, Version 2.0 (the
-  ~ "License"); you may not use this file except in compliance
-  ~ with the License.  You may obtain a copy of the License at
-  ~
-  ~   http://www.apache.org/licenses/LICENSE-2.0
-  ~
-  ~ Unless required by applicable law or agreed to in writing,
-  ~ software distributed under the License is distributed on an
-  ~ "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
-  ~ KIND, either express or implied.  See the License for the
-  ~ specific language governing permissions and limitations
-  ~ under the License.
-  -->
+
 <definitions id="CONTEXT_DUP_ENTRY" name="CONTEXT_DUP_ENTRY"
     namespace="https://github.com/kiegroup/kie-dmn"
     xmlns="http://www.omg.org/spec/DMN/20151101/dmn.xsd"

--- a/kie-dmn/kie-dmn-legacy-tests/src/test/resources/org/kie/dmn/legacy/tests/validation/v1_1/context/CONTEXT_ENTRY_MISSING_VARIABLE.dmn
+++ b/kie-dmn/kie-dmn-legacy-tests/src/test/resources/org/kie/dmn/legacy/tests/validation/v1_1/context/CONTEXT_ENTRY_MISSING_VARIABLE.dmn
@@ -19,24 +19,7 @@
   -->
 
 <!-- THIS IS AN OLD VERSION OF DMN EXAMPLE/TEST, PLEASE USE THE MORE RECENT VERSION -->
-<!--
-  ~ Licensed to the Apache Software Foundation (ASF) under one
-  ~ or more contributor license agreements.  See the NOTICE file
-  ~ distributed with this work for additional information
-  ~ regarding copyright ownership.  The ASF licenses this file
-  ~ to you under the Apache License, Version 2.0 (the
-  ~ "License"); you may not use this file except in compliance
-  ~ with the License.  You may obtain a copy of the License at
-  ~
-  ~   http://www.apache.org/licenses/LICENSE-2.0
-  ~
-  ~ Unless required by applicable law or agreed to in writing,
-  ~ software distributed under the License is distributed on an
-  ~ "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
-  ~ KIND, either express or implied.  See the License for the
-  ~ specific language governing permissions and limitations
-  ~ under the License.
-  -->
+
 <definitions id="CONTEXT_MISSING_EXPR" name="CONTEXT_MISSING_EXPR"
     namespace="https://github.com/kiegroup/kie-dmn"
     xmlns="http://www.omg.org/spec/DMN/20151101/dmn.xsd"

--- a/kie-dmn/kie-dmn-legacy-tests/src/test/resources/org/kie/dmn/legacy/tests/validation/v1_1/context/CONTEXT_ENTRY_NOTYPEREF.dmn
+++ b/kie-dmn/kie-dmn-legacy-tests/src/test/resources/org/kie/dmn/legacy/tests/validation/v1_1/context/CONTEXT_ENTRY_NOTYPEREF.dmn
@@ -19,24 +19,7 @@
   -->
 
 <!-- THIS IS AN OLD VERSION OF DMN EXAMPLE/TEST, PLEASE USE THE MORE RECENT VERSION -->
-<!--
-  ~ Licensed to the Apache Software Foundation (ASF) under one
-  ~ or more contributor license agreements.  See the NOTICE file
-  ~ distributed with this work for additional information
-  ~ regarding copyright ownership.  The ASF licenses this file
-  ~ to you under the Apache License, Version 2.0 (the
-  ~ "License"); you may not use this file except in compliance
-  ~ with the License.  You may obtain a copy of the License at
-  ~
-  ~   http://www.apache.org/licenses/LICENSE-2.0
-  ~
-  ~ Unless required by applicable law or agreed to in writing,
-  ~ software distributed under the License is distributed on an
-  ~ "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
-  ~ KIND, either express or implied.  See the License for the
-  ~ specific language governing permissions and limitations
-  ~ under the License.
-  -->
+
 <definitions id="CONTEXT_ENTRY_NOTYPEREF" name="CONTEXT_ENTRY_NOTYPEREF"
     namespace="https://github.com/kiegroup/kie-dmn"
     xmlns="http://www.omg.org/spec/DMN/20151101/dmn.xsd"

--- a/kie-dmn/kie-dmn-legacy-tests/src/test/resources/org/kie/dmn/legacy/tests/validation/v1_1/context/CONTEXT_MISSING_ENTRIES.dmn
+++ b/kie-dmn/kie-dmn-legacy-tests/src/test/resources/org/kie/dmn/legacy/tests/validation/v1_1/context/CONTEXT_MISSING_ENTRIES.dmn
@@ -19,24 +19,7 @@
   -->
 
 <!-- THIS IS AN OLD VERSION OF DMN EXAMPLE/TEST, PLEASE USE THE MORE RECENT VERSION -->
-<!--
-  ~ Licensed to the Apache Software Foundation (ASF) under one
-  ~ or more contributor license agreements.  See the NOTICE file
-  ~ distributed with this work for additional information
-  ~ regarding copyright ownership.  The ASF licenses this file
-  ~ to you under the Apache License, Version 2.0 (the
-  ~ "License"); you may not use this file except in compliance
-  ~ with the License.  You may obtain a copy of the License at
-  ~
-  ~   http://www.apache.org/licenses/LICENSE-2.0
-  ~
-  ~ Unless required by applicable law or agreed to in writing,
-  ~ software distributed under the License is distributed on an
-  ~ "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
-  ~ KIND, either express or implied.  See the License for the
-  ~ specific language governing permissions and limitations
-  ~ under the License.
-  -->
+
 <definitions id="CONTEXT_MISSING_EXPR" name="CONTEXT_MISSING_EXPR"
     namespace="https://github.com/kiegroup/kie-dmn"
     xmlns="http://www.omg.org/spec/DMN/20151101/dmn.xsd"

--- a/kie-dmn/kie-dmn-legacy-tests/src/test/resources/org/kie/dmn/legacy/tests/validation/v1_1/context/CONTEXT_MISSING_EXPR.dmn
+++ b/kie-dmn/kie-dmn-legacy-tests/src/test/resources/org/kie/dmn/legacy/tests/validation/v1_1/context/CONTEXT_MISSING_EXPR.dmn
@@ -19,24 +19,7 @@
   -->
 
 <!-- THIS IS AN OLD VERSION OF DMN EXAMPLE/TEST, PLEASE USE THE MORE RECENT VERSION -->
-<!--
-  ~ Licensed to the Apache Software Foundation (ASF) under one
-  ~ or more contributor license agreements.  See the NOTICE file
-  ~ distributed with this work for additional information
-  ~ regarding copyright ownership.  The ASF licenses this file
-  ~ to you under the Apache License, Version 2.0 (the
-  ~ "License"); you may not use this file except in compliance
-  ~ with the License.  You may obtain a copy of the License at
-  ~
-  ~   http://www.apache.org/licenses/LICENSE-2.0
-  ~
-  ~ Unless required by applicable law or agreed to in writing,
-  ~ software distributed under the License is distributed on an
-  ~ "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
-  ~ KIND, either express or implied.  See the License for the
-  ~ specific language governing permissions and limitations
-  ~ under the License.
-  -->
+
 <definitions id="CONTEXT_MISSING_EXPR" name="CONTEXT_MISSING_EXPR"
     namespace="https://github.com/kiegroup/kie-dmn"
     xmlns="http://www.omg.org/spec/DMN/20151101/dmn.xsd"

--- a/kie-dmn/kie-dmn-legacy-tests/src/test/resources/org/kie/dmn/legacy/tests/validation/v1_1/decision/DECISION_CYCLIC_DEPENDENCY.dmn
+++ b/kie-dmn/kie-dmn-legacy-tests/src/test/resources/org/kie/dmn/legacy/tests/validation/v1_1/decision/DECISION_CYCLIC_DEPENDENCY.dmn
@@ -19,24 +19,7 @@
   -->
 
 <!-- THIS IS AN OLD VERSION OF DMN EXAMPLE/TEST, PLEASE USE THE MORE RECENT VERSION -->
-<!--
-  ~ Licensed to the Apache Software Foundation (ASF) under one
-  ~ or more contributor license agreements.  See the NOTICE file
-  ~ distributed with this work for additional information
-  ~ regarding copyright ownership.  The ASF licenses this file
-  ~ to you under the Apache License, Version 2.0 (the
-  ~ "License"); you may not use this file except in compliance
-  ~ with the License.  You may obtain a copy of the License at
-  ~
-  ~   http://www.apache.org/licenses/LICENSE-2.0
-  ~
-  ~ Unless required by applicable law or agreed to in writing,
-  ~ software distributed under the License is distributed on an
-  ~ "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
-  ~ KIND, either express or implied.  See the License for the
-  ~ specific language governing permissions and limitations
-  ~ under the License.
-  -->
+
 
 <definitions id="DECISION_CYCLIC_DEPENDENCY" name="DECISION_CYCLIC_DEPENDENCY"
     namespace="https://github.com/kiegroup/kie-dmn"

--- a/kie-dmn/kie-dmn-legacy-tests/src/test/resources/org/kie/dmn/legacy/tests/validation/v1_1/decision/DECISION_CYCLIC_DEPENDENCY_SELF_REFERENCE.dmn
+++ b/kie-dmn/kie-dmn-legacy-tests/src/test/resources/org/kie/dmn/legacy/tests/validation/v1_1/decision/DECISION_CYCLIC_DEPENDENCY_SELF_REFERENCE.dmn
@@ -19,24 +19,7 @@
   -->
 
 <!-- THIS IS AN OLD VERSION OF DMN EXAMPLE/TEST, PLEASE USE THE MORE RECENT VERSION -->
-<!--
-  ~ Licensed to the Apache Software Foundation (ASF) under one
-  ~ or more contributor license agreements.  See the NOTICE file
-  ~ distributed with this work for additional information
-  ~ regarding copyright ownership.  The ASF licenses this file
-  ~ to you under the Apache License, Version 2.0 (the
-  ~ "License"); you may not use this file except in compliance
-  ~ with the License.  You may obtain a copy of the License at
-  ~
-  ~   http://www.apache.org/licenses/LICENSE-2.0
-  ~
-  ~ Unless required by applicable law or agreed to in writing,
-  ~ software distributed under the License is distributed on an
-  ~ "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
-  ~ KIND, either express or implied.  See the License for the
-  ~ specific language governing permissions and limitations
-  ~ under the License.
-  -->
+
 
 <definitions id="DECISION_CYCLIC_DEPENDENCY_SELF_REFERENCE" name="DECISION_CYCLIC_DEPENDENCY_SELF_REFERENCE"
     namespace="https://github.com/kiegroup/kie-dmn"

--- a/kie-dmn/kie-dmn-legacy-tests/src/test/resources/org/kie/dmn/legacy/tests/validation/v1_1/decision/DECISION_DEADLY_DIAMOND.dmn
+++ b/kie-dmn/kie-dmn-legacy-tests/src/test/resources/org/kie/dmn/legacy/tests/validation/v1_1/decision/DECISION_DEADLY_DIAMOND.dmn
@@ -19,24 +19,7 @@
   -->
 
 <!-- THIS IS AN OLD VERSION OF DMN EXAMPLE/TEST, PLEASE USE THE MORE RECENT VERSION -->
-<!--
-  ~ Licensed to the Apache Software Foundation (ASF) under one
-  ~ or more contributor license agreements.  See the NOTICE file
-  ~ distributed with this work for additional information
-  ~ regarding copyright ownership.  The ASF licenses this file
-  ~ to you under the Apache License, Version 2.0 (the
-  ~ "License"); you may not use this file except in compliance
-  ~ with the License.  You may obtain a copy of the License at
-  ~
-  ~   http://www.apache.org/licenses/LICENSE-2.0
-  ~
-  ~ Unless required by applicable law or agreed to in writing,
-  ~ software distributed under the License is distributed on an
-  ~ "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
-  ~ KIND, either express or implied.  See the License for the
-  ~ specific language governing permissions and limitations
-  ~ under the License.
-  -->
+
 
 <definitions id="DECISION_DEADLY_DIAMOND" name="DECISION_DEADLY_DIAMOND"
     namespace="https://github.com/kiegroup/kie-dmn"

--- a/kie-dmn/kie-dmn-legacy-tests/src/test/resources/org/kie/dmn/legacy/tests/validation/v1_1/decision/DECISION_DEADLY_KITE.dmn
+++ b/kie-dmn/kie-dmn-legacy-tests/src/test/resources/org/kie/dmn/legacy/tests/validation/v1_1/decision/DECISION_DEADLY_KITE.dmn
@@ -19,24 +19,7 @@
   -->
 
 <!-- THIS IS AN OLD VERSION OF DMN EXAMPLE/TEST, PLEASE USE THE MORE RECENT VERSION -->
-<!--
-  ~ Licensed to the Apache Software Foundation (ASF) under one
-  ~ or more contributor license agreements.  See the NOTICE file
-  ~ distributed with this work for additional information
-  ~ regarding copyright ownership.  The ASF licenses this file
-  ~ to you under the Apache License, Version 2.0 (the
-  ~ "License"); you may not use this file except in compliance
-  ~ with the License.  You may obtain a copy of the License at
-  ~
-  ~   http://www.apache.org/licenses/LICENSE-2.0
-  ~
-  ~ Unless required by applicable law or agreed to in writing,
-  ~ software distributed under the License is distributed on an
-  ~ "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
-  ~ KIND, either express or implied.  See the License for the
-  ~ specific language governing permissions and limitations
-  ~ under the License.
-  -->
+
 
 <definitions id="DECISION_DEADLY_KITE" name="DECISION_DEADLY_KITE"
     namespace="https://github.com/kiegroup/kie-dmn"

--- a/kie-dmn/kie-dmn-legacy-tests/src/test/resources/org/kie/dmn/legacy/tests/validation/v1_1/decision/DECISION_DECISION_MAKER_WRONG_TYPE.dmn
+++ b/kie-dmn/kie-dmn-legacy-tests/src/test/resources/org/kie/dmn/legacy/tests/validation/v1_1/decision/DECISION_DECISION_MAKER_WRONG_TYPE.dmn
@@ -19,24 +19,7 @@
   -->
 
 <!-- THIS IS AN OLD VERSION OF DMN EXAMPLE/TEST, PLEASE USE THE MORE RECENT VERSION -->
-<!--
-  ~ Licensed to the Apache Software Foundation (ASF) under one
-  ~ or more contributor license agreements.  See the NOTICE file
-  ~ distributed with this work for additional information
-  ~ regarding copyright ownership.  The ASF licenses this file
-  ~ to you under the Apache License, Version 2.0 (the
-  ~ "License"); you may not use this file except in compliance
-  ~ with the License.  You may obtain a copy of the License at
-  ~
-  ~   http://www.apache.org/licenses/LICENSE-2.0
-  ~
-  ~ Unless required by applicable law or agreed to in writing,
-  ~ software distributed under the License is distributed on an
-  ~ "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
-  ~ KIND, either express or implied.  See the License for the
-  ~ specific language governing permissions and limitations
-  ~ under the License.
-  -->
+
 
 <definitions id="DECISION_DECISION_MAKER_WRONG_TYPE" name="DECISION_DECISION_MAKER_WRONG_TYPE"
              namespace="https://github.com/kiegroup/kie-dmn"

--- a/kie-dmn/kie-dmn-legacy-tests/src/test/resources/org/kie/dmn/legacy/tests/validation/v1_1/decision/DECISION_DECISION_OWNER_WRONG_TYPE.dmn
+++ b/kie-dmn/kie-dmn-legacy-tests/src/test/resources/org/kie/dmn/legacy/tests/validation/v1_1/decision/DECISION_DECISION_OWNER_WRONG_TYPE.dmn
@@ -19,24 +19,7 @@
   -->
 
 <!-- THIS IS AN OLD VERSION OF DMN EXAMPLE/TEST, PLEASE USE THE MORE RECENT VERSION -->
-<!--
-  ~ Licensed to the Apache Software Foundation (ASF) under one
-  ~ or more contributor license agreements.  See the NOTICE file
-  ~ distributed with this work for additional information
-  ~ regarding copyright ownership.  The ASF licenses this file
-  ~ to you under the Apache License, Version 2.0 (the
-  ~ "License"); you may not use this file except in compliance
-  ~ with the License.  You may obtain a copy of the License at
-  ~
-  ~   http://www.apache.org/licenses/LICENSE-2.0
-  ~
-  ~ Unless required by applicable law or agreed to in writing,
-  ~ software distributed under the License is distributed on an
-  ~ "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
-  ~ KIND, either express or implied.  See the License for the
-  ~ specific language governing permissions and limitations
-  ~ under the License.
-  -->
+
 
 <definitions id="DECISION_DECISION_MAKER_WRONG_TYPE" name="DECISION_DECISION_MAKER_WRONG_TYPE"
              namespace="https://github.com/kiegroup/kie-dmn"

--- a/kie-dmn/kie-dmn-legacy-tests/src/test/resources/org/kie/dmn/legacy/tests/validation/v1_1/decision/DECISION_MISMATCH_VAR.dmn
+++ b/kie-dmn/kie-dmn-legacy-tests/src/test/resources/org/kie/dmn/legacy/tests/validation/v1_1/decision/DECISION_MISMATCH_VAR.dmn
@@ -19,24 +19,7 @@
   -->
 
 <!-- THIS IS AN OLD VERSION OF DMN EXAMPLE/TEST, PLEASE USE THE MORE RECENT VERSION -->
-<!--
-  ~ Licensed to the Apache Software Foundation (ASF) under one
-  ~ or more contributor license agreements.  See the NOTICE file
-  ~ distributed with this work for additional information
-  ~ regarding copyright ownership.  The ASF licenses this file
-  ~ to you under the Apache License, Version 2.0 (the
-  ~ "License"); you may not use this file except in compliance
-  ~ with the License.  You may obtain a copy of the License at
-  ~
-  ~   http://www.apache.org/licenses/LICENSE-2.0
-  ~
-  ~ Unless required by applicable law or agreed to in writing,
-  ~ software distributed under the License is distributed on an
-  ~ "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
-  ~ KIND, either express or implied.  See the License for the
-  ~ specific language governing permissions and limitations
-  ~ under the License.
-  -->
+
 
 <definitions id="DECISION_MISSING_VAR" name="DECISION_MISSING_VAR"
     namespace="https://github.com/kiegroup/kie-dmn"

--- a/kie-dmn/kie-dmn-legacy-tests/src/test/resources/org/kie/dmn/legacy/tests/validation/v1_1/decision/DECISION_MISSING_EXPR.dmn
+++ b/kie-dmn/kie-dmn-legacy-tests/src/test/resources/org/kie/dmn/legacy/tests/validation/v1_1/decision/DECISION_MISSING_EXPR.dmn
@@ -19,24 +19,7 @@
   -->
 
 <!-- THIS IS AN OLD VERSION OF DMN EXAMPLE/TEST, PLEASE USE THE MORE RECENT VERSION -->
-<!--
-  ~ Licensed to the Apache Software Foundation (ASF) under one
-  ~ or more contributor license agreements.  See the NOTICE file
-  ~ distributed with this work for additional information
-  ~ regarding copyright ownership.  The ASF licenses this file
-  ~ to you under the Apache License, Version 2.0 (the
-  ~ "License"); you may not use this file except in compliance
-  ~ with the License.  You may obtain a copy of the License at
-  ~
-  ~   http://www.apache.org/licenses/LICENSE-2.0
-  ~
-  ~ Unless required by applicable law or agreed to in writing,
-  ~ software distributed under the License is distributed on an
-  ~ "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
-  ~ KIND, either express or implied.  See the License for the
-  ~ specific language governing permissions and limitations
-  ~ under the License.
-  -->
+
 
 <definitions id="DECISION_MISSING_EXPR" name="DECISION_MISSING_EXPR"
              namespace="https://github.com/kiegroup/kie-dmn"

--- a/kie-dmn/kie-dmn-legacy-tests/src/test/resources/org/kie/dmn/legacy/tests/validation/v1_1/decision/DECISION_MISSING_VAR.dmn
+++ b/kie-dmn/kie-dmn-legacy-tests/src/test/resources/org/kie/dmn/legacy/tests/validation/v1_1/decision/DECISION_MISSING_VAR.dmn
@@ -19,24 +19,7 @@
   -->
 
 <!-- THIS IS AN OLD VERSION OF DMN EXAMPLE/TEST, PLEASE USE THE MORE RECENT VERSION -->
-<!--
-  ~ Licensed to the Apache Software Foundation (ASF) under one
-  ~ or more contributor license agreements.  See the NOTICE file
-  ~ distributed with this work for additional information
-  ~ regarding copyright ownership.  The ASF licenses this file
-  ~ to you under the Apache License, Version 2.0 (the
-  ~ "License"); you may not use this file except in compliance
-  ~ with the License.  You may obtain a copy of the License at
-  ~
-  ~   http://www.apache.org/licenses/LICENSE-2.0
-  ~
-  ~ Unless required by applicable law or agreed to in writing,
-  ~ software distributed under the License is distributed on an
-  ~ "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
-  ~ KIND, either express or implied.  See the License for the
-  ~ specific language governing permissions and limitations
-  ~ under the License.
-  -->
+
 
 <definitions id="DECISION_MISSING_VAR" name="DECISION_MISSING_VAR"
     namespace="https://github.com/kiegroup/kie-dmn"

--- a/kie-dmn/kie-dmn-legacy-tests/src/test/resources/org/kie/dmn/legacy/tests/validation/v1_1/decision/DECISION_MISSING_VARbis.dmn
+++ b/kie-dmn/kie-dmn-legacy-tests/src/test/resources/org/kie/dmn/legacy/tests/validation/v1_1/decision/DECISION_MISSING_VARbis.dmn
@@ -19,24 +19,7 @@
   -->
 
 <!-- THIS IS AN OLD VERSION OF DMN EXAMPLE/TEST, PLEASE USE THE MORE RECENT VERSION -->
-<!--
-  ~ Licensed to the Apache Software Foundation (ASF) under one
-  ~ or more contributor license agreements.  See the NOTICE file
-  ~ distributed with this work for additional information
-  ~ regarding copyright ownership.  The ASF licenses this file
-  ~ to you under the Apache License, Version 2.0 (the
-  ~ "License"); you may not use this file except in compliance
-  ~ with the License.  You may obtain a copy of the License at
-  ~
-  ~   http://www.apache.org/licenses/LICENSE-2.0
-  ~
-  ~ Unless required by applicable law or agreed to in writing,
-  ~ software distributed under the License is distributed on an
-  ~ "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
-  ~ KIND, either express or implied.  See the License for the
-  ~ specific language governing permissions and limitations
-  ~ under the License.
-  -->
+
 
 <definitions id="DECISION_MISSING_VARbis" name="DECISION_MISSING_VARbis"
     namespace="https://github.com/kiegroup/kie-dmn"

--- a/kie-dmn/kie-dmn-legacy-tests/src/test/resources/org/kie/dmn/legacy/tests/validation/v1_1/decision/DECISION_MULTIPLE_EXPRESSIONS.dmn
+++ b/kie-dmn/kie-dmn-legacy-tests/src/test/resources/org/kie/dmn/legacy/tests/validation/v1_1/decision/DECISION_MULTIPLE_EXPRESSIONS.dmn
@@ -19,24 +19,7 @@
   -->
 
 <!-- THIS IS AN OLD VERSION OF DMN EXAMPLE/TEST, PLEASE USE THE MORE RECENT VERSION -->
-<!--
-  ~ Licensed to the Apache Software Foundation (ASF) under one
-  ~ or more contributor license agreements.  See the NOTICE file
-  ~ distributed with this work for additional information
-  ~ regarding copyright ownership.  The ASF licenses this file
-  ~ to you under the Apache License, Version 2.0 (the
-  ~ "License"); you may not use this file except in compliance
-  ~ with the License.  You may obtain a copy of the License at
-  ~
-  ~   http://www.apache.org/licenses/LICENSE-2.0
-  ~
-  ~ Unless required by applicable law or agreed to in writing,
-  ~ software distributed under the License is distributed on an
-  ~ "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
-  ~ KIND, either express or implied.  See the License for the
-  ~ specific language governing permissions and limitations
-  ~ under the License.
-  -->
+
 
 <definitions id="DECISION_MULTIPLE_EXPRESSIONS" name="DECISION_MULTIPLE_EXPRESSIONS"
              namespace="https://github.com/kiegroup/kie-dmn"

--- a/kie-dmn/kie-dmn-legacy-tests/src/test/resources/org/kie/dmn/legacy/tests/validation/v1_1/decision/DECISION_PERF_INDICATOR_WRONG_TYPE.dmn
+++ b/kie-dmn/kie-dmn-legacy-tests/src/test/resources/org/kie/dmn/legacy/tests/validation/v1_1/decision/DECISION_PERF_INDICATOR_WRONG_TYPE.dmn
@@ -19,24 +19,7 @@
   -->
 
 <!-- THIS IS AN OLD VERSION OF DMN EXAMPLE/TEST, PLEASE USE THE MORE RECENT VERSION -->
-<!--
-  ~ Licensed to the Apache Software Foundation (ASF) under one
-  ~ or more contributor license agreements.  See the NOTICE file
-  ~ distributed with this work for additional information
-  ~ regarding copyright ownership.  The ASF licenses this file
-  ~ to you under the Apache License, Version 2.0 (the
-  ~ "License"); you may not use this file except in compliance
-  ~ with the License.  You may obtain a copy of the License at
-  ~
-  ~   http://www.apache.org/licenses/LICENSE-2.0
-  ~
-  ~ Unless required by applicable law or agreed to in writing,
-  ~ software distributed under the License is distributed on an
-  ~ "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
-  ~ KIND, either express or implied.  See the License for the
-  ~ specific language governing permissions and limitations
-  ~ under the License.
-  -->
+
 
 <definitions id="DECISION_PERF_INDICATOR_WRONG_TYPE" name="DECISION_PERF_INDICATOR_WRONG_TYPE"
              namespace="https://github.com/kiegroup/kie-dmn"

--- a/kie-dmn/kie-dmn-legacy-tests/src/test/resources/org/kie/dmn/legacy/tests/validation/v1_1/dmnelementref/ELEMREF_NOHASH.dmn
+++ b/kie-dmn/kie-dmn-legacy-tests/src/test/resources/org/kie/dmn/legacy/tests/validation/v1_1/dmnelementref/ELEMREF_NOHASH.dmn
@@ -19,19 +19,7 @@
   -->
 
 <!-- THIS IS AN OLD VERSION OF DMN EXAMPLE/TEST, PLEASE USE THE MORE RECENT VERSION -->
-<!--
-  ~ Licensed under the Apache License, Version 2.0 (the "License");
-  ~ you may not use this file except in compliance with the License.
-  ~ You may obtain a copy of the License at
-  ~
-  ~       http://www.apache.org/licenses/LICENSE-2.0
-  ~
-  ~ Unless required by applicable law or agreed to in writing, software
-  ~ distributed under the License is distributed on an "AS IS" BASIS,
-  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-  ~ See the License for the specific language governing permissions and
-  ~ limitations under the License.
-  -->
+
 
 <definitions id="ELEMREF_NOHASH" name="ELEMREF_NOHASH"
     namespace="https://github.com/kiegroup/kie-dmn"

--- a/kie-dmn/kie-dmn-legacy-tests/src/test/resources/org/kie/dmn/legacy/tests/validation/v1_1/informationrequirement/INFOREQ_DECISION_NOT_DECISION.dmn
+++ b/kie-dmn/kie-dmn-legacy-tests/src/test/resources/org/kie/dmn/legacy/tests/validation/v1_1/informationrequirement/INFOREQ_DECISION_NOT_DECISION.dmn
@@ -19,24 +19,7 @@
   -->
 
 <!-- THIS IS AN OLD VERSION OF DMN EXAMPLE/TEST, PLEASE USE THE MORE RECENT VERSION -->
-<!--
-  ~ Licensed to the Apache Software Foundation (ASF) under one
-  ~ or more contributor license agreements.  See the NOTICE file
-  ~ distributed with this work for additional information
-  ~ regarding copyright ownership.  The ASF licenses this file
-  ~ to you under the Apache License, Version 2.0 (the
-  ~ "License"); you may not use this file except in compliance
-  ~ with the License.  You may obtain a copy of the License at
-  ~
-  ~   http://www.apache.org/licenses/LICENSE-2.0
-  ~
-  ~ Unless required by applicable law or agreed to in writing,
-  ~ software distributed under the License is distributed on an
-  ~ "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
-  ~ KIND, either express or implied.  See the License for the
-  ~ specific language governing permissions and limitations
-  ~ under the License.
-  -->
+
 
 <definitions id="INFOREQ_DECISION_NOT_DECISION" name="INFOREQ_DECISION_NOT_DECISION"
     namespace="https://github.com/kiegroup/kie-dmn"

--- a/kie-dmn/kie-dmn-legacy-tests/src/test/resources/org/kie/dmn/legacy/tests/validation/v1_1/informationrequirement/INFOREQ_INPUT_NOT_INPUTDATA.dmn
+++ b/kie-dmn/kie-dmn-legacy-tests/src/test/resources/org/kie/dmn/legacy/tests/validation/v1_1/informationrequirement/INFOREQ_INPUT_NOT_INPUTDATA.dmn
@@ -19,24 +19,7 @@
   -->
 
 <!-- THIS IS AN OLD VERSION OF DMN EXAMPLE/TEST, PLEASE USE THE MORE RECENT VERSION -->
-<!--
-  ~ Licensed to the Apache Software Foundation (ASF) under one
-  ~ or more contributor license agreements.  See the NOTICE file
-  ~ distributed with this work for additional information
-  ~ regarding copyright ownership.  The ASF licenses this file
-  ~ to you under the Apache License, Version 2.0 (the
-  ~ "License"); you may not use this file except in compliance
-  ~ with the License.  You may obtain a copy of the License at
-  ~
-  ~   http://www.apache.org/licenses/LICENSE-2.0
-  ~
-  ~ Unless required by applicable law or agreed to in writing,
-  ~ software distributed under the License is distributed on an
-  ~ "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
-  ~ KIND, either express or implied.  See the License for the
-  ~ specific language governing permissions and limitations
-  ~ under the License.
-  -->
+
 
 <definitions id="INFOREQ_INPUT_NOT_INPUTDATA" name="INFOREQ_INPUT_NOT_INPUTDATA"
     namespace="https://github.com/kiegroup/kie-dmn"

--- a/kie-dmn/kie-dmn-legacy-tests/src/test/resources/org/kie/dmn/legacy/tests/validation/v1_1/informationrequirement/INFOREQ_MISSING_DECISION.dmn
+++ b/kie-dmn/kie-dmn-legacy-tests/src/test/resources/org/kie/dmn/legacy/tests/validation/v1_1/informationrequirement/INFOREQ_MISSING_DECISION.dmn
@@ -19,24 +19,7 @@
   -->
 
 <!-- THIS IS AN OLD VERSION OF DMN EXAMPLE/TEST, PLEASE USE THE MORE RECENT VERSION -->
-<!--
-  ~ Licensed to the Apache Software Foundation (ASF) under one
-  ~ or more contributor license agreements.  See the NOTICE file
-  ~ distributed with this work for additional information
-  ~ regarding copyright ownership.  The ASF licenses this file
-  ~ to you under the Apache License, Version 2.0 (the
-  ~ "License"); you may not use this file except in compliance
-  ~ with the License.  You may obtain a copy of the License at
-  ~
-  ~   http://www.apache.org/licenses/LICENSE-2.0
-  ~
-  ~ Unless required by applicable law or agreed to in writing,
-  ~ software distributed under the License is distributed on an
-  ~ "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
-  ~ KIND, either express or implied.  See the License for the
-  ~ specific language governing permissions and limitations
-  ~ under the License.
-  -->
+
 
 <definitions id="INFOREQ_MISSING_DECISION" name="INFOREQ_MISSING_DECISION"
     namespace="https://github.com/kiegroup/kie-dmn"

--- a/kie-dmn/kie-dmn-legacy-tests/src/test/resources/org/kie/dmn/legacy/tests/validation/v1_1/informationrequirement/INFOREQ_MISSING_INPUT.dmn
+++ b/kie-dmn/kie-dmn-legacy-tests/src/test/resources/org/kie/dmn/legacy/tests/validation/v1_1/informationrequirement/INFOREQ_MISSING_INPUT.dmn
@@ -19,24 +19,7 @@
   -->
 
 <!-- THIS IS AN OLD VERSION OF DMN EXAMPLE/TEST, PLEASE USE THE MORE RECENT VERSION -->
-<!--
-  ~ Licensed to the Apache Software Foundation (ASF) under one
-  ~ or more contributor license agreements.  See the NOTICE file
-  ~ distributed with this work for additional information
-  ~ regarding copyright ownership.  The ASF licenses this file
-  ~ to you under the Apache License, Version 2.0 (the
-  ~ "License"); you may not use this file except in compliance
-  ~ with the License.  You may obtain a copy of the License at
-  ~
-  ~   http://www.apache.org/licenses/LICENSE-2.0
-  ~
-  ~ Unless required by applicable law or agreed to in writing,
-  ~ software distributed under the License is distributed on an
-  ~ "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
-  ~ KIND, either express or implied.  See the License for the
-  ~ specific language governing permissions and limitations
-  ~ under the License.
-  -->
+
 
 <definitions id="INFOREQ_MISSING_INPUT" name="INFOREQ_MISSING_INPUT"
     namespace="https://github.com/kiegroup/kie-dmn"

--- a/kie-dmn/kie-dmn-legacy-tests/src/test/resources/org/kie/dmn/legacy/tests/validation/v1_1/inputdata/INPUTDATA_MISMATCH_VAR.dmn
+++ b/kie-dmn/kie-dmn-legacy-tests/src/test/resources/org/kie/dmn/legacy/tests/validation/v1_1/inputdata/INPUTDATA_MISMATCH_VAR.dmn
@@ -19,24 +19,7 @@
   -->
 
 <!-- THIS IS AN OLD VERSION OF DMN EXAMPLE/TEST, PLEASE USE THE MORE RECENT VERSION -->
-<!--
-  ~ Licensed to the Apache Software Foundation (ASF) under one
-  ~ or more contributor license agreements.  See the NOTICE file
-  ~ distributed with this work for additional information
-  ~ regarding copyright ownership.  The ASF licenses this file
-  ~ to you under the Apache License, Version 2.0 (the
-  ~ "License"); you may not use this file except in compliance
-  ~ with the License.  You may obtain a copy of the License at
-  ~
-  ~   http://www.apache.org/licenses/LICENSE-2.0
-  ~
-  ~ Unless required by applicable law or agreed to in writing,
-  ~ software distributed under the License is distributed on an
-  ~ "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
-  ~ KIND, either express or implied.  See the License for the
-  ~ specific language governing permissions and limitations
-  ~ under the License.
-  -->
+
 
 <definitions id="INPUTDATA_MISSING_VAR" name="INPUTDATA_MISSING_VAR"
     namespace="https://github.com/kiegroup/kie-dmn"

--- a/kie-dmn/kie-dmn-legacy-tests/src/test/resources/org/kie/dmn/legacy/tests/validation/v1_1/inputdata/INPUTDATA_MISSING_VAR.dmn
+++ b/kie-dmn/kie-dmn-legacy-tests/src/test/resources/org/kie/dmn/legacy/tests/validation/v1_1/inputdata/INPUTDATA_MISSING_VAR.dmn
@@ -19,24 +19,7 @@
   -->
 
 <!-- THIS IS AN OLD VERSION OF DMN EXAMPLE/TEST, PLEASE USE THE MORE RECENT VERSION -->
-<!--
-  ~ Licensed to the Apache Software Foundation (ASF) under one
-  ~ or more contributor license agreements.  See the NOTICE file
-  ~ distributed with this work for additional information
-  ~ regarding copyright ownership.  The ASF licenses this file
-  ~ to you under the Apache License, Version 2.0 (the
-  ~ "License"); you may not use this file except in compliance
-  ~ with the License.  You may obtain a copy of the License at
-  ~
-  ~   http://www.apache.org/licenses/LICENSE-2.0
-  ~
-  ~ Unless required by applicable law or agreed to in writing,
-  ~ software distributed under the License is distributed on an
-  ~ "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
-  ~ KIND, either express or implied.  See the License for the
-  ~ specific language governing permissions and limitations
-  ~ under the License.
-  -->
+
 
 <definitions id="INPUTDATA_MISSING_VAR" name="INPUTDATA_MISSING_VAR"
     namespace="https://github.com/kiegroup/kie-dmn"

--- a/kie-dmn/kie-dmn-legacy-tests/src/test/resources/org/kie/dmn/legacy/tests/validation/v1_1/invalidXml.dmn
+++ b/kie-dmn/kie-dmn-legacy-tests/src/test/resources/org/kie/dmn/legacy/tests/validation/v1_1/invalidXml.dmn
@@ -19,24 +19,7 @@
   -->
 
 <!-- THIS IS AN OLD VERSION OF DMN EXAMPLE/TEST, PLEASE USE THE MORE RECENT VERSION -->
-<!--
-  ~ Licensed to the Apache Software Foundation (ASF) under one
-  ~ or more contributor license agreements.  See the NOTICE file
-  ~ distributed with this work for additional information
-  ~ regarding copyright ownership.  The ASF licenses this file
-  ~ to you under the Apache License, Version 2.0 (the
-  ~ "License"); you may not use this file except in compliance
-  ~ with the License.  You may obtain a copy of the License at
-  ~
-  ~   http://www.apache.org/licenses/LICENSE-2.0
-  ~
-  ~ Unless required by applicable law or agreed to in writing,
-  ~ software distributed under the License is distributed on an
-  ~ "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
-  ~ KIND, either express or implied.  See the License for the
-  ~ specific language governing permissions and limitations
-  ~ under the License.
-  -->
+
 
 <definitions id="invalidXml" name="invalidXml"
     namespace="https://github.com/kiegroup/kie-dmn"

--- a/kie-dmn/kie-dmn-legacy-tests/src/test/resources/org/kie/dmn/legacy/tests/validation/v1_1/knowledgerequirement/KNOWREQ_MISSING_BKM.dmn
+++ b/kie-dmn/kie-dmn-legacy-tests/src/test/resources/org/kie/dmn/legacy/tests/validation/v1_1/knowledgerequirement/KNOWREQ_MISSING_BKM.dmn
@@ -19,24 +19,7 @@
   -->
 
 <!-- THIS IS AN OLD VERSION OF DMN EXAMPLE/TEST, PLEASE USE THE MORE RECENT VERSION -->
-<!--
-  ~ Licensed to the Apache Software Foundation (ASF) under one
-  ~ or more contributor license agreements.  See the NOTICE file
-  ~ distributed with this work for additional information
-  ~ regarding copyright ownership.  The ASF licenses this file
-  ~ to you under the Apache License, Version 2.0 (the
-  ~ "License"); you may not use this file except in compliance
-  ~ with the License.  You may obtain a copy of the License at
-  ~
-  ~   http://www.apache.org/licenses/LICENSE-2.0
-  ~
-  ~ Unless required by applicable law or agreed to in writing,
-  ~ software distributed under the License is distributed on an
-  ~ "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
-  ~ KIND, either express or implied.  See the License for the
-  ~ specific language governing permissions and limitations
-  ~ under the License.
-  -->
+
 
 <definitions id="KNOWREQ_MISSING_BKM" name="KNOWREQ_MISSING_BKM"
     namespace="https://github.com/kiegroup/kie-dmn"

--- a/kie-dmn/kie-dmn-legacy-tests/src/test/resources/org/kie/dmn/legacy/tests/validation/v1_1/knowledgerequirement/KNOWREQ_REQ_DECISION_NOT_BKM.dmn
+++ b/kie-dmn/kie-dmn-legacy-tests/src/test/resources/org/kie/dmn/legacy/tests/validation/v1_1/knowledgerequirement/KNOWREQ_REQ_DECISION_NOT_BKM.dmn
@@ -19,24 +19,7 @@
   -->
 
 <!-- THIS IS AN OLD VERSION OF DMN EXAMPLE/TEST, PLEASE USE THE MORE RECENT VERSION -->
-<!--
-  ~ Licensed to the Apache Software Foundation (ASF) under one
-  ~ or more contributor license agreements.  See the NOTICE file
-  ~ distributed with this work for additional information
-  ~ regarding copyright ownership.  The ASF licenses this file
-  ~ to you under the Apache License, Version 2.0 (the
-  ~ "License"); you may not use this file except in compliance
-  ~ with the License.  You may obtain a copy of the License at
-  ~
-  ~   http://www.apache.org/licenses/LICENSE-2.0
-  ~
-  ~ Unless required by applicable law or agreed to in writing,
-  ~ software distributed under the License is distributed on an
-  ~ "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
-  ~ KIND, either express or implied.  See the License for the
-  ~ specific language governing permissions and limitations
-  ~ under the License.
-  -->
+
 
 <definitions id="KNOWREQ_REQ_DECISION_NOT_BKM" name="KNOWREQ_REQ_DECISION_NOT_BKM"
     namespace="https://github.com/kiegroup/kie-dmn"

--- a/kie-dmn/kie-dmn-legacy-tests/src/test/resources/org/kie/dmn/legacy/tests/validation/v1_1/knowledgesource/KNOW_SOURCE_MISSING_OWNER.dmn
+++ b/kie-dmn/kie-dmn-legacy-tests/src/test/resources/org/kie/dmn/legacy/tests/validation/v1_1/knowledgesource/KNOW_SOURCE_MISSING_OWNER.dmn
@@ -19,24 +19,7 @@
   -->
 
 <!-- THIS IS AN OLD VERSION OF DMN EXAMPLE/TEST, PLEASE USE THE MORE RECENT VERSION -->
-<!--
-  ~ Licensed to the Apache Software Foundation (ASF) under one
-  ~ or more contributor license agreements.  See the NOTICE file
-  ~ distributed with this work for additional information
-  ~ regarding copyright ownership.  The ASF licenses this file
-  ~ to you under the Apache License, Version 2.0 (the
-  ~ "License"); you may not use this file except in compliance
-  ~ with the License.  You may obtain a copy of the License at
-  ~
-  ~   http://www.apache.org/licenses/LICENSE-2.0
-  ~
-  ~ Unless required by applicable law or agreed to in writing,
-  ~ software distributed under the License is distributed on an
-  ~ "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
-  ~ KIND, either express or implied.  See the License for the
-  ~ specific language governing permissions and limitations
-  ~ under the License.
-  -->
+
 
 <definitions id="KNOW_SOURCE_MISSING_OWNER" name="KNOW_SOURCE_MISSING_OWNER"
              namespace="https://github.com/kiegroup/kie-dmn"

--- a/kie-dmn/kie-dmn-legacy-tests/src/test/resources/org/kie/dmn/legacy/tests/validation/v1_1/knowledgesource/KNOW_SOURCE_OWNER_NOT_ORG_UNIT.dmn
+++ b/kie-dmn/kie-dmn-legacy-tests/src/test/resources/org/kie/dmn/legacy/tests/validation/v1_1/knowledgesource/KNOW_SOURCE_OWNER_NOT_ORG_UNIT.dmn
@@ -19,24 +19,7 @@
   -->
 
 <!-- THIS IS AN OLD VERSION OF DMN EXAMPLE/TEST, PLEASE USE THE MORE RECENT VERSION -->
-<!--
-  ~ Licensed to the Apache Software Foundation (ASF) under one
-  ~ or more contributor license agreements.  See the NOTICE file
-  ~ distributed with this work for additional information
-  ~ regarding copyright ownership.  The ASF licenses this file
-  ~ to you under the Apache License, Version 2.0 (the
-  ~ "License"); you may not use this file except in compliance
-  ~ with the License.  You may obtain a copy of the License at
-  ~
-  ~   http://www.apache.org/licenses/LICENSE-2.0
-  ~
-  ~ Unless required by applicable law or agreed to in writing,
-  ~ software distributed under the License is distributed on an
-  ~ "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
-  ~ KIND, either express or implied.  See the License for the
-  ~ specific language governing permissions and limitations
-  ~ under the License.
-  -->
+
 
 <definitions id="KNOW_SOURCE_OWNER_NOT_ORG_UNIT" name="KNOW_SOURCE_OWNER_NOT_ORG_UNIT"
              namespace="https://github.com/kiegroup/kie-dmn"

--- a/kie-dmn/kie-dmn-legacy-tests/src/test/resources/org/kie/dmn/legacy/tests/validation/v1_1/typeref/TYPEREF_NOT_FEEL_NOT_DEF.dmn
+++ b/kie-dmn/kie-dmn-legacy-tests/src/test/resources/org/kie/dmn/legacy/tests/validation/v1_1/typeref/TYPEREF_NOT_FEEL_NOT_DEF.dmn
@@ -19,24 +19,7 @@
   -->
 
 <!-- THIS IS AN OLD VERSION OF DMN EXAMPLE/TEST, PLEASE USE THE MORE RECENT VERSION -->
-<!--
-  ~ Licensed to the Apache Software Foundation (ASF) under one
-  ~ or more contributor license agreements.  See the NOTICE file
-  ~ distributed with this work for additional information
-  ~ regarding copyright ownership.  The ASF licenses this file
-  ~ to you under the Apache License, Version 2.0 (the
-  ~ "License"); you may not use this file except in compliance
-  ~ with the License.  You may obtain a copy of the License at
-  ~
-  ~   http://www.apache.org/licenses/LICENSE-2.0
-  ~
-  ~ Unless required by applicable law or agreed to in writing,
-  ~ software distributed under the License is distributed on an
-  ~ "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
-  ~ KIND, either express or implied.  See the License for the
-  ~ specific language governing permissions and limitations
-  ~ under the License.
-  -->
+
 
 <definitions id="TYPEREF_NOT_FEEL_NOT_DEF" name="TYPEREF_NOT_FEEL_NOT_DEF"
     namespace="https://github.com/kiegroup/kie-dmn"

--- a/kie-dmn/kie-dmn-legacy-tests/src/test/resources/org/kie/dmn/legacy/tests/validation/v1_1/typeref/TYPEREF_NOT_FEEL_NOT_DEF_valid.dmn
+++ b/kie-dmn/kie-dmn-legacy-tests/src/test/resources/org/kie/dmn/legacy/tests/validation/v1_1/typeref/TYPEREF_NOT_FEEL_NOT_DEF_valid.dmn
@@ -19,24 +19,7 @@
   -->
 
 <!-- THIS IS AN OLD VERSION OF DMN EXAMPLE/TEST, PLEASE USE THE MORE RECENT VERSION -->
-<!--
-  ~ Licensed to the Apache Software Foundation (ASF) under one
-  ~ or more contributor license agreements.  See the NOTICE file
-  ~ distributed with this work for additional information
-  ~ regarding copyright ownership.  The ASF licenses this file
-  ~ to you under the Apache License, Version 2.0 (the
-  ~ "License"); you may not use this file except in compliance
-  ~ with the License.  You may obtain a copy of the License at
-  ~
-  ~   http://www.apache.org/licenses/LICENSE-2.0
-  ~
-  ~ Unless required by applicable law or agreed to in writing,
-  ~ software distributed under the License is distributed on an
-  ~ "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
-  ~ KIND, either express or implied.  See the License for the
-  ~ specific language governing permissions and limitations
-  ~ under the License.
-  -->
+
 
 <definitions id="TYPEREF_NOT_FEEL_NOT_DEF_valid" name="TYPEREF_NOT_FEEL_NOT_DEF_valid"
     namespace="https://github.com/kiegroup/kie-dmn"

--- a/kie-dmn/kie-dmn-legacy-tests/src/test/resources/org/kie/dmn/legacy/tests/validation/v1_1/typeref/TYPEREF_NO_FEEL_TYPE.dmn
+++ b/kie-dmn/kie-dmn-legacy-tests/src/test/resources/org/kie/dmn/legacy/tests/validation/v1_1/typeref/TYPEREF_NO_FEEL_TYPE.dmn
@@ -19,24 +19,7 @@
   -->
 
 <!-- THIS IS AN OLD VERSION OF DMN EXAMPLE/TEST, PLEASE USE THE MORE RECENT VERSION -->
-<!--
-  ~ Licensed to the Apache Software Foundation (ASF) under one
-  ~ or more contributor license agreements.  See the NOTICE file
-  ~ distributed with this work for additional information
-  ~ regarding copyright ownership.  The ASF licenses this file
-  ~ to you under the Apache License, Version 2.0 (the
-  ~ "License"); you may not use this file except in compliance
-  ~ with the License.  You may obtain a copy of the License at
-  ~
-  ~   http://www.apache.org/licenses/LICENSE-2.0
-  ~
-  ~ Unless required by applicable law or agreed to in writing,
-  ~ software distributed under the License is distributed on an
-  ~ "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
-  ~ KIND, either express or implied.  See the License for the
-  ~ specific language governing permissions and limitations
-  ~ under the License.
-  -->
+
 
 <definitions id="TYPEREF_NO_FEEL_TYPE" name="TYPEREF_NO_FEEL_TYPE"
     namespace="https://github.com/kiegroup/kie-dmn"

--- a/kie-dmn/kie-dmn-legacy-tests/src/test/resources/org/kie/dmn/legacy/tests/validation/v1_1/typeref/TYPEREF_NO_NS.dmn
+++ b/kie-dmn/kie-dmn-legacy-tests/src/test/resources/org/kie/dmn/legacy/tests/validation/v1_1/typeref/TYPEREF_NO_NS.dmn
@@ -19,24 +19,7 @@
   -->
 
 <!-- THIS IS AN OLD VERSION OF DMN EXAMPLE/TEST, PLEASE USE THE MORE RECENT VERSION -->
-<!--
-  ~ Licensed to the Apache Software Foundation (ASF) under one
-  ~ or more contributor license agreements.  See the NOTICE file
-  ~ distributed with this work for additional information
-  ~ regarding copyright ownership.  The ASF licenses this file
-  ~ to you under the Apache License, Version 2.0 (the
-  ~ "License"); you may not use this file except in compliance
-  ~ with the License.  You may obtain a copy of the License at
-  ~
-  ~   http://www.apache.org/licenses/LICENSE-2.0
-  ~
-  ~ Unless required by applicable law or agreed to in writing,
-  ~ software distributed under the License is distributed on an
-  ~ "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
-  ~ KIND, either express or implied.  See the License for the
-  ~ specific language governing permissions and limitations
-  ~ under the License.
-  -->
+
 
 <definitions id="TYPEREF_NO_NS" name="TYPEREF_NO_NS"
     namespace="https://github.com/kiegroup/kie-dmn"

--- a/kie-dmn/kie-dmn-validation/src/test/resources/org/kie/dmn/validation/DTABLE_EMPTY_ENTRY.dmn
+++ b/kie-dmn/kie-dmn-validation/src/test/resources/org/kie/dmn/validation/DTABLE_EMPTY_ENTRY.dmn
@@ -18,19 +18,7 @@
   under the License.
   -->
 
-<!--
-  ~ Licensed under the Apache License, Version 2.0 (the "License");
-  ~ you may not use this file except in compliance with the License.
-  ~ You may obtain a copy of the License at
-  ~
-  ~       http://www.apache.org/licenses/LICENSE-2.0
-  ~
-  ~ Unless required by applicable law or agreed to in writing, software
-  ~ distributed under the License is distributed on an "AS IS" BASIS,
-  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-  ~ See the License for the specific language governing permissions and
-  ~ limitations under the License.
-  -->
+
 <semantic:definitions xmlns="https://github.com/kiegroup/kie-dmn"
                       xmlns:dc="http://www.omg.org/spec/DMN/20180521/DC/"
                       xmlns:di="http://www.omg.org/spec/DMN/20180521/DI/"

--- a/kie-dmn/kie-dmn-validation/src/test/resources/org/kie/dmn/validation/DTABLE_MULTIPLEOUTPUT_WRONG_OUTPUT.dmn
+++ b/kie-dmn/kie-dmn-validation/src/test/resources/org/kie/dmn/validation/DTABLE_MULTIPLEOUTPUT_WRONG_OUTPUT.dmn
@@ -18,19 +18,7 @@
   under the License.
   -->
 
-<!--
-  ~ Licensed under the Apache License, Version 2.0 (the "License");
-  ~ you may not use this file except in compliance with the License.
-  ~ You may obtain a copy of the License at
-  ~
-  ~       http://www.apache.org/licenses/LICENSE-2.0
-  ~
-  ~ Unless required by applicable law or agreed to in writing, software
-  ~ distributed under the License is distributed on an "AS IS" BASIS,
-  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-  ~ See the License for the specific language governing permissions and
-  ~ limitations under the License.
-  -->
+
 <semantic:definitions xmlns="https://github.com/kiegroup/kie-dmn"
                       xmlns:dc="http://www.omg.org/spec/DMN/20180521/DC/"
                       xmlns:di="http://www.omg.org/spec/DMN/20180521/DI/"

--- a/kie-dmn/kie-dmn-validation/src/test/resources/org/kie/dmn/validation/DTABLE_PRIORITY_MISSING_OUTVALS.dmn
+++ b/kie-dmn/kie-dmn-validation/src/test/resources/org/kie/dmn/validation/DTABLE_PRIORITY_MISSING_OUTVALS.dmn
@@ -18,19 +18,7 @@
   under the License.
   -->
 
-<!--
-  ~ Licensed under the Apache License, Version 2.0 (the "License");
-  ~ you may not use this file except in compliance with the License.
-  ~ You may obtain a copy of the License at
-  ~
-  ~       http://www.apache.org/licenses/LICENSE-2.0
-  ~
-  ~ Unless required by applicable law or agreed to in writing, software
-  ~ distributed under the License is distributed on an "AS IS" BASIS,
-  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-  ~ See the License for the specific language governing permissions and
-  ~ limitations under the License.
-  -->
+
 <semantic:definitions xmlns="https://github.com/kiegroup/kie-dmn"
                       xmlns:dc="http://www.omg.org/spec/DMN/20180521/DC/"
                       xmlns:di="http://www.omg.org/spec/DMN/20180521/DI/"

--- a/kie-dmn/kie-dmn-validation/src/test/resources/org/kie/dmn/validation/DTABLE_SINGLEOUTPUT_WRONG_OUTPUT.dmn
+++ b/kie-dmn/kie-dmn-validation/src/test/resources/org/kie/dmn/validation/DTABLE_SINGLEOUTPUT_WRONG_OUTPUT.dmn
@@ -18,19 +18,7 @@
   under the License.
   -->
 
-<!--
-  ~ Licensed under the Apache License, Version 2.0 (the "License");
-  ~ you may not use this file except in compliance with the License.
-  ~ You may obtain a copy of the License at
-  ~
-  ~       http://www.apache.org/licenses/LICENSE-2.0
-  ~
-  ~ Unless required by applicable law or agreed to in writing, software
-  ~ distributed under the License is distributed on an "AS IS" BASIS,
-  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-  ~ See the License for the specific language governing permissions and
-  ~ limitations under the License.
-  -->
+
 <semantic:definitions xmlns="https://github.com/kiegroup/kie-dmn"
                       xmlns:dc="http://www.omg.org/spec/DMN/20180521/DC/"
                       xmlns:di="http://www.omg.org/spec/DMN/20180521/DI/"

--- a/kie-dmn/kie-dmn-validation/src/test/resources/org/kie/dmn/validation/REQAUTH_NOT_KNOWLEDGESOURCEbis.dmn
+++ b/kie-dmn/kie-dmn-validation/src/test/resources/org/kie/dmn/validation/REQAUTH_NOT_KNOWLEDGESOURCEbis.dmn
@@ -18,19 +18,7 @@
   under the License.
   -->
 
-<!--
-  ~ Licensed under the Apache License, Version 2.0 (the "License");
-  ~ you may not use this file except in compliance with the License.
-  ~ You may obtain a copy of the License at
-  ~
-  ~       http://www.apache.org/licenses/LICENSE-2.0
-  ~
-  ~ Unless required by applicable law or agreed to in writing, software
-  ~ distributed under the License is distributed on an "AS IS" BASIS,
-  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-  ~ See the License for the specific language governing permissions and
-  ~ limitations under the License.
-  -->
+
 <semantic:definitions xmlns="https://github.com/kiegroup/kie-dmn"
                       xmlns:dc="http://www.omg.org/spec/DMN/20180521/DC/"
                       xmlns:di="http://www.omg.org/spec/DMN/20180521/DI/"

--- a/kie-dmn/kie-dmn-validation/src/test/resources/org/kie/dmn/validation/authorityrequirement/AUTHREQ_DEP_REQ_AUTH_NOT_KNOWLEDGESOURCE.dmn
+++ b/kie-dmn/kie-dmn-validation/src/test/resources/org/kie/dmn/validation/authorityrequirement/AUTHREQ_DEP_REQ_AUTH_NOT_KNOWLEDGESOURCE.dmn
@@ -18,19 +18,7 @@
   under the License.
   -->
 
-<!--
-  ~ Licensed under the Apache License, Version 2.0 (the "License");
-  ~ you may not use this file except in compliance with the License.
-  ~ You may obtain a copy of the License at
-  ~
-  ~       http://www.apache.org/licenses/LICENSE-2.0
-  ~
-  ~ Unless required by applicable law or agreed to in writing, software
-  ~ distributed under the License is distributed on an "AS IS" BASIS,
-  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-  ~ See the License for the specific language governing permissions and
-  ~ limitations under the License.
-  -->
+
 <semantic:definitions xmlns="https://github.com/kiegroup/kie-dmn"
                       xmlns:dc="http://www.omg.org/spec/DMN/20180521/DC/"
                       xmlns:di="http://www.omg.org/spec/DMN/20180521/DI/"

--- a/kie-dmn/kie-dmn-validation/src/test/resources/org/kie/dmn/validation/dmnelementref/ELEMREF_NOHASH.dmn
+++ b/kie-dmn/kie-dmn-validation/src/test/resources/org/kie/dmn/validation/dmnelementref/ELEMREF_NOHASH.dmn
@@ -18,19 +18,7 @@
   under the License.
   -->
 
-<!--
-  ~ Licensed under the Apache License, Version 2.0 (the "License");
-  ~ you may not use this file except in compliance with the License.
-  ~ You may obtain a copy of the License at
-  ~
-  ~       http://www.apache.org/licenses/LICENSE-2.0
-  ~
-  ~ Unless required by applicable law or agreed to in writing, software
-  ~ distributed under the License is distributed on an "AS IS" BASIS,
-  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-  ~ See the License for the specific language governing permissions and
-  ~ limitations under the License.
-  -->
+
 <semantic:definitions xmlns="https://github.com/kiegroup/kie-dmn"
                       xmlns:dc="http://www.omg.org/spec/DMN/20180521/DC/"
                       xmlns:di="http://www.omg.org/spec/DMN/20180521/DI/"


### PR DESCRIPTION
- Remaining Category A license
- Remove duplicate headers

Not urgent. This is not a blocker of 10.0.0