### PR TITLE
[DO-NOT-MERGE] Experiment a special prefix for Custom Operator

### DIFF
--- a/.github/workflows/pr-downstream.yml
+++ b/.github/workflows/pr-downstream.yml
@@ -33,6 +33,7 @@ on:
 
 jobs:
   kogito-downstream-build:
+    if: false
     concurrency:
       group: pr-${{ matrix.job_name }}_${{ matrix.os }}_${{ matrix.java-version }}_${{ matrix.maven-version }}_${{ github.head_ref }}
       cancel-in-progress: true

--- a/.github/workflows/pr-drools.yml
+++ b/.github/workflows/pr-drools.yml
@@ -61,7 +61,7 @@ jobs:
       - name: Build Chain
         uses: apache/incubator-kie-kogito-pipelines/.ci/actions/build-chain@main
         env:
-          BUILD_MVN_OPTS_CURRENT: '-Dfull -Dreproducible'
+          BUILD_MVN_OPTS_CURRENT: '-Dfull -Dreproducible -DenableNewParser'
           MAVEN_OPTS: "-Dfile.encoding=UTF-8"
         with:
           definition-file: https://raw.githubusercontent.com/${GROUP:apache}/incubator-kie-kogito-pipelines/${BRANCH:main}/.ci/pull-request-config.yaml

--- a/drools-drl/drools-drl-ast/src/main/java/org/drools/drl/ast/descr/OperatorDescr.java
+++ b/drools-drl/drools-drl-ast/src/main/java/org/drools/drl/ast/descr/OperatorDescr.java
@@ -26,6 +26,9 @@ import java.util.List;
 public class OperatorDescr extends BaseDescr {
     private static final long serialVersionUID = 520l;
 
+    // prefix for custom operators which are not built-in
+    public static final String CUSTOM_OPERATOR_PREFIX = "##";
+
     private String            operator;
     private boolean           negated;
     private List<String>      parameters;
@@ -55,7 +58,15 @@ public class OperatorDescr extends BaseDescr {
     }
 
     public void setOperator( String operator ) {
-        this.operator = operator != null ? operator.trim() : null;
+        this.operator = operator != null ? trimOperator(operator) : null;
+    }
+
+    private String trimOperator(String operator) {
+        operator = operator.trim();
+        if (operator.startsWith(CUSTOM_OPERATOR_PREFIX)) {
+            operator = operator.substring(CUSTOM_OPERATOR_PREFIX.length());
+        }
+        return operator;
     }
 
     public boolean isNegated() {

--- a/drools-drl/drools-drl-parser-tests/src/test/java/org/drools/drl/parser/antlr4/DRLExprParserTest.java
+++ b/drools-drl/drools-drl-parser-tests/src/test/java/org/drools/drl/parser/antlr4/DRLExprParserTest.java
@@ -458,7 +458,7 @@ class DRLExprParserTest {
             assertThat(exception.getColumn()).isEqualTo(2);
             assertThat(exception.getOffset()).isEqualTo(2);
             assertThat(exception.getMessage())
-                    .isEqualToIgnoringCase("[ERR 101] Line 1:2 no viable alternative at input 'a'");
+                    .isEqualToIgnoringCase("[ERR 101] Line 1:2 no viable alternative at input '~a'");
         } else {
             assertThat(parser.hasErrors()).isFalse();
         }

--- a/drools-drl/drools-drl-parser-tests/src/test/java/org/drools/drl/parser/antlr4/ParserTestUtils.java
+++ b/drools-drl/drools-drl-parser-tests/src/test/java/org/drools/drl/parser/antlr4/ParserTestUtils.java
@@ -55,6 +55,13 @@ public class ParserTestUtils {
         DrlParser.ANTLR4_PARSER_ENABLED = false;
     }
 
+    /**
+     * Enables the new parser. Just for quick testing purposes.
+     */
+    public static void enableNewParser() {
+        DrlParser.ANTLR4_PARSER_ENABLED = true;
+    }
+
     public static List<String> javaKeywords() {
         return javaKeywords;
     }

--- a/drools-drl/drools-drl-parser/src/main/antlr4/org/drools/drl/parser/antlr4/DRL6Expressions.g4
+++ b/drools-drl/drools-drl-parser/src/main/antlr4/org/drools/drl/parser/antlr4/DRL6Expressions.g4
@@ -1000,12 +1000,11 @@ in_key
     ;
 
 operator_key
-  // IDENTIFIER is required to accept custom operators. We need to keep this semantic predicate for custom operators
-  :      {(helper.isPluggableEvaluator(false))}? id=IDENTIFIER { helper.emit($id, DroolsEditorType.KEYWORD); }
+  :      DRL_CUSTOM_OPERATOR_PREFIX {(helper.isPluggableEvaluator(false))}? id=IDENTIFIER { helper.emit($id, DroolsEditorType.KEYWORD); }
   |      op=builtInOperator { helper.emit($op.token, DroolsEditorType.KEYWORD); }
   ;
 
 neg_operator_key
-  :      {(helper.isPluggableEvaluator(true))}? id=IDENTIFIER { helper.emit($id, DroolsEditorType.KEYWORD); }
+  :      DRL_CUSTOM_OPERATOR_PREFIX {(helper.isPluggableEvaluator(true))}? id=IDENTIFIER { helper.emit($id, DroolsEditorType.KEYWORD); }
   |      op=builtInOperator { helper.emit($op.token, DroolsEditorType.KEYWORD); }
   ;

--- a/drools-drl/drools-drl-parser/src/main/antlr4/org/drools/drl/parser/antlr4/DRLLexer.g4
+++ b/drools-drl/drools-drl-parser/src/main/antlr4/org/drools/drl/parser/antlr4/DRLLexer.g4
@@ -125,6 +125,8 @@ DRL_CALENDARS : 'calendars';
 DRL_TIMER : 'timer';
 DRL_DURATION : 'duration';
 
+DRL_CUSTOM_OPERATOR_PREFIX : '##' ;
+
 /////////////////
 // LEXER
 /////////////////

--- a/drools-model/drools-mvel-parser/src/main/java/org/drools/mvel/parser/TokenTypes.java
+++ b/drools-model/drools-mvel-parser/src/main/java/org/drools/mvel/parser/TokenTypes.java
@@ -213,6 +213,7 @@ public class TokenTypes {
             case COMMA:
             case DOT:
             case AT:
+            case CUSTOM_OPERATOR_PREFIX:
                 return JavaToken.Category.SEPARATOR;
             case MVEL_STARTS_WITH:
             case MVEL_ENDS_WITH:

--- a/drools-model/drools-mvel-parser/src/main/javacc/mvel.jj
+++ b/drools-model/drools-mvel-parser/src/main/javacc/mvel.jj
@@ -425,6 +425,7 @@ TOKEN :
 | < MVEL_ENDS_WITH: "str[endsWith]" >
 | < MVEL_LENGTH: "str[length]" >
 | < DOT_DOT_SLASH: "../" >
+| < CUSTOM_OPERATOR_PREFIX: "##" >
 | < HASHMARK: "#" >
 | < EXCL_DOT: "!." >
 | < PASSIVE_OOPATH: "?/" >
@@ -6419,6 +6420,7 @@ Expression PointFreeExpr():
                           { negated = true; }
             )*
             (
+                [ <CUSTOM_OPERATOR_PREFIX> ]
                 operator = SimpleName()
                 temporalLiteralArguments = TemporalLiteralArguments()
                 (

--- a/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/compiler/integrationtests/CustomOperatorOnlyDrlTest.java
+++ b/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/compiler/integrationtests/CustomOperatorOnlyDrlTest.java
@@ -74,7 +74,7 @@ public class CustomOperatorOnlyDrlTest {
                         "when\n" +
                         "   gnId : GN()\n" +
                         "   la : t547147( )\n" +
-                        "   v1717 : Tra48( gnId.gNo == gNo, name F_str[startsWith] la.c547148 || postCode F_str[contains] la.c547149 )\n" +
+                        "   v1717 : Tra48( gnId.gNo == gNo, name ##F_str[startsWith] la.c547148 || postCode ##F_str[contains] la.c547149 )\n" +
                         "then\n" +
                         "end\n";
 

--- a/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/compiler/integrationtests/CustomOperatorTest.java
+++ b/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/compiler/integrationtests/CustomOperatorTest.java
@@ -58,7 +58,16 @@ public class CustomOperatorTest {
     public void testCustomOperatorUsingCollections(KieBaseTestConfiguration kieBaseTestConfiguration) {
         String constraints =
                 "    $alice : Person(name == \"Alice\")\n" +
-                "    $bob : Person(name == \"Bob\", addresses supersetOf $alice.addresses)\n";
+                "    $bob : Person(name == \"Bob\", addresses ##supersetOf $alice.addresses)\n";
+        customOperatorUsingCollections(kieBaseTestConfiguration, constraints);
+    }
+
+    @ParameterizedTest(name = "KieBase type={0}")
+    @MethodSource("parameters")
+    public void testCustomOperatorUsingCollectionsWithNot(KieBaseTestConfiguration kieBaseTestConfiguration) {
+        String constraints =
+                "    $alice : Person(name == \"Alice\")\n" +
+                        "    $bob : Person(name == \"Bob\", $alice.addresses not ##supersetOf this.addresses)\n";
         customOperatorUsingCollections(kieBaseTestConfiguration, constraints);
     }
 
@@ -67,8 +76,8 @@ public class CustomOperatorTest {
     public void testNoOperatorInstancesCreatedAtRuntime(KieBaseTestConfiguration kieBaseTestConfiguration) {
         String constraints =
                 "    $alice : Person(name == \"Alice\")\n" +
-                "    $bob : Person(name == \"Bob\", addresses supersetOf $alice.addresses)\n" +
-                "    Person(name == \"Bob\", addresses supersetOf $alice.addresses)\n";
+                "    $bob : Person(name == \"Bob\", addresses ##supersetOf $alice.addresses)\n" +
+                "    Person(name == \"Bob\", addresses ##supersetOf $alice.addresses)\n";
 
         customOperatorUsingCollections(kieBaseTestConfiguration, constraints);
 
@@ -81,7 +90,7 @@ public class CustomOperatorTest {
         // DROOLS-6983
         String constraints =
                 "    $bob : Person(name == \"Bob\")\n" +
-                "    $alice : Person(name == \"Alice\", $bob.addresses supersetOf this.addresses)\n";
+                "    $alice : Person(name == \"Alice\", $bob.addresses ##supersetOf this.addresses)\n";
         customOperatorUsingCollections(kieBaseTestConfiguration, constraints);
     }
 
@@ -201,7 +210,7 @@ public class CustomOperatorTest {
         }
 
         public boolean evaluateAll(final Collection leftCollection, final Collection rightCollection) {
-            return rightCollection.containsAll(leftCollection);
+            return getOperator().isNegated() ^ rightCollection.containsAll(leftCollection);
         }
     }
 
@@ -212,7 +221,7 @@ public class CustomOperatorTest {
                 "import " + Person.class.getCanonicalName() + ";\n" +
                 "rule R when\n" +
                 "    $alice : Person(name == \"Alice\")\n" +
-                "    $bob : Person(name == \"Bob\", addresses supersetOf $alice.addresses)\n" +
+                "    $bob : Person(name == \"Bob\", addresses ##supersetOf $alice.addresses)\n" +
                 "then\n" +
                 "end\n";
 

--- a/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/integrationtests/Misc2Test.java
+++ b/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/integrationtests/Misc2Test.java
@@ -9060,7 +9060,7 @@ public class Misc2Test {
                         "import " + Person.class.getCanonicalName() + ";\n" +
                         "rule R when\n" +
                         "    $alice : Person(name == \"Alice\")\n" +
-                        "    $bob : Person(name == \"Bob\", addresses supersetOf $alice.addresses)\n" +
+                        "    $bob : Person(name == \"Bob\", addresses ##supersetOf $alice.addresses)\n" +
                         "then\n" +
                         "end\n";
 

--- a/drools-test-coverage/test-compiler-integration/src/test/resources/logback-test.xml
+++ b/drools-test-coverage/test-compiler-integration/src/test/resources/logback-test.xml
@@ -34,7 +34,7 @@
 <!--     <logger name="org.drools.core.management" level="debug"/> -->
 <!--    <logger name="org.drools.modelcompiler.builder" level="debug"/>-->
 <!--    <logger name="org.drools.ancompiler" level="debug"/>-->
-<!--    <logger name="org.drools.drl.parser.DrlParser" level="debug"/>-->
+    <logger name="org.drools.drl.parser.DrlParser" level="debug"/>
 
     <root level="warn">
         <appender-ref ref="consoleAppender" />

--- a/drools-traits/src/test/java/org/drools/traits/compiler/factmodel/traits/LegacyTraitTest.java
+++ b/drools-traits/src/test/java/org/drools/traits/compiler/factmodel/traits/LegacyTraitTest.java
@@ -241,7 +241,7 @@ public class LegacyTraitTest extends CommonTraitTest {
 
                         "rule 'Bar Don'" +
                         "when " +
-                        "   $b : BarImpl(this isA Foo.class, this not isA Foo2.class)\n" +
+                        "   $b : BarImpl(this ##isA Foo.class, this not ##isA Foo2.class)\n" +
                         "   String()\n" +
                         "then " +
                         "   list.add(3); " +

--- a/drools-traits/src/test/java/org/drools/traits/compiler/factmodel/traits/LogicalTraitTest.java
+++ b/drools-traits/src/test/java/org/drools/traits/compiler/factmodel/traits/LogicalTraitTest.java
@@ -127,7 +127,7 @@ public class LogicalTraitTest extends CommonTraitTest {
                      "" +
                      "rule Check \n" +
                      "when \n" +
-                     "  X( fld isA T ) \n" +
+                     "  X( fld ##isA T ) \n" +
                      "then \n" +
                      "  list.add( \"ok\" );" +
                      "end \n";
@@ -194,14 +194,14 @@ public class LogicalTraitTest extends CommonTraitTest {
                      "rule Check \n" +
                      "salience 1 \n" +
                      "when \n" +
-                     "  $x : Y( fld isA T ) \n" +
+                     "  $x : Y( fld ##isA T ) \n" +
                      "then \n" +
                      "  list.add( \"ok1\" );" +
                      "end \n" +
                      "" +
                      "rule Check2 \n" +
                      "when \n" +
-                     "  $x : X( fld isA T ) \n" +
+                     "  $x : X( fld ##isA T ) \n" +
                      "then \n" +
                      "  list.add( \"ok2\" );" +
                      "end \n" +
@@ -271,7 +271,7 @@ public class LogicalTraitTest extends CommonTraitTest {
                      "rule Check \n" +
                      "salience 1 \n" +
                      "when \n" +
-                     "  $x : Y( fld isA B, fld isA A ) \n" +
+                     "  $x : Y( fld ##isA B, fld ##isA A ) \n" +
                      "then \n" +
                      "  list.add( \"ok\" ); \n" +
                      "end \n" +
@@ -729,7 +729,7 @@ public class LogicalTraitTest extends CommonTraitTest {
                      "rule Check \n" +
                      "salience 1 \n" +
                      "when \n" +
-                     "  $x : Pers( friend isA VIP ) \n" +
+                     "  $x : Pers( friend ##isA VIP ) \n" +
                      "then \n" +
                      "  list.add( \"ok1\" );" +
                      "end \n" +
@@ -809,7 +809,7 @@ public class LogicalTraitTest extends CommonTraitTest {
                      "rule Check \n" +
                      "salience 1 \n" +
                      "when \n" +
-                     "  $x : K( fld isA S, fld not isA R ) \n" +
+                     "  $x : K( fld ##isA S, fld not ##isA R ) \n" +
                      "then \n" +
                      "  list.add( \"ok1\" );" +
                      "end \n" +
@@ -818,7 +818,7 @@ public class LogicalTraitTest extends CommonTraitTest {
                      "salience 1 \n" +
                      "when \n" +
                      "  String() \n" +
-                     "  $x : K( fld isA S ) \n" +
+                     "  $x : K( fld ##isA S ) \n" +
                      "then \n" +
                      "  don( $x, U.class ); \n" +
                      "end \n" +
@@ -907,7 +907,7 @@ public class LogicalTraitTest extends CommonTraitTest {
                      "" +
                      "rule Check \n" +
                      "when \n" +
-                     "  $x : X( this isA V, fld isA T ) \n" +
+                     "  $x : X( this ##isA V, fld ##isA T ) \n" +
                      "then \n" +
                      "  shed( $x, V.class ); \n" +
                      "  list.add( \"ok\" );" +
@@ -927,7 +927,7 @@ public class LogicalTraitTest extends CommonTraitTest {
                      "salience 5 \n" +
                      "when \n" +
                      "  String( this == \"go2\" ) \n" +
-                     "  K( this isA Q ) \n" +
+                     "  K( this ##isA Q ) \n" +
                      "  not X() not V() " +
                      "then \n" +
                      "  list.add( \"ok3\" );" +

--- a/drools-traits/src/test/java/org/drools/traits/compiler/factmodel/traits/TraitFieldsAndLegacyClassesTest.java
+++ b/drools-traits/src/test/java/org/drools/traits/compiler/factmodel/traits/TraitFieldsAndLegacyClassesTest.java
@@ -23,6 +23,7 @@ import java.util.Arrays;
 import java.util.Collection;
 import java.util.List;
 
+import org.drools.drl.parser.DrlParser;
 import org.drools.traits.compiler.CommonTraitTest;
 import org.drools.traits.compiler.ReviseTraitTestWithPRAlwaysCategory;
 import org.drools.traits.core.factmodel.TraitFactoryImpl;
@@ -182,7 +183,7 @@ public class TraitFieldsAndLegacyClassesTest extends CommonTraitTest {
 
                      "rule \"test parent and child traits\" \n" +
                      "when\n" +
-                     "    $p : ParentTrait( $c : child isA ChildTrait.class )\n" +
+                     "    $p : ParentTrait( $c : child ##isA ChildTrait.class )\n" +
                      "then\n" +
                      "   //shed ( $p , ParentTrait.class );\n"+
                      "   list.add(\"correct\");\n"+
@@ -270,7 +271,7 @@ public class TraitFieldsAndLegacyClassesTest extends CommonTraitTest {
                      "when\n" +
                      "   $c : Child( gender == \"male\" )\n" +
                      "   $p : Parent( name == \"parent\" )\n" +
-                     "   ParentTrait( child not isA ChildTrait.class )\n" +
+                     "   ParentTrait( child not ##isA ChildTrait.class )\n" +
                      "   ChildTrait()\n"+
                      "then\n" +
                      "   " +
@@ -282,7 +283,7 @@ public class TraitFieldsAndLegacyClassesTest extends CommonTraitTest {
 
                      "rule \"test parent and child traits\" \n" +
                      "when\n" +
-                     "    $p : ParentTrait( child isA ChildTrait.class )\n" +
+                     "    $p : ParentTrait( child ##isA ChildTrait.class )\n" +
                      "then\n" +
                      "   //shed ( $p , ParentTrait.class );\n"+
                      "   list.add(\"correct\");\n"+
@@ -369,7 +370,7 @@ public class TraitFieldsAndLegacyClassesTest extends CommonTraitTest {
                      "when\n" +
                      "   Child( gender == \"male\" )\n" +
                      "   $p : Parent( name == \"parent\" )\n" +
-                     "   ParentTrait( child not isA ChildTrait.class )\n" +
+                     "   ParentTrait( child not ##isA ChildTrait.class )\n" +
                      "   $c : ChildTrait()\n"+             //<<<<<
                      "then\n" +
                      "   $p.setChild((Child)$c.getCore());\n"+     //<<<<<
@@ -379,7 +380,7 @@ public class TraitFieldsAndLegacyClassesTest extends CommonTraitTest {
 
                      "rule \"test parent and child traits\" \n" +
                      "when\n" +
-                     "    $p : ParentTrait( child isA ChildTrait.class )\n" +
+                     "    $p : ParentTrait( child ##isA ChildTrait.class )\n" +
                      "then\n" +
                      "   //shed ( $p , ParentTrait.class );\n"+
                      "   list.add(\"correct\");\n"+
@@ -448,7 +449,7 @@ public class TraitFieldsAndLegacyClassesTest extends CommonTraitTest {
 
                      "rule \"trait child\" \n" +
                      "when\n" +
-                     "   $p : Parent( $c := child not isA ChildTrait )\n"+
+                     "   $p : Parent( $c := child not ##isA ChildTrait )\n"+
                      "   $c := Child( gender == \"male\" )\n" +
                      "then\n" +
                      "   ChildTrait c = don ( $c , ChildTrait.class );\n" +
@@ -460,7 +461,7 @@ public class TraitFieldsAndLegacyClassesTest extends CommonTraitTest {
 
                      "rule \"test parent and a child trait\" \n" +
                      "when\n" +
-                     "    $p : Parent( child isA ChildTrait.class ) \n" +    //<<<<<
+                     "    $p : Parent( child ##isA ChildTrait.class ) \n" +    //<<<<<
                      "then\n" +
                      "   list.add(\"correct\");\n"+
                      "end\n"+
@@ -545,7 +546,7 @@ public class TraitFieldsAndLegacyClassesTest extends CommonTraitTest {
                      "rule \"test parent and child traits\" \n" +
                      "\n" +
                      "when\n" +
-                     "    $p : ParentTrait( $c : child isA ChildTrait.class ) \n" +     //<<<<<
+                     "    $p : ParentTrait( $c : child ##isA ChildTrait.class ) \n" +     //<<<<<
                      "then\n" +
                      "   list.add(\"correct\");\n"+
                      "end\n"+
@@ -627,14 +628,14 @@ public class TraitFieldsAndLegacyClassesTest extends CommonTraitTest {
                      "" +
                      "rule \"Side effect\" \n" +
                      "when \n" +
-                     "  $p : Parent( child isA ChildTrait ) \n" +
+                     "  $p : Parent( child ##isA ChildTrait ) \n" +
                      "then \n" +
                      "   list.add(\"correct2\");\n"+
                      "end \n"+
                      "rule \"test parent and child traits\" \n" +
                      "\n" +
                      "when\n" +
-                     "    $p : ParentTrait( child isA ChildTrait.class )\n" +
+                     "    $p : ParentTrait( child ##isA ChildTrait.class )\n" +
                      "then\n" +
                      "   //shed ( $p , ParentTrait.class );\n"+
                      "   list.add(\"correct\");\n"+
@@ -720,7 +721,7 @@ public class TraitFieldsAndLegacyClassesTest extends CommonTraitTest {
                      "\n" +
                      "when\n" +
 //                     "   $c : Child( $gender := gender )\n"+
-                     "   $p : ParentTrait( child isA ChildTrait )\n" +    //<<<<<
+                     "   $p : ParentTrait( child ##isA ChildTrait )\n" +    //<<<<<
                      "then\n" +
                      "   list.add(\"correct\");\n"+
                      "end\n"+
@@ -805,7 +806,7 @@ public class TraitFieldsAndLegacyClassesTest extends CommonTraitTest {
                      "rule \"test parent and child traits\" \n" +
                      "\n" +
                      "when\n" +
-                     "    $p : ParentTrait( child isA ChildTrait.class )\n" +
+                     "    $p : ParentTrait( child ##isA ChildTrait.class )\n" +
                      "then\n" +
                      "   //shed ( $p , ParentTrait.class );\n"+
                      "   list.add(\"correct\");\n"+
@@ -885,8 +886,8 @@ public class TraitFieldsAndLegacyClassesTest extends CommonTraitTest {
                      "rule \"trait and assign the child\" \n" +
                      "\n" +
                      "when\n" +
-                     "   $c : Child( gender == \"male\", this not isA ChildTrait )\n" +
-                     "   $p : Parent( this isA ParentTrait )\n" +
+                     "   $c : Child( gender == \"male\", this not ##isA ChildTrait )\n" +
+                     "   $p : Parent( this ##isA ParentTrait )\n" +
                      "then\n" +
                      "   ChildTrait c =  don ( $c , ChildTrait.class );\n"+   //<<<<<<
                      "   modify($p){\n"+
@@ -897,7 +898,7 @@ public class TraitFieldsAndLegacyClassesTest extends CommonTraitTest {
                      "rule \"test parent and child traits\" \n" +
                      "\n" +
                      "when\n" +
-                     "    $p : ParentTrait( child isA ChildTrait.class, child.gender == \"male\" )\n" +    //<<<<<
+                     "    $p : ParentTrait( child ##isA ChildTrait.class, child.gender == \"male\" )\n" +    //<<<<<
                      "then\n" +
                      "   //shed ( $p , ParentTrait.class );\n"+
                      "   list.add(\"correct\");\n"+
@@ -978,8 +979,8 @@ public class TraitFieldsAndLegacyClassesTest extends CommonTraitTest {
                      "rule \"trait and assign the child\" \n" +
                      "\n" +
                      "when\n" +
-                     "   $c : Child( gender == \"male\", this not isA ChildTrait )\n" +
-                     "   $p : Parent( this isA ParentTrait )\n" +
+                     "   $c : Child( gender == \"male\", this not ##isA ChildTrait )\n" +
+                     "   $p : Parent( this ##isA ParentTrait )\n" +
                      "then\n" +
                      "   ChildTrait c =  don ( $c , ChildTrait.class );\n"+   //<<<<<<
                      "   modify($p){\n"+
@@ -1103,7 +1104,7 @@ public class TraitFieldsAndLegacyClassesTest extends CommonTraitTest {
                      "rule \"test three traits\" \n" +
                      "\n" +
                      "when\n" +
-                     "   $p : FatherTrait( this isA ParentTrait, this isA GrandParentTrait )\n" +    //<<<<<
+                     "   $p : FatherTrait( this ##isA ParentTrait, this ##isA GrandParentTrait )\n" +    //<<<<<
                      "then\n" +
                      "   list.add(\"correct\");\n"+
                      "end\n"+

--- a/drools-traits/src/test/java/org/drools/traits/compiler/factmodel/traits/TraitMapCoreTest.java
+++ b/drools-traits/src/test/java/org/drools/traits/compiler/factmodel/traits/TraitMapCoreTest.java
@@ -234,7 +234,7 @@ public class TraitMapCoreTest extends CommonTraitTest {
                         "rule Last  \n" +
                         "salience -99 \n" +
                         "when  \n" +
-                        "  $m : Map( this not isA StudentMap.class )\n" +
+                        "  $m : Map( this not ##isA StudentMap.class )\n" +
                         "then  \n" +
                         "   $m.put( \"final\", true );" +
                         "\n" +
@@ -451,7 +451,7 @@ public class TraitMapCoreTest extends CommonTraitTest {
                 "salience 1\n" +
                 "no-loop\n" +
                 "when\n" +
-                "    $map : Map($stu : this[\"worker\"] isA Student.class)\n" +
+                "    $map : Map($stu : this[\"worker\"] ##isA Student.class)\n" +
                 "then\n" +
                 "    Object obj = don( $map , Worker.class );\n" +
                 "    list.add(\"worker is donned\");\n" +
@@ -536,7 +536,7 @@ public class TraitMapCoreTest extends CommonTraitTest {
                 "salience 1\n" +
                 "no-loop\n" +
                 "when\n" +
-                "    $map : Map($stu : this[\"worker\"], $stu isA Student.class)\n" +
+                "    $map : Map($stu : this[\"worker\"], $stu ##isA Student.class)\n" +
                 "then\n" +
                 "    Object obj = don( $map , Worker.class );\n" +
                 "    list.add(\"worker is donned\");\n" +
@@ -629,7 +629,7 @@ public class TraitMapCoreTest extends CommonTraitTest {
                 "no-loop\n" +
                 "when\n" +
                 "    $map : Map($stu : this[\"worker\"])\n" +
-                "    Map($stu isA Student.class, this == $map)\n" +
+                "    Map($stu ##isA Student.class, this == $map)\n" +
                 "then\n" +
                 "    Object obj = don( $map , Worker.class );\n" +
                 "    list.add(\"worker is donned\");\n" +

--- a/drools-traits/src/test/java/org/drools/traits/compiler/factmodel/traits/TraitTest.java
+++ b/drools-traits/src/test/java/org/drools/traits/compiler/factmodel/traits/TraitTest.java
@@ -869,7 +869,7 @@ public class TraitTest extends CommonTraitTest {
                         "rule \"Worker Students v6\"\n" +
                         "when\n" +
                         "    $x2 := Person(name == \"john\")\n" +
-                        "    $x1 := Worker(core != $x2.core, this not isA $x2)\n" +
+                        "    $x1 := Worker(core != $x2.core, this not ##isA $x2)\n" +
                         "then\n" +
                         "    list.add(\"ok\");\n" +
                         "end\n" +
@@ -1272,7 +1272,7 @@ public class TraitTest extends CommonTraitTest {
                      "\n" +
                      "rule \"print student\"\n" +
                      "  when\n" +
-                     "    student : Person(this isA Student)\n" +
+                     "    student : Person(this ##isA Student)\n" +
                      "  then" +
                      "    list.add(1);\n" +
                      "end\n" +
@@ -1734,7 +1734,7 @@ public class TraitTest extends CommonTraitTest {
                      "rule \"Check\" \n" +
                      "no-loop \n" +
                      "when \n" +
-                     "  $p : IPerson(this isA IStudent) \n" +
+                     "  $p : IPerson(this ##isA IStudent) \n" +
                      "then \n" +
                      "   modify ($p) { setAge(37); } \n" +
                      "   shed($p, IStudent.class);\n" +
@@ -2167,7 +2167,7 @@ public class TraitTest extends CommonTraitTest {
                     "" +
                     "rule \"Log W\" \n" +
                     "when \n" +
-                    "  $t : Worker(this isA StudentWorker) @watch(name) \n" +
+                    "  $t : Worker(this ##isA StudentWorker) @watch(name) \n" +
                     "then \n" +
                     "  list.add(true); \n" +
                     "end \n" +
@@ -2515,7 +2515,7 @@ public class TraitTest extends CommonTraitTest {
                         "" +
                         "rule \"Rule 0 >> http://t/x#D\"\n" +
                         "when\n" +
-                        "   $t : org.drools.base.factmodel.traits.Thing($c : core, this not isA t.x.E.class, this isA t.x.D.class) " +
+                        "   $t : org.drools.base.factmodel.traits.Thing($c : core, this not ##isA t.x.E.class, this ##isA t.x.D.class) " +
                         "then\n" +
                         "   list.add(\"E\"); \n" +
                         "   don($t, E.class); \n" +
@@ -2575,7 +2575,7 @@ public class TraitTest extends CommonTraitTest {
                         "" +
                         "rule \"Rule 0 >> http://t/x#D\"\n" +
                         "when\n" +
-                        "   $t : org.drools.base.factmodel.traits.Thing($c : core, _isTop(), this not isA t.x.E.class, this isA t.x.D.class) " +
+                        "   $t : org.drools.base.factmodel.traits.Thing($c : core, _isTop(), this not ##isA t.x.E.class, this ##isA t.x.D.class) " +
                         "then\n" +
                         "   list.add(\"E\"); \n" +
                         "   don($t, E.class); \n" +
@@ -2724,11 +2724,11 @@ public class TraitTest extends CommonTraitTest {
                         "end\n" +
                         "" +
                         "rule Check when\n" +
-                        "   $x : Bar(this not isA Foo) \n" +
+                        "   $x : Bar(this not ##isA Foo) \n" +
                         "then \n" +
                         "end\n" +
                         "rule Check2 when\n" +
-                        "   $x : Bar2(this not isA Foo) \n" +
+                        "   $x : Bar2(this not ##isA Foo) \n" +
                         "then \n" +
                         "end\n" +
                         "";
@@ -2774,19 +2774,19 @@ public class TraitTest extends CommonTraitTest {
                         "end\n" +
                         "" +
                         "rule Check_1 when\n" +
-                        "   $x : Kore(this isA [ B, D ]) \n" +
+                        "   $x : Kore(this ##isA [ B, D ]) \n" +
                         "then \n" +
                         "   list.add(\" B+D \"); \n" +
                         "end\n" +
                         "" +
                         "rule Check_2 when\n" +
-                        "   $x : Kore(this isA [ A ]) \n" +
+                        "   $x : Kore(this ##isA [ A ]) \n" +
                         "then \n" +
                         "   list.add(\" A \"); \n" +
                         "end\n" +
 
                         "rule Check_3 when\n" +
-                        "   $x : Kore(this not isA [ F ]) \n" +
+                        "   $x : Kore(this not ##isA [ F ]) \n" +
                         "then \n" +
                         "   list.add(\" F \"); \n" +
                         "end\n" +
@@ -3143,7 +3143,7 @@ public class TraitTest extends CommonTraitTest {
                         "" +
                         " \n" +
                         "query queryA\n" +
-                        "   $x := Kore(this isA A) \n" +
+                        "   $x := Kore(this ##isA A) \n" +
                         "end\n" +
                         "";
 
@@ -3205,7 +3205,7 @@ public class TraitTest extends CommonTraitTest {
                         "rule React \n" +
                         "salience 1" +
                         "when\n" +
-                        "   $x : Kore(this isA A.class) \n" +
+                        "   $x : Kore(this ##isA A.class) \n" +
                         "then \n" +
                         "   list.add($x); \n" +
                         "end\n" +
@@ -3713,7 +3713,7 @@ public class TraitTest extends CommonTraitTest {
                         "rule \"Init\"\n" +
                         "salience 10 \n" +
                         "when\n" +
-                        "  $p : Person(this not isA Student)\n" +
+                        "  $p : Person(this not ##isA Student)\n" +
                         "then\n" +
                         "  don($p, Student.class);\n" +
                         "end\n" +
@@ -3981,7 +3981,7 @@ public class TraitTest extends CommonTraitTest {
             drl += "rule \"Log " + x + "\" when " + x + "() then list.add(\"" + x + "\"); end \n";
 
             drl += "rule \"Log II" + x + "\" salience -1 when " + x + "(";
-            drl += "this isA H";
+            drl += "this ##isA H";
             drl += ") then list.add(\"H" + x + "\"); end \n";
         }
 
@@ -4355,19 +4355,19 @@ public class TraitTest extends CommonTraitTest {
                      "" +
                      "rule C \n" +
                      "when\n" +
-                     "  B(this isA C) \n" +
+                     "  B(this ##isA C) \n" +
                      "then \n" +
                      "  list.add(1); \n" +
                      "end \n" +
                      "rule D \n" +
                      "when\n" +
-                     "  D(this isA A, this isA C) \n" +
+                     "  D(this ##isA A, this ##isA C) \n" +
                      "then \n" +
                      "  list.add(2); \n" +
                      "end \n"+
                      "rule E \n" +
                      "when\n" +
-                     "  D(this isA A, this isA E) \n" +
+                     "  D(this ##isA A, this ##isA E) \n" +
                      "then \n" +
                      "  list.add(3); \n" +
                      "end \n";
@@ -4455,7 +4455,7 @@ public class TraitTest extends CommonTraitTest {
                      "" +
                      "rule \"Test Don A,B\" " +
                      "when \n" +
-                     "  A(this isA B) \n" +
+                     "  A(this ##isA B) \n" +
                      "then \n" +
                      "  list.add(0); \n" +
                      "end \n";
@@ -4806,7 +4806,7 @@ public class TraitTest extends CommonTraitTest {
                           "rule Check " +
                           " when " +
                           "  $s : StudentImpl() " +
-                          "  $e : Entity(this isA $s) " +
+                          "  $e : Entity(this ##isA $s) " +
                           " then " +
                           "  list.add(1); " +
                           " end ";
@@ -4848,21 +4848,21 @@ public class TraitTest extends CommonTraitTest {
 
                      "rule One " +
                      "when " +
-                     "  $f : Foo(this not isA A) " +
+                     "  $f : Foo(this not ##isA A) " +
                      "then " +
                      "  don($f, A.class); " +
                      "end " +
 
                      "rule Two " +
                      "when " +
-                     "  $f : Foo(this not isA B) " +
+                     "  $f : Foo(this not ##isA B) " +
                      "then " +
                      "  don($f, B.class); " +
                      "end " +
 
                      "rule Check " +
                      "when " +
-                     "    $f : Foo(this isA B || this isA A) " +
+                     "    $f : Foo(this ##isA B || this ##isA A) " +
                      "then " +
                      "  list.add(1); " +
                      "end " +
@@ -4917,7 +4917,7 @@ public class TraitTest extends CommonTraitTest {
                      "rule Match1 " +
                      "when " +
                      "  $f : Foo($x : object) " +
-                     "  $p : StudentImpl(this isA $f) from $x " +
+                     "  $p : StudentImpl(this ##isA $f) from $x " +
                      "then " +
                      "  list.add(1); " +
                      "end " +
@@ -4925,7 +4925,7 @@ public class TraitTest extends CommonTraitTest {
                      "rule Match2 " +
                      "when " +
                      "  $f : Foo($x : object) " +
-                     "  $p : StudentImpl($f isA this) from $x " +
+                     "  $p : StudentImpl($f ##isA this) from $x " +
                      "then " +
                      "  list.add(2); " +
                      "end " +
@@ -5171,12 +5171,12 @@ public class TraitTest extends CommonTraitTest {
                 "end\n" +
 
                 "rule One when" +
-                "    $core: Entity(this isA Person) " +
+                "    $core: Entity(this ##isA Person) " +
                 "then " +
                 "end " +
 
                 "rule Two when" +
-                "    $core: Entity(this isA Person) " +
+                "    $core: Entity(this ##isA Person) " +
                 "then " +
                 "end " +
 
@@ -5446,12 +5446,12 @@ public class TraitTest extends CommonTraitTest {
 
                      "rule Test1 " +
                      "when " +
-                     "  StudentImpl(this isA IStudent.class) " +
+                     "  StudentImpl(this ##isA IStudent.class) " +
                      "then list.add(1); end " +
 
                      "rule Test2 " +
                      "when " +
-                     "  IStudent(this isA StudentImpl.class) " +
+                     "  IStudent(this ##isA StudentImpl.class) " +
                      "then list.add(2); end " +
 
                      "";
@@ -5478,7 +5478,7 @@ public class TraitTest extends CommonTraitTest {
 
                      "rule Test1 " +
                      "when " +
-                     "  Object(this isA String.class) " +
+                     "  Object(this ##isA String.class) " +
                      "then list.add(1); end " +
 
                      "";
@@ -5543,12 +5543,12 @@ public class TraitTest extends CommonTraitTest {
 
                      "rule Test1 " +
                      "when " +
-                     "  StudentImpl(this isA IStudent.class) " +
+                     "  StudentImpl(this ##isA IStudent.class) " +
                      "then list.add(1); end " +
 
                      "rule Test2 " +
                      "when " +
-                     "  IStudent(this isA StudentImpl.class) " +
+                     "  IStudent(this ##isA StudentImpl.class) " +
                      "then list.add(2); end " +
 
                      "";
@@ -5803,8 +5803,8 @@ public class TraitTest extends CommonTraitTest {
                 "end " +
                 "" +
                 "rule Rec no-loop when\n" +
-                " MyThing($x_0 := core, this isA D.class, $p : this#RootThing.objProp) " +
-                " exists MyThing($x_1 := core , core memberOf $p, this isA F.class) " +
+                " MyThing($x_0 := core, this ##isA D.class, $p : this#RootThing.objProp) " +
+                " exists MyThing($x_1 := core , core memberOf $p, this ##isA F.class) " +
                 "then " +
                 " don($x_0, E.class, true); " +
                 "end " +

--- a/drools-traits/src/test/java/org/drools/traits/compiler/integrationtests/TraitTypeGenerationTest.java
+++ b/drools-traits/src/test/java/org/drools/traits/compiler/integrationtests/TraitTypeGenerationTest.java
@@ -171,7 +171,7 @@ public class TraitTypeGenerationTest extends CommonTraitTest {
                         "\n" +
                         "rule \"create student\" \n" +
                         "    when\n" +
-                        "        $student : Person( age < 26, this not isA Student )\n" +
+                        "        $student : Person( age < 26, this not ##isA Student )\n" +
                         "    then\n" +
                         "        Student s = don( $student, Student.class );\n" +
                         "        s.setSchool(\"Masaryk University\");\n" +
@@ -181,7 +181,7 @@ public class TraitTypeGenerationTest extends CommonTraitTest {
                         "rule \"found student\"\n" +
                         "    salience 10\n" +
                         "    when\n" +
-                        "        student : Person( this isA Student )\n" +
+                        "        student : Person( this ##isA Student )\n" +
                         "    then\n" +
                         "        students.add(student);\n" +
                         "end";

--- a/drools-traits/src/test/resources/org/drools/compiler/factmodel/traits/testDeclaredFactTrait.drl
+++ b/drools-traits/src/test/resources/org/drools/compiler/factmodel/traits/testDeclaredFactTrait.drl
@@ -56,14 +56,14 @@ end
 
 rule "True Traits"
 	when
-		DeclaredFact( $id : id, this isA TrueTrait )
+		DeclaredFact( $id : id, this ##isA TrueTrait )
 	then
 		trueTraits.add($id);
 end
 
 rule "Untrue Traits"
 	when
-		DeclaredFact( $id : id, this not isA TrueTrait )
+		DeclaredFact( $id : id, this not ##isA TrueTrait )
 	then
 		untrueTraits.add($id);
 end

--- a/drools-traits/src/test/resources/org/drools/compiler/factmodel/traits/testPojoFactTrait.drl
+++ b/drools-traits/src/test/resources/org/drools/compiler/factmodel/traits/testPojoFactTrait.drl
@@ -56,14 +56,14 @@ end
 
 rule "True Traits"
 	when
-		PojoFact( $id : id, this isA TrueTrait )
+		PojoFact( $id : id, this ##isA TrueTrait )
 	then
 		trueTraits.add($id);
 end
 
 rule "Untrue Traits"
 	when
-		PojoFact( $id : id, this not isA TrueTrait )
+		PojoFact( $id : id, this not ##isA TrueTrait )
 	then
 		untrueTraits.add($id);
 end

--- a/drools-traits/src/test/resources/org/drools/compiler/factmodel/traits/testTraitIsA.drl
+++ b/drools-traits/src/test/resources/org/drools/compiler/factmodel/traits/testTraitIsA.drl
@@ -116,14 +116,14 @@ end
 
 rule "Worker Students v2"
 when
-    $x1 := Worker( this isA Student )
+    $x1 := Worker( this ##isA Student )
 then
     list.add( "5" );
 end
 
 rule "Worker Students v3"
 when
-    $x1 := Worker( this isA "org.test.Student" )
+    $x1 := Worker( this ##isA "org.test.Student" )
 then
     list.add( "6" );
 end
@@ -131,14 +131,14 @@ end
 
 rule "Worker Students v4"
 when
-    $x1 := Worker( core isA "org.test.Student" )
+    $x1 := Worker( core ##isA "org.test.Student" )
 then
     list.add( "7" );
 end
 
 rule "Worker Students v5"
 when
-    $x1 := Imp( this isA "org.test.Student" )
+    $x1 := Imp( this ##isA "org.test.Student" )
 then
     list.add( "8" );
 end
@@ -146,7 +146,7 @@ end
 rule "Worker Students v6" salience 100
 when
     $x2 := Student(  )
-    $x1 := Worker( core != $x2.core, this isA $x2 )
+    $x1 := Worker( core != $x2.core, this ##isA $x2 )
 then
     list.add( "9" );
 end

--- a/drools-traits/src/test/resources/org/drools/compiler/factmodel/traits/testTraitIsA2.drl
+++ b/drools-traits/src/test/resources/org/drools/compiler/factmodel/traits/testTraitIsA2.drl
@@ -27,7 +27,7 @@ end
 
 rule "create student" 
     when
-        $student : Person( age < 26, this not isA Student )
+        $student : Person( age < 26, this not ##isA Student )
     then
         Student s = don( $student, Student.class );
         s.setSchool("Masaryk University");
@@ -37,7 +37,7 @@ end
 rule "print student"
     salience 10
     when
-        student : Person( this isA Student )
+        student : Person( this ##isA Student )
     then
 end
 

--- a/drools-traits/src/test/resources/org/drools/compiler/factmodel/traits/testTraitIsAWithBC.drl
+++ b/drools-traits/src/test/resources/org/drools/compiler/factmodel/traits/testTraitIsAWithBC.drl
@@ -54,7 +54,7 @@ declare IsIn
 end
 
 query is_in( Place $p, Class $type, Location $q )
-    ( IsIn( $p, $x ; ) and $q := Location( core == $x, this isA $type ) )
+    ( IsIn( $p, $x ; ) and $q := Location( core == $x, this ##isA $type ) )
     or
     ( IsIn( $p, $x ; ) and is_in( $x, $type, $q ; ) )
 end

--- a/drools-traits/src/test/resources/org/drools/compiler/factmodel/traits/testTraitShed.drl
+++ b/drools-traits/src/test/resources/org/drools/compiler/factmodel/traits/testTraitShed.drl
@@ -53,7 +53,7 @@ end
 rule "Trait1"
 no-loop
 when
-    $core: Imp( this not isA Thing )
+    $core: Imp( this not ##isA Thing )
 then
     Student s = don( $core, Student.class );
     list.add( "Student" );
@@ -63,7 +63,7 @@ end
 
 rule "Trait2"
 when
-    $s : Student( this not isA Worker )
+    $s : Student( this not ##isA Worker )
     String( this == "hire" )
 then
     don( $s, Worker.class );
@@ -73,7 +73,7 @@ end
 
 rule "Conflict of interest"
 when
-    $w : Worker( this isA Student )
+    $w : Worker( this ##isA Student )
     String( this == "check" )
 then
     shed( $w, Student.class );
@@ -82,7 +82,7 @@ end
 
 rule "Conflict resolved"
 when
-    $w : Worker( this not isA Student )
+    $w : Worker( this not ##isA Student )
 then
     list.add( "Conflict" );
     shed( $w, Worker.class );
@@ -91,7 +91,7 @@ end
 
 rule "Nothing Left"
 when
-    $t : Thing( this not isA Student, this not isA Worker )
+    $t : Thing( this not ##isA Student, this not ##isA Worker )
 then
     list.add( "Nothing" );
 end

--- a/drools-traits/src/test/resources/org/drools/compiler/factmodel/traits/testTraitedAliasing.drl
+++ b/drools-traits/src/test/resources/org/drools/compiler/factmodel/traits/testTraitedAliasing.drl
@@ -97,9 +97,9 @@ end
 
 rule "Procedures v4"
 when
-    $o : PolishingProcedure( approachBodySite isA LeftNail, targetBodySite isA RightNail,
+    $o : PolishingProcedure( approachBodySite ##isA LeftNail, targetBodySite ##isA RightNail,
                              $app : approachBodySite, $tgt : targetBodySite,
-                             $eff : effectRegion isA Region,
+                             $eff : effectRegion ##isA Region,
                              $loc : locus, $foc : focus,
                              price > 100.0 )
 then

--- a/pom.xml
+++ b/pom.xml
@@ -271,6 +271,7 @@
     <profile>
       <id>enableNewParser</id>
       <activation>
+        <activeByDefault>true</activeByDefault>
         <property>
           <name>enableNewParser</name>
         </property>


### PR DESCRIPTION
Experiment to use `##` as a prefix for Custom Operator.

This PR sets profile `enableNewParser` as activeByDefault to test with the new parser. We will not make it default yet. We will follow a gradual approach as discussed in the dev ML.