### PR TITLE
[incubator-kie-issues#1737] [CVE] [Medium] CVE-2023-0833 okhttp-3.12.12.jar 

### DIFF
--- a/build-parent/pom.xml
+++ b/build-parent/pom.xml
@@ -126,6 +126,7 @@
     <!-- simple-jndi is a small library that helps us avoid JNDI error messages during testing -->
     <version.simple-jndi>0.11.4.1</version.simple-jndi>
     <version.xerces>2.12.0.SP04</version.xerces>
+    <version.com.squareup.okhttp3>4.9.2</version.com.squareup.okhttp3>
 
     <!-- External dependency versions bom -->
     <!-- ################################################################################ -->
@@ -335,6 +336,12 @@
         <groupId>com.h2database</groupId>
         <artifactId>h2</artifactId>
         <version>${version.com.h2database}</version>
+      </dependency>
+
+      <dependency>
+        <groupId>com.squareup.okhttp3</groupId>
+        <artifactId>okhttp</artifactId>
+        <version>${version.com.squareup.okhttp3}</version>
       </dependency>
 
       <dependency>

--- a/drools-reliability/drools-reliability-tests/pom.xml
+++ b/drools-reliability/drools-reliability-tests/pom.xml
@@ -36,6 +36,7 @@
   <properties>
     <java.module.name>org.drools.reliability.infinispan</java.module.name>
     <version.testcontainers>1.17.2</version.testcontainers>
+    <version.com.squareup.okhttp3>4.9.2</version.com.squareup.okhttp3>
   </properties>
 
   <dependencyManagement>
@@ -139,6 +140,11 @@
           <artifactId>log4j-slf4j-impl</artifactId>
         </exclusion>
       </exclusions>
+    </dependency>
+    <dependency>
+      <groupId>com.squareup.okhttp3</groupId>
+      <artifactId>okhttp</artifactId>
+      <version>${version.com.squareup.okhttp3}</version>
     </dependency>
     <dependency>
       <groupId>org.infinispan</groupId>

--- a/drools-reliability/drools-reliability-tests/pom.xml
+++ b/drools-reliability/drools-reliability-tests/pom.xml
@@ -36,7 +36,6 @@
   <properties>
     <java.module.name>org.drools.reliability.infinispan</java.module.name>
     <version.testcontainers>1.17.2</version.testcontainers>
-    <version.com.squareup.okhttp3>4.9.2</version.com.squareup.okhttp3>
   </properties>
 
   <dependencyManagement>
@@ -140,11 +139,6 @@
           <artifactId>log4j-slf4j-impl</artifactId>
         </exclusion>
       </exclusions>
-    </dependency>
-    <dependency>
-      <groupId>com.squareup.okhttp3</groupId>
-      <artifactId>okhttp</artifactId>
-      <version>${version.com.squareup.okhttp3}</version>
     </dependency>
     <dependency>
       <groupId>org.infinispan</groupId>


### PR DESCRIPTION
Closes https://github.com/apache/incubator-kie-issues/issues/1781

GroupId: com.squareup.okhttp3
ArtifactId: okhttp
Version: 3.12.12

Description: A flaw was found in Red Hat's AMQ-Streams, which ships a version of the OKHttp component with an information disclosure flaw via an exception triggered by a header containing an illegal value. This issue could allow an authenticated attacker to access information outside of their regular permissions.

Top fix: Upgrade to version com.squareup.okhttp3:okhttp:4.9.2
Message: Upgrade to version