### PR TITLE
[incubator-kie-drools-6136] Migrate drools tests to JUnit5 - #9

### DIFF
--- a/drools-test-coverage/test-compiler-integration/pom.xml
+++ b/drools-test-coverage/test-compiler-integration/pom.xml
@@ -119,26 +119,11 @@
       <artifactId>xstream</artifactId>
       <scope>test</scope>
     </dependency>
-        <dependency>
-            <groupId>org.junit.vintage</groupId>
-            <artifactId>junit-vintage-engine</artifactId>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>org.junit.jupiter</groupId>
-            <artifactId>junit-jupiter-api</artifactId>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>org.junit.jupiter</groupId>
-            <artifactId>junit-jupiter-engine</artifactId>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>org.junit.jupiter</groupId>
-            <artifactId>junit-jupiter-params</artifactId>
-            <scope>test</scope>
-        </dependency>
+    <dependency>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter</artifactId>
+      <scope>test</scope>
+    </dependency>
     <dependency>
       <groupId>org.assertj</groupId>
       <artifactId>assertj-core</artifactId>
@@ -189,17 +174,6 @@
       <groupId>org.mockito</groupId>
       <artifactId>mockito-core</artifactId>
       <scope>test</scope>
-    </dependency>
-    <dependency>
-      <groupId>junit</groupId>
-      <artifactId>junit</artifactId>
-      <scope>test</scope>
-      <exclusions>
-        <exclusion>
-          <groupId>org.hamcrest</groupId>
-          <artifactId>hamcrest-core</artifactId>
-        </exclusion>
-      </exclusions>
     </dependency>
   </dependencies>
 

--- a/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/compiler/integrationtests/concurrency/AccumulateFunctionConcurrencyTest.java
+++ b/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/compiler/integrationtests/concurrency/AccumulateFunctionConcurrencyTest.java
@@ -22,10 +22,9 @@ import java.util.stream.Stream;
 
 import org.drools.testcoverage.common.util.KieBaseTestConfiguration;
 import org.drools.testcoverage.common.util.TestParametersUtil2;
-import org.junit.experimental.categories.Category;
-import org.kie.test.testcategory.TurtleTestCategory;
+import org.junit.jupiter.api.condition.EnabledIfEnvironmentVariable;
 
-@Category(TurtleTestCategory.class)
+@EnabledIfEnvironmentVariable(named = "runTurtleTests", matches = "*")
 public class AccumulateFunctionConcurrencyTest extends BaseConcurrencyTest {
 
     public static Stream<KieBaseTestConfiguration> parameters() {

--- a/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/compiler/integrationtests/concurrency/ConsequenceConcurrencyTest.java
+++ b/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/compiler/integrationtests/concurrency/ConsequenceConcurrencyTest.java
@@ -24,11 +24,10 @@ import java.util.stream.Stream;
 
 import org.drools.testcoverage.common.util.KieBaseTestConfiguration;
 import org.drools.testcoverage.common.util.TestParametersUtil2;
-import org.junit.experimental.categories.Category;
+import org.junit.jupiter.api.condition.EnabledIfEnvironmentVariable;
 import org.kie.api.runtime.KieSession;
-import org.kie.test.testcategory.TurtleTestCategory;
 
-@Category(TurtleTestCategory.class)
+@EnabledIfEnvironmentVariable(named = "runTurtleTests", matches = "*")
 public class ConsequenceConcurrencyTest extends BaseConcurrencyTest {
 	
     public static Stream<KieBaseTestConfiguration> parameters() {

--- a/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/compiler/integrationtests/concurrency/ConsequenceWithAndOrConcurrencyTest.java
+++ b/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/compiler/integrationtests/concurrency/ConsequenceWithAndOrConcurrencyTest.java
@@ -24,12 +24,11 @@ import java.util.stream.Stream;
 
 import org.drools.testcoverage.common.util.KieBaseTestConfiguration;
 import org.drools.testcoverage.common.util.TestParametersUtil2;
-import org.junit.experimental.categories.Category;
+import org.junit.jupiter.api.condition.EnabledIfEnvironmentVariable;
 import org.kie.api.KieBase;
 import org.kie.api.runtime.KieSession;
-import org.kie.test.testcategory.TurtleTestCategory;
 
-@Category(TurtleTestCategory.class)
+@EnabledIfEnvironmentVariable(named = "runTurtleTests", matches = "*")
 public class ConsequenceWithAndOrConcurrencyTest extends BaseConcurrencyTest {
 
     public static Stream<KieBaseTestConfiguration> parameters() {

--- a/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/compiler/integrationtests/concurrency/ConstraintConcurrencyTest.java
+++ b/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/compiler/integrationtests/concurrency/ConstraintConcurrencyTest.java
@@ -22,10 +22,9 @@ import java.util.stream.Stream;
 
 import org.drools.testcoverage.common.util.KieBaseTestConfiguration;
 import org.drools.testcoverage.common.util.TestParametersUtil2;
-import org.junit.experimental.categories.Category;
-import org.kie.test.testcategory.TurtleTestCategory;
+import org.junit.jupiter.api.condition.EnabledIfEnvironmentVariable;
 
-@Category(TurtleTestCategory.class)
+@EnabledIfEnvironmentVariable(named = "runTurtleTests", matches = "*")
 public class ConstraintConcurrencyTest extends BaseConcurrencyTest {
 	
     public static Stream<KieBaseTestConfiguration> parameters() {

--- a/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/compiler/integrationtests/concurrency/ConstraintWithAndOrConcurrencyTest.java
+++ b/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/compiler/integrationtests/concurrency/ConstraintWithAndOrConcurrencyTest.java
@@ -22,12 +22,11 @@ import java.util.stream.Stream;
 
 import org.drools.testcoverage.common.util.KieBaseTestConfiguration;
 import org.drools.testcoverage.common.util.TestParametersUtil2;
-import org.junit.experimental.categories.Category;
+import org.junit.jupiter.api.condition.EnabledIfEnvironmentVariable;
 import org.kie.api.KieBase;
 import org.kie.api.runtime.KieSession;
-import org.kie.test.testcategory.TurtleTestCategory;
 
-@Category(TurtleTestCategory.class)
+@EnabledIfEnvironmentVariable(named = "runTurtleTests", matches = "*")
 public class ConstraintWithAndOrConcurrencyTest extends BaseConcurrencyTest {
 
     public static Stream<KieBaseTestConfiguration> parameters() {

--- a/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/compiler/integrationtests/concurrency/ConstraintWithAndOrJittingConcurrencyTest.java
+++ b/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/compiler/integrationtests/concurrency/ConstraintWithAndOrJittingConcurrencyTest.java
@@ -22,12 +22,11 @@ import java.util.stream.Stream;
 
 import org.drools.testcoverage.common.util.KieBaseTestConfiguration;
 import org.drools.testcoverage.common.util.TestParametersUtil2;
-import org.junit.experimental.categories.Category;
+import org.junit.jupiter.api.condition.EnabledIfEnvironmentVariable;
 import org.kie.api.KieBase;
 import org.kie.api.runtime.KieSession;
-import org.kie.test.testcategory.TurtleTestCategory;
 
-@Category(TurtleTestCategory.class)
+@EnabledIfEnvironmentVariable(named = "runTurtleTests", matches = "*")
 public class ConstraintWithAndOrJittingConcurrencyTest extends BaseConcurrencyTest {
 
     public static Stream<KieBaseTestConfiguration> parameters() {

--- a/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/compiler/integrationtests/concurrency/EvalConcurrencyTest.java
+++ b/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/compiler/integrationtests/concurrency/EvalConcurrencyTest.java
@@ -22,10 +22,9 @@ import java.util.stream.Stream;
 
 import org.drools.testcoverage.common.util.KieBaseTestConfiguration;
 import org.drools.testcoverage.common.util.TestParametersUtil2;
-import org.junit.experimental.categories.Category;
-import org.kie.test.testcategory.TurtleTestCategory;
+import org.junit.jupiter.api.condition.EnabledIfEnvironmentVariable;
 
-@Category(TurtleTestCategory.class)
+@EnabledIfEnvironmentVariable(named = "runTurtleTests", matches = "*")
 public class EvalConcurrencyTest extends BaseConcurrencyTest {
 
     public static Stream<KieBaseTestConfiguration> parameters() {

--- a/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/compiler/integrationtests/concurrency/FromAccumulateConcurrencyTest.java
+++ b/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/compiler/integrationtests/concurrency/FromAccumulateConcurrencyTest.java
@@ -22,10 +22,9 @@ import java.util.stream.Stream;
 
 import org.drools.testcoverage.common.util.KieBaseTestConfiguration;
 import org.drools.testcoverage.common.util.TestParametersUtil2;
-import org.junit.experimental.categories.Category;
-import org.kie.test.testcategory.TurtleTestCategory;
+import org.junit.jupiter.api.condition.EnabledIfEnvironmentVariable;
 
-@Category(TurtleTestCategory.class)
+@EnabledIfEnvironmentVariable(named = "runTurtleTests", matches = "*")
 public class FromAccumulateConcurrencyTest extends BaseConcurrencyTest {
 
     public static Stream<KieBaseTestConfiguration> parameters() {

--- a/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/compiler/integrationtests/concurrency/GlobalConcurrencyTest.java
+++ b/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/compiler/integrationtests/concurrency/GlobalConcurrencyTest.java
@@ -30,18 +30,17 @@ import org.drools.testcoverage.common.model.Person;
 import org.drools.testcoverage.common.model.Result;
 import org.drools.testcoverage.common.util.KieBaseTestConfiguration;
 import org.drools.testcoverage.common.util.KieBaseUtil;
-import org.junit.experimental.categories.Category;
+import org.junit.jupiter.api.condition.EnabledIfEnvironmentVariable;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.MethodSource;
 import org.kie.api.KieBase;
 import org.kie.api.runtime.KieSession;
-import org.kie.test.testcategory.TurtleTestCategory;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-@Category(TurtleTestCategory.class)
+@EnabledIfEnvironmentVariable(named = "runTurtleTests", matches = "*")
 public class GlobalConcurrencyTest {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(GlobalConcurrencyTest.class);

--- a/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/compiler/integrationtests/concurrency/MVELDateClassFieldReaderConcurrencyTest.java
+++ b/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/compiler/integrationtests/concurrency/MVELDateClassFieldReaderConcurrencyTest.java
@@ -23,11 +23,10 @@ import java.util.stream.Stream;
 
 import org.drools.testcoverage.common.util.KieBaseTestConfiguration;
 import org.drools.testcoverage.common.util.TestParametersUtil2;
-import org.junit.experimental.categories.Category;
+import org.junit.jupiter.api.condition.EnabledIfEnvironmentVariable;
 import org.kie.api.runtime.KieSession;
-import org.kie.test.testcategory.TurtleTestCategory;
 
-@Category(TurtleTestCategory.class)
+@EnabledIfEnvironmentVariable(named = "runTurtleTests", matches = "*")
 public class MVELDateClassFieldReaderConcurrencyTest extends BaseConcurrencyTest {
 
     public static Stream<KieBaseTestConfiguration> parameters() {

--- a/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/compiler/integrationtests/concurrency/MVELNumberClassFieldReaderConcurrencyTest.java
+++ b/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/compiler/integrationtests/concurrency/MVELNumberClassFieldReaderConcurrencyTest.java
@@ -22,11 +22,10 @@ import java.util.stream.Stream;
 
 import org.drools.testcoverage.common.util.KieBaseTestConfiguration;
 import org.drools.testcoverage.common.util.TestParametersUtil2;
-import org.junit.experimental.categories.Category;
+import org.junit.jupiter.api.condition.EnabledIfEnvironmentVariable;
 import org.kie.api.runtime.KieSession;
-import org.kie.test.testcategory.TurtleTestCategory;
 
-@Category(TurtleTestCategory.class)
+@EnabledIfEnvironmentVariable(named = "runTurtleTests", matches = "*")
 public class MVELNumberClassFieldReaderConcurrencyTest extends BaseConcurrencyTest {
 
     public static Stream<KieBaseTestConfiguration> parameters() {

--- a/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/compiler/integrationtests/concurrency/MVELObjectClassFieldReaderConcurrencyTest.java
+++ b/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/compiler/integrationtests/concurrency/MVELObjectClassFieldReaderConcurrencyTest.java
@@ -22,11 +22,10 @@ import java.util.stream.Stream;
 
 import org.drools.testcoverage.common.util.KieBaseTestConfiguration;
 import org.drools.testcoverage.common.util.TestParametersUtil2;
-import org.junit.experimental.categories.Category;
+import org.junit.jupiter.api.condition.EnabledIfEnvironmentVariable;
 import org.kie.api.runtime.KieSession;
-import org.kie.test.testcategory.TurtleTestCategory;
 
-@Category(TurtleTestCategory.class)
+@EnabledIfEnvironmentVariable(named = "runTurtleTests", matches = "*")
 public class MVELObjectClassFieldReaderConcurrencyTest extends BaseConcurrencyTest {
 
     public static Stream<KieBaseTestConfiguration> parameters() {

--- a/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/compiler/integrationtests/incrementalcompilation/AbstractAddRemoveGenerated2RulesTest.java
+++ b/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/compiler/integrationtests/incrementalcompilation/AbstractAddRemoveGenerated2RulesTest.java
@@ -26,17 +26,18 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
-import org.junit.Test;
-import org.junit.experimental.categories.Category;
-import org.kie.test.testcategory.TurtleTestCategory;
+import org.junit.jupiter.api.Timeout;
+import org.junit.jupiter.api.condition.EnabledIfEnvironmentVariable;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
 
-@Category(TurtleTestCategory.class)
+@EnabledIfEnvironmentVariable(named = "runTurtleTests", matches = "*")
 public abstract class AbstractAddRemoveGenerated2RulesTest {
 
-    private final String rule1;
-    private final String rule2;
+    private String rule1;
+    private String rule2;
 
-    public AbstractAddRemoveGenerated2RulesTest(final ConstraintsPair constraintsPair) {
+    private void generateRules(final ConstraintsPair constraintsPair) {
         final String rule1 = "package " + TestUtil.RULES_PACKAGE_NAME + ";" +
                 "global java.util.List list\n" +
                 "rule " + TestUtil.RULE1_NAME + " \n" +
@@ -59,11 +60,11 @@ public abstract class AbstractAddRemoveGenerated2RulesTest {
 
     // This takes only three different constraints - this is intentional, because it is needed to
     // keep the number of combinations at reasonable number.
-    public static Collection<ConstraintsPair[]> generateRulesConstraintsCombinations(final String constraint1,
+    public static Collection<ConstraintsPair> generateRulesConstraintsCombinations(final String constraint1,
                                                                                      final String constraint2,
                                                                                      final String constraint3) {
         final Set<ConstraintsPair> constraintsPairs = new HashSet<>();
-        final List<ConstraintsPair[]> result = new ArrayList<>();
+        final List<ConstraintsPair> result = new ArrayList<>();
 
         final List<String> constraintsList = new ArrayList<>();
         constraintsList.add(constraint1);
@@ -75,7 +76,7 @@ public abstract class AbstractAddRemoveGenerated2RulesTest {
             for (final String constraintsRule2 : constraintsCombinations) {
                 final ConstraintsPair constraintsPair = new ConstraintsPair(constraintsRule1, constraintsRule2);
                 if (constraintsPairs.add(constraintsPair)) {
-                    result.add(new ConstraintsPair[]{constraintsPair});
+                    result.add(constraintsPair);
                 }
             }
         }
@@ -98,57 +99,81 @@ public abstract class AbstractAddRemoveGenerated2RulesTest {
 
     /////////////////////////// TESTS //////////////////////////////////
 
-    @Test(timeout = 40000)
-    public void testInsertFactsFireRulesRemoveRules() {
+    @ParameterizedTest(name = "KieBase type={0}")
+	@MethodSource("parameters")
+    @Timeout(40000)
+    public void testInsertFactsFireRulesRemoveRules(ConstraintsPair constraintsPair) {
+    	generateRules(constraintsPair);
         AddRemoveTestCases.insertFactsFireRulesRemoveRules1(rule1, rule2, TestUtil.RULE1_NAME, TestUtil.RULE2_NAME, null, getFacts());
         AddRemoveTestCases.insertFactsFireRulesRemoveRules2(rule1, rule2, TestUtil.RULE1_NAME, TestUtil.RULE2_NAME, null, getFacts());
         AddRemoveTestCases.insertFactsFireRulesRemoveRules3(rule1, rule2, TestUtil.RULE1_NAME, TestUtil.RULE2_NAME, null, getFacts());
     }
 
-    @Test(timeout = 40000)
-    public void testInsertFactsFireRulesRemoveRulesRevertedRules() {
+    @ParameterizedTest(name = "KieBase type={0}")
+	@MethodSource("parameters")
+    @Timeout(40000)
+    public void testInsertFactsFireRulesRemoveRulesRevertedRules(ConstraintsPair constraintsPair) {
+    	generateRules(constraintsPair);
         AddRemoveTestCases.insertFactsFireRulesRemoveRules1(rule2, rule1, TestUtil.RULE2_NAME, TestUtil.RULE1_NAME, null, getFacts());
         AddRemoveTestCases.insertFactsFireRulesRemoveRules2(rule2, rule1, TestUtil.RULE2_NAME, TestUtil.RULE1_NAME, null, getFacts());
         AddRemoveTestCases.insertFactsFireRulesRemoveRules3(rule2, rule1, TestUtil.RULE2_NAME, TestUtil.RULE1_NAME, null, getFacts());
     }
 
-    @Test(timeout = 40000)
-    public void testFireRulesInsertFactsFireRulesRemoveRules() {
+    @ParameterizedTest(name = "KieBase type={0}")
+	@MethodSource("parameters")
+    @Timeout(40000)
+    public void testFireRulesInsertFactsFireRulesRemoveRules(ConstraintsPair constraintsPair) {
+    	generateRules(constraintsPair);
         AddRemoveTestCases.fireRulesInsertFactsFireRulesRemoveRules1(rule1, rule2, TestUtil.RULE1_NAME, TestUtil.RULE2_NAME, null, getFacts());
         AddRemoveTestCases.fireRulesInsertFactsFireRulesRemoveRules2(rule1, rule2, TestUtil.RULE1_NAME, TestUtil.RULE2_NAME, null, getFacts());
         AddRemoveTestCases.fireRulesInsertFactsFireRulesRemoveRules3(rule1, rule2, TestUtil.RULE1_NAME, TestUtil.RULE2_NAME, null, getFacts());
     }
 
-    @Test(timeout = 40000)
-    public void testFireRulesInsertFactsFireRulesRemoveRulesRevertedRules() {
+    @ParameterizedTest(name = "KieBase type={0}")
+	@MethodSource("parameters")
+    @Timeout(40000)
+    public void testFireRulesInsertFactsFireRulesRemoveRulesRevertedRules(ConstraintsPair constraintsPair) {
+    	generateRules(constraintsPair);
         AddRemoveTestCases.fireRulesInsertFactsFireRulesRemoveRules1(rule2, rule1, TestUtil.RULE2_NAME, TestUtil.RULE1_NAME, null, getFacts());
         AddRemoveTestCases.fireRulesInsertFactsFireRulesRemoveRules2(rule2, rule1, TestUtil.RULE2_NAME, TestUtil.RULE1_NAME, null, getFacts());
         AddRemoveTestCases.fireRulesInsertFactsFireRulesRemoveRules3(rule2, rule1, TestUtil.RULE2_NAME, TestUtil.RULE1_NAME, null, getFacts());
     }
 
-    @Test(timeout = 40000)
-    public void testInsertFactsRemoveRulesFireRulesRemoveRules() {
+    @ParameterizedTest(name = "KieBase type={0}")
+	@MethodSource("parameters")
+    @Timeout(40000)
+    public void testInsertFactsRemoveRulesFireRulesRemoveRules(ConstraintsPair constraintsPair) {
+    	generateRules(constraintsPair);
         AddRemoveTestCases.insertFactsRemoveRulesFireRulesRemoveRules1(rule1, rule2, TestUtil.RULE1_NAME, TestUtil.RULE2_NAME, null, getFacts());
         AddRemoveTestCases.insertFactsRemoveRulesFireRulesRemoveRules2(rule1, rule2, TestUtil.RULE1_NAME, TestUtil.RULE2_NAME, null, getFacts());
         AddRemoveTestCases.insertFactsRemoveRulesFireRulesRemoveRules3(rule1, rule2, TestUtil.RULE1_NAME, TestUtil.RULE2_NAME, null, getFacts());
     }
 
-    @Test(timeout = 40000)
-    public void testInsertFactsRemoveRulesFireRulesRemoveRulesRevertedRules() {
+    @ParameterizedTest(name = "KieBase type={0}")
+	@MethodSource("parameters")
+    @Timeout(40000)
+    public void testInsertFactsRemoveRulesFireRulesRemoveRulesRevertedRules(ConstraintsPair constraintsPair) {
+    	generateRules(constraintsPair);
         AddRemoveTestCases.insertFactsRemoveRulesFireRulesRemoveRules1(rule2, rule1, TestUtil.RULE2_NAME, TestUtil.RULE1_NAME, null, getFacts());
         AddRemoveTestCases.insertFactsRemoveRulesFireRulesRemoveRules2(rule2, rule1, TestUtil.RULE2_NAME, TestUtil.RULE1_NAME, null, getFacts());
         AddRemoveTestCases.insertFactsRemoveRulesFireRulesRemoveRules3(rule2, rule1, TestUtil.RULE2_NAME, TestUtil.RULE1_NAME, null, getFacts());
     }
 
-    @Test(timeout = 40000)
-    public void testInsertFactsFireRulesRemoveRulesReinsertRules() {
+    @ParameterizedTest(name = "KieBase type={0}")
+	@MethodSource("parameters")
+    @Timeout(40000)
+    public void testInsertFactsFireRulesRemoveRulesReinsertRules(ConstraintsPair constraintsPair) {
+    	generateRules(constraintsPair);
         AddRemoveTestCases.insertFactsFireRulesRemoveRulesReinsertRules1(rule1, rule2, TestUtil.RULE1_NAME, TestUtil.RULE2_NAME, null, getFacts());
         AddRemoveTestCases.insertFactsFireRulesRemoveRulesReinsertRules2(rule1, rule2, TestUtil.RULE1_NAME, TestUtil.RULE2_NAME, null, getFacts());
         AddRemoveTestCases.insertFactsFireRulesRemoveRulesReinsertRules3(rule1, rule2, TestUtil.RULE1_NAME, TestUtil.RULE2_NAME, null, getFacts());
     }
 
-    @Test(timeout = 40000)
-    public void testInsertFactsFireRulesRemoveRulesReinsertRulesRevertedRules() {
+    @ParameterizedTest(name = "KieBase type={0}")
+	@MethodSource("parameters")
+    @Timeout(40000)
+    public void testInsertFactsFireRulesRemoveRulesReinsertRulesRevertedRules(ConstraintsPair constraintsPair) {
+    	generateRules(constraintsPair);
         AddRemoveTestCases.insertFactsFireRulesRemoveRulesReinsertRules1(rule2, rule1, TestUtil.RULE2_NAME, TestUtil.RULE1_NAME, null, getFacts());
         AddRemoveTestCases.insertFactsFireRulesRemoveRulesReinsertRules2(rule2, rule1, TestUtil.RULE2_NAME, TestUtil.RULE1_NAME, null, getFacts());
         AddRemoveTestCases.insertFactsFireRulesRemoveRulesReinsertRules3(rule2, rule1, TestUtil.RULE2_NAME, TestUtil.RULE1_NAME, null, getFacts());

--- a/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/compiler/integrationtests/incrementalcompilation/AddRemoveGenerated2RulesEval2Test.java
+++ b/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/compiler/integrationtests/incrementalcompilation/AddRemoveGenerated2RulesEval2Test.java
@@ -18,20 +18,12 @@
  */
 package org.drools.compiler.integrationtests.incrementalcompilation;
 
-import java.util.Collection;
+import java.util.stream.Stream;
 
-import org.junit.runner.RunWith;
-import org.junit.runners.Parameterized;
-
-@RunWith(Parameterized.class)
 public class AddRemoveGenerated2RulesEval2Test extends AbstractAddRemoveGenerated2RulesTest {
 
-    public AddRemoveGenerated2RulesEval2Test(final ConstraintsPair constraintsPair) {
-        super(constraintsPair);
-    }
 
-    @Parameterized.Parameters
-    public static Collection<ConstraintsPair[]> getRulesConstraints() {
+    public static Stream<ConstraintsPair> parameters() {
         // Placeholder is replaced by actual variable name during constraints generation.
         // This is needed, because when generator generates the same constraint 3-times for a rule,
         // in each constraint must be different variable name, so Drools can process it
@@ -39,6 +31,6 @@ public class AddRemoveGenerated2RulesEval2Test extends AbstractAddRemoveGenerate
         return generateRulesConstraintsCombinations(
                 " Integer() \n",
                 " ${variableNamePlaceholder}: Integer() eval(${variableNamePlaceholder} == 1) \n",
-                " ${variableNamePlaceholder}: Integer() and (eval(true) or eval(${variableNamePlaceholder} == 1) )\n");
+                " ${variableNamePlaceholder}: Integer() and (eval(true) or eval(${variableNamePlaceholder} == 1) )\n").stream();
     }
 }

--- a/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/compiler/integrationtests/incrementalcompilation/AddRemoveGenerated2RulesEvalTest.java
+++ b/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/compiler/integrationtests/incrementalcompilation/AddRemoveGenerated2RulesEvalTest.java
@@ -22,7 +22,7 @@ import java.util.stream.Stream;
 
 import org.junit.jupiter.api.Disabled;
 
-@Disabled("TODO: Open issue. It gets stuck")
+@Disabled("It gets stuck. See issue #6190")
 public class AddRemoveGenerated2RulesEvalTest extends AbstractAddRemoveGenerated2RulesTest {
 
     public static Stream<ConstraintsPair> parameters() {

--- a/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/compiler/integrationtests/incrementalcompilation/AddRemoveGenerated2RulesEvalTest.java
+++ b/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/compiler/integrationtests/incrementalcompilation/AddRemoveGenerated2RulesEvalTest.java
@@ -18,20 +18,14 @@
  */
 package org.drools.compiler.integrationtests.incrementalcompilation;
 
-import org.junit.runner.RunWith;
-import org.junit.runners.Parameterized;
+import java.util.stream.Stream;
 
-import java.util.Collection;
+import org.junit.jupiter.api.Disabled;
 
-@RunWith(Parameterized.class)
+@Disabled("TODO: Open issue. It gets stuck")
 public class AddRemoveGenerated2RulesEvalTest extends AbstractAddRemoveGenerated2RulesTest {
 
-    public AddRemoveGenerated2RulesEvalTest(final ConstraintsPair constraintsPair) {
-        super(constraintsPair);
-    }
-
-    @Parameterized.Parameters
-    public static Collection<ConstraintsPair[]> getRulesConstraints() {
+    public static Stream<ConstraintsPair> parameters() {
         // Placeholder is replaced by actual variable name during constraints generation.
         // This is needed, because when generator generates the same constraint 3-times for a rule,
         // in each constraint must be different variable name, so Drools can process it
@@ -39,6 +33,6 @@ public class AddRemoveGenerated2RulesEvalTest extends AbstractAddRemoveGenerated
         return generateRulesConstraintsCombinations(
                 " Integer() \n",
                 " ${variableNamePlaceholder}: Integer() eval(${variableNamePlaceholder} == 1) \n",
-                " exists(Integer() and exists(Integer() and Integer())) \n");
+                " exists(Integer() and exists(Integer() and Integer())) \n").stream();
     }
 }

--- a/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/compiler/integrationtests/incrementalcompilation/AddRemoveGenerated2RulesIntegerTest.java
+++ b/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/compiler/integrationtests/incrementalcompilation/AddRemoveGenerated2RulesIntegerTest.java
@@ -18,23 +18,17 @@
  */
 package org.drools.compiler.integrationtests.incrementalcompilation;
 
-import org.junit.runner.RunWith;
-import org.junit.runners.Parameterized;
+import java.util.stream.Stream;
 
-import java.util.Collection;
+import org.junit.jupiter.api.Disabled;
 
-@RunWith(Parameterized.class)
+@Disabled("TODO: Open issue. It gets stuck")
 public class AddRemoveGenerated2RulesIntegerTest extends AbstractAddRemoveGenerated2RulesTest {
 
-    public AddRemoveGenerated2RulesIntegerTest(final ConstraintsPair constraintsPair) {
-        super(constraintsPair);
-    }
-
-    @Parameterized.Parameters
-    public static Collection<ConstraintsPair[]> getRulesConstraints() {
+    public static Stream<ConstraintsPair> parameters() {
         return generateRulesConstraintsCombinations(
                 " Integer() \n",
                 " exists(Integer() and Integer()) \n",
-                " exists(Integer() and exists(Integer() and Integer())) \n");
+                " exists(Integer() and exists(Integer() and Integer())) \n").stream();
     }
 }

--- a/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/compiler/integrationtests/incrementalcompilation/AddRemoveGenerated2RulesIntegerTest.java
+++ b/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/compiler/integrationtests/incrementalcompilation/AddRemoveGenerated2RulesIntegerTest.java
@@ -22,7 +22,7 @@ import java.util.stream.Stream;
 
 import org.junit.jupiter.api.Disabled;
 
-@Disabled("TODO: Open issue. It gets stuck")
+@Disabled("It gets stuck. See issue #6190")
 public class AddRemoveGenerated2RulesIntegerTest extends AbstractAddRemoveGenerated2RulesTest {
 
     public static Stream<ConstraintsPair> parameters() {

--- a/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/compiler/integrationtests/incrementalcompilation/AddRemoveGenerated2RulesMapContainsTest.java
+++ b/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/compiler/integrationtests/incrementalcompilation/AddRemoveGenerated2RulesMapContainsTest.java
@@ -18,23 +18,17 @@
  */
 package org.drools.compiler.integrationtests.incrementalcompilation;
 
-import org.junit.runner.RunWith;
-import org.junit.runners.Parameterized;
+import java.util.stream.Stream;
 
-import java.util.Collection;
+import org.junit.jupiter.api.Disabled;
 
-@RunWith(Parameterized.class)
+@Disabled("TODO: Open issue. It gets stuck")
 public class AddRemoveGenerated2RulesMapContainsTest extends AbstractAddRemoveGenerated2RulesTest {
 
-    public AddRemoveGenerated2RulesMapContainsTest(final ConstraintsPair constraintsPair) {
-        super(constraintsPair);
-    }
-
-    @Parameterized.Parameters
-    public static Collection<ConstraintsPair[]> getRulesConstraints() {
+    public static Stream<ConstraintsPair> parameters() {
         return generateRulesConstraintsCombinations(
                 " java.util.Map(values() contains \"1\") \n",
                 " Integer() \n",
-                " exists(Integer() and exists(Integer() and Integer())) \n");
+                " exists(Integer() and exists(Integer() and Integer())) \n").stream();
     }
 }

--- a/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/compiler/integrationtests/incrementalcompilation/AddRemoveGenerated2RulesMapContainsTest.java
+++ b/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/compiler/integrationtests/incrementalcompilation/AddRemoveGenerated2RulesMapContainsTest.java
@@ -22,7 +22,7 @@ import java.util.stream.Stream;
 
 import org.junit.jupiter.api.Disabled;
 
-@Disabled("TODO: Open issue. It gets stuck")
+@Disabled("It gets stuck. See issue #6190")
 public class AddRemoveGenerated2RulesMapContainsTest extends AbstractAddRemoveGenerated2RulesTest {
 
     public static Stream<ConstraintsPair> parameters() {

--- a/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/compiler/integrationtests/incrementalcompilation/AddRemoveGenerated2RulesNotNotTest.java
+++ b/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/compiler/integrationtests/incrementalcompilation/AddRemoveGenerated2RulesNotNotTest.java
@@ -18,23 +18,17 @@
  */
 package org.drools.compiler.integrationtests.incrementalcompilation;
 
-import java.util.Collection;
+import java.util.stream.Stream;
 
-import org.junit.runner.RunWith;
-import org.junit.runners.Parameterized;
+import org.junit.jupiter.api.Disabled;
 
-@RunWith(Parameterized.class)
+@Disabled("TODO: Open issue. It gets stuck")
 public class AddRemoveGenerated2RulesNotNotTest extends AbstractAddRemoveGenerated2RulesTest {
 
-    public AddRemoveGenerated2RulesNotNotTest(final ConstraintsPair constraintsPair) {
-        super(constraintsPair);
-    }
-
-    @Parameterized.Parameters
-    public static Collection<ConstraintsPair[]> getRulesConstraints() {
+    public static Stream<ConstraintsPair> parameters() {
         return generateRulesConstraintsCombinations(
                 " Integer() \n",
                 " Integer() not(not(exists(Integer() and Integer()))) \n",
-                " exists(Integer() and exists(Integer() and Integer())) \n");
+                " exists(Integer() and exists(Integer() and Integer())) \n").stream();
     }
 }

--- a/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/compiler/integrationtests/incrementalcompilation/AddRemoveGenerated2RulesNotNotTest.java
+++ b/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/compiler/integrationtests/incrementalcompilation/AddRemoveGenerated2RulesNotNotTest.java
@@ -22,7 +22,7 @@ import java.util.stream.Stream;
 
 import org.junit.jupiter.api.Disabled;
 
-@Disabled("TODO: Open issue. It gets stuck")
+@Disabled("It gets stuck. See issue #6190")
 public class AddRemoveGenerated2RulesNotNotTest extends AbstractAddRemoveGenerated2RulesTest {
 
     public static Stream<ConstraintsPair> parameters() {

--- a/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/compiler/integrationtests/incrementalcompilation/AddRemoveGenerated2RulesNotTest.java
+++ b/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/compiler/integrationtests/incrementalcompilation/AddRemoveGenerated2RulesNotTest.java
@@ -22,7 +22,7 @@ import java.util.stream.Stream;
 
 import org.junit.jupiter.api.Disabled;
 
-@Disabled("TODO: Open issue. It gets stuck")
+@Disabled("It gets stuck. See issue #6190")
 public class AddRemoveGenerated2RulesNotTest extends AbstractAddRemoveGenerated2RulesTest {
 
     public static Stream<ConstraintsPair> parameters() {

--- a/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/compiler/integrationtests/incrementalcompilation/AddRemoveGenerated2RulesNotTest.java
+++ b/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/compiler/integrationtests/incrementalcompilation/AddRemoveGenerated2RulesNotTest.java
@@ -18,23 +18,17 @@
  */
 package org.drools.compiler.integrationtests.incrementalcompilation;
 
-import org.junit.runner.RunWith;
-import org.junit.runners.Parameterized;
+import java.util.stream.Stream;
 
-import java.util.Collection;
+import org.junit.jupiter.api.Disabled;
 
-@RunWith(Parameterized.class)
+@Disabled("TODO: Open issue. It gets stuck")
 public class AddRemoveGenerated2RulesNotTest extends AbstractAddRemoveGenerated2RulesTest {
 
-    public AddRemoveGenerated2RulesNotTest(final ConstraintsPair constraintsPair) {
-        super(constraintsPair);
-    }
-
-    @Parameterized.Parameters
-    public static Collection<ConstraintsPair[]> getRulesConstraints() {
+    public static Stream<ConstraintsPair> parameters() {
         return generateRulesConstraintsCombinations(
                 " Integer() \n",
                 " Integer() not(exists(Double() and Double())) \n",
-                " exists(Integer() and exists(Integer() and Integer())) \n");
+                " exists(Integer() and exists(Integer() and Integer())) \n").stream();
     }
 }

--- a/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/compiler/integrationtests/incrementalcompilation/AddRemoveGenerated2RulesStringIntegerTest.java
+++ b/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/compiler/integrationtests/incrementalcompilation/AddRemoveGenerated2RulesStringIntegerTest.java
@@ -22,7 +22,7 @@ import java.util.stream.Stream;
 
 import org.junit.jupiter.api.Disabled;
 
-@Disabled("TODO: Open issue. It gets stuck")
+@Disabled("It gets stuck. See issue #6190")
 public class AddRemoveGenerated2RulesStringIntegerTest extends AbstractAddRemoveGenerated2RulesTest {
 
     public static Stream<ConstraintsPair> parameters() {

--- a/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/compiler/integrationtests/incrementalcompilation/AddRemoveGenerated2RulesStringIntegerTest.java
+++ b/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/compiler/integrationtests/incrementalcompilation/AddRemoveGenerated2RulesStringIntegerTest.java
@@ -18,23 +18,17 @@
  */
 package org.drools.compiler.integrationtests.incrementalcompilation;
 
-import org.junit.runner.RunWith;
-import org.junit.runners.Parameterized;
+import java.util.stream.Stream;
 
-import java.util.Collection;
+import org.junit.jupiter.api.Disabled;
 
-@RunWith(Parameterized.class)
+@Disabled("TODO: Open issue. It gets stuck")
 public class AddRemoveGenerated2RulesStringIntegerTest extends AbstractAddRemoveGenerated2RulesTest {
 
-    public AddRemoveGenerated2RulesStringIntegerTest(final ConstraintsPair constraintsPair) {
-        super(constraintsPair);
-    }
-
-    @Parameterized.Parameters
-    public static Collection<ConstraintsPair[]> getRulesConstraints() {
+    public static Stream<ConstraintsPair> parameters() {
         return generateRulesConstraintsCombinations(
                 " String() \n",
                 " exists(Integer() and Integer()) \n",
-                " exists(Integer() and exists(Integer() and Integer())) \n");
+                " exists(Integer() and exists(Integer() and Integer())) \n").stream();
     }
 }

--- a/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/compiler/integrationtests/incrementalcompilation/AddRemoveGenerated2RulesStringTest.java
+++ b/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/compiler/integrationtests/incrementalcompilation/AddRemoveGenerated2RulesStringTest.java
@@ -22,7 +22,7 @@ import java.util.stream.Stream;
 
 import org.junit.jupiter.api.Disabled;
 
-@Disabled("TODO: Open issue. It gets stuck")
+@Disabled("It gets stuck. See issue #6190")
 public class AddRemoveGenerated2RulesStringTest extends AbstractAddRemoveGenerated2RulesTest {
 
     public static Stream<ConstraintsPair> parameters() {

--- a/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/compiler/integrationtests/incrementalcompilation/AddRemoveGenerated2RulesStringTest.java
+++ b/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/compiler/integrationtests/incrementalcompilation/AddRemoveGenerated2RulesStringTest.java
@@ -18,23 +18,17 @@
  */
 package org.drools.compiler.integrationtests.incrementalcompilation;
 
-import org.junit.runner.RunWith;
-import org.junit.runners.Parameterized;
+import java.util.stream.Stream;
 
-import java.util.Collection;
+import org.junit.jupiter.api.Disabled;
 
-@RunWith(Parameterized.class)
+@Disabled("TODO: Open issue. It gets stuck")
 public class AddRemoveGenerated2RulesStringTest extends AbstractAddRemoveGenerated2RulesTest {
 
-    public AddRemoveGenerated2RulesStringTest(final ConstraintsPair constraintsPair) {
-        super(constraintsPair);
-    }
-
-    @Parameterized.Parameters
-    public static Collection<ConstraintsPair[]> getRulesConstraints() {
+    public static Stream<ConstraintsPair> parameters() {
         return generateRulesConstraintsCombinations(
                 " String() \n",
                 " exists(String() and String()) \n",
-                " exists(String() and exists(String() and String())) \n");
+                " exists(String() and exists(String() and String())) \n").stream();
     }
 }

--- a/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/compiler/integrationtests/incrementalcompilation/AddRemoveRulesAddDeleteFactsTest.java
+++ b/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/compiler/integrationtests/incrementalcompilation/AddRemoveRulesAddDeleteFactsTest.java
@@ -24,30 +24,21 @@ import java.util.Collection;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
+import java.util.stream.Stream;
 
-import org.junit.Test;
-import org.junit.experimental.categories.Category;
-import org.junit.runner.RunWith;
-import org.junit.runners.Parameterized;
+import org.junit.jupiter.api.condition.EnabledIfEnvironmentVariable;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
 import org.kie.api.runtime.KieSession;
 import org.kie.api.runtime.rule.FactHandle;
-import org.kie.test.testcategory.TurtleTestCategory;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-@Category(TurtleTestCategory.class)
-@RunWith(Parameterized.class)
+@EnabledIfEnvironmentVariable(named = "runTurtleTests", matches = "*")
 public class AddRemoveRulesAddDeleteFactsTest {
 
-    private final StringPermutation rulesPermutation;
-
-    public AddRemoveRulesAddDeleteFactsTest(final StringPermutation rulesPermutation) {
-        this.rulesPermutation = rulesPermutation;
-    }
-
-    @Parameterized.Parameters
-    public static Collection<StringPermutation[]> getRulesPermutations() {
-        final Collection<StringPermutation[]> rulesPermutations = new HashSet<>();
+    public static Stream<StringPermutation> parameters() {
+        final Collection<StringPermutation> rulesPermutations = new HashSet<>();
 
         final Set<StringPermutation> parametersPermutations = new HashSet<>();
         getStringPermutations(
@@ -56,14 +47,15 @@ public class AddRemoveRulesAddDeleteFactsTest {
                 parametersPermutations);
 
         for (final StringPermutation permutation : parametersPermutations) {
-            rulesPermutations.add(new StringPermutation[]{permutation});
+            rulesPermutations.add(permutation);
         }
 
-        return rulesPermutations;
+        return rulesPermutations.stream();
     }
 
-    @Test
-    public void testAddRemoveRulesAddRemoveFacts() {
+    @ParameterizedTest
+	@MethodSource("parameters")
+    public void testAddRemoveRulesAddRemoveFacts(StringPermutation rulesPermutation) {
         final KieSession kieSession = TestUtil.buildSessionInSteps(getRules());
         try {
             final List<String> resultsList = new ArrayList<>();

--- a/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/compiler/integrationtests/incrementalcompilation/AddRemoveRulesAdvOperatorsTest.java
+++ b/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/compiler/integrationtests/incrementalcompilation/AddRemoveRulesAdvOperatorsTest.java
@@ -24,18 +24,18 @@ import java.util.List;
 import java.util.Map;
 import java.util.concurrent.atomic.AtomicInteger;
 
-import org.junit.Ignore;
-import org.junit.Test;
-import org.junit.experimental.categories.Category;
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
+import org.junit.jupiter.api.condition.EnabledIfEnvironmentVariable;
 import org.kie.api.runtime.KieSession;
-import org.kie.test.testcategory.TurtleTestCategory;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
 /**
  * Tests adding and removing rules with advanced operators.
  */
-@Category(TurtleTestCategory.class)
+@EnabledIfEnvironmentVariable(named = "runTurtleTests", matches = "*")
 public class AddRemoveRulesAdvOperatorsTest {
 
     @Test
@@ -551,7 +551,8 @@ public class AddRemoveRulesAdvOperatorsTest {
         AddRemoveTestCases.runAllTestCases(rule2, rule1, TestUtil.RULE2_NAME, TestUtil.RULE1_NAME, getGlobalsMemberOf(memberString), memberString, "fact");
     }
 
-    @Test @Ignore
+    @Test 
+    @Disabled
     public void testAddRemoveRuleWithContainsMatchesExists() {
         final String rule1 = "package " + TestUtil.RULES_PACKAGE_NAME + ";\n" +
                 " global java.util.List memberList\n" +
@@ -656,7 +657,8 @@ public class AddRemoveRulesAdvOperatorsTest {
         }
     }
 
-    @Test(timeout = 10000L)
+    @Test
+    @Timeout(10000L)
     public void testAddRemoveRuleContainsExists3RulesDoubledExists() {
         final String rule1 = "package " + TestUtil.RULES_PACKAGE_NAME + ";" +
                 "global java.util.concurrent.atomic.AtomicInteger globalInt\n" +

--- a/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/compiler/integrationtests/incrementalcompilation/AddRemoveRulesTest.java
+++ b/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/compiler/integrationtests/incrementalcompilation/AddRemoveRulesTest.java
@@ -26,6 +26,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.atomic.AtomicInteger;
+import java.util.stream.Stream;
 
 import org.drools.core.common.InternalFactHandle;
 import org.drools.core.reteoo.LeftTuple;
@@ -35,11 +36,9 @@ import org.drools.kiesession.rulebase.InternalKnowledgeBase;
 import org.drools.kiesession.rulebase.KnowledgeBaseFactory;
 import org.drools.testcoverage.common.util.KieBaseTestConfiguration;
 import org.drools.testcoverage.common.util.KieUtil;
-import org.drools.testcoverage.common.util.TestParametersUtil;
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.junit.runners.Parameterized;
+import org.drools.testcoverage.common.util.TestParametersUtil2;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
 import org.kie.api.KieBase;
 import org.kie.api.KieServices;
 import org.kie.api.builder.ReleaseId;
@@ -58,18 +57,10 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.fail;
 import static org.drools.core.util.DroolsTestUtil.rulestoMap;
 
-@RunWith(Parameterized.class)
 public class AddRemoveRulesTest {
 
-    private final KieBaseTestConfiguration kieBaseTestConfiguration;
-
-    public AddRemoveRulesTest(final KieBaseTestConfiguration kieBaseTestConfiguration) {
-        this.kieBaseTestConfiguration = kieBaseTestConfiguration;
-    }
-
-    @Parameterized.Parameters(name = "KieBase type={0}")
-    public static Collection<Object[]> getParameters() {
-        return TestParametersUtil.getKieBaseCloudConfigurations(true);
+    public static Stream<KieBaseTestConfiguration> parameters() {
+        return TestParametersUtil2.getKieBaseCloudConfigurations(true).stream();
     }
 
     private InternalKnowledgeBase base = KnowledgeBaseFactory.newKnowledgeBase();
@@ -88,8 +79,7 @@ public class AddRemoveRulesTest {
                 "end\n\n";
     }
 
-    @Before
-    public void createEmptyKnowledgeBase() {
+    public void createEmptyKnowledgeBase(KieBaseTestConfiguration kieBaseTestConfiguration) {
         final KieServices kieServices = KieServices.get();
         final ReleaseId releaseId = kieServices.newReleaseId("org.kie", "test-add-remove-rules", "1.0");
         KieUtil.getKieModuleFromDrls(releaseId, kieBaseTestConfiguration);
@@ -126,8 +116,10 @@ public class AddRemoveRulesTest {
         this.base.addPackages( pkgs );
     }
 
-    @Test
-    public void test() {
+    @ParameterizedTest(name = "KieBase type={0}")
+	@MethodSource("parameters")
+    public void test(KieBaseTestConfiguration kieBaseTestConfiguration) {
+    	createEmptyKnowledgeBase(kieBaseTestConfiguration);
         final KieSession knowledgeSession = base.newKieSession();
         knowledgeSession.fireAllRules();
 
@@ -227,9 +219,11 @@ public class AddRemoveRulesTest {
         assertThat(TestUtil.getRulesCount(base)).isEqualTo(8);
     }
 
-    @Test
-    public void testAddRemoveFromKB() {
+    @ParameterizedTest(name = "KieBase type={0}")
+	@MethodSource("parameters")
+    public void testAddRemoveFromKB(KieBaseTestConfiguration kieBaseTestConfiguration) {
         // DROOLS-328
+    	createEmptyKnowledgeBase(kieBaseTestConfiguration);
         final String drl = "\n" +
                 "rule A\n" +
                 "  when\n" +
@@ -279,9 +273,11 @@ public class AddRemoveRulesTest {
         ((InternalKnowledgeBase) kSession.getKieBase()).addPackages(kbuilder.getKnowledgePackages());
     }
 
-    @Test
-    public void testAddRemoveDeletingFact() {
+    @ParameterizedTest(name = "KieBase type={0}")
+	@MethodSource("parameters")
+    public void testAddRemoveDeletingFact(KieBaseTestConfiguration kieBaseTestConfiguration) {
         // DROOLS-328
+    	createEmptyKnowledgeBase(kieBaseTestConfiguration);
         final String drl = "\n" +
                 "rule B\n" +
                 "  when\n" +
@@ -304,8 +300,10 @@ public class AddRemoveRulesTest {
         kSession.delete(fh);
     }
 
-    @Test
-    public void testAddRemoveWithPartialSharing() {
+    @ParameterizedTest(name = "KieBase type={0}")
+	@MethodSource("parameters")
+    public void testAddRemoveWithPartialSharing(KieBaseTestConfiguration kieBaseTestConfiguration) {
+    	createEmptyKnowledgeBase(kieBaseTestConfiguration);
         final String drl = "package org.drools.test; \n" +
                 "\n" +
                 "declare A end \n" +
@@ -349,8 +347,10 @@ public class AddRemoveRulesTest {
         kSession.fireAllRules();
     }
 
-    @Test
-    public void testAddRemoveWithReloadInSamePackage_4Rules() {
+    @ParameterizedTest(name = "KieBase type={0}")
+	@MethodSource("parameters")
+    public void testAddRemoveWithReloadInSamePackage_4Rules(KieBaseTestConfiguration kieBaseTestConfiguration) {
+    	createEmptyKnowledgeBase(kieBaseTestConfiguration);
         final String drl = "package org.drools.test;\n" +
 
                 "declare Fakt enabled : boolean end \n" +
@@ -391,8 +391,10 @@ public class AddRemoveRulesTest {
         testAddRemoveWithReloadInSamePackage(drl);
     }
 
-    @Test
-    public void testAddRemoveWithReloadInSamePackage_3Rules() {
+    @ParameterizedTest(name = "KieBase type={0}")
+	@MethodSource("parameters")
+    public void testAddRemoveWithReloadInSamePackage_3Rules(KieBaseTestConfiguration kieBaseTestConfiguration) {
+    	createEmptyKnowledgeBase(kieBaseTestConfiguration);
         final String drl = "package org.drools.test;\n" +
 
                 "declare Fakt enabled : boolean end \n" +
@@ -428,8 +430,10 @@ public class AddRemoveRulesTest {
     }
 
 
-    @Test
-    public void testAddRemoveWithReloadInSamePackage_EntryPoints() {
+    @ParameterizedTest(name = "KieBase type={0}")
+	@MethodSource("parameters")
+    public void testAddRemoveWithReloadInSamePackage_EntryPoints(KieBaseTestConfiguration kieBaseTestConfiguration) {
+    	createEmptyKnowledgeBase(kieBaseTestConfiguration);
         final String drl = "package org.drools.test; \n" +
 
                 "rule \"Input_X\"\n" +
@@ -463,8 +467,10 @@ public class AddRemoveRulesTest {
         testAddRemoveWithReloadInSamePackage(drl);
     }
 
-    @Test
-    public void testAddRemoveWithReloadInSamePackage_EntryPointsVariety() {
+    @ParameterizedTest(name = "KieBase type={0}")
+	@MethodSource("parameters")
+    public void testAddRemoveWithReloadInSamePackage_EntryPointsVariety(KieBaseTestConfiguration kieBaseTestConfiguration) {
+    	createEmptyKnowledgeBase(kieBaseTestConfiguration);
         final String drl = "package org.drools.test; \n" +
 
                 "rule \"Input_X\"\n" +
@@ -517,8 +523,10 @@ public class AddRemoveRulesTest {
         assertThat(list).isEqualTo(Collections.singletonList("ok"));
     }
 
-    @Test
-    public void testRemoveWithDuplicatedCondition() {
+    @ParameterizedTest(name = "KieBase type={0}")
+	@MethodSource("parameters")
+    public void testRemoveWithDuplicatedCondition(KieBaseTestConfiguration kieBaseTestConfiguration) {
+    	createEmptyKnowledgeBase(kieBaseTestConfiguration);
         final String packageName = "test_same_condition_pk" ;
         final String rule = "package " + packageName + ";" +
                 "rule 'test_same_condition' \n" +
@@ -533,8 +541,10 @@ public class AddRemoveRulesTest {
         base.removeKiePackage(packageName);
     }
 
-    @Test
-    public void testFireAfterRemoveDuplicatedConditionInDifferentPackages() {
+    @ParameterizedTest(name = "KieBase type={0}")
+	@MethodSource("parameters")
+    public void testFireAfterRemoveDuplicatedConditionInDifferentPackages(KieBaseTestConfiguration kieBaseTestConfiguration) {
+    	createEmptyKnowledgeBase(kieBaseTestConfiguration);
         final String packageName = "test_same_condition_pk" ;
         final String packageName2 = "test_same_condition_pk_2" ;
         final String rule1 = "package " + packageName + ";" +
@@ -563,8 +573,10 @@ public class AddRemoveRulesTest {
         session.fireAllRules();
     }
 
-    @Test
-    public void testAddRemoveWithExtends() {
+    @ParameterizedTest(name = "KieBase type={0}")
+	@MethodSource("parameters")
+    public void testAddRemoveWithExtends(KieBaseTestConfiguration kieBaseTestConfiguration) {
+    	createEmptyKnowledgeBase(kieBaseTestConfiguration);
         final String packageName = "test_same_condition_pk" ;
         final String rule1 = "package " + packageName + ";" +
                 "import java.util.Map; \n" +
@@ -599,9 +611,11 @@ public class AddRemoveRulesTest {
         }
     }
 
-    @Test
-    public void testRemoveHasSameConElement() {
+    @ParameterizedTest(name = "KieBase type={0}")
+	@MethodSource("parameters")
+    public void testRemoveHasSameConElement(KieBaseTestConfiguration kieBaseTestConfiguration) {
         // DROOLS-891
+    	createEmptyKnowledgeBase(kieBaseTestConfiguration);
         final String packageName = "test";
         final String rule1 = "package " + packageName + ";" +
                 "import java.util.Map; \n" +
@@ -620,8 +634,9 @@ public class AddRemoveRulesTest {
         session.execute(new HashMap());
     }
 
-    @Test
-    public void testFireAfterRemoveWithSameCondition() {
+    @ParameterizedTest(name = "KieBase type={0}")
+	@MethodSource("parameters")
+    public void testFireAfterRemoveWithSameCondition(KieBaseTestConfiguration kieBaseTestConfiguration) {
         // DROOLS-893
         final String packageName = "pk1";
         final String packageName2 = "pk2";
@@ -668,9 +683,11 @@ public class AddRemoveRulesTest {
         ksession.fireAllRules();
     }
 
-    @Test
-    public void testSameEval() {
+    @ParameterizedTest(name = "KieBase type={0}")
+	@MethodSource("parameters")
+    public void testSameEval(KieBaseTestConfiguration kieBaseTestConfiguration) {
         // DROOLS-893
+    	createEmptyKnowledgeBase(kieBaseTestConfiguration);
         final String rule1Name = "rule1";
         final String rule2Name = "rule2";
 
@@ -697,9 +714,11 @@ public class AddRemoveRulesTest {
         statelessSession.execute(new Object());
     }
 
-    @Test
-    public void testFireAfterRemoveRule() {
+    @ParameterizedTest(name = "KieBase type={0}")
+	@MethodSource("parameters")
+    public void testFireAfterRemoveRule(KieBaseTestConfiguration kieBaseTestConfiguration) {
         // DROOLS-893
+    	createEmptyKnowledgeBase(kieBaseTestConfiguration);
         final String rule1Name = "rule1";
         final String rule2Name = "rule2";
 
@@ -737,8 +756,10 @@ public class AddRemoveRulesTest {
         session.execute(fact);
     }
 
-    @Test
-    public void testRemoveWithSameRuleNameInDiffPackage() {
+    @ParameterizedTest(name = "KieBase type={0}")
+	@MethodSource("parameters")
+    public void testRemoveWithSameRuleNameInDiffPackage(KieBaseTestConfiguration kieBaseTestConfiguration) {
+    	createEmptyKnowledgeBase(kieBaseTestConfiguration);
         final String packageName = "pk1";
         final String packageName2 = "pk2";
         final String rule1Name = "rule1";
@@ -766,8 +787,10 @@ public class AddRemoveRulesTest {
         session.fireAllRules();
     }
 
-    @Test
-    public void testRemoveWithSplitStartAtLianAndFollowedBySubNetworkNoSharing() {
+    @ParameterizedTest(name = "KieBase type={0}")
+	@MethodSource("parameters")
+    public void testRemoveWithSplitStartAtLianAndFollowedBySubNetworkNoSharing(KieBaseTestConfiguration kieBaseTestConfiguration) {
+    	createEmptyKnowledgeBase(kieBaseTestConfiguration);
         final String packageName = "pk1";
 
         final String rule1 = "package " + packageName + ";" +
@@ -790,8 +813,10 @@ public class AddRemoveRulesTest {
         session.getKieBase().removeKiePackage(packageName);
     }
 
-    @Test
-    public void testRemoveExistsPopulatedByInitialFact() {
+    @ParameterizedTest(name = "KieBase type={0}")
+	@MethodSource("parameters")
+    public void testRemoveExistsPopulatedByInitialFact(KieBaseTestConfiguration kieBaseTestConfiguration) {
+    	createEmptyKnowledgeBase(kieBaseTestConfiguration);
         final String rule1 = "package " + TestUtil.RULES_PACKAGE_NAME + ";" +
                 "global java.util.List list\n" +
                 "rule R1 when\n" +
@@ -813,8 +838,10 @@ public class AddRemoveRulesTest {
         AddRemoveTestCases.insertFactsRemoveFire(base, rule1, rule2, null, TestUtil.getDefaultFacts());
     }
 
-    @Test
-    public void testAddSplitInSubnetwork() {
+    @ParameterizedTest(name = "KieBase type={0}")
+	@MethodSource("parameters")
+    public void testAddSplitInSubnetwork(KieBaseTestConfiguration kieBaseTestConfiguration) {
+    	createEmptyKnowledgeBase(kieBaseTestConfiguration);
         final String rule1 = "package " + TestUtil.RULES_PACKAGE_NAME + ";" +
                 "global java.util.List list\n" +
                 "rule R1 when\n" +
@@ -836,8 +863,10 @@ public class AddRemoveRulesTest {
         AddRemoveTestCases. insertFactsRemoveFire(base, rule1, rule2, null, TestUtil.getDefaultFacts());
     }
 
-    @Test
-    public void testRemoveWithSplitStartAtLianAndFollowedBySubNetworkWithSharing() {
+    @ParameterizedTest(name = "KieBase type={0}")
+	@MethodSource("parameters")
+    public void testRemoveWithSplitStartAtLianAndFollowedBySubNetworkWithSharing(KieBaseTestConfiguration kieBaseTestConfiguration) {
+    	createEmptyKnowledgeBase(kieBaseTestConfiguration);
         final String rule1 = "package " + TestUtil.RULES_PACKAGE_NAME + ";" +
                 "global java.util.concurrent.atomic.AtomicInteger globalInt\n" +
                 "global java.util.List list\n" +
@@ -863,9 +892,11 @@ public class AddRemoveRulesTest {
         testRemoveWithSplitStartBasicTestSet(rule1, rule2, TestUtil.RULE1_NAME, TestUtil.RULE2_NAME);
     }
 
-    @Test
-    public void testRemoveWithSplitStartBeforeJoinAndFollowedBySubNetworkWithSharing() {
+    @ParameterizedTest(name = "KieBase type={0}")
+	@MethodSource("parameters")
+    public void testRemoveWithSplitStartBeforeJoinAndFollowedBySubNetworkWithSharing(KieBaseTestConfiguration kieBaseTestConfiguration) {
         //  moved the split start to after the Integer
+    	createEmptyKnowledgeBase(kieBaseTestConfiguration);
         final String rule1 = "package " + TestUtil.RULES_PACKAGE_NAME + ";" +
                 "global java.util.concurrent.atomic.AtomicInteger globalInt\n" +
                 "global java.util.List list\n" +
@@ -894,9 +925,11 @@ public class AddRemoveRulesTest {
         testRemoveWithSplitStartBasicTestSet(rule1, rule2, TestUtil.RULE1_NAME, TestUtil.RULE2_NAME);
     }
 
-    @Test
-    public void testRemoveWithSplitStartAtJoinAndFollowedBySubNetworkWithSharing() {
+    @ParameterizedTest(name = "KieBase type={0}")
+	@MethodSource("parameters")
+    public void testRemoveWithSplitStartAtJoinAndFollowedBySubNetworkWithSharing(KieBaseTestConfiguration kieBaseTestConfiguration) {
         //  moved the split start to after the Integer
+    	createEmptyKnowledgeBase(kieBaseTestConfiguration);
         final String rule1 = "package " + TestUtil.RULES_PACKAGE_NAME + ";" +
                 "global java.util.concurrent.atomic.AtomicInteger globalInt\n" +
                 "global java.util.List list\n" +
@@ -924,8 +957,10 @@ public class AddRemoveRulesTest {
         testRemoveWithSplitStartBasicTestSet(rule1, rule2, TestUtil.RULE1_NAME, TestUtil.RULE2_NAME);
     }
 
-    @Test
-    public void testRemoveWithSplitStartSameRules() {
+    @ParameterizedTest(name = "KieBase type={0}")
+	@MethodSource("parameters")
+    public void testRemoveWithSplitStartSameRules(KieBaseTestConfiguration kieBaseTestConfiguration) {
+    	createEmptyKnowledgeBase(kieBaseTestConfiguration);
         final String rule1 = "package " + TestUtil.RULES_PACKAGE_NAME + ";" +
                 "global java.util.concurrent.atomic.AtomicInteger globalInt\n" +
                 "global java.util.List list\n" +
@@ -953,8 +988,10 @@ public class AddRemoveRulesTest {
         testRemoveWithSplitStartBasicTestSet(rule1, rule2, TestUtil.RULE1_NAME, TestUtil.RULE2_NAME);
     }
 
-    @Test //(timeout=2000)
-    public void testRemoveWithSplitStartDoubledExistsConstraint() {
+    @ParameterizedTest(name = "KieBase type={0}")
+	@MethodSource("parameters")
+    public void testRemoveWithSplitStartDoubledExistsConstraint(KieBaseTestConfiguration kieBaseTestConfiguration) {
+    	createEmptyKnowledgeBase(kieBaseTestConfiguration);
         final String rule1 = "package " + TestUtil.RULES_PACKAGE_NAME + ";" +
                 "global java.util.concurrent.atomic.AtomicInteger globalInt\n" +
                 "global java.util.List list\n" +
@@ -983,8 +1020,10 @@ public class AddRemoveRulesTest {
         testRemoveWithSplitStartBasicTestSet(rule1, rule2, TestUtil.RULE1_NAME, TestUtil.RULE2_NAME);
     }
 
-    @Test
-    public void testRemoveWithSplitStartDoubledIntegerConstraint() {
+    @ParameterizedTest(name = "KieBase type={0}")
+	@MethodSource("parameters")
+    public void testRemoveWithSplitStartDoubledIntegerConstraint(KieBaseTestConfiguration kieBaseTestConfiguration) {
+    	createEmptyKnowledgeBase(kieBaseTestConfiguration);
         final String rule1 = "package " + TestUtil.RULES_PACKAGE_NAME + ";" +
                 "global java.util.concurrent.atomic.AtomicInteger globalInt\n" +
                 "global java.util.List list\n" +
@@ -1013,8 +1052,10 @@ public class AddRemoveRulesTest {
         testRemoveWithSplitStartBasicTestSet(rule1, rule2, TestUtil.RULE1_NAME, TestUtil.RULE2_NAME);
     }
 
-    @Test
-    public void testRemoveWithSplitStartAfterSubnetwork() {
+    @ParameterizedTest(name = "KieBase type={0}")
+	@MethodSource("parameters")
+    public void testRemoveWithSplitStartAfterSubnetwork(KieBaseTestConfiguration kieBaseTestConfiguration) {
+    	createEmptyKnowledgeBase(kieBaseTestConfiguration);
         final String rule1 = "package " + TestUtil.RULES_PACKAGE_NAME + ";" +
                 "global java.util.concurrent.atomic.AtomicInteger globalInt\n" +
                 "global java.util.List list\n" +
@@ -1043,8 +1084,10 @@ public class AddRemoveRulesTest {
         testRemoveWithSplitStartBasicTestSet(rule1, rule2, TestUtil.RULE1_NAME, TestUtil.RULE2_NAME);
     }
 
-    @Test
-    public void testRemoveWithSplitStartAfterSubnetwork3Rules() {
+    @ParameterizedTest(name = "KieBase type={0}")
+	@MethodSource("parameters")
+    public void testRemoveWithSplitStartAfterSubnetwork3Rules(KieBaseTestConfiguration kieBaseTestConfiguration) {
+    	createEmptyKnowledgeBase(kieBaseTestConfiguration);
         final String rule1 = "package " + TestUtil.RULES_PACKAGE_NAME + ";" +
                 "global java.util.concurrent.atomic.AtomicInteger globalInt\n" +
                 "global java.util.List list\n" +
@@ -1100,8 +1143,10 @@ public class AddRemoveRulesTest {
         }
     }
 
-    @Test
-    public void testRemoveWithSplitStartAfterSubnetwork3RulesAddOneAfterAnother() {
+    @ParameterizedTest(name = "KieBase type={0}")
+	@MethodSource("parameters")
+    public void testRemoveWithSplitStartAfterSubnetwork3RulesAddOneAfterAnother(KieBaseTestConfiguration kieBaseTestConfiguration) {
+    	createEmptyKnowledgeBase(kieBaseTestConfiguration);
         final String rule1 = "package " + TestUtil.RULES_PACKAGE_NAME + ";" +
                 "global java.util.concurrent.atomic.AtomicInteger globalInt\n" +
                 "global java.util.List list\n" +
@@ -1168,8 +1213,10 @@ public class AddRemoveRulesTest {
         }
     }
 
-    @Test
-    public void testRemoveWithSplitStartAfterSubnetwork3RulesReaddRule() {
+    @ParameterizedTest(name = "KieBase type={0}")
+	@MethodSource("parameters")
+    public void testRemoveWithSplitStartAfterSubnetwork3RulesReaddRule(KieBaseTestConfiguration kieBaseTestConfiguration) {
+    	createEmptyKnowledgeBase(kieBaseTestConfiguration);
         final String rule1 = "package " + TestUtil.RULES_PACKAGE_NAME + ";" +
                              "global java.util.List list\n" +
                              "rule " + TestUtil.RULE1_NAME + " \n" +
@@ -1268,8 +1315,10 @@ public class AddRemoveRulesTest {
         return new String[] { rule1, rule2 };
     }
 
-    @Test
-    public void testRemoveRuleChangeFHFirstLeftTuple() {
+    @ParameterizedTest(name = "KieBase type={0}")
+	@MethodSource("parameters")
+    public void testRemoveRuleChangeFHFirstLeftTuple(KieBaseTestConfiguration kieBaseTestConfiguration) {
+    	createEmptyKnowledgeBase(kieBaseTestConfiguration);
         final String[] rules = getRules1Pattern();
 
         final KieSession kieSession = TestUtil.buildSessionInSteps(base, rules);
@@ -1290,8 +1339,10 @@ public class AddRemoveRulesTest {
         }
     }
 
-    @Test
-    public void testRemoveRuleChangeFHLastLeftTuple() {
+    @ParameterizedTest(name = "KieBase type={0}")
+	@MethodSource("parameters")
+    public void testRemoveRuleChangeFHLastLeftTuple(KieBaseTestConfiguration kieBaseTestConfiguration) {
+    	createEmptyKnowledgeBase(kieBaseTestConfiguration);
         final String[] rules = getRules1Pattern();
 
         final KieSession kieSession = TestUtil.buildSessionInSteps(base, rules);
@@ -1312,8 +1363,10 @@ public class AddRemoveRulesTest {
         }
     }
 
-    @Test
-    public void testRemoveRightTupleThatWasFirst() {
+    @ParameterizedTest(name = "KieBase type={0}")
+	@MethodSource("parameters")
+    public void testRemoveRightTupleThatWasFirst(KieBaseTestConfiguration kieBaseTestConfiguration) {
+    	createEmptyKnowledgeBase(kieBaseTestConfiguration);
         final String[] rules = getRules2Pattern();
 
         final KieSession kieSession = TestUtil.buildSessionInSteps(base, rules);
@@ -1337,8 +1390,10 @@ public class AddRemoveRulesTest {
         }
     }
 
-    @Test
-    public void testRemoveRightTupleThatWasLast() {
+    @ParameterizedTest(name = "KieBase type={0}")
+	@MethodSource("parameters")
+    public void testRemoveRightTupleThatWasLast(KieBaseTestConfiguration kieBaseTestConfiguration) {
+    	createEmptyKnowledgeBase(kieBaseTestConfiguration);
         final String[] rules = getRules2Pattern();
 
         final KieSession kieSession = TestUtil.buildSessionInSteps(base, rules);
@@ -1400,8 +1455,10 @@ public class AddRemoveRulesTest {
         return new String[] { rule1, rule2, rule3 };
     }
 
-    @Test
-    public void testRemoveChildLeftTupleThatWasFirst() {
+    @ParameterizedTest(name = "KieBase type={0}")
+	@MethodSource("parameters")
+    public void testRemoveChildLeftTupleThatWasFirst(KieBaseTestConfiguration kieBaseTestConfiguration) {
+    	createEmptyKnowledgeBase(kieBaseTestConfiguration);
         final String[] rules = getRules3Pattern();
 
         final KieSession kieSession = TestUtil.buildSessionInSteps(base, rules[0], rules[1]);
@@ -1427,8 +1484,10 @@ public class AddRemoveRulesTest {
         }
     }
 
-    @Test
-    public void testRemoveChildLeftTupleThatWasLast() {
+    @ParameterizedTest(name = "KieBase type={0}")
+	@MethodSource("parameters")
+    public void testRemoveChildLeftTupleThatWasLast(KieBaseTestConfiguration kieBaseTestConfiguration) {
+    	createEmptyKnowledgeBase(kieBaseTestConfiguration);
         final String[] rules = getRules3Pattern();
 
         final KieSession kieSession = TestUtil.buildSessionInSteps(base, rules[0], rules[1]);
@@ -1454,8 +1513,10 @@ public class AddRemoveRulesTest {
         }
     }
 
-    @Test
-    public void testRemoveChildLeftTupleThatWasMiddle() {
+    @ParameterizedTest(name = "KieBase type={0}")
+	@MethodSource("parameters")
+    public void testRemoveChildLeftTupleThatWasMiddle(KieBaseTestConfiguration kieBaseTestConfiguration) {
+    	createEmptyKnowledgeBase(kieBaseTestConfiguration);
         final String[] rules = getRules3Pattern();
 
         final KieSession kieSession = TestUtil.buildSessionInSteps(base, rules);
@@ -1484,8 +1545,10 @@ public class AddRemoveRulesTest {
         }
     }
 
-    @Test
-    public void testRemoveChildLeftTupleThatWasFirstWithMultipleData() {
+    @ParameterizedTest(name = "KieBase type={0}")
+	@MethodSource("parameters")
+    public void testRemoveChildLeftTupleThatWasFirstWithMultipleData(KieBaseTestConfiguration kieBaseTestConfiguration) {
+    	createEmptyKnowledgeBase(kieBaseTestConfiguration);
         final String[] rules = getRules3Pattern();
 
         final KieSession kieSession = TestUtil.buildSessionInSteps(base, rules[0], rules[1]);
@@ -1559,8 +1622,10 @@ public class AddRemoveRulesTest {
         }
     }
 
-    @Test
-    public void testRemoveChildLeftTupleThatWasLastWithMultipleData() {
+    @ParameterizedTest(name = "KieBase type={0}")
+	@MethodSource("parameters")
+    public void testRemoveChildLeftTupleThatWasLastWithMultipleData(KieBaseTestConfiguration kieBaseTestConfiguration) {
+    	createEmptyKnowledgeBase(kieBaseTestConfiguration);
         final String[] rules = getRules3Pattern();
 
         final KieSession kieSession = TestUtil.buildSessionInSteps(base, rules[0], rules[1]);
@@ -1643,8 +1708,10 @@ public class AddRemoveRulesTest {
         AddRemoveTestCases.runAllTestCases(base, rule2, rule1, rule2Name, rule1Name, additionalGlobals,1, 2, "1");
     }
 
-    @Test
-    public void testMergeRTN() {
+    @ParameterizedTest(name = "KieBase type={0}")
+	@MethodSource("parameters")
+    public void testMergeRTN(KieBaseTestConfiguration kieBaseTestConfiguration) {
+    	createEmptyKnowledgeBase(kieBaseTestConfiguration);
         final String rule1 = "package " + TestUtil.RULES_PACKAGE_NAME + ";" +
                              "global java.util.List list\n" +
                              "rule " + TestUtil.RULE1_NAME + " \n" +
@@ -1684,8 +1751,10 @@ public class AddRemoveRulesTest {
         }
     }
 
-    @Test
-    public void testSubSubNetwork() {
+    @ParameterizedTest(name = "KieBase type={0}")
+	@MethodSource("parameters")
+    public void testSubSubNetwork(KieBaseTestConfiguration kieBaseTestConfiguration) {
+    	createEmptyKnowledgeBase(kieBaseTestConfiguration);
         final String rule1 = "package " + TestUtil.RULES_PACKAGE_NAME + ";" +
                              "global java.util.List list\n" +
                              "rule " + TestUtil.RULE1_NAME + " \n" +
@@ -1725,8 +1794,10 @@ public class AddRemoveRulesTest {
         }
     }
 
-    @Test
-    public void testSubSubNetwork2() {
+    @ParameterizedTest(name = "KieBase type={0}")
+	@MethodSource("parameters")
+    public void testSubSubNetwork2(KieBaseTestConfiguration kieBaseTestConfiguration) {
+    	createEmptyKnowledgeBase(kieBaseTestConfiguration);
         final String rule1 = "package " + TestUtil.RULES_PACKAGE_NAME + ";" +
                              "global java.util.List list\n" +
                              "rule " + TestUtil.RULE1_NAME + " \n" +
@@ -1762,8 +1833,10 @@ public class AddRemoveRulesTest {
         }
     }
 
-    @Test
-    public void testSubSubNetwork3() {
+    @ParameterizedTest(name = "KieBase type={0}")
+	@MethodSource("parameters")
+    public void testSubSubNetwork3(KieBaseTestConfiguration kieBaseTestConfiguration) {
+    	createEmptyKnowledgeBase(kieBaseTestConfiguration);
         final String rule1 = "package " + TestUtil.RULES_PACKAGE_NAME + ";" +
                              "global java.util.List list\n" +
                              "rule " + TestUtil.RULE1_NAME + " \n" +
@@ -1802,8 +1875,10 @@ public class AddRemoveRulesTest {
         }
     }
 
-    @Test
-    public void testSubSubNetwork4() {
+    @ParameterizedTest(name = "KieBase type={0}")
+	@MethodSource("parameters")
+    public void testSubSubNetwork4(KieBaseTestConfiguration kieBaseTestConfiguration) {
+    	createEmptyKnowledgeBase(kieBaseTestConfiguration);
         final String rule1 = "package " + TestUtil.RULES_PACKAGE_NAME + ";" +
                              "global java.util.List list\n" +
                              "rule " + TestUtil.RULE1_NAME + " \n" +
@@ -1839,8 +1914,10 @@ public class AddRemoveRulesTest {
         }
     }
 
-    @Test
-    public void testSubNetworkWithNot() {
+    @ParameterizedTest(name = "KieBase type={0}")
+	@MethodSource("parameters")
+    public void testSubNetworkWithNot(KieBaseTestConfiguration kieBaseTestConfiguration) {
+    	createEmptyKnowledgeBase(kieBaseTestConfiguration);
         final String rule1 = "package " + TestUtil.RULES_PACKAGE_NAME + ";" +
                              "global java.util.List list\n" +
                              "rule " + TestUtil.RULE1_NAME + " \n" +
@@ -1875,8 +1952,10 @@ public class AddRemoveRulesTest {
         }
     }
 
-    @Test
-    public void testSubNetworkWithNot2() {
+    @ParameterizedTest(name = "KieBase type={0}")
+	@MethodSource("parameters")
+    public void testSubNetworkWithNot2(KieBaseTestConfiguration kieBaseTestConfiguration) {
+    	createEmptyKnowledgeBase(kieBaseTestConfiguration);
         final String rule1 = "package " + TestUtil.RULES_PACKAGE_NAME + ";" +
                              "global java.util.List list\n" +
                              "rule " + TestUtil.RULE1_NAME + " \n" +
@@ -1912,8 +1991,10 @@ public class AddRemoveRulesTest {
         }
     }
 
-    @Test
-    public void testSubNetworkWithNot3() {
+    @ParameterizedTest(name = "KieBase type={0}")
+	@MethodSource("parameters")
+    public void testSubNetworkWithNot3(KieBaseTestConfiguration kieBaseTestConfiguration) {
+    	createEmptyKnowledgeBase(kieBaseTestConfiguration);
         final String rule1 = "package " + TestUtil.RULES_PACKAGE_NAME + ";" +
                              "global java.util.List list\n" +
                              "rule " + TestUtil.RULE1_NAME + " \n" +
@@ -1947,8 +2028,10 @@ public class AddRemoveRulesTest {
         }
     }
 
-    @Test
-    public void testSubNetworkWithNot4() {
+    @ParameterizedTest(name = "KieBase type={0}")
+	@MethodSource("parameters")
+    public void testSubNetworkWithNot4(KieBaseTestConfiguration kieBaseTestConfiguration) {
+    	createEmptyKnowledgeBase(kieBaseTestConfiguration);
         final String rule1 = "package " + TestUtil.RULES_PACKAGE_NAME + ";" +
                              "global java.util.List list\n" +
                              "rule " + TestUtil.RULE1_NAME + " \n" +
@@ -1986,8 +2069,10 @@ public class AddRemoveRulesTest {
         }
     }
 
-    @Test
-    public void testInsertFireRemoveWith2Nots() {
+    @ParameterizedTest(name = "KieBase type={0}")
+	@MethodSource("parameters")
+    public void testInsertFireRemoveWith2Nots(KieBaseTestConfiguration kieBaseTestConfiguration) {
+    	createEmptyKnowledgeBase(kieBaseTestConfiguration);
         final String rule1 = " package " + TestUtil.RULES_PACKAGE_NAME + ";\n" +
                 " global java.util.List list\n" +
                 " rule " + TestUtil.RULE1_NAME + " \n" +
@@ -2023,8 +2108,10 @@ public class AddRemoveRulesTest {
         }
     }
 
-    @Test
-    public void testSubSubNetwork5() {
+    @ParameterizedTest(name = "KieBase type={0}")
+	@MethodSource("parameters")
+    public void testSubSubNetwork5(KieBaseTestConfiguration kieBaseTestConfiguration) {
+    	createEmptyKnowledgeBase(kieBaseTestConfiguration);
         final String rule1 = "package " + TestUtil.RULES_PACKAGE_NAME + ";" +
                              "global java.util.List list\n" +
                              "rule " + TestUtil.RULE1_NAME + " \n" +
@@ -2059,8 +2146,10 @@ public class AddRemoveRulesTest {
         }
     }
 
-    @Test
-    public void testInsertRemoveFireWith2Nots() {
+    @ParameterizedTest(name = "KieBase type={0}")
+	@MethodSource("parameters")
+    public void testInsertRemoveFireWith2Nots(KieBaseTestConfiguration kieBaseTestConfiguration) {
+    	createEmptyKnowledgeBase(kieBaseTestConfiguration);
         final String rule1 = " package " + TestUtil.RULES_PACKAGE_NAME + ";\n" +
                 " global java.util.List list\n" +
                 " rule " + TestUtil.RULE1_NAME + " \n" +
@@ -2095,9 +2184,10 @@ public class AddRemoveRulesTest {
         }
     }
 
-    @Test
-    public void testSharedRian() {
-
+    @ParameterizedTest(name = "KieBase type={0}")
+	@MethodSource("parameters")
+    public void testSharedRian(KieBaseTestConfiguration kieBaseTestConfiguration) {
+    	createEmptyKnowledgeBase(kieBaseTestConfiguration);
         final String rule1 = " package " + TestUtil.RULES_PACKAGE_NAME + ";\n" +
                 " global java.util.List list\n" +
                 " rule " + TestUtil.RULE1_NAME + " \n" +
@@ -2131,9 +2221,10 @@ public class AddRemoveRulesTest {
         }
     }
 
-    @Test
-    public void testSharedRianWithFire() {
-
+    @ParameterizedTest(name = "KieBase type={0}")
+	@MethodSource("parameters")
+    public void testSharedRianWithFire(KieBaseTestConfiguration kieBaseTestConfiguration) {
+    	createEmptyKnowledgeBase(kieBaseTestConfiguration);
         final String rule1 = " package " + TestUtil.RULES_PACKAGE_NAME + ";\n" +
                 " global java.util.List list\n" +
                 " rule " + TestUtil.RULE1_NAME + " \n" +
@@ -2168,9 +2259,10 @@ public class AddRemoveRulesTest {
         }
     }
 
-    @Test
-    public void testSharedRian2() {
-
+    @ParameterizedTest(name = "KieBase type={0}")
+	@MethodSource("parameters")
+    public void testSharedRian2(KieBaseTestConfiguration kieBaseTestConfiguration) {
+    	createEmptyKnowledgeBase(kieBaseTestConfiguration);
         final String rule1 = " package " + TestUtil.RULES_PACKAGE_NAME + ";\n" +
                 " global java.util.List list\n" +
                 " rule " + TestUtil.RULE1_NAME + " \n" +
@@ -2208,8 +2300,10 @@ public class AddRemoveRulesTest {
         }
     }
 
-    @Test
-    public void testRemoveRuleWithSharedRia() {
+    @ParameterizedTest(name = "KieBase type={0}")
+	@MethodSource("parameters")
+    public void testRemoveRuleWithSharedRia(KieBaseTestConfiguration kieBaseTestConfiguration) {
+    	createEmptyKnowledgeBase(kieBaseTestConfiguration);
         final String rule1Name = "rule1";
         final String rule2Name = "rule2";
         final String rule1 = "rule " + rule1Name + " \n" +
@@ -2243,9 +2337,11 @@ public class AddRemoveRulesTest {
         assertThat(tuple.getPeer()).isNull();
     }
 
-    @Test
-    public void testAddRemoveFacts() {
-        final String rule1 = " package " + TestUtil.RULES_PACKAGE_NAME + ";\n" +
+    @ParameterizedTest(name = "KieBase type={0}")
+	@MethodSource("parameters")
+    public void testAddRemoveFacts(KieBaseTestConfiguration kieBaseTestConfiguration) {
+    	createEmptyKnowledgeBase(kieBaseTestConfiguration);
+    	final String rule1 = " package " + TestUtil.RULES_PACKAGE_NAME + ";\n" +
                 " global java.util.List list\n" +
                 " rule " + TestUtil.RULE1_NAME + " \n" +
                 " when \n" +
@@ -2282,9 +2378,10 @@ public class AddRemoveRulesTest {
         }
     }
 
-    @Test
-    public void testReaddRulesSharedRianDoubleNots() {
-
+    @ParameterizedTest(name = "KieBase type={0}")
+	@MethodSource("parameters")
+    public void testReaddRulesSharedRianDoubleNots(KieBaseTestConfiguration kieBaseTestConfiguration) {
+    	createEmptyKnowledgeBase(kieBaseTestConfiguration);
         final String rule1 = " package " + TestUtil.RULES_PACKAGE_NAME + ";\n" +
                              " global java.util.List list\n" +
                              " rule " + TestUtil.RULE1_NAME + " \n" +
@@ -2322,9 +2419,10 @@ public class AddRemoveRulesTest {
         }
     }
 
-    @Test
-    public void testOr() {
-
+    @ParameterizedTest(name = "KieBase type={0}")
+	@MethodSource("parameters")
+    public void testOr(KieBaseTestConfiguration kieBaseTestConfiguration) {
+    	createEmptyKnowledgeBase(kieBaseTestConfiguration);
         final String rule1 = " package " + TestUtil.RULES_PACKAGE_NAME + ";\n" +
                              " global java.util.List list\n" +
                              " rule " + TestUtil.RULE1_NAME + " \n" +
@@ -2363,9 +2461,10 @@ public class AddRemoveRulesTest {
         }
     }
 
-    @Test
-    public void testOr2() {
-
+    @ParameterizedTest(name = "KieBase type={0}")
+	@MethodSource("parameters")
+    public void testOr2(KieBaseTestConfiguration kieBaseTestConfiguration) {
+    	createEmptyKnowledgeBase(kieBaseTestConfiguration);
         final String rule1 = " package " + TestUtil.RULES_PACKAGE_NAME + ";\n" +
                              " global java.util.List list\n" +
                              " rule " + TestUtil.RULE1_NAME + " \n" +
@@ -2411,9 +2510,10 @@ public class AddRemoveRulesTest {
         }
     }
 
-    @Test
-    public void testEvals() {
-
+    @ParameterizedTest(name = "KieBase type={0}")
+	@MethodSource("parameters")
+    public void testEvals(KieBaseTestConfiguration kieBaseTestConfiguration) {
+    	createEmptyKnowledgeBase(kieBaseTestConfiguration);
         final String rule1 = " package " + TestUtil.RULES_PACKAGE_NAME + ";\n" +
                              " global java.util.List list\n" +
                              " rule " + TestUtil.RULE1_NAME + " \n" +
@@ -2451,9 +2551,10 @@ public class AddRemoveRulesTest {
         }
     }
 
-    @Test
-    public void testPathMemoryInitialization() {
-
+    @ParameterizedTest(name = "KieBase type={0}")
+	@MethodSource("parameters")
+    public void testPathMemoryInitialization(KieBaseTestConfiguration kieBaseTestConfiguration) {
+    	createEmptyKnowledgeBase(kieBaseTestConfiguration);
         final String rule1 = "package com.rules;global java.util.List list\n" +
                 "rule R1 \n" +
                 " when \n" +
@@ -2499,9 +2600,10 @@ public class AddRemoveRulesTest {
         assertThat(globalList).isEmpty();
     }
 
-    @Test
-    public void testBuildKieBaseIncrementally() {
-
+    @ParameterizedTest(name = "KieBase type={0}")
+	@MethodSource("parameters")
+    public void testBuildKieBaseIncrementally(KieBaseTestConfiguration kieBaseTestConfiguration) {
+    	createEmptyKnowledgeBase(kieBaseTestConfiguration);
         final String rule1 = "package com.rules;global java.util.List list\n" +
                 "rule R1 \n" +
                 " when \n" +
@@ -2538,9 +2640,10 @@ public class AddRemoveRulesTest {
         assertThat(globalList).contains("R1", "R2");
     }
 
-    @Test
-    public void testBuildKieBaseIncrementally2() {
-
+    @ParameterizedTest(name = "KieBase type={0}")
+	@MethodSource("parameters")
+    public void testBuildKieBaseIncrementally2(KieBaseTestConfiguration kieBaseTestConfiguration) {
+    	createEmptyKnowledgeBase(kieBaseTestConfiguration);
         final String rule1 = "package com.rules;global java.util.List list\n" +
                 "rule R1 \n" +
                 " when \n" +
@@ -2582,9 +2685,10 @@ public class AddRemoveRulesTest {
         assertThat(globalList).contains("R1", "R2");
     }
 
-    @Test
-    public void testBuildKieBaseIncrementally3() {
-
+    @ParameterizedTest(name = "KieBase type={0}")
+	@MethodSource("parameters")
+    public void testBuildKieBaseIncrementally3(KieBaseTestConfiguration kieBaseTestConfiguration) {
+    	createEmptyKnowledgeBase(kieBaseTestConfiguration);
         final String rule1 = "package com.rules;global java.util.List list\n" +
                 "rule R1 \n" +
                 " when \n" +

--- a/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/compiler/integrationtests/incrementalcompilation/AddRuleTest.java
+++ b/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/compiler/integrationtests/incrementalcompilation/AddRuleTest.java
@@ -22,15 +22,15 @@ import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Date;
 import java.util.List;
+import java.util.stream.Stream;
 
 import org.drools.kiesession.rulebase.InternalKnowledgeBase;
 import org.drools.testcoverage.common.model.Person;
 import org.drools.testcoverage.common.util.KieBaseTestConfiguration;
 import org.drools.testcoverage.common.util.KieUtil;
-import org.drools.testcoverage.common.util.TestParametersUtil;
-import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.junit.runners.Parameterized;
+import org.drools.testcoverage.common.util.TestParametersUtil2;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
 import org.kie.api.KieServices;
 import org.kie.api.builder.ReleaseId;
 import org.kie.api.definition.KiePackage;
@@ -39,22 +39,15 @@ import org.kie.api.runtime.KieSession;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-@RunWith(Parameterized.class)
 public class AddRuleTest {
 
-    private final KieBaseTestConfiguration kieBaseTestConfiguration;
-
-    public AddRuleTest(final KieBaseTestConfiguration kieBaseTestConfiguration) {
-        this.kieBaseTestConfiguration = kieBaseTestConfiguration;
+    public static Stream<KieBaseTestConfiguration> parameters() {
+        return TestParametersUtil2.getKieBaseCloudConfigurations(true).stream();
     }
 
-    @Parameterized.Parameters(name = "KieBase type={0}")
-    public static Collection<Object[]> getParameters() {
-        return TestParametersUtil.getKieBaseCloudConfigurations(true);
-    }
-
-    @Test
-    public void testMemoriesCCEWhenAddRemoveAddRule() {
+    @ParameterizedTest(name = "KieBase type={0}")
+	@MethodSource("parameters")
+    public void testMemoriesCCEWhenAddRemoveAddRule(KieBaseTestConfiguration kieBaseTestConfiguration) {
         // JBRULES-3656
         final String rule1 = "import " + AddRuleTest.class.getCanonicalName() + ".*\n" +
                 "import java.util.Date\n" +
@@ -89,8 +82,9 @@ public class AddRuleTest {
         kbase.addPackages(TestUtil.createKnowledgeBuilder(null, rule2).getKnowledgePackages());
     }
 
-    @Test
-    public void testAddRuleWithFrom() {
+    @ParameterizedTest(name = "KieBase type={0}")
+	@MethodSource("parameters")
+    public void testAddRuleWithFrom(KieBaseTestConfiguration kieBaseTestConfiguration) {
         // JBRULES-3499
         final String str1 = "global java.util.List names;\n" +
                 "global java.util.List list;\n";
@@ -134,8 +128,9 @@ public class AddRuleTest {
         ksession.dispose();
     }
 
-    @Test
-    public void testDynamicallyAddInitialFactRule() {
+    @ParameterizedTest(name = "KieBase type={0}")
+	@MethodSource("parameters")
+    public void testDynamicallyAddInitialFactRule(KieBaseTestConfiguration kieBaseTestConfiguration) {
         String rule = "package org.drools.compiler.test\n" +
                 "global java.util.List list\n" +
                 "rule xxx when\n" +

--- a/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/compiler/integrationtests/incrementalcompilation/ClassLoaderLeakTest.java
+++ b/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/compiler/integrationtests/incrementalcompilation/ClassLoaderLeakTest.java
@@ -22,7 +22,7 @@ import org.drools.compiler.kie.builder.impl.KieContainerImpl;
 import org.drools.compiler.kie.builder.impl.KieProject;
 import org.drools.model.codegen.ExecutableModelProject;
 import org.drools.wiring.api.classloader.ProjectClassLoader;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.kie.api.KieServices;
 import org.kie.api.builder.KieBuilder;
 import org.kie.api.builder.KieFileSystem;

--- a/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/compiler/integrationtests/incrementalcompilation/IncrementalCompilationCepTest.java
+++ b/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/compiler/integrationtests/incrementalcompilation/IncrementalCompilationCepTest.java
@@ -23,13 +23,13 @@ import java.io.Serializable;
 import java.time.Duration;
 import java.time.temporal.ChronoUnit;
 import java.util.ArrayList;
-import java.util.Collection;
 import java.util.Date;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
+import java.util.stream.Stream;
 
 import org.drools.base.base.ClassObjectType;
 import org.drools.base.base.ObjectType;
@@ -45,10 +45,9 @@ import org.drools.testcoverage.common.model.Person;
 import org.drools.testcoverage.common.util.KieBaseTestConfiguration;
 import org.drools.testcoverage.common.util.KieSessionTestConfiguration;
 import org.drools.testcoverage.common.util.KieUtil;
-import org.drools.testcoverage.common.util.TestParametersUtil;
-import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.junit.runners.Parameterized;
+import org.drools.testcoverage.common.util.TestParametersUtil2;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
 import org.kie.api.KieServices;
 import org.kie.api.builder.ReleaseId;
 import org.kie.api.builder.Results;
@@ -70,22 +69,15 @@ import org.kie.internal.builder.conf.PropertySpecificOption;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-@RunWith(Parameterized.class)
 public class IncrementalCompilationCepTest {
 
-    private final KieBaseTestConfiguration kieBaseTestConfiguration;
-
-    public IncrementalCompilationCepTest(final KieBaseTestConfiguration kieBaseTestConfiguration) {
-        this.kieBaseTestConfiguration = kieBaseTestConfiguration;
+    public static Stream<KieBaseTestConfiguration> parameters() {
+        return TestParametersUtil2.getKieBaseStreamConfigurations(true).stream();
     }
 
-    @Parameterized.Parameters(name = "KieBase type={0}")
-    public static Collection<Object[]> getParameters() {
-        return TestParametersUtil.getKieBaseStreamConfigurations(true);
-    }
-
-    @Test
-    public void testRemoveRuleAndThenFactInStreamMode() {
+    @ParameterizedTest(name = "KieBase type={0}")
+	@MethodSource("parameters")
+    public void testRemoveRuleAndThenFactInStreamMode(KieBaseTestConfiguration kieBaseTestConfiguration) {
         // DROOLS-731
         final String header = "package org.some.test\n" +
                 "import " + MyFact.class.getCanonicalName() + "\n";
@@ -125,8 +117,9 @@ public class IncrementalCompilationCepTest {
         ksession.delete(fh);
     }
 
-    @Test
-    public void testAlphaNodeSharingIsOK() {
+    @ParameterizedTest(name = "KieBase type={0}")
+	@MethodSource("parameters")
+    public void testAlphaNodeSharingIsOK(KieBaseTestConfiguration kieBaseTestConfiguration) {
         // inspired by drools-usage Fmt9wZUFi8g
         // check timer -scheduled activations are preserved if rule untouched by incremental compilation even with alpha node sharing.
 
@@ -215,8 +208,9 @@ public class IncrementalCompilationCepTest {
         assertThat(list2.size()).as("1. RS is preserved").isEqualTo(1);
     }
 
-    @Test
-    public void testRemoveRuleWithNonInitializedPath() {
+    @ParameterizedTest(name = "KieBase type={0}")
+	@MethodSource("parameters")
+    public void testRemoveRuleWithNonInitializedPath(KieBaseTestConfiguration kieBaseTestConfiguration) {
         // DROOLS-1177
         final String drl1 =
                 "import " + MyEvent.class.getCanonicalName() + "\n" +
@@ -273,8 +267,9 @@ public class IncrementalCompilationCepTest {
         }
     }
 
-    @Test
-    public void testUpdateWithDeclarationPresent() {
+    @ParameterizedTest(name = "KieBase type={0}")
+	@MethodSource("parameters")
+    public void testUpdateWithDeclarationPresent(KieBaseTestConfiguration kieBaseTestConfiguration) {
         // DROOLS-560
         final String header = "package org.drools.compiler\n"
                 + "import " + FooEvent.class.getCanonicalName() + ";\n"
@@ -326,8 +321,9 @@ public class IncrementalCompilationCepTest {
         assertThat(ksession.fireAllRules()).isEqualTo(2);
     }
 
-    @Test
-    public void testChangeWindowTime() {
+    @ParameterizedTest(name = "KieBase type={0}")
+	@MethodSource("parameters")
+    public void testChangeWindowTime(KieBaseTestConfiguration kieBaseTestConfiguration) {
         // DROOLS-853
         final String drl1 =
                 "import " + MyEvent.class.getCanonicalName() + "\n" +
@@ -402,8 +398,9 @@ public class IncrementalCompilationCepTest {
         assertThat(result.get()).isEqualTo(0);
     }
 
-    @Test
-    public void testIncrementalCompilationWithSlidingWindow() {
+    @ParameterizedTest(name = "KieBase type={0}")
+	@MethodSource("parameters")
+    public void testIncrementalCompilationWithSlidingWindow(KieBaseTestConfiguration kieBaseTestConfiguration) {
         // DROOLS-881
         final String drl1 =
                 "import " + MyEvent.class.getCanonicalName() + "\n" +
@@ -466,8 +463,9 @@ public class IncrementalCompilationCepTest {
         ksession.fireAllRules();
     }
 
-    @Test
-    public void testDrlRenamingWithEvents() {
+    @ParameterizedTest(name = "KieBase type={0}")
+	@MethodSource("parameters")
+    public void testDrlRenamingWithEvents(KieBaseTestConfiguration kieBaseTestConfiguration) {
         // DROOLS-965
         final String drl1 =
                 "import " + SimpleEvent.class.getCanonicalName() + ";\n" +
@@ -567,8 +565,9 @@ public class IncrementalCompilationCepTest {
         }
     }
 
-    @Test
-    public void testIncrementalCompilationWithTimerNode() {
+    @ParameterizedTest(name = "KieBase type={0}")
+	@MethodSource("parameters")
+    public void testIncrementalCompilationWithTimerNode(KieBaseTestConfiguration kieBaseTestConfiguration) {
         // DROOLS-1195
         final String drl1 = "package org.drools.test\n" +
                 "import " + DummyEvent.class.getCanonicalName() + "\n" +
@@ -714,8 +713,9 @@ public class IncrementalCompilationCepTest {
         }
     }
 
-    @Test
-    public void testEventDeclarationInSeparatedDRL() {
+    @ParameterizedTest(name = "KieBase type={0}")
+	@MethodSource("parameters")
+    public void testEventDeclarationInSeparatedDRL(KieBaseTestConfiguration kieBaseTestConfiguration) {
         // DROOLS-1241
         final String drl1 =
                 "import " + SimpleEvent.class.getCanonicalName() + ";\n" +
@@ -777,8 +777,9 @@ public class IncrementalCompilationCepTest {
         assertThat(list.get(0)).isEqualTo("YOUR_CODE");
     }
 
-    @Test
-    public void testKeepBuilderConfAfterIncrementalUpdate() {
+    @ParameterizedTest(name = "KieBase type={0}")
+	@MethodSource("parameters")
+    public void testKeepBuilderConfAfterIncrementalUpdate(KieBaseTestConfiguration kieBaseTestConfiguration) {
         // DROOLS-1282
         final String drl1 = "import " + DummyEvent.class.getCanonicalName() + "\n" +
                 "rule R1 when\n" +
@@ -810,8 +811,9 @@ public class IncrementalCompilationCepTest {
         assertThat(results.getMessages().size()).isEqualTo(0);
     }
 
-    @Test
-    public void testIncrementalCompilationWithNewEvent() {
+    @ParameterizedTest(name = "KieBase type={0}")
+	@MethodSource("parameters")
+    public void testIncrementalCompilationWithNewEvent(KieBaseTestConfiguration kieBaseTestConfiguration) {
         // DROOLS-1395
         final String drl1 = "package org.drools.test\n" +
                 "import " + DummyEvent.class.getCanonicalName() + "\n" +
@@ -894,8 +896,9 @@ public class IncrementalCompilationCepTest {
         }
     }
 
-    @Test
-    public void testAddRuleWithSlidingWindows() throws Exception {
+    @ParameterizedTest(name = "KieBase type={0}")
+	@MethodSource("parameters")
+    public void testAddRuleWithSlidingWindows(KieBaseTestConfiguration kieBaseTestConfiguration) throws Exception {
         // DROOLS-2292
         final String drl1 = "package org.drools.compiler\n" +
                 "import " + List.class.getCanonicalName() + "\n" +
@@ -952,8 +955,9 @@ public class IncrementalCompilationCepTest {
         }
     }
 
-    @Test
-    public void testObjectTypeNodeExpirationOffset() {
+    @ParameterizedTest(name = "KieBase type={0}")
+	@MethodSource("parameters")
+    public void testObjectTypeNodeExpirationOffset(KieBaseTestConfiguration kieBaseTestConfiguration) {
         // DROOLS-6296
         final String drl1 = "package org.drools.test;\n" +
                             "import " + ParentEvent.class.getCanonicalName() + "\n" +
@@ -1110,17 +1114,19 @@ public class IncrementalCompilationCepTest {
         kieSession2.dispose();
     }
 
-    @Test
-    public void testIncrementalCompilationWithExpiringEvent() {
-        incrementalCompilationWithExpiringEventFromEntryPoint(false);
+    @ParameterizedTest(name = "KieBase type={0}")
+	@MethodSource("parameters")
+    public void testIncrementalCompilationWithExpiringEvent(KieBaseTestConfiguration kieBaseTestConfiguration) {
+        incrementalCompilationWithExpiringEventFromEntryPoint(kieBaseTestConfiguration, false);
     }
 
-    @Test
-    public void testIncrementalCompilationWithExpiringEventFromEntryPoint() {
-        incrementalCompilationWithExpiringEventFromEntryPoint(true);
+    @ParameterizedTest(name = "KieBase type={0}")
+	@MethodSource("parameters")
+    public void testIncrementalCompilationWithExpiringEventFromEntryPoint(KieBaseTestConfiguration kieBaseTestConfiguration) {
+        incrementalCompilationWithExpiringEventFromEntryPoint(kieBaseTestConfiguration, true);
     }
 
-    private void incrementalCompilationWithExpiringEventFromEntryPoint(boolean useEntryPoint) {
+    private void incrementalCompilationWithExpiringEventFromEntryPoint(KieBaseTestConfiguration kieBaseTestConfiguration, boolean useEntryPoint) {
         // DROOLS-7582
         final String drl1 =
                 "import " + ExpiringEvent.class.getCanonicalName() + "\n" +

--- a/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/compiler/integrationtests/incrementalcompilation/IncrementalCompilationNonExecModelTest.java
+++ b/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/compiler/integrationtests/incrementalcompilation/IncrementalCompilationNonExecModelTest.java
@@ -18,15 +18,14 @@
  */
 package org.drools.compiler.integrationtests.incrementalcompilation;
 
-import java.util.Collection;
+import java.util.stream.Stream;
 
 import org.drools.testcoverage.common.model.Message;
 import org.drools.testcoverage.common.util.KieBaseTestConfiguration;
 import org.drools.testcoverage.common.util.KieUtil;
-import org.drools.testcoverage.common.util.TestParametersUtil;
-import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.junit.runners.Parameterized;
+import org.drools.testcoverage.common.util.TestParametersUtil2;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
 import org.kie.api.KieServices;
 import org.kie.api.builder.KieBuilder;
 import org.kie.api.builder.KieFileSystem;
@@ -42,18 +41,10 @@ import static org.assertj.core.api.Assertions.assertThat;
 /**
  * Incremental compilation tests which don't work with exec-model. Each test should be fixed by JIRA one-by-one
  */
-@RunWith(Parameterized.class)
 public class IncrementalCompilationNonExecModelTest {
 
-    private final KieBaseTestConfiguration kieBaseTestConfiguration;
-
-    public IncrementalCompilationNonExecModelTest(final KieBaseTestConfiguration kieBaseTestConfiguration) {
-        this.kieBaseTestConfiguration = kieBaseTestConfiguration;
-    }
-
-    @Parameterized.Parameters(name = "KieBase type={0}")
-    public static Collection<Object[]> getParameters() {
-        return TestParametersUtil.getKieBaseCloudConfigurations(false);
+    public static Stream<KieBaseTestConfiguration> parameters() {
+        return TestParametersUtil2.getKieBaseCloudConfigurations(false).stream();
     }
 
     private static final String DRL2_COMMON_SRC = "package myPkg\n" +
@@ -77,8 +68,9 @@ public class IncrementalCompilationNonExecModelTest {
                                                   "then\n" +
                                                   "end\n";
 
-    @Test
-    public void testCreateFileSetWithDeclaredModel() throws InstantiationException, IllegalAccessException {
+    @ParameterizedTest(name = "KieBase type={0}")
+	@MethodSource("parameters")
+    public void testCreateFileSetWithDeclaredModel(KieBaseTestConfiguration kieBaseTestConfiguration) throws InstantiationException, IllegalAccessException {
 
         final String drl1 = "package myPkg\n" +
                             "declare StringWrapper\n" +

--- a/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/compiler/integrationtests/incrementalcompilation/IncrementalCompilationTest.java
+++ b/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/compiler/integrationtests/incrementalcompilation/IncrementalCompilationTest.java
@@ -37,11 +37,11 @@ import org.drools.testcoverage.common.util.KieBaseTestConfiguration;
 import org.drools.testcoverage.common.util.KieSessionTestConfiguration;
 import org.drools.testcoverage.common.util.KieUtil;
 import org.drools.testcoverage.common.util.TestConstants;
-import org.drools.testcoverage.common.util.TestParametersUtil;
-import org.junit.Ignore;
-import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.junit.runners.Parameterized;
+import org.drools.testcoverage.common.util.TestParametersUtil2;
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.Timeout;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
 import org.kie.api.KieBase;
 import org.kie.api.KieServices;
 import org.kie.api.builder.KieBuilder;
@@ -91,28 +91,22 @@ import java.util.concurrent.ExecutorCompletionService;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.atomic.AtomicInteger;
+import java.util.stream.Stream;
 
 import static java.util.Arrays.asList;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.fail;
 import static org.drools.core.util.DroolsTestUtil.rulestoMap;
 
-@RunWith(Parameterized.class)
 public class IncrementalCompilationTest {
 
-    private final KieBaseTestConfiguration kieBaseTestConfiguration;
-
-    public IncrementalCompilationTest(final KieBaseTestConfiguration kieBaseTestConfiguration) {
-        this.kieBaseTestConfiguration = kieBaseTestConfiguration;
+    public static Stream<KieBaseTestConfiguration> parameters() {
+        return TestParametersUtil2.getKieBaseCloudConfigurations(true).stream();
     }
 
-    @Parameterized.Parameters(name = "KieBase type={0}")
-    public static Collection<Object[]> getParameters() {
-        return TestParametersUtil.getKieBaseCloudConfigurations(true);
-    }
-
-    @Test
-    public void testLoadOrderAfterRuleRemoval() {
+    @ParameterizedTest(name = "KieBase type={0}")
+	@MethodSource("parameters")
+    public void testLoadOrderAfterRuleRemoval(KieBaseTestConfiguration kieBaseTestConfiguration) {
         final String header = "package org.drools.compiler\n" +
                 "import " + Message.class.getCanonicalName() + ";\n";
 
@@ -141,20 +135,20 @@ public class IncrementalCompilationTest {
         KieUtil.getKieModuleFromDrls(releaseId1, kieBaseTestConfiguration, header);
         final KieContainer kc = ks.newKieContainer(releaseId1);
 
-        createAndDeployAndTest(kc, "2", header, drl1 + drl2 + drl3, "R1", "R2", "R3");
+        createAndDeployAndTest(kieBaseTestConfiguration, kc, "2", header, drl1 + drl2 + drl3, "R1", "R2", "R3");
 
-        createAndDeployAndTest(kc, "3", header, drl1 + drl3, "R1", "R3");
+        createAndDeployAndTest(kieBaseTestConfiguration, kc, "3", header, drl1 + drl3, "R1", "R3");
 
-        createAndDeployAndTest(kc, "4", header, drl2 + drl1 + drl4, "R2", "R1", "R4");
+        createAndDeployAndTest(kieBaseTestConfiguration, kc, "4", header, drl2 + drl1 + drl4, "R2", "R1", "R4");
 
-        createAndDeployAndTest(kc, "5", header, drl2 + drl1, "R2", "R1");
+        createAndDeployAndTest(kieBaseTestConfiguration, kc, "5", header, drl2 + drl1, "R2", "R1");
 
-        createAndDeployAndTest(kc, "6", header, "");
+        createAndDeployAndTest(kieBaseTestConfiguration, kc, "6", header, "");
 
-        createAndDeployAndTest(kc, "7", header, drl3, "R3");
+        createAndDeployAndTest(kieBaseTestConfiguration, kc, "7", header, drl3, "R3");
     }
 
-    private void createAndDeployAndTest(final KieContainer kc,
+    private void createAndDeployAndTest(KieBaseTestConfiguration kieBaseTestConfiguration, final KieContainer kc,
                                         final String version,
                                         final String header,
                                         final String drls,
@@ -178,8 +172,9 @@ public class IncrementalCompilationTest {
         }
     }
 
-    @Test
-    public void testKJarUpgrade() {
+    @ParameterizedTest(name = "KieBase type={0}")
+	@MethodSource("parameters")
+    public void testKJarUpgrade(KieBaseTestConfiguration kieBaseTestConfiguration) {
         final String drl1 = "package org.drools.compiler\n" +
                 "import " + Message.class.getCanonicalName() + ";\n" +
                 "rule R1 when\n" +
@@ -227,8 +222,9 @@ public class IncrementalCompilationTest {
         assertThat(ksession.fireAllRules()).isEqualTo(2);
     }
 
-    @Test
-    public void testKJarUpgradeSameSession() {
+    @ParameterizedTest(name = "KieBase type={0}")
+	@MethodSource("parameters")
+    public void testKJarUpgradeSameSession(KieBaseTestConfiguration kieBaseTestConfiguration) {
         final String drl1 = "package org.drools.compiler\n" +
                 "import " + Message.class.getCanonicalName() + ";\n" +
                 "rule R1 when\n" +
@@ -273,8 +269,9 @@ public class IncrementalCompilationTest {
         assertThat(ksession.fireAllRules()).isEqualTo(3);
     }
 
-    @Test
-    public void testDeletedFile() {
+    @ParameterizedTest(name = "KieBase type={0}")
+	@MethodSource("parameters")
+    public void testDeletedFile(KieBaseTestConfiguration kieBaseTestConfiguration) {
         final String drl1 = "package org.drools.compiler\n" +
                 "import " + Message.class.getCanonicalName() + ";\n" +
                 "rule R1 when\n" +
@@ -320,8 +317,9 @@ public class IncrementalCompilationTest {
         assertThat(ksession2.fireAllRules()).isEqualTo(2);
     }
 
-    @Test
-    public void testIncrementalCompilationWithAddedError() {
+    @ParameterizedTest(name = "KieBase type={0}")
+	@MethodSource("parameters")
+    public void testIncrementalCompilationWithAddedError(KieBaseTestConfiguration kieBaseTestConfiguration) {
         final String drl1 = "package org.drools.compiler\n" +
                 "import " + Message.class.getCanonicalName() + ";\n" +
                 "rule R1 when\n" +
@@ -368,8 +366,9 @@ public class IncrementalCompilationTest {
         assertThat(ksession.fireAllRules()).isEqualTo(1);
     }
 
-    @Test
-    public void testIncrementalCompilationWithRemovedError() {
+    @ParameterizedTest(name = "KieBase type={0}")
+	@MethodSource("parameters")
+    public void testIncrementalCompilationWithRemovedError(KieBaseTestConfiguration kieBaseTestConfiguration) {
         final String drl1 = "package org.drools.compiler\n" +
                 "import " + Message.class.getCanonicalName() + ";\n" +
                 "rule R1 when\n" +
@@ -412,8 +411,9 @@ public class IncrementalCompilationTest {
         assertThat(ksession.fireAllRules()).isEqualTo(2);
     }
 
-    @Test
-    public void testIncrementalCompilationAddErrorThenRemoveError() {
+    @ParameterizedTest(name = "KieBase type={0}")
+	@MethodSource("parameters")
+    public void testIncrementalCompilationAddErrorThenRemoveError(KieBaseTestConfiguration kieBaseTestConfiguration) {
         //Valid
         final String drl1 = "package org.drools.compiler\n" +
                 "import " + Message.class.getCanonicalName() + ";\n" +
@@ -461,8 +461,9 @@ public class IncrementalCompilationTest {
         assertThat(removeResults.getRemovedMessages().size()).isEqualTo(1);
     }
 
-    @Test
-    public void testIncrementalCompilationAddErrorThenRemoveIt() {
+    @ParameterizedTest(name = "KieBase type={0}")
+	@MethodSource("parameters")
+    public void testIncrementalCompilationAddErrorThenRemoveIt(KieBaseTestConfiguration kieBaseTestConfiguration) {
         //Fact Type is unknown ("NonExistentClass" not "Message")
         final String drl1 = "package org.drools.compiler\n" +
                 "import " + Message.class.getCanonicalName() + ";\n" +
@@ -511,8 +512,9 @@ public class IncrementalCompilationTest {
         assertThat(removeResults.getRemovedMessages().size()).isEqualTo(1);
     }
 
-    @Test
-    public void testIncrementalCompilationWithDuplicatedRule() {
+    @ParameterizedTest(name = "KieBase type={0}")
+	@MethodSource("parameters")
+    public void testIncrementalCompilationWithDuplicatedRule(KieBaseTestConfiguration kieBaseTestConfiguration) {
         final String drl1 = "package org.drools.compiler\n" +
                 "import " + Message.class.getCanonicalName() + ";\n" +
                 "rule R1 when\n" +
@@ -548,8 +550,9 @@ public class IncrementalCompilationTest {
         assertThat(removeResults.getRemovedMessages().size()).isEqualTo(0);
     }
 
-    @Test
-    public void testIncrementalCompilationWithDuplicatedRuleInSameDRL() {
+    @ParameterizedTest(name = "KieBase type={0}")
+	@MethodSource("parameters")
+    public void testIncrementalCompilationWithDuplicatedRuleInSameDRL(KieBaseTestConfiguration kieBaseTestConfiguration) {
         final String drl1 = "package org.drools.compiler\n" +
                 "import " + Message.class.getCanonicalName() + ";\n" +
                 "rule R1 when\n" +
@@ -571,8 +574,9 @@ public class IncrementalCompilationTest {
         assertThat(kieBuilder.getResults().getMessages(org.kie.api.builder.Message.Level.ERROR).isEmpty()).isFalse();
     }
 
-    @Test
-    public void testIncrementalCompilationAddErrorBuildAllMessages() {
+    @ParameterizedTest(name = "KieBase type={0}")
+	@MethodSource("parameters")
+    public void testIncrementalCompilationAddErrorBuildAllMessages(KieBaseTestConfiguration kieBaseTestConfiguration) {
         //Valid
         final String drl1 = "package org.drools.compiler\n" +
                 "import " + Message.class.getCanonicalName() + ";\n" +
@@ -608,8 +612,9 @@ public class IncrementalCompilationTest {
         assertThat(ks.newKieBuilder(kfs).buildAll().getResults().getMessages().size()).isEqualTo(1);
     }
 
-    @Test
-    public void testIncrementalCompilationAddErrorThenEmptyWithoutError() {
+    @ParameterizedTest(name = "KieBase type={0}")
+	@MethodSource("parameters")
+    public void testIncrementalCompilationAddErrorThenEmptyWithoutError(KieBaseTestConfiguration kieBaseTestConfiguration) {
         // BZ-1009369
 
         //Invalid. Type "Smurf" is unknown
@@ -647,8 +652,9 @@ public class IncrementalCompilationTest {
         assertThat(addResults2.getRemovedMessages().size()).isEqualTo(0);
     }
 
-    @Test
-    public void testRuleRemoval() {
+    @ParameterizedTest(name = "KieBase type={0}")
+	@MethodSource("parameters")
+    public void testRuleRemoval(KieBaseTestConfiguration kieBaseTestConfiguration) {
         final String drl1 = "package org.drools.compiler\n" +
                 "import " + Message.class.getCanonicalName() + ";\n" +
                 "rule R1 when\n" +
@@ -709,30 +715,33 @@ public class IncrementalCompilationTest {
         assertThat(rules.get("R3")).isNotNull();
     }
 
-    @Test
-    public void testIncrementalCompilationWithSnapshots() {
+    @ParameterizedTest(name = "KieBase type={0}")
+	@MethodSource("parameters")
+    public void testIncrementalCompilationWithSnapshots(KieBaseTestConfiguration kieBaseTestConfiguration) {
         // DROOLS-358
         final ReleaseId releaseId = KieServices.Factory.get().newReleaseId("org.test", "test", "1.0.0-SNAPSHOT");
-        testIncrementalCompilation(releaseId, releaseId, false);
+        testIncrementalCompilation(kieBaseTestConfiguration, releaseId, releaseId, false);
     }
 
-    @Test
-    public void testIncrementalCompilationWithFixedVersions() {
+    @ParameterizedTest(name = "KieBase type={0}")
+	@MethodSource("parameters")
+    public void testIncrementalCompilationWithFixedVersions(KieBaseTestConfiguration kieBaseTestConfiguration) {
         // DROOLS-358
         final ReleaseId releaseId1 = KieServices.Factory.get().newReleaseId("org.test", "test", "1.0.1");
         final ReleaseId releaseId2 = KieServices.Factory.get().newReleaseId("org.test", "test", "1.0.2");
-        testIncrementalCompilation(releaseId1, releaseId2, false);
+        testIncrementalCompilation(kieBaseTestConfiguration, releaseId1, releaseId2, false);
     }
 
-    @Test
-    public void testIncrementalCompilationWithDeclaredType() {
+    @ParameterizedTest(name = "KieBase type={0}")
+	@MethodSource("parameters")
+    public void testIncrementalCompilationWithDeclaredType(KieBaseTestConfiguration kieBaseTestConfiguration) {
         // DROOLS-358
         final ReleaseId releaseId1 = KieServices.Factory.get().newReleaseId("org.test", "test", "1.0.1");
         final ReleaseId releaseId2 = KieServices.Factory.get().newReleaseId("org.test", "test", "1.0.2");
-        testIncrementalCompilation(releaseId1, releaseId2, true);
+        testIncrementalCompilation(kieBaseTestConfiguration, releaseId1, releaseId2, true);
     }
 
-    private void testIncrementalCompilation(final ReleaseId releaseId1,
+    private void testIncrementalCompilation(KieBaseTestConfiguration kieBaseTestConfiguration, final ReleaseId releaseId1,
                                             final ReleaseId releaseId2,
                                             final boolean useDeclaredType) {
         final String drl1 = "package org.drools.compiler\n" +
@@ -797,8 +806,9 @@ public class IncrementalCompilationTest {
         assertThat(list.containsAll(asList("bBar", "bFoo", "aBar"))).isTrue();
     }
 
-    @Test
-    public void testIncrementalCompilationWithRedeclares() {
+    @ParameterizedTest(name = "KieBase type={0}")
+	@MethodSource("parameters")
+    public void testIncrementalCompilationWithRedeclares(KieBaseTestConfiguration kieBaseTestConfiguration) {
         // DROOLS-363
         final String drl1 = "package org.drools.compiler\n" +
                 "global java.util.List list\n" +
@@ -847,8 +857,9 @@ public class IncrementalCompilationTest {
         assertThat(list.size()).isEqualTo(2);
     }
 
-    @Test
-    public void testIncrementalCompilationWithAmbiguousRedeclares() {
+    @ParameterizedTest(name = "KieBase type={0}")
+	@MethodSource("parameters")
+    public void testIncrementalCompilationWithAmbiguousRedeclares(KieBaseTestConfiguration kieBaseTestConfiguration) {
         final String drl1 = "package domestic; " +
 
                 "import foreign.*; " +
@@ -903,8 +914,9 @@ public class IncrementalCompilationTest {
         assertThat(updateResults.getMessages().size()).isEqualTo(0);
     }
 
-    @Test
-    public void testIncrementalCompilationWithModuleOverride() {
+    @ParameterizedTest(name = "KieBase type={0}")
+	@MethodSource("parameters")
+    public void testIncrementalCompilationWithModuleOverride(KieBaseTestConfiguration kieBaseTestConfiguration) {
         final String drl1 = "package org.test.compiler; " +
                 "global java.util.List list; " +
 
@@ -976,8 +988,9 @@ public class IncrementalCompilationTest {
         assertThat(list).isEqualTo(Arrays.asList("AX", "BX", "CX"));
     }
 
-    @Test
-    public void testIncrementalCompilationWithMissingKSession() {
+    @ParameterizedTest(name = "KieBase type={0}")
+	@MethodSource("parameters")
+    public void testIncrementalCompilationWithMissingKSession(KieBaseTestConfiguration kieBaseTestConfiguration) {
         //https://bugzilla.redhat.com/show_bug.cgi?id=1066059
         final String pom = "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n" +
                 "<project xsi:schemaLocation=\"http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd\" xmlns=\"http://maven.apache.org/POM/4.0.0\"\n" +
@@ -1025,8 +1038,9 @@ public class IncrementalCompilationTest {
         assertThat(results.getRemovedMessages().size()).isEqualTo(0);
     }
 
-    @Test
-    public void testIncrementalCompilationWithIncludes() {
+    @ParameterizedTest(name = "KieBase type={0}")
+	@MethodSource("parameters")
+    public void testIncrementalCompilationWithIncludes(KieBaseTestConfiguration kieBaseTestConfiguration) {
         // DROOLS-462
 
         final String drl1 = "global java.util.List list\n" +
@@ -1093,8 +1107,9 @@ public class IncrementalCompilationTest {
         assertThat(list.containsAll(asList("bBar", "bFoo"))).isTrue();
     }
 
-    @Test
-    public void testIncrementalCompilationWithInvalidDRL() {
+    @ParameterizedTest(name = "KieBase type={0}")
+	@MethodSource("parameters")
+    public void testIncrementalCompilationWithInvalidDRL(KieBaseTestConfiguration kieBaseTestConfiguration) {
         final String drl1 = "Smurf";
 
         final String drl2_1 = "package org.drools.compiler\n" +
@@ -1144,8 +1159,9 @@ public class IncrementalCompilationTest {
         assertThat(results4.getRemovedMessages().size()).isEqualTo(2);
     }
 
-    @Test
-    public void testKJarUpgradeSameSessionAddingGlobal() {
+    @ParameterizedTest(name = "KieBase type={0}")
+	@MethodSource("parameters")
+    public void testKJarUpgradeSameSessionAddingGlobal(KieBaseTestConfiguration kieBaseTestConfiguration) {
         // DROOLS-523
         final String drl1 = "package org.drools.compiler\n" +
                 "import " + Message.class.getCanonicalName() + ";\n" +
@@ -1196,8 +1212,9 @@ public class IncrementalCompilationTest {
         assertThat(ksession.fireAllRules()).isEqualTo(2);
     }
 
-    @Test
-    public void testKJarUpgradeWithDSL() {
+    @ParameterizedTest(name = "KieBase type={0}")
+	@MethodSource("parameters")
+    public void testKJarUpgradeWithDSL(KieBaseTestConfiguration kieBaseTestConfiguration) {
         // DROOLS-718
         final String dsl = "[when][]There is a Message=Message()\n" +
                 "[when][]-with message \"{factId}\"=message==\"{factId}\"\n" +
@@ -1254,9 +1271,10 @@ public class IncrementalCompilationTest {
         assertThat(ksession.fireAllRules()).isEqualTo(1);
     }
 
-    @Test
-    @Ignore("this test takes too long and cannot be emulated with a pseudo clock")
-    public void testIncrementalCompilationWithFireUntilHalt() {
+    @ParameterizedTest(name = "KieBase type={0}")
+	@MethodSource("parameters")
+    @Disabled("this test takes too long and cannot be emulated with a pseudo clock")
+    public void testIncrementalCompilationWithFireUntilHalt(KieBaseTestConfiguration kieBaseTestConfiguration) {
         // DROOLS-782
         final String drl1 = getCronRule(3) + getCronRule(6);
         final String drl2 = getCronRule(8) + getCronRule(10) + getCronRule(5);
@@ -1294,8 +1312,9 @@ public class IncrementalCompilationTest {
                 "end\n";
     }
 
-    @Test
-    public void testKJarUpgradeSameSessionRemovingGlobal() {
+    @ParameterizedTest(name = "KieBase type={0}")
+	@MethodSource("parameters")
+    public void testKJarUpgradeSameSessionRemovingGlobal(KieBaseTestConfiguration kieBaseTestConfiguration) {
         // DROOLS-752
         final String drl1 = "package org.drools.compiler\n" +
                 "import " + Message.class.getCanonicalName() + ";\n" +
@@ -1339,8 +1358,9 @@ public class IncrementalCompilationTest {
         assertThat(ksession.getGlobal("baz")).isEqualTo("baz");
     }
 
-    @Test
-    public void testUpdateVersionWithKSessionLogger() {
+    @ParameterizedTest(name = "KieBase type={0}")
+	@MethodSource("parameters")
+    public void testUpdateVersionWithKSessionLogger(KieBaseTestConfiguration kieBaseTestConfiguration) {
         // DROOLS-790
         final String drl1 =
                 "import java.util.List\n" +
@@ -1387,8 +1407,9 @@ public class IncrementalCompilationTest {
         kc.updateToVersion(releaseId2);
     }
 
-    @Test
-    public void testChangeParentRule() {
+    @ParameterizedTest(name = "KieBase type={0}")
+	@MethodSource("parameters")
+    public void testChangeParentRule(KieBaseTestConfiguration kieBaseTestConfiguration) {
         final String drl1 =
                 "global java.util.List list;" +
                         "rule B extends A when\n" +
@@ -1463,8 +1484,9 @@ public class IncrementalCompilationTest {
         assertThat(list.size()).isEqualTo(0);
     }
 
-    @Test
-    public void testRuleRemovalAfterUpdate() {
+    @ParameterizedTest(name = "KieBase type={0}")
+	@MethodSource("parameters")
+    public void testRuleRemovalAfterUpdate(KieBaseTestConfiguration kieBaseTestConfiguration) {
         // DROOLS-801
         final String drl = "rule Rule1\n" +
                 "  when\n" +
@@ -1507,8 +1529,9 @@ public class IncrementalCompilationTest {
         kc.updateToVersion(releaseId3);
     }
 
-    @Test
-    public void testIncrementalTypeDeclarationOnInterface() {
+    @ParameterizedTest(name = "KieBase type={0}")
+	@MethodSource("parameters")
+    public void testIncrementalTypeDeclarationOnInterface(KieBaseTestConfiguration kieBaseTestConfiguration) {
         // DROOLS-861
         final String drl1 =
                 "import " + KieService.class.getCanonicalName() + "\n" +
@@ -1538,8 +1561,9 @@ public class IncrementalCompilationTest {
         kc.updateToVersion(releaseId2);
     }
 
-    @Test
-    public void testNonHashablePropertyWithIncrementalCompilation() {
+    @ParameterizedTest(name = "KieBase type={0}")
+	@MethodSource("parameters")
+    public void testNonHashablePropertyWithIncrementalCompilation(KieBaseTestConfiguration kieBaseTestConfiguration) {
         // DROOLS-870
         final String drl1 =
                 "rule \"HelloGreetingService\"\n" +
@@ -1582,8 +1606,9 @@ public class IncrementalCompilationTest {
         kc.updateToVersion(releaseId2);
     }
 
-    @Test
-    public void testConcurrentKJarDeployment() throws Exception {
+    @ParameterizedTest(name = "KieBase type={0}")
+	@MethodSource("parameters")
+    public void testConcurrentKJarDeployment(KieBaseTestConfiguration kieBaseTestConfiguration) throws Exception {
         // DROOLS-923
         final int parallelThreads = 10;
         final ExecutorService executor = Executors.newFixedThreadPool(parallelThreads);
@@ -1641,8 +1666,9 @@ public class IncrementalCompilationTest {
         }
     }
 
-    @Test
-    public void testSegmentSplitOnIncrementalCompilation() {
+    @ParameterizedTest(name = "KieBase type={0}")
+	@MethodSource("parameters")
+    public void testSegmentSplitOnIncrementalCompilation(KieBaseTestConfiguration kieBaseTestConfiguration) {
         // DROOLS-930
         final String drl =
                 "import " + Person.class.getCanonicalName() + "\n" +
@@ -1692,8 +1718,9 @@ public class IncrementalCompilationTest {
         assertThat(list.containsAll(asList("R1", "R2"))).isTrue();
     }
 
-    @Test
-    public void testSegmentMergeOnRuleRemovalWithNotExistingSegment() {
+    @ParameterizedTest(name = "KieBase type={0}")
+	@MethodSource("parameters")
+    public void testSegmentMergeOnRuleRemovalWithNotExistingSegment(KieBaseTestConfiguration kieBaseTestConfiguration) {
         // DROOLS-950
         final String drl1 =
                 "rule R1 when\n" +
@@ -1727,8 +1754,9 @@ public class IncrementalCompilationTest {
         kc.updateToVersion(releaseId2);
     }
 
-    @Test
-    public void testRemoveRuleWithRia() {
+    @ParameterizedTest(name = "KieBase type={0}")
+	@MethodSource("parameters")
+    public void testRemoveRuleWithRia(KieBaseTestConfiguration kieBaseTestConfiguration) {
         // DROOLS-954
         final String drl1 =
                 "import " + List.class.getCanonicalName() + "\n" +
@@ -1758,8 +1786,9 @@ public class IncrementalCompilationTest {
         }
     }
 
-    @Test
-    public void testRetractLogicalAssertedObjectOnRuleRemoval() {
+    @ParameterizedTest(name = "KieBase type={0}")
+	@MethodSource("parameters")
+    public void testRetractLogicalAssertedObjectOnRuleRemoval(KieBaseTestConfiguration kieBaseTestConfiguration) {
         // DROOLS-951
         final String drl1 =
                 "rule R1 when\n" +
@@ -1811,8 +1840,9 @@ public class IncrementalCompilationTest {
         assertThat(ksession.getObjects(new ClassObjectFilter(String.class)).size()).isEqualTo(0);
     }
 
-    @Test
-    public void testRetractLogicalAssertedObjectOnRuleRemovalWithSameObject() {
+    @ParameterizedTest(name = "KieBase type={0}")
+	@MethodSource("parameters")
+    public void testRetractLogicalAssertedObjectOnRuleRemovalWithSameObject(KieBaseTestConfiguration kieBaseTestConfiguration) {
         // DROOLS-951
         final String drl1 =
                 "rule R1 when\n" +
@@ -1864,8 +1894,9 @@ public class IncrementalCompilationTest {
         assertThat(ksession.getObjects(new ClassObjectFilter(String.class)).size()).isEqualTo(0);
     }
 
-    @Test
-    public void testUpdateWithNewDrlAndChangeInOldOne() {
+    @ParameterizedTest(name = "KieBase type={0}")
+	@MethodSource("parameters")
+    public void testUpdateWithNewDrlAndChangeInOldOne(KieBaseTestConfiguration kieBaseTestConfiguration) {
         // BZ-1275378
         String drl1 = "package org.kie.test\n" +
                 "global java.util.List list\n" +
@@ -1919,8 +1950,9 @@ public class IncrementalCompilationTest {
         assertThat(list.contains("rule2")).isTrue();
     }
 
-    @Test
-    public void testIncrementalCompilationWithEagerRules() {
+    @ParameterizedTest(name = "KieBase type={0}")
+	@MethodSource("parameters")
+    public void testIncrementalCompilationWithEagerRules(KieBaseTestConfiguration kieBaseTestConfiguration) {
         // DROOLS-978
         final String drl1 =
                 "rule R1 when\n" +
@@ -1960,8 +1992,9 @@ public class IncrementalCompilationTest {
         ksession.fireAllRules();
     }
 
-    @Test
-    public void testMultipleIncrementalCompilationWithExistentialRules() {
+    @ParameterizedTest(name = "KieBase type={0}")
+	@MethodSource("parameters")
+    public void testMultipleIncrementalCompilationWithExistentialRules(KieBaseTestConfiguration kieBaseTestConfiguration) {
         // DROOLS-988
         final List<String> drls = new ArrayList<>();
         drls.add(getExistenzialRule("R0", "> 10"));
@@ -1999,8 +2032,9 @@ public class IncrementalCompilationTest {
                 "end";
     }
 
-    @Test
-    public void testRuleRemovalWithOR() {
+    @ParameterizedTest(name = "KieBase type={0}")
+	@MethodSource("parameters")
+    public void testRuleRemovalWithOR(KieBaseTestConfiguration kieBaseTestConfiguration) {
         // DROOLS-1007
         final String drl1 =
                 "rule R1 when\n" +
@@ -2031,8 +2065,9 @@ public class IncrementalCompilationTest {
         ksession.fireAllRules();
     }
 
-    @Test
-    public void testSplitAfterQuery() {
+    @ParameterizedTest(name = "KieBase type={0}")
+	@MethodSource("parameters")
+    public void testSplitAfterQuery(KieBaseTestConfiguration kieBaseTestConfiguration) {
         final String drl1 =
                 "global java.util.List list; " +
                         "query foo( Integer $i ) " +
@@ -2114,8 +2149,9 @@ public class IncrementalCompilationTest {
         assertThat((int) list.get(1)).isEqualTo(22);
     }
 
-    @Test
-    public void testGetFactTypeOnIncrementalUpdate() throws Exception {
+    @ParameterizedTest(name = "KieBase type={0}")
+	@MethodSource("parameters")
+    public void testGetFactTypeOnIncrementalUpdate(KieBaseTestConfiguration kieBaseTestConfiguration) throws Exception {
         // DROOLS-980 - DROOLS-2195
         final String drl1 =
                 "package org.mytest\n" +
@@ -2167,8 +2203,9 @@ public class IncrementalCompilationTest {
         ftype.set(fact, "address", "World");
     }
 
-    @Test
-    public void testRuleRemovalWithSubnetworkAndOR() {
+    @ParameterizedTest(name = "KieBase type={0}")
+	@MethodSource("parameters")
+    public void testRuleRemovalWithSubnetworkAndOR(KieBaseTestConfiguration kieBaseTestConfiguration) {
         // DROOLS-1025
         final String drl1 =
                 "global java.util.concurrent.atomic.AtomicInteger globalInt\n" +
@@ -2207,8 +2244,9 @@ public class IncrementalCompilationTest {
         ksession.fireAllRules();
     }
 
-    @Test
-    public void testIncrementalCompilationWithClassFieldReader() {
+    @ParameterizedTest(name = "KieBase type={0}")
+	@MethodSource("parameters")
+    public void testIncrementalCompilationWithClassFieldReader(KieBaseTestConfiguration kieBaseTestConfiguration) {
         // BZ-1318532
         final String personSrc = "package org.test;" +
                 "import java.util.ArrayList;" +
@@ -2281,8 +2319,9 @@ public class IncrementalCompilationTest {
         ksession.fireAllRules();
     }
 
-    @Test
-    public void testIncrementalCompilationRemovingParentRule() {
+    @ParameterizedTest(name = "KieBase type={0}")
+	@MethodSource("parameters")
+    public void testIncrementalCompilationRemovingParentRule(KieBaseTestConfiguration kieBaseTestConfiguration) {
         // DROOLS-1031
         final String drl1 = "package org.drools.compiler\n" +
                 "rule R1 when\n" +
@@ -2323,8 +2362,9 @@ public class IncrementalCompilationTest {
         assertThat(ksession.fireAllRules()).isEqualTo(2);
     }
 
-    @Test
-    public void testIncrementalCompilationChangeParentRule() {
+    @ParameterizedTest(name = "KieBase type={0}")
+	@MethodSource("parameters")
+    public void testIncrementalCompilationChangeParentRule(KieBaseTestConfiguration kieBaseTestConfiguration) {
         // DROOLS-1031
         final String drl1_1 =
                 "rule R1 when\n" +
@@ -2363,8 +2403,9 @@ public class IncrementalCompilationTest {
         assertThat(ksession.fireAllRules()).isEqualTo(2);
     }
 
-    @Test
-    public void testIncrementalCompilationChangeParentRuleInDifferentFile() {
+    @ParameterizedTest(name = "KieBase type={0}")
+	@MethodSource("parameters")
+    public void testIncrementalCompilationChangeParentRuleInDifferentFile(KieBaseTestConfiguration kieBaseTestConfiguration) {
         // DROOLS-6497
         final String drl1_1 =
                 "rule R1 when\n" +
@@ -2403,8 +2444,9 @@ public class IncrementalCompilationTest {
         assertThat(ksession.fireAllRules()).isEqualTo(2);
     }
 
-    @Test
-    public void testRemovePackageFromKieBaseModel() {
+    @ParameterizedTest(name = "KieBase type={0}")
+	@MethodSource("parameters")
+    public void testRemovePackageFromKieBaseModel(KieBaseTestConfiguration kieBaseTestConfiguration) {
         // DROOLS-1287
         final String drl1 = "global java.util.List list;\n" +
                 "rule R1 when\n" +
@@ -2456,8 +2498,9 @@ public class IncrementalCompilationTest {
         assertThat(list.contains("R2")).isTrue();
     }
 
-    @Test
-    public void testAddPackageToKieBaseModel() {
+    @ParameterizedTest(name = "KieBase type={0}")
+	@MethodSource("parameters")
+    public void testAddPackageToKieBaseModel(KieBaseTestConfiguration kieBaseTestConfiguration) {
         // DROOLS-1287
         // DROOLS-1287
         final String drl1 = "global java.util.List list;\n" +
@@ -2510,8 +2553,9 @@ public class IncrementalCompilationTest {
         assertThat(list.containsAll(asList("R1", "R2"))).isTrue();
     }
 
-    @Test
-    public void testKJarUpgradeWithSpace() {
+    @ParameterizedTest(name = "KieBase type={0}")
+	@MethodSource("parameters")
+    public void testKJarUpgradeWithSpace(KieBaseTestConfiguration kieBaseTestConfiguration) {
         // DROOLS-1399
         final String drl1 = "package org.drools.compiler\n" +
                 "import " + Message.class.getCanonicalName() + ";\n" +
@@ -2527,11 +2571,12 @@ public class IncrementalCompilationTest {
                 "then\n" +
                 "end\n";
 
-        testKJarUpgradeDRLWithSpace(drl1, drl2, "Hello World", 1, 0);
+        testKJarUpgradeDRLWithSpace(kieBaseTestConfiguration, drl1, drl2, "Hello World", 1, 0);
     }
 
-    @Test
-    public void testKJarUpgradeDRLWithSpace2() {
+    @ParameterizedTest(name = "KieBase type={0}")
+	@MethodSource("parameters")
+    public void testKJarUpgradeDRLWithSpace2(KieBaseTestConfiguration kieBaseTestConfiguration) {
         // DROOLS-1399 bis
         final String drl1 = "package org.drools.compiler\n" +
                 "import " + Message.class.getCanonicalName() + ";\n" +
@@ -2547,11 +2592,12 @@ public class IncrementalCompilationTest {
                 "then\n" +
                 "end\n";
 
-        testKJarUpgradeDRLWithSpace(drl1, drl2, "Hello World", 1, 0);
+        testKJarUpgradeDRLWithSpace(kieBaseTestConfiguration, drl1, drl2, "Hello World", 1, 0);
     }
 
-    @Test
-    public void testKJarUpgradeDRLWithSpace3() {
+    @ParameterizedTest(name = "KieBase type={0}")
+	@MethodSource("parameters")
+    public void testKJarUpgradeDRLWithSpace3(KieBaseTestConfiguration kieBaseTestConfiguration) {
         // DROOLS-1399 ter
         final String drl1 = "package org.drools.compiler\n" +
                 "import " + Message.class.getCanonicalName() + ";\n" +
@@ -2571,11 +2617,12 @@ public class IncrementalCompilationTest {
                 "  System.out.println($m); \n" +
                 "end\n";
 
-        testKJarUpgradeWithSpaceVariant2(drl1, drl2);
+        testKJarUpgradeWithSpaceVariant2(kieBaseTestConfiguration, drl1, drl2);
     }
 
-    @Test
-    public void testKJarUpgradeDRLWithSpace4() {
+    @ParameterizedTest(name = "KieBase type={0}")
+	@MethodSource("parameters")
+    public void testKJarUpgradeDRLWithSpace4(KieBaseTestConfiguration kieBaseTestConfiguration) {
         // DROOLS-1399 quater
         final String drl1 = "package org.drools.compiler\n" +
                 "import " + Message.class.getCanonicalName() + ";\n" +
@@ -2591,11 +2638,12 @@ public class IncrementalCompilationTest {
                 "then\n" +
                 "end\n";
 
-        testKJarUpgradeDRLWithSpace(drl1, drl2, "Hello World", 0, 1);
+        testKJarUpgradeDRLWithSpace(kieBaseTestConfiguration, drl1, drl2, "Hello World", 0, 1);
     }
 
-    @Test
-    public void testKJarUpgradeDRLWithSpace5() {
+    @ParameterizedTest(name = "KieBase type={0}")
+	@MethodSource("parameters")
+    public void testKJarUpgradeDRLWithSpace5(KieBaseTestConfiguration kieBaseTestConfiguration) {
         // DROOLS-1399 quinquies
         final String drl1 = "package org.drools.compiler\n" +
                 "import " + Message.class.getCanonicalName() + ";\n" +
@@ -2611,11 +2659,12 @@ public class IncrementalCompilationTest {
                 "then\n" +
                 "end\n";
 
-        testKJarUpgradeDRLWithSpace(drl1, drl2, "Hello' World", 0, 1); // <<- notice the ' character
+        testKJarUpgradeDRLWithSpace(kieBaseTestConfiguration, drl1, drl2, "Hello' World", 0, 1); // <<- notice the ' character
     }
 
-    @Test
-    public void testKJarUpgradeWithSpace_usingSingleQuote() {
+    @ParameterizedTest(name = "KieBase type={0}")
+	@MethodSource("parameters")
+    public void testKJarUpgradeWithSpace_usingSingleQuote(KieBaseTestConfiguration kieBaseTestConfiguration) {
         // DROOLS-1399 (using single quote)
         final String drl1 = "package org.drools.compiler\n" +
                 "import " + Message.class.getCanonicalName() + ";\n" +
@@ -2631,11 +2680,12 @@ public class IncrementalCompilationTest {
                 "then\n" +
                 "end\n";
 
-        testKJarUpgradeDRLWithSpace(drl1, drl2, "Hello World", 1, 0);
+        testKJarUpgradeDRLWithSpace(kieBaseTestConfiguration, drl1, drl2, "Hello World", 1, 0);
     }
 
-    @Test
-    public void testKJarUpgradeDRLWithSpace2_usingSingleQuote() {
+    @ParameterizedTest(name = "KieBase type={0}")
+	@MethodSource("parameters")
+    public void testKJarUpgradeDRLWithSpace2_usingSingleQuote(KieBaseTestConfiguration kieBaseTestConfiguration) {
         // DROOLS-1399 bis (using single quote)
         final String drl1 = "package org.drools.compiler\n" +
                 "import " + Message.class.getCanonicalName() + ";\n" +
@@ -2651,11 +2701,12 @@ public class IncrementalCompilationTest {
                 "then\n" +
                 "end\n";
 
-        testKJarUpgradeDRLWithSpace(drl1, drl2, "Hello World", 1, 0);
+        testKJarUpgradeDRLWithSpace(kieBaseTestConfiguration, drl1, drl2, "Hello World", 1, 0);
     }
 
-    @Test
-    public void testKJarUpgradeDRLWithSpace3_usingSingleQuote() {
+    @ParameterizedTest(name = "KieBase type={0}")
+	@MethodSource("parameters")
+    public void testKJarUpgradeDRLWithSpace3_usingSingleQuote(KieBaseTestConfiguration kieBaseTestConfiguration) {
         // DROOLS-1399 ter (using single quote)
         final String drl1 = "package org.drools.compiler\n" +
                 "import " + Message.class.getCanonicalName() + ";\n" +
@@ -2675,11 +2726,12 @@ public class IncrementalCompilationTest {
                 "  System.out.println($m); \n" +
                 "end\n";
 
-        testKJarUpgradeWithSpaceVariant2(drl1, drl2);
+        testKJarUpgradeWithSpaceVariant2(kieBaseTestConfiguration, drl1, drl2);
     }
 
-    @Test
-    public void testKJarUpgradeDRLWithSpace4_usingSingleQuote() {
+    @ParameterizedTest(name = "KieBase type={0}")
+	@MethodSource("parameters")
+    public void testKJarUpgradeDRLWithSpace4_usingSingleQuote(KieBaseTestConfiguration kieBaseTestConfiguration) {
         // DROOLS-1399 quater (using single quote)
         final String drl1 = "package org.drools.compiler\n" +
                 "import " + Message.class.getCanonicalName() + ";\n" +
@@ -2695,11 +2747,12 @@ public class IncrementalCompilationTest {
                 "then\n" +
                 "end\n";
 
-        testKJarUpgradeDRLWithSpace(drl1, drl2, "Hello World", 0, 1);
+        testKJarUpgradeDRLWithSpace(kieBaseTestConfiguration, drl1, drl2, "Hello World", 0, 1);
     }
 
-    @Test
-    public void testKJarUpgradeDRLWithSpace5_usingSingleQuote() {
+    @ParameterizedTest(name = "KieBase type={0}")
+	@MethodSource("parameters")
+    public void testKJarUpgradeDRLWithSpace5_usingSingleQuote(KieBaseTestConfiguration kieBaseTestConfiguration) {
         // DROOLS-1399 quinquies (using single quote)
         final String drl1 = "package org.drools.compiler\n" +
                 "import " + Message.class.getCanonicalName() + ";\n" +
@@ -2715,10 +2768,10 @@ public class IncrementalCompilationTest {
                 "then\n" +
                 "end\n";
 
-        testKJarUpgradeDRLWithSpace(drl1, drl2, "Hello' World", 0, 1);
+        testKJarUpgradeDRLWithSpace(kieBaseTestConfiguration, drl1, drl2, "Hello' World", 0, 1);
     }
 
-    private void testKJarUpgradeDRLWithSpace(final String drl1, final String drl2, final String factString,
+    private void testKJarUpgradeDRLWithSpace(KieBaseTestConfiguration kieBaseTestConfiguration, final String drl1, final String drl2, final String factString,
                                              final int firstFireCount, final int secondFireCount) {
         final KieServices ks = KieServices.Factory.get();
 
@@ -2737,7 +2790,7 @@ public class IncrementalCompilationTest {
         assertThat(ksession.fireAllRules()).isEqualTo(secondFireCount);
     }
 
-    private void testKJarUpgradeWithSpaceVariant2(final String drl1, final String drl2) {
+    private void testKJarUpgradeWithSpaceVariant2(KieBaseTestConfiguration kieBaseTestConfiguration, final String drl1, final String drl2) {
         final KieServices ks = KieServices.Factory.get();
 
         final ReleaseId releaseId1 = ks.newReleaseId("org.kie", "test-upgrade", "1.0.0");
@@ -2772,8 +2825,9 @@ public class IncrementalCompilationTest {
         assertThat(fired.contains("Rx")).isFalse();
     }
 
-    @Test
-    public void testJavaClassRedefinition() {
+    @ParameterizedTest(name = "KieBase type={0}")
+	@MethodSource("parameters")
+    public void testJavaClassRedefinition(KieBaseTestConfiguration kieBaseTestConfiguration) {
         // DROOLS-1402
         final String JAVA1 = "package org.test;" +
                 "    public class MyBean {\n" +
@@ -2885,8 +2939,9 @@ public class IncrementalCompilationTest {
         assertThat(fired).isEqualTo(2);
     }
 
-    @Test
-    public void testJavaClassRedefinitionJoined() {
+    @ParameterizedTest(name = "KieBase type={0}")
+	@MethodSource("parameters")
+    public void testJavaClassRedefinitionJoined(KieBaseTestConfiguration kieBaseTestConfiguration) {
         // DROOLS-1402
         final String JAVA1 = "package org.test;" +
                 "    public class MyBean {\n" +
@@ -3001,8 +3056,10 @@ public class IncrementalCompilationTest {
         assertThat(fired).isEqualTo(2);
     }
 
-    @Test(timeout = 20000L)
-    public void testMultipleIncrementalCompilationsWithFireUntilHalt() throws Exception {
+    @ParameterizedTest(name = "KieBase type={0}")
+	@MethodSource("parameters")
+    @Timeout(20000L)
+    public void testMultipleIncrementalCompilationsWithFireUntilHalt(KieBaseTestConfiguration kieBaseTestConfiguration) throws Exception {
         // DROOLS-1406
         final KieServices ks = KieServices.Factory.get();
 
@@ -3071,8 +3128,9 @@ public class IncrementalCompilationTest {
         }
     }
 
-    @Test
-    public void testIncrementalCompilationWithExtendsRule() {
+    @ParameterizedTest(name = "KieBase type={0}")
+	@MethodSource("parameters")
+    public void testIncrementalCompilationWithExtendsRule(KieBaseTestConfiguration kieBaseTestConfiguration) {
         // DROOLS-1405
         final String drl1 =
                 "rule \"test1\" when then end\n";
@@ -3108,8 +3166,9 @@ public class IncrementalCompilationTest {
         }
     }
 
-    @Test
-    public void testUpdateWithPojoExtensionDifferentPackages() throws Exception {
+    @ParameterizedTest(name = "KieBase type={0}")
+	@MethodSource("parameters")
+    public void testUpdateWithPojoExtensionDifferentPackages(KieBaseTestConfiguration kieBaseTestConfiguration) throws Exception {
         // DROOLS-1491
         final String drlDeclare = "package org.drools.compiler.integrationtests\n" +
                 "declare DroolsApplications extends " + BaseClass.class.getCanonicalName() + "\n" +
@@ -3174,8 +3233,9 @@ public class IncrementalCompilationTest {
         assertThat(ksession.fireAllRules()).isEqualTo(1);
     }
 
-    @Test
-    public void testPropertyReactivityOfAKnownClass() {
+    @ParameterizedTest(name = "KieBase type={0}")
+	@MethodSource("parameters")
+    public void testPropertyReactivityOfAKnownClass(KieBaseTestConfiguration kieBaseTestConfiguration) {
         final String drl1 =
                 "import " + TypeA.class.getCanonicalName() + "\n" +
                         "import " + TypeB.class.getCanonicalName() + "\n" +
@@ -3213,8 +3273,9 @@ public class IncrementalCompilationTest {
         assertThat(fired).isEqualTo(1);
     }
 
-    @Test
-    public void testPropertyReactivityOfAnOriginallyUnknownClass() {
+    @ParameterizedTest(name = "KieBase type={0}")
+	@MethodSource("parameters")
+    public void testPropertyReactivityOfAnOriginallyUnknownClass(KieBaseTestConfiguration kieBaseTestConfiguration) {
         // DROOLS-1684
         final String drl1 =
                 "import " + TypeA.class.getCanonicalName() + "\n" +
@@ -3299,8 +3360,9 @@ public class IncrementalCompilationTest {
                     "    insert( new Message(\"HAL\", \"reply 2\" ) ); \n" +
                     "end \n";
 
-    @Test
-    public void testDeclaredTypeInDifferentPackage() throws IllegalAccessException, InstantiationException {
+    @ParameterizedTest(name = "KieBase type={0}")
+	@MethodSource("parameters")
+    public void testDeclaredTypeInDifferentPackage(KieBaseTestConfiguration kieBaseTestConfiguration) throws IllegalAccessException, InstantiationException {
         // DROOLS-1707
         final KieServices ks = KieServices.Factory.get();
 
@@ -3317,8 +3379,9 @@ public class IncrementalCompilationTest {
         doFire(kContainer.getKieBase(), "reply 2");
     }
 
-    @Test
-    public void testDeclaredTypeInIncludedKieBase() throws IllegalAccessException, InstantiationException {
+    @ParameterizedTest(name = "KieBase type={0}")
+	@MethodSource("parameters")
+    public void testDeclaredTypeInIncludedKieBase(KieBaseTestConfiguration kieBaseTestConfiguration) throws IllegalAccessException, InstantiationException {
         // DROOLS-1707
         final KieServices ks = KieServices.Factory.get();
 
@@ -3379,8 +3442,9 @@ public class IncrementalCompilationTest {
         return fact;
     }
 
-    @Test
-    public void testRemoveAndReaddJavaClass() {
+    @ParameterizedTest(name = "KieBase type={0}")
+	@MethodSource("parameters")
+    public void testRemoveAndReaddJavaClass(KieBaseTestConfiguration kieBaseTestConfiguration) {
         // DROOLS-1704
         final String javaSource = "package org.drools.test;\n" +
                 "public class Person { }\n";
@@ -3425,8 +3489,9 @@ public class IncrementalCompilationTest {
         kContainer.updateToVersion(releaseId3);
     }
 
-    @Test
-    public void testChangedPackage() {
+    @ParameterizedTest(name = "KieBase type={0}")
+	@MethodSource("parameters")
+    public void testChangedPackage(KieBaseTestConfiguration kieBaseTestConfiguration) {
         // DROOLS-1742
         final String drl1 = "package org.a\n" +
                 "rule \"RG_1\"\n" +
@@ -3463,8 +3528,9 @@ public class IncrementalCompilationTest {
         assertThat(kieSession.fireAllRules()).isEqualTo(0);
     }
 
-    @Test
-    public void testSegmentSplitAfterMerge() {
+    @ParameterizedTest(name = "KieBase type={0}")
+	@MethodSource("parameters")
+    public void testSegmentSplitAfterMerge(KieBaseTestConfiguration kieBaseTestConfiguration) {
         final String drl1A = "package org.hightea.a\n" +
                 "rule \"RG_1\"\n" +
                 "    when\n" +
@@ -3508,8 +3574,9 @@ public class IncrementalCompilationTest {
         assertThat(kieSession.fireAllRules()).isEqualTo(0);
     }
 
-    @Test
-    public void testAddFieldToDeclaredType() {
+    @ParameterizedTest(name = "KieBase type={0}")
+	@MethodSource("parameters")
+    public void testAddFieldToDeclaredType(KieBaseTestConfiguration kieBaseTestConfiguration) {
         // DROOLS-2197
         final String declares1 = "declare Address\n" +
                 "   streetName : String\n" +
@@ -3550,8 +3617,9 @@ public class IncrementalCompilationTest {
         assertThat(kieSession.fireAllRules()).isEqualTo(0);
     }
 
-    @Test
-    public void testIncremenatalCompilationAddingFieldToDeclaredType() {
+    @ParameterizedTest(name = "KieBase type={0}")
+	@MethodSource("parameters")
+    public void testIncremenatalCompilationAddingFieldToDeclaredType(KieBaseTestConfiguration kieBaseTestConfiguration) {
         // DROOLS-2197
         final String declares1 = "declare Address\n" +
                 "   streetName : String\n" +
@@ -3615,8 +3683,9 @@ public class IncrementalCompilationTest {
         assertThat(updateResults.getMessages().size()).isEqualTo(0);
     }
 
-    @Test
-    public void testUnchangedAccumulate() {
+    @ParameterizedTest(name = "KieBase type={0}")
+	@MethodSource("parameters")
+    public void testUnchangedAccumulate(KieBaseTestConfiguration kieBaseTestConfiguration) {
         // DROOLS-2194
         final String drl1 =
                 "import java.util.*;\n" +
@@ -3658,8 +3727,9 @@ public class IncrementalCompilationTest {
         ksession.fireAllRules();
     }
 
-    @Test
-    public void testGlobalRemovedFromOneDrl() {
+    @ParameterizedTest(name = "KieBase type={0}")
+	@MethodSource("parameters")
+    public void testGlobalRemovedFromOneDrl(KieBaseTestConfiguration kieBaseTestConfiguration) {
         // RHDM-311
         final String drlAWithGlobal = "package org.x.a\nglobal Boolean globalBool\n";
         final String drlANoGlobal = "package org.x.a\n";
@@ -3694,8 +3764,9 @@ public class IncrementalCompilationTest {
         }
     }
 
-    @Test
-    public void testGlobalRemovedAndAdded() {
+    @ParameterizedTest(name = "KieBase type={0}")
+	@MethodSource("parameters")
+    public void testGlobalRemovedAndAdded(KieBaseTestConfiguration kieBaseTestConfiguration) {
         // RHDM-311
         final String drlAWithGlobal = "package org.x.a\nglobal Boolean globalBool\n";
         final String drlANoGlobal = "package org.x.a\n";
@@ -3719,8 +3790,9 @@ public class IncrementalCompilationTest {
         ksession.setGlobal("globalBool", Boolean.TRUE);
     }
 
-    @Test
-    public void testRuleRemovalAndEval() {
+    @ParameterizedTest(name = "KieBase type={0}")
+	@MethodSource("parameters")
+    public void testRuleRemovalAndEval(KieBaseTestConfiguration kieBaseTestConfiguration) {
         // DROOLS-2276
         final String drl1 = "package org.drools.compiler\n" +
                 "import " + Message.class.getCanonicalName() + ";\n" +
@@ -3787,8 +3859,9 @@ public class IncrementalCompilationTest {
         assertThat(ksession.fireAllRules()).isEqualTo(1);
     }
 
-    @Test
-    public void testGetFactTypeOnIncrementalUpdateWithNestedFacts() throws Exception {
+    @ParameterizedTest(name = "KieBase type={0}")
+	@MethodSource("parameters")
+    public void testGetFactTypeOnIncrementalUpdateWithNestedFacts(KieBaseTestConfiguration kieBaseTestConfiguration) throws Exception {
         // DROOLS-2385
         final String drl1 =
                 "package org.drools.example.api.kiemodulemodel\n" +
@@ -3856,8 +3929,9 @@ public class IncrementalCompilationTest {
         ftype.set(fact, "nested", nestedfact);
     }
 
-    @Test
-    public void testKJarUpgradeWithNewRule() throws Exception {
+    @ParameterizedTest(name = "KieBase type={0}")
+	@MethodSource("parameters")
+    public void testKJarUpgradeWithNewRule(KieBaseTestConfiguration kieBaseTestConfiguration) throws Exception {
         // DROOLS-2596
         String drl1a = "package org.drools.incremental\n" +
                 "global java.util.List list\n" +
@@ -3914,8 +3988,9 @@ public class IncrementalCompilationTest {
         assertThat(list.get(1)).isEqualTo("1");
     }
 
-    @Test
-    public void testKJarUpgradeWithNewRuleAndStatelessSession() throws Exception {
+    @ParameterizedTest(name = "KieBase type={0}")
+	@MethodSource("parameters")
+    public void testKJarUpgradeWithNewRuleAndStatelessSession(KieBaseTestConfiguration kieBaseTestConfiguration) throws Exception {
         // DROOLS-2596
         String drl1a = "package org.drools.incremental\n" +
                 "global java.util.List list\n" +
@@ -3973,8 +4048,9 @@ public class IncrementalCompilationTest {
         assertThat(list.get(1)).isEqualTo("1");
     }
 
-    @Test
-    public void testArgumentRedefinitionInStaticInvocation() {
+    @ParameterizedTest(name = "KieBase type={0}")
+	@MethodSource("parameters")
+    public void testArgumentRedefinitionInStaticInvocation(KieBaseTestConfiguration kieBaseTestConfiguration) {
         // RHDM-709
         final String ARG1 = "package org.test;" +
                 "    public class MyArg {\n" +
@@ -4054,8 +4130,9 @@ public class IncrementalCompilationTest {
         assertThat(updateResults.hasMessages(Level.ERROR)).isFalse();
     }
 
-    @Test
-    public void testRemoveRulesWithLogicalAssertions() {
+    @ParameterizedTest(name = "KieBase type={0}")
+	@MethodSource("parameters")
+    public void testRemoveRulesWithLogicalAssertions(KieBaseTestConfiguration kieBaseTestConfiguration) {
         // DROOLS-2646
         final String DRL1 =
                 "declare MyInt\n" +
@@ -4130,8 +4207,9 @@ public class IncrementalCompilationTest {
         assertThat(kieSession.getObjects().size()).isEqualTo(4);
     }
 
-    @Test
-    public void testRemoveRulesWithAccumulateAndLogicalAssertions() {
+    @ParameterizedTest(name = "KieBase type={0}")
+	@MethodSource("parameters")
+    public void testRemoveRulesWithAccumulateAndLogicalAssertions(KieBaseTestConfiguration kieBaseTestConfiguration) {
         // DROOLS-3554
         final String DRL1 =
                 "rule R1 when\n" +
@@ -4187,17 +4265,19 @@ public class IncrementalCompilationTest {
         assertThat(kieSession.getObjects(new ClassObjectFilter( Integer.class )).isEmpty()).isTrue();
     }
 
-    @Test
-    public void testRemoveRulesWithSubnetworkAndOR() throws Exception {
-        checkRemoveRulesWithSubnetworkAndOR(false);
+    @ParameterizedTest(name = "KieBase type={0}")
+	@MethodSource("parameters")
+    public void testRemoveRulesWithSubnetworkAndOR(KieBaseTestConfiguration kieBaseTestConfiguration) throws Exception {
+        checkRemoveRulesWithSubnetworkAndOR(kieBaseTestConfiguration, false);
     }
 
-    @Test
-    public void testRemoveRulesWithSubnetworkAndORWithDispose() throws Exception {
-        checkRemoveRulesWithSubnetworkAndOR(true);
+    @ParameterizedTest(name = "KieBase type={0}")
+	@MethodSource("parameters")
+    public void testRemoveRulesWithSubnetworkAndORWithDispose(KieBaseTestConfiguration kieBaseTestConfiguration) throws Exception {
+        checkRemoveRulesWithSubnetworkAndOR(kieBaseTestConfiguration, true);
     }
 
-    public void checkRemoveRulesWithSubnetworkAndOR(boolean dispose) throws Exception {
+    public void checkRemoveRulesWithSubnetworkAndOR(KieBaseTestConfiguration kieBaseTestConfiguration, boolean dispose) throws Exception {
         // DROOLS-4454
         String DRL1 =
                 " package org.drools.compiler;\n" +
@@ -4324,17 +4404,19 @@ public class IncrementalCompilationTest {
         ks2.dispose();
     }
 
-    @Test
-    public void testRemoveAndAddRules() throws Exception {
-        checkRemoveAndAddRules(false);
+    @ParameterizedTest(name = "KieBase type={0}")
+	@MethodSource("parameters")
+    public void testRemoveAndAddRules(KieBaseTestConfiguration kieBaseTestConfiguration) throws Exception {
+        checkRemoveAndAddRules(kieBaseTestConfiguration, false);
     }
 
-    @Test
-    public void testRemoveAndAddRulesWithDispose() throws Exception {
-        checkRemoveAndAddRules(true);
+    @ParameterizedTest(name = "KieBase type={0}")
+	@MethodSource("parameters")
+    public void testRemoveAndAddRulesWithDispose(KieBaseTestConfiguration kieBaseTestConfiguration) throws Exception {
+        checkRemoveAndAddRules(kieBaseTestConfiguration, true);
     }
 
-    public void checkRemoveAndAddRules(boolean dispose) throws Exception {
+    public void checkRemoveAndAddRules(KieBaseTestConfiguration kieBaseTestConfiguration, boolean dispose) throws Exception {
         String DRL1 =
                 "package org.kie.test\n" +
                 "global java.util.List list\n" +
@@ -4431,8 +4513,9 @@ public class IncrementalCompilationTest {
         assertThat(list2.containsAll(Arrays.asList("R2", "R3"))).isTrue();
     }
 
-    @Test
-    public void testKJarUpgradeWithSerializedSession() {
+    @ParameterizedTest(name = "KieBase type={0}")
+	@MethodSource("parameters")
+    public void testKJarUpgradeWithSerializedSession(KieBaseTestConfiguration kieBaseTestConfiguration) {
         final String drl1 = "package org.drools.compiler\n" +
                 "import " + Message.class.getCanonicalName() + ";\n" +
                 "rule R1 when\n" +
@@ -4498,8 +4581,9 @@ public class IncrementalCompilationTest {
         assertThat(ksession2.fireAllRules()).isEqualTo(3);
     }
 
-    @Test
-    public void testGetFactTypeOnIncrementalUpdateWithNestedFactsRulesFired() throws Exception {
+    @ParameterizedTest(name = "KieBase type={0}")
+	@MethodSource("parameters")
+    public void testGetFactTypeOnIncrementalUpdateWithNestedFactsRulesFired(KieBaseTestConfiguration kieBaseTestConfiguration) throws Exception {
         // DROOLS-4886
         final String drl1 =
                 "package org.drools.example.api.kiemodulemodel\n" +
@@ -4577,13 +4661,15 @@ public class IncrementalCompilationTest {
         session.dispose();
     }
 
-    @Test
-    public void testDecisionTable() {
+    @ParameterizedTest(name = "KieBase type={0}")
+	@MethodSource("parameters")
+    @Disabled("This test fails, see issue")
+    public void testDecisionTable(KieBaseTestConfiguration kieBaseTestConfiguration) {
         KieServices ks = KieServices.get();
         KieResources kr = ks.getResources();
 
         ReleaseId releaseId1 = ks.newReleaseId("org.kie", "test-dtable", "1.1.1");
-        buildDTableProject( ks, kr, releaseId1, "CanDrinkAndDrive.drl.xls" );
+        buildDTableProject( kieBaseTestConfiguration, ks, kr, releaseId1, "CanDrinkAndDrive.drl.xls" );
 
         KieContainer kc = ks.newKieContainer(releaseId1);
 
@@ -4601,7 +4687,7 @@ public class IncrementalCompilationTest {
         }
 
         ReleaseId releaseId2 = ks.newReleaseId("org.kie", "test-dtable", "1.1.2");
-        buildDTableProject( ks, kr, releaseId2, "CanDrinkAndDrive2.drl.xls" );
+        buildDTableProject( kieBaseTestConfiguration, ks, kr, releaseId2, "CanDrinkAndDrive2.drl.xls" );
 
         kc.updateToVersion(releaseId2);
 
@@ -4615,7 +4701,7 @@ public class IncrementalCompilationTest {
         }
     }
 
-    private void buildDTableProject( KieServices ks, KieResources kr, ReleaseId releaseId, String dtableFile ) {
+    private void buildDTableProject(KieBaseTestConfiguration kieBaseTestConfiguration, KieServices ks, KieResources kr, ReleaseId releaseId, String dtableFile ) {
         KieFileSystem kfs = ks.newKieFileSystem()
                 .write( "src/main/resources/org/drools/simple/candrink/CanDrink.drl.xls",
                         kr.newFileSystemResource( "src/test/resources/data/" + dtableFile ) )
@@ -4638,8 +4724,9 @@ public class IncrementalCompilationTest {
         }
     }
 
-    @Test
-    public void testIncrementalCompilationFromEmptyProject() {
+    @ParameterizedTest(name = "KieBase type={0}")
+	@MethodSource("parameters")
+    public void testIncrementalCompilationFromEmptyProject(KieBaseTestConfiguration kieBaseTestConfiguration) {
         // DROOLS-5547
         final String drl1 =
                 "rule \"test1\" when then end\n";
@@ -4664,8 +4751,9 @@ public class IncrementalCompilationTest {
         assertThat(addResults2.getAddedMessages().size()).isEqualTo(0);
     }
 
-    @Test
-    public void testIncrementalCompilationFromEmptyProject2() {
+    @ParameterizedTest(name = "KieBase type={0}")
+	@MethodSource("parameters")
+    public void testIncrementalCompilationFromEmptyProject2(KieBaseTestConfiguration kieBaseTestConfiguration) {
         // DROOLS-5584
         final String drl1 =
                 "package org.drools.test;\n" +
@@ -4698,8 +4786,9 @@ public class IncrementalCompilationTest {
         assertThat(globals.iterator().next()).isEqualTo("list");
     }
 
-    @Test
-    public void testIncrementalCompilationWithErrorFromEmptyProject() {
+    @ParameterizedTest(name = "KieBase type={0}")
+	@MethodSource("parameters")
+    public void testIncrementalCompilationWithErrorFromEmptyProject(KieBaseTestConfiguration kieBaseTestConfiguration) {
         // DROOLS-5584
         final String drl_KO =
                 "package org.drools.test;\n" +
@@ -4732,8 +4821,9 @@ public class IncrementalCompilationTest {
         assertThat(addResults2.getRemovedMessages().size()).isEqualTo(1);
     }
 
-    @Test
-    public void testUnusedDeclaredTypeUpdate() throws Exception {
+    @ParameterizedTest(name = "KieBase type={0}")
+	@MethodSource("parameters")
+    public void testUnusedDeclaredTypeUpdate(KieBaseTestConfiguration kieBaseTestConfiguration) throws Exception {
         // DROOLS-5560
         final String drl1 = "package org.example.rules \n" +
                 "\n" +
@@ -4802,8 +4892,9 @@ public class IncrementalCompilationTest {
         assertThat(ksession.fireAllRules()).isEqualTo(1);
     }
 
-    @Test
-    public void testConsecutiveDeclaredTypeUpdates() throws Exception {
+    @ParameterizedTest(name = "KieBase type={0}")
+	@MethodSource("parameters")
+    public void testConsecutiveDeclaredTypeUpdates(KieBaseTestConfiguration kieBaseTestConfiguration) throws Exception {
         // DROOLS-5687
         final String drl1 =
                 "package org.example.rules \n" +
@@ -4874,8 +4965,9 @@ public class IncrementalCompilationTest {
         ksession = kc.newKieSession();
     }
 
-    @Test
-    public void testUnlinkedPathUpdate() throws Exception {
+    @ParameterizedTest(name = "KieBase type={0}")
+	@MethodSource("parameters")
+    public void testUnlinkedPathUpdate(KieBaseTestConfiguration kieBaseTestConfiguration) throws Exception {
         // DROOLS-5982
         final String drl1 =
                 "rule R1 when\n" +
@@ -4934,8 +5026,10 @@ public class IncrementalCompilationTest {
         assertThat(ksession.fireAllRules()).isEqualTo(2);
     }
 
-    @Test(timeout = 20000L)
-    public void testUpdateToVersionWithFireUntilHaltWithSlowRHS() throws Exception {
+    @ParameterizedTest(name = "KieBase type={0}")
+	@MethodSource("parameters")
+    @Timeout(20000L)
+    public void testUpdateToVersionWithFireUntilHaltWithSlowRHS(KieBaseTestConfiguration kieBaseTestConfiguration) throws Exception {
         // DROOLS-6392
         final KieServices ks = KieServices.Factory.get();
 
@@ -4995,8 +5089,9 @@ public class IncrementalCompilationTest {
                 "end\n";
     }
 
-    @Test
-    public void testAddEntryPoint() {
+    @ParameterizedTest(name = "KieBase type={0}")
+	@MethodSource("parameters")
+    public void testAddEntryPoint(KieBaseTestConfiguration kieBaseTestConfiguration) {
         // DROOLS-6906
         final KieServices ks = KieServices.Factory.get();
 
@@ -5036,8 +5131,9 @@ public class IncrementalCompilationTest {
         return rules.toString();
     }
 
-    @Test
-    public void testRemoveSharedConstraintWithEval() throws Exception {
+    @ParameterizedTest(name = "KieBase type={0}")
+	@MethodSource("parameters")
+    public void testRemoveSharedConstraintWithEval(KieBaseTestConfiguration kieBaseTestConfiguration) throws Exception {
         // DROOLS-6960
         final String drl1 =
                 "rule R1 when\n" +
@@ -5074,8 +5170,9 @@ public class IncrementalCompilationTest {
         assertThat(ksession.fireAllRules()).isEqualTo(1);
     }
 
-    @Test
-    public void testReaddAllRulesWithComplexNodeSharing() {
+    @ParameterizedTest(name = "KieBase type={0}")
+	@MethodSource("parameters")
+    public void testReaddAllRulesWithComplexNodeSharing(KieBaseTestConfiguration kieBaseTestConfiguration) {
         // DROOLS-7430
         final String drl1 =
                 "import " + Message.class.getCanonicalName() + ";\n" +
@@ -5169,8 +5266,9 @@ public class IncrementalCompilationTest {
         assertThat(fired).containsExactly("R6");
     }
 
-    @Test
-    public void testReaddAllRulesWithIdenticalRules() {
+    @ParameterizedTest(name = "KieBase type={0}")
+	@MethodSource("parameters")
+    public void testReaddAllRulesWithIdenticalRules(KieBaseTestConfiguration kieBaseTestConfiguration) {
         // DROOLS-7462
 
         final String drl1 =

--- a/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/compiler/integrationtests/incrementalcompilation/IncrementalCompilationTest.java
+++ b/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/compiler/integrationtests/incrementalcompilation/IncrementalCompilationTest.java
@@ -4663,7 +4663,7 @@ public class IncrementalCompilationTest {
 
     @ParameterizedTest(name = "KieBase type={0}")
 	@MethodSource("parameters")
-    @Disabled("This test fails, see issue")
+    @Disabled("It fails. See issue #6190")
     public void testDecisionTable(KieBaseTestConfiguration kieBaseTestConfiguration) {
         KieServices ks = KieServices.get();
         KieResources kr = ks.getResources();

--- a/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/compiler/integrationtests/incrementalcompilation/RemoveRuleTest.java
+++ b/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/compiler/integrationtests/incrementalcompilation/RemoveRuleTest.java
@@ -19,11 +19,10 @@
 package org.drools.compiler.integrationtests.incrementalcompilation;
 
 import java.util.Arrays;
-import java.util.Collection;
+import java.util.stream.Stream;
 
 import org.drools.core.common.DefaultFactHandle;
 import org.drools.core.reteoo.EntryPointNode;
-import org.drools.core.reteoo.LeftTuple;
 import org.drools.core.reteoo.ObjectSink;
 import org.drools.core.reteoo.ObjectTypeNode;
 import org.drools.core.reteoo.TupleImpl;
@@ -34,10 +33,9 @@ import org.drools.testcoverage.common.model.Cheese;
 import org.drools.testcoverage.common.model.Person;
 import org.drools.testcoverage.common.util.KieBaseTestConfiguration;
 import org.drools.testcoverage.common.util.KieUtil;
-import org.drools.testcoverage.common.util.TestParametersUtil;
-import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.junit.runners.Parameterized;
+import org.drools.testcoverage.common.util.TestParametersUtil2;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
 import org.kie.api.KieBase;
 import org.kie.api.KieServices;
 import org.kie.api.builder.ReleaseId;
@@ -47,22 +45,15 @@ import org.kie.api.runtime.KieSession;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.fail;
 
-@RunWith(Parameterized.class)
 public class RemoveRuleTest {
 
-    private final KieBaseTestConfiguration kieBaseTestConfiguration;
-
-    public RemoveRuleTest(final KieBaseTestConfiguration kieBaseTestConfiguration) {
-        this.kieBaseTestConfiguration = kieBaseTestConfiguration;
+    public static Stream<KieBaseTestConfiguration> parameters() {
+        return TestParametersUtil2.getKieBaseCloudConfigurations(true).stream();
     }
 
-    @Parameterized.Parameters(name = "KieBase type={0}")
-    public static Collection<Object[]> getParameters() {
-        return TestParametersUtil.getKieBaseCloudConfigurations(true);
-    }
-
-    @Test
-    public void testRemoveBigRule() {
+    @ParameterizedTest(name = "KieBase type={0}")
+	@MethodSource("parameters")
+    public void testRemoveBigRule(KieBaseTestConfiguration kieBaseTestConfiguration) {
         // JBRULES-3496
         final String str =
                 "package org.drools.compiler.test\n" +
@@ -164,8 +155,9 @@ public class RemoveRuleTest {
         }
     }
 
-    @Test
-    public void testRemoveRuleWithFromNode() {
+    @ParameterizedTest(name = "KieBase type={0}")
+	@MethodSource("parameters")
+    public void testRemoveRuleWithFromNode(KieBaseTestConfiguration kieBaseTestConfiguration) {
         // JBRULES-3631
         final String str =
                 "package org.drools.compiler;\n" +
@@ -192,8 +184,9 @@ public class RemoveRuleTest {
         assertThat(kbase.getKiePackage("org.drools.compiler").getRules().size()).isEqualTo(1);
     }
 
-    @Test
-    public void testRuleRemovalWithJoinedRootPattern() {
+    @ParameterizedTest(name = "KieBase type={0}")
+	@MethodSource("parameters")
+    public void testRuleRemovalWithJoinedRootPattern(KieBaseTestConfiguration kieBaseTestConfiguration) {
         String str = "";
         str += "package org.drools.compiler \n";
         str += "import " + Person.class.getCanonicalName() + ";\n";
@@ -229,8 +222,9 @@ public class RemoveRuleTest {
         assertThat((Tuple) leftTuple.getHandleNext()).isNull();
     }
 
-     @Test
-    public void testRemoveAccumulateRule() {
+     @ParameterizedTest(name = "KieBase type={0}")
+	@MethodSource("parameters")
+    public void testRemoveAccumulateRule(KieBaseTestConfiguration kieBaseTestConfiguration) {
         // DROOLS-4864
         final String str =
                 "package org.drools.compiler.test\n" +

--- a/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/compiler/integrationtests/operators/EnabledTest.java
+++ b/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/compiler/integrationtests/operators/EnabledTest.java
@@ -30,7 +30,6 @@ import org.drools.testcoverage.common.util.KieUtil;
 import org.drools.testcoverage.common.util.TestParametersUtil2;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.MethodSource;
-import org.junit.runners.Parameterized;
 import org.kie.api.KieBase;
 import org.kie.api.KieServices;
 import org.kie.api.builder.KieModule;
@@ -47,7 +46,6 @@ import static org.mockito.Mockito.verify;
 
 public class EnabledTest {
 
-    @Parameterized.Parameters(name = "KieBase type={0}")
     public static Stream<KieBaseTestConfiguration> parameters() {
         return TestParametersUtil2.getKieBaseCloudConfigurations(false).stream();
     }

--- a/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/compiler/rule/builder/dialect/java/RuleBuilderTest.java
+++ b/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/compiler/rule/builder/dialect/java/RuleBuilderTest.java
@@ -48,7 +48,7 @@ import org.drools.mvel.MVELConstraint;
 import org.kie.internal.builder.conf.LanguageLevelOption;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.Assert.fail;
+import static org.assertj.core.api.Assertions.fail;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;

--- a/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/integrationtests/Misc2Test.java
+++ b/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/integrationtests/Misc2Test.java
@@ -131,9 +131,9 @@ import org.slf4j.LoggerFactory;
 
 import static java.util.Arrays.asList;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assumptions.assumeThat;
 import static org.assertj.core.api.Assertions.fail;
 import static org.drools.mvel.compiler.TestUtil.assertDrlHasCompilationError;
-import static org.junit.Assume.assumeTrue;
 
 /**
  * Run all the tests with the ReteOO engine implementation
@@ -7910,7 +7910,7 @@ public class Misc2Test {
     }
 
     private void checkJava8InRhs(KieBaseTestConfiguration kieBaseTestConfiguration, String expr) {
-        assumeTrue(System.getProperty("java.version").startsWith( "1.8" ));
+        assumeThat(System.getProperty("java.version").startsWith( "1.8" ));
 
         // BZ-1199965
         String drl =


### PR DESCRIPTION
<!--
  Licensed to the Apache Software Foundation (ASF) under one
  or more contributor license agreements.  See the NOTICE file
  distributed with this work for additional information
  regarding copyright ownership.  The ASF licenses this file
  to you under the Apache License, Version 2.0 (the
  "License"); you may not use this file except in compliance
  with the License.  You may obtain a copy of the License at

    http://www.apache.org/licenses/LICENSE-2.0

  Unless required by applicable law or agreed to in writing,
  software distributed under the License is distributed on an
  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
  KIND, either express or implied.  See the License for the
  specific language governing permissions and limitations
  under the License.
  -->

With this patch we have migrated all drools test coverage to JUnit5.

Some tests are disabled because they are failing - but with the exception of one case, this seems unrelated to the migration.

See https://github.com/apache/incubator-kie-drools/issues/6190 for details

Issue: https://github.com/apache/incubator-kie-drools/issues/6136

<details>
<summary>
How to replicate CI configuration locally?
</summary>

Build Chain tool does "simple" maven build(s), the builds are just Maven commands, but because the repositories relates and depends on each other and any change in API or class method could affect several of those repositories there is a need to use [build-chain tool](https://github.com/kiegroup/github-action-build-chain) to handle cross repository builds and be sure that we always use latest version of the code for each repository.
 
[build-chain tool](https://github.com/kiegroup/github-action-build-chain) is a build tool which can be used on command line locally or in Github Actions workflow(s), in case you need to change multiple repositories and send multiple dependent pull requests related with a change you can easily reproduce the same build by executing it on Github hosted environment or locally in your development environment. See [local execution](https://github.com/kiegroup/github-action-build-chain#local-execution) details to get more information about it.
</details>

<details>
<summary>
How to retest this PR or trigger a specific build:
</summary>

- for <b>pull request and downstream checks</b>  
  - Push a new commit to the PR. An empty commit would be enough.

- for a <b>full downstream build</b>
  - for <b>github actions</b> job: add the label `run_fdb`

- for <b>Jenkins PR check only</b>
  - If you are an ASF committer for KIE podling, login to Jenkins (https://ci-builds.apache.org/job/KIE/job/drools/), go to the specific PR job, and click on `Build Now` button.
</details>
