### PR TITLE
NO-ISSUE: Remove `io.github.bonigarcia:webdrivermanager` unused dependency

### DIFF
--- a/build-parent/pom.xml
+++ b/build-parent/pom.xml
@@ -210,7 +210,6 @@
     <jacoco.exec.file>${project.root.dir}/target/jacoco.exec</jacoco.exec.file>
 
     <version.org.awaitility>4.2.0</version.org.awaitility>
-    <version.io.github.bonigarcia>5.1.1</version.io.github.bonigarcia>
 
     <!-- DROOLS-7140 Drools 8 enforce JDK and Maven versions as a rule --> 
     <version.jdk>${maven.compiler.release}</version.jdk>
@@ -1102,13 +1101,6 @@
         <groupId>org.awaitility</groupId>
         <artifactId>awaitility</artifactId>
         <version>${version.org.awaitility}</version>
-        <scope>test</scope>
-      </dependency>
-
-      <dependency>
-        <groupId>io.github.bonigarcia</groupId>
-        <artifactId>webdrivermanager</artifactId>
-        <version>${version.io.github.bonigarcia}</version>
         <scope>test</scope>
       </dependency>
 


### PR DESCRIPTION
Unused dependency previously used for testing GWT assets no longer present.