### PR TITLE
[incubator-kie-drools-6361] Dormant matches memory leak

### DIFF
--- a/drools-core/src/main/java/org/drools/core/reteoo/AlphaTerminalNode.java
+++ b/drools-core/src/main/java/org/drools/core/reteoo/AlphaTerminalNode.java
@@ -96,6 +96,7 @@ public class AlphaTerminalNode extends LeftInputAdapterNode {
         ActivationsManager activationsManager = reteEvaluator.getActivationsManager();
         leftTuple.setPropagationContext( context );
         TerminalNode rtn = (TerminalNode) leftTuple.getSink();
+        leftTuple.setStagedType(Tuple.DELETE);
         PhreakRuleTerminalNode.doLeftDelete( activationsManager, getRuleAgendaItem( reteEvaluator, activationsManager, rtn, false ).getRuleExecutor(), (RuleTerminalNodeLeftTuple) leftTuple );
     }
 

--- a/drools-core/src/main/java/org/drools/core/reteoo/AlphaTerminalNode.java
+++ b/drools-core/src/main/java/org/drools/core/reteoo/AlphaTerminalNode.java
@@ -96,7 +96,9 @@ public class AlphaTerminalNode extends LeftInputAdapterNode {
         ActivationsManager activationsManager = reteEvaluator.getActivationsManager();
         leftTuple.setPropagationContext( context );
         TerminalNode rtn = (TerminalNode) leftTuple.getSink();
-        leftTuple.setStagedType(Tuple.DELETE);
+        if (((InternalMatch)leftTuple).isMatched()) {
+            leftTuple.setStagedType(Tuple.DELETE);
+        }
         PhreakRuleTerminalNode.doLeftDelete( activationsManager, getRuleAgendaItem( reteEvaluator, activationsManager, rtn, false ).getRuleExecutor(), (RuleTerminalNodeLeftTuple) leftTuple );
     }
 

--- a/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/compiler/MemoryLeakTest.java
+++ b/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/compiler/MemoryLeakTest.java
@@ -351,7 +351,7 @@ public class MemoryLeakTest {
             }
             System.out.println("------------------");
             // Allow some memory for the processing overhead
-            // The acceptableMemoryOverhead may not be a critical threshold. If the test fails, you may consider increasing it unless it's not a memory leak.
+            // The acceptableMemoryOverhead may not be a critical threshold. If the test fails, you may consider increasing it if it's not a memory leak.
             long acceptableMemoryOverhead = 10 * 1024 * 1024; // 10 MB
             System.gc();
             long usedMemory = Runtime.getRuntime().totalMemory() - Runtime.getRuntime().freeMemory();
@@ -405,7 +405,7 @@ public class MemoryLeakTest {
             }
             System.out.println("------------------");
             // Allow some memory for the processing overhead
-            // The acceptableMemoryOverhead may not be a critical threshold. If the test fails, you may consider increasing it unless it's not a memory leak.
+            // The acceptableMemoryOverhead may not be a critical threshold. If the test fails, you may consider increasing it if it's not a memory leak.
             long acceptableMemoryOverhead = 10 * 1024 * 1024; // 10 MB
             System.gc();
             long usedMemory = Runtime.getRuntime().totalMemory() - Runtime.getRuntime().freeMemory();

--- a/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/compiler/MemoryLeakTest.java
+++ b/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/compiler/MemoryLeakTest.java
@@ -314,6 +314,7 @@ public class MemoryLeakTest {
         return childObjects;
     }
 
+    @Disabled("disabled by default as this could be unstable")
     @ParameterizedTest(name = "KieBase type={0}")
     @MethodSource("parameters")
     @Timeout(60)
@@ -361,6 +362,7 @@ public class MemoryLeakTest {
         }
     }
 
+    @Disabled("disabled by default as this could be unstable")
     @ParameterizedTest(name = "KieBase type={0}")
     @MethodSource("parameters")
     @Timeout(60)

--- a/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/compiler/MemoryLeakTest.java
+++ b/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/compiler/MemoryLeakTest.java
@@ -316,7 +316,7 @@ public class MemoryLeakTest {
 
     @ParameterizedTest(name = "KieBase type={0}")
     @MethodSource("parameters")
-    @Timeout(60000)
+    @Timeout(60)
     public void testLeakWithMatchAndDelete(KieBaseTestConfiguration kieBaseTestConfiguration) {
         String drl =
                 "import " + Person.class.getCanonicalName() + "\n" +
@@ -344,7 +344,6 @@ public class MemoryLeakTest {
                 ksession.fireAllRules();
 
                 if (i % 1000 == 0) {
-                    System.out.println("Processed " + i + " persons");
                     System.gc();
                     long usedMemory = Runtime.getRuntime().totalMemory() - Runtime.getRuntime().freeMemory();
                     System.out.println("Used memory: " + usedMemory);
@@ -352,19 +351,19 @@ public class MemoryLeakTest {
             }
             System.out.println("------------------");
             // Allow some memory for the processing overhead
-            // The memoryOverhead may not be a critical threshold. If the test fails, you may consider increasing it unless it's not a memory leak.
-            long memoryOverhead = 10 * 1000 * 1024; // 10 MB
+            // The acceptableMemoryOverhead may not be a critical threshold. If the test fails, you may consider increasing it unless it's not a memory leak.
+            long acceptableMemoryOverhead = 10 * 1024 * 1024; // 10 MB
             System.gc();
             long usedMemory = Runtime.getRuntime().totalMemory() - Runtime.getRuntime().freeMemory();
             System.out.println("Base memory: " + baseMemory);
             System.out.println("User memory: " + usedMemory);
-            assertThat(usedMemory).isLessThan(baseMemory + memoryOverhead);
+            assertThat(usedMemory).isLessThan(baseMemory + acceptableMemoryOverhead);
         }
     }
 
     @ParameterizedTest(name = "KieBase type={0}")
     @MethodSource("parameters")
-    @Timeout(60000)
+    @Timeout(60)
     public void testLeakWithJoinMatchAndDelete(KieBaseTestConfiguration kieBaseTestConfiguration) {
         String drl =
                 "import " + Person.class.getCanonicalName() + "\n" +
@@ -399,7 +398,6 @@ public class MemoryLeakTest {
                 ksession.fireAllRules();
 
                 if (i % 1000 == 0) {
-                    System.out.println("Processed " + i + " persons");
                     System.gc();
                     long usedMemory = Runtime.getRuntime().totalMemory() - Runtime.getRuntime().freeMemory();
                     System.out.println("Used memory: " + usedMemory);
@@ -407,13 +405,13 @@ public class MemoryLeakTest {
             }
             System.out.println("------------------");
             // Allow some memory for the processing overhead
-            // The memoryOverhead may not be a critical threshold. If the test fails, you may consider increasing it unless it's not a memory leak.
-            long memoryOverhead = 10 * 1000 * 1024; // 10 MB
+            // The acceptableMemoryOverhead may not be a critical threshold. If the test fails, you may consider increasing it unless it's not a memory leak.
+            long acceptableMemoryOverhead = 10 * 1024 * 1024; // 10 MB
             System.gc();
             long usedMemory = Runtime.getRuntime().totalMemory() - Runtime.getRuntime().freeMemory();
             System.out.println("Base memory: " + baseMemory);
             System.out.println("User memory: " + usedMemory);
-            assertThat(usedMemory).isLessThan(baseMemory + memoryOverhead);
+            assertThat(usedMemory).isLessThan(baseMemory + acceptableMemoryOverhead);
         }
     }
 }

--- a/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/compiler/MemoryLeakTest.java
+++ b/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/compiler/MemoryLeakTest.java
@@ -337,8 +337,66 @@ public class MemoryLeakTest {
                 Person person = new Person("Mario", i);
                 person.setLikes(text24kb + i); // make sure that different String instances are created
                 FactHandle factHandle = ksession.insert(person);
-                ksession.fireAllRules();
+                int fired = ksession.fireAllRules();
+                assertThat(fired).isEqualTo(1);
+
                 ksession.delete(factHandle);
+                ksession.fireAllRules();
+
+                if (i % 1000 == 0) {
+                    System.out.println("Processed " + i + " persons");
+                    System.gc();
+                    long usedMemory = Runtime.getRuntime().totalMemory() - Runtime.getRuntime().freeMemory();
+                    System.out.println("Used memory: " + usedMemory);
+                }
+            }
+            System.out.println("------------------");
+            // Allow some memory for the processing overhead
+            // The memoryOverhead may not be a critical threshold. If the test fails, you may consider increasing it unless it's not a memory leak.
+            long memoryOverhead = 10 * 1000 * 1024; // 10 MB
+            System.gc();
+            long usedMemory = Runtime.getRuntime().totalMemory() - Runtime.getRuntime().freeMemory();
+            System.out.println("Base memory: " + baseMemory);
+            System.out.println("User memory: " + usedMemory);
+            assertThat(usedMemory).isLessThan(baseMemory + memoryOverhead);
+        }
+    }
+
+    @ParameterizedTest(name = "KieBase type={0}")
+    @MethodSource("parameters")
+    @Timeout(60000)
+    public void testLeakWithJoinMatchAndDelete(KieBaseTestConfiguration kieBaseTestConfiguration) {
+        String drl =
+                "import " + Person.class.getCanonicalName() + "\n" +
+                        "import " + Cheese.class.getCanonicalName() + "\n" +
+                        "rule R when\n" +
+                        "    $p : Person(name == \"Mario\")\n" +
+                        "    $c : Cheese(type == \"stilton\")\n" +
+                        "then\n" +
+                        "end\n";
+
+        KieBase kBase = KieBaseUtil.getKieBaseFromKieModuleFromDrl("test", kieBaseTestConfiguration, drl);
+
+        try (KieSession ksession = kBase.newKieSession()) {
+            String text24kb = "A".repeat(24 * 1024);
+
+            System.gc();
+            long baseMemory = Runtime.getRuntime().totalMemory() - Runtime.getRuntime().freeMemory();
+
+            for (int i = 0; i < 10000; i++) {
+                Person person = new Person("Mario", i);
+                person.setLikes(text24kb + i); // make sure that different String instances are created
+                FactHandle factHandlePerson = ksession.insert(person);
+
+                Cheese cheese = new Cheese("stilton");
+                FactHandle factHandleCheese = ksession.insert(cheese);
+
+                int fired = ksession.fireAllRules();
+                assertThat(fired).isEqualTo(1);
+
+                ksession.delete(factHandlePerson);
+                ksession.delete(factHandleCheese);
+                ksession.fireAllRules();
 
                 if (i % 1000 == 0) {
                     System.out.println("Processed " + i + " persons");

--- a/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/compiler/MemoryLeakTest.java
+++ b/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/compiler/MemoryLeakTest.java
@@ -313,4 +313,49 @@ public class MemoryLeakTest {
         }
         return childObjects;
     }
+
+    @ParameterizedTest(name = "KieBase type={0}")
+    @MethodSource("parameters")
+    @Timeout(60000)
+    public void testLeakWithMatchAndDelete(KieBaseTestConfiguration kieBaseTestConfiguration) {
+        String drl =
+                "import " + Person.class.getCanonicalName() + "\n" +
+                        "rule R when\n" +
+                        "    $p : Person(name == \"Mario\")\n" +
+                        "then\n" +
+                        "end\n";
+
+        KieBase kBase = KieBaseUtil.getKieBaseFromKieModuleFromDrl("test", kieBaseTestConfiguration, drl);
+
+        try (KieSession ksession = kBase.newKieSession()) {
+            String text24kb = "A".repeat(24 * 1024);
+
+            System.gc();
+            long baseMemory = Runtime.getRuntime().totalMemory() - Runtime.getRuntime().freeMemory();
+
+            for (int i = 0; i < 10000; i++) {
+                Person person = new Person("Mario", i);
+                person.setLikes(text24kb + i); // make sure that different String instances are created
+                FactHandle factHandle = ksession.insert(person);
+                ksession.fireAllRules();
+                ksession.delete(factHandle);
+
+                if (i % 1000 == 0) {
+                    System.out.println("Processed " + i + " persons");
+                    System.gc();
+                    long usedMemory = Runtime.getRuntime().totalMemory() - Runtime.getRuntime().freeMemory();
+                    System.out.println("Used memory: " + usedMemory);
+                }
+            }
+            System.out.println("------------------");
+            // Allow some memory for the processing overhead
+            // The memoryOverhead may not be a critical threshold. If the test fails, you may consider increasing it unless it's not a memory leak.
+            long memoryOverhead = 10 * 1000 * 1024; // 10 MB
+            System.gc();
+            long usedMemory = Runtime.getRuntime().totalMemory() - Runtime.getRuntime().freeMemory();
+            System.out.println("Base memory: " + baseMemory);
+            System.out.println("User memory: " + usedMemory);
+            assertThat(usedMemory).isLessThan(baseMemory + memoryOverhead);
+        }
+    }
 }


### PR DESCRIPTION
test fix


Issue:
- https://github.com/apache/incubator-kie-drools/issues/6361

----
`RuleTerminalNodeLeftTuple` objects are retained by `RuleExecutor.dormantMatches`, which was introduced by https://github.com/apache/incubator-kie-drools/pull/5821

----
I think we expect that such a `RuleTerminalNodeLeftTuple` should be removed here (by calling `delete`).

https://github.com/apache/incubator-kie-drools/blob/10.0.0/drools-core/src/main/java/org/drools/core/phreak/PhreakRuleTerminalNode.java#L272-L274

However, a simple rule like this unit test, `leftTuple.getStagedType()` is `Tuple.NONE`, not `Tuple.DELETE`, so it misses the removal.

----
Added `testLeakWithJoinMatchAndDelete`. This test doesn't cause a memory leak, because PhreakJoinNode sets `Tuple.DELETE` to the child `RuleTerminalNodeLeftTuple`.

Hmm, so we need to set `Tuple.DELETE` to `RuleTerminalNodeLeftTuple` in `AlphaTerminalNode.retractLeftTuple`? 
```
leftTuple.setStagedType(Tuple.DELETE);
```