### PR TITLE
[DROOLS-6340] preserve order of used declaration traversing method expressions recursively

### DIFF
--- a/drools-model/drools-model-codegen/src/main/java/org/drools/model/codegen/execmodel/generator/DrlxParseUtil.java
+++ b/drools-model/drools-model-codegen/src/main/java/org/drools/model/codegen/execmodel/generator/DrlxParseUtil.java
@@ -895,15 +895,18 @@ public class DrlxParseUtil {
     }
 
     public static List<String> collectUsedDeclarationsInExpression(Expression expr) {
-        Stream<NameExpr> namesStream = expr instanceof MethodCallExpr methodCallExpr ?
-                Stream.concat(methodCallExpr.getScope().stream(), methodCallExpr.getArguments().stream())
-                        .flatMap(e -> e.findAll(NameExpr.class).stream()) :
-                expr.findAll(NameExpr.class).stream();
+        return exprToOrderedNameExprStream(expr)
+                .map(NameExpr::getName)
+                .map(SimpleName::getIdentifier)
+                .distinct()
+                .collect(toList());
+    }
 
-        return namesStream.map(NameExpr::getName)
-                   .map(SimpleName::getIdentifier)
-                   .distinct()
-                   .collect(toList());
+    private static Stream<NameExpr> exprToOrderedNameExprStream(Expression expr) {
+        return expr instanceof MethodCallExpr methodCallExpr ?
+                Stream.concat(methodCallExpr.getScope().stream(), methodCallExpr.getArguments().stream())
+                        .flatMap(DrlxParseUtil::exprToOrderedNameExprStream) :
+                expr.findAll(NameExpr.class).stream();
     }
 
     public static Optional<java.lang.reflect.Type> safeResolveType(TypeResolver typeResolver, String typeName) {

--- a/drools-model/drools-model-codegen/src/test/java/org/drools/model/codegen/execmodel/MixedArgumentTest.java
+++ b/drools-model/drools-model-codegen/src/test/java/org/drools/model/codegen/execmodel/MixedArgumentTest.java
@@ -24,10 +24,6 @@ import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.MethodSource;
 import org.kie.api.runtime.KieSession;
 
-import java.io.IOException;
-import java.net.URISyntaxException;
-import java.nio.file.Files;
-import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -48,14 +44,17 @@ public class MixedArgumentTest extends BaseModelTest {
             "    $person2 : Person(age == 40)\n" +
             "    $child2 : Child(age == 5 && parent == \"Bob\")\n" +
             "    $personNo : Integer() from doNothing($person1, $child1.getName, $child2.getName, $person2.getName)\n" +
+            "    $person_method : Integer() from doNothingAgain($person1.addAges($child1.getAge, $child2.getAge))\n" +
             "then \n" +
             "     result.add($personNo); \n " +
             "end \n" +
             "\n" +
             "function Integer doNothing(Person person, String firstName, String secondName, String thirdName) {\n" +
             "    return 1; \n" +
+            "}\n" +
+            "function Integer doNothingAgain(int age) {\n" +
+            "    return 1; \n" +
             "}";
-
 
     @ParameterizedTest
     @MethodSource("parameters")

--- a/drools-model/drools-model-codegen/src/test/java/org/drools/model/codegen/execmodel/domain/Person.java
+++ b/drools-model/drools-model-codegen/src/test/java/org/drools/model/codegen/execmodel/domain/Person.java
@@ -329,4 +329,8 @@ public class Person extends AbstractReactiveObject {
     public static boolean isEvenFloat( float i ){
         return (i % 2) == 0;
     }
+
+    public int addAges(int age1, int age2) {
+        return age1 + age2;
+    }
 }


### PR DESCRIPTION
Fixes https://github.com/apache/incubator-kie-drools/issues/6340