### PR TITLE
[incubator-kie-issues#1940] Correctly include unnamed and nested imports.

### DIFF
--- a/kie-dmn/kie-dmn-core/src/main/java/org/kie/dmn/core/compiler/DMNCompilerImpl.java
+++ b/kie-dmn/kie-dmn-core/src/main/java/org/kie/dmn/core/compiler/DMNCompilerImpl.java
@@ -146,8 +146,7 @@ public class DMNCompilerImpl implements DMNCompiler {
     @Override
     public DMNModel compile(Resource resource, Collection<DMNModel> dmnModels) {
         try {
-            DMNModel model = compile(resource.getReader(), dmnModels, resource);
-            return model;
+            return compile(resource.getReader(), dmnModels, resource);
         } catch ( IOException e ) {
             logger.error( "Error retrieving reader for resource: " + resource.getSourcePath(), e );
         }
@@ -162,8 +161,7 @@ public class DMNCompilerImpl implements DMNCompiler {
     public DMNModel compile(Reader source, Collection<DMNModel> dmnModels, Resource resource) {
         try {
             Definitions dmndefs = getMarshaller().unmarshal(source);
-            DMNModel model = compile(dmndefs, dmnModels, resource, null);
-            return model;
+            return compile(dmndefs, dmnModels, resource, null);
         } catch ( Exception e ) {
             logger.error( "Error compiling model from source.", e );
         }
@@ -228,7 +226,6 @@ public class DMNCompilerImpl implements DMNCompiler {
      * @return A configured DMNCompilerContext instance that can be used in the DMN compilation process.
      */
     private DMNCompilerContext configureDMNCompiler(FEELDialect feeldialect, Function<String, Reader> relativeResolver) {
-
         DMNCompilerConfigurationImpl cc = (DMNCompilerConfigurationImpl) dmnCompilerConfig;
         List<FEELProfile> helperFEELProfiles = cc.getFeelProfiles();
         DMNFEELHelper feel = new DMNFEELHelper(cc.getRootClassLoader(), helperFEELProfiles, feeldialect);
@@ -666,7 +663,7 @@ public class DMNCompilerImpl implements DMNCompiler {
                     }
                 }
             }
-        } else if (itemDef.getItemComponent() != null && itemDef.getItemComponent().size() > 0) {
+        } else if (itemDef.getItemComponent() != null && !itemDef.getItemComponent().isEmpty()) {
             // this is a composite type
             // first, locate preregistered or create anonymous inner composite
             if (topLevel == null) {

--- a/kie-dmn/kie-dmn-core/src/main/java/org/kie/dmn/core/compiler/UnnamedImportUtils.java
+++ b/kie-dmn/kie-dmn-core/src/main/java/org/kie/dmn/core/compiler/UnnamedImportUtils.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information
@@ -57,10 +57,12 @@ public class UnnamedImportUtils {
         mergedModel.getTypeRegistry().getTypes().forEach((s, stringDMNTypeMap) ->
                                                                  stringDMNTypeMap.values().
                                                                          forEach(dmnType -> parentModel.getTypeRegistry().registerType(dmnType)));
+        mergedModel.getDecisions().forEach(parentModel::addDecision);
+        mergedModel.getImportAliasesForNS().forEach((s, qName) -> parentModel.setImportAliasForNS(s, qName.getNamespaceURI(), qName.getLocalPart()));
     }
 
     public static void mergeDefinitions(Definitions parentDefinitions, Definitions mergedDefinitions) {
-        // incubator-kie-issues#852: The idea is to not treat the anonymous models as import, but to "merge" them with original opne,
+        // incubator-kie-issues#852: The idea is to not treat the anonymous models as import, but to "merge" them with original one,
         // Here we try to put all the definitions from the "imported" model inside the parent one
         parentDefinitions.getArtifact().addAll(mergedDefinitions.getArtifact());
 

--- a/kie-dmn/kie-dmn-core/src/main/java/org/kie/dmn/core/impl/DMNModelImpl.java
+++ b/kie-dmn/kie-dmn-core/src/main/java/org/kie/dmn/core/impl/DMNModelImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information
@@ -18,6 +18,8 @@
  */
 package org.kie.dmn.core.impl;
 
+import javax.xml.namespace.QName;
+
 import java.io.Externalizable;
 import java.io.IOException;
 import java.io.ObjectInput;
@@ -33,13 +35,9 @@ import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
-import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
 import java.util.stream.Collectors;
-
-import javax.xml.namespace.QName;
-
 import org.drools.base.common.DroolsObjectInputStream;
 import org.drools.base.common.DroolsObjectOutputStream;
 import org.kie.api.io.Resource;

--- a/kie-dmn/kie-dmn-core/src/test/java/org/kie/dmn/core/compiler/UnnamedImportUtilsTest.java
+++ b/kie-dmn/kie-dmn-core/src/test/java/org/kie/dmn/core/compiler/UnnamedImportUtilsTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information
@@ -80,11 +80,11 @@ class UnnamedImportUtilsTest {
         try (InputStream is = importedModelFileResource.openStream()) {
             String xml = new String(is.readAllBytes(), StandardCharsets.UTF_8);
             Definitions definitions = DMNMarshallerFactory.newDefaultMarshaller().unmarshal(xml);
-            assertThat(definitions.getDecisionService()).allMatch(definition -> added(definition));
-            assertThat(definitions.getBusinessContextElement()).allMatch(definition -> added(definition));
-            assertThat(definitions.getDrgElement()).allMatch(definition -> added(definition));
-            assertThat(definitions.getImport()).allMatch(definition -> added(definition));
-            assertThat(definitions.getItemDefinition()).allMatch(definition -> added(definition));
+            assertThat(definitions.getDecisionService()).allMatch(this::added);
+            assertThat(definitions.getBusinessContextElement()).allMatch(this::added);
+            assertThat(definitions.getDrgElement()).allMatch(this::added);
+            assertThat(definitions.getImport()).allMatch(this::added);
+            assertThat(definitions.getItemDefinition()).allMatch(this::added);
         }
     }
 

--- a/kie-dmn/kie-dmn-core/src/test/java/org/kie/dmn/core/imports/ImportsTest.java
+++ b/kie-dmn/kie-dmn-core/src/test/java/org/kie/dmn/core/imports/ImportsTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information
@@ -23,7 +23,6 @@ import java.util.Arrays;
 import java.util.Collections;
 import java.util.function.Function;
 
-import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.MethodSource;
 import org.kie.dmn.api.core.DMNContext;
@@ -547,5 +546,52 @@ public class ImportsTest extends BaseInterpretedVsCompiledTest {
         LOG.debug("{}", evaluateAll);
         assertThat(evaluateAll.getDecisionResultByName("Is A Bigger?").getResult()).isEqualTo(Boolean.TRUE);
     }
+
+    @ParameterizedTest
+    @MethodSource("params")
+    void importNestedModelsWithUnnamedImport(boolean useExecModelCompiler) {
+        init(useExecModelCompiler);
+        String basePath = "valid_models/DMNv1_5/nested_imports";
+        String dmnMain = String.format("%s/DMNMainUnnamedImport.dmn", basePath);
+        String dmn1 = String.format("%s/DMN1.dmn", basePath);
+        String dmn2 = String.format("%s/DMN2.dmn", basePath);
+        final DMNRuntime runtime = DMNRuntimeUtil.createRuntimeWithAdditionalResources(dmnMain,
+                                                                                       this.getClass(),
+                                                                                       dmn1,
+                                                                                       dmn2);
+        String dmnMainNamespace = "https://kie.org/dmn/_84840481-6BE8-4C7D-AB86-CE933B145B9B";
+        String dmnMainModelName = "MainUnnamedImport";
+        String dmn1Namespace = "https://kie.org/dmn/_9330C60C-CD07-40EB-98BA-E56D186CCDE1";
+        String dmn1ModelName = "DMN_CDC9A17D-C69A-4F6A-8366-FF9638F398B1";
+        String dmn2Namespace = "https://kie.org/dmn/_484279FA-4F72-4596-A18A-6F265AC06DAD";
+        String dmn2ModelName = "DMN_8F060061-5BD2-400A-99B4-A54E371875C0";
+        getAndAssertModelNoErrors(runtime, dmn1Namespace, dmn1ModelName);
+        getAndAssertModelNoErrors(runtime, dmn2Namespace, dmn2ModelName);
+        getAndAssertModelNoErrors(runtime, dmnMainNamespace, dmnMainModelName);
+    }
+
+    @ParameterizedTest
+    @MethodSource("params")
+    void importNestedModelsWithNamedImport(boolean useExecModelCompiler) {
+        init(useExecModelCompiler);
+        String basePath = "valid_models/DMNv1_5/nested_imports";
+        String dmnMain = String.format("%s/DMNMainNamedImport.dmn", basePath);
+        String dmn1 = String.format("%s/DMN1.dmn", basePath);
+        String dmn2 = String.format("%s/DMN2.dmn", basePath);
+        final DMNRuntime runtime = DMNRuntimeUtil.createRuntimeWithAdditionalResources(dmnMain,
+                                                                                       this.getClass(),
+                                                                                       dmn1,
+                                                                                       dmn2);
+        String dmnMainNamespace = "https://kie.org/dmn/_84840481-6BE8-4C7D-AB86-CE933B145B9B";
+        String dmnMainModelName = "MainNamedImport";
+        String dmn1Namespace = "https://kie.org/dmn/_9330C60C-CD07-40EB-98BA-E56D186CCDE1";
+        String dmn1ModelName = "DMN_CDC9A17D-C69A-4F6A-8366-FF9638F398B1";
+        String dmn2Namespace = "https://kie.org/dmn/_484279FA-4F72-4596-A18A-6F265AC06DAD";
+        String dmn2ModelName = "DMN_8F060061-5BD2-400A-99B4-A54E371875C0";
+        getAndAssertModelNoErrors(runtime, dmn1Namespace, dmn1ModelName);
+        getAndAssertModelNoErrors(runtime, dmn2Namespace, dmn2ModelName);
+        getAndAssertModelNoErrors(runtime, dmnMainNamespace, dmnMainModelName);
+    }
+
 }
 

--- a/kie-dmn/kie-dmn-core/src/test/java/org/kie/dmn/core/imports/ImportsTest.java
+++ b/kie-dmn/kie-dmn-core/src/test/java/org/kie/dmn/core/imports/ImportsTest.java
@@ -373,7 +373,7 @@ public class ImportsTest extends BaseInterpretedVsCompiledTest {
                                                                                        "ModelC.dmn");
 
         final DMNModelImpl modelA = (DMNModelImpl) getAndAssertModelNoErrors(runtime, "http://www.trisotech.com/dmn/definitions/_ae5b3c17-1ac3-4e1d-b4f9-2cf861aec6d9", "Say hello 1ID1D");
-        assertThat(modelA.getImportChainAliases()).hasSize(0);
+        assertThat(modelA.getImportChainAliases()).isEmpty();
 
         final DMNModelImpl modelB = (DMNModelImpl) getAndAssertModelNoErrors(runtime, "http://www.trisotech.com/dmn/definitions/_2a1d771a-a899-4fef-abd6-fc894332337c", "Model B");
         assertThat(modelB.getImportChainAliases()).hasSize(1);
@@ -568,6 +568,12 @@ public class ImportsTest extends BaseInterpretedVsCompiledTest {
         getAndAssertModelNoErrors(runtime, dmn1Namespace, dmn1ModelName);
         getAndAssertModelNoErrors(runtime, dmn2Namespace, dmn2ModelName);
         getAndAssertModelNoErrors(runtime, dmnMainNamespace, dmnMainModelName);
+
+        final DMNModel dmnModel = runtime.getModel(dmnMainNamespace,
+                                                   dmnMainModelName);
+        final DMNResult evaluateAll = runtime.evaluateAll(dmnModel, runtime.newContext());
+        assertThat(evaluateAll.hasErrors()).as(DMNRuntimeUtil.formatMessages(evaluateAll.getMessages())).isFalse();
+        assertThat(evaluateAll.getDecisionResultByName("DecisionMain").getResult()).isEqualTo(Boolean.TRUE);
     }
 
     @ParameterizedTest
@@ -591,6 +597,11 @@ public class ImportsTest extends BaseInterpretedVsCompiledTest {
         getAndAssertModelNoErrors(runtime, dmn1Namespace, dmn1ModelName);
         getAndAssertModelNoErrors(runtime, dmn2Namespace, dmn2ModelName);
         getAndAssertModelNoErrors(runtime, dmnMainNamespace, dmnMainModelName);
+        final DMNModel dmnModel = runtime.getModel(dmnMainNamespace,
+                                                   dmnMainModelName);
+        final DMNResult evaluateAll = runtime.evaluateAll(dmnModel, runtime.newContext());
+        assertThat(evaluateAll.hasErrors()).as(DMNRuntimeUtil.formatMessages(evaluateAll.getMessages())).isFalse();
+        assertThat(evaluateAll.getDecisionResultByName("DecisionMain").getResult()).isEqualTo(Boolean.TRUE);
     }
 
 }

--- a/kie-dmn/kie-dmn-test-resources/src/test/resources/valid_models/DMNv1_5/nested_imports/DMN1.dmn
+++ b/kie-dmn/kie-dmn-test-resources/src/test/resources/valid_models/DMNv1_5/nested_imports/DMN1.dmn
@@ -1,0 +1,31 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<definitions xmlns="https://www.omg.org/spec/DMN/20230324/MODEL/"
+             xmlns:dmndi="https://www.omg.org/spec/DMN/20230324/DMNDI/"
+             xmlns:dc="http://www.omg.org/spec/DMN/20180521/DC/"
+             xmlns:di="http://www.omg.org/spec/DMN/20180521/DI/"
+             xmlns:kie="https://kie.org/dmn/extensions/1.0"
+             expressionLanguage="https://www.omg.org/spec/DMN/20230324/FEEL/"
+             namespace="https://kie.org/dmn/_9330C60C-CD07-40EB-98BA-E56D186CCDE1"
+             id="_B4C6A7FC-BA0A-461B-A731-1F9E3E3AA9B2"
+             name="DMN_CDC9A17D-C69A-4F6A-8366-FF9638F398B1">
+  <decision name="Decision1" id="_F86E12F0-F994-47ED-8C74-F48F4FA76A06">
+    <variable name="Decision1" id="_A248A017-98F6-4D14-A51F-21F49F5F83E6" typeRef="boolean" />
+    <literalExpression id="_2D88DEA6-ADA7-44CD-871A-A66139121DAD" label="Decision1" typeRef="boolean">
+      <text>true</text>
+    </literalExpression>
+  </decision>
+  <dmndi:DMNDI>
+    <dmndi:DMNDiagram id="_174C0FE2-72A6-4536-82E7-F6A9F3C89757" name="Default DRD" useAlternativeInputDataShape="false">
+      <di:extension>
+        <kie:ComponentsWidthsExtension>
+          <kie:ComponentWidths dmnElementRef="_2D88DEA6-ADA7-44CD-871A-A66139121DAD">
+            <kie:width>190</kie:width>
+          </kie:ComponentWidths>
+        </kie:ComponentsWidthsExtension>
+      </di:extension>
+      <dmndi:DMNShape id="_5F0C1D3D-4472-4E57-A2DB-5C69582A535A" dmnElementRef="_F86E12F0-F994-47ED-8C74-F48F4FA76A06" isCollapsed="false" isListedInputData="false">
+        <dc:Bounds x="360" y="120" width="160" height="80" />
+      </dmndi:DMNShape>
+    </dmndi:DMNDiagram>
+  </dmndi:DMNDI>
+</definitions>

--- a/kie-dmn/kie-dmn-test-resources/src/test/resources/valid_models/DMNv1_5/nested_imports/DMN1.dmn
+++ b/kie-dmn/kie-dmn-test-resources/src/test/resources/valid_models/DMNv1_5/nested_imports/DMN1.dmn
@@ -1,4 +1,23 @@
-<?xml version="1.0" encoding="UTF-8" ?>
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  Licensed to the Apache Software Foundation (ASF) under one
+  or more contributor license agreements.  See the NOTICE file
+  distributed with this work for additional information
+  regarding copyright ownership.  The ASF licenses this file
+  to you under the Apache License, Version 2.0 (the
+  "License"); you may not use this file except in compliance
+  with the License.  You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing,
+  software distributed under the License is distributed on an
+  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+  KIND, either express or implied.  See the License for the
+  specific language governing permissions and limitations
+  under the License.
+  -->
+
 <definitions xmlns="https://www.omg.org/spec/DMN/20230324/MODEL/"
              xmlns:dmndi="https://www.omg.org/spec/DMN/20230324/DMNDI/"
              xmlns:dc="http://www.omg.org/spec/DMN/20180521/DC/"

--- a/kie-dmn/kie-dmn-test-resources/src/test/resources/valid_models/DMNv1_5/nested_imports/DMN2.dmn
+++ b/kie-dmn/kie-dmn-test-resources/src/test/resources/valid_models/DMNv1_5/nested_imports/DMN2.dmn
@@ -1,0 +1,46 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<definitions xmlns="https://www.omg.org/spec/DMN/20230324/MODEL/"
+             xmlns:dmndi="https://www.omg.org/spec/DMN/20230324/DMNDI/"
+             xmlns:dc="http://www.omg.org/spec/DMN/20180521/DC/"
+             xmlns:di="http://www.omg.org/spec/DMN/20180521/DI/"
+             xmlns:kie="https://kie.org/dmn/extensions/1.0"
+             expressionLanguage="https://www.omg.org/spec/DMN/20230324/FEEL/"
+             namespace="https://kie.org/dmn/_484279FA-4F72-4596-A18A-6F265AC06DAD"
+             id="_9E01BF81-57DA-4C97-99FB-0E0401EFC817"
+             name="DMN_8F060061-5BD2-400A-99B4-A54E371875C0"
+             xmlns:included0="https://kie.org/dmn/_9330C60C-CD07-40EB-98BA-E56D186CCDE1">
+  <import id="_598A4A96-D213-4E13-B7ED-7111428C75F4" name="d1"
+          importType="https://www.omg.org/spec/DMN/20230324/MODEL/"
+          namespace="https://kie.org/dmn/_9330C60C-CD07-40EB-98BA-E56D186CCDE1"
+          locationURI="./DMN1.dmn" />
+  <decision name="Decision2" id="_3236C4B7-F5B5-4A24-92DD-1F4BB6D3C4EF">
+    <variable name="Decision2" id="_D3BE7BA2-5B87-4C7E-93D1-049A50AFD29D" typeRef="boolean" />
+    <informationRequirement id="_7E9CA5BA-B7F2-4BCC-86A6-56E133A3456E">
+      <requiredDecision href="https://kie.org/dmn/_9330C60C-CD07-40EB-98BA-E56D186CCDE1#_F86E12F0-F994-47ED-8C74-F48F4FA76A06" />
+    </informationRequirement>
+    <literalExpression id="_35E82230-8F5B-4E28-A478-9684195C1DCE" typeRef="boolean" label="Decision2">
+      <text>not(d1.Decision1)</text>
+    </literalExpression>
+  </decision>
+  <dmndi:DMNDI>
+    <dmndi:DMNDiagram id="_EB5FAA65-ED07-4BCE-B294-ADAD1174BF16" name="Default DRD" useAlternativeInputDataShape="false">
+      <di:extension>
+        <kie:ComponentsWidthsExtension>
+          <kie:ComponentWidths dmnElementRef="_35E82230-8F5B-4E28-A478-9684195C1DCE">
+            <kie:width>190</kie:width>
+          </kie:ComponentWidths>
+        </kie:ComponentsWidthsExtension>
+      </di:extension>
+      <dmndi:DMNShape id="_DB2FA6AC-21D5-4976-84EB-1A7D16DE7D70" dmnElementRef="_3236C4B7-F5B5-4A24-92DD-1F4BB6D3C4EF" isCollapsed="false" isListedInputData="false">
+        <dc:Bounds x="160" y="60" width="160" height="80" />
+      </dmndi:DMNShape>
+      <dmndi:DMNShape id="_094E3361-AD8A-44FD-BCEE-E8279C17CD58" dmnElementRef="included0:_F86E12F0-F994-47ED-8C74-F48F4FA76A06">
+        <dc:Bounds x="160" y="200" width="160" height="80" />
+      </dmndi:DMNShape>
+      <dmndi:DMNEdge id="_770BED15-2FAD-4192-A53D-E424ACBE602B" dmnElementRef="_7E9CA5BA-B7F2-4BCC-86A6-56E133A3456E" sourceElement="_094E3361-AD8A-44FD-BCEE-E8279C17CD58" targetElement="_DB2FA6AC-21D5-4976-84EB-1A7D16DE7D70">
+        <di:waypoint x="240" y="240" />
+        <di:waypoint x="240" y="140" />
+      </dmndi:DMNEdge>
+    </dmndi:DMNDiagram>
+  </dmndi:DMNDI>
+</definitions>

--- a/kie-dmn/kie-dmn-test-resources/src/test/resources/valid_models/DMNv1_5/nested_imports/DMN2.dmn
+++ b/kie-dmn/kie-dmn-test-resources/src/test/resources/valid_models/DMNv1_5/nested_imports/DMN2.dmn
@@ -1,4 +1,23 @@
-<?xml version="1.0" encoding="UTF-8" ?>
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  Licensed to the Apache Software Foundation (ASF) under one
+  or more contributor license agreements.  See the NOTICE file
+  distributed with this work for additional information
+  regarding copyright ownership.  The ASF licenses this file
+  to you under the Apache License, Version 2.0 (the
+  "License"); you may not use this file except in compliance
+  with the License.  You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing,
+  software distributed under the License is distributed on an
+  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+  KIND, either express or implied.  See the License for the
+  specific language governing permissions and limitations
+  under the License.
+  -->
+
 <definitions xmlns="https://www.omg.org/spec/DMN/20230324/MODEL/"
              xmlns:dmndi="https://www.omg.org/spec/DMN/20230324/DMNDI/"
              xmlns:dc="http://www.omg.org/spec/DMN/20180521/DC/"

--- a/kie-dmn/kie-dmn-test-resources/src/test/resources/valid_models/DMNv1_5/nested_imports/DMNMainNamedImport.dmn
+++ b/kie-dmn/kie-dmn-test-resources/src/test/resources/valid_models/DMNv1_5/nested_imports/DMNMainNamedImport.dmn
@@ -1,4 +1,23 @@
-<?xml version="1.0" encoding="UTF-8" ?>
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  Licensed to the Apache Software Foundation (ASF) under one
+  or more contributor license agreements.  See the NOTICE file
+  distributed with this work for additional information
+  regarding copyright ownership.  The ASF licenses this file
+  to you under the Apache License, Version 2.0 (the
+  "License"); you may not use this file except in compliance
+  with the License.  You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing,
+  software distributed under the License is distributed on an
+  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+  KIND, either express or implied.  See the License for the
+  specific language governing permissions and limitations
+  under the License.
+  -->
+
 <definitions xmlns="https://www.omg.org/spec/DMN/20230324/MODEL/"
              expressionLanguage="https://www.omg.org/spec/DMN/20230324/FEEL/"
              namespace="https://kie.org/dmn/_84840481-6BE8-4C7D-AB86-CE933B145B9B"

--- a/kie-dmn/kie-dmn-test-resources/src/test/resources/valid_models/DMNv1_5/nested_imports/DMNMainNamedImport.dmn
+++ b/kie-dmn/kie-dmn-test-resources/src/test/resources/valid_models/DMNv1_5/nested_imports/DMNMainNamedImport.dmn
@@ -1,0 +1,46 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<definitions xmlns="https://www.omg.org/spec/DMN/20230324/MODEL/"
+             expressionLanguage="https://www.omg.org/spec/DMN/20230324/FEEL/"
+             namespace="https://kie.org/dmn/_84840481-6BE8-4C7D-AB86-CE933B145B9B"
+             id="_EC356BF7-D8EA-461C-8BC6-F01FD670C473"
+             name="MainNamedImport"
+             xmlns:included0="https://kie.org/dmn/_484279FA-4F72-4596-A18A-6F265AC06DAD"
+             xmlns:dmndi="https://www.omg.org/spec/DMN/20230324/DMNDI/"
+             xmlns:dc="http://www.omg.org/spec/DMN/20180521/DC/"
+             xmlns:di="http://www.omg.org/spec/DMN/20180521/DI/"
+             xmlns:kie="https://kie.org/dmn/extensions/1.0">
+  <import id="_5DB3DA5F-6794-49C5-96BE-4D69B8EF3F13" name="d2"
+          importType="https://www.omg.org/spec/DMN/20230324/MODEL/"
+          namespace="https://kie.org/dmn/_484279FA-4F72-4596-A18A-6F265AC06DAD"
+          locationURI="./DMN2.dmn" />
+  <decision name="DecisionMain" id="_D34EEFAD-F481-4F56-A180-E7B4C9D61940">
+    <variable name="DecisionMain" id="_06ECF799-512B-4B47-83B4-DFB97446C1E8" typeRef="boolean" />
+    <informationRequirement id="_292FFC51-4C27-4935-8870-46F0BBD7B4E2">
+      <requiredDecision href="https://kie.org/dmn/_484279FA-4F72-4596-A18A-6F265AC06DAD#_3236C4B7-F5B5-4A24-92DD-1F4BB6D3C4EF" />
+    </informationRequirement>
+    <literalExpression id="_9DDFEA16-E103-4871-AA9E-5DEF5FD4A8AB" typeRef="boolean" label="DecisionMain">
+      <text>not(d2.Decision2)</text>
+    </literalExpression>
+  </decision>
+  <dmndi:DMNDI>
+    <dmndi:DMNDiagram id="_E2A2D3DD-D761-420D-9930-872D98084693" name="Default DRD" useAlternativeInputDataShape="false">
+      <di:extension>
+        <kie:ComponentsWidthsExtension>
+          <kie:ComponentWidths dmnElementRef="_9DDFEA16-E103-4871-AA9E-5DEF5FD4A8AB">
+            <kie:width>190</kie:width>
+          </kie:ComponentWidths>
+        </kie:ComponentsWidthsExtension>
+      </di:extension>
+      <dmndi:DMNShape id="_015C8D1F-9ECF-483C-8318-3A28B38BBAAD" dmnElementRef="_D34EEFAD-F481-4F56-A180-E7B4C9D61940" isCollapsed="false" isListedInputData="false">
+        <dc:Bounds x="300" y="20" width="160" height="80" />
+      </dmndi:DMNShape>
+      <dmndi:DMNShape id="_D7B8B922-E482-4CDE-B11C-1727A12157E9" dmnElementRef="included0:_3236C4B7-F5B5-4A24-92DD-1F4BB6D3C4EF">
+        <dc:Bounds x="300" y="200" width="160" height="80" />
+      </dmndi:DMNShape>
+      <dmndi:DMNEdge id="_9ADF7B9A-6652-4F36-AE46-50C86E316A53" dmnElementRef="_292FFC51-4C27-4935-8870-46F0BBD7B4E2" sourceElement="_D7B8B922-E482-4CDE-B11C-1727A12157E9" targetElement="_015C8D1F-9ECF-483C-8318-3A28B38BBAAD">
+        <di:waypoint x="380" y="240" />
+        <di:waypoint x="380" y="100" />
+      </dmndi:DMNEdge>
+    </dmndi:DMNDiagram>
+  </dmndi:DMNDI>
+</definitions>

--- a/kie-dmn/kie-dmn-test-resources/src/test/resources/valid_models/DMNv1_5/nested_imports/DMNMainUnnamedImport.dmn
+++ b/kie-dmn/kie-dmn-test-resources/src/test/resources/valid_models/DMNv1_5/nested_imports/DMNMainUnnamedImport.dmn
@@ -1,4 +1,23 @@
-<?xml version="1.0" encoding="UTF-8" ?>
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  Licensed to the Apache Software Foundation (ASF) under one
+  or more contributor license agreements.  See the NOTICE file
+  distributed with this work for additional information
+  regarding copyright ownership.  The ASF licenses this file
+  to you under the Apache License, Version 2.0 (the
+  "License"); you may not use this file except in compliance
+  with the License.  You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing,
+  software distributed under the License is distributed on an
+  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+  KIND, either express or implied.  See the License for the
+  specific language governing permissions and limitations
+  under the License.
+  -->
+
 <definitions xmlns="https://www.omg.org/spec/DMN/20230324/MODEL/"
              expressionLanguage="https://www.omg.org/spec/DMN/20230324/FEEL/"
              namespace="https://kie.org/dmn/_84840481-6BE8-4C7D-AB86-CE933B145B9B"

--- a/kie-dmn/kie-dmn-test-resources/src/test/resources/valid_models/DMNv1_5/nested_imports/DMNMainUnnamedImport.dmn
+++ b/kie-dmn/kie-dmn-test-resources/src/test/resources/valid_models/DMNv1_5/nested_imports/DMNMainUnnamedImport.dmn
@@ -1,0 +1,46 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<definitions xmlns="https://www.omg.org/spec/DMN/20230324/MODEL/"
+             expressionLanguage="https://www.omg.org/spec/DMN/20230324/FEEL/"
+             namespace="https://kie.org/dmn/_84840481-6BE8-4C7D-AB86-CE933B145B9B"
+             id="_EC356BF7-D8EA-461C-8BC6-F01FD670C473"
+             name="MainUnnamedImport"
+             xmlns:included0="https://kie.org/dmn/_484279FA-4F72-4596-A18A-6F265AC06DAD"
+             xmlns:dmndi="https://www.omg.org/spec/DMN/20230324/DMNDI/"
+             xmlns:dc="http://www.omg.org/spec/DMN/20180521/DC/"
+             xmlns:di="http://www.omg.org/spec/DMN/20180521/DI/"
+             xmlns:kie="https://kie.org/dmn/extensions/1.0">
+  <import id="_5DB3DA5F-6794-49C5-96BE-4D69B8EF3F13" name=""
+          importType="https://www.omg.org/spec/DMN/20230324/MODEL/"
+          namespace="https://kie.org/dmn/_484279FA-4F72-4596-A18A-6F265AC06DAD"
+          locationURI="./DMN2.dmn" />
+  <decision name="DecisionMain" id="_D34EEFAD-F481-4F56-A180-E7B4C9D61940">
+    <variable name="DecisionMain" id="_06ECF799-512B-4B47-83B4-DFB97446C1E8" typeRef="boolean" />
+    <informationRequirement id="_292FFC51-4C27-4935-8870-46F0BBD7B4E2">
+      <requiredDecision href="https://kie.org/dmn/_484279FA-4F72-4596-A18A-6F265AC06DAD#_3236C4B7-F5B5-4A24-92DD-1F4BB6D3C4EF" />
+    </informationRequirement>
+    <literalExpression id="_9DDFEA16-E103-4871-AA9E-5DEF5FD4A8AB" typeRef="boolean" label="DecisionMain">
+      <text>not(Decision2)</text>
+    </literalExpression>
+  </decision>
+  <dmndi:DMNDI>
+    <dmndi:DMNDiagram id="_E2A2D3DD-D761-420D-9930-872D98084693" name="Default DRD" useAlternativeInputDataShape="false">
+      <di:extension>
+        <kie:ComponentsWidthsExtension>
+          <kie:ComponentWidths dmnElementRef="_9DDFEA16-E103-4871-AA9E-5DEF5FD4A8AB">
+            <kie:width>190</kie:width>
+          </kie:ComponentWidths>
+        </kie:ComponentsWidthsExtension>
+      </di:extension>
+      <dmndi:DMNShape id="_015C8D1F-9ECF-483C-8318-3A28B38BBAAD" dmnElementRef="_D34EEFAD-F481-4F56-A180-E7B4C9D61940" isCollapsed="false" isListedInputData="false">
+        <dc:Bounds x="300" y="20" width="160" height="80" />
+      </dmndi:DMNShape>
+      <dmndi:DMNShape id="_D7B8B922-E482-4CDE-B11C-1727A12157E9" dmnElementRef="included0:_3236C4B7-F5B5-4A24-92DD-1F4BB6D3C4EF">
+        <dc:Bounds x="300" y="200" width="160" height="80" />
+      </dmndi:DMNShape>
+      <dmndi:DMNEdge id="_9ADF7B9A-6652-4F36-AE46-50C86E316A53" dmnElementRef="_292FFC51-4C27-4935-8870-46F0BBD7B4E2" sourceElement="_D7B8B922-E482-4CDE-B11C-1727A12157E9" targetElement="_015C8D1F-9ECF-483C-8318-3A28B38BBAAD">
+        <di:waypoint x="380" y="240" />
+        <di:waypoint x="380" y="100" />
+      </dmndi:DMNEdge>
+    </dmndi:DMNDiagram>
+  </dmndi:DMNDI>
+</definitions>

--- a/kie-dmn/kie-dmn-validation/src/main/resources/org/kie/dmn/validation/DMNv1_3/dmn-validation-rules-dmndi.drl
+++ b/kie-dmn/kie-dmn-validation/src/main/resources/org/kie/dmn/validation/DMNv1_3/dmn-validation-rules-dmndi.drl
@@ -98,12 +98,15 @@ end
 rule DMNSHAPE_UNKNOWN_REF_WITH_IMPORT
 when
     DMNDI()
-    $shape : DMNShape($prefix : dmnElementRef.prefix != XMLConstants.DEFAULT_NS_PREFIX)
-    Definitions($nsContext : nsContext)
+    $shape : DMNShape($prefix : dmnElementRef.prefix != XMLConstants.DEFAULT_NS_PREFIX, $localPart : dmnElementRef.localPart)
+    $definitions : Definitions($nsContext : nsContext)
     $import : Import(DMNImportsUtil.whichImportType(this) == DMNImportsUtil.ImportType.DMN, namespace == $nsContext[$prefix])
     $importDef : Definitions(namespace == $import.namespace) from entry-point "DMNImports"
-    not DRGElement(id == $shape.dmnElementRef.localPart) from $importDef.drgElement
-    not TextAnnotation(id == $shape.dmnElementRef.localPart) from $importDef.artifact
+    $importRelatedDefinitions :  Definitions(drgElement[0].id == $localPart) from entry-point "RelatedImports"
+    not DRGElement(id == $localPart) from $importDef.drgElement
+    not DRGElement(id == $localPart) from $importRelatedDefinitions.drgElement
+    not DRGElement(id == $localPart)
+    not TextAnnotation(id == $localPart) from $importDef.artifact
     not Group(id == $shape.dmnElementRef.localPart) from $importDef.artifact
 then
     reporter.report(DMNMessage.Severity.ERROR, $shape, Msg.DMNDI_UNKNOWN_REF, $shape.getDmnElementRef(), $shape.getIdentifierString());

--- a/kie-dmn/kie-dmn-validation/src/test/java/org/kie/dmn/validation/ValidatorTest.java
+++ b/kie-dmn/kie-dmn-validation/src/test/java/org/kie/dmn/validation/ValidatorTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information
@@ -24,13 +24,19 @@ import java.io.InputStreamReader;
 import java.io.Reader;
 import java.net.URISyntaxException;
 import java.net.URL;
+import java.nio.file.Files;
+import java.nio.file.Path;
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.Objects;
 import java.util.jar.JarFile;
+import java.util.stream.Stream;
 import java.util.zip.ZipEntry;
 
 import org.drools.io.ClassPathResource;
+import org.drools.io.FileSystemResource;
 import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.kie.api.builder.Message;
@@ -66,30 +72,33 @@ class ValidatorTest extends AbstractValidatorTest {
     private static final Logger LOGGER = LoggerFactory.getLogger(ValidatorTest.class);
 
     static final DMNValidator validator = DMNValidatorFactory.newValidator(List.of(new ExtendedDMNProfile()));
-    static final DMNValidator.ValidatorBuilder validatorBuilder = validator.validateUsing(DMNValidator.Validation.VALIDATE_SCHEMA, DMNValidator.Validation.VALIDATE_MODEL);
+    static final DMNValidator.ValidatorBuilder validatorBuilder =
+            validator.validateUsing(DMNValidator.Validation.VALIDATE_SCHEMA, DMNValidator.Validation.VALIDATE_MODEL);
 
     @Test
     void dryRun() {
-        DMNRuntime runtime = DMNRuntimeUtil.createRuntime( "0001-input-data-string.dmn", DMNInputRuntimeTest.class );
-        DMNModel dmnModel = runtime.getModel( "https://github.com/kiegroup/drools/kie-dmn", "_0001-input-data-string" );
+        DMNRuntime runtime = DMNRuntimeUtil.createRuntime("0001-input-data-string.dmn", DMNInputRuntimeTest.class);
+        DMNModel dmnModel = runtime.getModel("https://github.com/kiegroup/drools/kie-dmn", "_0001-input-data-string");
         assertThat(dmnModel).isNotNull();
 
         Definitions definitions = dmnModel.getDefinitions();
         assertThat(dmnModel).isNotNull();
-        
+
         DMNValidatorFactory.newValidator().validate(definitions);
     }
 
     @Test
     void macdInputDefinitions() {
-        DMNRuntime runtime = DMNRuntimeUtil.createRuntime( "MACD-enhanced_iteration.dmn", DMNInputRuntimeTest.class );
-        DMNModel dmnModel = runtime.getModel( "http://www.trisotech.com/definitions/_6cfe7d88-6741-45d1-968c-b61a597d0964", "MACD-enhanced iteration" );
+        DMNRuntime runtime = DMNRuntimeUtil.createRuntime("MACD-enhanced_iteration.dmn", DMNInputRuntimeTest.class);
+        DMNModel dmnModel = runtime.getModel("http://www.trisotech.com/definitions/_6cfe7d88-6741-45d1-968c" +
+                                                     "-b61a597d0964", "MACD-enhanced iteration");
         assertThat(dmnModel).isNotNull();
 
         Definitions definitions = dmnModel.getDefinitions();
         assertThat(dmnModel).isNotNull();
 
-        List<DMNMessage> messages = DMNValidatorFactory.newValidator().validate(definitions, VALIDATE_MODEL, VALIDATE_COMPILATION);
+        List<DMNMessage> messages = DMNValidatorFactory.newValidator().validate(definitions, VALIDATE_MODEL,
+                                                                                VALIDATE_COMPILATION);
 
         assertThat(messages).as(messages.toString()).hasSize(0);
     }
@@ -97,35 +106,41 @@ class ValidatorTest extends AbstractValidatorTest {
     @Test
     void macdInputReader() throws IOException {
         try (final Reader reader = new InputStreamReader(Objects.requireNonNull(getClass().getResourceAsStream("/org/kie/dmn/core/MACD-enhanced_iteration.dmn")))) {
-            List<DMNMessage> messages = DMNValidatorFactory.newValidator().validate(reader, VALIDATE_MODEL, VALIDATE_COMPILATION);
+            List<DMNMessage> messages = DMNValidatorFactory.newValidator().validate(reader, VALIDATE_MODEL,
+                                                                                    VALIDATE_COMPILATION);
             assertThat(messages).withFailMessage(messages.toString()).hasSize(0);
         }
     }
 
     @Test
     void invalidXml() throws URISyntaxException {
-        List<DMNMessage> validateXML = validator.validate( new File(this.getClass().getResource( "invalidXml.dmn" ).toURI()), DMNValidator.Validation.VALIDATE_SCHEMA);
+        List<DMNMessage> validateXML =
+                validator.validate(new File(this.getClass().getResource("invalidXml.dmn").toURI()),
+                                   DMNValidator.Validation.VALIDATE_SCHEMA);
         assertThat(validateXML).withFailMessage(ValidatorUtil.formatMessages(validateXML)).hasSize(1);
-        assertThat(validateXML.get( 0 ).getMessageType()).withFailMessage(validateXML.get( 0 ).toString()).isEqualTo(DMNMessageType.FAILED_XML_VALIDATION);
-        assertThat( validateXML.get(0).getPath()).contains("invalidXml.dmn");
+        assertThat(validateXML.get(0).getMessageType()).withFailMessage(validateXML.get(0).toString()).isEqualTo(DMNMessageType.FAILED_XML_VALIDATION);
+        assertThat(validateXML.get(0).getPath()).contains("invalidXml.dmn");
     }
 
     @Test
     void invocationMissingExpr() {
-        List<DMNMessage> validate = validator.validate( getReader( "INVOCATION_MISSING_EXPR.dmn" ), VALIDATE_SCHEMA, VALIDATE_MODEL, VALIDATE_COMPILATION);
+        List<DMNMessage> validate = validator.validate(getReader("INVOCATION_MISSING_EXPR.dmn"), VALIDATE_SCHEMA,
+                                                       VALIDATE_MODEL, VALIDATE_COMPILATION);
         assertThat(validate).withFailMessage(ValidatorUtil.formatMessages(validate)).hasSizeGreaterThan(0);
         assertThat(validate.get(0).getMessageType()).withFailMessage(validate.get(0).toString()).isEqualTo(DMNMessageType.MISSING_EXPRESSION);
     }
 
     @Test
     void nameIsValid() {
-        List<DMNMessage> validate = validator.validate( getReader( "NAME_IS_VALID.dmn" ), VALIDATE_SCHEMA, VALIDATE_MODEL, VALIDATE_COMPILATION);
+        List<DMNMessage> validate = validator.validate(getReader("NAME_IS_VALID.dmn"), VALIDATE_SCHEMA,
+                                                       VALIDATE_MODEL, VALIDATE_COMPILATION);
         assertThat(validate).withFailMessage(ValidatorUtil.formatMessages(validate)).hasSize(0);
     }
 
     @Test
     void name_invalidEmptyName() {
-        List<DMNMessage> validate = validator.validate( getReader( "DROOLS-1447.dmn" ), VALIDATE_SCHEMA, VALIDATE_MODEL, VALIDATE_COMPILATION);
+        List<DMNMessage> validate = validator.validate(getReader("DROOLS-1447.dmn"), VALIDATE_SCHEMA, VALIDATE_MODEL,
+                                                       VALIDATE_COMPILATION);
         assertThat(validate).withFailMessage(ValidatorUtil.formatMessages(validate)).hasSize(5);
         assertThat(validate.stream().anyMatch(p -> p.getMessageType().equals(DMNMessageType.FAILED_XML_VALIDATION))).isTrue();
         assertThat(validate.stream().anyMatch(p -> p.getMessageType().equals(DMNMessageType.VARIABLE_NAME_MISMATCH))).isTrue();
@@ -135,67 +150,77 @@ class ValidatorTest extends AbstractValidatorTest {
 
     @Test
     void name_emptyEmptyModelName() {
-        List<DMNMessage> validate = validator.validate( getReader( "EmptyModelName.dmn" ), VALIDATE_SCHEMA, VALIDATE_MODEL, VALIDATE_COMPILATION);
+        List<DMNMessage> validate = validator.validate(getReader("EmptyModelName.dmn"), VALIDATE_SCHEMA,
+                                                       VALIDATE_MODEL, VALIDATE_COMPILATION);
         assertThat(validate).withFailMessage(ValidatorUtil.formatMessages(validate)).hasSize(1);
         assertThat(validate.stream().anyMatch(p -> p.getMessageType().equals(DMNMessageType.INVALID_NAME) && p.getSourceId().equals("_f27bb64b-6fc7-4e1f-9848-11ba35e0df44"))).isTrue();
     }
 
     @Test
     void drgelemNotUnique() {
-        List<DMNMessage> validate = validator.validate( getReader( "DRGELEM_NOT_UNIQUE.dmn" ), VALIDATE_SCHEMA, VALIDATE_MODEL, VALIDATE_COMPILATION);
+        List<DMNMessage> validate = validator.validate(getReader("DRGELEM_NOT_UNIQUE.dmn"), VALIDATE_SCHEMA,
+                                                       VALIDATE_MODEL, VALIDATE_COMPILATION);
         assertThat(validate).withFailMessage(ValidatorUtil.formatMessages(validate)).hasSize(2);
         assertThat(validate.stream().anyMatch(p -> p.getMessageType().equals(DMNMessageType.DUPLICATE_NAME))).isTrue();
     }
 
     @Test
     void formalParamDuplicated() {
-        List<DMNMessage> validate = validator.validate( getReader( "FORMAL_PARAM_DUPLICATED.dmn" ), VALIDATE_SCHEMA, VALIDATE_MODEL, VALIDATE_COMPILATION);
+        List<DMNMessage> validate = validator.validate(getReader("FORMAL_PARAM_DUPLICATED.dmn"), VALIDATE_SCHEMA,
+                                                       VALIDATE_MODEL, VALIDATE_COMPILATION);
         assertThat(validate).withFailMessage(ValidatorUtil.formatMessages(validate)).hasSize(3);
         assertThat(validate.stream().anyMatch(p -> p.getMessageType().equals(DMNMessageType.DUPLICATED_PARAM))).isTrue();
     }
 
     @Test
     void invocationInconsistentParamNames() {
-        List<DMNMessage> validate = validator.validate( getReader( "INVOCATION_INCONSISTENT_PARAM_NAMES.dmn" ), VALIDATE_SCHEMA, VALIDATE_MODEL, VALIDATE_COMPILATION);
+        List<DMNMessage> validate = validator.validate(getReader("INVOCATION_INCONSISTENT_PARAM_NAMES.dmn"),
+                                                       VALIDATE_SCHEMA, VALIDATE_MODEL, VALIDATE_COMPILATION);
         assertThat(validate).withFailMessage(ValidatorUtil.formatMessages(validate)).hasSizeGreaterThan(0);
         assertThat(validate.stream().anyMatch(p -> p.getMessageType().equals(DMNMessageType.PARAMETER_MISMATCH))).isTrue();
     }
 
     @Test
-    @Disabled("Needs to be improved as invocations can be used to invoke functions node defined in BKMs. E.g., FEEL built in functions, etc.")
+    @Disabled("Needs to be improved as invocations can be used to invoke functions node defined in BKMs. E.g., FEEL " +
+            "built in functions, etc.")
     void invocationMissingTarget() {
-        Definitions definitions = utilDefinitions( "INVOCATION_MISSING_TARGET.dmn" );
+        Definitions definitions = utilDefinitions("INVOCATION_MISSING_TARGET.dmn");
         List<DMNMessage> validate = validator.validate(definitions);
-        
-//        assertTrue( validate.stream().anyMatch( p -> p.getMessageType().equals( DMNMessageType.INVOCATION_MISSING_TARGET ) ) );
+
+//        assertTrue( validate.stream().anyMatch( p -> p.getMessageType().equals( DMNMessageType
+//        .INVOCATION_MISSING_TARGET ) ) );
     }
 
     @Disabled("known current limitation")
     @Test
     void invocation_missing_targetRbis() {
-        Definitions definitions = utilDefinitions( "INVOCATION_MISSING_TARGETbis.dmn");
+        Definitions definitions = utilDefinitions("INVOCATION_MISSING_TARGETbis.dmn");
         List<DMNMessage> validate = validator.validate(definitions);
-        
-//        assertTrue( validate.stream().anyMatch( p -> p.getMessageType().equals( DMNMessageType.INVOCATION_MISSING_TARGET ) ) );
+
+//        assertTrue( validate.stream().anyMatch( p -> p.getMessageType().equals( DMNMessageType
+//        .INVOCATION_MISSING_TARGET ) ) );
     }
 
     @Test
     void invocationWrongParamCount() {
-        List<DMNMessage> validate = validator.validate( getReader( "INVOCATION_WRONG_PARAM_COUNT.dmn" ), VALIDATE_SCHEMA, VALIDATE_MODEL, VALIDATE_COMPILATION);
+        List<DMNMessage> validate = validator.validate(getReader("INVOCATION_WRONG_PARAM_COUNT.dmn"), VALIDATE_SCHEMA
+                , VALIDATE_MODEL, VALIDATE_COMPILATION);
         assertThat(validate).withFailMessage(ValidatorUtil.formatMessages(validate)).hasSizeGreaterThan(0);
         assertThat(validate.stream().anyMatch(p -> p.getMessageType().equals(DMNMessageType.PARAMETER_MISMATCH))).isTrue();
     }
 
     @Test
     void itemcompDuplicated() {
-        List<DMNMessage> validate = validator.validate( getReader( "ITEMCOMP_DUPLICATED.dmn" ), VALIDATE_SCHEMA, VALIDATE_MODEL, VALIDATE_COMPILATION);
+        List<DMNMessage> validate = validator.validate(getReader("ITEMCOMP_DUPLICATED.dmn"), VALIDATE_SCHEMA,
+                                                       VALIDATE_MODEL, VALIDATE_COMPILATION);
         assertThat(validate).withFailMessage(ValidatorUtil.formatMessages(validate)).hasSize(2);
         assertThat(validate.stream().anyMatch(p -> p.getMessageType().equals(DMNMessageType.DUPLICATED_ITEM_DEF))).isTrue();
     }
 
     @Test
     void itemdefNotUnique() {
-        List<DMNMessage> validate = validator.validate( getReader( "ITEMDEF_NOT_UNIQUE.dmn" ), VALIDATE_SCHEMA, VALIDATE_MODEL, VALIDATE_COMPILATION);
+        List<DMNMessage> validate = validator.validate(getReader("ITEMDEF_NOT_UNIQUE.dmn"), VALIDATE_SCHEMA,
+                                                       VALIDATE_MODEL, VALIDATE_COMPILATION);
         assertThat(validate).withFailMessage(ValidatorUtil.formatMessages(validate)).hasSize(3);
         assertThat(validate.stream().anyMatch(p -> p.getMessageType().equals(DMNMessageType.DUPLICATED_ITEM_DEF))).isTrue();
     }
@@ -203,20 +228,23 @@ class ValidatorTest extends AbstractValidatorTest {
     @Test
     void itemdefNotUniqueDrools1450() {
         // DROOLS-1450
-        List<DMNMessage> validate = validator.validate( getReader( "ITEMDEF_NOT_UNIQUE_DROOLS-1450.dmn" ), VALIDATE_SCHEMA, VALIDATE_MODEL, VALIDATE_COMPILATION);
+        List<DMNMessage> validate = validator.validate(getReader("ITEMDEF_NOT_UNIQUE_DROOLS-1450.dmn"),
+                                                       VALIDATE_SCHEMA, VALIDATE_MODEL, VALIDATE_COMPILATION);
         assertThat(validate).withFailMessage(ValidatorUtil.formatMessages(validate)).hasSize(0);
     }
 
     @Test
     void relationDupColumn() {
-        List<DMNMessage> validate = validator.validate( getReader( "RELATION_DUP_COLUMN.dmn" ), VALIDATE_SCHEMA, VALIDATE_MODEL, VALIDATE_COMPILATION);
+        List<DMNMessage> validate = validator.validate(getReader("RELATION_DUP_COLUMN.dmn"), VALIDATE_SCHEMA,
+                                                       VALIDATE_MODEL, VALIDATE_COMPILATION);
         assertThat(validate).withFailMessage(ValidatorUtil.formatMessages(validate)).hasSize(2);
         assertThat(validate.stream().anyMatch(p -> p.getMessageType().equals(DMNMessageType.DUPLICATED_RELATION_COLUMN))).isTrue();
     }
 
     @Test
     void relationRowCellNotliteral() {
-        List<DMNMessage> validate = validator.validate( getReader( "RELATION_ROW_CELL_NOTLITERAL.dmn" ), VALIDATE_SCHEMA, VALIDATE_MODEL, VALIDATE_COMPILATION);
+        List<DMNMessage> validate = validator.validate(getReader("RELATION_ROW_CELL_NOTLITERAL.dmn"), VALIDATE_SCHEMA
+                , VALIDATE_MODEL, VALIDATE_COMPILATION);
         assertThat(validate).withFailMessage(ValidatorUtil.formatMessages(validate)).hasSize(2);
         assertThat(validate.stream().anyMatch(p -> p.getMessageType().equals(DMNMessageType.RELATION_CELL_NOT_LITERAL))).isTrue();
         assertThat(validate.stream().anyMatch(p -> p.getMessageType().equals(DMNMessageType.MISSING_EXPRESSION))).isTrue();
@@ -224,29 +252,34 @@ class ValidatorTest extends AbstractValidatorTest {
 
     @Test
     void relationRowCellcountmismatch() {
-        List<DMNMessage> validate = validator.validate( getReader( "RELATION_ROW_CELLCOUNTMISMATCH.dmn" ), VALIDATE_SCHEMA, VALIDATE_MODEL, VALIDATE_COMPILATION);
+        List<DMNMessage> validate = validator.validate(getReader("RELATION_ROW_CELLCOUNTMISMATCH.dmn"),
+                                                       VALIDATE_SCHEMA, VALIDATE_MODEL, VALIDATE_COMPILATION);
         assertThat(validate).withFailMessage(ValidatorUtil.formatMessages(validate)).hasSize(1);
         assertThat(validate.stream().anyMatch(p -> p.getMessageType().equals(DMNMessageType.RELATION_CELL_COUNT_MISMATCH))).isTrue();
     }
 
     @Test
     void mortgageRecommender() {
-        // This file has a gazillion errors. The goal of this test is simply check that the validator itself is not blowing up
+        // This file has a gazillion errors. The goal of this test is simply check that the validator itself is not
+        // blowing up
         // and raising an exception. The errors in the file itself are irrelevant.
-        List<DMNMessage> validate = validator.validate( getReader( "MortgageRecommender.dmn" ), VALIDATE_SCHEMA, VALIDATE_MODEL, VALIDATE_COMPILATION);
+        List<DMNMessage> validate = validator.validate(getReader("MortgageRecommender.dmn"), VALIDATE_SCHEMA,
+                                                       VALIDATE_MODEL, VALIDATE_COMPILATION);
         assertThat(validate).withFailMessage(ValidatorUtil.formatMessages(validate)).isNotEmpty();
     }
 
     @Test
     void reqauth_not_knowledgesourcEbis() {
         // DROOLS-1435
-        List<DMNMessage> validate = validator.validate( getReader( "REQAUTH_NOT_KNOWLEDGESOURCEbis.dmn" ), VALIDATE_SCHEMA, VALIDATE_MODEL, VALIDATE_COMPILATION);
+        List<DMNMessage> validate = validator.validate(getReader("REQAUTH_NOT_KNOWLEDGESOURCEbis.dmn"),
+                                                       VALIDATE_SCHEMA, VALIDATE_MODEL, VALIDATE_COMPILATION);
         assertThat(validate).withFailMessage(ValidatorUtil.formatMessages(validate)).hasSize(1);
     }
 
     @Test
     void variableLeadingTrailingSpaces() {
-        List<DMNMessage> validate = validator.validate( getReader( "VARIABLE_LEADING_TRAILING_SPACES.dmn" ), VALIDATE_SCHEMA, VALIDATE_MODEL, VALIDATE_COMPILATION);
+        List<DMNMessage> validate = validator.validate(getReader("VARIABLE_LEADING_TRAILING_SPACES.dmn"),
+                                                       VALIDATE_SCHEMA, VALIDATE_MODEL, VALIDATE_COMPILATION);
         assertThat(validate).withFailMessage(ValidatorUtil.formatMessages(validate)).isNotEmpty();
         assertThat(validate).anySatisfy(p -> {
             assertThat(p.getMessageType()).isEqualTo(DMNMessageType.INVALID_NAME);
@@ -260,7 +293,8 @@ class ValidatorTest extends AbstractValidatorTest {
 
     @Test
     void nameNotNormalized() {
-        List<DMNMessage> validate = validator.validate( getReader( "NAME_NOT_NORMALIZED.dmn" ), VALIDATE_SCHEMA, VALIDATE_MODEL, VALIDATE_COMPILATION);
+        List<DMNMessage> validate = validator.validate(getReader("NAME_NOT_NORMALIZED.dmn"), VALIDATE_SCHEMA,
+                                                       VALIDATE_MODEL, VALIDATE_COMPILATION);
         assertThat(validate).withFailMessage(ValidatorUtil.formatMessages(validate)).isNotEmpty();
         assertThat(validate).anySatisfy(p -> {
             assertThat(p.getMessageType()).isEqualTo(DMNMessageType.INVALID_NAME);
@@ -274,50 +308,57 @@ class ValidatorTest extends AbstractValidatorTest {
 
     @Test
     void unknownVariable() {
-        List<DMNMessage> validate = validator.validate( getReader( "UNKNOWN_VARIABLE.dmn" ), VALIDATE_SCHEMA, VALIDATE_MODEL, VALIDATE_COMPILATION);
+        List<DMNMessage> validate = validator.validate(getReader("UNKNOWN_VARIABLE.dmn"), VALIDATE_SCHEMA,
+                                                       VALIDATE_MODEL, VALIDATE_COMPILATION);
         assertThat(validate).withFailMessage(ValidatorUtil.formatMessages(validate)).hasSize(1);
         assertThat(validate.stream().anyMatch(p -> p.getMessageType().equals(DMNMessageType.ERR_COMPILING_FEEL))).isTrue();
     }
 
     @Test
     void unknownOperator() {
-        List<DMNMessage> validate = validator.validate( getReader( "UNKNOWN_OPERATOR.dmn" ),
-                                                        VALIDATE_SCHEMA,
-                                                        VALIDATE_MODEL,
-                                                        VALIDATE_COMPILATION);
+        List<DMNMessage> validate = validator.validate(getReader("UNKNOWN_OPERATOR.dmn"),
+                                                       VALIDATE_SCHEMA,
+                                                       VALIDATE_MODEL,
+                                                       VALIDATE_COMPILATION);
         assertThat(validate).withFailMessage(ValidatorUtil.formatMessages(validate)).hasSizeGreaterThan(0);
     }
 
     @Test
     void validation() {
-        List<DMNMessage> validate = validator.validate( getReader( "validation.dmn" ), VALIDATE_MODEL, VALIDATE_COMPILATION);
+        List<DMNMessage> validate = validator.validate(getReader("validation.dmn"), VALIDATE_MODEL,
+                                                       VALIDATE_COMPILATION);
         assertThat(validate).withFailMessage(ValidatorUtil.formatMessages(validate)).hasSize(7);
         assertThat(validate.stream().anyMatch(p -> p.getMessageType().equals(DMNMessageType.INVALID_NAME))).isTrue();
         assertThat(validate.stream().anyMatch(p -> p.getMessageType().equals(DMNMessageType.MISSING_TYPE_REF))).isTrue();
         assertThat(validate.stream().anyMatch(p -> p.getMessageType().equals(DMNMessageType.MISSING_EXPRESSION))).isTrue();
         assertThat(validate.stream().anyMatch(p -> p.getMessageType().equals(DMNMessageType.ERR_COMPILING_FEEL))).isTrue();
-        // on node DTI the `Loan Payment` is of type `tLoanPayment` hence the property is `monthlyAmount`, NOT `amount` as reported in the model FEEL expression: (Loan Payment.amount+...
+        // on node DTI the `Loan Payment` is of type `tLoanPayment` hence the property is `monthlyAmount`, NOT
+        // `amount` as reported in the model FEEL expression: (Loan Payment.amount+...
         assertThat(validate.stream().anyMatch(p -> p.getMessageType().equals(DMNMessageType.ERR_COMPILING_FEEL))).isTrue();
     }
 
     @Test
     void usingSemanticNamespacePrefix() {
         // DROOLS-2419
-        List<DMNMessage> validate = validator.validate(getReader("UsingSemanticNS.dmn"), VALIDATE_SCHEMA, VALIDATE_MODEL, VALIDATE_COMPILATION);
+        List<DMNMessage> validate = validator.validate(getReader("UsingSemanticNS.dmn"), VALIDATE_SCHEMA,
+                                                       VALIDATE_MODEL, VALIDATE_COMPILATION);
         assertThat(validate).withFailMessage(ValidatorUtil.formatMessages(validate)).hasSize(0);
     }
 
     @Test
     void usingSemanticNamespacePrefixAndExtensions() {
         // DROOLS-2447
-        List<DMNMessage> validate = validator.validate(getReader("Hello_World_semantic_namespace_with_extensions.dmn"), VALIDATE_SCHEMA, VALIDATE_MODEL, VALIDATE_COMPILATION);
+        List<DMNMessage> validate =
+                validator.validate(getReader("Hello_World_semantic_namespace_with_extensions.dmn"), VALIDATE_SCHEMA,
+                                   VALIDATE_MODEL, VALIDATE_COMPILATION);
         assertThat(validate).withFailMessage(ValidatorUtil.formatMessages(validate)).hasSize(0);
     }
 
     @Test
     void noPrefixAndExtensions() {
         // DROOLS-2447
-        List<DMNMessage> validate = validator.validate(getReader("Hello_World_no_prefix_with_extensions.dmn"), VALIDATE_SCHEMA, VALIDATE_MODEL, VALIDATE_COMPILATION);
+        List<DMNMessage> validate = validator.validate(getReader("Hello_World_no_prefix_with_extensions.dmn"),
+                                                       VALIDATE_SCHEMA, VALIDATE_MODEL, VALIDATE_COMPILATION);
         assertThat(validate).withFailMessage(ValidatorUtil.formatMessages(validate)).hasSize(0);
     }
 
@@ -325,27 +366,32 @@ class ValidatorTest extends AbstractValidatorTest {
     void relationwithemptycell() {
         // DROOLS-2439
         DMNRuntime runtime = DMNRuntimeUtil.createRuntime("relation_with_empty_cell.dmn", DMNRuntimeTest.class);
-        DMNModel dmnModel = runtime.getModel("http://www.trisotech.com/dmn/definitions/_99a00903-2943-47df-bab1-a32f276617ea", "Relation with empty cell");
+        DMNModel dmnModel = runtime.getModel("http://www.trisotech.com/dmn/definitions/_99a00903-2943-47df-bab1" +
+                                                     "-a32f276617ea", "Relation with empty cell");
         assertThat(dmnModel).isNotNull();
 
         Definitions definitions = dmnModel.getDefinitions();
         assertThat(dmnModel).isNotNull();
 
-        List<DMNMessage> messages = DMNValidatorFactory.newValidator().validate(definitions, VALIDATE_MODEL, VALIDATE_COMPILATION);
+        List<DMNMessage> messages = DMNValidatorFactory.newValidator().validate(definitions, VALIDATE_MODEL,
+                                                                                VALIDATE_COMPILATION);
         assertThat(messages).withFailMessage(messages.toString()).hasSize(0);
     }
 
     @Test
     void relationwithemptycellJustValidator() {
         // DROOLS-2439
-        List<DMNMessage> validate = validator.validate(getReader("relation_with_empty_cell.dmn", DMNRuntimeTest.class), VALIDATE_MODEL, VALIDATE_COMPILATION);
+        List<DMNMessage> validate = validator.validate(getReader("relation_with_empty_cell.dmn",
+                                                                 DMNRuntimeTest.class), VALIDATE_MODEL,
+                                                       VALIDATE_COMPILATION);
         assertThat(validate).withFailMessage(ValidatorUtil.formatMessages(validate)).hasSize(0);
     }
 
     @Test
     void boxedInvocationMissingExpression() {
         // DROOLS-2813 DMN boxed invocation missing expression NPE and Validator issue
-        List<DMNMessage> validate = validator.validate(getReader("DROOLS-2813-NPE-BoxedInvocationMissingExpression.dmn", DMNRuntimeTest.class), VALIDATE_MODEL);
+        List<DMNMessage> validate = validator.validate(getReader("DROOLS-2813-NPE-BoxedInvocationMissingExpression" +
+                                                                         ".dmn", DMNRuntimeTest.class), VALIDATE_MODEL);
         assertThat(validate.stream().anyMatch(p -> p.getMessageType().equals(DMNMessageType.MISSING_EXPRESSION) && p.getSourceId().equals("_a111c4df-c5b5-4d84-81e7-3ec735b50d06"))).isTrue();
     }
 
@@ -353,7 +399,7 @@ class ValidatorTest extends AbstractValidatorTest {
     void dMNv12Ch11Modified() {
         // DROOLS-2832
         List<DMNMessage> validate = validator.validate(getReader("v1_2/ch11MODIFIED.dmn", DMNRuntimeTest.class),
-                                                       VALIDATE_SCHEMA, 
+                                                       VALIDATE_SCHEMA,
                                                        VALIDATE_MODEL,
                                                        VALIDATE_COMPILATION);
         assertThat(validate).withFailMessage(ValidatorUtil.formatMessages(validate)).hasSize(0);
@@ -375,7 +421,8 @@ class ValidatorTest extends AbstractValidatorTest {
     @Test
     void decisionServiceCompiler20180830() {
         // DROOLS-2943 DMN DecisionServiceCompiler not correctly wired for DMNv1.2 format
-        List<DMNMessage> validate = validator.validate(getReader("DecisionServiceABC.dmn", DMNDecisionServicesTest.class),
+        List<DMNMessage> validate = validator.validate(getReader("DecisionServiceABC.dmn",
+                                                                 DMNDecisionServicesTest.class),
                                                        VALIDATE_MODEL,
                                                        VALIDATE_COMPILATION);
         assertThat(validate).withFailMessage(ValidatorUtil.formatMessages(validate)).hasSize(0);
@@ -384,11 +431,14 @@ class ValidatorTest extends AbstractValidatorTest {
     @Test
     void decisionServiceCompiler20180830DMNV12() {
         // DROOLS-2943 DMN DecisionServiceCompiler not correctly wired for DMNv1.2 format
-        List<DMNMessage> validate = validator.validate(getReader("DecisionServiceABC_DMN12.dmn", org.kie.dmn.core.v1_2.DMNDecisionServicesTest.class),
+        List<DMNMessage> validate = validator.validate(getReader("DecisionServiceABC_DMN12.dmn",
+                                                                 org.kie.dmn.core.v1_2.DMNDecisionServicesTest.class),
                                                        VALIDATE_MODEL,
                                                        VALIDATE_COMPILATION);
 
-        // DMNMessage{ severity=WARN, type=MISSING_TYPE_REF, message='Variable named 'Decision Service ABC' is missing its type reference on node 'Decision Service ABC'', sourceId='_63d05cff-8e3b-4dad-a355-fd88f8bcd613', exception='', feelEvent=''}
+        // DMNMessage{ severity=WARN, type=MISSING_TYPE_REF, message='Variable named 'Decision Service ABC' is
+        // missing its type reference on node 'Decision Service ABC'',
+        // sourceId='_63d05cff-8e3b-4dad-a355-fd88f8bcd613', exception='', feelEvent=''}
         assertThat(validate).withFailMessage(ValidatorUtil.formatMessages(validate)).hasSize(1);
         assertThat(validate.stream().anyMatch(p -> p.getMessageType().equals(DMNMessageType.MISSING_TYPE_REF) && p.getSourceId().equals("_63d05cff-8e3b-4dad-a355-fd88f8bcd613"))).isTrue();
     }
@@ -397,13 +447,13 @@ class ValidatorTest extends AbstractValidatorTest {
     void decisionService20181008() {
         // DROOLS-3087 DMN Validation of DecisionService referencing a missing import
         List<DMNMessage> validate = validator.validateUsing(VALIDATE_MODEL, VALIDATE_COMPILATION)
-                                             .theseModels(getReader("DSWithImport20181008-ModelA.dmn"),
-                                                          getReader("DSWithImport20181008-ModelB.dmn"));
+                .theseModels(getReader("DSWithImport20181008-ModelA.dmn"),
+                             getReader("DSWithImport20181008-ModelB.dmn"));
         assertThat(validate).withFailMessage(ValidatorUtil.formatMessages(validate)).hasSize(0);
 
         List<DMNMessage> missingDMNImport = validator.validateUsing(VALIDATE_MODEL)
-                                                     .theseModels(getReader("DSWithImport20181008-ModelA.dmn"),
-                                                                  getReader("DSWithImport20181008-ModelB-missingDMNImport.dmn"));
+                .theseModels(getReader("DSWithImport20181008-ModelA.dmn"),
+                             getReader("DSWithImport20181008-ModelB-missingDMNImport.dmn"));
         assertThat(missingDMNImport.stream().filter(p -> p.getMessageType().equals(DMNMessageType.REQ_NOT_FOUND))).hasSize(2); // on Decision and Decision Service missing to locate the dependency given Import is omitted.
     }
 
@@ -419,11 +469,12 @@ class ValidatorTest extends AbstractValidatorTest {
     void decisionNoExpr() {
         // DROOLS-4765 DMN validation rule alignment for missing expression
         List<DMNMessage> validate = validator.validate(getReader("noExpr.dmn", DMNRuntimeTest.class),
-                                                       VALIDATE_MODEL); // this test ensures the WARN for missing expr on the Decision node also applies when using static model validation rules (before compilation)
+                                                       VALIDATE_MODEL); // this test ensures the WARN for missing
+        // expr on the Decision node also applies when using static model validation rules (before compilation)
         assertThat(validate).withFailMessage(ValidatorUtil.formatMessages(validate)).hasSize(1);
         assertThat(validate.stream().filter(p -> p.getLevel() == Level.WARNING &&
-                                                 p.getMessageType().equals(DMNMessageType.MISSING_EXPRESSION) &&
-                                                 p.getSourceId().equals("_cdd03786-d1ab-47b5-ba05-df830458dc62"))).hasSize(1);
+                p.getMessageType().equals(DMNMessageType.MISSING_EXPRESSION) &&
+                p.getSourceId().equals("_cdd03786-d1ab-47b5-ba05-df830458dc62"))).hasSize(1);
     }
 
     @Test
@@ -431,8 +482,8 @@ class ValidatorTest extends AbstractValidatorTest {
         // DROOLS-4773 DMN Validator fluent builder schema & analysis using reader
         List<DMNMessage> validate = validator.validateUsing(VALIDATE_SCHEMA,
                                                             VALIDATE_MODEL)
-                                             .theseModels(getReader("base join.dmn", ImportsTest.class),
-                                                          getReader("use join.dmn", ImportsTest.class));
+                .theseModels(getReader("base join.dmn", ImportsTest.class),
+                             getReader("use join.dmn", ImportsTest.class));
         assertThat(validate).withFailMessage(ValidatorUtil.formatMessages(validate)).hasSize(0);
     }
 
@@ -450,8 +501,8 @@ class ValidatorTest extends AbstractValidatorTest {
         List<DMNMessage> validate = validator.validateUsing(VALIDATE_SCHEMA,
                                                             VALIDATE_MODEL,
                                                             VALIDATE_COMPILATION)
-                                             .theseModels(getReader("Financial.dmn", DMN13specificTest.class),
-                                                          getReader("Chapter 11 Example.dmn", DMN13specificTest.class));
+                .theseModels(getReader("Financial.dmn", DMN13specificTest.class),
+                             getReader("Chapter 11 Example.dmn", DMN13specificTest.class));
         assertThat(validate).withFailMessage(ValidatorUtil.formatMessages(validate)).hasSize(3);
         assertThat(validate.stream().anyMatch(p -> p.getLevel() == Level.WARNING &&
                 p.getMessageType().equals(DMNMessageType.MISSING_EXPRESSION) &&
@@ -466,7 +517,7 @@ class ValidatorTest extends AbstractValidatorTest {
         List<DMNMessage> validate = validator.validateUsing(VALIDATE_SCHEMA,
                                                             VALIDATE_MODEL,
                                                             VALIDATE_COMPILATION)
-                                             .theseModels(getReader("somethingInBetween.dmn"));
+                .theseModels(getReader("somethingInBetween.dmn"));
         assertThat(validate).withFailMessage(ValidatorUtil.formatMessages(validate)).hasSize(1);
         assertThat(validate.stream().anyMatch(p -> p.getLevel() == Level.ERROR &&
                 p.getMessageType().equals(DMNMessageType.ERR_COMPILING_FEEL) &&
@@ -478,14 +529,15 @@ class ValidatorTest extends AbstractValidatorTest {
         List<DMNMessage> validate = validator.validateUsing(VALIDATE_SCHEMA,
                                                             VALIDATE_MODEL,
                                                             VALIDATE_COMPILATION)
-                                             .theseModels(getReader("Recommended Loan Products.dmn", DMN13specificTest.class),
-                                                          getReader("Loan info.dmn", DMN13specificTest.class));
+                .theseModels(getReader("Recommended Loan Products.dmn", DMN13specificTest.class),
+                             getReader("Loan info.dmn", DMN13specificTest.class));
         assertThat(validate).withFailMessage(ValidatorUtil.formatMessages(validate)).hasSize(0);
     }
 
     @Test
     void dttyperef() {
-        List<DMNMessage> validate = validator.validate(getReader("wrongxml/dttyperef.dmn"), VALIDATE_SCHEMA, VALIDATE_MODEL, VALIDATE_COMPILATION);
+        List<DMNMessage> validate = validator.validate(getReader("wrongxml/dttyperef.dmn"), VALIDATE_SCHEMA,
+                                                       VALIDATE_MODEL, VALIDATE_COMPILATION);
         assertThat(validate).as(ValidatorUtil.formatMessages(validate)).hasSize(1);
         DMNMessage v0 = validate.get(0);
         assertThat(v0.getLevel()).isEqualTo(Level.ERROR);
@@ -506,7 +558,8 @@ class ValidatorTest extends AbstractValidatorTest {
                 p.getSourceId() != null &&
                 p.getSourceId().equals("_3ce3c41a-450a-40d1-9e9c-09180cd29879"))).as(ValidatorUtil.formatMessages(validate)).isTrue();
         assertThat(validate.stream().anyMatch(p -> p.getLevel() == Level.WARNING &&
-                ((DMNElement) ((DMNModelInstrumentedBase) p.getSourceReference()).getParent()).getId().equals("_d8b0c243-3fb6-40ec-a29c-28f8bdb92e13"))).as(ValidatorUtil.formatMessages(validate)).isTrue();
+                ((DMNElement) ((DMNModelInstrumentedBase) p.getSourceReference()).getParent()).getId().equals(
+                        "_d8b0c243-3fb6-40ec-a29c-28f8bdb92e13"))).as(ValidatorUtil.formatMessages(validate)).isTrue();
     }
 
     @Test
@@ -530,17 +583,29 @@ class ValidatorTest extends AbstractValidatorTest {
     @Test
     void validateAllValidSharedModels() throws IOException {
         String modelFilesPath = "valid_models/";
-        URL modelFilesJarURL = Collections.list(Thread.currentThread().getContextClassLoader().getResources(
-                "valid_models/"))
-                .stream()
-                .filter(url -> url.getProtocol().equals("jar"))
-                .findFirst()
-                .orElseThrow(() -> new RuntimeException("Failed to retrieve jar containing " + modelFilesPath));
-        String modelFilesJarFile = modelFilesJarURL.getFile();
-        String jarPath = modelFilesJarFile.substring(modelFilesJarFile.lastIndexOf(":") + 1,
-                                                     modelFilesJarFile.lastIndexOf("!"));
-        final JarFile jarFile = new JarFile(new File(jarPath));
-        testDirectoryInJar(jarFile, modelFilesPath);
+        Map<String, URL> mappedUrls = new HashMap<>();
+        Collections.list(Thread.currentThread().getContextClassLoader().getResources(
+                        "valid_models/"))
+                .forEach(url -> mappedUrls.put(url.getProtocol(), url));
+        if (mappedUrls.containsKey("jar")) {
+            String modelFilesJarFile = mappedUrls.get("jar").getFile();
+            String jarPath = modelFilesJarFile.substring(modelFilesJarFile.lastIndexOf(":") + 1,
+                                                         modelFilesJarFile.lastIndexOf("!"));
+            try {
+                final JarFile jarFile = new JarFile(new File(jarPath));
+                testDirectoryInJar(jarFile, modelFilesPath);
+            } catch (IOException e) {
+                fail(e.getMessage());
+            }
+        }
+        if (mappedUrls.containsKey("file")) {
+            try {
+                final Path path = Path.of(mappedUrls.get("file").toURI());
+                testDirectoryInPath(path);
+            } catch (URISyntaxException e) {
+                fail(e.getMessage());
+            }
+        }
     }
 
     @Test
@@ -558,33 +623,44 @@ class ValidatorTest extends AbstractValidatorTest {
     }
 
     private void testDirectoryInJar(JarFile jarFile, String directory) {
-        List<String> allFiles = Collections.list(jarFile.entries())
+        Resource[] resources = Collections.list(jarFile.entries())
                 .stream()
                 .filter(entry -> entry.getName().startsWith(directory) && !entry.isDirectory())
                 .map(ZipEntry::getName)
-                .toList();
-        testFiles(allFiles);
+                .map(ClassPathResource::new)
+                .toArray(Resource[]::new);
+        testResources(resources);
     }
 
-    private void testFiles(List<String> modelFiles) {
-        Resource[] resources = modelFiles.stream()
-                .map(ClassPathResource::new)
-                .toArray(value -> new Resource[modelFiles.size()]);
+    private void testDirectoryInPath(Path rootPath) {
+        try (Stream<Path> walk = Files.walk(rootPath)) {
+            Resource[] resources = walk.filter(Files::isRegularFile)
+                    .map(Path::toFile)
+                    .map(FileSystemResource::new)
+                    .toArray(Resource[]::new);
+            testResources(resources);
+        } catch (IOException e) {
+            fail(e.getMessage());
+        }
+    }
+
+    private void testResources(Resource[] resources) {
         List<DMNMessage> dmnMessages = validatorBuilder.theseModels(resources);
         assertThat(dmnMessages).isNotNull();
         dmnMessages.forEach(dmnMessage -> LOGGER.error(dmnMessage.toString()));
         assertThat(dmnMessages).isEmpty();
     }
 
-
     private Definitions utilDefinitions(String filename) {
         DMNMarshaller marshaller = DMNMarshallerFactory.newDefaultMarshaller();
-        try( InputStreamReader isr = new InputStreamReader(Objects.requireNonNull(getClass().getResourceAsStream(filename))) ) {
-            Definitions definitions = marshaller.unmarshal( isr );
+        try (InputStreamReader isr =
+                     new InputStreamReader(Objects.requireNonNull(getClass().getResourceAsStream(filename)))) {
+            Definitions definitions = marshaller.unmarshal(isr);
             assertThat(definitions).isNotNull();
             return definitions;
-        } catch ( IOException e ) {
-            String messageToShow = e.getMessage() != null && !e.getMessage().isEmpty() ? e.getMessage() : String.format("Unable to find file %s", filename);
+        } catch (IOException e) {
+            String messageToShow = e.getMessage() != null && !e.getMessage().isEmpty() ? e.getMessage() :
+                    String.format("Unable to find file %s", filename);
             LOGGER.error(messageToShow);
             LOGGER.debug(messageToShow, e);
             fail(String.format("Unable for the test suite to locate the file %s for validation.", filename));
@@ -598,5 +674,4 @@ class ValidatorTest extends AbstractValidatorTest {
         assertThat(validate.stream().allMatch(p -> p.getLevel() == Level.WARNING &&
                 p.getSourceId().equals("_FE47213A-2042-49DE-9A44-65831DA6AD11"))).as(ValidatorUtil.formatMessages(validate)).isTrue();
     }
-
 }


### PR DESCRIPTION
Fixes https://github.com/apache/incubator-kie-issues/issues/1940

This PR:
1. import further objects from unnamed imports
2. modify the drl file/rule used for business validation of dmndi
3. create tests for given scenario (unnamed import that, in turn, has a named import)

<details>
<summary>
How to retest this PR or trigger a specific build:
</summary>

- for <b>pull request and downstream checks</b>  
  - Push a new commit to the PR. An empty commit would be enough.

- for a <b>full downstream build</b>
  - for <b>github actions</b> job: add the label `run_fdb`

- for <b>Jenkins PR check only</b>
  - If you are an ASF committer for KIE podling, login to Jenkins (https://ci-builds.apache.org/job/KIE/job/drools/), go to the specific PR job, and click on `Build Now` button.
</details>
