### PR TITLE
[incubator-kie-drools-6165] license clarification for pmml files

### DIFF
--- a/.rat-excludes
+++ b/.rat-excludes
@@ -130,6 +130,22 @@ DMNDI15.xsd
 drools-model
 # kie-dmn/kie-dmn-feel/src/main/resources/dmn.xsd
 dmn.xsd
+# kie-dmn/kie-dmn-pmml-tests-parent/kie-dmn-pmml-tests/src/test/resources/org/kie/dmn/pmml/test_naive_bayes.pmml
+test_naive_bayes.pmml
+# kie-dmn/kie-dmn-ruleset2dmn-parent/kie-dmn-ruleset2dmn/src/test/resources/Churn Rules from SPSS Modeler.xml
+Churn Rules from SPSS Modeler.xml
+# kie-dmn/kie-dmn-ruleset2dmn-parent/kie-dmn-ruleset2dmn/src/test/resources/adult.pmml
+adult.pmml
+# kie-dmn/kie-dmn-ruleset2dmn-parent/kie-dmn-ruleset2dmn/src/test/resources/churn.pmml
+churn.pmml
+# kie-dmn/kie-dmn-ruleset2dmn-parent/kie-dmn-ruleset2dmn/src/test/resources/iris.pmml
+iris.pmml
+# kie-dmn/kie-dmn-ruleset2dmn-parent/kie-dmn-ruleset2dmn/src/test/resources/miniloan.pmml
+miniloan.pmml
+# kie-dmn/kie-dmn-ruleset2dmn-parent/kie-dmn-ruleset2dmn/src/test/resources/toto.pmml
+toto.pmml
+# kie-dmn/kie-dmn-ruleset2dmn-parent/kie-dmn-ruleset2dmn/src/test/resources/wifi.pmml
+wifi.pmml
 # kie-dmn/kie-dmn-trisotech/src/test/resources/DC.xsd
 DC.xsd
 # kie-dmn/kie-dmn-trisotech/src/test/resources/DI.xsd
@@ -180,6 +196,10 @@ IndexFile.drl_json
 IndexFile.drl_json
 # kie-drl/kie-drl-tests/src/test/resources/IndexFile.drl_json
 IndexFile.drl_json
+# kie-maven-plugin/src/it/kie-maven-plugin-test-kjar-12/src/main/resources/singleiriskmeansclustering/SingleIrisKMeansClustering.pmml
+SingleIrisKMeansClustering.pmml
+# kie-maven-plugin/src/test/resources/unit/pmml/resources/singleiriskmeansclustering/SingleIrisKMeansClustering.pmml
+SingleIrisKMeansClustering.pmml
 # kie-pmml-trusty/kie-pmml-commons/src/test/resources/IndexFile.pmml_json
 IndexFile.pmml_json
 # kie-pmml-trusty/kie-pmml-compiler/kie-pmml-compiler-commons/src/test/resources/KiePMMLApplyFactoryTest_01.txt
@@ -284,12 +304,64 @@ KiePMMLTruePredicateFactoryTest_01.txt
 TargetFieldFactoryTest_01.txt
 # kie-pmml-trusty/kie-pmml-compiler/kie-pmml-compiler-commons/src/test/resources/TargetValueFactoryTest_01.txt
 TargetValueFactoryTest_01.txt
+# kie-pmml-trusty/kie-pmml-compiler/kie-pmml-compiler-commons/src/test/resources/MultipleTargetsFieldSample.pmml
+MultipleTargetsFieldSample.pmml
+# kie-pmml-trusty/kie-pmml-compiler/kie-pmml-compiler-commons/src/test/resources/NoModelNameNoSegmentIdNoSegmentTargetFieldSample.pmml
+NoModelNameNoSegmentIdNoSegmentTargetFieldSample.pmml
+# kie-pmml-trusty/kie-pmml-compiler/kie-pmml-compiler-commons/src/test/resources/NoModelNameNoSegmentIdSample.pmml
+NoModelNameNoSegmentIdSample.pmml
+# kie-pmml-trusty/kie-pmml-compiler/kie-pmml-compiler-commons/src/test/resources/NoModelNameSample.pmml
+NoModelNameSample.pmml
+# kie-pmml-trusty/kie-pmml-compiler/kie-pmml-compiler-commons/src/test/resources/NoOutputFieldTargetNameSample.pmml
+NoOutputFieldTargetNameSample.pmml
+# kie-pmml-trusty/kie-pmml-compiler/kie-pmml-compiler-commons/src/test/resources/NoTargetFieldSample.pmml
+NoTargetFieldSample.pmml
+# kie-pmml-trusty/kie-pmml-compiler/kie-pmml-compiler-commons/src/test/resources/OneMiningTargetFieldSample.pmml
+OneMiningTargetFieldSample.pmml
+# kie-pmml-trusty/kie-pmml-compiler/kie-pmml-compiler-commons/src/test/resources/TreeSample.pmml
+TreeSample.pmml
+# kie-pmml-trusty/kie-pmml-compiler/kie-pmml-compiler-core/src/test/resources/LinearRegressionSample.pmml
+LinearRegressionSample.pmml
+# kie-pmml-trusty/kie-pmml-compiler/kie-pmml-compiler-core/src/test/resources/LinearRegressionSample.xml
+LinearRegressionSample.xml
 # kie-pmml-trusty/kie-pmml-evaluator/kie-pmml-evaluator-core/src/test/resources/IndexFile.pmml_json
 IndexFile.pmml_json
 # kie-pmml-trusty/kie-pmml-models/kie-pmml-models-clustering/kie-pmml-models-clustering-compiler/src/test/resources/KiePMMLClusteringModelFactoryTest_01.txt
 KiePMMLClusteringModelFactoryTest_01.txt
+# kie-pmml-trusty/kie-pmml-models/kie-pmml-models-clustering/kie-pmml-models-clustering-compiler/src/test/resources/SingleIrisKMeansClustering.pmml
+SingleIrisKMeansClustering.pmml
+# kie-pmml-trusty/kie-pmml-models/kie-pmml-models-clustering/kie-pmml-models-clustering-tests/src/main/resources/clusterwithtransformations/ClusterWithTransformations.pmml
+ClusterWithTransformations.pmml
+# kie-pmml-trusty/kie-pmml-models/kie-pmml-models-clustering/kie-pmml-models-clustering-tests/src/main/resources/singleiriskmeansclustering/SingleIrisKMeansClustering.pmml
+SingleIrisKMeansClustering.pmml
+# kie-pmml-trusty/kie-pmml-models/kie-pmml-models-clustering/kie-pmml-models-clustering-tests/src/main/resources/singleiriskmeansclustering/SingleIrisKMeansClustering_id.pmml
+SingleIrisKMeansClustering_id.pmml
+# kie-pmml-trusty/kie-pmml-models/kie-pmml-models-drools/kie-pmml-models-drools-tree/kie-pmml-models-drools-tree-compiler/src/test/resources/TreeSample.pmml
+TreeSample.pmml
+# kie-pmml-trusty/kie-pmml-models/kie-pmml-models-drools/kie-pmml-models-drools-tree/kie-pmml-models-drools-tree-evaluator/src/test/resources/TreeSample.pmml
+TreeSample.pmml
 # kie-pmml-trusty/kie-pmml-models/kie-pmml-models-mining/kie-pmml-models-mining-compiler/src/test/resources/KiePMMLSegmentFactoryTest_01.txt
 KiePMMLSegmentFactoryTest_01.txt
+# kie-pmml-trusty/kie-pmml-models/kie-pmml-models-mining/kie-pmml-models-mining-compiler/src/test/resources/MiningModel_Mixed.pmml
+MiningModel_Mixed.pmml
+# kie-pmml-trusty/kie-pmml-models/kie-pmml-models-mining/kie-pmml-models-mining-compiler/src/test/resources/MiningModel_NoSegmentId.pmml
+MiningModel_NoSegmentId.pmml
+# kie-pmml-trusty/kie-pmml-models/kie-pmml-models-mining/kie-pmml-models-mining-compiler/src/test/resources/MiningModel_Regression.pmml
+MiningModel_Regression.pmml
+# kie-pmml-trusty/kie-pmml-models/kie-pmml-models-mining/kie-pmml-models-mining-compiler/src/test/resources/MiningModel_Scorecard.pmml
+MiningModel_Scorecard.pmml
+# kie-pmml-trusty/kie-pmml-models/kie-pmml-models-mining/kie-pmml-models-mining-compiler/src/test/resources/MiningModel_SegmentId.pmml
+MiningModel_SegmentId.pmml
+# kie-pmml-trusty/kie-pmml-models/kie-pmml-models-mining/kie-pmml-models-mining-compiler/src/test/resources/MiningModel_TreeModel.pmml
+MiningModel_TreeModel.pmml
+# kie-pmml-trusty/kie-pmml-models/kie-pmml-models-mining/kie-pmml-models-mining-tests/src/main/resources/mixedmining/MiningModel_Mixed.pmml
+MiningModel_Mixed.pmml
+# kie-pmml-trusty/kie-pmml-models/kie-pmml-models-mining/kie-pmml-models-mining-tests/src/main/resources/multiplemining/MultipleMining.pmml
+MultipleMining.pmml
+# kie-pmml-trusty/kie-pmml-models/kie-pmml-models-mining/kie-pmml-models-mining-tests/src/main/resources/predicatesmining/MiningModel_Predicates.pmml
+MiningModel_Predicates.pmml
+# kie-pmml-trusty/kie-pmml-models/kie-pmml-models-mining/kie-pmml-models-mining-tests/src/main/resources/randomforestclassifiermining/RandomForestClassifier.pmml
+RandomForestClassifier.pmml
 # kie-pmml-trusty/kie-pmml-models/kie-pmml-models-regression/kie-pmml-models-regression-compiler/src/test/resources/KiePMMLClassificationTableFactoryTest_01.txt
 KiePMMLClassificationTableFactoryTest_01.txt
 # kie-pmml-trusty/kie-pmml-models/kie-pmml-models-regression/kie-pmml-models-regression-compiler/src/test/resources/KiePMMLClassificationTableFactoryTest_02.txt
@@ -310,6 +382,10 @@ KiePMMLRegressionTableFactoryTest_05.txt
 KiePMMLRegressionTableFactoryTest_06.txt
 # kie-pmml-trusty/kie-pmml-models/kie-pmml-models-regression/kie-pmml-models-regression-compiler/src/test/resources/KiePMMLRegressionTableFactoryTest_07.txt
 KiePMMLRegressionTableFactoryTest_07.txt
+# kie-pmml-trusty/kie-pmml-models/kie-pmml-models-regression/kie-pmml-models-regression-compiler/src/test/resources/LinearRegressionSample.pmml
+LinearRegressionSample.pmml
+# kie-pmml-trusty/kie-pmml-models/kie-pmml-models-regression/kie-pmml-models-regression-tests/src/main/resources/linearregressionsamplewithtransformations/LinearRegressionSampleWithTransformations.pmml
+LinearRegressionSampleWithTransformations.pmml
 # kie-pmml-trusty/kie-pmml-models/kie-pmml-models-scorecard/kie-pmml-models-scorecard-compiler/src/test/resources/KiePMMLAttributeFactoryTest_01.txt
 KiePMMLAttributeFactoryTest_01.txt
 # kie-pmml-trusty/kie-pmml-models/kie-pmml-models-scorecard/kie-pmml-models-scorecard-compiler/src/test/resources/KiePMMLCharacteristicFactoryTest_01.txt
@@ -322,5 +398,11 @@ KiePMMLComplexPartialScoreFactoryTest_01.txt
 KiePMMLComplexPartialScoreFactoryTest_02.txt
 # kie-pmml-trusty/kie-pmml-models/kie-pmml-models-scorecard/kie-pmml-models-scorecard-compiler/src/test/resources/KiePMMLComplexPartialScoreFactoryTest_03.txt
 KiePMMLComplexPartialScoreFactoryTest_03.txt
+# kie-pmml-trusty/kie-pmml-models/kie-pmml-models-tests/src/test/resources/MiningModel_Mixed.pmml
+MiningModel_Mixed.pmml
 # kie-pmml-trusty/kie-pmml-models/kie-pmml-models-tree/kie-pmml-models-tree-compiler/src/test/resources/KiePMMLNodeFactoryTest_01.txt
 KiePMMLNodeFactoryTest_01.txt
+# kie-pmml-trusty/kie-pmml-models/kie-pmml-models-tree/kie-pmml-models-tree-compiler/src/test/resources/TreeSample.pmml
+TreeSample.pmml
+# kie-pmml-trusty/kie-pmml-models/kie-pmml-models-tree/kie-pmml-models-tree-compiler/src/test/resources/TreeSimplified.pmml
+TreeSimplified.pmml

--- a/LICENSE
+++ b/LICENSE
@@ -662,3 +662,81 @@ for drools-util/src/main/java/org/drools/util/StringUtils.java
     Borrowed from Spring
 
 Licensed under the Apache License, Version 2.0 (the "License");
+
+------------------------------------------------------------------------------------
+for kie-dmn/kie-dmn-pmml-tests-parent/kie-dmn-pmml-tests/src/test/resources/org/kie/dmn/pmml/test_naive_bayes.pmml
+    kie-dmn/kie-dmn-ruleset2dmn-parent/kie-dmn-ruleset2dmn/src/test/resources/Churn Rules from SPSS Modeler.xml
+    kie-dmn/kie-dmn-ruleset2dmn-parent/kie-dmn-ruleset2dmn/src/test/resources/adult.pmml
+    kie-dmn/kie-dmn-ruleset2dmn-parent/kie-dmn-ruleset2dmn/src/test/resources/churn.pmml
+    kie-dmn/kie-dmn-ruleset2dmn-parent/kie-dmn-ruleset2dmn/src/test/resources/iris.pmml
+    kie-dmn/kie-dmn-ruleset2dmn-parent/kie-dmn-ruleset2dmn/src/test/resources/miniloan.pmml
+    kie-dmn/kie-dmn-ruleset2dmn-parent/kie-dmn-ruleset2dmn/src/test/resources/toto.pmml
+    kie-dmn/kie-dmn-ruleset2dmn-parent/kie-dmn-ruleset2dmn/src/test/resources/wifi.pmml
+    kie-maven-plugin/src/it/kie-maven-plugin-test-kjar-12/src/main/resources/singleiriskmeansclustering/SingleIrisKMeansClustering.pmml
+    kie-maven-plugin/src/test/resources/unit/pmml/resources/singleiriskmeansclustering/SingleIrisKMeansClustering.pmml
+    kie-pmml-trusty/kie-pmml-compiler/kie-pmml-compiler-commons/src/test/resources/MultipleTargetsFieldSample.pmml
+    kie-pmml-trusty/kie-pmml-compiler/kie-pmml-compiler-commons/src/test/resources/NoModelNameNoSegmentIdNoSegmentTargetFieldSample.pmml
+    kie-pmml-trusty/kie-pmml-compiler/kie-pmml-compiler-commons/src/test/resources/NoModelNameNoSegmentIdSample.pmml
+    kie-pmml-trusty/kie-pmml-compiler/kie-pmml-compiler-commons/src/test/resources/NoModelNameSample.pmml
+    kie-pmml-trusty/kie-pmml-compiler/kie-pmml-compiler-commons/src/test/resources/NoOutputFieldTargetNameSample.pmml
+    kie-pmml-trusty/kie-pmml-compiler/kie-pmml-compiler-commons/src/test/resources/NoTargetFieldSample.pmml
+    kie-pmml-trusty/kie-pmml-compiler/kie-pmml-compiler-commons/src/test/resources/OneMiningTargetFieldSample.pmml
+    kie-pmml-trusty/kie-pmml-compiler/kie-pmml-compiler-commons/src/test/resources/TreeSample.pmml
+    kie-pmml-trusty/kie-pmml-compiler/kie-pmml-compiler-core/src/test/resources/LinearRegressionSample.pmml
+    kie-pmml-trusty/kie-pmml-compiler/kie-pmml-compiler-core/src/test/resources/LinearRegressionSample.xml
+    kie-pmml-trusty/kie-pmml-models/kie-pmml-models-clustering/kie-pmml-models-clustering-compiler/src/test/resources/SingleIrisKMeansClustering.pmml
+    kie-pmml-trusty/kie-pmml-models/kie-pmml-models-clustering/kie-pmml-models-clustering-tests/src/main/resources/clusterwithtransformations/ClusterWithTransformations.pmml
+    kie-pmml-trusty/kie-pmml-models/kie-pmml-models-clustering/kie-pmml-models-clustering-tests/src/main/resources/singleiriskmeansclustering/SingleIrisKMeansClustering.pmml
+    kie-pmml-trusty/kie-pmml-models/kie-pmml-models-clustering/kie-pmml-models-clustering-tests/src/main/resources/singleiriskmeansclustering/SingleIrisKMeansClustering_id.pmml
+    kie-pmml-trusty/kie-pmml-models/kie-pmml-models-drools/kie-pmml-models-drools-tree/kie-pmml-models-drools-tree-compiler/src/test/resources/TreeSample.pmml
+    kie-pmml-trusty/kie-pmml-models/kie-pmml-models-drools/kie-pmml-models-drools-tree/kie-pmml-models-drools-tree-evaluator/src/test/resources/TreeSample.pmml
+    kie-pmml-trusty/kie-pmml-models/kie-pmml-models-mining/kie-pmml-models-mining-compiler/src/test/resources/MiningModel_Mixed.pmml
+    kie-pmml-trusty/kie-pmml-models/kie-pmml-models-mining/kie-pmml-models-mining-compiler/src/test/resources/MiningModel_NoSegmentId.pmml
+    kie-pmml-trusty/kie-pmml-models/kie-pmml-models-mining/kie-pmml-models-mining-compiler/src/test/resources/MiningModel_Regression.pmml
+    kie-pmml-trusty/kie-pmml-models/kie-pmml-models-mining/kie-pmml-models-mining-compiler/src/test/resources/MiningModel_Scorecard.pmml
+    kie-pmml-trusty/kie-pmml-models/kie-pmml-models-mining/kie-pmml-models-mining-compiler/src/test/resources/MiningModel_SegmentId.pmml
+    kie-pmml-trusty/kie-pmml-models/kie-pmml-models-mining/kie-pmml-models-mining-compiler/src/test/resources/MiningModel_TreeModel.pmml
+    kie-pmml-trusty/kie-pmml-models/kie-pmml-models-mining/kie-pmml-models-mining-tests/src/main/resources/mixedmining/MiningModel_Mixed.pmml
+    kie-pmml-trusty/kie-pmml-models/kie-pmml-models-mining/kie-pmml-models-mining-tests/src/main/resources/multiplemining/MultipleMining.pmml
+    kie-pmml-trusty/kie-pmml-models/kie-pmml-models-mining/kie-pmml-models-mining-tests/src/main/resources/predicatesmining/MiningModel_Predicates.pmml
+    kie-pmml-trusty/kie-pmml-models/kie-pmml-models-mining/kie-pmml-models-mining-tests/src/main/resources/randomforestclassifiermining/RandomForestClassifier.pmml
+    kie-pmml-trusty/kie-pmml-models/kie-pmml-models-regression/kie-pmml-models-regression-compiler/src/test/resources/LinearRegressionSample.pmml
+    kie-pmml-trusty/kie-pmml-models/kie-pmml-models-regression/kie-pmml-models-regression-tests/src/main/resources/linearregressionsamplewithtransformations/LinearRegressionSampleWithTransformations.pmml
+    kie-pmml-trusty/kie-pmml-models/kie-pmml-models-tests/src/test/resources/MiningModel_Mixed.pmml
+    kie-pmml-trusty/kie-pmml-models/kie-pmml-models-tree/kie-pmml-models-tree-compiler/src/test/resources/TreeSample.pmml
+    kie-pmml-trusty/kie-pmml-models/kie-pmml-models-tree/kie-pmml-models-tree-compiler/src/test/resources/TreeSimplified.pmml
+
+Copyright (c) 2020 jovyan
+(C) Copyright IBM Corp. 1994, 2021
+Copyright IBM Corp, exported to PMML by Nyoka (c) 2022 Software AG
+copyright KNIME
+Copyright (c) 2018 Software AG
+
+Copyright (c) 2008-2016,  The Data Mining Group
+All rights reserved.
+This notice and license applies the.pmml
+notice and license is selected by the working group developing the release and is approved
+by the DMG Chair.
+
+Redistribution and use in source and binary forms, with or without modification, are
+permitted provided that the following conditions are met:
+* Redistributions of source code must include the copyright notice below, this list of
+conditions and the following disclaimer.
+* Redistributions in binary form must reproduce the copyright notice below, this list
+of conditions and the following disclaimer in the documentation and/or other
+materials provided with the distribution
+* Neither the name of the Data Mining Group nor the names of its members or
+contributors may be used to endorse or promote products derived from a release
+without specific prior written permission.
+
+THIS STANDARD IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS 
+IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS;
+OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR
+OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS RELEASE, EVEN IF ADVISED
+OF THE POSSIBILITY OF SUCH DAMAGE.

--- a/kie-dmn/kie-dmn-pmml-tests-parent/kie-dmn-pmml-tests/src/test/resources/org/kie/dmn/pmml/test_naive_bayes.pmml
+++ b/kie-dmn/kie-dmn-pmml-tests-parent/kie-dmn-pmml-tests/src/test/resources/org/kie/dmn/pmml/test_naive_bayes.pmml
@@ -1,21 +1,3 @@
-<!--
-  Licensed to the Apache Software Foundation (ASF) under one
-  or more contributor license agreements.  See the NOTICE file
-  distributed with this work for additional information
-  regarding copyright ownership.  The ASF licenses this file
-  to you under the Apache License, Version 2.0 (the
-  "License"); you may not use this file except in compliance
-  with the License.  You may obtain a copy of the License at
-
-    http://www.apache.org/licenses/LICENSE-2.0
-
-  Unless required by applicable law or agreed to in writing,
-  software distributed under the License is distributed on an
-  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
-  KIND, either express or implied.  See the License for the
-  specific language governing permissions and limitations
-  under the License.
-  -->
 
 <PMML version="4.2" xsi:schemaLocation="http://www.dmg.org/PMML-4_2 http://www.dmg.org/v4-2-1/pmml-4-2.xsd" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://www.dmg.org/PMML-4_2">
  <Header copyright="Copyright (c) 2020 jovyan" description="NaiveBayes Model">

--- a/kie-dmn/kie-dmn-ruleset2dmn-parent/kie-dmn-ruleset2dmn/src/test/resources/Churn Rules from SPSS Modeler.xml
+++ b/kie-dmn/kie-dmn-ruleset2dmn-parent/kie-dmn-ruleset2dmn/src/test/resources/Churn Rules from SPSS Modeler.xml
@@ -1,24 +1,4 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no" ?>
-<!--
-
-    Licensed to the Apache Software Foundation (ASF) under one
-    or more contributor license agreements.  See the NOTICE file
-    distributed with this work for additional information
-    regarding copyright ownership.  The ASF licenses this file
-    to you under the Apache License, Version 2.0 (the
-    "License"); you may not use this file except in compliance
-    with the License.  You may obtain a copy of the License at
-
-      http://www.apache.org/licenses/LICENSE-2.0
-
-    Unless required by applicable law or agreed to in writing,
-    software distributed under the License is distributed on an
-    "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
-    KIND, either express or implied.  See the License for the
-    specific language governing permissions and limitations
-    under the License.
-
--->
 <PMML version="4.2" xmlns="http://www.dmg.org/PMML-4_2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
   <Header copyright="(C) Copyright IBM Corp. 1994, 2021">
     <Application name="IBM SPSS Modeler" version="18.3"/>

--- a/kie-dmn/kie-dmn-ruleset2dmn-parent/kie-dmn-ruleset2dmn/src/test/resources/adult.pmml
+++ b/kie-dmn/kie-dmn-ruleset2dmn-parent/kie-dmn-ruleset2dmn/src/test/resources/adult.pmml
@@ -1,22 +1,4 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!--
-  Licensed to the Apache Software Foundation (ASF) under one
-  or more contributor license agreements.  See the NOTICE file
-  distributed with this work for additional information
-  regarding copyright ownership.  The ASF licenses this file
-  to you under the Apache License, Version 2.0 (the
-  "License"); you may not use this file except in compliance
-  with the License.  You may obtain a copy of the License at
-
-    http://www.apache.org/licenses/LICENSE-2.0
-
-  Unless required by applicable law or agreed to in writing,
-  software distributed under the License is distributed on an
-  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
-  KIND, either express or implied.  See the License for the
-  specific language governing permissions and limitations
-  under the License.
-  -->
 
 <PMML xmlns="http://www.dmg.org/PMML-4_4" version="4.4.1">
     <Header copyright="Copyright IBM Corp, exported to PMML by Nyoka (c) 2022 Software AG" description="Default description">

--- a/kie-dmn/kie-dmn-ruleset2dmn-parent/kie-dmn-ruleset2dmn/src/test/resources/churn.pmml
+++ b/kie-dmn/kie-dmn-ruleset2dmn-parent/kie-dmn-ruleset2dmn/src/test/resources/churn.pmml
@@ -1,22 +1,4 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!--
-  Licensed to the Apache Software Foundation (ASF) under one
-  or more contributor license agreements.  See the NOTICE file
-  distributed with this work for additional information
-  regarding copyright ownership.  The ASF licenses this file
-  to you under the Apache License, Version 2.0 (the
-  "License"); you may not use this file except in compliance
-  with the License.  You may obtain a copy of the License at
-
-    http://www.apache.org/licenses/LICENSE-2.0
-
-  Unless required by applicable law or agreed to in writing,
-  software distributed under the License is distributed on an
-  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
-  KIND, either express or implied.  See the License for the
-  specific language governing permissions and limitations
-  under the License.
-  -->
 
 <PMML xmlns="http://www.dmg.org/PMML-4_4" version="4.4.1">
     <Header copyright="Copyright IBM Corp, exported to PMML by Nyoka (c) 2022 Software AG" description="Default description">

--- a/kie-dmn/kie-dmn-ruleset2dmn-parent/kie-dmn-ruleset2dmn/src/test/resources/iris.pmml
+++ b/kie-dmn/kie-dmn-ruleset2dmn-parent/kie-dmn-ruleset2dmn/src/test/resources/iris.pmml
@@ -1,22 +1,4 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!--
-  Licensed to the Apache Software Foundation (ASF) under one
-  or more contributor license agreements.  See the NOTICE file
-  distributed with this work for additional information
-  regarding copyright ownership.  The ASF licenses this file
-  to you under the Apache License, Version 2.0 (the
-  "License"); you may not use this file except in compliance
-  with the License.  You may obtain a copy of the License at
-
-    http://www.apache.org/licenses/LICENSE-2.0
-
-  Unless required by applicable law or agreed to in writing,
-  software distributed under the License is distributed on an
-  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
-  KIND, either express or implied.  See the License for the
-  specific language governing permissions and limitations
-  under the License.
-  -->
 
 <PMML xmlns="http://www.dmg.org/PMML-4_4" version="4.4.1">
     <Header copyright="Copyright IBM Corp, exported to PMML by Nyoka (c) 2022 Software AG" description="Default description">

--- a/kie-dmn/kie-dmn-ruleset2dmn-parent/kie-dmn-ruleset2dmn/src/test/resources/miniloan.pmml
+++ b/kie-dmn/kie-dmn-ruleset2dmn-parent/kie-dmn-ruleset2dmn/src/test/resources/miniloan.pmml
@@ -1,22 +1,4 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!--
-  Licensed to the Apache Software Foundation (ASF) under one
-  or more contributor license agreements.  See the NOTICE file
-  distributed with this work for additional information
-  regarding copyright ownership.  The ASF licenses this file
-  to you under the Apache License, Version 2.0 (the
-  "License"); you may not use this file except in compliance
-  with the License.  You may obtain a copy of the License at
-
-    http://www.apache.org/licenses/LICENSE-2.0
-
-  Unless required by applicable law or agreed to in writing,
-  software distributed under the License is distributed on an
-  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
-  KIND, either express or implied.  See the License for the
-  specific language governing permissions and limitations
-  under the License.
-  -->
 
 <PMML xmlns="http://www.dmg.org/PMML-4_4" version="4.4.1">
     <Header copyright="Copyright IBM Corp, exported to PMML by Nyoka (c) 2022 Software AG" description="Default description">

--- a/kie-dmn/kie-dmn-ruleset2dmn-parent/kie-dmn-ruleset2dmn/src/test/resources/toto.pmml
+++ b/kie-dmn/kie-dmn-ruleset2dmn-parent/kie-dmn-ruleset2dmn/src/test/resources/toto.pmml
@@ -1,22 +1,4 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!--
-  Licensed to the Apache Software Foundation (ASF) under one
-  or more contributor license agreements.  See the NOTICE file
-  distributed with this work for additional information
-  regarding copyright ownership.  The ASF licenses this file
-  to you under the Apache License, Version 2.0 (the
-  "License"); you may not use this file except in compliance
-  with the License.  You may obtain a copy of the License at
-
-    http://www.apache.org/licenses/LICENSE-2.0
-
-  Unless required by applicable law or agreed to in writing,
-  software distributed under the License is distributed on an
-  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
-  KIND, either express or implied.  See the License for the
-  specific language governing permissions and limitations
-  under the License.
-  -->
 
 <PMML xmlns="http://www.dmg.org/PMML-4_4" version="4.4.1">
     <Header copyright="Copyright IBM Corp, exported to PMML by Nyoka (c) 2022 Software AG" description="Default description">

--- a/kie-dmn/kie-dmn-ruleset2dmn-parent/kie-dmn-ruleset2dmn/src/test/resources/wifi.pmml
+++ b/kie-dmn/kie-dmn-ruleset2dmn-parent/kie-dmn-ruleset2dmn/src/test/resources/wifi.pmml
@@ -1,22 +1,4 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!--
-  Licensed to the Apache Software Foundation (ASF) under one
-  or more contributor license agreements.  See the NOTICE file
-  distributed with this work for additional information
-  regarding copyright ownership.  The ASF licenses this file
-  to you under the Apache License, Version 2.0 (the
-  "License"); you may not use this file except in compliance
-  with the License.  You may obtain a copy of the License at
-
-    http://www.apache.org/licenses/LICENSE-2.0
-
-  Unless required by applicable law or agreed to in writing,
-  software distributed under the License is distributed on an
-  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
-  KIND, either express or implied.  See the License for the
-  specific language governing permissions and limitations
-  under the License.
-  -->
 
 <PMML xmlns="http://www.dmg.org/PMML-4_4" version="4.4.1">
     <Header copyright="Copyright IBM Corp, exported to PMML by Nyoka (c) 2022 Software AG" description="Default description">

--- a/kie-maven-plugin/src/it/kie-maven-plugin-test-kjar-12/src/main/resources/singleiriskmeansclustering/SingleIrisKMeansClustering.pmml
+++ b/kie-maven-plugin/src/it/kie-maven-plugin-test-kjar-12/src/main/resources/singleiriskmeansclustering/SingleIrisKMeansClustering.pmml
@@ -1,22 +1,4 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!--
-  Licensed to the Apache Software Foundation (ASF) under one
-  or more contributor license agreements.  See the NOTICE file
-  distributed with this work for additional information
-  regarding copyright ownership.  The ASF licenses this file
-  to you under the Apache License, Version 2.0 (the
-  "License"); you may not use this file except in compliance
-  with the License.  You may obtain a copy of the License at
-
-    http://www.apache.org/licenses/LICENSE-2.0
-
-  Unless required by applicable law or agreed to in writing,
-  software distributed under the License is distributed on an
-  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
-  KIND, either express or implied.  See the License for the
-  specific language governing permissions and limitations
-  under the License.
-  -->
 
 <PMML version="4.1" xmlns="http://www.dmg.org/PMML-4_1">
   <Header copyright="KNIME">

--- a/kie-maven-plugin/src/test/resources/unit/pmml/resources/singleiriskmeansclustering/SingleIrisKMeansClustering.pmml
+++ b/kie-maven-plugin/src/test/resources/unit/pmml/resources/singleiriskmeansclustering/SingleIrisKMeansClustering.pmml
@@ -1,22 +1,4 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!--
-  Licensed to the Apache Software Foundation (ASF) under one
-  or more contributor license agreements.  See the NOTICE file
-  distributed with this work for additional information
-  regarding copyright ownership.  The ASF licenses this file
-  to you under the Apache License, Version 2.0 (the
-  "License"); you may not use this file except in compliance
-  with the License.  You may obtain a copy of the License at
-
-    http://www.apache.org/licenses/LICENSE-2.0
-
-  Unless required by applicable law or agreed to in writing,
-  software distributed under the License is distributed on an
-  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
-  KIND, either express or implied.  See the License for the
-  specific language governing permissions and limitations
-  under the License.
-  -->
 
 <PMML version="4.1" xmlns="http://www.dmg.org/PMML-4_1">
   <Header copyright="KNIME">

--- a/kie-pmml-trusty/kie-pmml-compiler/kie-pmml-compiler-commons/src/test/resources/MultipleTargetsFieldSample.pmml
+++ b/kie-pmml-trusty/kie-pmml-compiler/kie-pmml-compiler-commons/src/test/resources/MultipleTargetsFieldSample.pmml
@@ -1,21 +1,3 @@
-<!--
-  Licensed to the Apache Software Foundation (ASF) under one
-  or more contributor license agreements.  See the NOTICE file
-  distributed with this work for additional information
-  regarding copyright ownership.  The ASF licenses this file
-  to you under the Apache License, Version 2.0 (the
-  "License"); you may not use this file except in compliance
-  with the License.  You may obtain a copy of the License at
-
-    http://www.apache.org/licenses/LICENSE-2.0
-
-  Unless required by applicable law or agreed to in writing,
-  software distributed under the License is distributed on an
-  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
-  KIND, either express or implied.  See the License for the
-  specific language governing permissions and limitations
-  under the License.
-  -->
 
 <PMML xmlns="http://www.dmg.org/PMML-4_2" version="4.2">
   <Header copyright="DMG.org"/>

--- a/kie-pmml-trusty/kie-pmml-compiler/kie-pmml-compiler-commons/src/test/resources/NoModelNameNoSegmentIdNoSegmentTargetFieldSample.pmml
+++ b/kie-pmml-trusty/kie-pmml-compiler/kie-pmml-compiler-commons/src/test/resources/NoModelNameNoSegmentIdNoSegmentTargetFieldSample.pmml
@@ -1,22 +1,4 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!--
-  Licensed to the Apache Software Foundation (ASF) under one
-  or more contributor license agreements.  See the NOTICE file
-  distributed with this work for additional information
-  regarding copyright ownership.  The ASF licenses this file
-  to you under the Apache License, Version 2.0 (the
-  "License"); you may not use this file except in compliance
-  with the License.  You may obtain a copy of the License at
-
-    http://www.apache.org/licenses/LICENSE-2.0
-
-  Unless required by applicable law or agreed to in writing,
-  software distributed under the License is distributed on an
-  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
-  KIND, either express or implied.  See the License for the
-  specific language governing permissions and limitations
-  under the License.
-  -->
 
 <PMML version="4.4" xmlns="http://www.dmg.org/PMML-4_4">
   <Header copyright="KNIME">

--- a/kie-pmml-trusty/kie-pmml-compiler/kie-pmml-compiler-commons/src/test/resources/NoModelNameNoSegmentIdSample.pmml
+++ b/kie-pmml-trusty/kie-pmml-compiler/kie-pmml-compiler-commons/src/test/resources/NoModelNameNoSegmentIdSample.pmml
@@ -1,22 +1,4 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!--
-  Licensed to the Apache Software Foundation (ASF) under one
-  or more contributor license agreements.  See the NOTICE file
-  distributed with this work for additional information
-  regarding copyright ownership.  The ASF licenses this file
-  to you under the Apache License, Version 2.0 (the
-  "License"); you may not use this file except in compliance
-  with the License.  You may obtain a copy of the License at
-
-    http://www.apache.org/licenses/LICENSE-2.0
-
-  Unless required by applicable law or agreed to in writing,
-  software distributed under the License is distributed on an
-  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
-  KIND, either express or implied.  See the License for the
-  specific language governing permissions and limitations
-  under the License.
-  -->
 
 <PMML version="4.4" xmlns="http://www.dmg.org/PMML-4_4">
   <Header copyright="KNIME">

--- a/kie-pmml-trusty/kie-pmml-compiler/kie-pmml-compiler-commons/src/test/resources/NoModelNameSample.pmml
+++ b/kie-pmml-trusty/kie-pmml-compiler/kie-pmml-compiler-commons/src/test/resources/NoModelNameSample.pmml
@@ -1,22 +1,3 @@
-<!--
-  Licensed to the Apache Software Foundation (ASF) under one
-  or more contributor license agreements.  See the NOTICE file
-  distributed with this work for additional information
-  regarding copyright ownership.  The ASF licenses this file
-  to you under the Apache License, Version 2.0 (the
-  "License"); you may not use this file except in compliance
-  with the License.  You may obtain a copy of the License at
-
-    http://www.apache.org/licenses/LICENSE-2.0
-
-  Unless required by applicable law or agreed to in writing,
-  software distributed under the License is distributed on an
-  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
-  KIND, either express or implied.  See the License for the
-  specific language governing permissions and limitations
-  under the License.
-  -->
-
 <PMML xmlns="http://www.dmg.org/PMML-4_4" version="4.4">
   <Header copyright="DMG.org"/>
   <DataDictionary numberOfFields="4">

--- a/kie-pmml-trusty/kie-pmml-compiler/kie-pmml-compiler-commons/src/test/resources/NoOutputFieldTargetNameSample.pmml
+++ b/kie-pmml-trusty/kie-pmml-compiler/kie-pmml-compiler-commons/src/test/resources/NoOutputFieldTargetNameSample.pmml
@@ -1,21 +1,3 @@
-<!--
-  Licensed to the Apache Software Foundation (ASF) under one
-  or more contributor license agreements.  See the NOTICE file
-  distributed with this work for additional information
-  regarding copyright ownership.  The ASF licenses this file
-  to you under the Apache License, Version 2.0 (the
-  "License"); you may not use this file except in compliance
-  with the License.  You may obtain a copy of the License at
-
-    http://www.apache.org/licenses/LICENSE-2.0
-
-  Unless required by applicable law or agreed to in writing,
-  software distributed under the License is distributed on an
-  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
-  KIND, either express or implied.  See the License for the
-  specific language governing permissions and limitations
-  under the License.
-  -->
 
 <PMML xmlns="http://www.dmg.org/PMML-4_2" version="4.2">
   <Header copyright="www.dmg.org" description="A very small binary tree model to show structure."/>

--- a/kie-pmml-trusty/kie-pmml-compiler/kie-pmml-compiler-commons/src/test/resources/NoTargetFieldSample.pmml
+++ b/kie-pmml-trusty/kie-pmml-compiler/kie-pmml-compiler-commons/src/test/resources/NoTargetFieldSample.pmml
@@ -1,21 +1,3 @@
-<!--
-  Licensed to the Apache Software Foundation (ASF) under one
-  or more contributor license agreements.  See the NOTICE file
-  distributed with this work for additional information
-  regarding copyright ownership.  The ASF licenses this file
-  to you under the Apache License, Version 2.0 (the
-  "License"); you may not use this file except in compliance
-  with the License.  You may obtain a copy of the License at
-
-    http://www.apache.org/licenses/LICENSE-2.0
-
-  Unless required by applicable law or agreed to in writing,
-  software distributed under the License is distributed on an
-  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
-  KIND, either express or implied.  See the License for the
-  specific language governing permissions and limitations
-  under the License.
-  -->
 
 <PMML xmlns="http://www.dmg.org/PMML-4_2" version="4.2">
   <Header copyright="www.dmg.org" description="A very small binary tree model to show structure."/>

--- a/kie-pmml-trusty/kie-pmml-compiler/kie-pmml-compiler-commons/src/test/resources/OneMiningTargetFieldSample.pmml
+++ b/kie-pmml-trusty/kie-pmml-compiler/kie-pmml-compiler-commons/src/test/resources/OneMiningTargetFieldSample.pmml
@@ -1,22 +1,3 @@
-<!--
-  Licensed to the Apache Software Foundation (ASF) under one
-  or more contributor license agreements.  See the NOTICE file
-  distributed with this work for additional information
-  regarding copyright ownership.  The ASF licenses this file
-  to you under the Apache License, Version 2.0 (the
-  "License"); you may not use this file except in compliance
-  with the License.  You may obtain a copy of the License at
-
-    http://www.apache.org/licenses/LICENSE-2.0
-
-  Unless required by applicable law or agreed to in writing,
-  software distributed under the License is distributed on an
-  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
-  KIND, either express or implied.  See the License for the
-  specific language governing permissions and limitations
-  under the License.
-  -->
-
 <PMML xmlns="http://www.dmg.org/PMML-4_2" version="4.2">
   <Header copyright="www.dmg.org" description="A very small binary tree model to show structure."/>
   <DataDictionary numberOfFields="5">

--- a/kie-pmml-trusty/kie-pmml-compiler/kie-pmml-compiler-commons/src/test/resources/TreeSample.pmml
+++ b/kie-pmml-trusty/kie-pmml-compiler/kie-pmml-compiler-commons/src/test/resources/TreeSample.pmml
@@ -1,21 +1,3 @@
-<!--
-  Licensed to the Apache Software Foundation (ASF) under one
-  or more contributor license agreements.  See the NOTICE file
-  distributed with this work for additional information
-  regarding copyright ownership.  The ASF licenses this file
-  to you under the Apache License, Version 2.0 (the
-  "License"); you may not use this file except in compliance
-  with the License.  You may obtain a copy of the License at
-
-    http://www.apache.org/licenses/LICENSE-2.0
-
-  Unless required by applicable law or agreed to in writing,
-  software distributed under the License is distributed on an
-  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
-  KIND, either express or implied.  See the License for the
-  specific language governing permissions and limitations
-  under the License.
-  -->
 
 <PMML xmlns="http://www.dmg.org/PMML-4_2" version="4.2">
   <Header copyright="www.dmg.org" description="A very small binary tree model to show structure."/>

--- a/kie-pmml-trusty/kie-pmml-compiler/kie-pmml-compiler-core/src/test/resources/LinearRegressionSample.pmml
+++ b/kie-pmml-trusty/kie-pmml-compiler/kie-pmml-compiler-core/src/test/resources/LinearRegressionSample.pmml
@@ -1,21 +1,3 @@
-<!--
-  Licensed to the Apache Software Foundation (ASF) under one
-  or more contributor license agreements.  See the NOTICE file
-  distributed with this work for additional information
-  regarding copyright ownership.  The ASF licenses this file
-  to you under the Apache License, Version 2.0 (the
-  "License"); you may not use this file except in compliance
-  with the License.  You may obtain a copy of the License at
-
-    http://www.apache.org/licenses/LICENSE-2.0
-
-  Unless required by applicable law or agreed to in writing,
-  software distributed under the License is distributed on an
-  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
-  KIND, either express or implied.  See the License for the
-  specific language governing permissions and limitations
-  under the License.
-  -->
 
 <PMML xmlns="http://www.dmg.org/PMML-4_2" version="4.2">
     <Header copyright="DMG.org"/>

--- a/kie-pmml-trusty/kie-pmml-compiler/kie-pmml-compiler-core/src/test/resources/LinearRegressionSample.xml
+++ b/kie-pmml-trusty/kie-pmml-compiler/kie-pmml-compiler-core/src/test/resources/LinearRegressionSample.xml
@@ -1,23 +1,3 @@
-<!--
-
-    Licensed to the Apache Software Foundation (ASF) under one
-    or more contributor license agreements.  See the NOTICE file
-    distributed with this work for additional information
-    regarding copyright ownership.  The ASF licenses this file
-    to you under the Apache License, Version 2.0 (the
-    "License"); you may not use this file except in compliance
-    with the License.  You may obtain a copy of the License at
-
-      http://www.apache.org/licenses/LICENSE-2.0
-
-    Unless required by applicable law or agreed to in writing,
-    software distributed under the License is distributed on an
-    "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
-    KIND, either express or implied.  See the License for the
-    specific language governing permissions and limitations
-    under the License.
-
--->
 <PMML xmlns="http://www.dmg.org/PMML-4_2" version="4.2">
   <Header copyright="DMG.org"/>
   <DataDictionary numberOfFields="4">

--- a/kie-pmml-trusty/kie-pmml-models/kie-pmml-models-clustering/kie-pmml-models-clustering-compiler/src/test/resources/SingleIrisKMeansClustering.pmml
+++ b/kie-pmml-trusty/kie-pmml-models/kie-pmml-models-clustering/kie-pmml-models-clustering-compiler/src/test/resources/SingleIrisKMeansClustering.pmml
@@ -1,22 +1,4 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!--
-  Licensed to the Apache Software Foundation (ASF) under one
-  or more contributor license agreements.  See the NOTICE file
-  distributed with this work for additional information
-  regarding copyright ownership.  The ASF licenses this file
-  to you under the Apache License, Version 2.0 (the
-  "License"); you may not use this file except in compliance
-  with the License.  You may obtain a copy of the License at
-
-    http://www.apache.org/licenses/LICENSE-2.0
-
-  Unless required by applicable law or agreed to in writing,
-  software distributed under the License is distributed on an
-  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
-  KIND, either express or implied.  See the License for the
-  specific language governing permissions and limitations
-  under the License.
-  -->
 
 <PMML version="4.1" xmlns="http://www.dmg.org/PMML-4_1">
   <Header copyright="KNIME">

--- a/kie-pmml-trusty/kie-pmml-models/kie-pmml-models-clustering/kie-pmml-models-clustering-tests/src/main/resources/clusterwithtransformations/ClusterWithTransformations.pmml
+++ b/kie-pmml-trusty/kie-pmml-models/kie-pmml-models-clustering/kie-pmml-models-clustering-tests/src/main/resources/clusterwithtransformations/ClusterWithTransformations.pmml
@@ -1,22 +1,4 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!--
-  Licensed to the Apache Software Foundation (ASF) under one
-  or more contributor license agreements.  See the NOTICE file
-  distributed with this work for additional information
-  regarding copyright ownership.  The ASF licenses this file
-  to you under the Apache License, Version 2.0 (the
-  "License"); you may not use this file except in compliance
-  with the License.  You may obtain a copy of the License at
-
-    http://www.apache.org/licenses/LICENSE-2.0
-
-  Unless required by applicable law or agreed to in writing,
-  software distributed under the License is distributed on an
-  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
-  KIND, either express or implied.  See the License for the
-  specific language governing permissions and limitations
-  under the License.
-  -->
 
 <PMML xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="4.4"
       xsi:schemaLocation="http://www.dmg.org/PMML-4_4

--- a/kie-pmml-trusty/kie-pmml-models/kie-pmml-models-clustering/kie-pmml-models-clustering-tests/src/main/resources/singleiriskmeansclustering/SingleIrisKMeansClustering.pmml
+++ b/kie-pmml-trusty/kie-pmml-models/kie-pmml-models-clustering/kie-pmml-models-clustering-tests/src/main/resources/singleiriskmeansclustering/SingleIrisKMeansClustering.pmml
@@ -1,22 +1,4 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!--
-  Licensed to the Apache Software Foundation (ASF) under one
-  or more contributor license agreements.  See the NOTICE file
-  distributed with this work for additional information
-  regarding copyright ownership.  The ASF licenses this file
-  to you under the Apache License, Version 2.0 (the
-  "License"); you may not use this file except in compliance
-  with the License.  You may obtain a copy of the License at
-
-    http://www.apache.org/licenses/LICENSE-2.0
-
-  Unless required by applicable law or agreed to in writing,
-  software distributed under the License is distributed on an
-  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
-  KIND, either express or implied.  See the License for the
-  specific language governing permissions and limitations
-  under the License.
-  -->
 
 <PMML version="4.1" xmlns="http://www.dmg.org/PMML-4_1">
   <Header copyright="KNIME">

--- a/kie-pmml-trusty/kie-pmml-models/kie-pmml-models-clustering/kie-pmml-models-clustering-tests/src/main/resources/singleiriskmeansclustering/SingleIrisKMeansClustering_id.pmml
+++ b/kie-pmml-trusty/kie-pmml-models/kie-pmml-models-clustering/kie-pmml-models-clustering-tests/src/main/resources/singleiriskmeansclustering/SingleIrisKMeansClustering_id.pmml
@@ -1,22 +1,4 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!--
-  Licensed to the Apache Software Foundation (ASF) under one
-  or more contributor license agreements.  See the NOTICE file
-  distributed with this work for additional information
-  regarding copyright ownership.  The ASF licenses this file
-  to you under the Apache License, Version 2.0 (the
-  "License"); you may not use this file except in compliance
-  with the License.  You may obtain a copy of the License at
-
-    http://www.apache.org/licenses/LICENSE-2.0
-
-  Unless required by applicable law or agreed to in writing,
-  software distributed under the License is distributed on an
-  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
-  KIND, either express or implied.  See the License for the
-  specific language governing permissions and limitations
-  under the License.
-  -->
 
 <PMML version="4.1" xmlns="http://www.dmg.org/PMML-4_1">
   <Header copyright="KNIME">

--- a/kie-pmml-trusty/kie-pmml-models/kie-pmml-models-drools/kie-pmml-models-drools-tree/kie-pmml-models-drools-tree-compiler/src/test/resources/TreeSample.pmml
+++ b/kie-pmml-trusty/kie-pmml-models/kie-pmml-models-drools/kie-pmml-models-drools-tree/kie-pmml-models-drools-tree-compiler/src/test/resources/TreeSample.pmml
@@ -1,21 +1,3 @@
-<!--
-  Licensed to the Apache Software Foundation (ASF) under one
-  or more contributor license agreements.  See the NOTICE file
-  distributed with this work for additional information
-  regarding copyright ownership.  The ASF licenses this file
-  to you under the Apache License, Version 2.0 (the
-  "License"); you may not use this file except in compliance
-  with the License.  You may obtain a copy of the License at
-
-    http://www.apache.org/licenses/LICENSE-2.0
-
-  Unless required by applicable law or agreed to in writing,
-  software distributed under the License is distributed on an
-  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
-  KIND, either express or implied.  See the License for the
-  specific language governing permissions and limitations
-  under the License.
-  -->
 
 <PMML xmlns="http://www.dmg.org/PMML-4_2" version="4.2">
   <Header copyright="www.dmg.org" description="A very small binary tree model to show structure."/>

--- a/kie-pmml-trusty/kie-pmml-models/kie-pmml-models-drools/kie-pmml-models-drools-tree/kie-pmml-models-drools-tree-evaluator/src/test/resources/TreeSample.pmml
+++ b/kie-pmml-trusty/kie-pmml-models/kie-pmml-models-drools/kie-pmml-models-drools-tree/kie-pmml-models-drools-tree-evaluator/src/test/resources/TreeSample.pmml
@@ -1,21 +1,3 @@
-<!--
-  Licensed to the Apache Software Foundation (ASF) under one
-  or more contributor license agreements.  See the NOTICE file
-  distributed with this work for additional information
-  regarding copyright ownership.  The ASF licenses this file
-  to you under the Apache License, Version 2.0 (the
-  "License"); you may not use this file except in compliance
-  with the License.  You may obtain a copy of the License at
-
-    http://www.apache.org/licenses/LICENSE-2.0
-
-  Unless required by applicable law or agreed to in writing,
-  software distributed under the License is distributed on an
-  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
-  KIND, either express or implied.  See the License for the
-  specific language governing permissions and limitations
-  under the License.
-  -->
 
 <PMML xmlns="http://www.dmg.org/PMML-4_2" version="4.2">
   <Header copyright="www.dmg.org" description="A very small binary tree model to show structure."/>

--- a/kie-pmml-trusty/kie-pmml-models/kie-pmml-models-mining/kie-pmml-models-mining-compiler/src/test/resources/MiningModel_Mixed.pmml
+++ b/kie-pmml-trusty/kie-pmml-models/kie-pmml-models-mining/kie-pmml-models-mining-compiler/src/test/resources/MiningModel_Mixed.pmml
@@ -1,22 +1,4 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!--
-  Licensed to the Apache Software Foundation (ASF) under one
-  or more contributor license agreements.  See the NOTICE file
-  distributed with this work for additional information
-  regarding copyright ownership.  The ASF licenses this file
-  to you under the Apache License, Version 2.0 (the
-  "License"); you may not use this file except in compliance
-  with the License.  You may obtain a copy of the License at
-
-    http://www.apache.org/licenses/LICENSE-2.0
-
-  Unless required by applicable law or agreed to in writing,
-  software distributed under the License is distributed on an
-  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
-  KIND, either express or implied.  See the License for the
-  specific language governing permissions and limitations
-  under the License.
-  -->
 
 <PMML version="4.4" xmlns="http://www.dmg.org/PMML-4_4">
   <Header copyright="KNIME">

--- a/kie-pmml-trusty/kie-pmml-models/kie-pmml-models-mining/kie-pmml-models-mining-compiler/src/test/resources/MiningModel_NoSegmentId.pmml
+++ b/kie-pmml-trusty/kie-pmml-models/kie-pmml-models-mining/kie-pmml-models-mining-compiler/src/test/resources/MiningModel_NoSegmentId.pmml
@@ -1,22 +1,4 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!--
-  Licensed to the Apache Software Foundation (ASF) under one
-  or more contributor license agreements.  See the NOTICE file
-  distributed with this work for additional information
-  regarding copyright ownership.  The ASF licenses this file
-  to you under the Apache License, Version 2.0 (the
-  "License"); you may not use this file except in compliance
-  with the License.  You may obtain a copy of the License at
-
-    http://www.apache.org/licenses/LICENSE-2.0
-
-  Unless required by applicable law or agreed to in writing,
-  software distributed under the License is distributed on an
-  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
-  KIND, either express or implied.  See the License for the
-  specific language governing permissions and limitations
-  under the License.
-  -->
 
 <PMML version="4.4" xmlns="http://www.dmg.org/PMML-4_4">
   <Header copyright="KNIME">

--- a/kie-pmml-trusty/kie-pmml-models/kie-pmml-models-mining/kie-pmml-models-mining-compiler/src/test/resources/MiningModel_Regression.pmml
+++ b/kie-pmml-trusty/kie-pmml-models/kie-pmml-models-mining/kie-pmml-models-mining-compiler/src/test/resources/MiningModel_Regression.pmml
@@ -1,22 +1,4 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!--
-  Licensed to the Apache Software Foundation (ASF) under one
-  or more contributor license agreements.  See the NOTICE file
-  distributed with this work for additional information
-  regarding copyright ownership.  The ASF licenses this file
-  to you under the Apache License, Version 2.0 (the
-  "License"); you may not use this file except in compliance
-  with the License.  You may obtain a copy of the License at
-
-    http://www.apache.org/licenses/LICENSE-2.0
-
-  Unless required by applicable law or agreed to in writing,
-  software distributed under the License is distributed on an
-  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
-  KIND, either express or implied.  See the License for the
-  specific language governing permissions and limitations
-  under the License.
-  -->
 
 <PMML version="4.4" xmlns="http://www.dmg.org/PMML-4_4">
   <Header copyright="KNIME">

--- a/kie-pmml-trusty/kie-pmml-models/kie-pmml-models-mining/kie-pmml-models-mining-compiler/src/test/resources/MiningModel_Scorecard.pmml
+++ b/kie-pmml-trusty/kie-pmml-models/kie-pmml-models-mining/kie-pmml-models-mining-compiler/src/test/resources/MiningModel_Scorecard.pmml
@@ -1,22 +1,4 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!--
-  Licensed to the Apache Software Foundation (ASF) under one
-  or more contributor license agreements.  See the NOTICE file
-  distributed with this work for additional information
-  regarding copyright ownership.  The ASF licenses this file
-  to you under the Apache License, Version 2.0 (the
-  "License"); you may not use this file except in compliance
-  with the License.  You may obtain a copy of the License at
-
-    http://www.apache.org/licenses/LICENSE-2.0
-
-  Unless required by applicable law or agreed to in writing,
-  software distributed under the License is distributed on an
-  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
-  KIND, either express or implied.  See the License for the
-  specific language governing permissions and limitations
-  under the License.
-  -->
 
 <PMML version="4.4" xmlns="http://www.dmg.org/PMML-4_4">
   <Header copyright="KNIME">

--- a/kie-pmml-trusty/kie-pmml-models/kie-pmml-models-mining/kie-pmml-models-mining-compiler/src/test/resources/MiningModel_SegmentId.pmml
+++ b/kie-pmml-trusty/kie-pmml-models/kie-pmml-models-mining/kie-pmml-models-mining-compiler/src/test/resources/MiningModel_SegmentId.pmml
@@ -1,22 +1,4 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!--
-  Licensed to the Apache Software Foundation (ASF) under one
-  or more contributor license agreements.  See the NOTICE file
-  distributed with this work for additional information
-  regarding copyright ownership.  The ASF licenses this file
-  to you under the Apache License, Version 2.0 (the
-  "License"); you may not use this file except in compliance
-  with the License.  You may obtain a copy of the License at
-
-    http://www.apache.org/licenses/LICENSE-2.0
-
-  Unless required by applicable law or agreed to in writing,
-  software distributed under the License is distributed on an
-  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
-  KIND, either express or implied.  See the License for the
-  specific language governing permissions and limitations
-  under the License.
-  -->
 
 <PMML version="4.4" xmlns="http://www.dmg.org/PMML-4_4">
   <Header copyright="KNIME">

--- a/kie-pmml-trusty/kie-pmml-models/kie-pmml-models-mining/kie-pmml-models-mining-compiler/src/test/resources/MiningModel_TreeModel.pmml
+++ b/kie-pmml-trusty/kie-pmml-models/kie-pmml-models-mining/kie-pmml-models-mining-compiler/src/test/resources/MiningModel_TreeModel.pmml
@@ -1,22 +1,4 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!--
-  Licensed to the Apache Software Foundation (ASF) under one
-  or more contributor license agreements.  See the NOTICE file
-  distributed with this work for additional information
-  regarding copyright ownership.  The ASF licenses this file
-  to you under the Apache License, Version 2.0 (the
-  "License"); you may not use this file except in compliance
-  with the License.  You may obtain a copy of the License at
-
-    http://www.apache.org/licenses/LICENSE-2.0
-
-  Unless required by applicable law or agreed to in writing,
-  software distributed under the License is distributed on an
-  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
-  KIND, either express or implied.  See the License for the
-  specific language governing permissions and limitations
-  under the License.
-  -->
 
 <PMML version="4.4" xmlns="http://www.dmg.org/PMML-4_4">
   <Header copyright="KNIME">

--- a/kie-pmml-trusty/kie-pmml-models/kie-pmml-models-mining/kie-pmml-models-mining-tests/src/main/resources/mixedmining/MiningModel_Mixed.pmml
+++ b/kie-pmml-trusty/kie-pmml-models/kie-pmml-models-mining/kie-pmml-models-mining-tests/src/main/resources/mixedmining/MiningModel_Mixed.pmml
@@ -1,22 +1,4 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!--
-  Licensed to the Apache Software Foundation (ASF) under one
-  or more contributor license agreements.  See the NOTICE file
-  distributed with this work for additional information
-  regarding copyright ownership.  The ASF licenses this file
-  to you under the Apache License, Version 2.0 (the
-  "License"); you may not use this file except in compliance
-  with the License.  You may obtain a copy of the License at
-
-    http://www.apache.org/licenses/LICENSE-2.0
-
-  Unless required by applicable law or agreed to in writing,
-  software distributed under the License is distributed on an
-  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
-  KIND, either express or implied.  See the License for the
-  specific language governing permissions and limitations
-  under the License.
-  -->
 
 <PMML version="4.4" xmlns="http://www.dmg.org/PMML-4_4">
   <Header copyright="KNIME">

--- a/kie-pmml-trusty/kie-pmml-models/kie-pmml-models-mining/kie-pmml-models-mining-tests/src/main/resources/multiplemining/MultipleMining.pmml
+++ b/kie-pmml-trusty/kie-pmml-models/kie-pmml-models-mining/kie-pmml-models-mining-tests/src/main/resources/multiplemining/MultipleMining.pmml
@@ -1,22 +1,4 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!--
-  Licensed to the Apache Software Foundation (ASF) under one
-  or more contributor license agreements.  See the NOTICE file
-  distributed with this work for additional information
-  regarding copyright ownership.  The ASF licenses this file
-  to you under the Apache License, Version 2.0 (the
-  "License"); you may not use this file except in compliance
-  with the License.  You may obtain a copy of the License at
-
-    http://www.apache.org/licenses/LICENSE-2.0
-
-  Unless required by applicable law or agreed to in writing,
-  software distributed under the License is distributed on an
-  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
-  KIND, either express or implied.  See the License for the
-  specific language governing permissions and limitations
-  under the License.
-  -->
 
 <PMML version="4.4" xmlns="http://www.dmg.org/PMML-4_4">
   <Header copyright="KNIME">

--- a/kie-pmml-trusty/kie-pmml-models/kie-pmml-models-mining/kie-pmml-models-mining-tests/src/main/resources/predicatesmining/MiningModel_Predicates.pmml
+++ b/kie-pmml-trusty/kie-pmml-models/kie-pmml-models-mining/kie-pmml-models-mining-tests/src/main/resources/predicatesmining/MiningModel_Predicates.pmml
@@ -1,22 +1,4 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!--
-  Licensed to the Apache Software Foundation (ASF) under one
-  or more contributor license agreements.  See the NOTICE file
-  distributed with this work for additional information
-  regarding copyright ownership.  The ASF licenses this file
-  to you under the Apache License, Version 2.0 (the
-  "License"); you may not use this file except in compliance
-  with the License.  You may obtain a copy of the License at
-
-    http://www.apache.org/licenses/LICENSE-2.0
-
-  Unless required by applicable law or agreed to in writing,
-  software distributed under the License is distributed on an
-  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
-  KIND, either express or implied.  See the License for the
-  specific language governing permissions and limitations
-  under the License.
-  -->
 
 <PMML version="4.4" xmlns="http://www.dmg.org/PMML-4_4">
   <Header copyright="KNIME">

--- a/kie-pmml-trusty/kie-pmml-models/kie-pmml-models-mining/kie-pmml-models-mining-tests/src/main/resources/randomforestclassifiermining/RandomForestClassifier.pmml
+++ b/kie-pmml-trusty/kie-pmml-models/kie-pmml-models-mining/kie-pmml-models-mining-tests/src/main/resources/randomforestclassifiermining/RandomForestClassifier.pmml
@@ -1,22 +1,4 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!--
-  Licensed to the Apache Software Foundation (ASF) under one
-  or more contributor license agreements.  See the NOTICE file
-  distributed with this work for additional information
-  regarding copyright ownership.  The ASF licenses this file
-  to you under the Apache License, Version 2.0 (the
-  "License"); you may not use this file except in compliance
-  with the License.  You may obtain a copy of the License at
-
-    http://www.apache.org/licenses/LICENSE-2.0
-
-  Unless required by applicable law or agreed to in writing,
-  software distributed under the License is distributed on an
-  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
-  KIND, either express or implied.  See the License for the
-  specific language governing permissions and limitations
-  under the License.
-  -->
 
 <PMML xmlns="http://www.dmg.org/PMML-4_4" version="4.4.1">
   <Header copyright="Copyright (c) 2018 Software AG" description="Default Description">

--- a/kie-pmml-trusty/kie-pmml-models/kie-pmml-models-regression/kie-pmml-models-regression-compiler/src/test/resources/LinearRegressionSample.pmml
+++ b/kie-pmml-trusty/kie-pmml-models/kie-pmml-models-regression/kie-pmml-models-regression-compiler/src/test/resources/LinearRegressionSample.pmml
@@ -1,21 +1,3 @@
-<!--
-  Licensed to the Apache Software Foundation (ASF) under one
-  or more contributor license agreements.  See the NOTICE file
-  distributed with this work for additional information
-  regarding copyright ownership.  The ASF licenses this file
-  to you under the Apache License, Version 2.0 (the
-  "License"); you may not use this file except in compliance
-  with the License.  You may obtain a copy of the License at
-
-    http://www.apache.org/licenses/LICENSE-2.0
-
-  Unless required by applicable law or agreed to in writing,
-  software distributed under the License is distributed on an
-  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
-  KIND, either express or implied.  See the License for the
-  specific language governing permissions and limitations
-  under the License.
-  -->
 
 <PMML xmlns="http://www.dmg.org/PMML-4_2" version="4.2">
   <Header copyright="DMG.org"/>

--- a/kie-pmml-trusty/kie-pmml-models/kie-pmml-models-regression/kie-pmml-models-regression-tests/src/main/resources/linearregressionsamplewithtransformations/LinearRegressionSampleWithTransformations.pmml
+++ b/kie-pmml-trusty/kie-pmml-models/kie-pmml-models-regression/kie-pmml-models-regression-tests/src/main/resources/linearregressionsamplewithtransformations/LinearRegressionSampleWithTransformations.pmml
@@ -1,21 +1,3 @@
-<!--
-  Licensed to the Apache Software Foundation (ASF) under one
-  or more contributor license agreements.  See the NOTICE file
-  distributed with this work for additional information
-  regarding copyright ownership.  The ASF licenses this file
-  to you under the Apache License, Version 2.0 (the
-  "License"); you may not use this file except in compliance
-  with the License.  You may obtain a copy of the License at
-
-    http://www.apache.org/licenses/LICENSE-2.0
-
-  Unless required by applicable law or agreed to in writing,
-  software distributed under the License is distributed on an
-  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
-  KIND, either express or implied.  See the License for the
-  specific language governing permissions and limitations
-  under the License.
-  -->
 
 <PMML xmlns="http://www.dmg.org/PMML-4_4" version="4.4">
   <Header copyright="DMG.org"/>

--- a/kie-pmml-trusty/kie-pmml-models/kie-pmml-models-tests/src/test/resources/MiningModel_Mixed.pmml
+++ b/kie-pmml-trusty/kie-pmml-models/kie-pmml-models-tests/src/test/resources/MiningModel_Mixed.pmml
@@ -1,22 +1,4 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!--
-  Licensed to the Apache Software Foundation (ASF) under one
-  or more contributor license agreements.  See the NOTICE file
-  distributed with this work for additional information
-  regarding copyright ownership.  The ASF licenses this file
-  to you under the Apache License, Version 2.0 (the
-  "License"); you may not use this file except in compliance
-  with the License.  You may obtain a copy of the License at
-
-    http://www.apache.org/licenses/LICENSE-2.0
-
-  Unless required by applicable law or agreed to in writing,
-  software distributed under the License is distributed on an
-  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
-  KIND, either express or implied.  See the License for the
-  specific language governing permissions and limitations
-  under the License.
-  -->
 
 <PMML version="4.4" xmlns="http://www.dmg.org/PMML-4_4">
     <Header copyright="KNIME">

--- a/kie-pmml-trusty/kie-pmml-models/kie-pmml-models-tree/kie-pmml-models-tree-compiler/src/test/resources/TreeSample.pmml
+++ b/kie-pmml-trusty/kie-pmml-models/kie-pmml-models-tree/kie-pmml-models-tree-compiler/src/test/resources/TreeSample.pmml
@@ -1,21 +1,3 @@
-<!--
-  Licensed to the Apache Software Foundation (ASF) under one
-  or more contributor license agreements.  See the NOTICE file
-  distributed with this work for additional information
-  regarding copyright ownership.  The ASF licenses this file
-  to you under the Apache License, Version 2.0 (the
-  "License"); you may not use this file except in compliance
-  with the License.  You may obtain a copy of the License at
-
-    http://www.apache.org/licenses/LICENSE-2.0
-
-  Unless required by applicable law or agreed to in writing,
-  software distributed under the License is distributed on an
-  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
-  KIND, either express or implied.  See the License for the
-  specific language governing permissions and limitations
-  under the License.
-  -->
 
 <PMML xmlns="http://www.dmg.org/PMML-4_2" version="4.2">
   <Header copyright="www.dmg.org" description="A very small binary tree model to show structure."/>

--- a/kie-pmml-trusty/kie-pmml-models/kie-pmml-models-tree/kie-pmml-models-tree-compiler/src/test/resources/TreeSimplified.pmml
+++ b/kie-pmml-trusty/kie-pmml-models/kie-pmml-models-tree/kie-pmml-models-tree-compiler/src/test/resources/TreeSimplified.pmml
@@ -1,21 +1,3 @@
-<!--
-  Licensed to the Apache Software Foundation (ASF) under one
-  or more contributor license agreements.  See the NOTICE file
-  distributed with this work for additional information
-  regarding copyright ownership.  The ASF licenses this file
-  to you under the Apache License, Version 2.0 (the
-  "License"); you may not use this file except in compliance
-  with the License.  You may obtain a copy of the License at
-
-    http://www.apache.org/licenses/LICENSE-2.0
-
-  Unless required by applicable law or agreed to in writing,
-  software distributed under the License is distributed on an
-  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
-  KIND, either express or implied.  See the License for the
-  specific language governing permissions and limitations
-  under the License.
-  -->
 
 <PMML xmlns="http://www.dmg.org/PMML-4_2" version="4.2">
   <Header copyright="www.dmg.org" description="A very small binary tree model to show structure."/>


### PR DESCRIPTION
- Remove Apache License header
- List files in LICENSE
- List files in .rat-excludes

**Issue**: 

* https://github.com/apache/incubator-kie-drools/issues/6165

