### PR TITLE
[kie-issues#1915] Upgrade javaparser to 3.26.4.

### DIFF
--- a/build-parent/pom.xml
+++ b/build-parent/pom.xml
@@ -198,7 +198,7 @@
     <version.io.smallrye.jandex>3.3.0</version.io.smallrye.jandex>
     <version.org.eclipse.yasson>3.0.3</version.org.eclipse.yasson>
 
-    <version.com.github.javaparser>3.25.8</version.com.github.javaparser>
+    <version.com.github.javaparser>3.26.4</version.com.github.javaparser>
 
     <version.com.google.guava>32.0.1-jre</version.com.google.guava>
 

--- a/drools-model/drools-mvel-compiler/src/main/java/org/drools/mvelcompiler/RHSPhase.java
+++ b/drools-model/drools-mvel-compiler/src/main/java/org/drools/mvelcompiler/RHSPhase.java
@@ -45,9 +45,11 @@ import com.github.javaparser.ast.expr.MethodCallExpr;
 import com.github.javaparser.ast.expr.NullLiteralExpr;
 import com.github.javaparser.ast.expr.ObjectCreationExpr;
 import com.github.javaparser.ast.expr.PatternExpr;
+import com.github.javaparser.ast.expr.RecordPatternExpr;
 import com.github.javaparser.ast.expr.SimpleName;
 import com.github.javaparser.ast.expr.StringLiteralExpr;
 import com.github.javaparser.ast.expr.TextBlockLiteralExpr;
+import com.github.javaparser.ast.expr.TypePatternExpr;
 import com.github.javaparser.ast.expr.UnaryExpr;
 import com.github.javaparser.ast.expr.VariableDeclarationExpr;
 import com.github.javaparser.ast.stmt.ExpressionStmt;
@@ -171,7 +173,12 @@ public class RHSPhase implements DrlGenericVisitor<TypedExpression, VisitorConte
     }
 
     @Override
-    public TypedExpression visit(PatternExpr n, VisitorContext arg) {
+    public TypedExpression visit(TypePatternExpr n, VisitorContext arg) {
+        return null;
+    }
+
+    @Override
+    public TypedExpression visit(RecordPatternExpr n, VisitorContext arg) {
         return null;
     }
 

--- a/drools-model/drools-mvel-parser/src/main/java/org/drools/mvel/parser/TokenTypes.java
+++ b/drools-model/drools-mvel-parser/src/main/java/org/drools/mvel/parser/TokenTypes.java
@@ -20,7 +20,7 @@ package org.drools.mvel.parser;
 
 import com.github.javaparser.JavaToken;
 
-import static com.github.javaparser.utils.Utils.EOL;
+import static com.github.javaparser.utils.LineSeparator.SYSTEM;
 import static org.drools.mvel.parser.GeneratedMvelParserConstants.*;
 
 /**
@@ -67,13 +67,13 @@ public class TokenTypes {
      * @return the kind of EOL token to use on the platform you're running on.
      */
     public static int eolTokenKind() {
-        if (EOL.equals("\n")) {
+        if (SYSTEM.asRawString().equals("\n")) {
             return UNIX_EOL;
         }
-        if (EOL.equals("\r\n")) {
+        if (SYSTEM.asRawString().equals("\r\n")) {
             return WINDOWS_EOL;
         }
-        if (EOL.equals("\r")) {
+        if (SYSTEM.asRawString().equals("\r")) {
             return OLD_MAC_EOL;
         }
         throw new AssertionError("Unknown EOL character sequence");

--- a/drools-model/drools-mvel-parser/src/main/java/org/drools/mvel/parser/ast/visitor/DrlGenericVisitor.java
+++ b/drools-model/drools-mvel-parser/src/main/java/org/drools/mvel/parser/ast/visitor/DrlGenericVisitor.java
@@ -69,6 +69,7 @@ import com.github.javaparser.ast.expr.NormalAnnotationExpr;
 import com.github.javaparser.ast.expr.NullLiteralExpr;
 import com.github.javaparser.ast.expr.ObjectCreationExpr;
 import com.github.javaparser.ast.expr.PatternExpr;
+import com.github.javaparser.ast.expr.RecordPatternExpr;
 import com.github.javaparser.ast.expr.SimpleName;
 import com.github.javaparser.ast.expr.SingleMemberAnnotationExpr;
 import com.github.javaparser.ast.expr.StringLiteralExpr;
@@ -77,6 +78,7 @@ import com.github.javaparser.ast.expr.SwitchExpr;
 import com.github.javaparser.ast.expr.TextBlockLiteralExpr;
 import com.github.javaparser.ast.expr.ThisExpr;
 import com.github.javaparser.ast.expr.TypeExpr;
+import com.github.javaparser.ast.expr.TypePatternExpr;
 import com.github.javaparser.ast.expr.UnaryExpr;
 import com.github.javaparser.ast.expr.VariableDeclarationExpr;
 import com.github.javaparser.ast.modules.ModuleDeclaration;
@@ -679,7 +681,12 @@ public interface DrlGenericVisitor<R, A> extends GenericVisitor<R,A> {
     }
 
     @Override
-    default R visit(PatternExpr n, A arg) {
+    default R visit(TypePatternExpr n, A arg) {
+        return defaultMethod(n, arg);
+    }
+
+    @Override
+    default R visit(RecordPatternExpr n, A arg) {
         return defaultMethod(n, arg);
     }
 }

--- a/drools-model/drools-mvel-parser/src/main/java/org/drools/mvel/parser/ast/visitor/DrlVoidVisitor.java
+++ b/drools-model/drools-mvel-parser/src/main/java/org/drools/mvel/parser/ast/visitor/DrlVoidVisitor.java
@@ -68,6 +68,7 @@ import com.github.javaparser.ast.expr.NormalAnnotationExpr;
 import com.github.javaparser.ast.expr.NullLiteralExpr;
 import com.github.javaparser.ast.expr.ObjectCreationExpr;
 import com.github.javaparser.ast.expr.PatternExpr;
+import com.github.javaparser.ast.expr.RecordPatternExpr;
 import com.github.javaparser.ast.expr.SimpleName;
 import com.github.javaparser.ast.expr.SingleMemberAnnotationExpr;
 import com.github.javaparser.ast.expr.StringLiteralExpr;
@@ -76,6 +77,7 @@ import com.github.javaparser.ast.expr.SwitchExpr;
 import com.github.javaparser.ast.expr.TextBlockLiteralExpr;
 import com.github.javaparser.ast.expr.ThisExpr;
 import com.github.javaparser.ast.expr.TypeExpr;
+import com.github.javaparser.ast.expr.TypePatternExpr;
 import com.github.javaparser.ast.expr.UnaryExpr;
 import com.github.javaparser.ast.expr.VariableDeclarationExpr;
 import com.github.javaparser.ast.modules.ModuleDeclaration;
@@ -669,6 +671,10 @@ public interface DrlVoidVisitor<A> extends VoidVisitor<A> {
     }
 
     @Override
-    default void visit(PatternExpr n, A arg) {
+    default void visit(TypePatternExpr n, A arg) {
+    }
+
+    @Override
+    default void visit(RecordPatternExpr n, A arg) {
     }
 }

--- a/drools-model/drools-mvel-parser/src/main/java/org/drools/mvel/parser/printer/ConstraintPrintVisitor.java
+++ b/drools-model/drools-mvel-parser/src/main/java/org/drools/mvel/parser/printer/ConstraintPrintVisitor.java
@@ -370,35 +370,6 @@ public class ConstraintPrintVisitor extends DefaultPrettyPrinterVisitor implemen
         }
     }
 
-
-    public void printArguments(final NodeList<Expression> args, final Void arg) {
-        printer.print("(");
-        if (!isNullOrEmpty(args)) {
-            boolean columnAlignParameters = (args.size() > 1) &&
-                    configuration.get(new DefaultConfigurationOption(DefaultPrinterConfiguration.ConfigOption.COLUMN_ALIGN_PARAMETERS))
-                                    .map(ConfigurationOption::asBoolean).orElse(false);
-            if (columnAlignParameters) {
-                printer.indentWithAlignTo(printer.getCursor().column);
-            }
-            for (final Iterator<Expression> i = args.iterator(); i.hasNext(); ) {
-                final Expression e = i.next();
-                e.accept(this, arg);
-                if (i.hasNext()) {
-                    printer.print(",");
-                    if (columnAlignParameters) {
-                        printer.println();
-                    } else {
-                        printer.print(" ");
-                    }
-                }
-            }
-            if (columnAlignParameters) {
-                printer.unindent();
-            }
-        }
-        printer.print(")");
-    }
-
     @Override
     public void visit(DrlNameExpr n, Void arg) {
         printComment(n.getComment(), arg);

--- a/drools-model/drools-mvel-parser/src/main/javacc/mvel.jj
+++ b/drools-model/drools-mvel-parser/src/main/javacc/mvel.jj
@@ -3373,7 +3373,7 @@ Expression EqualityExpression():
  *         ReferenceType Identifier
  * }<pre>
  */
-PatternExpr PatternExpression():
+TypePatternExpr PatternExpression():
 {
     ModifierHolder modifier;
     ReferenceType type;
@@ -3383,7 +3383,7 @@ PatternExpr PatternExpression():
     modifier = Modifiers()
     type = ReferenceType(modifier.annotations)
     name = SimpleName()
-    { return new PatternExpr(range(type, token()), modifier.modifiers, type, name); }
+    { return new TypePatternExpr(range(type, token()), modifier.modifiers, type, name); }
 }
 
 
@@ -3405,7 +3405,7 @@ Expression InstanceOfExpression():
     Expression ret;
     ReferenceType type;
     NodeList<AnnotationExpr> annotations;
-    PatternExpr pattern;
+    TypePatternExpr pattern;
 }
 {
     ret = RelationalExpression()
@@ -3414,7 +3414,7 @@ Expression InstanceOfExpression():
         (
             LOOKAHEAD(PatternExpression())
             pattern = PatternExpression()
-            { ret = new InstanceOfExpr(range(ret, token()), ret, pattern.getType(), pattern); }
+            { ret = new InstanceOfExpr(range(ret, token()), ret, pattern.getType().asReferenceType(), pattern); }
          |
             type = AnnotatedReferenceType()
             { ret = new InstanceOfExpr(range(ret, token()), ret, type, null); }


### PR DESCRIPTION
Issue: https://github.com/apache/incubator-kie-issues/issues/1915

Upgrades javaparser library to 3.26.4 to align it with kogito-runtimes. 

- The printArguments(final NodeList<Expression> args, final Void arg) method now comes directly from the javaparser library itself - that is the reason it got deleted (it has the same content as the one we had). 
- If I understood correctly, the PatternExpr got changed in Javaparser to accomodate also record types, so it got split there. I aligned to the original TypePatternExpr. We could extend the features to support also records in the future when migrating to newer Java versions. 

Related PR in kogito-runtimes: https://github.com/apache/incubator-kie-kogito-runtimes/pull/3942