### PR TITLE
[incubator-kie-issues#1886] Implementing PathUtils

### DIFF
--- a/drools-util/src/main/java/org/drools/util/PathUtils.java
+++ b/drools-util/src/main/java/org/drools/util/PathUtils.java
@@ -1,0 +1,51 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.drools.util;
+
+import java.nio.file.Path;
+import java.nio.file.Paths;
+
+/**
+ * Class meant to provide utility methods specific to <code>Path</code> management
+ */
+public class PathUtils {
+
+    private PathUtils() {
+    }
+
+    public static Path getSecuredPath(Path basePath, String userPathStr) {
+        Path targetPath = basePath.resolve(userPathStr).normalize();
+
+        if (!targetPath.startsWith(basePath)) {
+            throw new SecurityException("Path traversal attempt detected: " + userPathStr);
+        }
+
+        String securePath = trimTrailingSeparator(targetPath.toString().replace('\\', '/'));
+        return Paths.get(securePath);
+    }
+
+    public static Path getSecuredPath(String basePathStr, String userPathStr) {
+        Path basePath = Paths.get(basePathStr).normalize();
+        return getSecuredPath(basePath, userPathStr);
+    }
+
+    public static String trimTrailingSeparator(String p) {
+        return !p.isEmpty() && p.charAt( p.length() -1 ) == '/' ? p.substring( 0, p.length() -1 ) : p;
+    }
+}

--- a/drools-util/src/main/java/org/drools/util/PortablePath.java
+++ b/drools-util/src/main/java/org/drools/util/PortablePath.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information
@@ -20,9 +20,9 @@ package org.drools.util;
 
 import java.io.File;
 import java.io.Serializable;
-import java.nio.file.Path;
-import java.nio.file.Paths;
 import java.util.Objects;
+
+import static org.drools.util.PathUtils.trimTrailingSeparator;
 
 public class PortablePath implements Serializable {
 
@@ -37,11 +37,6 @@ public class PortablePath implements Serializable {
     private PortablePath(String path) {
         this.path = path;
     }
-
-    public Path toPath() {
-        return Paths.get(path);
-    }
-
 
     public static PortablePath of(String s) {
         return of(s, IS_WINDOWS_SEPARATOR);
@@ -74,18 +69,6 @@ public class PortablePath implements Serializable {
 
     public PortablePath resolve(String name) {
         return resolve(of(name));
-    }
-
-    public static PortablePath resolveInternal(String basePathStr, String userPathStr) {
-        Path basePath = Paths.get(basePathStr).normalize();
-        Path targetPath = basePath.resolve(userPathStr).normalize();
-
-        if (!targetPath.startsWith(basePath)) {
-            throw new SecurityException("Path traversal attempt detected: " + userPathStr);
-        }
-
-        String securePath = trimTrailingSeparator(targetPath.toString().replace('\\', '/'));
-        return new PortablePath(securePath);
     }
 
     public String getFileName() {
@@ -137,7 +120,4 @@ public class PortablePath implements Serializable {
         return of(path.substring(beginIndex, endIndex));
     }
 
-    public static String trimTrailingSeparator(String p) {
-        return !p.isEmpty() && p.charAt( p.length() -1 ) == '/' ? p.substring( 0, p.length() -1 ) : p;
-    }
 }

--- a/drools-util/src/test/java/org/drools/util/PathUtilsTest.java
+++ b/drools-util/src/test/java/org/drools/util/PathUtilsTest.java
@@ -1,0 +1,90 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.drools.util;
+
+import java.util.stream.Stream;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Named;
+
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
+
+class PathUtilsTest {
+
+    @DisplayName("getSecuredPath by String base path with valid paths")
+    @ParameterizedTest
+    @MethodSource("validPaths")
+    void getSecuredPathByStringBasePathValidPaths(String[] parameters) {
+        Path retrieved = PathUtils.getSecuredPath("src/test/resources", parameters[0]);
+        assertThat(retrieved.toFile().getName()).isEqualTo(parameters[1]);
+    }
+
+    @DisplayName("getSecuredPath by Path base path with valid paths")
+    @ParameterizedTest
+    @MethodSource("validPaths")
+    void getSecuredPathByPathBasePathValidPaths(String[] parameters) {
+        Path basePath = Paths.get("src/test/resources");
+        Path retrieved = PathUtils.getSecuredPath(basePath, parameters[0]);
+        assertThat(retrieved.toFile().getName()).isEqualTo(parameters[1]);
+    }
+
+    @DisplayName("getSecuredPath by String base path with invalid paths")
+    @ParameterizedTest
+    @MethodSource("invalidPaths")
+    void getSecuredPathByStringBasePathInvalidPaths(String invalidPath) {
+        assertThatExceptionOfType(SecurityException.class)
+                .isThrownBy(() -> PathUtils.getSecuredPath("src/test/resources", invalidPath))
+                .withMessageContaining("Path traversal attempt detected");
+    }
+
+    @DisplayName("getSecuredPath by Path base path with invalid paths")
+    @ParameterizedTest
+    @MethodSource("invalidPaths")
+    void getSecuredPathByPathBasePathInvalidPaths(String invalidPath) {
+        Path basePath = Paths.get("src/test/resources");
+        assertThatExceptionOfType(SecurityException.class)
+                .isThrownBy(() -> PathUtils.getSecuredPath(basePath, invalidPath))
+                .withMessageContaining("Path traversal attempt detected");
+    }
+
+    static Stream<Arguments> validPaths() {
+        return Stream.of(
+                Arguments.of(Named.of("ValidPath", new String[]{"META-INF/file.svg", "file.svg"})),
+                Arguments.of(Named.of("WindowsSeparators", new String[]{"META-INF\\file.svg", "file.svg"})),
+                Arguments.of(Named.of("TrailingSlash", new String[]{"META-INF/", "META-INF"})),
+                Arguments.of(Named.of("RedundantDots", new String[]{"./META-INF/./file.svg", "file.svg"})),
+                Arguments.of(Named.of("ParentDirectory", new String[]{"META-INF/../META-INF/file.svg", "file.svg"}))
+        );
+    }
+
+    static Stream<Arguments> invalidPaths() {
+        return Stream.of(
+                Arguments.of(Named.of("PathTraversal", "../outside/file.svg")),
+                Arguments.of(Named.of("DeepTraversal", "../../../etc/passwd")),
+                Arguments.of(Named.of("AbsolutePath", "/etc/passwd"))
+        );
+    }
+
+}

--- a/drools-util/src/test/java/org/drools/util/PortablePathTest.java
+++ b/drools-util/src/test/java/org/drools/util/PortablePathTest.java
@@ -21,11 +21,7 @@ package org.drools.util;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
-import java.nio.file.Path;
-import java.nio.file.Paths;
-
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 
 class PortablePathTest {
 
@@ -80,64 +76,6 @@ class PortablePathTest {
         PortablePath result = base.resolve("subdir/../subdir/file.svg");
         assertThat(result.asString()).startsWith(base.asString());
         assertThat(result.getFileName()).isEqualTo("file.svg");
-    }
-
-
-    @Test
-    void testResolveInternalAcceptsValidPath() {
-        Path result = PortablePath.resolveInternal("src/test/resources", "META-INF/file.svg").toPath();
-        PortablePath p = PortablePath.of(result.toString());
-        assertThat(p.getFileName()).isEqualTo("file.svg");
-    }
-
-    @Test
-    void testResolveInternalRejectsPathTraversal() {
-        assertThatExceptionOfType(SecurityException.class)
-                .isThrownBy(() -> PortablePath.resolveInternal("src/test/resources", "../outside/file.svg").toPath())
-                .withMessageContaining("Path traversal attempt detected");
-    }
-
-    @Test
-    void testResolveInternalRejectsDeepTraversal() {
-        assertThatExceptionOfType(SecurityException.class)
-                .isThrownBy(() -> PortablePath.resolveInternal("src/test/resources", "../../../etc/passwd").toPath())
-                .withMessageContaining("Path traversal attempt detected");
-    }
-
-    @Test
-    void testResolveInternalRejectsAbsolutePath() {
-        String absPath = Paths.get("/etc/passwd").toAbsolutePath().toString();
-        assertThatExceptionOfType(SecurityException.class)
-                .isThrownBy(() -> PortablePath.resolveInternal("src/test/resources", absPath))
-                .withMessageContaining("Path traversal attempt detected");
-    }
-
-    @Test
-    void testResolveInternalNormalizesWindowsSeparators() {
-        Path result = PortablePath.resolveInternal("src/test/resources", "META-INF\\file.svg").toPath();
-        PortablePath p = PortablePath.of(result.toString());
-        assertThat(p.getFileName()).isEqualTo("file.svg");                                                                           
-    }
-
-    @Test
-    void testResolveInternalHandlesTrailingSlash() {
-        Path result = PortablePath.resolveInternal("src/test/resources", "META-INF/").toPath();
-        PortablePath p = PortablePath.of(result.toString());
-        assertThat(p.getFileName()).isEqualTo("META-INF");
-    }
-
-    @Test
-    void testResolveInternalStripsRedundantDots() {
-        Path result = PortablePath.resolveInternal("src/test/resources", "./META-INF/./file.svg").toPath();
-        PortablePath p = PortablePath.of(result.toString());
-        assertThat(p.getFileName()).isEqualTo("file.svg");
-    }
-
-    @Test
-    void testResolveInternalNormalizesParentDirectory() {
-        Path result = PortablePath.resolveInternal("src/test/resources", "META-INF/../META-INF/file.svg").toPath();
-        PortablePath p = PortablePath.of(result.toString());
-        assertThat(p.getFileName()).isEqualTo("file.svg");
     }
 
 }

--- a/drools-util/src/test/java/org/drools/util/PortablePathTest.java
+++ b/drools-util/src/test/java/org/drools/util/PortablePathTest.java
@@ -1,0 +1,143 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.drools.util;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.nio.file.Path;
+import java.nio.file.Paths;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
+
+class PortablePathTest {
+
+    private PortablePath base;
+
+    @BeforeEach
+    void setUp() {
+        base = PortablePath.of("src/test/resources/META-INF/processSVG");
+    }
+
+    @Test
+    void testResolveAcceptsValidPath() {
+        PortablePath result = base.resolve("travels.svg");
+        assertThat(result.asString()).startsWith(base.asString());
+    }
+
+    @Test
+    void testResolveNestedPathIsValid() {
+        PortablePath result = base.resolve("subdir/file.svg");
+        assertThat(result.asString()).startsWith(base.asString());
+        assertThat(result.getFileName()).isEqualTo("file.svg");
+    }
+
+    @Test
+    void testResolveCleansUpRedundantNavigation() {
+        PortablePath result = base.resolve("subdir/../file.svg");
+        assertThat(result.asString()).startsWith(base.asString());
+        assertThat(result.getFileName()).isEqualTo("file.svg");
+    }
+
+    @Test
+    void testResolvePathWithTrailingSlash() {
+        PortablePath result = base.resolve("subdir/");
+        assertThat(result.asString()).isEqualTo(base.asString() + "/subdir");
+    }
+
+    @Test
+    void testResolveWithValidDeepNestedPath() {
+        PortablePath result = base.resolve("deep/nested/subdir/file.svg");
+        assertThat(result.asString()).startsWith(base.asString());
+    }
+
+    @Test
+    void testResolveWithRedundantCurrentDirectory() {
+        PortablePath result = base.resolve("subdir/./file.svg");
+        assertThat(result.asString()).startsWith(base.asString());
+        assertThat(result.getFileName()).isEqualTo("file.svg");
+    }
+
+    @Test
+    void testResolveWithRedundantParentDirectory() {
+        PortablePath result = base.resolve("subdir/../subdir/file.svg");
+        assertThat(result.asString()).startsWith(base.asString());
+        assertThat(result.getFileName()).isEqualTo("file.svg");
+    }
+
+
+    @Test
+    void testResolveInternalAcceptsValidPath() {
+        Path result = PortablePath.resolveInternal("src/test/resources", "META-INF/file.svg").toPath();
+        PortablePath p = PortablePath.of(result.toString());
+        assertThat(p.getFileName()).isEqualTo("file.svg");
+    }
+
+    @Test
+    void testResolveInternalRejectsPathTraversal() {
+        assertThatExceptionOfType(SecurityException.class)
+                .isThrownBy(() -> PortablePath.resolveInternal("src/test/resources", "../outside/file.svg").toPath())
+                .withMessageContaining("Path traversal attempt detected");
+    }
+
+    @Test
+    void testResolveInternalRejectsDeepTraversal() {
+        assertThatExceptionOfType(SecurityException.class)
+                .isThrownBy(() -> PortablePath.resolveInternal("src/test/resources", "../../../etc/passwd").toPath())
+                .withMessageContaining("Path traversal attempt detected");
+    }
+
+    @Test
+    void testResolveInternalRejectsAbsolutePath() {
+        String absPath = Paths.get("/etc/passwd").toAbsolutePath().toString();
+        assertThatExceptionOfType(SecurityException.class)
+                .isThrownBy(() -> PortablePath.resolveInternal("src/test/resources", absPath))
+                .withMessageContaining("Path traversal attempt detected");
+    }
+
+    @Test
+    void testResolveInternalNormalizesWindowsSeparators() {
+        Path result = PortablePath.resolveInternal("src/test/resources", "META-INF\\file.svg").toPath();
+        PortablePath p = PortablePath.of(result.toString());
+        assertThat(p.getFileName()).isEqualTo("file.svg");                                                                           
+    }
+
+    @Test
+    void testResolveInternalHandlesTrailingSlash() {
+        Path result = PortablePath.resolveInternal("src/test/resources", "META-INF/").toPath();
+        PortablePath p = PortablePath.of(result.toString());
+        assertThat(p.getFileName()).isEqualTo("META-INF");
+    }
+
+    @Test
+    void testResolveInternalStripsRedundantDots() {
+        Path result = PortablePath.resolveInternal("src/test/resources", "./META-INF/./file.svg").toPath();
+        PortablePath p = PortablePath.of(result.toString());
+        assertThat(p.getFileName()).isEqualTo("file.svg");
+    }
+
+    @Test
+    void testResolveInternalNormalizesParentDirectory() {
+        Path result = PortablePath.resolveInternal("src/test/resources", "META-INF/../META-INF/file.svg").toPath();
+        PortablePath p = PortablePath.of(result.toString());
+        assertThat(p.getFileName()).isEqualTo("file.svg");
+    }
+
+}


### PR DESCRIPTION
Fixes https://github.com/apache/incubator-kie-issues/issues/1886

Needed by https://github.com/apache/incubator-kie-kogito-runtimes/pull/3934

This PR
1. implement PathUtils inside drools-util module
2. create test for it
3. create test for PortablePath

<details>
<summary>
How to replicate CI configuration locally?
</summary>

Build Chain tool does "simple" maven build(s), the builds are just Maven commands, but because the repositories relates and depends on each other and any change in API or class method could affect several of those repositories there is a need to use [build-chain tool](https://github.com/kiegroup/github-action-build-chain) to handle cross repository builds and be sure that we always use latest version of the code for each repository.
 
[build-chain tool](https://github.com/kiegroup/github-action-build-chain) is a build tool which can be used on command line locally or in Github Actions workflow(s), in case you need to change multiple repositories and send multiple dependent pull requests related with a change you can easily reproduce the same build by executing it on Github hosted environment or locally in your development environment. See [local execution](https://github.com/kiegroup/github-action-build-chain#local-execution) details to get more information about it.
</details>

<details>
<summary>
How to retest this PR or trigger a specific build:
</summary>

- for <b>pull request and downstream checks</b>  
  - Push a new commit to the PR. An empty commit would be enough.

- for a <b>full downstream build</b>
  - for <b>github actions</b> job: add the label `run_fdb`

- for <b>Jenkins PR check only</b>
  - If you are an ASF committer for KIE podling, login to Jenkins (https://ci-builds.apache.org/job/KIE/job/drools/), go to the specific PR job, and click on `Build Now` button.
</details>
