### PR TITLE
[incubator-kie-drools-6265] Apache RAT check misses drools-model

### DIFF
--- a/.github/workflows/pr-rat-check.yml
+++ b/.github/workflows/pr-rat-check.yml
@@ -40,6 +40,7 @@ jobs:
           java -jar apache-rat-0.16.1.jar -d . -E .rat-excludes | grep "== File:" && echo "The files listed above are missing license headers." && exit 1 || echo "All files have license headers."
 
       # This is a temporary workaround for https://github.com/apache/incubator-kie-drools/issues/6265
+      # To be checked after apache-rat 0.17 release
       - name: Run Apache RAT under drools-model
         run: |
           cd drools-model

--- a/.github/workflows/pr-rat-check.yml
+++ b/.github/workflows/pr-rat-check.yml
@@ -38,3 +38,9 @@ jobs:
       - name: Run Apache RAT
         run: |
           java -jar apache-rat-0.16.1.jar -d . -E .rat-excludes | grep "== File:" && echo "The files listed above are missing license headers." && exit 1 || echo "All files have license headers."
+
+      # This is a temporary workaround for https://github.com/apache/incubator-kie-drools/issues/6265
+      - name: Run Apache RAT under drools-model
+        run: |
+          cd drools-model
+          java -jar ../apache-rat-0.16.1.jar -d . -E ../.rat-excludes | grep "== File:" && echo "The files listed above are missing license headers." && exit 1 || echo "All files have license headers."


### PR DESCRIPTION
- A temporary workaround until Apache RAT 0.17 will be released

**Issue**: 

* https://github.com/apache/incubator-kie-drools/issues/6265
