### PR TITLE
[kie-issues#1930] replace() and matches() functions doesn't work with XML Character References

### DIFF
--- a/kie-dmn/kie-dmn-feel/src/main/java/org/kie/dmn/feel/util/XQueryImplUtil.java
+++ b/kie-dmn/kie-dmn-feel/src/main/java/org/kie/dmn/feel/util/XQueryImplUtil.java
@@ -30,7 +30,7 @@ import java.util.regex.Pattern;
 
 public class XQueryImplUtil {
 
-    static Pattern XML_CHARACTER_REFERENCES_PATTERN = Pattern.compile("['\"&<>]");
+    private static final Pattern XML_CHARACTER_REFERENCES_PATTERN = Pattern.compile("['\"&<>]");
 
     private XQueryImplUtil() {
         // Util class with static methods only.
@@ -38,13 +38,13 @@ public class XQueryImplUtil {
 
     public static Boolean executeMatchesFunction(String input, String pattern, String flags) {
         flags = flags == null ? "" : flags;
-        String xQueryExpression = String.format("matches('%s', '%s', '%s')", sanitizeXmlCharacterReferences(input), sanitizeXmlCharacterReferences(pattern), flags);
+        String xQueryExpression = String.format("matches('%s', '%s', '%s')", escapeXmlCharactersReferencesForXPath(input), escapeXmlCharactersReferencesForXPath(pattern), flags);
         return evaluateXQueryExpression(xQueryExpression, Boolean.class);
     }
 
     public static String executeReplaceFunction(String input, String pattern, String replacement, String flags) {
         flags = flags == null ? "" : flags;
-        String xQueryExpression = String.format("replace('%s', '%s', '%s', '%s')", sanitizeXmlCharacterReferences(input), sanitizeXmlCharacterReferences(pattern), sanitizeXmlCharacterReferences(replacement), flags);
+        String xQueryExpression = String.format("replace('%s', '%s', '%s', '%s')", escapeXmlCharactersReferencesForXPath(input), escapeXmlCharactersReferencesForXPath(pattern), escapeXmlCharactersReferencesForXPath(replacement), flags);
         return evaluateXQueryExpression(xQueryExpression, String.class);
     }
 
@@ -74,7 +74,7 @@ public class XQueryImplUtil {
      * @param input A string input representing one of the parameter of managed functions
      * @return A sanitized string
      */
-    static String sanitizeXmlCharacterReferences(String input) {
+    static String escapeXmlCharactersReferencesForXPath(String input) {
         if (input != null && XML_CHARACTER_REFERENCES_PATTERN.matcher(input).find()) {
             input = input.contains("&") ? input.replace("&", "&amp;") : input;
             input = input.contains("\"") ? input.replace("\"",  "&quot;") : input;

--- a/kie-dmn/kie-dmn-feel/src/test/java/org/kie/dmn/feel/runtime/functions/MatchesFunctionTest.java
+++ b/kie-dmn/kie-dmn-feel/src/test/java/org/kie/dmn/feel/runtime/functions/MatchesFunctionTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-feel/src/test/java/org/kie/dmn/feel/runtime/functions/MatchesFunctionTest.java
+++ b/kie-dmn/kie-dmn-feel/src/test/java/org/kie/dmn/feel/runtime/functions/MatchesFunctionTest.java
@@ -136,6 +136,20 @@ class MatchesFunctionTest {
         };
     }
 
+    @ParameterizedTest
+    @MethodSource("invokeWithXmlCharacterReferencesData")
+    void invokeWithXmlCharacterReferencesTest(String input, String pattern, Boolean expectedResult) {
+        FunctionTestUtil.assertResult(matchesFunction.invoke(input, pattern), expectedResult);
+    }
+
+    private static Object[][] invokeWithXmlCharacterReferencesData() {
+        return new Object[][] {
+                { "t&st", "t&st", true },
+                { "a<bra>cadabra", "<bra>", true },
+                { "abracada\"bra'", "bra", true },
+        };
+    }
+
     @Test
     void invokeWithFlagDotAll() {
         FunctionTestUtil.assertResult(matchesFunction.invoke("fo\nbar", "fo.bar", "s"), true);

--- a/kie-dmn/kie-dmn-feel/src/test/java/org/kie/dmn/feel/runtime/functions/ReplaceFunctionTest.java
+++ b/kie-dmn/kie-dmn-feel/src/test/java/org/kie/dmn/feel/runtime/functions/ReplaceFunctionTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-feel/src/test/java/org/kie/dmn/feel/runtime/functions/ReplaceFunctionTest.java
+++ b/kie-dmn/kie-dmn-feel/src/test/java/org/kie/dmn/feel/runtime/functions/ReplaceFunctionTest.java
@@ -98,6 +98,20 @@ class ReplaceFunctionTest {
         };
     }
 
+    @ParameterizedTest
+    @MethodSource("invokeWithXmlCharacterReferencesData")
+    void invokeWithXmlCharacterReferencesTest(String input, String pattern, String replacement, String expectedResult) {
+        FunctionTestUtil.assertResult(replaceFunction.invoke(input, pattern, replacement), expectedResult);
+    }
+
+    private static Object[][] invokeWithXmlCharacterReferencesData() {
+        return new Object[][] {
+                { "abc&123", "abc", "123", "123&123" },
+                { "abc'123", "abc'", "123", "123123" },
+                { "abc\"123", "abc\"", "123<>", "123<>123" }
+        };
+    }
+
     @Test
     void invokeInvalidRegExPattern() {
         FunctionTestUtil.assertResultError(replaceFunction.invoke("testString", "(?=\\s)", "ttt"), InvalidParametersEvent.class);

--- a/kie-dmn/kie-dmn-feel/src/test/java/org/kie/dmn/feel/runtime/functions/ReplaceFunctionTest.java
+++ b/kie-dmn/kie-dmn-feel/src/test/java/org/kie/dmn/feel/runtime/functions/ReplaceFunctionTest.java
@@ -106,6 +106,7 @@ class ReplaceFunctionTest {
 
     private static Object[][] invokeWithXmlCharacterReferencesData() {
         return new Object[][] {
+                { "<'&'>", "abc", "123", "<'&'>" },
                 { "abc&123", "abc", "123", "123&123" },
                 { "abc'123", "abc'", "123", "123123" },
                 { "abc\"123", "abc\"", "123<>", "123<>123" }

--- a/kie-dmn/kie-dmn-feel/src/test/java/org/kie/dmn/feel/util/XQueryImplUtilTest.java
+++ b/kie-dmn/kie-dmn-feel/src/test/java/org/kie/dmn/feel/util/XQueryImplUtilTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-feel/src/test/java/org/kie/dmn/feel/util/XQueryImplUtilTest.java
+++ b/kie-dmn/kie-dmn-feel/src/test/java/org/kie/dmn/feel/util/XQueryImplUtilTest.java
@@ -114,4 +114,21 @@ class XQueryImplUtilTest {
         };
     }
 
+    @ParameterizedTest
+    @MethodSource("sanitizeXmlCharacterReferencesTestData")
+    void sanitizeXmlCharacterReferencesTest(String expression, String expectedResult) {
+        assertThat(XQueryImplUtil.sanitizeXmlCharacterReferences(expression)).isEqualTo(expectedResult);
+    }
+
+    private static Object[][] sanitizeXmlCharacterReferencesTestData() {
+        return new Object[][] {
+                { null, null },
+                { "", "" },
+                { "lolASD", "lolASD" },
+                { "List<String>", "List&lt;String&gt;" },
+                { "\"Mr.Y\"", "&quot;Mr.Y&quot;" },
+                { "'<&>'", "&apos;&lt;&amp;&gt;&apos;" },
+        };
+    }
+
 }

--- a/kie-dmn/kie-dmn-feel/src/test/java/org/kie/dmn/feel/util/XQueryImplUtilTest.java
+++ b/kie-dmn/kie-dmn-feel/src/test/java/org/kie/dmn/feel/util/XQueryImplUtilTest.java
@@ -115,12 +115,12 @@ class XQueryImplUtilTest {
     }
 
     @ParameterizedTest
-    @MethodSource("sanitizeXmlCharacterReferencesTestData")
-    void sanitizeXmlCharacterReferencesTest(String expression, String expectedResult) {
-        assertThat(XQueryImplUtil.sanitizeXmlCharacterReferences(expression)).isEqualTo(expectedResult);
+    @MethodSource("escapeXmlCharactersReferencesForXPathTestData")
+    void escapeXmlCharactersReferencesForXPathTest(String expression, String expectedResult) {
+        assertThat(XQueryImplUtil.escapeXmlCharactersReferencesForXPath(expression)).isEqualTo(expectedResult);
     }
 
-    private static Object[][] sanitizeXmlCharacterReferencesTestData() {
+    private static Object[][] escapeXmlCharactersReferencesForXPathTestData() {
         return new Object[][] {
                 { null, null },
                 { "", "" },


### PR DESCRIPTION
Closes https://github.com/apache/incubator-kie-issues/issues/1930

XML Character References are special characters internally used in XML to refer to other entities Objects.
Those characters are:
- `&`
- `"`
- `'`
- `<`
- `>`

DMN Functions like `matches()` and `replace()` work with XPath specs and implementation. Passing a string that contains one or more of the above characters list will throw an exception. 
To fix the issue, it's necessary to escape the above character list, replacing them with:
- `&`  ---> `&amp;`
- `"`    ---> `&quot;`
- `'`    ---> `&apos;`
- `<`   ---> `&lt;`
- `>`   ---> `&gt;`
