### PR TITLE
[incubator-kie-drools-6309] Normalize spring boot path

### DIFF
--- a/drools-util/src/main/java/org/drools/util/JarUtils.java
+++ b/drools-util/src/main/java/org/drools/util/JarUtils.java
@@ -18,6 +18,8 @@
  */
 package org.drools.util;
 
+import java.net.URL;
+
 /**
  * Utility to access jar files
  */
@@ -25,6 +27,7 @@ public class JarUtils {
 
     private static final String SPRING_BOOT_PREFIX = "BOOT-INF/classes/"; // Actual path prefix in Spring Boot JAR
     private static final String SPRING_BOOT_URL_PREFIX = "BOOT-INF/classes!/"; // Spring Boot adds "!" to resource url as a "nest" separator
+    private static final String SPRING_BOOT_URL_PREFIX_3_2 = "BOOT-INF/classes/!/"; // Spring Boot 3.2 adds "!/" to resource url as a "nest" separator
 
     private static final String SPRING_BOOT_NESTED_PREFIX_BEFORE_3_2 = "!/BOOT-INF/"; // Before Spring Boot 3.2
     private static final String SPRING_BOOT_NESTED_PREFIX_AFTER_3_2 = "/!BOOT-INF/"; // Since Spring Boot 3.2
@@ -34,16 +37,25 @@ public class JarUtils {
     }
 
     /**
-     * Spring Boot executable jar contains path "BOOT-INF/classes/org/example/MyClass.class" in the jar file.
-     * However, when resource urls are acquired by spring boot classloader's getResources(),
-     * "!" is added to the path prefix as a "nest" separator, resulting in "BOOT-INF/classes!/org/example/MyClass.class".
-     * This method removes the "!" from the path to make it consistent with the actual path in the jar file.
+     * Fix resource urls are acquired by spring boot classloader's getResources() for Spring Boot fat jar
+     * in order to be consistent with the actual path in the jar file.
+     *
+     * For example, Spring Boot 3.2 classloader's getResources() returns like
+     * "jar:nested:/path/to/demo.jar/!BOOT-INF/classes/!/org/example/MyClass.class"
+     * while the actual path in the jar file is
+     * "jar:nested:/path/to/demo.jar!/BOOT-INF/classes/org/example/MyClass.class"
+     *
+     * This method normalizes only the path part. The scheme part (e.g. "jar:nested:") can be handled by getPathWithoutScheme
      * @param resourceUrlPath resource url path
      * @return normalized resource url path
      */
     public static String normalizeSpringBootResourceUrlPath(String resourceUrlPath) {
-        if (resourceUrlPath.startsWith(SPRING_BOOT_URL_PREFIX)) {
-            return resourceUrlPath.replace(SPRING_BOOT_URL_PREFIX, SPRING_BOOT_PREFIX); // Remove "!"
+        resourceUrlPath = replaceNestedPathForSpringBoot32(resourceUrlPath);
+
+        if (resourceUrlPath.contains(SPRING_BOOT_URL_PREFIX)) {
+            return resourceUrlPath.replace(SPRING_BOOT_URL_PREFIX, SPRING_BOOT_PREFIX);
+        } else if (resourceUrlPath.contains(SPRING_BOOT_URL_PREFIX_3_2)) {
+            return resourceUrlPath.replace(SPRING_BOOT_URL_PREFIX_3_2, SPRING_BOOT_PREFIX);
         } else {
             return resourceUrlPath;
         }
@@ -59,6 +71,20 @@ public class JarUtils {
             return urlPath.replace(SPRING_BOOT_NESTED_PREFIX_AFTER_3_2, SPRING_BOOT_NESTED_PREFIX_BEFORE_3_2);
         } else {
             return urlPath;
+        }
+    }
+
+    /**
+     * get path removing scheme prefix including additional scheme e.g. "jar:nested:"
+     */
+    public static String getPathWithoutScheme(URL url) {
+        String path = url.getPath(); // "jar:" scheme is removed here
+        if (path.startsWith("file:")) {
+            return path.substring("file:".length());
+        } else if (path.startsWith("nested:")) {
+            return path.substring("nested:".length());
+        } else {
+            return path;
         }
     }
 }

--- a/drools-util/src/test/java/org/drools/util/JarUtilsTest.java
+++ b/drools-util/src/test/java/org/drools/util/JarUtilsTest.java
@@ -6,9 +6,9 @@
  * to you under the Apache License, Version 2.0 (the
  * "License"); you may not use this file except in compliance
  * with the License.  You may obtain a copy of the License at
- *
- *   http://www.apache.org/licenses/LICENSE-2.0
- *
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
  * Unless required by applicable law or agreed to in writing,
  * software distributed under the License is distributed on an
  * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
@@ -18,28 +18,43 @@
  */
 package org.drools.util;
 
-
-import static org.assertj.core.api.Assertions.assertThat;
+import java.net.MalformedURLException;
+import java.net.URL;
 
 import org.junit.jupiter.api.Test;
 
-public class JarUtilsTest {
+import static org.assertj.core.api.Assertions.assertThat;
+
+class JarUtilsTest {
 
     @Test
-    public void normalizeSpringBootResourceUrlPath() {
-        String normalized = JarUtils.normalizeSpringBootResourceUrlPath("BOOT-INF/classes!/org/example/MyClass.class");
-        assertThat(normalized).isEqualTo("BOOT-INF/classes/org/example/MyClass.class");
+    void normalizeSpringBootResourceUrlPath() {
+        String normalized = JarUtils.normalizeSpringBootResourceUrlPath("/path/to/demo.jar!/BOOT-INF/classes!/org/example/MyClass.class");
+        assertThat(normalized).isEqualTo("/path/to/demo.jar!/BOOT-INF/classes/org/example/MyClass.class");
     }
 
     @Test
-    public void replaceNestedPathForSpringBoot32_shouldNotAffectOldPath() {
+    void normalizeSpringBootResourceUrlPathSB32() {
+        String normalized = JarUtils.normalizeSpringBootResourceUrlPath("/path/to/demo.jar/!BOOT-INF/classes/!/org/example/MyClass.class");
+        assertThat(normalized).isEqualTo("/path/to/demo.jar!/BOOT-INF/classes/org/example/MyClass.class");
+    }
+
+    @Test
+    void replaceNestedPathForSpringBoot32_shouldNotAffectOldPath() {
         String result = JarUtils.replaceNestedPathForSpringBoot32("/dir/myapp.jar!/BOOT-INF/lib/mykjar.jar");
         assertThat(result).isEqualTo("/dir/myapp.jar!/BOOT-INF/lib/mykjar.jar");
     }
 
     @Test
-    public void replaceNestedPathForSpringBoot32_shouldReplaceNewPath() {
+    void replaceNestedPathForSpringBoot32_shouldReplaceNewPath() {
         String result = JarUtils.replaceNestedPathForSpringBoot32("/dir/myapp.jar/!BOOT-INF/lib/mykjar.jar");
         assertThat(result).isEqualTo("/dir/myapp.jar!/BOOT-INF/lib/mykjar.jar");
+    }
+
+    @Test
+    void getPathWithoutScheme() throws MalformedURLException {
+        URL url = new URL("jar", "", "nested:/path/to/demo.jar/!BOOT-INF/classes/!/org/example/MyClass.class");
+        String path = JarUtils.getPathWithoutScheme(url);
+        assertThat(path).isEqualTo("/path/to/demo.jar/!BOOT-INF/classes/!/org/example/MyClass.class");
     }
 }


### PR DESCRIPTION
**Issue**:
* https://github.com/apache/incubator-kie-drools/issues/6309

---
- Handle both "jar:file:" and "jar:nested:" cases
- Normalize a path String provided by spring boot classloader to be consistent with the actual path in the jar file

Note: While it may be worth discussing the need of spring-boot integration tests, this issue is specific to "java -jar" execution use case which is not covered by `@SpringBootTest` (AFAIK), so a test is `JarUtilsTest` anyway.