### PR TITLE
[incubator-kie-issues#1997] Implementing fallback downloads for DMN XSDs.

### DIFF
--- a/kie-dmn/kie-dmn-xsd-resources/pom.xml
+++ b/kie-dmn/kie-dmn-xsd-resources/pom.xml
@@ -62,6 +62,7 @@
               <unpack>false</unpack>
               <outputDirectory>${output.spec.directory}/20151101/</outputDirectory>
               <md5>ff4a266fa7a91b51b5c7ffde0e19aa5f</md5>
+              <failOnError>false</failOnError>
             </configuration>
           </execution>
           <!-- DMN 1.2 -->
@@ -76,6 +77,7 @@
               <unpack>false</unpack>
               <outputDirectory>${output.spec.directory}/20180521/</outputDirectory>
               <md5>89afb8f008550f81cc3989c5d0b9e4ea</md5>
+              <failOnError>false</failOnError>
             </configuration>
           </execution>
           <execution>
@@ -89,6 +91,7 @@
               <unpack>false</unpack>
               <outputDirectory>${output.spec.directory}/20180521/</outputDirectory>
               <md5>635f0e1e62ba09c22ca302c6103738ba</md5>
+              <failOnError>false</failOnError>
             </configuration>
           </execution>
           <execution>
@@ -102,6 +105,7 @@
               <unpack>false</unpack>
               <outputDirectory>${output.spec.directory}/20180521/</outputDirectory>
               <md5>f2fdcef4f5a1a32473e0ddca2dd72592</md5>
+              <failOnError>false</failOnError>
             </configuration>
           </execution>
           <execution>
@@ -115,6 +119,7 @@
               <unpack>false</unpack>
               <outputDirectory>${output.spec.directory}/20180521/</outputDirectory>
               <md5>96e6865c368fa27ada05ed85eaa4b370</md5>
+              <failOnError>false</failOnError>
             </configuration>
           </execution>
           <!-- DMN 1.3 -->
@@ -129,6 +134,7 @@
               <unpack>false</unpack>
               <outputDirectory>${output.spec.directory}/20191111/</outputDirectory>
               <md5>89afb8f008550f81cc3989c5d0b9e4ea</md5>
+              <failOnError>false</failOnError>
             </configuration>
           </execution>
           <execution>
@@ -142,6 +148,7 @@
               <unpack>false</unpack>
               <outputDirectory>${output.spec.directory}/20191111/</outputDirectory>
               <md5>635f0e1e62ba09c22ca302c6103738ba</md5>
+              <failOnError>false</failOnError>
             </configuration>
           </execution>
           <execution>
@@ -155,6 +162,7 @@
               <unpack>false</unpack>
               <outputDirectory>${output.spec.directory}/20191111/</outputDirectory>
               <md5>ae7ca8c95404dc3af5acde0b40d7f975</md5>
+              <failOnError>false</failOnError>
             </configuration>
           </execution>
           <execution>
@@ -168,6 +176,7 @@
               <unpack>false</unpack>
               <outputDirectory>${output.spec.directory}/20191111/</outputDirectory>
               <md5>f8934f1d8538ec404d3cf459755bc0ed</md5>
+              <failOnError>false</failOnError>
             </configuration>
           </execution>
           <!-- DMN 1.4 -->
@@ -182,6 +191,7 @@
               <unpack>false</unpack>
               <outputDirectory>${output.spec.directory}/20211108/</outputDirectory>
               <md5>89afb8f008550f81cc3989c5d0b9e4ea</md5>
+              <failOnError>false</failOnError>
             </configuration>
           </execution>
           <execution>
@@ -195,6 +205,7 @@
               <unpack>false</unpack>
               <outputDirectory>${output.spec.directory}/20211108/</outputDirectory>
               <md5>635f0e1e62ba09c22ca302c6103738ba</md5>
+              <failOnError>false</failOnError>
             </configuration>
           </execution>
           <execution>
@@ -208,6 +219,7 @@
               <unpack>false</unpack>
               <outputDirectory>${output.spec.directory}/20211108/</outputDirectory>
               <md5>576746eb17873791d683908b1fa60ec1</md5>
+              <failOnError>false</failOnError>
             </configuration>
           </execution>
           <execution>
@@ -221,6 +233,7 @@
               <unpack>false</unpack>
               <outputDirectory>${output.spec.directory}/20211108/</outputDirectory>
               <md5>f8934f1d8538ec404d3cf459755bc0ed</md5>
+              <failOnError>false</failOnError>
             </configuration>
           </execution>
           <!-- DMN 1.5 -->
@@ -235,6 +248,7 @@
               <unpack>false</unpack>
               <outputDirectory>${output.spec.directory}/20230324/</outputDirectory>
               <md5>89afb8f008550f81cc3989c5d0b9e4ea</md5>
+              <failOnError>false</failOnError>
             </configuration>
           </execution>
           <execution>
@@ -248,6 +262,7 @@
               <unpack>false</unpack>
               <outputDirectory>${output.spec.directory}/20230324/</outputDirectory>
               <md5>635f0e1e62ba09c22ca302c6103738ba</md5>
+              <failOnError>false</failOnError>
             </configuration>
           </execution>
           <execution>
@@ -261,6 +276,7 @@
               <unpack>false</unpack>
               <outputDirectory>${output.spec.directory}/20230324/</outputDirectory>
               <md5>49a582b2cd228d4a5102d41b688ddc6b</md5>
+              <failOnError>false</failOnError>
             </configuration>
           </execution>
           <execution>
@@ -274,6 +290,269 @@
               <unpack>false</unpack>
               <outputDirectory>${output.spec.directory}/20230324/</outputDirectory>
               <md5>b453d960af8c505c14b671373c370d7c</md5>
+              <failOnError>false</failOnError>
+            </configuration>
+          </execution>
+
+          <!-- Fallback downloads, if the first are not available due to OMG outage or similar.
+               They have overwriting set to false, so if the XSD is already downloaded, the plugins skips the download. -->
+          <execution>
+            <id>20151101_dmn-fallback-download</id>
+            <phase>generate-resources</phase>
+            <goals>
+              <goal>wget</goal>
+            </goals>
+            <configuration>
+              <url>https://github.com/omg-dmn-taskforce/omg-dmn-spec/tree/1.1/xsd/dmn.xsd</url>
+              <unpack>false</unpack>
+              <outputDirectory>${output.spec.directory}/20151101/</outputDirectory>
+              <md5>ff4a266fa7a91b51b5c7ffde0e19aa5f</md5>
+              <failOnError>true</failOnError>
+              <overwrite>false</overwrite>
+            </configuration>
+          </execution>
+          <!-- DMN 1.2 -->
+          <execution>
+            <id>20180521_DC-fallback-download</id>
+            <phase>generate-resources</phase>
+            <goals>
+              <goal>wget</goal>
+            </goals>
+            <configuration>
+              <url>https://github.com/omg-dmn-taskforce/omg-dmn-spec/tree/1.2/xsd/DC.xsd</url>
+              <unpack>false</unpack>
+              <outputDirectory>${output.spec.directory}/20180521/</outputDirectory>
+              <md5>89afb8f008550f81cc3989c5d0b9e4ea</md5>
+              <failOnError>true</failOnError>
+              <overwrite>false</overwrite>
+            </configuration>
+          </execution>
+          <execution>
+            <id>20180521_DI-fallback-download</id>
+            <phase>generate-resources</phase>
+            <goals>
+              <goal>wget</goal>
+            </goals>
+            <configuration>
+              <url>https://github.com/omg-dmn-taskforce/omg-dmn-spec/tree/1.2/xsd/DI.xsd</url>
+              <unpack>false</unpack>
+              <outputDirectory>${output.spec.directory}/20180521/</outputDirectory>
+              <md5>635f0e1e62ba09c22ca302c6103738ba</md5>
+              <failOnError>true</failOnError>
+              <overwrite>false</overwrite>
+            </configuration>
+          </execution>
+          <execution>
+            <id>20180521_DMN12-fallback-download</id>
+            <phase>generate-resources</phase>
+            <goals>
+              <goal>wget</goal>
+            </goals>
+            <configuration>
+              <url>https://github.com/omg-dmn-taskforce/omg-dmn-spec/tree/1.2/xsd/DMN12.xsd</url>
+              <unpack>false</unpack>
+              <outputDirectory>${output.spec.directory}/20180521/</outputDirectory>
+              <md5>f2fdcef4f5a1a32473e0ddca2dd72592</md5>
+              <failOnError>true</failOnError>
+              <overwrite>false</overwrite>
+            </configuration>
+          </execution>
+          <execution>
+            <id>20180521_DMNDI12-fallback-download</id>
+            <phase>generate-resources</phase>
+            <goals>
+              <goal>wget</goal>
+            </goals>
+            <configuration>
+              <url>https://github.com/omg-dmn-taskforce/omg-dmn-spec/tree/1.2/xsd/DMNDI12.xsd</url>
+              <unpack>false</unpack>
+              <outputDirectory>${output.spec.directory}/20180521/</outputDirectory>
+              <md5>96e6865c368fa27ada05ed85eaa4b370</md5>
+              <failOnError>true</failOnError>
+              <overwrite>false</overwrite>
+            </configuration>
+          </execution>
+          <!-- DMN 1.3 -->
+          <execution>
+            <id>20191111_DC-fallback-download</id>
+            <phase>generate-resources</phase>
+            <goals>
+              <goal>wget</goal>
+            </goals>
+            <configuration>
+              <url>https://github.com/omg-dmn-taskforce/omg-dmn-spec/tree/v1.3/xsd/DC.xsd</url>
+              <unpack>false</unpack>
+              <outputDirectory>${output.spec.directory}/20191111/</outputDirectory>
+              <md5>89afb8f008550f81cc3989c5d0b9e4ea</md5>
+              <failOnError>true</failOnError>
+              <overwrite>false</overwrite>
+            </configuration>
+          </execution>
+          <execution>
+            <id>20191111_DI-fallback-download</id>
+            <phase>generate-resources</phase>
+            <goals>
+              <goal>wget</goal>
+            </goals>
+            <configuration>
+              <url>https://github.com/omg-dmn-taskforce/omg-dmn-spec/tree/v1.3/xsd/DI.xsd</url>
+              <unpack>false</unpack>
+              <outputDirectory>${output.spec.directory}/20191111/</outputDirectory>
+              <md5>635f0e1e62ba09c22ca302c6103738ba</md5>
+              <failOnError>true</failOnError>
+              <overwrite>false</overwrite>
+            </configuration>
+          </execution>
+          <execution>
+            <id>20191111_DMN13-fallback-download</id>
+            <phase>generate-resources</phase>
+            <goals>
+              <goal>wget</goal>
+            </goals>
+            <configuration>
+              <url>https://github.com/omg-dmn-taskforce/omg-dmn-spec/tree/v1.3/xsd/DMN13.xsd</url>
+              <unpack>false</unpack>
+              <outputDirectory>${output.spec.directory}/20191111/</outputDirectory>
+              <md5>ae7ca8c95404dc3af5acde0b40d7f975</md5>
+              <failOnError>true</failOnError>
+              <overwrite>false</overwrite>
+            </configuration>
+          </execution>
+          <execution>
+            <id>20191111_DMNDI13-fallback-download</id>
+            <phase>generate-resources</phase>
+            <goals>
+              <goal>wget</goal>
+            </goals>
+            <configuration>
+              <url>https://github.com/omg-dmn-taskforce/omg-dmn-spec/tree/v1.3/xsd/DMNDI13.xsd</url>
+              <unpack>false</unpack>
+              <outputDirectory>${output.spec.directory}/20191111/</outputDirectory>
+              <md5>f8934f1d8538ec404d3cf459755bc0ed</md5>
+              <failOnError>true</failOnError>
+              <overwrite>false</overwrite>
+            </configuration>
+          </execution>
+          <!-- DMN 1.4 -->
+          <execution>
+            <id>20211108_DC-fallback-download</id>
+            <phase>generate-resources</phase>
+            <goals>
+              <goal>wget</goal>
+            </goals>
+            <configuration>
+              <url>https://github.com/omg-dmn-taskforce/omg-dmn-spec/tree/v1.4/xsd/DC.xsd</url>
+              <unpack>false</unpack>
+              <outputDirectory>${output.spec.directory}/20211108/</outputDirectory>
+              <md5>89afb8f008550f81cc3989c5d0b9e4ea</md5>
+              <failOnError>true</failOnError>
+              <overwrite>false</overwrite>
+            </configuration>
+          </execution>
+          <execution>
+            <id>20211108_DI-fallback-download</id>
+            <phase>generate-resources</phase>
+            <goals>
+              <goal>wget</goal>
+            </goals>
+            <configuration>
+              <url>https://github.com/omg-dmn-taskforce/omg-dmn-spec/tree/v1.4/xsd/DI.xsd</url>
+              <unpack>false</unpack>
+              <outputDirectory>${output.spec.directory}/20211108/</outputDirectory>
+              <md5>635f0e1e62ba09c22ca302c6103738ba</md5>
+              <failOnError>true</failOnError>
+              <overwrite>false</overwrite>
+            </configuration>
+          </execution>
+          <execution>
+            <id>20211108_DMN14-fallback-download</id>
+            <phase>generate-resources</phase>
+            <goals>
+              <goal>wget</goal>
+            </goals>
+            <configuration>
+              <url>https://github.com/omg-dmn-taskforce/omg-dmn-spec/tree/v1.4/xsd/DMN14.xsd</url>
+              <unpack>false</unpack>
+              <outputDirectory>${output.spec.directory}/20211108/</outputDirectory>
+              <md5>576746eb17873791d683908b1fa60ec1</md5>
+              <failOnError>true</failOnError>
+              <overwrite>false</overwrite>
+            </configuration>
+          </execution>
+          <execution>
+            <id>20211108_DMNDI13-fallback-download</id>
+            <phase>generate-resources</phase>
+            <goals>
+              <goal>wget</goal>
+            </goals>
+            <configuration>
+              <url>https://github.com/omg-dmn-taskforce/omg-dmn-spec/tree/v1.4/xsd/DMNDI13.xsd</url>
+              <unpack>false</unpack>
+              <outputDirectory>${output.spec.directory}/20211108/</outputDirectory>
+              <md5>f8934f1d8538ec404d3cf459755bc0ed</md5>
+              <failOnError>true</failOnError>
+              <overwrite>false</overwrite>
+            </configuration>
+          </execution>
+          <!-- DMN 1.5 -->
+          <execution>
+            <id>20230324_DC-fallback-download</id>
+            <phase>generate-resources</phase>
+            <goals>
+              <goal>wget</goal>
+            </goals>
+            <configuration>
+              <url>https://github.com/omg-dmn-taskforce/omg-dmn-spec/tree/v1.5/xsd/DC.xsd</url>
+              <unpack>false</unpack>
+              <outputDirectory>${output.spec.directory}/20230324/</outputDirectory>
+              <md5>89afb8f008550f81cc3989c5d0b9e4ea</md5>
+              <failOnError>true</failOnError>
+              <overwrite>false</overwrite>
+            </configuration>
+          </execution>
+          <execution>
+            <id>20230324_DI-fallback-download</id>
+            <phase>generate-resources</phase>
+            <goals>
+              <goal>wget</goal>
+            </goals>
+            <configuration>
+              <url>https://github.com/omg-dmn-taskforce/omg-dmn-spec/tree/v1.5/xsd/DI.xsd</url>
+              <unpack>false</unpack>
+              <outputDirectory>${output.spec.directory}/20230324/</outputDirectory>
+              <md5>635f0e1e62ba09c22ca302c6103738ba</md5>
+              <failOnError>true</failOnError>
+              <overwrite>false</overwrite>
+            </configuration>
+          </execution>
+          <execution>
+            <id>20230324_DMN15-fallback-download</id>
+            <phase>generate-resources</phase>
+            <goals>
+              <goal>wget</goal>
+            </goals>
+            <configuration>
+              <url>https://github.com/omg-dmn-taskforce/omg-dmn-spec/tree/v1.5/xsd/DMN15.xsd</url>
+              <unpack>false</unpack>
+              <outputDirectory>${output.spec.directory}/20230324/</outputDirectory>
+              <md5>49a582b2cd228d4a5102d41b688ddc6b</md5>
+              <failOnError>true</failOnError>
+              <overwrite>false</overwrite>
+            </configuration>
+          </execution>
+          <execution>
+            <id>20230324_DMNDI15-fallback-download</id>
+            <phase>generate-resources</phase>
+            <goals>
+              <goal>wget</goal>
+            </goals>
+            <configuration>
+              <url>https://github.com/omg-dmn-taskforce/omg-dmn-spec/tree/v1.5/xsd/DMNDI15.xsd</url>
+              <unpack>false</unpack>
+              <outputDirectory>${output.spec.directory}/20230324/</outputDirectory>
+              <md5>b453d960af8c505c14b671373c370d7c</md5>
+              <failOnError>true</failOnError>
+              <overwrite>false</overwrite>
             </configuration>
           </execution>
         </executions>


### PR DESCRIPTION
Issue: https://github.com/apache/incubator-kie-issues/issues/1997

This is an alternative approach of setting fallback URLs for DMN XSDs. Original approach is here: https://github.com/apache/incubator-kie-drools/pull/6370. 

By setting failOnError for the original downloads, if some download doesn't work, it doesn't fail the build. With overwrite set to false for the fallback ones, if the original download works, the fallback is skipped. 