### PR TITLE
[incubator-kie-issues#1771] Fixing BooleanEvalHelper to avoid class cast exceptions

### DIFF
--- a/kie-dmn/kie-dmn-feel/src/main/java/org/kie/dmn/feel/util/BooleanEvalHelper.java
+++ b/kie-dmn/kie-dmn-feel/src/main/java/org/kie/dmn/feel/util/BooleanEvalHelper.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information
@@ -205,15 +205,13 @@ public class BooleanEvalHelper {
      * @return
      */
     public static Boolean getBooleanOrDialectDefault(Object rawReturn, FEELDialect feelDialect) {
-        if (feelDialect.equals(FEELDialect.BFEEL)) {
-            if (rawReturn instanceof Boolean bool) {
-                return bool;
-            } else {
-                return false;
-            }
-        } else {
-            return (Boolean) rawReturn;
+        Boolean toReturn = null;
+        if (rawReturn instanceof Boolean bool) {
+            toReturn = bool;
+        } else if (feelDialect.equals(FEELDialect.BFEEL)) {
+            toReturn = false;
         }
+        return toReturn;
     }
 
     /**

--- a/kie-dmn/kie-dmn-feel/src/test/java/org/kie/dmn/feel/runtime/FEELTernaryLogicTest.java
+++ b/kie-dmn/kie-dmn-feel/src/test/java/org/kie/dmn/feel/runtime/FEELTernaryLogicTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information
@@ -58,7 +58,12 @@ public class FEELTernaryLogicTest extends BaseFEELTest {
                 { "false and false or true", Boolean.TRUE , null},
                 { "false and (false or true)", Boolean.FALSE , null},
                 { "true or false and false", Boolean.TRUE , null},
-                { "(true or false) and false", Boolean.FALSE , null}
+                { "(true or false) and false", Boolean.FALSE , null},
+                //
+                { "123 and false", Boolean.FALSE , null},
+                { "\"true\" and false", Boolean.FALSE , null},
+                { "123 or true", Boolean.TRUE , null},
+                { "\"true\" or true", Boolean.TRUE , null}
         };
         return addAdditionalParameters(cases, false);
     }

--- a/kie-dmn/kie-dmn-feel/src/test/java/org/kie/dmn/feel/util/BooleanEvalHelperTest.java
+++ b/kie-dmn/kie-dmn-feel/src/test/java/org/kie/dmn/feel/util/BooleanEvalHelperTest.java
@@ -28,6 +28,8 @@ import org.mockito.MockedStatic;
 import org.mockito.Mockito;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.kie.dmn.feel.util.BooleanEvalHelper.getBooleanOrDialectDefault;
+import static org.kie.dmn.feel.util.BooleanEvalHelper.getFalseOrDialectDefault;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.times;
 
@@ -48,6 +50,38 @@ class BooleanEvalHelperTest {
         assertThat(BooleanEvalHelper.compare(BigInteger.valueOf(1), BigInteger.valueOf(2), FEELDialect.FEEL, (l, r) -> l.compareTo(r) == 0)).isFalse();
         assertThat(BooleanEvalHelper.compare(BigInteger.valueOf(1), 2, FEELDialect.FEEL, (l, r) -> l.compareTo(r) < 0)).isTrue();
         assertThat(BooleanEvalHelper.compare(BigInteger.valueOf(1), 2.3,  FEELDialect.FEEL,(l, r) -> l.compareTo(r) == 0)).isFalse();
+    }
+
+    @Test
+    void getBooleanOrDialectDefaultFEEL() {
+        assertThat(getBooleanOrDialectDefault(false, FEELDialect.FEEL)).isEqualTo(Boolean.FALSE);
+        assertThat(getBooleanOrDialectDefault(true, FEELDialect.FEEL)).isEqualTo(Boolean.TRUE);
+        assertThat(getBooleanOrDialectDefault("true", FEELDialect.FEEL)).isNull();
+        assertThat(getBooleanOrDialectDefault(null, FEELDialect.FEEL)).isNull();
+    }
+
+    @Test
+    void getBooleanOrDialectDefaultBFEEL() {
+        assertThat(getBooleanOrDialectDefault(false, FEELDialect.BFEEL)).isEqualTo(Boolean.FALSE);
+        assertThat(getBooleanOrDialectDefault(true, FEELDialect.BFEEL)).isEqualTo(Boolean.TRUE);
+        assertThat(getBooleanOrDialectDefault("true", FEELDialect.BFEEL)).isEqualTo(Boolean.FALSE);
+        assertThat(getBooleanOrDialectDefault(null, FEELDialect.BFEEL)).isEqualTo(Boolean.FALSE);
+    }
+
+    @Test
+    void getFalseOrDialectDefaultFEEL() {
+        assertThat(getFalseOrDialectDefault(false, FEELDialect.FEEL)).isEqualTo(Boolean.FALSE);
+        assertThat(getFalseOrDialectDefault(true, FEELDialect.FEEL)).isNull();
+        assertThat(getFalseOrDialectDefault("true", FEELDialect.FEEL)).isNull();
+        assertThat(getFalseOrDialectDefault(null, FEELDialect.FEEL)).isNull();
+    }
+
+    @Test
+    void getFalseOrDialectDefaultBFEEL() {
+        assertThat(getFalseOrDialectDefault(false, FEELDialect.BFEEL)).isEqualTo(Boolean.FALSE);
+        assertThat(getFalseOrDialectDefault(true, FEELDialect.BFEEL)).isEqualTo(Boolean.FALSE);
+        assertThat(getFalseOrDialectDefault("true", FEELDialect.BFEEL)).isEqualTo(Boolean.FALSE);
+        assertThat(getFalseOrDialectDefault(null, FEELDialect.BFEEL)).isEqualTo(Boolean.FALSE);
     }
 
     @Test


### PR DESCRIPTION
Fixes https://github.com/apache/incubator-kie-issues/issues/1771

This PR:
1. refactor BooleanEvalHelper methods to avoid class cast exception
2. add related TCK cases to FEELTernaryLogicTest
3. add unit tests for modified methods

<details>
<summary>
How to replicate CI configuration locally?
</summary>

Build Chain tool does "simple" maven build(s), the builds are just Maven commands, but because the repositories relates and depends on each other and any change in API or class method could affect several of those repositories there is a need to use [build-chain tool](https://github.com/kiegroup/github-action-build-chain) to handle cross repository builds and be sure that we always use latest version of the code for each repository.
 
[build-chain tool](https://github.com/kiegroup/github-action-build-chain) is a build tool which can be used on command line locally or in Github Actions workflow(s), in case you need to change multiple repositories and send multiple dependent pull requests related with a change you can easily reproduce the same build by executing it on Github hosted environment or locally in your development environment. See [local execution](https://github.com/kiegroup/github-action-build-chain#local-execution) details to get more information about it.
</details>

<details>
<summary>
How to retest this PR or trigger a specific build:
</summary>

- for <b>pull request and downstream checks</b>  
  - Push a new commit to the PR. An empty commit would be enough.

- for a <b>full downstream build</b>
  - for <b>github actions</b> job: add the label `run_fdb`

- for <b>Jenkins PR check only</b>
  - If you are an ASF committer for KIE podling, login to Jenkins (https://ci-builds.apache.org/job/KIE/job/drools/), go to the specific PR job, and click on `Build Now` button.
</details>
