### PR TITLE
[incubator-kie-drools-6304] Unschdule event expiration job when orphaned

### DIFF
--- a/drools-core/src/main/java/org/drools/core/phreak/PropagationEntry.java
+++ b/drools-core/src/main/java/org/drools/core/phreak/PropagationEntry.java
@@ -239,6 +239,9 @@ public interface PropagationEntry {
             if ( isOrphanHandle(handle, reteEvaluator) ) {
                 handle.setDisconnected(true);
                 handle.getEntryPoint(reteEvaluator).getObjectStore().removeHandle( handle );
+                if (handle instanceof DefaultEventHandle eventHandle) {
+                    eventHandle.unscheduleAllJobs(reteEvaluator);
+                }
             }
         }
 


### PR DESCRIPTION
**Issue**: 

* https://github.com/apache/incubator-kie-drools/issues/6304

---
This PR is to fix the memory leak described in https://github.com/kiegroup/drools-ansible-rulebook-integration/pull/132

As we don't have an easy way to optimize the scheduling (See https://github.com/apache/incubator-kie-drools/pull/6313), this PR only fixes a bug.
