### PR TITLE
[kie-issues#1908] Upgrade Quarkus to 3.20.x

### DIFF
--- a/build-parent/pom.xml
+++ b/build-parent/pom.xml
@@ -74,7 +74,7 @@
     <version.info.picocli>4.7.5</version.info.picocli>
     <version.io.micrometer>1.14.5</version.io.micrometer>
     <version.io.quarkus>3.20.1</version.io.quarkus>
-    <version.io.netty>4.1.118.Final</version.io.netty>
+    <version.io.netty>4.1.119.Final</version.io.netty>
     <version.io.smallrye.openapi.core>4.0.10</version.io.smallrye.openapi.core>
     <version.io.smallrye.config.core>3.11.4</version.io.smallrye.config.core>
 

--- a/build-parent/pom.xml
+++ b/build-parent/pom.xml
@@ -73,7 +73,7 @@
     <version.guru.nidi>0.18.0</version.guru.nidi>
     <version.info.picocli>4.7.5</version.info.picocli>
     <version.io.micrometer>1.12.2</version.io.micrometer>
-    <version.io.quarkus>3.15.3.1</version.io.quarkus>
+    <version.io.quarkus>3.20.0</version.io.quarkus>
     <version.io.netty>4.1.118.Final</version.io.netty>
     <version.io.smallrye.openapi.core>3.10.0</version.io.smallrye.openapi.core>
     <version.it.unimi.dsi.fastutil>8.5.11</version.it.unimi.dsi.fastutil>
@@ -99,11 +99,11 @@
     <!--This needs to be in sync with JUnit-->
     <version.org.hamcrest>2.2</version.org.hamcrest>
     <version.org.hsqldb>2.3.0</version.org.hsqldb>
-    <version.org.infinispan>15.0.11.Final</version.org.infinispan>
-    <version.org.infinispan.protostream>5.0.8.Final</version.org.infinispan.protostream>
+    <version.org.infinispan>15.0.14.Final</version.org.infinispan>
+    <version.org.infinispan.protostream>5.0.13.Final</version.org.infinispan.protostream>
     <version.org.javassist>3.26.0-GA</version.org.javassist>
     <version.org.jboss.narayana.tomcat>7.0.2.Final</version.org.jboss.narayana.tomcat>
-    <version.org.jboss.logging>3.5.3.Final</version.org.jboss.logging>
+    <version.org.jboss.logging>3.6.1.Final</version.org.jboss.logging>
     <version.org.jboss.transaction.spi>8.0.0.Final</version.org.jboss.transaction.spi>
     <version.org.jboss.weld.weld>3.1.6.Final</version.org.jboss.weld.weld>
     <version.org.eclipse.microprofile.config>3.1</version.org.eclipse.microprofile.config>
@@ -190,10 +190,10 @@
 
     <version.net.byte-buddy>1.14.11</version.net.byte-buddy>
 
-    <version.org.postgresql>42.7.4</version.org.postgresql>
+    <version.org.postgresql>42.7.5</version.org.postgresql>
 
     <version.ch.obermuhlner>2.0.1</version.ch.obermuhlner>
-    <version.io.smallrye.jandex>3.2.3</version.io.smallrye.jandex>
+    <version.io.smallrye.jandex>3.2.7</version.io.smallrye.jandex>
     <version.org.eclipse.yasson>3.0.3</version.org.eclipse.yasson>
 
     <version.com.github.javaparser>3.25.8</version.com.github.javaparser>

--- a/build-parent/pom.xml
+++ b/build-parent/pom.xml
@@ -57,7 +57,7 @@
     <version.commons-codec>1.18.0</version.commons-codec>
     <version.commons-collections>3.2.2</version.commons-collections>
     <version.commons-logging>1.1.1</version.commons-logging>
-    <version.commons-io>2.18.0</version.commons-io>
+    <version.commons-io>2.19.0</version.commons-io>
     <version.common-text>1.11.0</version.common-text>
     <version.com.fasterxml.jackson>2.18.4</version.com.fasterxml.jackson>
     <version.com.fasterxml.jackson.databind>2.18.4</version.com.fasterxml.jackson.databind>

--- a/build-parent/pom.xml
+++ b/build-parent/pom.xml
@@ -59,10 +59,10 @@
     <version.commons-logging>1.1.1</version.commons-logging>
     <version.commons-io>2.18.0</version.commons-io>
     <version.common-text>1.11.0</version.common-text>
-    <version.com.fasterxml.jackson>2.17.2</version.com.fasterxml.jackson>
-    <version.com.fasterxml.jackson.databind>2.17.2</version.com.fasterxml.jackson.databind>
-    <version.com.fasterxml.jackson.annotations>2.17.2</version.com.fasterxml.jackson.annotations>
-    <version.com.github.victools>4.31.0</version.com.github.victools> <!-- victools should align with Jackson if possible -->
+    <version.com.fasterxml.jackson>2.18.2</version.com.fasterxml.jackson>
+    <version.com.fasterxml.jackson.databind>2.18.2</version.com.fasterxml.jackson.databind>
+    <version.com.fasterxml.jackson.annotations>2.18.2</version.com.fasterxml.jackson.annotations>
+    <version.com.github.victools>4.37.0</version.com.github.victools> <!-- victools should align with Jackson if possible -->
     <version.com.miglayout>3.7.4</version.com.miglayout>
     <version.domino-slf4j-logger>1.0.1</version.domino-slf4j-logger>
     <version.com.google.protobuf>3.25.5</version.com.google.protobuf>
@@ -72,10 +72,12 @@
     <version.com.thoughtworks.xstream>1.4.21</version.com.thoughtworks.xstream>
     <version.guru.nidi>0.18.0</version.guru.nidi>
     <version.info.picocli>4.7.5</version.info.picocli>
-    <version.io.micrometer>1.12.2</version.io.micrometer>
+    <version.io.micrometer>1.14.5</version.io.micrometer>
     <version.io.quarkus>3.20.0</version.io.quarkus>
     <version.io.netty>4.1.118.Final</version.io.netty>
-    <version.io.smallrye.openapi.core>3.10.0</version.io.smallrye.openapi.core>
+    <version.io.smallrye.openapi.core>4.0.8</version.io.smallrye.openapi.core>
+    <version.io.smallrye.config.core>3.11.4</version.io.smallrye.config.core>
+
     <version.it.unimi.dsi.fastutil>8.5.11</version.it.unimi.dsi.fastutil>
     <version.junit>4.13.2</version.junit>
     <version.net.java.dev.glazedlists>1.8.0</version.net.java.dev.glazedlists>
@@ -411,6 +413,22 @@
         <groupId>io.smallrye</groupId>
         <artifactId>smallrye-open-api-core</artifactId>
         <version>${version.io.smallrye.openapi.core}</version>
+      </dependency>
+
+      <dependency>
+        <groupId>io.smallrye.config</groupId>
+        <artifactId>smallrye-config</artifactId>
+        <version>${version.io.smallrye.config.core}</version>
+        <exclusions>
+          <exclusion>
+            <groupId>org.osgi</groupId>
+            <artifactId>org.osgi.annotation.versioning</artifactId>
+          </exclusion>
+          <exclusion>
+            <groupId>org.ow2.asm</groupId>
+            <artifactId>asm</artifactId>
+          </exclusion>
+        </exclusions>
       </dependency>
 
       <dependency>

--- a/build-parent/pom.xml
+++ b/build-parent/pom.xml
@@ -59,9 +59,9 @@
     <version.commons-logging>1.1.1</version.commons-logging>
     <version.commons-io>2.18.0</version.commons-io>
     <version.common-text>1.11.0</version.common-text>
-    <version.com.fasterxml.jackson>2.18.2</version.com.fasterxml.jackson>
-    <version.com.fasterxml.jackson.databind>2.18.2</version.com.fasterxml.jackson.databind>
-    <version.com.fasterxml.jackson.annotations>2.18.2</version.com.fasterxml.jackson.annotations>
+    <version.com.fasterxml.jackson>2.18.4</version.com.fasterxml.jackson>
+    <version.com.fasterxml.jackson.databind>2.18.4</version.com.fasterxml.jackson.databind>
+    <version.com.fasterxml.jackson.annotations>2.18.4</version.com.fasterxml.jackson.annotations>
     <version.com.github.victools>4.37.0</version.com.github.victools> <!-- victools should align with Jackson if possible -->
     <version.com.miglayout>3.7.4</version.com.miglayout>
     <version.domino-slf4j-logger>1.0.1</version.domino-slf4j-logger>
@@ -74,7 +74,7 @@
     <version.info.picocli>4.7.5</version.info.picocli>
     <version.io.micrometer>1.14.5</version.io.micrometer>
     <version.io.quarkus>3.20.1</version.io.quarkus>
-    <version.io.netty>4.1.119.Final</version.io.netty>
+    <version.io.netty>4.1.121.Final</version.io.netty>
     <version.io.smallrye.openapi.core>4.0.10</version.io.smallrye.openapi.core>
     <version.io.smallrye.config.core>3.11.4</version.io.smallrye.config.core>
 

--- a/build-parent/pom.xml
+++ b/build-parent/pom.xml
@@ -73,9 +73,9 @@
     <version.guru.nidi>0.18.0</version.guru.nidi>
     <version.info.picocli>4.7.5</version.info.picocli>
     <version.io.micrometer>1.14.5</version.io.micrometer>
-    <version.io.quarkus>3.20.0</version.io.quarkus>
+    <version.io.quarkus>3.20.1</version.io.quarkus>
     <version.io.netty>4.1.118.Final</version.io.netty>
-    <version.io.smallrye.openapi.core>4.0.8</version.io.smallrye.openapi.core>
+    <version.io.smallrye.openapi.core>4.0.10</version.io.smallrye.openapi.core>
     <version.io.smallrye.config.core>3.11.4</version.io.smallrye.config.core>
 
     <version.it.unimi.dsi.fastutil>8.5.11</version.it.unimi.dsi.fastutil>
@@ -195,7 +195,7 @@
     <version.org.postgresql>42.7.5</version.org.postgresql>
 
     <version.ch.obermuhlner>2.0.1</version.ch.obermuhlner>
-    <version.io.smallrye.jandex>3.2.7</version.io.smallrye.jandex>
+    <version.io.smallrye.jandex>3.3.0</version.io.smallrye.jandex>
     <version.org.eclipse.yasson>3.0.3</version.org.eclipse.yasson>
 
     <version.com.github.javaparser>3.25.8</version.com.github.javaparser>

--- a/build-parent/pom.xml
+++ b/build-parent/pom.xml
@@ -53,7 +53,7 @@
       - A version property must be specified in the format "version.{groupId}", optionally with a suffix to make it unique.
       - Version properties must be sorted alphabetically (other form of sorting were found to be unclear and ambiguous).
     -->
-    <version.ch.qos.logback>1.5.16</version.ch.qos.logback>
+    <version.ch.qos.logback>1.5.18</version.ch.qos.logback>
     <version.commons-codec>1.18.0</version.commons-codec>
     <version.commons-collections>3.2.2</version.commons-collections>
     <version.commons-logging>1.1.1</version.commons-logging>

--- a/drools-quarkus-extension/drools-quarkus-examples/drools-quarkus-examples-multiunit/pom.xml
+++ b/drools-quarkus-extension/drools-quarkus-examples/drools-quarkus-examples-multiunit/pom.xml
@@ -82,6 +82,16 @@
         </exclusion>
       </exclusions>
     </dependency>
+    <dependency>
+      <groupId>org.drools</groupId>
+      <artifactId>drools-quarkus-util-deployment</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>io.quarkus</groupId>
+      <artifactId>quarkus-rest</artifactId>
+      <scope>test</scope>
+    </dependency>
 
   </dependencies>
 

--- a/drools-quarkus-extension/drools-quarkus-examples/drools-quarkus-examples-reactive/pom.xml
+++ b/drools-quarkus-extension/drools-quarkus-examples/drools-quarkus-examples-reactive/pom.xml
@@ -97,6 +97,16 @@
         </exclusion>
       </exclusions>
     </dependency>
+    <dependency>
+      <groupId>org.drools</groupId>
+      <artifactId>drools-quarkus-util-deployment</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>io.quarkus</groupId>
+      <artifactId>quarkus-rest</artifactId>
+      <scope>test</scope>
+    </dependency>
 
   </dependencies>
 

--- a/drools-quarkus-extension/drools-quarkus-integration-test-kmodule/pom.xml
+++ b/drools-quarkus-extension/drools-quarkus-integration-test-kmodule/pom.xml
@@ -57,7 +57,7 @@
 
     <dependency> <!-- enable REST endpoint as hook point for E2E opaque testing -->
       <groupId>io.quarkus</groupId>
-      <artifactId>quarkus-resteasy-reactive</artifactId>
+      <artifactId>quarkus-rest</artifactId>
     </dependency>
     <dependency> <!-- enable assertions in REST endpoint as hook point for E2E opaque testing -->
       <groupId>org.assertj</groupId>

--- a/drools-quarkus-extension/drools-quarkus-integration-test/pom.xml
+++ b/drools-quarkus-extension/drools-quarkus-integration-test/pom.xml
@@ -61,7 +61,7 @@
 
     <dependency> <!-- enable REST endpoint as hook point for E2E opaque testing -->
       <groupId>io.quarkus</groupId>
-      <artifactId>quarkus-resteasy-reactive</artifactId>
+      <artifactId>quarkus-rest</artifactId>
     </dependency>
     <dependency> <!-- enable assertions in REST endpoint as hook point for E2E opaque testing -->
       <groupId>org.assertj</groupId>

--- a/drools-quarkus-extension/drools-quarkus-ruleunit-integration-test/pom.xml
+++ b/drools-quarkus-extension/drools-quarkus-ruleunit-integration-test/pom.xml
@@ -52,11 +52,11 @@
 
     <dependency> <!-- enable REST endpoint as hook point for E2E opaque testing -->
       <groupId>io.quarkus</groupId>
-      <artifactId>quarkus-resteasy-reactive</artifactId>
+      <artifactId>quarkus-rest</artifactId>
     </dependency>
     <dependency>
       <groupId>io.quarkus</groupId>
-      <artifactId>quarkus-resteasy-reactive-jackson</artifactId>
+      <artifactId>quarkus-rest-jackson</artifactId>
     </dependency>
     <dependency> <!-- enable assertions in REST endpoint as hook point for E2E opaque testing -->
       <groupId>org.assertj</groupId>

--- a/drools-reliability/drools-reliability-tests/infinispan-remote-config/infinispan-local.xml
+++ b/drools-reliability/drools-reliability-tests/infinispan-remote-config/infinispan-local.xml
@@ -1,20 +1,24 @@
 <!--
-     Licensed to the Apache Software Foundation (ASF) under one
-     or more contributor license agreements.  See the NOTICE file
-     distributed with this work for additional information
-     regarding copyright ownership.  The ASF licenses this file
-     to you under the Apache License, Version 2.0 (the
-     "License"); you may not use this file except in compliance
-     with the License.  You may obtain a copy of the License at
-       http://www.apache.org/licenses/LICENSE-2.0
-     Unless required by applicable law or agreed to in writing,
-     software distributed under the License is distributed on an
-     "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
-     KIND, either express or implied.  See the License for the
-     specific language governing permissions and limitations
-     under the License.
- -->
- <infinispan
+
+    Licensed to the Apache Software Foundation (ASF) under one
+    or more contributor license agreements.  See the NOTICE file
+    distributed with this work for additional information
+    regarding copyright ownership.  The ASF licenses this file
+    to you under the Apache License, Version 2.0 (the
+    "License"); you may not use this file except in compliance
+    with the License.  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing,
+    software distributed under the License is distributed on an
+    "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+    KIND, either express or implied.  See the License for the
+    specific language governing permissions and limitations
+    under the License.
+
+-->
+<infinispan
         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
         xsi:schemaLocation="urn:infinispan:config:15.0 https://infinispan.org/schemas/infinispan-config-15.0.xsd
                             urn:infinispan:server:15.0 https://infinispan.org/schemas/infinispan-server-15.0.xsd"

--- a/drools-reliability/drools-reliability-tests/infinispan-remote-config/infinispan-local.xml
+++ b/drools-reliability/drools-reliability-tests/infinispan-remote-config/infinispan-local.xml
@@ -1,4 +1,20 @@
-<infinispan
+<!--
+     Licensed to the Apache Software Foundation (ASF) under one
+     or more contributor license agreements.  See the NOTICE file
+     distributed with this work for additional information
+     regarding copyright ownership.  The ASF licenses this file
+     to you under the Apache License, Version 2.0 (the
+     "License"); you may not use this file except in compliance
+     with the License.  You may obtain a copy of the License at
+       http://www.apache.org/licenses/LICENSE-2.0
+     Unless required by applicable law or agreed to in writing,
+     software distributed under the License is distributed on an
+     "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+     KIND, either express or implied.  See the License for the
+     specific language governing permissions and limitations
+     under the License.
+ -->
+ <infinispan
         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
         xsi:schemaLocation="urn:infinispan:config:15.0 https://infinispan.org/schemas/infinispan-config-15.0.xsd
                             urn:infinispan:server:15.0 https://infinispan.org/schemas/infinispan-server-15.0.xsd"

--- a/drools-reliability/drools-reliability-tests/infinispan-remote-config/infinispan-local.xml
+++ b/drools-reliability/drools-reliability-tests/infinispan-remote-config/infinispan-local.xml
@@ -1,38 +1,17 @@
-<!--
-
-    Licensed to the Apache Software Foundation (ASF) under one
-    or more contributor license agreements.  See the NOTICE file
-    distributed with this work for additional information
-    regarding copyright ownership.  The ASF licenses this file
-    to you under the Apache License, Version 2.0 (the
-    "License"); you may not use this file except in compliance
-    with the License.  You may obtain a copy of the License at
-
-      http://www.apache.org/licenses/LICENSE-2.0
-
-    Unless required by applicable law or agreed to in writing,
-    software distributed under the License is distributed on an
-    "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
-    KIND, either express or implied.  See the License for the
-    specific language governing permissions and limitations
-    under the License.
-
--->
 <infinispan
-      xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-      xsi:schemaLocation="urn:infinispan:config:14.0 https://infinispan.org/schemas/infinispan-config-14.0.xsd
-                            urn:infinispan:server:14.0 https://infinispan.org/schemas/infinispan-server-14.0.xsd"
-      xmlns="urn:infinispan:config:14.0"
-      xmlns:server="urn:infinispan:server:14.0">
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:schemaLocation="urn:infinispan:config:15.0 https://infinispan.org/schemas/infinispan-config-15.0.xsd
+                            urn:infinispan:server:15.0 https://infinispan.org/schemas/infinispan-server-15.0.xsd"
+        xmlns="urn:infinispan:config:15.0"
+        xmlns:server="urn:infinispan:server:15.0">
 
    <cache-container name="default" statistics="true">
-      <!-- no transport = local cache -->
       <security>
          <authorization/>
       </security>
    </cache-container>
 
-   <server xmlns="urn:infinispan:server:14.0">
+   <server xmlns="urn:infinispan:server:15.0">
       <interfaces>
          <interface name="public">
             <inet-address value="${infinispan.bind.address:127.0.0.1}"/>
@@ -41,29 +20,20 @@
 
       <socket-bindings default-interface="public" port-offset="${infinispan.socket.binding.port-offset:0}">
          <socket-binding name="default" port="${infinispan.bind.port:11222}"/>
-         <socket-binding name="memcached" port="11221"/>
       </socket-bindings>
 
       <security>
-         <credential-stores>
-            <credential-store name="credentials" path="credentials.pfx">
-               <clear-text-credential clear-text="secret"/>
-            </credential-store>
-         </credential-stores>
          <security-realms>
             <security-realm name="default">
                <!-- Uncomment to enable TLS on the realm -->
                <!-- server-identities>
                   <ssl>
-                     <keystore path="application.keystore"
+                     <keystore path="server.pfx"
                                password="password" alias="server"
                                generate-self-signed-certificate-host="localhost"/>
                   </ssl>
                </server-identities-->
-               <properties-realm groups-attribute="Roles">
-                  <user-properties path="users.properties"/>
-                  <group-properties path="groups.properties"/>
-               </properties-realm>
+               <properties-realm/>
             </security-realm>
          </security-realms>
       </security>

--- a/drools-reliability/drools-reliability-tests/src/test/java/org/drools/reliability/test/example/infinispan/RemoteCacheManagerExample.java
+++ b/drools-reliability/drools-reliability-tests/src/test/java/org/drools/reliability/test/example/infinispan/RemoteCacheManagerExample.java
@@ -41,7 +41,7 @@ import java.util.List;
  * After running this example, you can run RemoteCacheManagerExampleAfterFailOver to see the results.
  * <p>
  * So the steps are:
- * docker run -p 11222:11222 -e USER="admin" -e PASS="secret" quay.io/infinispan/server:14.0
+ * docker run -p 11222:11222 -e USER="admin" -e PASS="secret" quay.io/infinispan/server:15.0
  * Run RemoteCacheManagerExample
  * Run RemoteCacheManagerExampleAfterFailOver
  */

--- a/kie-dmn/kie-dmn-feel/pom.xml
+++ b/kie-dmn/kie-dmn-feel/pom.xml
@@ -38,7 +38,7 @@
     <java.module.name>org.kie.dmn.feel</java.module.name>
     <surefire.forkCount>2</surefire.forkCount>
     <enforcer.skip>true</enforcer.skip>
-    <version.net.sf.saxon.Saxon-HE>12.5</version.net.sf.saxon.Saxon-HE>
+    <version.net.sf.saxon.Saxon-HE>12.7</version.net.sf.saxon.Saxon-HE>
   </properties>
 
   <dependencyManagement>

--- a/kie-dmn/kie-dmn-openapi/pom.xml
+++ b/kie-dmn/kie-dmn-openapi/pom.xml
@@ -95,6 +95,12 @@
     </dependency>
 
     <dependency>
+      <groupId>io.smallrye.config</groupId>
+      <artifactId>smallrye-config</artifactId>
+      <scope>test</scope>
+    </dependency>
+
+    <dependency>
       <groupId>org.junit.jupiter</groupId>
       <artifactId>junit-jupiter-api</artifactId>
       <scope>test</scope>

--- a/kie-dmn/kie-dmn-openapi/src/main/java/org/kie/dmn/openapi/impl/DMNOASConstants.java
+++ b/kie-dmn/kie-dmn-openapi/src/main/java/org/kie/dmn/openapi/impl/DMNOASConstants.java
@@ -20,12 +20,15 @@ package org.kie.dmn.openapi.impl;
 
 public class DMNOASConstants {
 
+    public static final String X_NULLABLE = "nullable";
     public static final String X_DMN_TYPE = "x-dmn-type";
     public static final String X_DMN_ALLOWED_VALUES = "x-dmn-allowed-values";
     public static final String X_DMN_TYPE_CONSTRAINTS = "x-dmn-type-constraints";
     public static final String X_DMN_DESCRIPTIONS = "x-dmn-descriptions";
     public static final String X_DMN_MINIMUM_VALUE = "x-dmn-minimum-value";
     public static final String X_DMN_MAXIMUM_VALUE = "x-dmn-maximum-value";
+    public static final String X_DMN_EXCLUSIVE_MINIMUM_VALUE = "x-dmn-exclusive-minimum-value";
+    public static final String X_DMN_EXCLUSIVE_MAXIMUM_VALUE = "x-dmn-exclusive-maximum-value";
 
     private DMNOASConstants() {
         // no constructor for contants/utility classes.

--- a/kie-dmn/kie-dmn-openapi/src/main/java/org/kie/dmn/openapi/impl/DMNTypeSchemas.java
+++ b/kie-dmn/kie-dmn-openapi/src/main/java/org/kie/dmn/openapi/impl/DMNTypeSchemas.java
@@ -147,7 +147,7 @@ public class DMNTypeSchemas {
     }
 
     private Schema schemaFromCompositeType(CompositeTypeImpl ct) {
-        Schema schema = OASFactory.createObject(Schema.class).type(SchemaType.OBJECT);
+        Schema schema = OASFactory.createObject(Schema.class).addType(SchemaType.OBJECT);
         if (ct.getBaseType() == null) { // main case
             for (Entry<String, DMNType> fkv : ct.getFields().entrySet()) {
                 schema.addProperty(fkv.getKey(), refOrBuiltinSchema(fkv.getValue()));
@@ -170,7 +170,7 @@ public class DMNTypeSchemas {
 
     private Schema nestAsItemIfCollection(Schema original, DMNType t) {
         if (t.isCollection()) {
-            return OASFactory.createObject(Schema.class).type(SchemaType.ARRAY).items(original);
+            return OASFactory.createObject(Schema.class).addType(SchemaType.ARRAY).items(original);
         } else {
             return original;
         }

--- a/kie-dmn/kie-dmn-openapi/src/main/java/org/kie/dmn/openapi/impl/DMNUnaryTestsMapper.java
+++ b/kie-dmn/kie-dmn-openapi/src/main/java/org/kie/dmn/openapi/impl/DMNUnaryTestsMapper.java
@@ -44,6 +44,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import static java.util.stream.Collectors.groupingBy;
+import static org.kie.dmn.openapi.impl.DMNOASConstants.X_NULLABLE;
 import static org.kie.dmn.openapi.impl.RangeNodeSchemaMapper.populateSchemaFromListOfRanges;
 
 public class DMNUnaryTestsMapper {
@@ -64,7 +65,7 @@ public class DMNUnaryTestsMapper {
                 throw new IllegalArgumentException("At most one null value is allowed for enum definition");
             }
             // If there is a NullNode, the item is nullable
-            toPopulate.setNullable(!nullNodes.isEmpty());
+            toPopulate.addExtension(X_NULLABLE, !nullNodes.isEmpty());
             if (enumBaseNodes.size() > nullNodes.size()) {
                 // Let's create enum only if there is at least one node != NullNode
                 enumBaseNodes.forEach(unaryEvaluationNode -> populateSchemaFromBaseNode(toPopulate, unaryEvaluationNode));

--- a/kie-dmn/kie-dmn-openapi/src/main/java/org/kie/dmn/openapi/impl/FEELBuiltinTypeSchemaMapper.java
+++ b/kie-dmn/kie-dmn-openapi/src/main/java/org/kie/dmn/openapi/impl/FEELBuiltinTypeSchemaMapper.java
@@ -26,6 +26,8 @@ import org.kie.dmn.feel.lang.SimpleType;
 import org.kie.dmn.feel.lang.types.BuiltInType;
 import org.kie.dmn.typesafe.DMNTypeUtils;
 
+import java.util.List;
+
 public class FEELBuiltinTypeSchemaMapper {
 
     public static Schema from(DMNType t) {
@@ -41,10 +43,10 @@ public class FEELBuiltinTypeSchemaMapper {
         switch (t.getName()) {
             case SimpleType.YEARS_AND_MONTHS_DURATION:
             case "yearMonthDuration":
-                return OASFactory.createObject(Schema.class).addExtension(DMNOASConstants.X_DMN_TYPE, "FEEL:years and months duration").type(SchemaType.STRING).format("years and months duration").example("P1Y2M");
+                return OASFactory.createObject(Schema.class).addExtension(DMNOASConstants.X_DMN_TYPE, "FEEL:years and months duration").addType(SchemaType.STRING).format("years and months duration").examples(List.of("P1Y2M"));
             case SimpleType.DAYS_AND_TIME_DURATION:
             case "dayTimeDuration":
-                return OASFactory.createObject(Schema.class).addExtension(DMNOASConstants.X_DMN_TYPE, "FEEL:days and time duration").type(SchemaType.STRING).format("days and time duration").example("P1D");
+                return OASFactory.createObject(Schema.class).addExtension(DMNOASConstants.X_DMN_TYPE, "FEEL:days and time duration").addType(SchemaType.STRING).format("days and time duration").examples(List.of("P1D"));
             default:
                 throw new IllegalArgumentException();
         }
@@ -55,17 +57,17 @@ public class FEELBuiltinTypeSchemaMapper {
             case UNKNOWN:
                 return OASFactory.createObject(Schema.class).addExtension(DMNOASConstants.X_DMN_TYPE, "FEEL:Any"); // intentional, do NOT add .type(SchemaType.OBJECT), the JSONSchema to represent FEEL:Any is {}
             case DATE:
-                return OASFactory.createObject(Schema.class).type(SchemaType.STRING).format("date").addExtension(DMNOASConstants.X_DMN_TYPE, "FEEL:date");
+                return OASFactory.createObject(Schema.class).addType(SchemaType.STRING).format("date").addExtension(DMNOASConstants.X_DMN_TYPE, "FEEL:date");
             case TIME:
-                return OASFactory.createObject(Schema.class).type(SchemaType.STRING).format("time").addExtension(DMNOASConstants.X_DMN_TYPE, "FEEL:time");
+                return OASFactory.createObject(Schema.class).addType(SchemaType.STRING).format("time").addExtension(DMNOASConstants.X_DMN_TYPE, "FEEL:time");
             case DATE_TIME:
-                return OASFactory.createObject(Schema.class).type(SchemaType.STRING).format("date-time").addExtension(DMNOASConstants.X_DMN_TYPE, "FEEL:date and time");
+                return OASFactory.createObject(Schema.class).addType(SchemaType.STRING).format("date-time").addExtension(DMNOASConstants.X_DMN_TYPE, "FEEL:date and time");
             case BOOLEAN:
-                return OASFactory.createObject(Schema.class).type(SchemaType.BOOLEAN).addExtension(DMNOASConstants.X_DMN_TYPE, "FEEL:boolean");
+                return OASFactory.createObject(Schema.class).addType(SchemaType.BOOLEAN).addExtension(DMNOASConstants.X_DMN_TYPE, "FEEL:boolean");
             case NUMBER:
-                return OASFactory.createObject(Schema.class).type(SchemaType.NUMBER).addExtension(DMNOASConstants.X_DMN_TYPE, "FEEL:number");
+                return OASFactory.createObject(Schema.class).addType(SchemaType.NUMBER).addExtension(DMNOASConstants.X_DMN_TYPE, "FEEL:number");
             case STRING:
-                return OASFactory.createObject(Schema.class).type(SchemaType.STRING).addExtension(DMNOASConstants.X_DMN_TYPE, "FEEL:string");
+                return OASFactory.createObject(Schema.class).addType(SchemaType.STRING).addExtension(DMNOASConstants.X_DMN_TYPE, "FEEL:string");
             case CONTEXT:
                 return OASFactory.createObject(Schema.class).addExtension(DMNOASConstants.X_DMN_TYPE, "FEEL:context"); // intentional, do NOT add .type(SchemaType.OBJECT), the JSONSchema to represent FEEL:context is {}
             case DURATION:

--- a/kie-dmn/kie-dmn-openapi/src/main/java/org/kie/dmn/openapi/impl/RangeNodeSchemaMapper.java
+++ b/kie-dmn/kie-dmn-openapi/src/main/java/org/kie/dmn/openapi/impl/RangeNodeSchemaMapper.java
@@ -35,19 +35,33 @@ public class RangeNodeSchemaMapper {
         if (range != null) {
             if (range.getLowEndPoint() != null) {
                 if (range.getLowEndPoint() instanceof BigDecimal bigDecimal) {
-                    toPopulate.minimum(bigDecimal);
+                    if (range.getLowBoundary() == Range.RangeBoundary.OPEN){
+                        toPopulate.exclusiveMinimum(bigDecimal);
+                    } else {
+                        toPopulate.minimum(bigDecimal);
+                    }
                 } else {
-                    toPopulate.addExtension(DMNOASConstants.X_DMN_MINIMUM_VALUE, range.getLowEndPoint());
+                    if (range.getLowBoundary() == Range.RangeBoundary.OPEN){
+                        toPopulate.addExtension(DMNOASConstants.X_DMN_EXCLUSIVE_MINIMUM_VALUE, range.getLowEndPoint());
+                    } else {
+                        toPopulate.addExtension(DMNOASConstants.X_DMN_MINIMUM_VALUE, range.getLowEndPoint());
+                    }
                 }
-                toPopulate.exclusiveMinimum(range.getLowBoundary() == Range.RangeBoundary.OPEN);
             }
             if (range.getHighEndPoint() != null) {
                 if (range.getHighEndPoint() instanceof BigDecimal bigDecimal) {
-                    toPopulate.maximum(bigDecimal);
+                    if (range.getHighBoundary() == Range.RangeBoundary.OPEN ){
+                        toPopulate.exclusiveMaximum(bigDecimal);
+                    } else {
+                        toPopulate.maximum(bigDecimal);
+                    }
                 } else {
-                    toPopulate.addExtension(DMNOASConstants.X_DMN_MAXIMUM_VALUE, range.getHighEndPoint());
+                    if (range.getHighBoundary() == Range.RangeBoundary.OPEN){
+                        toPopulate.addExtension(DMNOASConstants.X_DMN_EXCLUSIVE_MAXIMUM_VALUE, range.getHighEndPoint());
+                    } else {
+                        toPopulate.addExtension(DMNOASConstants.X_DMN_MAXIMUM_VALUE, range.getHighEndPoint());
+                    }
                 }
-                toPopulate.exclusiveMaximum(range.getHighBoundary() == Range.RangeBoundary.OPEN);
             }
         }
     }

--- a/kie-dmn/kie-dmn-openapi/src/test/java/org/kie/dmn/openapi/BaseDMNOASTest.java
+++ b/kie-dmn/kie-dmn-openapi/src/test/java/org/kie/dmn/openapi/BaseDMNOASTest.java
@@ -24,12 +24,12 @@ import java.util.Set;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.json.JsonMapper;
+import com.fasterxml.jackson.databind.node.JsonNodeFactory;
 import com.fasterxml.jackson.databind.node.ObjectNode;
 import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
 import com.networknt.schema.JsonSchema;
 import com.networknt.schema.JsonSchemaFactory;
 import com.networknt.schema.ValidationMessage;
-import io.smallrye.openapi.runtime.io.JsonUtil;
 import org.kie.dmn.api.core.DMNModel;
 import org.kie.dmn.api.core.DMNRuntime;
 import org.kie.dmn.api.core.DMNType;
@@ -71,7 +71,7 @@ public abstract class BaseDMNOASTest {
     private static ObjectNode synthesizeSchema(DMNOASResult result, DMNType InputSetTypeUT) {
         String dollarRef = result.getNamingPolicy().getRef(InputSetTypeUT);
         ObjectNode syntheticJSONSchema = result.getJsonSchemaNode().deepCopy();
-        JsonUtil.stringProperty(syntheticJSONSchema, "$ref", dollarRef);
+        syntheticJSONSchema.set("$ref", JsonNodeFactory.instance.textNode(dollarRef));
         JacksonUtils.printoutJSON(syntheticJSONSchema);
         return syntheticJSONSchema;
     }

--- a/kie-dmn/kie-dmn-openapi/src/test/java/org/kie/dmn/openapi/EnumGenerationTest.java
+++ b/kie-dmn/kie-dmn-openapi/src/test/java/org/kie/dmn/openapi/EnumGenerationTest.java
@@ -35,6 +35,7 @@ import org.kie.dmn.api.core.DMNRuntime;
 import org.kie.dmn.openapi.model.DMNOASResult;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.kie.dmn.openapi.impl.DMNOASConstants.X_NULLABLE;
 
 class EnumGenerationTest extends BaseDMNOASTest {
 
@@ -65,8 +66,8 @@ class EnumGenerationTest extends BaseDMNOASTest {
             assertThat(e).isInstanceOf(DecimalNode.class);
             assertThat(expected).contains(e.decimalValue());
         });
-        assertThat(node.get("nullable")).isNotNull().isInstanceOf(BooleanNode.class);
-        assertThat(node.get("nullable").asBoolean()).isFalse();
+        assertThat(node.get(X_NULLABLE)).isNotNull().isInstanceOf(BooleanNode.class);
+        assertThat(node.get(X_NULLABLE).asBoolean()).isFalse();
     }
 
     @Test
@@ -80,8 +81,8 @@ class EnumGenerationTest extends BaseDMNOASTest {
             assertThat(e).isInstanceOf(TextNode.class);
             assertThat(expected).contains(e.textValue());
         });
-        assertThat(node.get("nullable")).isNotNull().isInstanceOf(BooleanNode.class);
-        assertThat(node.get("nullable").asBoolean()).isFalse();
+        assertThat(node.get(X_NULLABLE)).isNotNull().isInstanceOf(BooleanNode.class);
+        assertThat(node.get(X_NULLABLE).asBoolean()).isFalse();
     }
 
     @Test
@@ -94,8 +95,8 @@ class EnumGenerationTest extends BaseDMNOASTest {
         assertThat(arrayNode).allSatisfy(e -> {
             assertThat(expected).contains(e.textValue());
         });
-        assertThat(node.get("nullable")).isNotNull().isInstanceOf(BooleanNode.class);
-        assertThat(node.get("nullable").asBoolean()).isTrue();
+        assertThat(node.get(X_NULLABLE)).isNotNull().isInstanceOf(BooleanNode.class);
+        assertThat(node.get(X_NULLABLE).asBoolean()).isTrue();
     }
 
     @Test
@@ -109,8 +110,8 @@ class EnumGenerationTest extends BaseDMNOASTest {
             assertThat(e).isInstanceOf(DecimalNode.class);
             assertThat(expected).contains(e.decimalValue());
         });
-        assertThat(node.get("nullable")).isNotNull().isInstanceOf(BooleanNode.class);
-        assertThat(node.get("nullable").asBoolean()).isFalse();
+        assertThat(node.get(X_NULLABLE)).isNotNull().isInstanceOf(BooleanNode.class);
+        assertThat(node.get(X_NULLABLE).asBoolean()).isFalse();
     }
 
     @Test
@@ -124,8 +125,8 @@ class EnumGenerationTest extends BaseDMNOASTest {
             assertThat(e).isInstanceOf(TextNode.class);
             assertThat(expected).contains(e.textValue());
         });
-        assertThat(node.get("nullable")).isNotNull().isInstanceOf(BooleanNode.class);
-        assertThat(node.get("nullable").asBoolean()).isFalse();
+        assertThat(node.get(X_NULLABLE)).isNotNull().isInstanceOf(BooleanNode.class);
+        assertThat(node.get(X_NULLABLE).asBoolean()).isFalse();
     }
 
     @Test
@@ -137,7 +138,7 @@ class EnumGenerationTest extends BaseDMNOASTest {
         
         assertThat(arrayNode).extracting(node1 -> node1.textValue()).containsExactlyInAnyOrder("a", "b", "c", null);
 
-        assertThat(node.get("nullable")).isNotNull().isInstanceOf(BooleanNode.class);
-        assertThat(node.get("nullable").asBoolean()).isTrue();
+        assertThat(node.get(X_NULLABLE)).isNotNull().isInstanceOf(BooleanNode.class);
+        assertThat(node.get(X_NULLABLE).asBoolean()).isTrue();
     }
 }

--- a/kie-dmn/kie-dmn-openapi/src/test/java/org/kie/dmn/openapi/impl/DMNTypeSchemasTest.java
+++ b/kie-dmn/kie-dmn-openapi/src/test/java/org/kie/dmn/openapi/impl/DMNTypeSchemasTest.java
@@ -104,10 +104,8 @@ class DMNTypeSchemasTest {
         SimpleTypeImpl toRead = getSimpleType(allowedValuesString, null, FEEL_STRING, BuiltInType.STRING);
         AtomicReference<Schema> toPopulate = new AtomicReference<>(getSchemaForSimpleType(toRead));
         DMNTypeSchemas.populateSchemaWithConstraints(toPopulate.get(), toRead);
-        assertThat(toPopulate.get().getMinimum()).isEqualTo(BigDecimal.ONE);
-        assertThat(toPopulate.get().getExclusiveMinimum()).isTrue();
+        assertThat(toPopulate.get().getExclusiveMinimum()).isEqualTo(BigDecimal.ONE);
         assertThat(toPopulate.get().getMaximum()).isEqualTo(BigDecimal.TEN);
-        assertThat(toPopulate.get().getExclusiveMaximum()).isFalse();
         assertThat(toPopulate.get().getExtensions()).containsKey(DMNOASConstants.X_DMN_ALLOWED_VALUES);
         String retrieved =
                 ((String) toPopulate.get().getExtensions().get(DMNOASConstants.X_DMN_ALLOWED_VALUES)).replace(" ", "");
@@ -123,10 +121,8 @@ class DMNTypeSchemasTest {
         SimpleTypeImpl toRead = getSimpleType(null, typeConstraintsString, FEEL_STRING, BuiltInType.STRING);
         AtomicReference<Schema> toPopulate = new AtomicReference<>(getSchemaForSimpleType(toRead));
         DMNTypeSchemas.populateSchemaWithConstraints(toPopulate.get(), toRead);
-        assertThat(toPopulate.get().getMinimum()).isEqualTo(BigDecimal.ONE);
-        assertThat(toPopulate.get().getExclusiveMinimum()).isTrue();
+        assertThat(toPopulate.get().getExclusiveMinimum()).isEqualTo(BigDecimal.ONE);
         assertThat(toPopulate.get().getMaximum()).isEqualTo(BigDecimal.TEN);
-        assertThat(toPopulate.get().getExclusiveMaximum()).isFalse();
         assertThat(toPopulate.get().getExtensions().containsKey(DMNOASConstants.X_DMN_TYPE_CONSTRAINTS)).isTrue();
         String retrieved =
                 ((String) toPopulate.get().getExtensions().get(DMNOASConstants.X_DMN_TYPE_CONSTRAINTS)).replace(" ",

--- a/kie-dmn/kie-dmn-openapi/src/test/java/org/kie/dmn/openapi/impl/DMNUnaryTestsMapperTest.java
+++ b/kie-dmn/kie-dmn-openapi/src/test/java/org/kie/dmn/openapi/impl/DMNUnaryTestsMapperTest.java
@@ -34,6 +34,7 @@ import org.kie.dmn.feel.lang.types.BuiltInType;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatIllegalArgumentException;
+import static org.kie.dmn.openapi.impl.DMNOASConstants.X_NULLABLE;
 import static org.kie.dmn.openapi.impl.DMNUnaryTestsMapper.getUnaryEvaluationNodesFromUnaryTests;
 import static org.kie.dmn.openapi.impl.SchemaMapperTestUtils.FEEL_NUMBER;
 import static org.kie.dmn.openapi.impl.SchemaMapperTestUtils.FEEL_STRING;
@@ -51,7 +52,7 @@ class DMNUnaryTestsMapperTest {
         expression += ", count (?) > 1";
         List<DMNUnaryTest> unaryTests = feel.evaluateUnaryTests(expression).stream().map(DMNUnaryTest.class::cast).toList();
         DMNUnaryTestsMapper.populateSchemaFromUnaryTests(toPopulate, unaryTests);
-        assertThat(toPopulate.getNullable()).isFalse();
+        assertThat(toPopulate.getExtensions().get(X_NULLABLE)).isNotNull().isEqualTo(Boolean.FALSE);
         assertThat(toPopulate.getEnumeration()).isNotNull();
         assertThat(toPopulate.getEnumeration()).hasSameSizeAs(expectedStrings).containsAll(expectedStrings);
     }
@@ -64,7 +65,7 @@ class DMNUnaryTestsMapperTest {
         String expression = String.join(",", toEnum.stream().map(toMap -> String.format("%s", toMap.toString())).toList());
         List<DMNUnaryTest> unaryTests = feel.evaluateUnaryTests(expression).stream().map(DMNUnaryTest.class::cast).toList();
         DMNUnaryTestsMapper.populateSchemaFromUnaryTests(toPopulate, unaryTests);
-        assertThat(toPopulate.getNullable()).isTrue();
+        assertThat(toPopulate.getExtensions().get(X_NULLABLE)).isNotNull().isEqualTo(Boolean.TRUE);
         assertThat(toPopulate.getEnumeration()).isNotNull();
         assertThat(toPopulate.getEnumeration()).hasSameSizeAs(expectedStrings).containsAll(expectedStrings);
     }
@@ -95,7 +96,7 @@ class DMNUnaryTestsMapperTest {
                 .toList();
         expression = String.join(",", formattedDates.stream().map(toMap -> String.format("%s", toMap)).toList());
         toCheck = feel.evaluateUnaryTests(expression).stream().map(DMNUnaryTest.class::cast).toList();
-        assertThat(toPopulate.get().getNullable()).isNull();
+        assertThat(toPopulate.get().getExtensions()).isNull();
         DMNUnaryTestsMapper.populateSchemaFromUnaryTests(toPopulate.get(), toCheck);
         assertThat(toPopulate.get().getEnumeration()).isNotNull();
         assertThat(toPopulate.get().getEnumeration()).hasSameSizeAs(expectedDates).containsAll(expectedDates);

--- a/kie-dmn/kie-dmn-openapi/src/test/java/org/kie/dmn/openapi/impl/RangeNodeSchemaMapperTest.java
+++ b/kie-dmn/kie-dmn-openapi/src/test/java/org/kie/dmn/openapi/impl/RangeNodeSchemaMapperTest.java
@@ -45,10 +45,10 @@ class RangeNodeSchemaMapperTest {
         List<RangeNode> ranges = getBaseNodes(toRange, RangeNode.class);
         Schema toPopulate = OASFactory.createObject(Schema.class);
         RangeNodeSchemaMapper.populateSchemaFromListOfRanges(toPopulate, ranges);
-        assertThat(toPopulate.getMinimum()).isEqualTo(BigDecimal.ONE);
-        assertThat(toPopulate.getExclusiveMinimum()).isTrue();
+        assertThat(toPopulate.getExclusiveMinimum()).isEqualTo(BigDecimal.ONE);
+        assertThat(toPopulate.getMinimum()).isNull();
         assertThat(toPopulate.getMaximum()).isEqualTo(BigDecimal.TEN);
-        assertThat(toPopulate.getExclusiveMaximum()).isFalse();
+        assertThat(toPopulate.getExclusiveMaximum()).isNull();
     }
 
     @Test
@@ -63,10 +63,10 @@ class RangeNodeSchemaMapperTest {
 
         Schema toPopulate = OASFactory.createObject(Schema.class);
         RangeNodeSchemaMapper.populateSchemaFromListOfRanges(toPopulate, ranges);
-        assertThat(toPopulate.getExtensions().get(DMNOASConstants.X_DMN_MINIMUM_VALUE)).isEqualTo(expectedDates.get(0));
-        assertThat(toPopulate.getExclusiveMinimum()).isTrue();
+        assertThat(toPopulate.getExtensions().get(DMNOASConstants.X_DMN_EXCLUSIVE_MINIMUM_VALUE)).isEqualTo(expectedDates.get(0));
+        assertThat(toPopulate.getExtensions().get(DMNOASConstants.X_DMN_MINIMUM_VALUE)).isNull();
         assertThat(toPopulate.getExtensions().get(DMNOASConstants.X_DMN_MAXIMUM_VALUE)).isEqualTo(expectedDates.get(1));
-        assertThat(toPopulate.getExclusiveMaximum()).isFalse();
+        assertThat(toPopulate.getExtensions().get(DMNOASConstants.X_DMN_EXCLUSIVE_MAXIMUM_VALUE)).isNull();
     }
 
     @Test


### PR DESCRIPTION
Updates Quarkus to version 3.20.1. Replaces the original PRs as they got stale (https://github.com/apache/incubator-kie-drools/pull/6296). This one is updated and rebased. 

Issue: https://github.com/apache/incubator-kie-issues/issues/1908

Related PRs: 
https://github.com/apache/incubator-kie-optaplanner/pull/3176
https://github.com/apache/incubator-kie-kogito-runtimes/pull/3935
https://github.com/apache/incubator-kie-kogito-apps/pull/2227
https://github.com/apache/incubator-kie-kogito-examples/pull/2108