### PR TITLE
[DROOLS-6323] preserve order of used declaration in method expressions when generatic the executable model

### DIFF
--- a/drools-model/drools-model-codegen/src/main/java/org/drools/model/codegen/execmodel/generator/DrlxParseUtil.java
+++ b/drools-model/drools-model-codegen/src/main/java/org/drools/model/codegen/execmodel/generator/DrlxParseUtil.java
@@ -894,11 +894,15 @@ public class DrlxParseUtil {
         }
     }
 
-    public static Collection<String> collectUsedDeclarationsInExpression(Expression expr) {
-        return expr.findAll(NameExpr.class)
-                   .stream()
-                   .map(NameExpr::getName)
+    public static List<String> collectUsedDeclarationsInExpression(Expression expr) {
+        Stream<NameExpr> namesStream = expr instanceof MethodCallExpr methodCallExpr ?
+                Stream.concat(methodCallExpr.getScope().stream(), methodCallExpr.getArguments().stream())
+                        .flatMap(e -> e.findAll(NameExpr.class).stream()) :
+                expr.findAll(NameExpr.class).stream();
+
+        return namesStream.map(NameExpr::getName)
                    .map(SimpleName::getIdentifier)
+                   .distinct()
                    .collect(toList());
     }
 

--- a/drools-model/drools-model-codegen/src/main/java/org/drools/model/codegen/execmodel/generator/expression/AbstractExpressionBuilder.java
+++ b/drools-model/drools-model-codegen/src/main/java/org/drools/model/codegen/execmodel/generator/expression/AbstractExpressionBuilder.java
@@ -62,6 +62,7 @@ import org.kie.api.io.Resource;
 
 import static java.util.Optional.ofNullable;
 import static org.drools.model.codegen.execmodel.generator.DrlxParseUtil.THIS_PLACEHOLDER;
+import static org.drools.model.codegen.execmodel.generator.DrlxParseUtil.collectUsedDeclarationsInExpression;
 import static org.drools.model.codegen.execmodel.generator.DrlxParseUtil.generateLambdaWithoutParameters;
 import static org.drools.model.codegen.execmodel.generator.DrlxParseUtil.isThisExpression;
 import static org.drools.model.codegen.execmodel.generator.DrlxParseUtil.toClassOrInterfaceType;
@@ -338,7 +339,7 @@ public abstract class AbstractExpressionBuilder {
 
     protected Expression generateLambdaForTemporalConstraint(TypedExpression typedExpression, Class<?> patternType) {
         Expression expr = typedExpression.getExpression();
-        Collection<String> usedDeclarations = DrlxParseUtil.collectUsedDeclarationsInExpression(expr);
+        Collection<String> usedDeclarations = collectUsedDeclarationsInExpression(expr);
         boolean containsThis = usedDeclarations.contains(THIS_PLACEHOLDER);
         if (containsThis) {
             usedDeclarations.remove(THIS_PLACEHOLDER);

--- a/drools-model/drools-model-codegen/src/main/java/org/drools/model/codegen/execmodel/generator/visitor/FromVisitor.java
+++ b/drools-model/drools-model-codegen/src/main/java/org/drools/model/codegen/execmodel/generator/visitor/FromVisitor.java
@@ -51,7 +51,9 @@ import org.drools.mvel.parser.printer.PrintUtil;
 
 import static java.util.Optional.of;
 import static java.util.Optional.ofNullable;
+import static java.util.stream.Collectors.toList;
 import static org.drools.base.rule.Pattern.isCompatibleWithFromReturnType;
+import static org.drools.model.codegen.execmodel.generator.DrlxParseUtil.collectUsedDeclarationsInExpression;
 import static org.drools.model.codegen.execmodel.generator.DrlxParseUtil.findViaScopeWithPredicate;
 import static org.drools.model.codegen.execmodel.generator.DrlxParseUtil.generateLambdaWithoutParameters;
 import static org.drools.model.codegen.execmodel.generator.DrlxParseUtil.toStringLiteral;
@@ -199,13 +201,10 @@ public class FromVisitor {
     }
 
     private String addFromArgument( Expression methodCallExpr, MethodCallExpr fromCall ) {
-        Collection<String> args = methodCallExpr
-                .findAll(NameExpr.class)
+        Collection<String> args = collectUsedDeclarationsInExpression(methodCallExpr)
                 .stream()
-                .map(Object::toString)
                 .filter(context::hasDeclaration)
-                .distinct()
-                .collect(Collectors.toList());
+                .collect(toList());
 
         addArgumentWithPreexistingCheck(fromCall, args);
 

--- a/drools-model/drools-model-codegen/src/test/java/org/drools/model/codegen/execmodel/MixedArgumentTest.java
+++ b/drools-model/drools-model-codegen/src/test/java/org/drools/model/codegen/execmodel/MixedArgumentTest.java
@@ -1,0 +1,77 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.drools.model.codegen.execmodel;
+
+import org.drools.model.codegen.execmodel.domain.Child;
+import org.drools.model.codegen.execmodel.domain.Person;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
+import org.kie.api.runtime.KieSession;
+
+import java.io.IOException;
+import java.net.URISyntaxException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class MixedArgumentTest extends BaseModelTest {
+
+    private static final String RULE_STRING = "package mixedarguments\n" +
+            "\n" +
+            "import " + Person.class.getCanonicalName() + "\n" +
+            "import " + Child.class.getCanonicalName() + "\n" +
+            "import java.util.List; \n" +
+            "global java.util.List result; \n" +
+            "rule \"mixedArguments\"\n" +
+            "when \n" +
+            "    $person1 : Person(age == 37)\n" +
+            "    $child1 : Child(age == 5 && parent == \"John\")\n" +
+            "    $person2 : Person(age == 40)\n" +
+            "    $child2 : Child(age == 5 && parent == \"Bob\")\n" +
+            "    $personNo : Integer() from doNothing($person1, $child1.getName, $child2.getName, $person2.getName)\n" +
+            "then \n" +
+            "     result.add($personNo); \n " +
+            "end \n" +
+            "\n" +
+            "function Integer doNothing(Person person, String firstName, String secondName, String thirdName) {\n" +
+            "    return 1; \n" +
+            "}";
+
+
+    @ParameterizedTest
+    @MethodSource("parameters")
+    void mixedArgumentsTest(RUN_TYPE runType){
+
+        KieSession ksession = getKieSession(runType, RULE_STRING);
+        List<Integer> result = new ArrayList<>();
+        ksession.setGlobal("result", result);
+
+        ksession.insert(new Person("John", 37));
+        ksession.insert(new Child("Johnny", 5, "John"));
+        ksession.insert(new Person("Bob", 40));
+        ksession.insert(new Child("Bobby", 5, "Bob"));
+
+        int rulesFired = ksession.fireAllRules();
+
+        assertThat(rulesFired).isEqualTo(1);
+    }
+}


### PR DESCRIPTION
Fixes https://github.com/apache/incubator-kie-drools/issues/6323 and replaces https://github.com/apache/incubator-kie-drools/pull/6324