### PR TITLE
[incubator-kie-drools-6273] DroolsAssetsProcessor#generateSources thr…

### DIFF
--- a/drools-model/drools-model-codegen/src/main/java/org/drools/model/codegen/project/RuleCodegen.java
+++ b/drools-model/drools-model-codegen/src/main/java/org/drools/model/codegen/project/RuleCodegen.java
@@ -18,6 +18,7 @@
  */
 package org.drools.model.codegen.project;
 
+import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.Map;
@@ -49,7 +50,7 @@ public class RuleCodegen {
     }
 
     private final Collection<Resource> resources;
-    private Collection<PackageModel> packageModels;
+    private Collection<PackageModel> packageModels = Collections.emptySet();
 
     private boolean hotReloadMode = false;
     private final boolean decisionTableSupported;
@@ -110,7 +111,7 @@ public class RuleCodegen {
 
     public final Collection<GeneratedFile> generate() {
         if (isEmpty()) {
-            return Collections.emptySet();
+            return new ArrayList<>(); // mutable
         }
         return internalGenerate();
     }

--- a/drools-quarkus-extension/drools-quarkus-deployment/src/test/java/org/drools/quarkus/deployment/NoDrlTest.java
+++ b/drools-quarkus-extension/drools-quarkus-deployment/src/test/java/org/drools/quarkus/deployment/NoDrlTest.java
@@ -1,0 +1,40 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.drools.quarkus.deployment;
+
+import io.quarkus.test.QuarkusUnitTest;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import static org.assertj.core.api.Assertions.assertThatNoException;
+
+public class NoDrlTest {
+
+    static final Logger LOG = LoggerFactory.getLogger(NoDrlTest.class);
+
+    @RegisterExtension
+    static final QuarkusUnitTest config = new QuarkusUnitTest(); // Not adding Drl to the project
+
+    @Test
+    public void testQuarkusUTByAddBuildChainCustomizer() {
+        assertThatNoException().isThrownBy(() -> LOG.info("No exception with no DRL"));
+    }
+}


### PR DESCRIPTION
…ew an exception: java.lang.UnsupportedOperationException when no drl resources are presents

If an application project has no DRLs nor any rule assets (assuming this is the very first phase of application development), the build fails with UnsupportedOperationException. It happens in dev-mode and QuarkusTest.

```
Caused by: java.lang.UnsupportedOperationException
	at java.base/java.util.AbstractCollection.add(AbstractCollection.java:253)
	at org.drools.quarkus.deployment.DroolsAssetsProcessor.generateSources(DroolsAssetsProcessor.java:116)
	at java.base/java.lang.invoke.MethodHandle.invokeWithArguments(MethodHandle.java:733)
	at io.quarkus.deployment.ExtensionLoader$3.execute(ExtensionLoader.java:856)
	at io.quarkus.builder.BuildContext.run(BuildContext.java:255)
	at org.jboss.threads.ContextHandler$1.runWith(ContextHandler.java:18)
	at org.jboss.threads.EnhancedQueueExecutor$Task.doRunWith(EnhancedQueueExecutor.java:2675)
	at org.jboss.threads.EnhancedQueueExecutor$Task.run(EnhancedQueueExecutor.java:2654)
	at org.jboss.threads.EnhancedQueueExecutor.runThreadBody(EnhancedQueueExecutor.java:1627)
	at org.jboss.threads.EnhancedQueueExecutor$ThreadBody.run(EnhancedQueueExecutor.java:1594)
	at java.base/java.lang.Thread.run(Thread.java:1583)
	at org.jboss.threads.JBossThread.run(JBossThread.java:499)
```

**Issue**:

* https://github.com/apache/incubator-kie-drools/issues/6273
