### PR TITLE
Improve assertJ tests by using containsExactlyInAnyOrder

### DIFF
--- a/drools-beliefs/src/test/java/org/drools/beliefs/bayes/JunctionTreeBuilderTest.java
+++ b/drools-beliefs/src/test/java/org/drools/beliefs/bayes/JunctionTreeBuilderTest.java
@@ -187,7 +187,7 @@ public class JunctionTreeBuilderTest {
         jtBuilder.createClique(dX1.getId(), clonedAdjMatrix, vertices, adjList );
 
         assertThat(vertices).hasSize(3);
-        assertThat(vertices).containsExactly(2, 3, 4);
+        assertThat(vertices).containsExactlyInAnyOrder(2, 3, 4);
 
         assertLinkedNode(jtBuilder, 1, 2, 3, 4);
         assertLinkedNode(jtBuilder, 2, 1, 3, 4);
@@ -477,7 +477,7 @@ public class JunctionTreeBuilderTest {
         adjList = clonedAdjMatrix[ id  ];
         jtBuilder.createClique(4, clonedAdjMatrix, verticesToUpdate, adjList);
         assertThat(verticesToUpdate).hasSize(3);
-        assertThat(verticesToUpdate).containsExactly(1, 2, 6); // don't forget 3 and 5 were already eliminated
+        assertThat(verticesToUpdate).containsExactlyInAnyOrder(1, 2, 6); // don't forget 3 and 5 were already eliminated
         jtBuilder.eliminateVertex(p, elmVertMap, clonedAdjMatrix, adjList, verticesToUpdate, v );
 
         // assert all new edges


### PR DESCRIPTION
### Description:
- The modified two tests could sometimes fail. Improved AssertJ tests by using `containsExactlyInAnyOrder` to account for `HashSet` 's unordered nature. 
- `containsExactly` inherently relies on stream to populate the `collections` and test if the target values are the same and **in order**
- According to AssertJ's [documentation](https://github.com/assertj/assertj/blob/1d6614aeef9b68f0e828bc828b3bcb538ac87a25/assertj-core/src/main/java/org/assertj/core/api/ObjectEnumerableAssert.java#L154C4-L155C21):
  - `containsExactly` verifies that the actual group contains exactly the given values **in order**.
  - `containsExactlyInAnyOrder` verifies that the actual group contains exactly the given values **in any order**.

