### PR TITLE
NO-ISSUE: Fix maven build warnings

### DIFF
--- a/build-parent/pom.xml
+++ b/build-parent/pom.xml
@@ -59,9 +59,9 @@
     <version.commons-logging>1.1.1</version.commons-logging>
     <version.commons-io>2.19.0</version.commons-io>
     <version.common-text>1.11.0</version.common-text>
-    <version.com.fasterxml.jackson>2.18.4</version.com.fasterxml.jackson>
-    <version.com.fasterxml.jackson.databind>2.18.4</version.com.fasterxml.jackson.databind>
-    <version.com.fasterxml.jackson.annotations>2.18.4</version.com.fasterxml.jackson.annotations>
+    <version.com.fasterxml.jackson>2.19.0</version.com.fasterxml.jackson>
+    <version.com.fasterxml.jackson.databind>2.19.0</version.com.fasterxml.jackson.databind>
+    <version.com.fasterxml.jackson.annotations>2.19.0</version.com.fasterxml.jackson.annotations>
     <version.com.github.victools>4.37.0</version.com.github.victools> <!-- victools should align with Jackson if possible -->
     <version.com.miglayout>3.7.4</version.com.miglayout>
     <version.domino-slf4j-logger>1.0.1</version.domino-slf4j-logger>
@@ -220,6 +220,7 @@
 
     <!-- download-maven-plugin used to download arbitrary files at compile time -->
     <version.download-maven-plugin>2.0.0</version.download-maven-plugin>
+    <version.property-maven-plugin>1.2.1</version.property-maven-plugin>
     <!-- plugin used to enforce architectural constraints -->
     <archunit.maven.plugin.version>2.9.1</archunit.maven.plugin.version>
     <version.archunit.junit5>1.4.0</version.archunit.junit5>
@@ -1893,11 +1894,20 @@
           <artifactId>frontend-maven-plugin</artifactId>
           <version>${version.com.github.eirslett}</version>
         </plugin>
-
         <plugin>
           <groupId>com.societegenerale.commons</groupId>
           <artifactId>arch-unit-maven-plugin</artifactId>
           <version>${archunit.maven.plugin.version}</version>
+        </plugin>
+        <plugin>
+          <groupId>io.github.download-maven-plugin</groupId>
+          <artifactId>download-maven-plugin</artifactId>
+          <version>${version.download-maven-plugin}</version>
+        </plugin>
+        <plugin>
+          <groupId>org.codehaus.mojo</groupId>
+          <artifactId>properties-maven-plugin</artifactId>
+          <version>${version.property-maven-plugin}</version>
         </plugin>
       </plugins>
     </pluginManagement>
@@ -2038,12 +2048,6 @@
                 </execution>
               </executions>
             </plugin>
-            <plugin>
-              <groupId>io.github.download-maven-plugin</groupId>
-              <artifactId>download-maven-plugin</artifactId>
-              <version>${version.download-maven-plugin}</version>
-            </plugin>
-
           </plugins>
         </pluginManagement>
       </build>

--- a/build-parent/pom.xml
+++ b/build-parent/pom.xml
@@ -59,9 +59,9 @@
     <version.commons-logging>1.1.1</version.commons-logging>
     <version.commons-io>2.19.0</version.commons-io>
     <version.common-text>1.11.0</version.common-text>
-    <version.com.fasterxml.jackson>2.19.0</version.com.fasterxml.jackson>
-    <version.com.fasterxml.jackson.databind>2.19.0</version.com.fasterxml.jackson.databind>
-    <version.com.fasterxml.jackson.annotations>2.19.0</version.com.fasterxml.jackson.annotations>
+    <version.com.fasterxml.jackson>2.18.4</version.com.fasterxml.jackson>
+    <version.com.fasterxml.jackson.databind>2.18.4</version.com.fasterxml.jackson.databind>
+    <version.com.fasterxml.jackson.annotations>2.18.4</version.com.fasterxml.jackson.annotations>
     <version.com.github.victools>4.37.0</version.com.github.victools> <!-- victools should align with Jackson if possible -->
     <version.com.miglayout>3.7.4</version.com.miglayout>
     <version.domino-slf4j-logger>1.0.1</version.domino-slf4j-logger>

--- a/kie-dmn/kie-dmn-efesto-runtime/pom.xml
+++ b/kie-dmn/kie-dmn-efesto-runtime/pom.xml
@@ -42,17 +42,17 @@
             <dependency>
                 <groupId>org.kie</groupId>
                 <artifactId>kie-dmn-efesto-api</artifactId>
-                <version>${version}</version>
+                <version>${project.version}</version>
             </dependency>
           <dependency>
             <groupId>org.kie</groupId>
             <artifactId>efesto-runtime-manager-api</artifactId>
-            <version>${version}</version>
+            <version>${project.version}</version>
           </dependency>
           <dependency>
             <groupId>org.kie</groupId>
             <artifactId>efesto-runtime-manager-core</artifactId>
-            <version>${version}</version>
+            <version>${project.version}</version>
           </dependency>
         </dependencies>
     </dependencyManagement>

--- a/kie-maven-plugin/src/test/resources/unit/pmml/pom.xml
+++ b/kie-maven-plugin/src/test/resources/unit/pmml/pom.xml
@@ -121,7 +121,6 @@
         <plugin>
           <groupId>org.codehaus.mojo</groupId>
           <artifactId>properties-maven-plugin</artifactId>
-          <version>1.0.0</version>
         </plugin>
         <plugin>
           <groupId>org.kie</groupId>


### PR DESCRIPTION
When starting the drools build, this warning is raised:

```
[INFO] Scanning for projects...
[WARNING] 
[WARNING] Some problems were encountered while building the effective model for org.kie:kie-dmn-xsd-resources:jar:999-SNAPSHOT
[WARNING] 'build.plugins.plugin.version' for io.github.download-maven-plugin:download-maven-plugin is missing. @ line 49, column 15
[WARNING] 
[WARNING] Some problems were encountered while building the effective model for org.kie:kie-dmn-efesto-runtime:jar:999-SNAPSHOT
[WARNING] The expression ${version} is deprecated. Please use ${project.version} instead.
[WARNING] 
[WARNING] Some problems were encountered while building the effective model for org.kie:kie-dmn-validation:jar:999-SNAPSHOT
[WARNING] 'build.plugins.plugin.version' for org.codehaus.mojo:properties-maven-plugin is missing. @ line 265, column 15
[WARNING] 
[WARNING] It is highly recommended to fix these problems because they threaten the stability of your build.
[WARNING] 
[WARNING] For this reason, future Maven versions might no longer support building such malformed projects.
[WARNING] 
```

This PR addresses the above issues.
