### PR TITLE
[KIE-DROOLS-6190] fix removal of detached tuples during incremental compilation

### DIFF
--- a/drools-core/src/main/java/org/drools/core/common/DefaultFactHandle.java
+++ b/drools-core/src/main/java/org/drools/core/common/DefaultFactHandle.java
@@ -507,30 +507,6 @@ public class DefaultFactHandle extends AbstractLinkedListNode<DefaultFactHandle>
             lastLeftTuple = leftTuple;
         }
 
-        private void addLastTuple(TupleImpl tuple, boolean left) {
-            if (left) {
-                addLastLeftTuple(tuple);
-            } else {
-                addLastRightTuple(tuple);
-            }
-        }
-
-        private void setFirstTuple(TupleImpl tuple, boolean left) {
-            if (left) {
-                firstLeftTuple = tuple;
-            } else {
-                firstRightTuple = tuple;
-            }
-        }
-
-        private void setLastTuple(TupleImpl tuple, boolean left) {
-            if (left) {
-                lastLeftTuple = tuple;
-            } else {
-                lastRightTuple = tuple;
-            }
-        }
-
         @Override
         public void removeLeftTuple( TupleImpl leftTuple ) {
             TupleImpl previous = leftTuple.getHandlePrevious();
@@ -681,21 +657,8 @@ public class DefaultFactHandle extends AbstractLinkedListNode<DefaultFactHandle>
             }
 
             if (detached != null) {
-                if (firstLeftTuple == detached) {
-                    firstLeftTuple = null;
-                }
-
-                if (lastLeftTuple == detached) {
-                    lastLeftTuple = null;
-                }
-
-                if (detached.getHandlePrevious() != null) {
-                    lastLeftTuple = detached.getHandlePrevious();
-                    detached.setHandlePrevious(null);
-                    lastLeftTuple.setHandleNext(null);
-                }
+                removeLeftTuple(detached);
             }
-
             return detached;
         }
 
@@ -709,21 +672,8 @@ public class DefaultFactHandle extends AbstractLinkedListNode<DefaultFactHandle>
             }
 
             if (detached != null) {
-                if (firstRightTuple == detached) {
-                    firstRightTuple = null;
-                }
-
-                if (lastRightTuple == detached) {
-                    lastRightTuple = null;
-                }
-
-                if (detached.getHandlePrevious() != null) {
-                    lastRightTuple = detached.getHandlePrevious();
-                    detached.setHandlePrevious(null);
-                    lastRightTuple.setHandleNext(null);
-                }
+                removeRightTuple(detached);
             }
-
             return detached;
         }
 

--- a/drools-core/src/main/java/org/drools/core/common/DefaultFactHandle.java
+++ b/drools-core/src/main/java/org/drools/core/common/DefaultFactHandle.java
@@ -657,7 +657,20 @@ public class DefaultFactHandle extends AbstractLinkedListNode<DefaultFactHandle>
             }
 
             if (detached != null) {
-                removeLeftTuple(detached);
+                if (firstLeftTuple == detached) {
+                    firstLeftTuple = null;
+                    lastLeftTuple = null;
+                }
+
+                if (lastLeftTuple == detached) {
+                    lastLeftTuple = null;
+                }
+
+                if (detached.getHandlePrevious() != null) {
+                    lastLeftTuple = detached.getHandlePrevious();
+                    detached.setHandlePrevious(null);
+                    lastLeftTuple.setHandleNext(null);
+                }
             }
             return detached;
         }
@@ -672,7 +685,20 @@ public class DefaultFactHandle extends AbstractLinkedListNode<DefaultFactHandle>
             }
 
             if (detached != null) {
-                removeRightTuple(detached);
+                if (firstRightTuple == detached) {
+                    firstRightTuple = null;
+                    lastRightTuple = null;
+                }
+
+                if (lastRightTuple == detached) {
+                    lastRightTuple = null;
+                }
+
+                if (detached.getHandlePrevious() != null) {
+                    lastRightTuple = detached.getHandlePrevious();
+                    detached.setHandlePrevious(null);
+                    lastRightTuple.setHandleNext(null);
+                }
             }
             return detached;
         }

--- a/drools-core/src/main/java/org/drools/core/phreak/EagerPhreakBuilder.java
+++ b/drools-core/src/main/java/org/drools/core/phreak/EagerPhreakBuilder.java
@@ -151,8 +151,6 @@ public class EagerPhreakBuilder implements PhreakBuilder {
             }
         }
 
-        Set<SegmentMemoryPair> smemsToNotify = new HashSet<>();
-
         if (exclBranchRoots.isEmpty()) {
             LeftTupleNode lian = tn.getPathNodes()[0];
             processLeftTuples(lian, false, tn, wms);
@@ -163,7 +161,7 @@ public class EagerPhreakBuilder implements PhreakBuilder {
 
             // Process existing branches from the split  points
             Set<Integer> visited = new HashSet<>();
-            exclBranchRoots.forEach(pair -> Remove.processMerges(pair.parent, tn, kBase, wms, visited, smemsToNotify));
+            exclBranchRoots.forEach(pair -> Remove.processMerges(pair.parent, tn, kBase, wms, visited));
         }
 
         for (InternalWorkingMemory wm : wms) {
@@ -174,8 +172,6 @@ public class EagerPhreakBuilder implements PhreakBuilder {
                 pmem.getRuleAgendaItem().dequeue();
             }
         }
-
-        smemsToNotify.forEach(pair -> pair.sm.notifyRuleLinkSegment(pair.wm));
     }
 
     public static void notifyImpactedSegments(SegmentMemory smem, InternalWorkingMemory wm, Set<SegmentMemoryPair> segmentsToNotify) {
@@ -736,8 +732,7 @@ public class EagerPhreakBuilder implements PhreakBuilder {
             }
         }
 
-
-        private static void processMerges(LeftTupleNode splitNode, TerminalNode tn, InternalRuleBase kBase, Collection<InternalWorkingMemory> wms, Set<Integer> visited, Set<SegmentMemoryPair> smemsToNotify) {
+        private static void processMerges(LeftTupleNode splitNode, TerminalNode tn, InternalRuleBase kBase, Collection<InternalWorkingMemory> wms, Set<Integer> visited) {
             // it's possible for a rule to have multiple exclBranches, pointing to the same parent. So need to ensure it's processed once.
             if ( !visited.add(splitNode.getId())) {
                 return;
@@ -766,10 +761,7 @@ public class EagerPhreakBuilder implements PhreakBuilder {
                 }
 
                 SegmentPrototype proto2 = kBase.getSegmentPrototype(ltn);
-
                 mergeSegments(proto1, proto2, kBase, wms);
-
-                notifyImpactedSegments(wms, proto1, smemsToNotify);
             }
         }
 
@@ -1439,17 +1431,6 @@ public class EagerPhreakBuilder implements PhreakBuilder {
                     }
                 }
                 pmem.setSegmentMemories(newSmems);
-            }
-        }
-    }
-
-    private static void notifyImpactedSegments(Collection<InternalWorkingMemory> wms, SegmentPrototype proto1, Set<SegmentMemoryPair> smemsToNotify) {
-        // any impacted segments must be notified for potential linking
-        for (InternalWorkingMemory wm : wms) {
-            Memory mem1 = wm.getNodeMemories().peekNodeMemory(proto1.getRootNode());
-            if (mem1 != null && mem1.getSegmentMemory() != null) {
-                // there was a split segment, both need notifying.
-                notifyImpactedSegments(mem1.getSegmentMemory(), wm, smemsToNotify);
             }
         }
     }

--- a/drools-core/src/main/java/org/drools/core/phreak/RuleNetworkEvaluator.java
+++ b/drools-core/src/main/java/org/drools/core/phreak/RuleNetworkEvaluator.java
@@ -273,7 +273,7 @@ public class RuleNetworkEvaluator {
             }
 
             boolean emptySrcTuples = srcTuples.isEmpty();
-            if ( !(NodeTypeEnums.isBetaNode(node) && ((BetaNode)node).isRightInputIsRiaNode() ) ) {
+            if ( !(NodeTypeEnums.isBetaNode(node) && node.isRightInputIsRiaNode() ) ) {
                 // The engine cannot skip a ria node, as the dirty might be several levels deep
                 if ( emptySrcTuples && smem.getDirtyNodeMask() == 0) {
                     // empty sources and segment is not dirty, skip to non empty src tuples or dirty segment.

--- a/drools-core/src/main/java/org/drools/core/reteoo/ReteooBuilder.java
+++ b/drools-core/src/main/java/org/drools/core/reteoo/ReteooBuilder.java
@@ -193,9 +193,7 @@ public class ReteooBuilder
 
         tn.visitLeftTupleNodes(n -> n.removeAssociatedTerminal(tn));
 
-        BaseNode node = (BaseNode) tn;
-        removeNodeAssociation(node, context.getRule(), new HashSet<>(), context);
-
+        removeNodeAssociation((BaseNode) tn, context.getRule(), new HashSet<>(), context);
         resetMasks(removeNodes((AbstractTerminalNode)tn, workingMemories, context));
     }
 

--- a/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/compiler/integrationtests/incrementalcompilation/AddRemoveGenerated2RulesEvalTest.java
+++ b/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/compiler/integrationtests/incrementalcompilation/AddRemoveGenerated2RulesEvalTest.java
@@ -22,7 +22,6 @@ import java.util.stream.Stream;
 
 import org.junit.jupiter.api.Disabled;
 
-@Disabled("It gets stuck. See issue #6190")
 public class AddRemoveGenerated2RulesEvalTest extends AbstractAddRemoveGenerated2RulesTest {
 
     public static Stream<ConstraintsPair> parameters() {

--- a/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/compiler/integrationtests/incrementalcompilation/AddRemoveGenerated2RulesIntegerTest.java
+++ b/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/compiler/integrationtests/incrementalcompilation/AddRemoveGenerated2RulesIntegerTest.java
@@ -22,7 +22,6 @@ import java.util.stream.Stream;
 
 import org.junit.jupiter.api.Disabled;
 
-@Disabled("It gets stuck. See issue #6190")
 public class AddRemoveGenerated2RulesIntegerTest extends AbstractAddRemoveGenerated2RulesTest {
 
     public static Stream<ConstraintsPair> parameters() {

--- a/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/compiler/integrationtests/incrementalcompilation/AddRemoveGenerated2RulesMapContainsTest.java
+++ b/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/compiler/integrationtests/incrementalcompilation/AddRemoveGenerated2RulesMapContainsTest.java
@@ -22,7 +22,6 @@ import java.util.stream.Stream;
 
 import org.junit.jupiter.api.Disabled;
 
-@Disabled("It gets stuck. See issue #6190")
 public class AddRemoveGenerated2RulesMapContainsTest extends AbstractAddRemoveGenerated2RulesTest {
 
     public static Stream<ConstraintsPair> parameters() {

--- a/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/compiler/integrationtests/incrementalcompilation/AddRemoveGenerated2RulesNotNotTest.java
+++ b/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/compiler/integrationtests/incrementalcompilation/AddRemoveGenerated2RulesNotNotTest.java
@@ -22,7 +22,6 @@ import java.util.stream.Stream;
 
 import org.junit.jupiter.api.Disabled;
 
-@Disabled("It gets stuck. See issue #6190")
 public class AddRemoveGenerated2RulesNotNotTest extends AbstractAddRemoveGenerated2RulesTest {
 
     public static Stream<ConstraintsPair> parameters() {

--- a/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/compiler/integrationtests/incrementalcompilation/AddRemoveGenerated2RulesNotTest.java
+++ b/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/compiler/integrationtests/incrementalcompilation/AddRemoveGenerated2RulesNotTest.java
@@ -22,7 +22,6 @@ import java.util.stream.Stream;
 
 import org.junit.jupiter.api.Disabled;
 
-@Disabled("It gets stuck. See issue #6190")
 public class AddRemoveGenerated2RulesNotTest extends AbstractAddRemoveGenerated2RulesTest {
 
     public static Stream<ConstraintsPair> parameters() {

--- a/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/compiler/integrationtests/incrementalcompilation/AddRemoveGenerated2RulesStringIntegerTest.java
+++ b/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/compiler/integrationtests/incrementalcompilation/AddRemoveGenerated2RulesStringIntegerTest.java
@@ -22,7 +22,6 @@ import java.util.stream.Stream;
 
 import org.junit.jupiter.api.Disabled;
 
-@Disabled("It gets stuck. See issue #6190")
 public class AddRemoveGenerated2RulesStringIntegerTest extends AbstractAddRemoveGenerated2RulesTest {
 
     public static Stream<ConstraintsPair> parameters() {

--- a/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/compiler/integrationtests/incrementalcompilation/AddRemoveGenerated2RulesStringTest.java
+++ b/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/compiler/integrationtests/incrementalcompilation/AddRemoveGenerated2RulesStringTest.java
@@ -22,7 +22,6 @@ import java.util.stream.Stream;
 
 import org.junit.jupiter.api.Disabled;
 
-@Disabled("It gets stuck. See issue #6190")
 public class AddRemoveGenerated2RulesStringTest extends AbstractAddRemoveGenerated2RulesTest {
 
     public static Stream<ConstraintsPair> parameters() {

--- a/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/compiler/integrationtests/incrementalcompilation/CasesFromGeneratedRulesTest.java
+++ b/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/compiler/integrationtests/incrementalcompilation/CasesFromGeneratedRulesTest.java
@@ -1,0 +1,37 @@
+package org.drools.compiler.integrationtests.incrementalcompilation;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
+
+public class CasesFromGeneratedRulesTest {
+
+    @Test
+    @Timeout(40000)
+    public void testInsertFactsFireRulesRemoveRulesReinsertRulesRevertedRules() {
+        String rule1 = """
+                package com.rules;
+                global java.util.List list
+                rule R1
+                 when
+                  Integer()
+                 then
+                 list.add('R1');
+                end
+                """;
+
+        String rule2 = """
+                package com.rules;
+                global java.util.List list
+                rule R2
+                 when
+                  Integer()
+                 exists(Integer() and Integer())
+                 exists(Integer() and Integer())
+                 then
+                 list.add('R2');
+                end
+                """;
+
+        AddRemoveTestCases.insertFactsFireRulesRemoveRulesReinsertRules1(rule1, rule2, TestUtil.RULE1_NAME, TestUtil.RULE2_NAME, null, 1, 2);
+    }
+}

--- a/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/compiler/integrationtests/incrementalcompilation/CasesFromGeneratedRulesTest.java
+++ b/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/compiler/integrationtests/incrementalcompilation/CasesFromGeneratedRulesTest.java
@@ -1,3 +1,21 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
 package org.drools.compiler.integrationtests.incrementalcompilation;
 
 import org.junit.jupiter.api.Test;

--- a/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/compiler/integrationtests/incrementalcompilation/CasesFromGeneratedRulesTest.java
+++ b/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/compiler/integrationtests/incrementalcompilation/CasesFromGeneratedRulesTest.java
@@ -52,4 +52,36 @@ public class CasesFromGeneratedRulesTest {
 
         AddRemoveTestCases.insertFactsFireRulesRemoveRulesReinsertRules1(rule1, rule2, TestUtil.RULE1_NAME, TestUtil.RULE2_NAME, null, 1, 2);
     }
+
+    @Test
+    @Timeout(40000)
+    public void testInsertFactsRemoveRulesFireRulesRemoveRules() {
+        String rule1 = """
+                package com.rules;
+                global java.util.List list
+                rule R1
+                 when
+                  exists(Integer())
+                  not(Double() and Double())
+                  Integer() not(Double() and Double())
+                 then
+                 list.add('R1');
+                end
+                """;
+
+        String rule2 = """
+                package com.rules;
+                global java.util.List list
+                rule R2
+                 when
+                  exists(Integer())
+                  not(Double() and Double())
+                  exists(Integer())
+                 then
+                 list.add('R2');
+                end
+                """;
+
+        AddRemoveTestCases.insertFactsRemoveRulesFireRulesRemoveRules2(rule1, rule2, TestUtil.RULE1_NAME, TestUtil.RULE2_NAME, null, 1);
+    }
 }


### PR DESCRIPTION
Fixes https://github.com/apache/incubator-kie-drools/issues/6190

There are a few other incremental compilation tests that are failing for a totally unrelated reason and anyway without causing any endless loop. I left them disabled and I will keep investigating and fix them with a subsequent pull request.