### PR TITLE
kie-issues#1807: Test Scenario version attribute is not correctly retrieved

### DIFF
--- a/drools-scenario-simulation/drools-scenario-simulation-api/src/main/java/org/drools/scenariosimulation/api/utils/ConstantsHolder.java
+++ b/drools-scenario-simulation/drools-scenario-simulation-api/src/main/java/org/drools/scenariosimulation/api/utils/ConstantsHolder.java
@@ -53,6 +53,7 @@ public class ConstantsHolder {
     public static final String SCENARIO_SIMULATION_MODEL_NODE = "ScenarioSimulationModel";
     public static final String SETTINGS_NODE = "settings";
     public static final String FACT_MAPPING_VALUE_TYPE_NODE = "factMappingValueType";
+    public static final String VERSION_ATTRIBUTE = "version";
     public static final String NOT_EXPRESSION = "NOT_EXPRESSION";
     public static final String EXECUTED = "EXECUTED";
     public static final List<String> SETTINGS = Collections.unmodifiableList(Arrays.asList(DMO_SESSION_NODE, "dmnFilePath", "type", "fileName", "kieSession",

--- a/drools-scenario-simulation/drools-scenario-simulation-backend/src/main/java/org/drools/scenariosimulation/backend/util/ScenarioSimulationXMLPersistence.java
+++ b/drools-scenario-simulation/drools-scenario-simulation-backend/src/main/java/org/drools/scenariosimulation/backend/util/ScenarioSimulationXMLPersistence.java
@@ -39,7 +39,13 @@ import org.drools.scenariosimulation.backend.interfaces.ThrowingConsumer;
 import org.kie.utll.xml.XStreamUtils;
 import org.w3c.dom.Document;
 
-import static org.drools.scenariosimulation.api.utils.ConstantsHolder.*;
+import static org.drools.scenariosimulation.api.utils.ConstantsHolder.BACKGROUND_NODE;
+import static org.drools.scenariosimulation.api.utils.ConstantsHolder.SCENARIO_SIMULATION_MODEL_NODE;
+import static org.drools.scenariosimulation.api.utils.ConstantsHolder.SCESIM_MODEL_DESCRIPTOR_NODE;
+import static org.drools.scenariosimulation.api.utils.ConstantsHolder.SETTINGS;
+import static org.drools.scenariosimulation.api.utils.ConstantsHolder.SIMULATION_DESCRIPTOR_NODE;
+import static org.drools.scenariosimulation.api.utils.ConstantsHolder.SIMULATION_NODE;
+import static org.drools.scenariosimulation.api.utils.ConstantsHolder.VERSION_ATTRIBUTE;
 
 public class ScenarioSimulationXMLPersistence {
 

--- a/drools-scenario-simulation/drools-scenario-simulation-backend/src/main/java/org/drools/scenariosimulation/backend/util/ScenarioSimulationXMLPersistence.java
+++ b/drools-scenario-simulation/drools-scenario-simulation-backend/src/main/java/org/drools/scenariosimulation/backend/util/ScenarioSimulationXMLPersistence.java
@@ -39,12 +39,7 @@ import org.drools.scenariosimulation.backend.interfaces.ThrowingConsumer;
 import org.kie.utll.xml.XStreamUtils;
 import org.w3c.dom.Document;
 
-import static org.drools.scenariosimulation.api.utils.ConstantsHolder.BACKGROUND_NODE;
-import static org.drools.scenariosimulation.api.utils.ConstantsHolder.SCENARIO_SIMULATION_MODEL_NODE;
-import static org.drools.scenariosimulation.api.utils.ConstantsHolder.SCESIM_MODEL_DESCRIPTOR_NODE;
-import static org.drools.scenariosimulation.api.utils.ConstantsHolder.SETTINGS;
-import static org.drools.scenariosimulation.api.utils.ConstantsHolder.SIMULATION_DESCRIPTOR_NODE;
-import static org.drools.scenariosimulation.api.utils.ConstantsHolder.SIMULATION_NODE;
+import static org.drools.scenariosimulation.api.utils.ConstantsHolder.*;
 
 public class ScenarioSimulationXMLPersistence {
 
@@ -182,7 +177,8 @@ public class ScenarioSimulationXMLPersistence {
 
     public String extractVersion(Document document) {
         try {
-            return document.getElementsByTagName(SCENARIO_SIMULATION_MODEL_NODE).item(0).getAttributes().getNamedItem("version").getTextContent();
+            return document.getElementsByTagName(SCENARIO_SIMULATION_MODEL_NODE)
+                    .item(0).getAttributes().getNamedItem(VERSION_ATTRIBUTE).getTextContent();
         } catch (Exception e) {
             throw new IllegalArgumentException("Impossible to extract version from the file", e);
         }

--- a/drools-scenario-simulation/drools-scenario-simulation-backend/src/main/java/org/drools/scenariosimulation/backend/util/ScenarioSimulationXMLPersistence.java
+++ b/drools-scenario-simulation/drools-scenario-simulation-backend/src/main/java/org/drools/scenariosimulation/backend/util/ScenarioSimulationXMLPersistence.java
@@ -53,7 +53,7 @@ public class ScenarioSimulationXMLPersistence {
 
     private static final ScenarioSimulationXMLPersistence INSTANCE = new ScenarioSimulationXMLPersistence();
     private static final String CURRENT_VERSION = new ScenarioSimulationModel().getVersion();
-    private static final Pattern p = Pattern.compile(SCENARIO_SIMULATION_MODEL_NODE + " version=\"([0-9]+\\.[0-9]+)");
+    private static final Pattern SCENARIO_SIMULATION_VERSION_EXTRACTOR_PATTERN = Pattern.compile("<" + SCENARIO_SIMULATION_MODEL_NODE + ".*version=\"([0-9]+\\.[0-9]+)");
 
     private XStream xt;
     private MigrationStrategy migrationStrategy = new InMemoryMigrationStrategy();
@@ -185,7 +185,7 @@ public class ScenarioSimulationXMLPersistence {
     }
 
     public String extractVersion(String rawXml) {
-        Matcher m = p.matcher(rawXml);
+        Matcher m = SCENARIO_SIMULATION_VERSION_EXTRACTOR_PATTERN.matcher(rawXml);
 
         if (m.find()) {
             return m.group(1);

--- a/drools-scenario-simulation/drools-scenario-simulation-backend/src/main/java/org/drools/scenariosimulation/backend/util/ScenarioSimulationXMLPersistence.java
+++ b/drools-scenario-simulation/drools-scenario-simulation-backend/src/main/java/org/drools/scenariosimulation/backend/util/ScenarioSimulationXMLPersistence.java
@@ -18,9 +18,6 @@
  */
 package org.drools.scenariosimulation.backend.util;
 
-import java.util.regex.Matcher;
-import java.util.regex.Pattern;
-
 import com.thoughtworks.xstream.XStream;
 import com.thoughtworks.xstream.io.xml.DomDriver;
 import com.thoughtworks.xstream.security.WildcardTypePermission;
@@ -53,7 +50,6 @@ public class ScenarioSimulationXMLPersistence {
 
     private static final ScenarioSimulationXMLPersistence INSTANCE = new ScenarioSimulationXMLPersistence();
     private static final String CURRENT_VERSION = new ScenarioSimulationModel().getVersion();
-    private static final Pattern SCENARIO_SIMULATION_VERSION_EXTRACTOR_PATTERN = Pattern.compile("<" + SCENARIO_SIMULATION_MODEL_NODE + ".*version=\"([0-9]+\\.[0-9]+)");
 
     private XStream xt;
     private MigrationStrategy migrationStrategy = new InMemoryMigrationStrategy();
@@ -147,7 +143,8 @@ public class ScenarioSimulationXMLPersistence {
     }
 
     public String migrateIfNecessary(String rawXml) throws Exception {
-        String fileVersion = extractVersion(rawXml);
+        Document document = DOMParserUtil.getDocument(rawXml);
+        String fileVersion = extractVersion(document);
         ThrowingConsumer<Document> migrator = getMigrationStrategy().start();
         boolean supported;
         switch (fileVersion) {
@@ -179,18 +176,16 @@ public class ScenarioSimulationXMLPersistence {
                                                        .append(CURRENT_VERSION).toString());
         }
         migrator = migrator.andThen(getMigrationStrategy().end());
-        Document document = DOMParserUtil.getDocument(rawXml);
         migrator.accept(document);
         return DOMParserUtil.getString(document);
     }
 
-    public String extractVersion(String rawXml) {
-        Matcher m = SCENARIO_SIMULATION_VERSION_EXTRACTOR_PATTERN.matcher(rawXml);
-
-        if (m.find()) {
-            return m.group(1);
+    public String extractVersion(Document document) {
+        try {
+            return document.getElementsByTagName(SCENARIO_SIMULATION_MODEL_NODE).item(0).getAttributes().getNamedItem("version").getTextContent();
+        } catch (Exception e) {
+            throw new IllegalArgumentException("Impossible to extract version from the file", e);
         }
-        throw new IllegalArgumentException("Impossible to extract version from the file");
     }
 
     public MigrationStrategy getMigrationStrategy() {

--- a/drools-scenario-simulation/drools-scenario-simulation-backend/src/test/java/org/drools/scenariosimulation/backend/util/ScenarioSimulationXMLPersistenceTest.java
+++ b/drools-scenario-simulation/drools-scenario-simulation-backend/src/test/java/org/drools/scenariosimulation/backend/util/ScenarioSimulationXMLPersistenceTest.java
@@ -365,39 +365,76 @@ public class ScenarioSimulationXMLPersistenceTest {
     }
 
     @Test
-    public void extractVersionWhenXmlPrologIsPresent() throws ParserConfigurationException, IOException, SAXException {
-        String version = instance.extractVersion(DOMParserUtil.getDocument("<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n" +
+    public void extractVersionMissingVersionAttribute_prolog() {
+        assertThatThrownBy(() -> instance.extractVersion(DOMParserUtil.getDocument(
+                "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n" +
+                "<ScenarioSimulationModel />")))
+                .isInstanceOf(IllegalArgumentException.class);
+    }
+
+    @Test
+    public void extractVersionMissingVersionAttribute_prolog_attribute() {
+        assertThatThrownBy(() -> instance.extractVersion(DOMParserUtil.getDocument(
+                "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n" +
+                        "<ScenarioSimulationModel xmlns=\"whatever\" />")))
+                .isInstanceOf(IllegalArgumentException.class);
+    }
+
+    @Test
+    public void extractVersionWithVersionAttribute() throws ParserConfigurationException, IOException, SAXException {
+        String version = instance.extractVersion(DOMParserUtil.getDocument(
                 "<ScenarioSimulationModel version=\"1.1\" />"));
         assertThat(version).isEqualTo("1.1");
     }
 
     @Test
-    public void extractVersionWhenXmlPrologIsPresentAndWithMultipleAttributes1() throws ParserConfigurationException, IOException, SAXException {
-        String version = instance.extractVersion(DOMParserUtil.getDocument("<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n" +
-                "<ScenarioSimulationModel version=\"1.1\" attribute1=\"whatever\" />"));
-        assertThat(version).isEqualTo("1.1");
-    }
-
-    @Test
-    public void extractVersionWhenXmlPrologIsPresentAndWithMultipleAttributes2() throws ParserConfigurationException, IOException, SAXException {
-        String version = instance.extractVersion(DOMParserUtil.getDocument("<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n" +
-                "<ScenarioSimulationModel attribute1=\"whatever\" version=\"1.2\" />"));
+    public void extractVersionWithVersionAttribute_prolog() throws ParserConfigurationException, IOException, SAXException {
+        String version = instance.extractVersion(DOMParserUtil.getDocument(
+                "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n" +
+                "<ScenarioSimulationModel version=\"1.2\" />"));
         assertThat(version).isEqualTo("1.2");
     }
 
     @Test
-    public void extractVersionWhenXmlPrologIsPresentAndWithMultipleAttributes3() throws ParserConfigurationException, IOException, SAXException  {
-        String version = instance.extractVersion(DOMParserUtil.getDocument("<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n" +
-                "<ScenarioSimulationModel attribute2=\"whatever\" version=\"1.3\" attribute1=\"whatever\" />"));
-        assertThat(version).isEqualTo("1.3");
+    public void extractVersionWithVersionAttribute_prolog_attributeRight() throws ParserConfigurationException, IOException, SAXException {
+        String version = instance.extractVersion(DOMParserUtil.getDocument(
+                "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n" +
+                        "<ScenarioSimulationModel version=\"1.4\" xmlns=\"whatever\" />"));
+        assertThat(version).isEqualTo("1.4");
     }
 
     @Test
-    public void extractVersionWhenXmlPrologIsPresentAndWithMultipleAttributes4() throws ParserConfigurationException, IOException, SAXException {
-        String version = instance.extractVersion(DOMParserUtil.getDocument("<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n" +
-                "<ScenarioSimulationModel attribute2=\"whatever\" attribute1=\"whatever\" version=\"1.4\" />"));
-        assertThat(version).isEqualTo("1.4");
+    public void extractVersionWithVersionAttribute_prolog_attributeLeft() throws ParserConfigurationException, IOException, SAXException {
+        String version = instance.extractVersion(DOMParserUtil.getDocument(
+                "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n" +
+                        "<ScenarioSimulationModel xmlns=\"whatever\" version=\"1.5\" />"));
+        assertThat(version).isEqualTo("1.5");
     }
+
+    @Test
+    public void extractVersionWithVersionAttribute_prolog_attributesMiddle() throws ParserConfigurationException, IOException, SAXException {
+        String version = instance.extractVersion(DOMParserUtil.getDocument(
+                "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n" +
+                        "<ScenarioSimulationModel attribute2=\"whatever\" version=\"1.6\" attribute1=\"whatever\" />"));
+        assertThat(version).isEqualTo("1.6");
+    }
+
+    @Test
+    public void extractVersionWithVersionAttribute_prolog_attributesRight() throws ParserConfigurationException, IOException, SAXException {
+        String version = instance.extractVersion(DOMParserUtil.getDocument(
+                "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n" +
+                        "<ScenarioSimulationModel attribute2=\"whatever\" attribute1=\"whatever\" version=\"1.7\" />"));
+        assertThat(version).isEqualTo("1.7");
+    }
+
+    @Test
+    public void extractVersionWithVersionAttribute_prolog_attributesLeft() throws ParserConfigurationException, IOException, SAXException {
+        String version = instance.extractVersion(DOMParserUtil.getDocument(
+                "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n" +
+                        "<ScenarioSimulationModel version=\"1.8\" attribute2=\"whatever\" attribute1=\"whatever\" />"));
+        assertThat(version).isEqualTo("1.8");
+    }
+
 
     @Test
     public void extractVersionWhenMoreVersionAttributesArePresent() throws ParserConfigurationException, IOException, SAXException {

--- a/drools-scenario-simulation/drools-scenario-simulation-backend/src/test/java/org/drools/scenariosimulation/backend/util/ScenarioSimulationXMLPersistenceTest.java
+++ b/drools-scenario-simulation/drools-scenario-simulation-backend/src/test/java/org/drools/scenariosimulation/backend/util/ScenarioSimulationXMLPersistenceTest.java
@@ -24,6 +24,8 @@ import java.util.Map;
 import org.drools.scenariosimulation.api.model.ScenarioSimulationModel;
 import org.drools.scenariosimulation.api.model.imports.Import;
 import org.junit.Test;
+import org.junit.jupiter.params.provider.MethodSource;
+import org.kie.dmn.feel.util.XQueryImplUtil;
 import org.w3c.dom.Document;
 import org.w3c.dom.Node;
 
@@ -351,7 +353,7 @@ public class ScenarioSimulationXMLPersistenceTest {
     @Test
     public void extractVersion() {
         String version = instance.extractVersion("<ScenarioSimulationModel version=\"1.0\" version=\"1.1\">");
-        assertThat(version).isEqualTo("1.0");
+        assertThat(version).isEqualTo("1.1");
     }
 
     @Test
@@ -359,6 +361,34 @@ public class ScenarioSimulationXMLPersistenceTest {
         String version = instance.extractVersion("<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n" +
                                                          "<ScenarioSimulationModel version=\"1.1\">");
         assertThat(version).isEqualTo("1.1");
+    }
+
+    @Test
+    public void extractVersionWhenXmlPrologIsPresentAndWithMultipleAttributes1() {
+        String version = instance.extractVersion("<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n" +
+                "<ScenarioSimulationModel version=\"1.1\" attribute1=\"whatever\">");
+        assertThat(version).isEqualTo("1.1");
+    }
+
+    @Test
+    public void extractVersionWhenXmlPrologIsPresentAndWithMultipleAttributes2() {
+        String version = instance.extractVersion("<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n" +
+                "<ScenarioSimulationModel attribute1=\"whatever\"> version=\"1.2\"");
+        assertThat(version).isEqualTo("1.2");
+    }
+
+    @Test
+    public void extractVersionWhenXmlPrologIsPresentAndWithMultipleAttributes3() {
+        String version = instance.extractVersion("<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n" +
+                "<ScenarioSimulationModel attribute2=\"whatever\" version=\"1.3\" attribute1=\"whatever\">");
+        assertThat(version).isEqualTo("1.3");
+    }
+
+    @Test
+    public void extractVersionWhenXmlPrologIsPresentAndWithMultipleAttributes4() {
+        String version = instance.extractVersion("<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n" +
+                "<ScenarioSimulationModel attribute2=\"whatever\" attribute1=\"whatever\"> version=\"1.4\"");
+        assertThat(version).isEqualTo("1.4");
     }
 
     @Test

--- a/drools-scenario-simulation/drools-scenario-simulation-backend/src/test/java/org/drools/scenariosimulation/backend/util/ScenarioSimulationXMLPersistenceTest.java
+++ b/drools-scenario-simulation/drools-scenario-simulation-backend/src/test/java/org/drools/scenariosimulation/backend/util/ScenarioSimulationXMLPersistenceTest.java
@@ -18,16 +18,18 @@
  */
 package org.drools.scenariosimulation.backend.util;
 
+import java.io.IOException;
 import java.util.List;
 import java.util.Map;
 
 import org.drools.scenariosimulation.api.model.ScenarioSimulationModel;
 import org.drools.scenariosimulation.api.model.imports.Import;
 import org.junit.Test;
-import org.junit.jupiter.params.provider.MethodSource;
-import org.kie.dmn.feel.util.XQueryImplUtil;
 import org.w3c.dom.Document;
 import org.w3c.dom.Node;
+import org.xml.sax.SAXException;
+
+import javax.xml.parsers.ParserConfigurationException;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
@@ -351,52 +353,52 @@ public class ScenarioSimulationXMLPersistenceTest {
     }
 
     @Test
-    public void extractVersion() {
-        String version = instance.extractVersion("<ScenarioSimulationModel version=\"1.0\" version=\"1.1\">");
+    public void extractVersionMissingAttribute() {
+        assertThatThrownBy(() -> instance.extractVersion(DOMParserUtil.getDocument("<ScenarioSimulationModel />")))
+                .isInstanceOf(IllegalArgumentException.class);
+    }
+
+    @Test
+    public void extractVersionWhenXmlPrologIsPresent() throws ParserConfigurationException, IOException, SAXException {
+        String version = instance.extractVersion(DOMParserUtil.getDocument("<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n" +
+                "<ScenarioSimulationModel version=\"1.1\" />"));
         assertThat(version).isEqualTo("1.1");
     }
 
     @Test
-    public void extractVersionWhenXmlPrologIsPresent() {
-        String version = instance.extractVersion("<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n" +
-                                                         "<ScenarioSimulationModel version=\"1.1\">");
+    public void extractVersionWhenXmlPrologIsPresentAndWithMultipleAttributes1() throws ParserConfigurationException, IOException, SAXException {
+        String version = instance.extractVersion(DOMParserUtil.getDocument("<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n" +
+                "<ScenarioSimulationModel version=\"1.1\" attribute1=\"whatever\" />"));
         assertThat(version).isEqualTo("1.1");
     }
 
     @Test
-    public void extractVersionWhenXmlPrologIsPresentAndWithMultipleAttributes1() {
-        String version = instance.extractVersion("<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n" +
-                "<ScenarioSimulationModel version=\"1.1\" attribute1=\"whatever\">");
-        assertThat(version).isEqualTo("1.1");
-    }
-
-    @Test
-    public void extractVersionWhenXmlPrologIsPresentAndWithMultipleAttributes2() {
-        String version = instance.extractVersion("<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n" +
-                "<ScenarioSimulationModel attribute1=\"whatever\"> version=\"1.2\"");
+    public void extractVersionWhenXmlPrologIsPresentAndWithMultipleAttributes2() throws ParserConfigurationException, IOException, SAXException {
+        String version = instance.extractVersion(DOMParserUtil.getDocument("<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n" +
+                "<ScenarioSimulationModel attribute1=\"whatever\" version=\"1.2\" />"));
         assertThat(version).isEqualTo("1.2");
     }
 
     @Test
-    public void extractVersionWhenXmlPrologIsPresentAndWithMultipleAttributes3() {
-        String version = instance.extractVersion("<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n" +
-                "<ScenarioSimulationModel attribute2=\"whatever\" version=\"1.3\" attribute1=\"whatever\">");
+    public void extractVersionWhenXmlPrologIsPresentAndWithMultipleAttributes3() throws ParserConfigurationException, IOException, SAXException  {
+        String version = instance.extractVersion(DOMParserUtil.getDocument("<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n" +
+                "<ScenarioSimulationModel attribute2=\"whatever\" version=\"1.3\" attribute1=\"whatever\" />"));
         assertThat(version).isEqualTo("1.3");
     }
 
     @Test
-    public void extractVersionWhenXmlPrologIsPresentAndWithMultipleAttributes4() {
-        String version = instance.extractVersion("<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n" +
-                "<ScenarioSimulationModel attribute2=\"whatever\" attribute1=\"whatever\"> version=\"1.4\"");
+    public void extractVersionWhenXmlPrologIsPresentAndWithMultipleAttributes4() throws ParserConfigurationException, IOException, SAXException {
+        String version = instance.extractVersion(DOMParserUtil.getDocument("<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n" +
+                "<ScenarioSimulationModel attribute2=\"whatever\" attribute1=\"whatever\" version=\"1.4\" />"));
         assertThat(version).isEqualTo("1.4");
     }
 
     @Test
-    public void extractVersionWhenMoreVersionAttributesArePresent() {
-        String version = instance.extractVersion("<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n" +
-                                                         "<ScenarioSimulationModel version=\"1.2\">\n" +
-                                                         "<someUnknownTag version=\"1.1\"/>\n" +
-                                                         "</ScenarioSimulationModel>");
+    public void extractVersionWhenMoreVersionAttributesArePresent() throws ParserConfigurationException, IOException, SAXException {
+        String version = instance.extractVersion(DOMParserUtil.getDocument("<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n" +
+                "<ScenarioSimulationModel version=\"1.2\">\n" +
+                "<someTag version=\"1.1\"/>\n" +
+                "</ScenarioSimulationModel>"));
         assertThat(version).isEqualTo("1.2");
     }
 

--- a/drools-scenario-simulation/drools-scenario-simulation-backend/src/test/java/org/drools/scenariosimulation/backend/util/ScenarioSimulationXMLPersistenceTest.java
+++ b/drools-scenario-simulation/drools-scenario-simulation-backend/src/test/java/org/drools/scenariosimulation/backend/util/ScenarioSimulationXMLPersistenceTest.java
@@ -353,6 +353,12 @@ public class ScenarioSimulationXMLPersistenceTest {
     }
 
     @Test
+    public void extractVersionNullDocument() {
+        assertThatThrownBy(() -> instance.extractVersion(null))
+                .isInstanceOf(IllegalArgumentException.class);
+    }
+
+    @Test
     public void extractVersionMissingAttribute() {
         assertThatThrownBy(() -> instance.extractVersion(DOMParserUtil.getDocument("<ScenarioSimulationModel />")))
                 .isInstanceOf(IllegalArgumentException.class);


### PR DESCRIPTION
Closes: https://github.com/apache/incubator-kie-issues/issues/1807

**The problem**
The Test Scenario Engine needs to retrieve the scesim version from the xml root node to apply the correct migration strategy.
The current logic that retrieves that info, uses a regex search, that is too strict: regex patterns with this exact structure 
`<ScenarioSimulationModel version=\"x.x\"` will be found. That means if any other attribute is present in the XML node (or just a single whitespace), the search will fail
eg. `<ScenarioSimulationModel    version=\"x.x\"`  `<ScenarioSimulationModel  namespace="..."  version=\"x.x\"` 

**The solution**
In the same block of code, the DomParser of the xml file is already called. So, I just moved that in the first method line and took advantage of that to retrieve the version in a "safer" way.
This means, the regex search is no longer required, and the version can be safely retrieved disregarding its position in the node and avoiding collision with other possible attributes with the name.


